### PR TITLE
Fix the Incorrect `soft_contact_margin` used in the Robot-Cloth Manipulation Demo

### DIFF
--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -189,8 +189,8 @@ class Example:
             self.model,
             self.iterations,
             handle_self_contact=True,
-            soft_contact_radius=0.2,
-            soft_contact_margin=0.35,
+            self_contact_radius=0.2,
+            self_contact_margin=0.35,
         )
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -191,6 +191,7 @@ class ExampleClothManipulation:
         #   contact
         #       body-cloth contact
         self.cloth_particle_radius = 0.8
+        self.cloth_body_contact_margin = 1.0
         #       self-contact
         self.self_contact_radius = 0.2
         self.self_contact_margin = 0.2
@@ -295,6 +296,7 @@ class ExampleClothManipulation:
         self.target_joint_qd = wp.empty_like(self.state_0.joint_qd)
 
         self.control = self.model.control()
+        self.contacts = self.model.collide(self.state_0)
 
         self.sim_time = 0.0
 
@@ -310,8 +312,8 @@ class ExampleClothManipulation:
             self.cloth_solver = VBDSolver(
                 self.model,
                 iterations=self.iterations,
-                soft_contact_radius=self.self_contact_radius,
-                soft_contact_margin=self.self_contact_margin,
+                self_contact_radius=self.self_contact_radius,
+                self_contact_margin=self.self_contact_margin,
                 handle_self_contact=True,
                 vertex_collision_buffer_pre_alloc=32,
                 edge_collision_buffer_pre_alloc=64,
@@ -603,7 +605,7 @@ class ExampleClothManipulation:
                 self.model.gravity = wp.vec3(0, self.gravity, 0)
 
             # cloth sim
-            self.contacts = self.model.collide(self.state_0)
+            self.contacts = self.model.collide(self.state_0, soft_contact_margin=self.cloth_body_contact_margin)
 
             if self.add_cloth:
                 self.cloth_sim_substep(self.state_0, self.state_1)


### PR DESCRIPTION
Renamed the `soft_contact_margin` in `VBDSolver` to `self_contact_margin` to differentiate from the parameter that controls particle-contact in `collide`.

Fix a bug where the default soft-contact margin is used for particle-body contact detection in the robot manipulation demo.



- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
