### PR TITLE
Improve opengl viz for example_cloth_self_contact

### DIFF
--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -228,6 +228,9 @@ class Example:
         self.renderer = None
         if stage_path:
             self.renderer = newton.utils.SimRendererOpenGL(path=stage_path, model=self.model, scaling=0.05)
+            self.renderer.enable_backface_culling = False
+            self.renderer.draw_grid = False
+            self.renderer.render_wireframe = True
 
         self.cuda_graph = None
         if self.use_cuda_graph:


### PR DESCRIPTION
## Description
Fixes #127.

Set better defaults for the open gl visualizer in example_cloth_self_contact.

Specifically default to:

- wireframe rendering (hard to see cloth deformation otherwise)
- no backface culling (sections of cloth otherwise disappear if we exit wireframe mode)
- no ground plane

Before:
![image](https://github.com/user-attachments/assets/e636b0f1-35f3-431f-bb97-8ccca6f63d52)

After:
![image](https://github.com/user-attachments/assets/52b898a4-ad73-4feb-9cca-8e1e99f05711)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
