### PR TITLE
Potential Fix when loading H1 from USD

### DIFF
--- a/newton/core/inertia.py
+++ b/newton/core/inertia.py
@@ -387,7 +387,6 @@ def transform_inertia(m, I, p, q) -> wp.mat33:
     # Steiner's theorem
     return R @ I @ wp.transpose(R) + m * (wp.dot(p, p) * wp.mat33(np.eye(3)) - wp.outer(p, p))
 
-
 def compute_shape_inertia(
     type: int,
     scale: Vec3,
@@ -460,11 +459,11 @@ def compute_shape_inertia(
         assert src is not None, "src must be provided for mesh or SDF shapes"
         if src.has_inertia and src.mass > 0.0 and src.is_solid == is_solid:
             m, c, I = src.mass, src.com, src.I
-
+            scale = wp.vec3(scale)
             sx, sy, sz = scale
 
             mass_ratio = sx * sy * sz * density
-            m_new = float(m * mass_ratio)
+            m_new = m * mass_ratio
 
             c_new = wp.cw_mul(c, scale)
 

--- a/newton/core/inertia.py
+++ b/newton/core/inertia.py
@@ -387,6 +387,7 @@ def transform_inertia(m, I, p, q) -> wp.mat33:
     # Steiner's theorem
     return R @ I @ wp.transpose(R) + m * (wp.dot(p, p) * wp.mat33(np.eye(3)) - wp.outer(p, p))
 
+
 def compute_shape_inertia(
     type: int,
     scale: Vec3,

--- a/newton/core/inertia.py
+++ b/newton/core/inertia.py
@@ -464,7 +464,7 @@ def compute_shape_inertia(
             sx, sy, sz = scale
 
             mass_ratio = sx * sy * sz * density
-            m_new = m * mass_ratio
+            m_new = float(m * mass_ratio)
 
             c_new = wp.cw_mul(c, scale)
 

--- a/newton/tests/assets/simple_articulation_with_mesh.usda
+++ b/newton/tests/assets/simple_articulation_with_mesh.usda
@@ -1,33 +1,12 @@
 #usda 1.0
 (
     customLayerData = {
-        dictionary cameraSettings = {
-            dictionary Front = {
-                double3 position = (5, 0, 0)
-                double radius = 5
-            }
-            dictionary Perspective = {
-                double3 position = (7.28913872358609, -1.760246560017226, 2.439578447916335)
-                double3 target = (-1.0625960084380548, -0.6522910993461004, 0.4343448797077323)
-            }
-            dictionary Right = {
-                double3 position = (0, -5, 0)
-                double radius = 5
-            }
-            dictionary Top = {
-                double3 position = (0, 0, 5)
-                double radius = 5
-            }
-            string boundCamera = "/OmniverseKit_Persp"
-        }
         dictionary omni_layer = {
             string authoring_layer = "./mesh_articulation.usda"
             dictionary locked = {
             }
             dictionary muteness = {
             }
-        }
-        dictionary renderSettings = {
         }
     }
     defaultPrim = "Robot"
@@ -37,37 +16,6 @@
     timeCodesPerSecond = 60
     upAxis = "Z"
 )
-
-def Xform "Environment"
-{
-    quatd xformOp:orient = (1, 0, 0, 0)
-    double3 xformOp:scale = (1, 1, 1)
-    double3 xformOp:translate = (0, 0, 0)
-    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
-
-    def DistantLight "defaultLight" (
-        prepend apiSchemas = ["ShapingAPI"]
-    )
-    {
-        float inputs:angle = 1
-        float inputs:intensity = 3000
-        float inputs:shaping:cone:angle = 180
-        float inputs:shaping:cone:softness
-        float inputs:shaping:focus
-        color3f inputs:shaping:focusTint
-        asset inputs:shaping:ies:file
-        quatd xformOp:orient = (0.6532814824381883, 0.2705980500730985, 0.27059805007309845, 0.6532814824381882)
-        double3 xformOp:scale = (1, 1, 1)
-        double3 xformOp:translate = (0, 0, 0)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
-    }
-}
-
-over "Render" (
-    hide_in_stage_window = true
-)
-{
-}
 
 def Xform "Robot" (
     prepend apiSchemas = ["PhysicsArticulationRootAPI", "PhysxArticulationAPI"]
@@ -95,7 +43,7 @@ def Xform "Robot" (
     }
 
     def Xform "left_rigid" (
-        prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI", "PhysicsMassAPI"]
+        prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI"]
     )
     {
         bool physics:kinematicEnabled = 0
@@ -164,4 +112,3 @@ def Xform "Robot" (
         }
     }
 }
-

--- a/newton/tests/assets/simple_articulation_with_mesh.usda
+++ b/newton/tests/assets/simple_articulation_with_mesh.usda
@@ -1,0 +1,167 @@
+#usda 1.0
+(
+    customLayerData = {
+        dictionary cameraSettings = {
+            dictionary Front = {
+                double3 position = (5, 0, 0)
+                double radius = 5
+            }
+            dictionary Perspective = {
+                double3 position = (7.28913872358609, -1.760246560017226, 2.439578447916335)
+                double3 target = (-1.0625960084380548, -0.6522910993461004, 0.4343448797077323)
+            }
+            dictionary Right = {
+                double3 position = (0, -5, 0)
+                double radius = 5
+            }
+            dictionary Top = {
+                double3 position = (0, 0, 5)
+                double radius = 5
+            }
+            string boundCamera = "/OmniverseKit_Persp"
+        }
+        dictionary omni_layer = {
+            string authoring_layer = "./mesh_articulation.usda"
+            dictionary locked = {
+            }
+            dictionary muteness = {
+            }
+        }
+        dictionary renderSettings = {
+        }
+    }
+    defaultPrim = "Robot"
+    endTimeCode = 1000000
+    metersPerUnit = 1
+    startTimeCode = 0
+    timeCodesPerSecond = 60
+    upAxis = "Z"
+)
+
+def Xform "Environment"
+{
+    quatd xformOp:orient = (1, 0, 0, 0)
+    double3 xformOp:scale = (1, 1, 1)
+    double3 xformOp:translate = (0, 0, 0)
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+    def DistantLight "defaultLight" (
+        prepend apiSchemas = ["ShapingAPI"]
+    )
+    {
+        float inputs:angle = 1
+        float inputs:intensity = 3000
+        float inputs:shaping:cone:angle = 180
+        float inputs:shaping:cone:softness
+        float inputs:shaping:focus
+        color3f inputs:shaping:focusTint
+        asset inputs:shaping:ies:file
+        quatd xformOp:orient = (0.6532814824381883, 0.2705980500730985, 0.27059805007309845, 0.6532814824381882)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+    }
+}
+
+over "Render" (
+    hide_in_stage_window = true
+)
+{
+}
+
+def Xform "Robot" (
+    prepend apiSchemas = ["PhysicsArticulationRootAPI", "PhysxArticulationAPI"]
+)
+{
+    def Xform "joints"
+    {
+        quatd xformOp:orient = (1, 0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def PhysicsRevoluteJoint "RevoluteJoint"
+        {
+            uniform token physics:axis = "Y"
+            rel physics:body0 = </Robot/left_rigid>
+            rel physics:body1 = </Robot/right_rigid>
+            float physics:breakForce = 3.4028235e38
+            float physics:breakTorque = 3.4028235e38
+            point3f physics:localPos0 = (0, -0.25, 0)
+            point3f physics:localPos1 = (0, 0.25, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+    }
+
+    def Xform "left_rigid" (
+        prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI", "PhysicsMassAPI"]
+    )
+    {
+        bool physics:kinematicEnabled = 0
+        bool physics:rigidBodyEnabled = 1
+        quatd xformOp:orient = (1, 0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (0, 0.25, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def Mesh "left_collider" (
+            prepend apiSchemas = ["PhysicsCollisionAPI", "PhysxCollisionAPI", "PhysxConvexHullCollisionAPI", "PhysicsMeshCollisionAPI"]
+        )
+        {
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 4, 6, 7, 5, 6, 2, 3, 7, 4, 5, 1, 0, 4, 0, 2, 6, 5, 7, 3, 1]
+            normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0)] (
+                interpolation = "faceVarying"
+            )
+            uniform token physics:approximation = "convexHull"
+            bool physics:collisionEnabled = 1
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)]
+            texCoord2f[] primvars:st = [(0, 0), (1, 0), (1, 1), (0, 1), (1, 0), (1, 1), (0, 1), (0, 0), (0, 1), (0, 0), (1, 0), (1, 1), (0, 0), (1, 0), (1, 1), (0, 1), (0, 0), (1, 0), (1, 1), (0, 1), (1, 0), (1, 1), (0, 1), (0, 0)] (
+                interpolation = "faceVarying"
+            )
+            uniform token subdivisionScheme = "none"
+            quatd xformOp:orient = (1, 0, 0, 0)
+            double3 xformOp:scale = (0.25, 0.5, 2)
+            double3 xformOp:translate = (0, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+        }
+    }
+
+    def Xform "right_rigid" (
+        prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI", "PhysicsMassAPI"]
+    )
+    {
+        bool physics:kinematicEnabled = 0
+        bool physics:rigidBodyEnabled = 1
+        quatd xformOp:orient = (1, 0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (0, -0.25, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def Mesh "right_collider" (
+            prepend apiSchemas = ["PhysicsCollisionAPI", "PhysxCollisionAPI", "PhysxConvexHullCollisionAPI", "PhysicsMeshCollisionAPI"]
+        )
+        {
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 4, 6, 7, 5, 6, 2, 3, 7, 4, 5, 1, 0, 4, 0, 2, 6, 5, 7, 3, 1]
+            normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0)] (
+                interpolation = "faceVarying"
+            )
+            uniform token physics:approximation = "convexHull"
+            bool physics:collisionEnabled = 1
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)]
+            texCoord2f[] primvars:st = [(0, 0), (1, 0), (1, 1), (0, 1), (1, 0), (1, 1), (0, 1), (0, 0), (0, 1), (0, 0), (1, 0), (1, 1), (0, 0), (1, 0), (1, 1), (0, 1), (0, 0), (1, 0), (1, 1), (0, 1), (1, 0), (1, 1), (0, 1), (0, 0)] (
+                interpolation = "faceVarying"
+            )
+            uniform token subdivisionScheme = "none"
+            quatd xformOp:orient = (1, 0, 0, 0)
+            double3 xformOp:scale = (0.25, 0.5, 2)
+            double3 xformOp:translate = (0, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+        }
+    }
+}
+

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -50,7 +50,7 @@ class TestImportUsd(unittest.TestCase):
     def test_import_articulation_with_mesh(self):
         builder = newton.ModelBuilder()
 
-        results = parse_usd(
+        _ = parse_usd(
             os.path.join(os.path.dirname(__file__), "assets", "simple_articulation_with_mesh.usda"),
             builder,
             collapse_fixed_joints=True,

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -47,6 +47,16 @@ class TestImportUsd(unittest.TestCase):
         self.assertEqual(len(results["path_shape_map"]), 13)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_articulation_with_mesh(self):
+        builder = newton.ModelBuilder()
+
+        results = parse_usd(
+            os.path.join(os.path.dirname(__file__), "assets", "simple_articulation_with_mesh.usda"),
+            builder,
+            collapse_fixed_joints=True,
+        )
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_ordering(self):
         builder_dfs = newton.ModelBuilder()
         parse_usd(


### PR DESCRIPTION
## Description

When loading H1 (the version that can be found in IsaacLab's Nucleus folder) the method `_update_body_mass` is failing with the following error message:
```
  File "/home/antoiner/Documents/newton/newton/utils/import_usd.py", line 854, in parse_usd
    shape_id = builder.add_shape_mesh(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/antoiner/Documents/newton/newton/core/builder.py", line 2124, in add_shape_mesh
    return self.add_shape(
           ^^^^^^^^^^^^^^^
  File "/home/antoiner/Documents/newton/newton/core/builder.py", line 1824, in add_shape
    self._update_body_mass(body, m, I, com_body, xform.q)
  File "/home/antoiner/Documents/newton/newton/core/builder.py", line 3101, in _update_body_mass
    new_com = (self.body_com[i] * self.body_mass[i] + p * m) / new_mass
                                                      ~~^~~
  File "/home/antoiner/Documents/IsaacLab-Internal/_isaac_sim/kit/python/lib/python3.11/site-packages/warp/types.py", line 339, in __mul__
    return warp.mul(self, y)
           ^^^^^^^^^^^^^^^^^
  File "/home/antoiner/Documents/IsaacLab-Internal/_isaac_sim/kit/python/lib/python3.11/site-packages/warp/context.py", line 330, in __call__
    raise RuntimeError(
RuntimeError: Couldn't find a function 'mul' compatible with the arguments 'vec3f, float64'
```

## Newton Migration Guide


- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [x] Documentation is up-to-date
- [x ] Code passes formatting and linting checks with `pre-commit run -a`
