### PR TITLE
Refactor warning message in `color_graph` function for clarity

### DIFF
--- a/newton/sim/graph_coloring.py
+++ b/newton/sim/graph_coloring.py
@@ -247,8 +247,10 @@ def color_graph(
         )
 
         if max_min_ratio > target_max_min_color_ratio:
-            warp.utils.warn(
-                f"The graph is not optimizable anymore, terminated with a max/min ratio: {max_min_ratio} without reaching the target ratio: {target_max_min_color_ratio}"
+            wp.utils.warn(
+                f"Color balancing terminated early: max/min ratio {max_min_ratio:.3f} "
+                f"exceeds target {target_max_min_color_ratio:.3f}. "
+                "The graph may not be further optimizable."
             )
 
     color_groups = convert_to_color_groups(num_colors, particle_colors, return_wp_array=False)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

I hope to address two issues with this common warning that appears in the cloth examples:

- It's not clear what this warning is talking about. What graph?
- The number of digits printed out is absurdly long and don't tell the user much (now limited to three after the decimal point)

Current:

```
Warp UserWarning: The graph is not optimizable anymore, terminated with a max/min ratio: 1.3333333730697632 without reaching the target ratio: 1.1
```

This pull request:

```
Warp UserWarning: Color balancing terminated early: max/min ratio 1.333 exceeds target 1.100. The graph may not be further optimizable.
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
