### PR TITLE
Make links follow the joint ordering in USD parser

### DIFF
--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -1497,6 +1497,9 @@ class ModelBuilder:
                         body_data[last_dynamic_body]["shapes"].append(shape)
                     else:
                         self.shape_body[shape] = -1
+                        if -1 not in self.body_shapes:
+                            self.body_shapes[-1] = []
+                        self.body_shapes[-1].append(shape)
 
                 if last_dynamic_body > -1:
                     source_m = body_data[last_dynamic_body]["mass"]

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -1256,9 +1256,6 @@ class MuJoCoSolver(SolverBase):
                 if stype in (newton.GEO_CAPSULE, newton.GEO_CYLINDER):
                     # mujoco aligns these shapes with the z-axis, Warp uses the y-axis
                     q = q * rot_y2z
-                if model.up_axis == 2 and warp_body_id == -1:
-                    # reverse rotation that aligned the z-axis with the y-axis
-                    q = q * wp.quat_inverse(rot_y2z)
                 if perm_position:
                     # mujoco aligns these shapes with the z-axis, Warp uses the y-axis
                     p = wp.vec3(p[0], -p[2], p[1])

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -44,7 +44,8 @@ def parse_usd(
     enable_self_collisions: bool = True,
     apply_up_axis_from_stage: bool = False,
     root_path: str = "/",
-    joint_ordering: Literal["bfs", "dfs"] = "dfs",
+    joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
+    bodies_follow_joint_ordering: bool = True,
 ) -> dict[str, Any]:
     """
     Parses a Universal Scene Description (USD) stage containing UsdPhysics schema definitions for rigid-body articulations and adds the bodies, shapes and joints to the given ModelBuilder.
@@ -68,7 +69,8 @@ def parse_usd(
         enable_self_collisions (bool): Determines the default behavior of whether self-collisions are enabled for all shapes. If a shape has the attribute ``physxArticulation:enabledSelfCollisions`` defined, this attribute takes precedence.
         apply_up_axis_from_stage (bool): If True, the up axis of the stage will be used to set :attr:`newton.ModelBuilder.up_axis`. Otherwise, the stage will be rotated such that its up axis aligns with the builder's up axis. Default is False.
         root_path (str): The USD path to import, defaults to "/".
-        joint_ordering (str): The ordering of the joints in the simulation. Can be either "bfs" or "dfs" for breadth-first or depth-first search. Default is "dfs".
+        joint_ordering (str): The ordering of the joints in the simulation. Can be either "bfs" or "dfs" for breadth-first or depth-first search, or ``None`` to keep joints in the order in which they appear in the USD. Default is "dfs".
+        bodies_follow_joint_ordering (bool): If True, the bodies are added to the builder in the same order as the joints (parent then child body). Otherwise, bodies are added in the order they appear in the USD. Default is True.
 
     Returns:
         dict: Dictionary with the following entries:
@@ -302,7 +304,7 @@ def parse_usd(
                 return is_warp_scene(physics_scene)
         return False
 
-    def parse_body(rigid_body_desc, prim, incoming_xform=None):
+    def parse_body(rigid_body_desc, prim, incoming_xform=None, add_body_to_builder=True):
         nonlocal path_body_map
         nonlocal physics_scene_prim
 
@@ -325,13 +327,20 @@ def parse_usd(
             (prim, physics_scene_prim), "warp:armature", builder.default_body_armature
         )
 
-        b = builder.add_body(
-            xform=origin,
-            key=path,
-            armature=body_armature,
-        )
-        path_body_map[path] = b
-        return b
+        if add_body_to_builder:
+            b = builder.add_body(
+                xform=origin,
+                key=path,
+                armature=body_armature,
+            )
+            path_body_map[path] = b
+            return b
+        else:
+            return {
+                "xform": origin,
+                "key": path,
+                "armature": body_armature,
+            }
 
     def parse_scale(prim):
         xform = UsdGeom.Xform(prim)
@@ -650,6 +659,7 @@ def parse_usd(
         articulation_has_self_collision = {}
 
         articulation_id = builder.articulation_count
+        body_data = {}
         for path, desc in zip(paths, articulation_descs):
             prim = stage.GetPrimAtPath(path)
             builder.add_articulation(str(path))
@@ -671,18 +681,28 @@ def parse_usd(
                         )
                         articulation_roots.append(key)
 
-                body_ids[key] = current_body_id
-                current_body_id += 1
                 if key in body_specs:
-                    # look up description and add body to builder
-                    body_id = parse_body(
-                        body_specs[key],
-                        stage.GetPrimAtPath(p),
-                    )
-                    if body_id >= 0:
-                        art_bodies.append(body_id)
+                    if bodies_follow_joint_ordering:
+                        # we just parse the body information without yet adding it to the builder
+                        body_data[current_body_id] = parse_body(
+                            body_specs[key],
+                            stage.GetPrimAtPath(p),
+                            add_body_to_builder=False,
+                        )
+                    else:
+                        # look up description and add body to builder
+                        body_id = parse_body(
+                            body_specs[key],
+                            stage.GetPrimAtPath(p),
+                            add_body_to_builder=True,
+                        )
+                        if body_id >= 0:
+                            art_bodies.append(body_id)
                     # remove body spec once we inserted it
                     del body_specs[key]
+
+                body_ids[key] = current_body_id
+                current_body_id += 1
 
             joint_names = []
             joint_edges: list[tuple[int, int]] = []
@@ -692,8 +712,31 @@ def parse_usd(
                 joint_edges.append((body_ids[str(joint_desc.body0)], body_ids[str(joint_desc.body1)]))
 
             # add joints in topological order
-            sorted_joints = topological_sort(joint_edges, use_dfs=joint_ordering == "dfs")
-            # sorted_joints = np.arange(len(joint_names))
+            if joint_ordering is not None:
+                if verbose:
+                    print(f"Sorting joints using {joint_ordering} ordering...")
+                sorted_joints = topological_sort(joint_edges, use_dfs=joint_ordering == "dfs")
+                if verbose:
+                    print("Joint ordering:", sorted_joints)
+            else:
+                sorted_joints = np.arange(len(joint_names))
+
+            # insert the bodies in the order of the joints
+            if bodies_follow_joint_ordering:
+                inserted_bodies = set()
+                for jid in sorted_joints:
+                    parent, child = joint_edges[jid]
+                    if parent >= 0 and parent not in inserted_bodies:
+                        b = builder.add_body(**body_data[parent])
+                        inserted_bodies.add(parent)
+                        art_bodies.append(b)
+                        path_body_map[body_data[parent]["key"]] = b
+                    if child >= 0 and child not in inserted_bodies:
+                        b = builder.add_body(**body_data[child])
+                        inserted_bodies.add(child)
+                        art_bodies.append(b)
+                        path_body_map[body_data[child]["key"]] = b
+
             articulation_xform = wp.mul(incoming_world_xform, parse_xform(prim))
             first_joint_parent = joint_edges[sorted_joints[0]][0]
             if first_joint_parent != -1:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* Make links follow the joint ordering in USD parser. Addresses https://github.com/newton-physics/newton/issues/248.
* Make sure `model/builder.body_shapes` has the shapes newly added to the world (-1)
* Fix rotation for static shapes (with body -1) in MuJoCoSolver

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
