### PR TITLE
Accelerate cloth grid generation

### DIFF
--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -2708,8 +2708,7 @@ class ModelBuilder:
         for y in range(0, dim_y + 1):
             for x in range(0, dim_x + 1):
                 local_pos = wp.vec3(x * cell_x, y * cell_y, 0.0)
-                world_pos = wp.quat_rotate(rot, local_pos) + pos
-                vertices.append(world_pos)
+                vertices.append(local_pos)
                 if x > 0 and y > 0:
                     v0 = grid_index(x - 1, y - 1, dim_x + 1)
                     v1 = grid_index(x, y - 1, dim_x + 1)


### PR DESCRIPTION
## Description

I've further optimized Builder::add_cloth_grid() for enhanced performance, through:
 
1.  Fix duplicate vertex transform intrudced in last my [PR#178](https://github.com/newton-physics/newton/pull/178)
2.  Accelerate vertex transforms with NumPy vectorization

Performance improvements:
| Grid Size | Before  | After | Speedup |
|----------------------------------------|
|  200x200  |  14.6 sec.  |  1.0 sec.  |   ~x15   |

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
