### PR TITLE
Add option for BFS joint ordering to USD importer

### DIFF
--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -63,6 +63,48 @@ class TestImportUsd(unittest.TestCase):
         self.assertEqual(len(results["path_shape_map"]), 13)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_joint_ordering(self):
+        builder_dfs = newton.ModelBuilder()
+        parse_usd(
+            os.path.join(os.path.dirname(__file__), "assets", "ant.usda"),
+            builder_dfs,
+            collapse_fixed_joints=True,
+            joint_ordering="dfs",
+        )
+        expected = [
+            "front_left_leg",
+            "front_left_foot",
+            "front_right_leg",
+            "front_right_foot",
+            "left_back_leg",
+            "left_back_foot",
+            "right_back_leg",
+            "right_back_foot",
+        ]
+        for i in range(8):
+            self.assertTrue(builder_dfs.joint_key[i + 1].endswith(expected[i]))
+
+        builder_bfs = newton.ModelBuilder()
+        parse_usd(
+            os.path.join(os.path.dirname(__file__), "assets", "ant.usda"),
+            builder_bfs,
+            collapse_fixed_joints=True,
+            joint_ordering="bfs",
+        )
+        expected = [
+            "front_left_leg",
+            "front_right_leg",
+            "left_back_leg",
+            "right_back_leg",
+            "front_left_foot",
+            "front_right_foot",
+            "left_back_foot",
+            "right_back_foot",
+        ]
+        for i in range(8):
+            self.assertTrue(builder_bfs.joint_key[i + 1].endswith(expected[i]))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_env_cloning(self):
         builder_no_cloning = newton.ModelBuilder()
         builder_cloning = newton.ModelBuilder()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Makes breadth-first search the default in joint ordering when parsing articulations from USD.
Closes https://github.com/newton-physics/newton/issues/96.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`

