### PR TITLE
Remove Windows test configuration from GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,9 @@ on:
 
 jobs:
   newton-unittests:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
-      OS: ${{ matrix.os }}
+      OS: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updated the CI configuration to run on a fixed 'ubuntu-latest' environment, removing the matrix strategy for OS selection.

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

We need to stop using GitHub actions minutes so quickly.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
