### PR TITLE
Allow quotation marks in type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ ignore = [
     "UP018",  # Warp kernels often use float(val) and int(val)
     "RUF046", # Warp kernels often use int(val)
     "F811",   # Allow Warp kernel/function overloads
+    "TCH001", # Allow quotations in type annotations, e.g. Literal["a"]
+    "TCH002",
+    "TCH003",
+    "F821",
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
The flake8 linter currently removes any quotation marks in type annotations. 
Sometimes those are necessary and removing them will result in a syntax error, for example when writing `Literal[a]` instead of `Literal["a"]`.
This PR ignores the corresponding warnings and disables the removal of these quotation marks.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
