### PR TITLE
Remove per-joint compliance attributes from Model

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -46,6 +46,12 @@ Importers
 |``ModelBuilder.add_shape_*(pos=..., rot=...)`` |``ModelBuilder.add_shape_*(xform=...)``       |
 +-----------------------------------------------+----------------------------------------------+
 
+The ``ModelBuilder.add_joint*()`` methods no longer accept ``linear_compliance`` and ``angular_compliance`` arguments
+and the ``Model`` no longer stores them as attributes.
+Instead, you can pass them as arguments to the :class:`newton.XPBDSolver` constructor. Note that now these values
+apply to all joints and cannot be set individually per joint anymore. We have not found applications that require
+per-joint compliance settings and have decided to remove this feature for memory efficiency.
+
 Renderers
 ---------
 

--- a/newton/core/model.py
+++ b/newton/core/model.py
@@ -452,8 +452,6 @@ class Model:
         joint_axis_start (array): Start index of the first axis per joint, shape [joint_count], int
         joint_axis_dim (array): Number of linear and angular axes per joint, shape [joint_count, 2], int
         joint_axis_mode (array): Joint axis mode, shape [joint_axis_count], int.
-        joint_linear_compliance (array): Joint linear compliance, shape [joint_count], float
-        joint_angular_compliance (array): Joint linear compliance, shape [joint_count], float
         joint_enabled (array): Controls which joint is simulated (bodies become disconnected if False), shape [joint_count], int
         joint_limit_lower (array): Joint lower position limits, shape [joint_axis_count], float
         joint_limit_upper (array): Joint upper position limits, shape [joint_axis_count], float
@@ -632,8 +630,6 @@ class Model:
         self.joint_axis_start = None
         self.joint_axis_dim = None
         self.joint_axis_mode = None
-        self.joint_linear_compliance = None
-        self.joint_angular_compliance = None
         self.joint_enabled = None
         self.joint_limit_lower = None
         self.joint_limit_upper = None
@@ -1143,8 +1139,6 @@ class ModelBuilder:
         self.joint_twist_lower = []
         self.joint_twist_upper = []
 
-        self.joint_linear_compliance = []
-        self.joint_angular_compliance = []
         self.joint_enabled = []
 
         self.joint_q_start = []
@@ -1391,8 +1385,6 @@ class ModelBuilder:
             "joint_limit_kd",
             "joint_target_ke",
             "joint_target_kd",
-            "joint_linear_compliance",
-            "joint_angular_compliance",
             "shape_key",
             "shape_visible",
             "shape_geo_type",
@@ -1515,8 +1507,6 @@ class ModelBuilder:
         key: str | None = None,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         collision_filter_parent: bool = True,
         enabled: bool = True,
@@ -1533,8 +1523,6 @@ class ModelBuilder:
             key (str): The key of the joint (optional)
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance (float): The linear compliance of the joint
-            angular_compliance (float): The angular compliance of the joint
             armature (float): Artificial inertia added around the joint axes (only considered by :class:`FeatherstoneIntegrator`)
             collision_filter_parent (bool): Whether to filter collisions between shapes of the parent and child bodies
             enabled (bool): Whether the joint is enabled (not considered by :class:`FeatherstoneIntegrator`)
@@ -1571,8 +1559,6 @@ class ModelBuilder:
         self.joint_axis_dim.append((len(linear_axes), len(angular_axes)))
         self.joint_axis_total_count += len(linear_axes) + len(angular_axes)
 
-        self.joint_linear_compliance.append(linear_compliance)
-        self.joint_angular_compliance.append(angular_compliance)
         self.joint_enabled.append(enabled)
 
         def add_axis_dim(dim: JointAxis):
