### PR TITLE
Set default up axis to Z

### DIFF
--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -244,7 +244,7 @@ affecting gravity direction, object placement, and overall scene orientation.
      - **Handedness**
      - **Notes**
    * - **Newton**
-     - ``Y`` (default)
+     - ``Z`` (default)
      - Right-handed
      - Configurable via ``Axis.X/Y/Z``
    * - **MuJoCo**

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -86,6 +86,8 @@ Using joints with zero stiffness (:class:`newton.ModelBuilder.JointDofConfig.tar
 ``ModelBuilder``
 ----------------
 
+The default up axis of the builder is now Z instead of Y.
+
 +--------------------------------------------------------+------------------------------------------------------------------------+
 | **warp.sim**                                           | **Newton**                                                             |
 +--------------------------------------------------------+------------------------------------------------------------------------+

--- a/newton/core/builder.py
+++ b/newton/core/builder.py
@@ -222,7 +222,7 @@ class ModelBuilder:
             ):
                 self.target = 0.5 * (self.limit_lower + self.limit_upper)
 
-    def __init__(self, up_axis: AxisType = Axis.Y, gravity: float = -9.81):
+    def __init__(self, up_axis: AxisType = Axis.Z, gravity: float = -9.81):
         self.num_envs = 0
 
         # region defaults
@@ -1961,7 +1961,7 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        up_axis: AxisType = Axis.Y,
+        up_axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:
@@ -2008,7 +2008,7 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        up_axis: AxisType = Axis.Y,
+        up_axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:
@@ -2055,7 +2055,7 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        up_axis: AxisType = Axis.Y,
+        up_axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:

--- a/newton/core/model.py
+++ b/newton/core/model.py
@@ -23,7 +23,7 @@ import warp as wp
 from .contact import Contact
 from .control import Control
 from .state import State
-from .types import ModelShapeGeometry, ModelShapeMaterials
+from .types import Devicelike, ModelShapeGeometry, ModelShapeMaterials
 
 
 class Model:
@@ -38,7 +38,7 @@ class Model:
         desired.
     """
 
-    def __init__(self, device=None):
+    def __init__(self, device: Devicelike | None = None):
         """
         Initializes the Model object.
 
@@ -335,9 +335,9 @@ class Model:
         """Ground plane 3D normal and offset, shape [4], float."""
         self.up_vector = np.array((0.0, 1.0, 0.0))
         """Up vector of the world, shape [3], float."""
-        self.up_axis = 1
+        self.up_axis = 2
         """Up axis, 0 for x, 1 for y, 2 for z."""
-        self.gravity = np.array((0.0, -9.81, 0.0))
+        self.gravity = np.array((0.0, 0.0, -9.81))
         """Gravity vector, shape [3], float."""
 
         self.particle_count = 0

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -17,20 +17,24 @@ import os
 
 import numpy as np
 
+import newton
 
-def get_source_directory():
+
+def get_source_directory() -> str:
     return os.path.realpath(os.path.dirname(__file__))
 
 
-def get_asset_directory():
+def get_asset_directory() -> str:
     return os.path.join(get_source_directory(), "assets")
 
 
-def get_asset(filename):
+def get_asset(filename: str) -> str:
     return os.path.join(get_asset_directory(), filename)
 
 
-def compute_env_offsets(num_envs, env_offset=(5.0, 0.0, 5.0), up_axis="Y"):
+def compute_env_offsets(
+    num_envs: int, env_offset: tuple[float, float, float] = (5.0, 5.0, 0.0), up_axis: newton.AxisType = newton.Axis.Z
+):
     # compute positional offsets per environment
     env_offset = np.array(env_offset)
     nonzeros = np.nonzero(env_offset)[0]

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -68,8 +68,7 @@ def compute_env_offsets(
         env_offsets = np.zeros((num_envs, 3))
     min_offsets = np.min(env_offsets, axis=0)
     correction = min_offsets + (np.max(env_offsets, axis=0) - min_offsets) / 2.0
-    if isinstance(up_axis, str):
-        up_axis = "XYZ".index(up_axis.upper())
-    correction[up_axis] = 0.0  # ensure the envs are not shifted below the ground plane
+    # ensure the envs are not shifted below the ground plane
+    correction[newton.Axis.from_any(up_axis)] = 0.0
     env_offsets -= correction
     return env_offsets

--- a/newton/examples/assets/nv_humanoid.xml
+++ b/newton/examples/assets/nv_humanoid.xml
@@ -20,7 +20,7 @@
   </default>
 
   <worldbody>
-    <geom name="floor" type="plane" conaffinity="1" size="100 100 .2" material="grid" zaxis="0 1 0"/>
+    <geom name="floor" type="plane" conaffinity="1" size="100 100 .2" material="grid"/>
     <body name="torso" pos="0 0 0" childclass="body">
       <light name="top" pos="0 0 2" mode="trackcom"/>
       <camera name="back" pos="-3 0 1" xyaxes="0 -1 0 1 0 2" mode="trackcom"/>

--- a/newton/examples/example_cartpole.py
+++ b/newton/examples/example_cartpole.py
@@ -56,7 +56,7 @@ class Example:
         self.sim_substeps = 10
         self.sim_dt = self.frame_dt / self.sim_substeps
 
-        positions = newton.examples.compute_env_offsets(num_envs, env_offset=(1.0, 0.0, 2.0))
+        positions = newton.examples.compute_env_offsets(num_envs, env_offset=(1.0, 2.0, 0.0))
 
         for i in range(self.num_envs):
             builder.add_builder(articulation_builder, xform=wp.transform(positions[i], wp.quat_identity()))

--- a/newton/examples/example_humanoid.py
+++ b/newton/examples/example_humanoid.py
@@ -47,20 +47,19 @@ class Example:
         newton.utils.parse_mjcf(
             mjcf_filename,
             articulation_builder,
-            collapse_fixed_joints=True,
             ignore_names=["floor", "ground"],
-            up_axis="Y",
+            up_axis="Z",
         )
 
         # joint initial positions
-        articulation_builder.joint_q[:7] = [0.0, 1.5, 0.0, *start_rot]
+        articulation_builder.joint_q[:7] = [0.0, 0.0, 1.5, *start_rot]
 
         spacing = 3.0
         sqn = int(wp.ceil(wp.sqrt(float(self.num_envs))))
 
         builder = newton.ModelBuilder()
         for i in range(self.num_envs):
-            pos = wp.vec3((i % sqn) * spacing, 0.0, (i // sqn) * spacing)
+            pos = wp.vec3((i % sqn) * spacing, (i // sqn) * spacing, 0.0)
             articulation_builder.joint_q[7:] = self.rng.uniform(
                 -1.0, 1.0, size=(len(articulation_builder.joint_q) - 7,)
             ).tolist()

--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -48,7 +48,7 @@ class Example:
         newton.utils.parse_urdf(
             newton.examples.get_asset("quadruped.urdf"),
             articulation_builder,
-            xform=wp.transform([0.0, 0.7, 0.0], wp.quat_identity()),
+            xform=wp.transform([0.0, 0.0, 0.7], wp.quat_identity()),
             floating=True,
         )
         articulation_builder.joint_q[-12:] = [0.2, 0.4, -0.6, -0.2, -0.4, 0.6, -0.2, 0.4, -0.6, 0.2, -0.4, 0.6]

--- a/newton/tests/test_collision.py
+++ b/newton/tests/test_collision.py
@@ -425,7 +425,7 @@ def test_vertex_triangle_collision(test, device):
     vertices, faces = get_data()
 
     # record triangle contacting vertices
-    model, collision_detector = init_model(vertices, faces, device, True)
+    model, collision_detector = init_model(vertices, faces, device)
 
     rs = [1e-2, 2e-2, 5e-2, 1e-1]
 
@@ -519,8 +519,7 @@ def test_vertex_triangle_collision(test, device):
         assert_np_equal(triangle_colliding_vertices_count_2, triangle_colliding_vertices_count_1)
         assert_np_equal(vertex_min_dis_2, vertex_min_dis_1)
 
-        # do not record triangle contacting vertices
-        model, collision_detector = init_model(vertices, faces, device, False)
+        model, collision_detector = init_model(vertices, faces, device)
 
         rs = [1e-2, 2e-2, 5e-2, 1e-1]
 

--- a/newton/tests/test_collision.py
+++ b/newton/tests/test_collision.py
@@ -386,7 +386,7 @@ def validate_edge_collisions(
 def init_model(vs, fs, device, record_triangle_contacting_vertices=True):
     vertices = [wp.vec3(v) for v in vs]
 
-    builder = newton.ModelBuilder()
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Y)
     builder.add_cloth_mesh(
         pos=wp.vec3(0.0, 200.0, 0.0),
         rot=wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 0.0),
@@ -401,7 +401,9 @@ def init_model(vs, fs, device, record_triangle_contacting_vertices=True):
     )
     model = builder.finalize(device=device)
 
-    collision_detector = TriMeshCollisionDetector(model=model, record_triangle_contacting_vertices=True)
+    collision_detector = TriMeshCollisionDetector(
+        model=model, record_triangle_contacting_vertices=record_triangle_contacting_vertices
+    )
 
     return model, collision_detector
 
@@ -641,7 +643,7 @@ def test_edge_edge_collision(test, device):
 def test_particle_collision(test, device):
     with wp.ScopedDevice(device):
         contact_radius = 1.23
-        builder1 = newton.ModelBuilder()
+        builder1 = newton.ModelBuilder(up_axis=newton.Axis.Y)
         builder1.add_cloth_grid(
             pos=wp.vec3(0.0, 0.0, 0.0),
             rot=wp.quat_identity(),
@@ -669,7 +671,7 @@ def test_particle_collision(test, device):
     vertices = [wp.vec3(v) for v in vertices]
     faces = [0, 1, 2, 3, 4, 5]
 
-    builder2 = newton.ModelBuilder()
+    builder2 = newton.ModelBuilder(up_axis=newton.Axis.Y)
     builder2.add_cloth_mesh(
         pos=wp.vec3(0.0, 0.0, 0.0),
         rot=wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 0.0),
@@ -706,7 +708,7 @@ def test_particle_collision(test, device):
     )
     test.assertTrue((np.linalg.norm(particle_f.numpy(), axis=1) != 0).all())
 
-    builder3 = newton.ModelBuilder()
+    builder3 = newton.ModelBuilder(up_axis=newton.Axis.Y)
     builder3.add_cloth_mesh(
         pos=wp.vec3(0.0, 0.0, 0.0),
         rot=wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 0.0),
@@ -754,7 +756,7 @@ def test_mesh_ground_collision_index(test, device):
         ]
     )
     mesh = Mesh(vertices=vertices, indices=[0, 1, 2])
-    builder = newton.ModelBuilder()
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Y)
     # create body with nonzero mass to ensure it is not static
     # and contact points will be computed
     b = builder.add_body(mass=1.0)

--- a/newton/tests/test_up_axis.py
+++ b/newton/tests/test_up_axis.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import warp as wp
+
+import newton
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+wp.config.quiet = True
+
+
+class TestControlForce(unittest.TestCase):
+    pass
+
+
+def test_gravity(test: TestControlForce, device, solver_fn, up_axis: newton.Axis):
+    builder = newton.ModelBuilder(up_axis=up_axis, gravity=-9.81)
+
+    b = builder.add_body()
+    builder.add_shape_capsule(b, up_axis=up_axis)
+    builder.add_joint_free(b)
+
+    model = builder.finalize(device=device)
+    model.ground = False
+
+    solver = solver_fn(model)
+
+    state_0, state_1 = model.state(), model.state()
+    control = model.control()
+
+    sim_dt = 1.0 / 10.0
+    solver.step(model, state_0, state_1, control, None, sim_dt)
+
+    lin_vel = state_1.body_qd.numpy()[0,3:]
+    test.assertAlmostEqual(lin_vel[up_axis.value], -0.981, delta=1e-5)
+
+
+devices = get_test_devices()
+solvers = {
+    "featherstone": lambda model: newton.solvers.FeatherstoneSolver(model, angular_damping=0.0),
+    "mujoco_c": lambda model: newton.solvers.MuJoCoSolver(
+        model, use_mujoco=True, update_data_every=0, disable_contacts=True
+    ),
+    "mujoco_warp": lambda model: newton.solvers.MuJoCoSolver(
+        model, use_mujoco=False, update_data_every=0, disable_contacts=True
+    ),
+    "xpbd": lambda model: newton.solvers.XPBDSolver(model, angular_damping=0.0),
+    "semi_implicit": lambda model: newton.solvers.SemiImplicitSolver(model, angular_damping=0.0),
+}
+for device in devices:
+    for solver_name, solver_fn in solvers.items():
+        add_function_test(
+            TestControlForce,
+            f"test_gravity_y_up_{solver_name}",
+            test_gravity,
+            devices=[device],
+            solver_fn=solver_fn,
+            up_axis=newton.Axis.Y,
+        )
+        add_function_test(
+            TestControlForce,
+            f"test_gravity_z_up_{solver_name}",
+            test_gravity,
+            devices=[device],
+            solver_fn=solver_fn,
+            up_axis=newton.Axis.Z,
+        )
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2)

--- a/newton/tests/test_up_axis.py
+++ b/newton/tests/test_up_axis.py
@@ -45,7 +45,7 @@ def test_gravity(test: TestControlForce, device, solver_fn, up_axis: newton.Axis
     sim_dt = 1.0 / 10.0
     solver.step(model, state_0, state_1, control, None, sim_dt)
 
-    lin_vel = state_1.body_qd.numpy()[0,3:]
+    lin_vel = state_1.body_qd.numpy()[0, 3:]
     test.assertAlmostEqual(lin_vel[up_axis.value], -0.981, delta=1e-5)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
