### PR TITLE
Support for model batching/DR

### DIFF
--- a/newton/core/model.py
+++ b/newton/core/model.py
@@ -338,8 +338,6 @@ class Model:
         self.rigid_contact_torsional_friction = 0.0
         self.rigid_contact_rolling_friction = 0.0
         self.enable_tri_collisions = False
-        self.contact_particle_pairs = None
-        self.contact_shape_pairs = None
 
         self.rigid_contact_count = None
         self.rigid_contact_point0 = None

--- a/newton/core/model.py
+++ b/newton/core/model.py
@@ -282,8 +282,9 @@ class Model:
         self.body_mass = None
         self.body_inv_mass = None
         self.body_key = []
-
-        self.joint_q = None
+        
+        self._joint_q = None
+        self._joint_q_dirty = False
         self.joint_qd = None
         self.joint_act = None
         self.joint_type = None
@@ -337,6 +338,8 @@ class Model:
         self.rigid_contact_torsional_friction = 0.0
         self.rigid_contact_rolling_friction = 0.0
         self.enable_tri_collisions = False
+        self.contact_particle_pairs = None
+        self.contact_shape_pairs = None
 
         self.rigid_contact_count = None
         self.rigid_contact_point0 = None
@@ -381,6 +384,15 @@ class Model:
         self.particle_colors = None
 
         self.device = wp.get_device(device)
+
+    @property
+    def joint_q(self):
+        return self._joint_q
+
+    @joint_q.setter
+    def joint_q(self, value):
+        self._joint_q = value
+        self._joint_q_dirty = True
 
     def state(self, requires_grad=None) -> State:
         """Returns a state object for the model

--- a/newton/examples/example_humanoid.py
+++ b/newton/examples/example_humanoid.py
@@ -114,6 +114,7 @@ class Example:
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):
+        self.solver.update_mjc_model(self.model, self.solver.mjw_model)
         with wp.ScopedTimer("step", active=False):
             if self.use_cuda_graph:
                 wp.capture_launch(self.graph)
@@ -150,9 +151,13 @@ if __name__ == "__main__":
     with wp.ScopedDevice(args.device):
         example = Example(stage_path=args.stage_path, num_envs=args.num_envs)
 
-        for _ in range(args.num_frames):
+        for i in range(args.num_frames):
             example.step()
             example.render()
+
+            if i % 100 == 0:
+                example.model.joint_q = wp.array(example.model.joint_q.numpy() + example.rng.uniform(-.1, 0.1, size=(example.model.joint_coord_count)), dtype=wp.float32)
+
 
         if example.renderer:
             example.renderer.save()

--- a/newton/examples/example_humanoid.py
+++ b/newton/examples/example_humanoid.py
@@ -79,6 +79,9 @@ class Example:
         self.model = builder.finalize()
         self.model.ground = True
 
+        # randomize qpos0
+        self.model.joint_q = wp.array(self.model.joint_q.numpy() + self.rng.uniform(-.1, 0.1, size=(self.model.joint_coord_count)), dtype=wp.float32)
+
         self.control = self.model.control()
 
         self.solver = newton.solvers.MuJoCoSolver(

--- a/newton/solvers/solver_mujoco.py
+++ b/newton/solvers/solver_mujoco.py
@@ -741,7 +741,7 @@ class MuJoCoSolver(SolverBase):
         actuator_gears: dict[str, float] | None = None,
         actuated_axes: list[int] | None = None,
         skip_visual_only_geoms=True,
-        add_axes: bool = True,
+        add_axes: bool = False,
     ) -> tuple[MjWarpModel, MjWarpData, MjModel, MjData]:
         """
         Convert a Newton model and state to MuJoCo (Warp) model and data.
@@ -1226,10 +1226,16 @@ class MuJoCoSolver(SolverBase):
         mujoco.mj_forward(m, d)
 
         mj_model = mujoco_warp.put_model(m)
+
         if separate_envs_to_worlds:
             nworld = model.num_envs
         else:
             nworld = 1
+
+        # expand model fields that can be expanded:
+        MuJoCoSolver.expand_model_fields(mj_model, nworld)
+
+        
         # TODO find better heuristics to determine nconmax and njmax
         if ncon_per_env:
             nconmax = nworld * ncon_per_env
@@ -1240,3 +1246,106 @@ class MuJoCoSolver(SolverBase):
         mj_data = mujoco_warp.put_data(m, d, nworld=nworld, nconmax=nconmax, njmax=njmax)
 
         return mj_model, mj_data, m, d
