### PR TITLE
Update Warp + Namespacing updates

### DIFF
--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -496,7 +496,7 @@ class ModelBuilder:
 
         # explicitly resolve the transform multiplication function to avoid
         # repeatedly resolving builtin overloads during shape transformation
-        transform_mul_cfunc = wp.context.runtime.core.builtin_mul_transformf_transformf
+        transform_mul_cfunc = wp.context.runtime.core.wp_builtin_mul_transformf_transformf
 
         # dispatches two transform multiplies to the native implementation
         def transform_mul(a, b):

--- a/newton/sim/graph_coloring.py
+++ b/newton/sim/graph_coloring.py
@@ -230,7 +230,7 @@ def color_graph(
     else:
         indices = wp.clone(graph_edge_indices, device="cpu")
 
-    num_colors = wp.context.runtime.core.graph_coloring(
+    num_colors = wp.context.runtime.core.wp_graph_coloring(
         num_nodes,
         indices.__ctype__(),
         algorithm.value,
@@ -238,7 +238,7 @@ def color_graph(
     )
 
     if balance_colors:
-        max_min_ratio = wp.context.runtime.core.balance_coloring(
+        max_min_ratio = wp.context.runtime.core.wp_balance_coloring(
             num_nodes,
             indices.__ctype__(),
             num_colors,

--- a/newton/tests/test_coloring.py
+++ b/newton/tests/test_coloring.py
@@ -81,7 +81,7 @@ def test_coloring_trimesh(test, device):
         edge_indices_cpu = wp.array(model.edge_indices.numpy()[:, 2:], dtype=int, device="cpu")
 
         # coloring without bending
-        num_colors_greedy = wp.context.runtime.core.graph_coloring(
+        num_colors_greedy = wp.context.runtime.core.wp_graph_coloring(
             model.particle_count,
             edge_indices_cpu.__ctype__(),
             ColoringAlgorithm.GREEDY.value,
@@ -94,7 +94,7 @@ def test_coloring_trimesh(test, device):
             device="cpu",
         )
 
-        num_colors_mcs = wp.context.runtime.core.graph_coloring(
+        num_colors_mcs = wp.context.runtime.core.wp_graph_coloring(
             model.particle_count,
             edge_indices_cpu.__ctype__(),
             ColoringAlgorithm.MCS.value,
@@ -109,13 +109,13 @@ def test_coloring_trimesh(test, device):
 
         # coloring with bending
         edge_indices_cpu_with_bending = construct_trimesh_graph_edges(model.edge_indices, True)
-        num_colors_greedy = wp.context.runtime.core.graph_coloring(
+        num_colors_greedy = wp.context.runtime.core.wp_graph_coloring(
             model.particle_count,
             edge_indices_cpu_with_bending.__ctype__(),
             ColoringAlgorithm.GREEDY.value,
             particle_colors.__ctype__(),
         )
-        wp.context.runtime.core.balance_coloring(
+        wp.context.runtime.core.wp_balance_coloring(
             model.particle_count,
             edge_indices_cpu_with_bending.__ctype__(),
             num_colors_greedy,
@@ -129,13 +129,13 @@ def test_coloring_trimesh(test, device):
             device="cpu",
         )
 
-        num_colors_mcs = wp.context.runtime.core.graph_coloring(
+        num_colors_mcs = wp.context.runtime.core.wp_graph_coloring(
             model.particle_count,
             edge_indices_cpu_with_bending.__ctype__(),
             ColoringAlgorithm.MCS.value,
             particle_colors.__ctype__(),
         )
-        max_min_ratio = wp.context.runtime.core.balance_coloring(
+        max_min_ratio = wp.context.runtime.core.wp_balance_coloring(
             model.particle_count,
             edge_indices_cpu_with_bending.__ctype__(),
             num_colors_mcs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["warp-lang>=1.7.0.dev20250326"]
+dependencies = ["warp-lang>=1.7.0.dev20250625"]
 
 [project.optional-dependencies]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1354,8 +1354,8 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.67.1" },
     { name = "trimesh", marker = "extra == 'dev'", specifier = ">=4.6.8" },
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'dev'", specifier = ">=25.5" },
-    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250326", index = "https://pypi.nvidia.com/" },
-    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250326" },
+    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250625", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250625" },
 ]
 provides-extras = ["dev", "docs"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1149,7 +1149,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.3.4.dev774705647"
+version = "3.3.4.dev775632047"
 source = { registry = "https://py.mujoco.org/" }
 dependencies = [
     { name = "absl-py" },
@@ -1162,32 +1162,27 @@ dependencies = [
     { name = "pyopengl" },
 ]
 wheels = [
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp310-cp310-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp310-cp310-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp311-cp311-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp311-cp311-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp312-cp312-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp312-cp312-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp313-cp313-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp313-cp313-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp39-cp39-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev774705647-cp39-cp39-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-win_amd64.whl" },
 ]
 
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp#5ca9b08590407dd59a5f49c5903623e765f94be9" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp#67c9f45f84d06976b0d208e8e7a6f15497a021c0" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
@@ -1197,7 +1192,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250623", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -1289,7 +1284,7 @@ name = "newton-physics"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250623", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -2452,7 +2447,7 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.8.0.dev20250623"
+version = "1.8.0.dev20250625"
 source = { registry = "https://pypi.nvidia.com/" }
 resolution-markers = [
     "python_full_version >= '3.11' and sys_platform != 'darwin'",
@@ -2465,9 +2460,9 @@ dependencies = [
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250623-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:5e663caf6699dbafe9cec82f579defe445faa7741a72922194703f255c6962dd" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250623-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3582dcb14aa47d410a6576d51f616287375bffcf8c118d6e143c52421fcfbf4a" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250623-py3-none-win_amd64.whl", hash = "sha256:21b6a939a5004266c6f0489bfa6a4e80a28e6c3f2fb33965b9739271aad075f2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce042da8e85f62acd0f8e1b61b18c02193c078581df5d9317ffd8310b386c9ce" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e6850770d6f6a51dc2794e0daff18fd988b0c8e9057ae4fcdce6d2ea5b482417" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-win_amd64.whl", hash = "sha256:b6b8811b695aae3ecb262c545852ee0371c2210f5753338650e0caede8342bd3" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This change bumps up the `uv.lock` file to use new versions...including Warp nightly, which has some changes regarding adding the `wp_` prefix to various functions.

Everyone using Newton after this pull request is merged will need to be on the nightly that this one uses (or newer).

```
Warp 1.8.0.dev20250625 initialized:
   Git commit: d3639b92807e402c0c33ee65516973066621f143
   CUDA Toolkit 12.8, Driver 12.4
   Devices:
     "cpu"      : "x86_64"
     "cuda:0"   : "NVIDIA A40" (47 GiB, sm_86, mempool enabled)
   Kernel cache:
     /home/horde/.cache/warp/1.8.0.dev20250625
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
