### PR TITLE
USD importer density fix

### DIFF
--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -16,8 +16,8 @@
 import os
 import unittest
 
-import warp as wp
 import numpy as np
+import warp as wp
 
 import newton
 from newton.tests.unittest_utils import USD_AVAILABLE, get_test_devices
@@ -130,7 +130,7 @@ class TestImportUsd(unittest.TestCase):
     def test_mass_calculations(self):
         builder = newton.ModelBuilder()
 
-        results = parse_usd(
+        _ = parse_usd(
             os.path.join(os.path.dirname(__file__), "assets", "ant.usda"),
             builder,
             collapse_fixed_joints=True,
@@ -138,7 +138,19 @@ class TestImportUsd(unittest.TestCase):
 
         np.testing.assert_allclose(
             np.array(builder.body_mass),
-            np.array([0.09677605, 0.00783155, 0.01351844, 0.00783155, 0.01351844, 0.00783155, 0.01351844, 0.00783155, 0.01351844]),
+            np.array(
+                [
+                    0.09677605,
+                    0.00783155,
+                    0.01351844,
+                    0.00783155,
+                    0.01351844,
+                    0.00783155,
+                    0.01351844,
+                    0.00783155,
+                    0.01351844,
+                ]
+            ),
             rtol=1e-5,
             atol=1e-7,
         )

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -17,6 +17,7 @@ import os
 import unittest
 
 import warp as wp
+import numpy as np
 
 import newton
 from newton.tests.unittest_utils import USD_AVAILABLE, get_test_devices
@@ -124,6 +125,23 @@ class TestImportUsd(unittest.TestCase):
         joint_key_cloning = [k for k in builder_cloning.joint_key if k.startswith("/World")]
         joint_key_no_cloning = [k for k in builder_no_cloning.joint_key if k.startswith("/World")]
         self.assertEqual(joint_key_cloning, joint_key_no_cloning)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mass_calculations(self):
+        builder = newton.ModelBuilder()
+
+        results = parse_usd(
+            os.path.join(os.path.dirname(__file__), "assets", "ant.usda"),
+            builder,
+            collapse_fixed_joints=True,
+        )
+
+        np.testing.assert_allclose(
+            np.array(builder.body_mass),
+            np.array([0.09677605, 0.00783155, 0.01351844, 0.00783155, 0.01351844, 0.00783155, 0.01351844, 0.00783155, 0.01351844]),
+            rtol=1e-5,
+            atol=1e-7,
+        )
 
 
 if __name__ == "__main__":

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -843,7 +843,7 @@ def parse_usd(
                         ),
                         mu=material.dynamicFriction,
                         restitution=material.restitution,
-                        density=material.density,
+                        density=body_density[body_path],
                         collision_group=collision_group,
                     ),
                     "key": path,


### PR DESCRIPTION
## Description

Fixes #287 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
