### PR TITLE
Fix some Markdown use in `.rst` files

### DIFF
--- a/docs/development-guide.rst
+++ b/docs/development-guide.rst
@@ -199,7 +199,7 @@ Roadmap and Future Work
 - More comprehensive sensor models
 - Expanded robotics examples
 
-See the [GitHub Discussions](https://github.com/newton-physics/newton/discussions) for ongoing feature planning.
+See the `GitHub Discussions <https://github.com/newton-physics/newton/discussions>`__ for ongoing feature planning.
 
 Contribution Guide
 ==================

--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -26,7 +26,7 @@ Key Features
 .. admonition:: Learn More
    :class: tip
 
-   For a deep conceptual introduction, see the [DeepWiki Newton Physics page](https://deepwiki.com/newton-physics/newton).
+   For a deep conceptual introduction, see the `DeepWiki Newton Physics page <https://deepwiki.com/newton-physics/newton>`__.
 
 
 High-Level Architecture


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Some links in the docs were using Markdown format inside a reST file, which doesn't work.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
