### PR TITLE
Fix soft contact handling, make `Model.collide()` graph-captureable

### DIFF
--- a/newton/examples/example_cloth_bending.py
+++ b/newton/examples/example_cloth_bending.py
@@ -94,7 +94,10 @@ class Example:
 
         if stage_path is not None:
             self.renderer = newton.utils.SimRendererOpenGL(
-                path=stage_path, model=self.model, scaling=self.renderer_scale_factor
+                path=stage_path,
+                model=self.model,
+                scaling=self.renderer_scale_factor,
+                enable_backface_culling=False,
             )
         else:
             self.renderer = None

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -293,7 +293,6 @@ class ExampleClothManipulation:
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
         self.target_joint_qd = wp.empty_like(self.state_0.joint_qd)
-        self.contacts = self.model.collide(self.state_0)
 
         self.control = self.model.control()
 

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -322,7 +322,14 @@ class ExampleClothManipulation:
 
         if self.stage_path is not None:
             self.renderer = newton.utils.SimRendererOpenGL(
-                path=self.stage_path, model=self.model, scaling=0.01, show_joints=True, show_particles=False
+                path=self.stage_path,
+                model=self.model,
+                scaling=0.05,
+                show_joints=False,
+                show_particles=False,
+                near_plane=0.01,
+                far_plane=100.0,
+                enable_backface_culling=False,
             )
 
         else:

--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -82,7 +82,7 @@ class ModelBuilder:
 
     Use the ModelBuilder to construct a simulation scene. The ModelBuilder
     and builds the scene representation using standard Python data structures (lists),
-    this means it is not differentiable. Once :func:`finalize()`
+    this means it is not differentiable. Once :meth:`finalize`
     has been called the ModelBuilder transfers all data to Warp tensors and returns
     an object that may be used for simulation.
 
@@ -3159,6 +3159,7 @@ class ModelBuilder:
 
             A model object.
         """
+        from .collide import count_rigid_contact_points
 
         # ensure the env count is set correctly
         self.num_envs = max(1, self.num_envs)
@@ -3375,6 +3376,7 @@ class ModelBuilder:
             m.articulation_count = len(self.articulation_start)
 
             self.find_shape_contact_pairs(m)
+            m.rigid_contact_max = count_rigid_contact_points(m)
 
             m.rigid_contact_torsional_friction = self.rigid_contact_torsional_friction
             m.rigid_contact_rolling_friction = self.rigid_contact_rolling_friction

--- a/newton/sim/collide.py
+++ b/newton/sim/collide.py
@@ -157,8 +157,6 @@ class CollisionPipeline:
 
         # generate soft contacts for particles and shapes
         if state.particle_q and shape_count > 0:
-            # clear old count
-            contacts.soft_contact_count.zero_()
             wp.launch(
                 kernel=create_soft_contacts,
                 dim=particle_count * shape_count,

--- a/newton/sim/collide.py
+++ b/newton/sim/collide.py
@@ -118,7 +118,7 @@ class CollisionPipeline:
         rigid_contact_max = None
         if rigid_contact_max_per_pair is None:
             # count the number of contacts
-            rigid_contact_max = count_rigid_contact_points(model)
+            rigid_contact_max = model.rigid_contact_max
             rigid_contact_max_per_pair = 0
         if requires_grad is None:
             requires_grad = model.requires_grad

--- a/newton/sim/collide.py
+++ b/newton/sim/collide.py
@@ -146,6 +146,8 @@ class CollisionPipeline:
                 requires_grad=self.requires_grad,
                 device=model.device,
             )
+        else:
+            self.contacts.clear()
 
         # output contacts buffer
         contacts = self.contacts
@@ -189,8 +191,6 @@ class CollisionPipeline:
 
         # generate rigid contacts for shapes
         if self.shape_pairs_filtered is not None:
-            # clear old count
-            contacts.rigid_contact_count.zero_()
             self.rigid_pair_shape0.fill_(-1)
             self.rigid_pair_shape1.fill_(-1)
 
@@ -223,7 +223,8 @@ class CollisionPipeline:
                 device=contacts.device,
             )
 
-            contacts.clear()
+            # clear old count
+            contacts.rigid_contact_count.zero_()
             if self.rigid_pair_point_count is not None:
                 self.rigid_pair_point_count.zero_()
 

--- a/newton/sim/model.py
+++ b/newton/sim/model.py
@@ -262,6 +262,8 @@ class Model:
         self.soft_contact_restitution = 0.0
         """Restitution coefficient of soft contacts (used by :class:`XPBDSolver`). Default is 0.0."""
 
+        self.rigid_contact_max = 0
+        """Number of potential contact points between rigid bodies."""
         self.rigid_contact_torsional_friction = 0.0
         """Torsional friction coefficient for rigid body contacts (used by :class:`XPBDSolver`)."""
         self.rigid_contact_rolling_friction = 0.0


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* Fix soft collision handling (fixes cloth sim examples from VBD). Fixes #215.
* Move rigid contact point counting to `ModelBuilder.finalize()` so that `Model.collide()` becomes graph-captureable. Fixes #234.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
