### PR TITLE
Updated Solver.Step() so that it uses the Model instance cached by So…

### DIFF
--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -323,7 +323,7 @@ class Example:
         self.contacts = self.model.collide(self.state_0, rigid_contact_margin=0.1)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -221,7 +221,7 @@ class Example:
     def simulate_sand(self):
         self._update_collider_mesh(self.state_0)
         # solve in-place, avoids having to resync robot sim state
-        self.mpm_solver.step(self.model, self.state_0, self.state_0, contacts=None, control=None, dt=self.frame_dt)
+        self.mpm_solver.step(self.state_0, self.state_0, contacts=None, control=None, dt=self.frame_dt)
 
     def step(self):
         with wp.ScopedTimer("step", synchronize=True):

--- a/newton/examples/example_cartpole.py
+++ b/newton/examples/example_cartpole.py
@@ -89,7 +89,7 @@ class Example:
     def simulate(self):
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, None, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, None, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_cloth_bending.py
+++ b/newton/examples/example_cloth_bending.py
@@ -112,7 +112,7 @@ class Example:
         for _ in range(self.num_substeps):
             contacts = self.model.collide(self.state_0)
             self.state_0.clear_forces()
-            self.solver.step(self.model, self.state_0, self.state_1, None, contacts, self.dt)
+            self.solver.step(self.state_0, self.state_1, None, contacts, self.dt)
             (self.state_0, self.state_1) = (self.state_1, self.state_0)
 
     def step(self):

--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -259,7 +259,7 @@ class Example:
                 ],
             )
 
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, self.contacts, self.dt)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.dt)
             (self.state_0, self.state_1) = (self.state_1, self.state_0)
 
     def step(self):

--- a/newton/examples/example_cloth_style3d.py
+++ b/newton/examples/example_cloth_style3d.py
@@ -134,7 +134,7 @@ class Example:
 
     def integrate_frame_substeps(self):
         for _ in range(self.num_substeps):
-            self.solver.step(self.model, self.state0, self.state1, self.control, None, self.dt)
+            self.solver.step(self.state0, self.state1, self.control, None, self.dt)
             (self.state0, self.state1) = (self.state1, self.state0)
 
     def advance_frame(self):

--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -146,7 +146,7 @@ class Example:
             self.contacts = self.model.collide(self.state_0)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_humanoid.py
