### PR TITLE
Ensure MuJoCoSolver can run on CPU

### DIFF
--- a/newton/tests/test_control_force.py
+++ b/newton/tests/test_control_force.py
@@ -23,7 +23,7 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.tests.unittest_utils import add_function_test
+from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 wp.config.quiet = True
 
@@ -126,7 +126,7 @@ def test_3d_articulation(test: TestControlForce, device, solver_fn):
             test.assertAlmostEqual(qd[i], 0.0, delta=1e-6)
 
 
-devices = ["cpu"]  # get_test_devices()
+devices = get_test_devices()
 solvers = {
     # "featherstone": lambda model: newton.solvers.FeatherstoneSolver(model, angular_damping=0.0),
     "mujoco_c": lambda model: newton.solvers.MuJoCoSolver(
@@ -158,5 +158,5 @@ for device in devices:
         )
 
 if __name__ == "__main__":
-    # wp.clear_kernel_cache()
+    wp.clear_kernel_cache()
     unittest.main(verbosity=2)

--- a/newton/tests/test_control_force.py
+++ b/newton/tests/test_control_force.py
@@ -23,7 +23,9 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.tests.unittest_utils import add_function_test, get_test_devices
+from newton.tests.unittest_utils import add_function_test
+
+wp.config.quiet = True
 
 
 class TestControlForce(unittest.TestCase):
@@ -124,7 +126,7 @@ def test_3d_articulation(test: TestControlForce, device, solver_fn):
             test.assertAlmostEqual(qd[i], 0.0, delta=1e-6)
 
 
-devices = get_test_devices()
+devices = ["cpu"]  # get_test_devices()
 solvers = {
     # "featherstone": lambda model: newton.solvers.FeatherstoneSolver(model, angular_damping=0.0),
     "mujoco_c": lambda model: newton.solvers.MuJoCoSolver(
@@ -156,5 +158,5 @@ for device in devices:
         )
 
 if __name__ == "__main__":
-    wp.clear_kernel_cache()
+    # wp.clear_kernel_cache()
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
This fixes the test_control_force tests.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
