### PR TITLE
Documentation updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ Please ensure the migration guide for **warp.sim** users is up-to-date with the 
 ## Before your PR is "Ready for review"
 
 - [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
+- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
 - [ ] Necessary tests have been added
 - [ ] Documentation is up-to-date
 - [ ] Code passes formatting and linting checks with `pre-commit run -a`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,3 +30,6 @@ jobs:
           python-version-file: ".python-version"
       - name: Build Sphinx documentation
         run: uv run --extra docs sphinx-build -W -b html docs docs/_build/html
+
+      - name: Run Sphinx doctests
+        run: uv run --extra docs sphinx-build -W -b doctest docs docs/_build/doctest

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -3,6 +3,10 @@ name: Deploy Sphinx documentation to Pages
 # Runs on every tag created beginning with the character v
 on:
   push:
+    # TODO: Remove the branches trigger once Newton is making production releases
+    branches:
+      - main
+      - "release-*"
     tags:
       - v*
   workflow_dispatch:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,15 @@ merge request docs:
   after_script:
     - echo "View the website at https://$CI_PROJECT_ROOT_NAMESPACE.$CI_PAGES_DOMAIN/-/$CI_PROJECT_NAME/-/jobs/$CI_JOB_ID/artifacts/public/index.html"
 
+doctest:
+  stage: docs
+  image: ghcr.io/astral-sh/uv:bookworm
+  needs: []
+  extends:
+    - .omni_nvks_gpu
+  script:
+    - uv run --extra docs sphinx-build -W -b doctest docs docs/_build/doctest
+
 # Build documentation and publish on gitlab-master
 # This only runs in the default branch pipeline. The "pages" name is special for GitLab.
 pages:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,12 @@ from typing import Any
 import numpy as np
 import warp as wp
 import newton
+
+# Suppress warnings by setting warp_showwarning to an empty function
+def empty_warning(*args, **kwargs):
+    pass
+wp.utils.warp_showwarning = empty_warning
+
 wp.config.quiet = True
 wp.init()
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",  # Markup to shorten external links
     "sphinx.ext.githubpages",
+    "sphinx.ext.doctest",  # Test code snippets in docs
     "sphinxcontrib.mermaid",
 ]
 
@@ -63,6 +64,15 @@ source_suffix = {
     ".rst": "restructuredtext",
     ".md": "markdown",
 }
+
+doctest_global_setup = """
+from typing import Any
+import numpy as np
+import warp as wp
+import newton
+wp.config.quiet = True
+wp.init()
+"""
 
 # -- Autodoc configuration ---------------------------------------------------
 

--- a/docs/development-guide.rst
+++ b/docs/development-guide.rst
@@ -151,7 +151,7 @@ Using uv
 .. code-block:: console
 
     rm -rf docs/_build
-    uv run --extra docs sphinx-build -b html docs docs/_build/html
+    uv run --extra docs sphinx-build -W -b html docs docs/_build/html
 
     # Alternatively using the Makefile
     uv sync --extra docs
@@ -166,12 +166,30 @@ Using venv
 .. code-block:: console
 
     python -m pip install -e .[docs]
-    python -m sphinx -b html docs docs/_build/html
+    python -m sphinx -W -b html docs docs/_build/html
 
     # Alternatively using the Makefile
     cd docs
     make clean
     make html
+
+Testing documentation code snippets
+-----------------------------------
+
+The ``doctest`` Sphinx builder is used to ensure that code snippets in the documentation remains up-to-date.
+
+The doctests can be run with:
+
+.. code-block:: console
+
+    # With uv installed
+    uv run --extra docs sphinx-build -W -b doctest docs docs/_build/doctest
+
+    # With venv
+    python -m sphinx -W -b doctest docs docs/_build/doctest
+
+For more information, see the `sphinx.ext.doctest <https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`__
+documentation.
 
 Packaging
 ---------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -61,3 +61,32 @@ Instead of rendering in real-time, you can also render the simulation as a time-
 
     # to save the USD stage:
     renderer.save()