@@ -1661,8 +1647,6 @@ class ModelBuilder:
         limit_upper: float = 2 * math.pi,
         limit_ke: float | None = None,
         limit_kd: float | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -1683,8 +1667,6 @@ class ModelBuilder:
             limit_upper: The upper limit of the joint
             limit_ke: The stiffness of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
             limit_kd: The damping of the joint limit (None to use the default value :attr:`default_joint_limit_kd`)
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axis
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -1728,8 +1710,6 @@ class ModelBuilder:
             parent_xform=parent_xform,
             child_xform=child_xform,
             angular_axes=[ax],
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -1751,8 +1731,6 @@ class ModelBuilder:
         limit_upper: float = 1e4,
         limit_ke: float | None = None,
         limit_kd: float | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -1773,8 +1751,6 @@ class ModelBuilder:
             limit_upper: The upper limit of the joint
             limit_ke: The stiffness of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
             limit_kd: The damping of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axis
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -1818,8 +1794,6 @@ class ModelBuilder:
             parent_xform=parent_xform,
             child_xform=child_xform,
             linear_axes=[ax],
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -1832,8 +1806,6 @@ class ModelBuilder:
         child: int,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -1846,8 +1818,6 @@ class ModelBuilder:
             child: The index of the child body
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature (float): Artificial inertia added around the joint axis (only considered by FeatherstoneIntegrator)
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -1869,8 +1839,6 @@ class ModelBuilder:
             child,
             parent_xform=parent_xform,
             child_xform=child_xform,
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -1883,8 +1851,6 @@ class ModelBuilder:
         child: int,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -1898,8 +1864,6 @@ class ModelBuilder:
             child: The index of the child body
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature (float): Artificial inertia added around the joint axis (only considered by FeatherstoneIntegrator)
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -1921,8 +1885,6 @@ class ModelBuilder:
             child,
             parent_xform=parent_xform,
             child_xform=child_xform,
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -1983,7 +1945,6 @@ class ModelBuilder:
         child_xform: wp.transform | None = None,
         min_distance: float = -1.0,
         max_distance: float = 1.0,
-        compliance: float = 0.0,
         collision_filter_parent: bool = True,
         enabled: bool = True,
     ) -> int:
@@ -1997,7 +1958,6 @@ class ModelBuilder:
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
             min_distance: The minimum distance between the bodies (no limit if negative)
             max_distance: The maximum distance between the bodies (no limit if negative)
-            compliance: The compliance of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
             enabled: Whether the joint is enabled
 
@@ -2025,7 +1985,6 @@ class ModelBuilder:
             parent_xform=parent_xform,
             child_xform=child_xform,
             linear_axes=[ax],
-            linear_compliance=compliance,
             collision_filter_parent=collision_filter_parent,
             enabled=enabled,
         )
@@ -2038,8 +1997,6 @@ class ModelBuilder:
         axis_1: JointAxis,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -2054,8 +2011,6 @@ class ModelBuilder:
             axis_1 (3D vector or JointAxis): The second axis of the joint, can be a JointAxis object whose settings will be used instead of the other arguments
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axes
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -2078,8 +2033,6 @@ class ModelBuilder:
             angular_axes=[JointAxis(axis_0), JointAxis(axis_1)],
             parent_xform=parent_xform,
             child_xform=child_xform,
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -2095,8 +2048,6 @@ class ModelBuilder:
         axis_2: JointAxis,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         key: str | None = None,
         collision_filter_parent: bool = True,
@@ -2115,8 +2066,6 @@ class ModelBuilder:
             axis_2 (3D vector or JointAxis): The third axis of the joint, can be a JointAxis object whose settings will be used instead of the other arguments
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axes
             key: The key of the joint
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
@@ -2139,8 +2088,6 @@ class ModelBuilder:
             angular_axes=[JointAxis(axis_0), JointAxis(axis_1), JointAxis(axis_2)],
             parent_xform=parent_xform,
             child_xform=child_xform,
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -2156,8 +2103,6 @@ class ModelBuilder:
         key: str | None = None,
         parent_xform: wp.transform | None = None,
         child_xform: wp.transform | None = None,
-        linear_compliance: float = 0.0,
-        angular_compliance: float = 0.0,
         armature: float = 1e-2,
         collision_filter_parent: bool = True,
         enabled: bool = True,
@@ -2172,8 +2117,6 @@ class ModelBuilder:
             key: The key of the joint
             parent_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the parent body's local frame
             child_xform (:external+warp:ref:`transform <transform>`): The transform of the joint in the child body's local frame
