### PR TITLE
Initialize free joint's coordinates from child's body_q

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -119,6 +119,12 @@ Instead, you can pass them as arguments to the :class:`newton.solvers.XPBDSolver
 apply to all joints and cannot be set individually per joint anymore. So far we have not found applications that require
 per-joint compliance settings and have decided to remove this feature for memory efficiency.
 
+The :meth:`newton.ModelBuilder.add_joint_free()` method now initializes the positional dofs of the free joint with the child body's transform (``body_q``).
+
+:meth:`newton.ModelBuilder.finalize()` now calls :func:`newton.eval_fk` to update the maximal coordinates :attr:`newton.Model.body_q` and :attr:`newton.Model.body_qd` from the
+builder's generalized coordinates :attr:`newton.ModelBuilder.joint_q` and :attr:`newton.ModelBuilder.joint_qd`.
+
+
 Renderers
 ---------
 

--- a/newton/core/articulation.py
+++ b/newton/core/articulation.py
@@ -501,7 +501,7 @@ def eval_fk(
     model: Model,
     joint_q: wp.array(dtype=float),
     joint_qd: wp.array(dtype=float),
-    state: State,
+    state: State | object,
     mask: wp.array(dtype=bool) | None = None,
 ):
     """

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -689,7 +689,7 @@ def parse_usd(
             first_joint_parent = joint_edges[sorted_joints[0]][0]
             if first_joint_parent != -1:
                 # the mechanism is floating since there is no joint connecting it to the world
-                # we explicitly add a free joint to make sure Featherstone can simulate it
+                # we explicitly add a free joint to make sure Featherstone and MuJoCo can simulate it
                 builder.add_joint_free(child=art_bodies[first_joint_parent])
                 builder.joint_q[-7:] = articulation_xform
             for joint_id, i in enumerate(sorted_joints):


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [X] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
