### PR TITLE
Map shapes, bodies, joints to MuJoCo based on collision group

### DIFF
--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -589,7 +589,7 @@ def update_body_inertia_kernel(
     # body_iquat_out[worldid, mjc_idx] = q
 
 
-@wp.kernel
+@wp.kernel(module="unique")
 def repeat_array_kernel(
     src: wp.array(dtype=Any),
     nelems_per_world: int,
@@ -1688,7 +1688,11 @@ class MuJoCoSolver(SolverBase):
             # Launch kernel to repeat data - one thread per destination element
             n_elems_per_world = dst_flat.shape[0] // nworld
             wp.launch(
-                repeat_array_kernel, dim=dst_flat.shape[0], inputs=[src_flat, n_elems_per_world], outputs=[dst_flat]
+                repeat_array_kernel,
+                dim=dst_flat.shape[0],
+                inputs=[src_flat, n_elems_per_world],
+                outputs=[dst_flat],
+                device=x.device,
             )
             return dst
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* Map shapes, bodies, joints to MuJoCo based on collision group (shapes and connected bodies, joints from the first collision group and negative collision groups get instantiated in MuJoCo). Closes https://github.com/newton-physics/newton/issues/255.
* Add `Model.to_newton_shape_index` Warp array index mapping and a dictionary `Model.to_mjc_geom_index` for the reverse mapping
* Generate collision group colors only for the selected shapes (i.e. the first collision group or -1). Addresses https://github.com/newton-physics/newton/issues/261.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