-            linear_compliance: The linear compliance of the joint
-            angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axes
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies
             enabled: Whether the joint is enabled
@@ -2202,8 +2145,6 @@ class ModelBuilder:
             child_xform=child_xform,
             linear_axes=[JointAxis(a) for a in linear_axes],
             angular_axes=[JointAxis(a) for a in angular_axes],
-            linear_compliance=linear_compliance,
-            angular_compliance=angular_compliance,
             armature=armature,
             key=key,
             collision_filter_parent=collision_filter_parent,
@@ -2386,8 +2327,6 @@ class ModelBuilder:
                 "armature": self.joint_armature[qd_start : qd_start + qd_dim],
                 "q_start": q_start,
                 "qd_start": qd_start,
-                "linear_compliance": self.joint_linear_compliance[i],
-                "angular_compliance": self.joint_angular_compliance[i],
                 "key": key,
                 "parent_xform": wp.transform_expand(self.joint_X_p[i]),
                 "child_xform": wp.transform_expand(self.joint_X_c[i]),
@@ -2564,8 +2503,6 @@ class ModelBuilder:
         self.joint_q_start.clear()
         self.joint_qd_start.clear()
         self.joint_enabled.clear()
-        self.joint_linear_compliance.clear()
-        self.joint_angular_compliance.clear()
         self.joint_armature.clear()
         self.joint_X_p.clear()
         self.joint_X_c.clear()
@@ -2591,8 +2528,6 @@ class ModelBuilder:
             self.joint_qd.extend(joint["qd"])
             self.joint_armature.extend(joint["armature"])
             self.joint_enabled.append(joint["enabled"])
-            self.joint_linear_compliance.append(joint["linear_compliance"])
-            self.joint_angular_compliance.append(joint["angular_compliance"])
             self.joint_X_p.append(list(joint["parent_xform"]))
             self.joint_X_c.append(list(joint["child_xform"]))
             self.joint_axis_dim.append(joint["axis_dim"])