+    
+
+    @staticmethod
+    def expand_model_fields(mj_model: MjWarpModel, nworld: int):
+
+        model_fields_to_expand = [
+            "qpos0",
+            "qpos_spring",
+            "body_pos",
+            "body_quat",
+            "body_ipos",
+            "body_iquat",
+            "body_mass",
+            "body_subtreemass",
+            "subtree_mass",
+            "body_inertia",
+            "body_invweight0",
+            "body_gravcomp",
+            "jnt_solref",
+            "jnt_solimp",
+            "jnt_pos",
+            "jnt_axis",
+            "jnt_stiffness",
+            "jnt_range",
+            "jnt_actfrcrange",
+            "jnt_margin",
+            "dof_armature",
+            "dof_damping",
+            "dof_invweight0",
+            "dof_frictionloss",
+            "dof_solimp",
+            "dof_solref",
+            "geom_matid",
+            "geom_solmix",
+            "geom_solref",
+            "geom_solimp",
+            "geom_size",
+            "geom_rbound",
+            "geom_pos",
+            "geom_quat",
+            "geom_friction",
+            "geom_margin",
+            "geom_gap",
+            "geom_rgba",
+            "site_pos",
+            "site_quat",
+            "cam_pos",
+            "cam_quat",
+            "cam_poscom0",
+            "cam_pos0",
+            "cam_mat0",
+            "light_pos",
+            "light_dir",
+            "light_poscom0",
+            "light_pos0",
+            "eq_solref",
+            "eq_solimp",
+            "eq_data",
+            "actuator_dynprm",
+            "actuator_gainprm",
+            "actuator_biasprm",
+            "actuator_ctrlrange",
+            "actuator_forcerange",
+            "actuator_actrange",
+            "actuator_gear",
+            "pair_solref",
+            "pair_solreffriction",
+            "pair_solimp",
+            "pair_margin",
+            "pair_gap",
+            "pair_friction",
+            "tendon_solref_lim",
+            "tendon_solimp_lim",
+            "tendon_range",
+            "tendon_margin",
+            "tendon_length0",
+            "tendon_invweight0",
+            "mat_rgba",
+        ]
+
+        def arr(x, dtype=None):
+            if not isinstance(x, np.ndarray):
+                x = np.array(x)
+            if dtype is None:
+                if np.issubdtype(x.dtype, np.integer):
+                    dtype = wp.int32
+                elif np.issubdtype(x.dtype, np.floating):
+                    dtype = wp.float32
+                elif np.issubdtype(x.dtype, np.bool):
+                    dtype = wp.bool
+                else:
+                    raise ValueError(f"Unsupported dtype: {x.dtype}")
+            wp_array = {1: wp.array, 2: wp.array2d, 3: wp.array3d, 4: wp.array4d}[x.ndim]
+            return wp_array(x, dtype=dtype)
+
+        def tile(x, dtype=None):
+            return arr(np.repeat(x.numpy(), nworld, axis=0), dtype)
+
+        for field in mj_model.__dataclass_fields__:
+            # todo: avoid numpy roundtrip
+            if field in model_fields_to_expand:
+                array = getattr(mj_model, field)
+                setattr(mj_model, field, tile(array, dtype=array.dtype))

--- a/newton/solvers/solver_mujoco.py
+++ b/newton/solvers/solver_mujoco.py
@@ -605,9 +605,8 @@ class MuJoCoSolver(SolverBase):
             self.mujoco.mj_step(self.mj_model, self.mj_data)
             self.update_newton_state(self.model, state_out, self.mj_data)
         else:
-            if self.model._joint_q_dirty:
-                self.update_model_joint_q(self.model, self.mjw_model)
-
+            # AD: this does not work with graph capture.. maybe use a conditional?
+            #self.update_mjc_model(self.model, self.mjw_model)
 
             self.apply_mjc_control(self.model, control, self.mjw_data)
             if self.update_data_every > 0 and self._step % self.update_data_every == 0:
@@ -1419,6 +1418,10 @@ class MuJoCoSolver(SolverBase):
                 array = getattr(mj_model, field)
                 setattr(mj_model, field, tile(array, dtype=array.dtype))
 
+
+    def update_mjc_model(self, model: Model, mjw_model: MjWarpModel):
+        if model._joint_q_dirty:
+            MuJoCoSolver.update_model_joint_q(model, mjw_model)
 
     @staticmethod
     def update_model_joint_q(model: Model, mjw_model: MjWarpModel):


### PR DESCRIPTION
This is a first try how the update logic could look like for model updates. This is purely for discussion purposes, and will likely be iterated on significantly.

Here's the gist:
* model fields are exposed as python properties, and the setters activate some dirty tracking.
* pre-step, we apply conversions to all the properties that need them, pass through the data that can be passed through directly or trigger a recompile (not implemented here)

Here are the current issues I'm fighting:
1. This is not really graph compatible, so we can't really bake it into the step logic of the solver. I do think it's not a good idea to rely on users to remember to call the update handler. Right now it's implemented that way to make it work at least. It could be an option to use conditional nodes but the problem remains that somehow we need to update some dirty flags, and this is most likely going to be a HtoD copy.
2. It's currently not working with the selection API as the selection API only does a get, but does not set. So we don't have a chance to update the dirty flags. This can be worked around though, I don't think that's a blocking issue.