+
+Example: Creating a particle chain
+----------------------------------
+
+.. testcode::
+
+    import newton
+
+    builder = newton.ModelBuilder()
+
+    # anchor point (zero mass)
+    builder.add_particle((0, 1.0, 0.0), (0.0, 0.0, 0.0), 0.0)
+
+    # build chain
+    for i in range(1, 10):
+        builder.add_particle((i, 1.0, 0.0), (0.0, 0.0, 0.0), 1.0)
+        builder.add_spring(i - 1, i, 1.0e3, 0.0, 0)
+
+    model = builder.finalize("cpu")
+
+    print(f"{model.spring_indices.numpy()=}")
+    print(f"{model.particle_count=}")
+    print(f"{model.particle_mass.numpy()=}")
+
+.. testoutput::
+
+    model.spring_indices.numpy()=array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9], dtype=int32)
+    model.particle_count=10
+    model.particle_mass.numpy()=array([0., 1., 1., 1., 1., 1., 1., 1., 1., 1.], dtype=float32)

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp#9ae65b3a457f018574f74fb1b64a2082c812bf98" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp#d6553e018579ca401453a761171d0848ae85a471" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
@@ -540,7 +540,7 @@ dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "warp-lang", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250507", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.8.0.dev20250508", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -593,7 +593,7 @@ name = "newton-physics"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang", version = "1.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250507", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.8.0.dev20250508", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -894,11 +894,11 @@ wheels = [
 
 [[package]]
 name = "snowballstemmer"
-version = "2.2.0"
+version = "3.0.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1", size = 86699, upload-time = "2021-11-16T18:38:38.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/81/f47e97c9850c529ab233fd1cd8319e0e5a1cfae49c87c49ab2fd0a19c744/snowballstemmer-3.0.0.1.tar.gz", hash = "sha256:1d09493a5ecc85fb5b433674e9c83fcd41c6739b6979ce4b54e81a40ec078342", size = 105321, upload-time = "2025-05-08T12:30:36.516Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a", size = 93002, upload-time = "2021-11-16T18:38:34.792Z" },
+    { url = "https://files.pythonhosted.org/packages/17/29/38d0cd1c958894aa042433a1515b7dab49a0a79b39df953b30b7ded716ce/snowballstemmer-3.0.0.1-py3-none-any.whl", hash = "sha256:d1cdabc06fb492e80620d9e2c44d39e67cfda290b2aaef8718b0691079443b10", size = 103250, upload-time = "2025-05-08T12:30:34.651Z" },
 ]
 
 [[package]]
@@ -1198,7 +1198,7 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.8.0.dev20250507"
+version = "1.8.0.dev20250508"
 source = { registry = "https://pypi.nvidia.com/" }
 resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'darwin'",
@@ -1210,8 +1210,9 @@ dependencies = [
     { name = "numpy", version = "2.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250507-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:379de6c93e47204b6de269bc69dded0061686b93d25153dcea983ac326f7b037" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250507-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:cbd7c282d8f3b16fb018ba5552d79fc9033e4c43b8af6c22ba55eef44af3eb24" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250508-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f110460ce4f9e3362b5f6809fc82ca502ef0c3002bc7f67ea9380b212d1d9583" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250508-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:8404d56eb3a0572db67f2cc59e3af4a60b6167af7778ccc2311146b7c97431a9" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250508-py3-none-win_amd64.whl", hash = "sha256:8d9537e715b7e68491b6d220fe97d1b73292f17d4187cbeef2d5a305590d3020" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This pull request enables `doctest` for Newton, including a job to test doctest snippets in the GitHub actions workflow (restricted to CPU only).

- A trivial example is added to the quickstart, which exercises this functionality.
- The Sphinx docs are changed to deploy on every push to main.
- The uv lockfile is also updated, which fixes an issue with the Windows wheel not being available for `warp-lang==1.8.0.dev20250507`.
- The pull request template is updated to remind authors that GitHub does not test the PR on GPUs
- `.gitlab-ci.yml` is updated to also run doctests

Closes #64 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