@@ -4645,12 +4580,6 @@ class ModelBuilder:
             m.joint_limit_upper = wp.array(self.joint_limit_upper, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_limit_ke = wp.array(self.joint_limit_ke, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_limit_kd = wp.array(self.joint_limit_kd, dtype=wp.float32, requires_grad=requires_grad)
-            m.joint_linear_compliance = wp.array(
-                self.joint_linear_compliance, dtype=wp.float32, requires_grad=requires_grad
-            )
-            m.joint_angular_compliance = wp.array(
-                self.joint_angular_compliance, dtype=wp.float32, requires_grad=requires_grad
-            )
             m.joint_enabled = wp.array(self.joint_enabled, dtype=wp.int32)
 
             # 'close' the start index arrays with a sentinel value

--- a/newton/solvers/solver_xpbd.py
+++ b/newton/solvers/solver_xpbd.py
@@ -1326,8 +1326,8 @@ def solve_simple_body_joints(
     joint_target: wp.array(dtype=float),
     joint_target_ke: wp.array(dtype=float),
     joint_target_kd: wp.array(dtype=float),
-    joint_linear_compliance: wp.array(dtype=float),
-    joint_angular_compliance: wp.array(dtype=float),
+    joint_linear_compliance: float,
+    joint_angular_compliance: float,
     angular_relaxation: float,
     linear_relaxation: float,
     dt: float,
@@ -1395,8 +1395,7 @@ def solve_simple_body_joints(
     # x_p = wp.transform_get_translation(X_wp)
     x_c = wp.transform_get_translation(X_wc)
 
-    # linear_compliance = joint_linear_compliance[tid]
-    angular_compliance = joint_angular_compliance[tid]
+    angular_compliance = joint_angular_compliance
     damping = 0.0
 
     axis_start = joint_axis_start[tid]
@@ -1608,7 +1607,7 @@ def solve_simple_body_joints(
     corr = wp.quat_rotate(q_dx, corr)
 
     lambda_in = 0.0
-    linear_alpha = joint_linear_compliance[tid]
+    linear_alpha = joint_linear_compliance
     lambda_n = compute_linear_correction_3d(
         corr, r_p, r_c, pose_p, pose_c, m_inv_p, m_inv_c, I_inv_p, I_inv_c, lambda_in, linear_alpha, damping, dt
     )
@@ -1648,8 +1647,8 @@ def solve_body_joints(
     joint_act: wp.array(dtype=float),
     joint_target_ke: wp.array(dtype=float),
     joint_target_kd: wp.array(dtype=float),
-    joint_linear_compliance: wp.array(dtype=float),
-    joint_angular_compliance: wp.array(dtype=float),
+    joint_linear_compliance: float,
+    joint_angular_compliance: float,
     angular_relaxation: float,
     linear_relaxation: float,
     dt: float,
@@ -1721,8 +1720,8 @@ def solve_body_joints(
     # x_p = wp.transform_get_translation(X_wp)
     x_c = wp.transform_get_translation(X_wc)
 
-    linear_compliance = joint_linear_compliance[tid]
-    angular_compliance = joint_angular_compliance[tid]
+    linear_compliance = joint_linear_compliance
+    angular_compliance = joint_angular_compliance
 
     axis_start = joint_axis_start[tid]
     lin_axis_count = joint_axis_dim[tid, 0]
@@ -2639,9 +2638,6 @@ class XPBDSolver(SolverBase):
         - Miles Macklin, Matthias Müller, and Nuttapong Chentanez. 2016. XPBD: position-based simulation of compliant constrained dynamics. In Proceedings of the 9th International Conference on Motion in Games (MIG '16). Association for Computing Machinery, New York, NY, USA, 49-54. https://doi.org/10.1145/2994258.2994272
         - Matthias Müller, Miles Macklin, Nuttapong Chentanez, Stefan Jeschke, and Tae-Yong Kim. 2020. Detailed rigid body simulation with extended position based dynamics. In Proceedings of the ACM SIGGRAPH/Eurographics Symposium on Computer Animation (SCA '20). Eurographics Association, Goslar, DEU, Article 10, 1-12. https://doi.org/10.1111/cgf.14105
 
-    After constructing :class:`Model`, :class:`State`, and :class:`Control` (optional) objects, this time-integrator
-    may be used to advance the simulation state forward in time.
-
     Example
     -------
 
@@ -2657,12 +2653,14 @@ class XPBDSolver(SolverBase):
 
     def __init__(
         self,
-        model: Model = None,
+        model: Model,
         iterations=2,
         soft_body_relaxation=0.9,
         soft_contact_relaxation=0.9,
         joint_linear_relaxation=0.7,
         joint_angular_relaxation=0.4,
+        joint_linear_compliance=0.0,
+        joint_angular_compliance=0.0,
         rigid_contact_relaxation=0.8,
         rigid_contact_con_weighting=True,
         angular_damping=0.0,
@@ -2676,6 +2674,8 @@ class XPBDSolver(SolverBase):
 
         self.joint_linear_relaxation = joint_linear_relaxation
         self.joint_angular_relaxation = joint_angular_relaxation
+        self.joint_linear_compliance = joint_linear_compliance
+        self.joint_angular_compliance = joint_angular_compliance
 
         self.rigid_contact_relaxation = rigid_contact_relaxation
         self.rigid_contact_con_weighting = rigid_contact_con_weighting
@@ -3089,8 +3089,8 @@ class XPBDSolver(SolverBase):
                                 control.joint_act,
                                 model.joint_target_ke,
                                 model.joint_target_kd,
-                                model.joint_linear_compliance,
-                                model.joint_angular_compliance,
+                                self.joint_linear_compliance,
+                                self.joint_angular_compliance,
                                 self.joint_angular_relaxation,
                                 self.joint_linear_relaxation,
                                 dt,


### PR DESCRIPTION
## Description

``ModelBuilder.add_joint*()`` methods no longer accept ``linear_compliance`` and ``angular_compliance`` arguments
and the ``Model`` no longer stores them as attributes.
Instead, you can pass them as arguments to the :class:`newton.XPBDSolver` constructor. Note that now these values
apply to all joints and cannot be set individually per joint anymore. We have not found applications that require
per-joint compliance settings and have decided to remove this feature for memory efficiency.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [X] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
