### PR TITLE
Draft of flexible batching

### DIFF
--- a/newton/core/model.py
+++ b/newton/core/model.py
@@ -328,6 +328,40 @@ class Model:
         self.rigid_contact_point_limit = None
         """Contact point limit, shape [rigid_contact_max], int."""
 
+        # batches: this is just metadata that can stay on CPU
+        self.batch_key = []
+        """Batch keys, shape [batch_count], str."""
+        self.batch_dim = []
+        """Batch size, shape [batch_count], int."""
+        self.batch_shape_start = []
+        """Start index of the first shape in the batch, shape [batch_count], int."""
+        self.batch_shape_count = []
+        """Number of shapes in the batch, shape [batch_count], int."""
+        self.batch_body_start = []
+        """Start index of the first body in the batch, shape [batch_count], int."""
+        self.batch_body_count = []
+        """Number of bodies in the batch, shape [batch_count], int."""
+        self.batch_joint_start = []
+        """Start index of the first joint in the batch, shape [batch_count], int."""
+        self.batch_joint_count = []
+        """Number of joints in the batch, shape [batch_count], int."""
+        self.batch_joint_coord_start = []
+        """Start index of the first joint position coordinate in the batch, shape [batch_count], int."""
+        self.batch_joint_coord_count = []
+        """Number of joint position coordinates in the batch, shape [batch_count], int."""
+        self.batch_joint_dof_start = []
+        """Start index of the first joint velocity coordinate in the batch, shape [batch_count], int."""
+        self.batch_joint_dof_count = []
+        """Number of joint velocity coordinates in the batch, shape [batch_count], int."""
+        self.batch_joint_axis_start = []
+        """Start index of the first joint_axis in the batch, shape [batch_count], int."""
+        self.batch_joint_axis_count = []
+        """Number of joint axes in the batch, shape [batch_count], int."""
+        self.batch_articulation_start = []
+        """Start index of the first articulation in the batch, shape [batch_count], int."""
+        self.batch_articulation_count = []
+        """Number of articulations in the batch, shape [batch_count], int."""
+
         # toggles ground contact for all shapes
         self.ground = True
         """Whether the ground plane and ground contacts are enabled."""
@@ -366,6 +400,8 @@ class Model:
         """Total number of velocity degrees of freedom of all joints in the system."""
         self.joint_coord_count = 0
         """Total number of position degrees of freedom of all joints in the system."""
+        self.batch_count = 0
+        """Total number of batches in the system."""
 
         # indices of particles sharing the same color
         self.particle_color_groups = []


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
In non-trivial reinforcement learning experiments, a stage doesn't just have multiple envs, but can also have some shared "global" geometry. This might include terrain, obstacles, or other stuff. So I don't think that just adding a batch dimension like `body_q[env_id, ...]` is sufficient. We need to be able to have things that are batched and other things that aren't batched. That should also open the door to non-homogeneous envs.

This PR proposes something like this:
```python
# env to replicate
env_builder = ModelBuilder(...)

# main builder for the whole scene
main_builder = ModelBuilder(...)

# [...] first, add some global geometry to the main_builder here

# next, replicate the envs a number of times
main_builder.add_batch(env_builder, count) 

# [...] can still add stuff to the main_builder without affecting the batched envs
```

That will replicate the `env_builder` in a contiguous chunk of the `main_builder`. Within that contiguous chunk, we can view the data with a batch dim (in the selection API or elsewhere). This should allow us to have global geometry added before or after the batched envs. It also supports the possibility to add multiple batches of things. That could work nicely with some heterogeneous envs, where you basically have sub-batches of homogeneous envs. Or you can slice-and-dice the envs - add a batch for the "base" layer that's common to all envs, then another batch or two for "extras" that only some envs will have.

This is a bit more versatile than just tying Newton to some single env/batch count.

One nice thing is that it wouldn't really affect the existing code that works with the flat unstructured arrays. There are no changes to the existing data structures, so solver code does not need modification. Any other existing code will also continue to work without changes. This just adds some metadata about the start and size of each batch that's "overlaid" on top of the existing data structures. Code that requires batching could take advantage of it by creating strided arrays with a batch dimension. For example, the selection API could use this to provide tensorized views of batched data that are compatible with PyTorch, JAX, and other array frameworks.

One possible usage would be something like this:
```python
# create a view of a batch based on a batch key (specified at creation)
batch = BatchView(model, "my_batch") 

# get a strided array with shape (batch_count, bodies_per_batch)
batch_body_q = batch.get_attribute("body_q", state_0)

# get a strided array with shape (batch_count, joint_coords_per_batch)
batch_joint_q = batch.get_attribute("joint_q", state_0)
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
