### PR TITLE
Fix skipping of shapes based on shapes_per_env variable

### DIFF
--- a/newton/examples/example_cartpole.py
+++ b/newton/examples/example_cartpole.py
@@ -68,7 +68,7 @@ class Example:
         self.model = builder.finalize()
         self.model.ground = False
 
-        self.solver = newton.solvers.MuJoCoSolver(self.model)
+        self.solver = newton.solvers.MuJoCoSolver(self.model, disable_contacts=True)
         # self.solver = newton.solvers.SemiImplicitSolver(self.model, joint_attach_ke=1600.0, joint_attach_kd=20.0)
         # self.solver = newton.solvers.FeatherstoneSolver(self.model)
 

--- a/newton/solvers/solver_mujoco.py
+++ b/newton/solvers/solver_mujoco.py
@@ -971,11 +971,11 @@ class MuJoCoSolver(SolverBase):
                     continue
                 elif skip_visual_only_geoms and not (shape_flags[shape] & int(newton.core.SHAPE_FLAG_COLLIDE_SHAPES)):
                     continue
-                elif separate_envs_to_worlds and shape >= shapes_per_env and shape != model.shape_count - 1:
-                    # this is a shape in a different environment, skip it
-                    # TODO fix handling of static shapes here, see cartpole.xml replication
-                    # that is missing the rail shapes
-                    continue
+                # elif separate_envs_to_worlds and shape >= shapes_per_env and shape != model.shape_count - 1:
+                #     # this is a shape in a different environment, skip it
+                #     # TODO fix handling of static shapes here, see cartpole.xml replication
+                #     # that is missing the rail shapes
+                #     continue
                 stype = shape_type[shape]
                 name = f"{geom_type_name[stype]}_{shape}"
                 if stype == newton.GEO_PLANE and warp_body_id != -1:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* Fixed an issue where the last shape of an articulation was not added to the mjModel when MJWarp is used (i.e. `separate_envs_to_worlds` is True)
* Use `disable_contacts=True` on the cartpole example

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