+++ b/newton/examples/example_humanoid.py
@@ -104,7 +104,7 @@ class Example:
 
     def simulate(self):
         for _ in range(self.sim_substeps):
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, None, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, None, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_mpm_granular.py
+++ b/newton/examples/example_mpm_granular.py
@@ -75,7 +75,7 @@ class Example:
     def simulate(self):
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
-            self.solver.step(self.model, self.state_0, self.state_1, None, None, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, None, None, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -105,7 +105,7 @@ class Example:
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
             self.contacts = self.model.collide(self.state_0)
-            self.solver.step(self.model, self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self):

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -570,7 +570,7 @@ class ExampleClothManipulation:
                 self.renderer.end_frame()
 
     def cloth_sim_substep(self, state_in, state_out):
-        self.cloth_solver.step(self.model, state_in, state_out, self.control, self.contacts, self.sim_dt)
+        self.cloth_solver.step(state_in, state_out, self.control, self.contacts, self.sim_dt)
 
     def advance_frame(self):
         self.generate_control_joint_qd(self.state_0)
@@ -597,7 +597,7 @@ class ExampleClothManipulation:
 
                 self.state_0.joint_qd.assign(self.target_joint_qd)
                 # Just update the forward kinematics to get body positions from joint coordinates
-                self.robot_solver.step(self.model, self.state_0, self.state_1, self.control, None, self.sim_dt)
+                self.robot_solver.step(self.state_0, self.state_1, self.control, None, self.sim_dt)
 
                 self.state_0.particle_f.zero_()
 

--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -116,7 +116,7 @@ class ModelBuilder:
         for i in range(10):
             state_0.clear_forces()
             contacts = model.collide(state_0)
-            solver.step(model, state_0, state_1, control, contacts, dt=1.0 / 60.0)
+            solver.step(state_0, state_1, control, contacts, dt=1.0 / 60.0)
             state_0, state_1 = state_1, state_0
 
     Note:

--- a/newton/sim/style3d/builder_style3d.py
+++ b/newton/sim/style3d/builder_style3d.py
@@ -84,7 +84,7 @@ class Style3DModelBuilder(ModelBuilder):
         for i in range(10):
             state_0.clear_forces()
             contacts = model.collide(state_0)
-            solver.step(model, state_0, state_1, control, contacts, dt=1.0 / 60.0)
+            solver.step(state_0, state_1, control, contacts, dt=1.0 / 60.0)
             state_0, state_1 = state_1, state_0
 
     Note:

--- a/newton/solvers/euler/solver_euler.py
+++ b/newton/solvers/euler/solver_euler.py
@@ -54,7 +54,7 @@ class SemiImplicitSolver(SolverBase):
 
         # simulation loop
         for i in range(100):
-            solver.step(model, state_in, state_out, control, contacts, dt)
+            solver.step(state_in, state_out, control, contacts, dt)
             state_in, state_out = state_out, state_in
 
     """
@@ -85,7 +85,6 @@ class SemiImplicitSolver(SolverBase):
     @override
     def step(
         self,
-        model: Model,
         state_in: State,
         state_out: State,
         control: Control,
@@ -101,6 +100,8 @@ class SemiImplicitSolver(SolverBase):
 
             if state_in.body_count:
                 body_f = state_in.body_f
+
+            model = self.model
 
             if control is None:
                 control = model.control(clone_variables=False)

--- a/newton/solvers/featherstone/solver_featherstone.py
+++ b/newton/solvers/featherstone/solver_featherstone.py
@@ -82,7 +82,7 @@ class FeatherstoneSolver(SolverBase):
 
         # simulation loop
         for i in range(100):
-            solver.step(model, state_in, state_out, control, contacts, dt)
+            solver.step(state_in, state_out, control, contacts, dt)
             state_in, state_out = state_out, state_in
 
     """
@@ -278,7 +278,6 @@ class FeatherstoneSolver(SolverBase):
     @override
     def step(
         self,
-        model: Model,
         state_in: State,
         state_out: State,
         control: Control,
@@ -292,6 +291,8 @@ class FeatherstoneSolver(SolverBase):
             state_aug = state_out
         else:
             state_aug = self
+
+        model = self.model
 
         if not getattr(state_aug, "_featherstone_augmented", False):
             self.allocate_state_aux_vars(model, state_aug, requires_grad)

--- a/newton/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -1198,13 +1198,14 @@ class ImplicitMPMSolver(SolverBase):
 
     def step(
         self,
-        model: Model,
         state_in: State,
         state_out: State,
         control: Control,
         contacts: Contacts,
         dt: float,
     ):
+        model = self.model
+
         with wp.ScopedDevice(model.device):
             if self.dynamic_grid:
                 scratch = self._rebuild_scratchpad(state_in)
@@ -1213,7 +1214,7 @@ class ImplicitMPMSolver(SolverBase):
                     self._fixed_scratchpad = self._rebuild_scratchpad(state_in)
                 scratch = self._fixed_scratchpad
 
-            self._step_impl(model, state_in, state_out, dt, scratch)
+            self._step_impl(state_in, state_out, dt, scratch)
 
     def project_outside(self, state_in: State, state_out: State, dt: float):
         """Projects particles outside of the colliders"""
@@ -1407,7 +1408,6 @@ class ImplicitMPMSolver(SolverBase):
 
     def _step_impl(
         self,
-        model: Model,
         state_in: State,
         state_out: State,
         dt: float,
@@ -1415,6 +1415,8 @@ class ImplicitMPMSolver(SolverBase):
     ):
         domain = scratch.velocity_test.domain
         inv_cell_volume = 1.0 / self.voxel_size**3
+
+        model = self.model
 
         with wp.ScopedTimer(
             "Warmstart fields",

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -736,7 +736,7 @@ class MuJoCoSolver(SolverBase):
 
         # simulation loop
         for i in range(100):
-            solver.step(model, state_in, state_out, control, contacts, dt)
+            solver.step(state_in, state_out, control, contacts, dt)
             state_in, state_out = state_out, state_in
     """
 
@@ -819,19 +819,19 @@ class MuJoCoSolver(SolverBase):
         self._step = 0
 
     @override
-    def step(self, model: Model, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
+    def step(self, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
         if self.use_mujoco:
             self.apply_mjc_control(self.model, state_in, control, self.mj_data)
             if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
                 # XXX updating the mujoco state at every step may introduce numerical instability
-                self.update_mjc_data(self.mj_data, model, state_in)
+                self.update_mjc_data(self.mj_data, self.model, state_in)
             self.mj_model.opt.timestep = dt
             self.mujoco.mj_step(self.mj_model, self.mj_data)
             self.update_newton_state(self.model, state_out, self.mj_data)
         else:
             self.apply_mjc_control(self.model, state_in, control, self.mjw_data)
             if self.update_data_interval > 0 and self._step % self.update_data_interval == 0:
-                self.update_mjc_data(self.mjw_data, model, state_in)
+                self.update_mjc_data(self.mjw_data, self.model, state_in)
             self.mjw_model.opt.timestep.fill_(dt)
             with wp.ScopedDevice(self.model.device):
                 self.mujoco_warp.step(self.mjw_model, self.mjw_data)

--- a/newton/solvers/solver.py
+++ b/newton/solvers/solver.py
@@ -247,7 +247,7 @@ class SolverBase:
                 device=model.device,
             )
 
-    def step(self, model: Model, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
+    def step(state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
         """
         Simulate the model for a given time step using the given control input.
 

--- a/newton/solvers/style3d/solver_style3d.py
+++ b/newton/solvers/style3d/solver_style3d.py
@@ -94,9 +94,7 @@ class Style3DSolver(SolverBase):
         else:
             return 4.0 / (4.0 - omega * rho * rho)
 
-    def step(
-        self, model: Style3DModel, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float
-    ):
+    def step(self, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
         if model is not self.model:
             raise ValueError("model must be the one used to initialize Style3DSolver")
 

--- a/newton/solvers/xpbd/solver_xpbd.py
+++ b/newton/solvers/xpbd/solver_xpbd.py
@@ -57,7 +57,7 @@ class XPBDSolver(SolverBase):
 
         # simulation loop
         for i in range(100):
-            solver.step(model, state_in, state_out, control, contacts, dt)
+            solver.step(state_in, state_out, control, contacts, dt)
             state_in, state_out = state_out, state_in
 
     """
@@ -204,10 +204,12 @@ class XPBDSolver(SolverBase):
         return new_body_q, new_body_qd
 
     @override
-    def step(self, model: Model, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
+    def step(self, state_in: State, state_out: State, control: Control, contacts: Contacts, dt: float):
         requires_grad = state_in.requires_grad
         self._particle_delta_counter = 0
         self._body_delta_counter = 0
+
+        model = self.model
 
         particle_q = None
         particle_qd = None

--- a/newton/tests/test_cloth.py
+++ b/newton/tests/test_cloth.py
@@ -799,7 +799,7 @@ class ClothSim:
             self.state0.clear_forces()
             contacts = self.model.collide(self.state0, soft_contact_margin=self.soft_contact_margin)
             control = self.model.control()
-            self.solver.step(self.model, self.state0, self.state1, control, contacts, self.dt)
+            self.solver.step(self.state0, self.state1, control, contacts, self.dt)
             (self.state0, self.state1) = (self.state1, self.state0)
 
     def run(self):

--- a/newton/tests/test_control_force.py
+++ b/newton/tests/test_control_force.py
@@ -60,7 +60,7 @@ def test_floating_body(test: TestControlForce, device, solver_fn, test_angular=T
     sim_dt = 1.0 / 10.0
 
     for _ in range(4):
-        solver.step(model, state_0, state_1, control, None, sim_dt)
+        solver.step(state_0, state_1, control, None, sim_dt)
         state_0, state_1 = state_1, state_0
 
     body_qd = state_0.body_qd.numpy()[0]
@@ -108,7 +108,7 @@ def test_3d_articulation(test: TestControlForce, device, solver_fn):
         sim_dt = 1.0 / 10.0
 
         for _ in range(4):
-            solver.step(model, state_0, state_1, control, None, sim_dt)
+            solver.step(state_0, state_1, control, None, sim_dt)
             state_0, state_1 = state_1, state_0
 
         if not isinstance(solver, (newton.solvers.MuJoCoSolver, newton.solvers.FeatherstoneSolver)):

--- a/newton/tests/test_implicit_mpm.py
+++ b/newton/tests/test_implicit_mpm.py
@@ -67,7 +67,7 @@ def test_sand_cube_on_plane(test, device):
 
     # Run a few steps
     for _k in range(25):
-        solver.step(model, state_0, state_1, control=None, contacts=None, dt=dt)
+        solver.step(state_0, state_1, control=None, contacts=None, dt=dt)
         state_0, state_1 = state_1, state_0
 
     # Checks the final bounding box corresponds to the expected collapse

--- a/newton/tests/test_joint_controllers.py
+++ b/newton/tests/test_joint_controllers.py
@@ -72,7 +72,7 @@ def test_revolute_controller(test: TestJointController, device, solver_fn, joint
     sim_time = 0.0
     for _ in range(100):
         state_0.clear_forces()
-        solver.step(model, state_0, state_1, control, None, sim_dt)
+        solver.step(state_0, state_1, control, None, sim_dt)
         state_0, state_1 = state_1, state_0
         # renderer.begin_frame(sim_time)
         # renderer.render(state_1)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -35,7 +35,7 @@ class TestMuJoCoSolver(unittest.TestCase):
     def _run_substeps_for_frame(self, sim_dt, sim_substeps):
         """Helper method to run simulation substeps for one rendered frame."""
         for _ in range(sim_substeps):
-            self.solver.step(self.model, self.state_in, self.state_out, self.control, self.contacts, sim_dt)
+            self.solver.step(self.state_in, self.state_out, self.control, self.contacts, sim_dt)
             self.state_in, self.state_out = self.state_out, self.state_in  # Output becomes input for next substep
 
     def test_setup_completes(self):
@@ -268,7 +268,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                     )
 
         # Run a simulation step
-        solver.step(self.model, self.state_in, self.state_out, self.control, self.contacts, 0.01)
+        solver.step(self.state_in, self.state_out, self.control, self.contacts, 0.01)
         self.state_in, self.state_out = self.state_out, self.state_in
 
         # Update masses again
@@ -328,7 +328,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                         )
 
         # Run a simulation step
-        solver.step(self.model, self.state_in, self.state_out, self.control, self.contacts, 0.01)
+        solver.step(self.state_in, self.state_out, self.control, self.contacts, 0.01)
         self.state_in, self.state_out = self.state_out, self.state_in
 
         # Update COM positions again
@@ -421,7 +421,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         check_inertias(new_inertias, "Initial ")
 
         # Run a simulation step
-        solver.step(self.model, self.state_in, self.state_out, self.control, self.contacts, 0.01)
+        solver.step(self.state_in, self.state_out, self.control, self.contacts, 0.01)
         self.state_in, self.state_out = self.state_out, self.state_in
 
         # Update inertia tensors again with new random values

--- a/newton/tests/test_up_axis.py
+++ b/newton/tests/test_up_axis.py
@@ -42,7 +42,7 @@ def test_gravity(test: TestControlForce, device, solver_fn, up_axis: newton.Axis
     control = model.control()
 
     sim_dt = 1.0 / 10.0
-    solver.step(model, state_0, state_1, control, None, sim_dt)
+    solver.step(state_0, state_1, control, None, sim_dt)
 
     lin_vel = state_1.body_qd.numpy()[0, 3:]
     test.assertAlmostEqual(lin_vel[up_axis.value], -0.981, delta=1e-5)


### PR DESCRIPTION
…lverBase

Signed-off-by: Gordon Yeoman <gyeoman@nvidia.com>

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
This is a fix for issue https://github.com/newton-physics/newton/issues/252
The issue is that each Solver caches a Model instance but the step() function requires a Model instance as function argument. These two model instances must be the same. 
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
