### PR TITLE
Reintroduce ncon_per_env for MuJoCo Solver

### DIFF
--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -90,6 +90,8 @@ class Example:
                 iterations=5,
                 ls_iterations=5,
                 nefc_per_env=1,
+                nefc_per_env=300,
+                ncon_per_env=150
             )
         else:
             self.solver = newton.solvers.XPBDSolver(self.model, iterations=20)

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -671,6 +671,7 @@ class MuJoCoSolver(SolverBase):
         mjw_data: MjWarpData | None = None,
         separate_envs_to_worlds: bool | None = None,
         nefc_per_env: int = 100,
+        ncon_per_env: int | None = None,
         iterations: int = 20,
         ls_iterations: int = 10,
         solver: int | str = "cg",
@@ -690,6 +691,7 @@ class MuJoCoSolver(SolverBase):
             mjw_data (MjWarpData | None): Optional pre-existing MuJoCo Warp data. If provided with `mjw_model`, conversion from Newton model is skipped.
             separate_envs_to_worlds (bool | None): If True, each Newton environment is mapped to a separate MuJoCo world. Defaults to `not use_mujoco`.
             nefc_per_env (int): Number of constraints per environment (world).
+            ncon_per_env (int | None): Number of contact points per environment (world). If None, the number of contact points is estimated from the model.
             iterations (int): Number of solver iterations.
             ls_iterations (int): Number of line search iterations for the solver.
             solver (int | str): Solver type. Can be "cg" or "newton", or their corresponding MuJoCo integer constants.
@@ -722,6 +724,7 @@ class MuJoCoSolver(SolverBase):
                 disableflags=disableflags,
                 separate_envs_to_worlds=separate_envs_to_worlds,
                 nefc_per_env=nefc_per_env,
+                ncon_per_env=ncon_per_env,
                 iterations=iterations,
                 ls_iterations=ls_iterations,
                 solver=solver,
@@ -949,6 +952,7 @@ class MuJoCoSolver(SolverBase):
         iterations: int = 20,
         ls_iterations: int = 10,
         nefc_per_env: int = 100,  # number of constraints per world
+        ncon_per_env: int | None = None,
         solver: int | str = "cg",
         integrator: int | str = "euler",
         disableflags: int = 0,
@@ -1527,7 +1531,10 @@ class MuJoCoSolver(SolverBase):
             self.notify_model_changed(flags)
 
             # TODO find better heuristics to determine nconmax and njmax
-            rigid_contact_max = newton.sim.count_rigid_contact_points(model)
+            if ncon_per_env is not None:
+                rigid_contact_max = nworld * ncon_per_env
+            else:
+                rigid_contact_max = newton.sim.count_rigid_contact_points(model)
             nconmax = max(rigid_contact_max, self.mj_data.ncon * nworld)  # this avoids error in mujoco.
             njmax = max(nworld * nefc_per_env, nworld * self.mj_data.nefc)
             self.mjw_data = mujoco_warp.put_data(


### PR DESCRIPTION
## Description

This adds an option to the MuJoCo solver to specify the number of contacts per world. The issue with the current approach is that the newton function is overly conservative and depends in the input meshes, while MjWarp is doing collisions on convex hulls. There is a large runtime overhead because MjWarp launches nconmax threads, but we actually very rarely have this many contacts. This change allows the user to fine-tune the number.

Should be fixed once we have indirect launch, but let's use this as a workaround in the mean time.

