### PR TITLE
MJCF Parsing: move geoms with contype == 0 and conaffinity == 0 to visual geoms

### DIFF
--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -610,6 +610,10 @@ def parse_mjcf(
 
             geom_name = geom_attrib.get("name", f"{body_name}_geom_{geo_count}")
 
+            contype = geom_attrib.get("contype", 1)
+            conaffinity = geom_attrib.get("conaffinity", 1)
+            collides_with_anything = not (int(contype) == 0 and int(conaffinity) == 0)
+
             if "class" in geom.attrib:
                 neither_visual_nor_collider = True
                 for pattern in visual_classes:
@@ -623,7 +627,7 @@ def parse_mjcf(
                         neither_visual_nor_collider = False
                         break
                 if neither_visual_nor_collider:
-                    if no_class_as_colliders:
+                    if no_class_as_colliders and collides_with_anything:
                         colliders.append(geom)
                     else:
                         visuals.append(geom)
@@ -631,7 +635,7 @@ def parse_mjcf(
                 no_class_class = "collision" if no_class_as_colliders else "visual"
                 if verbose:
                     print(f"MJCF parsing shape {geom_name} issue: no class defined for geom, assuming {no_class_class}")
-                if no_class_as_colliders:
+                if no_class_as_colliders and collides_with_anything:
                     colliders.append(geom)
                 else:
                     visuals.append(geom)


### PR DESCRIPTION
## Description

The G1 asset in the assets repo uses contype and conaffinity to encode that a geom is visual. This is a bit of a hack but moves geoms that don't collide with anything to the visual class.

We should follow up and actually implement proper support for contype and conaffinity as currently these things have no effect and we overwrite it once again when assembling the mujoco model.