### PR TITLE
Fix issues with `test_cloth.py` on CUDA drivers < 12.3

### DIFF
--- a/newton/tests/test_cloth.py
+++ b/newton/tests/test_cloth.py
@@ -658,6 +658,7 @@ class ClothSim:
         self.finalize(ground=False)
 
     def set_up_body_cloth_contact_experiment(self):
+        # fmt: off
         vs = [
             [0.0, 0.0, 0.0],
             [0.0, 0.0, 1.0],
@@ -665,13 +666,10 @@ class ClothSim:
             [1.0, 0.0, 0.0],
         ]
         fs = [
-            0,
-            1,
-            2,
-            2,
-            3,
-            0,
+            0, 1, 2,
+            2, 3, 0
         ]
+        # fmt: on
 
         if self.solver_name != "semi_implicit":
             stretching_stiffness = 1e4
@@ -703,20 +701,7 @@ class ClothSim:
             particle_radius=particle_radius,
         )
 
-        self.builder.add_shape_box(
-            -1,
-            wp.transform(
-                wp.vec3(
-                    0,
-                    -2,
-                    0,
-                ),
-                wp.quat_identity(),
-            ),
-            hx=2,
-            hy=2,
-            hz=2,
-        )
+        self.builder.add_shape_box(-1, wp.transform(wp.vec3(0, -2, 0), wp.quat_identity()), hx=2, hy=2, hz=2)
 
         self.renderer_scale_factor = 0.1
 
@@ -788,6 +773,7 @@ class ClothSim:
                 wp.set_module_options({"block_dim": 256}, newton.solvers.euler.solver_euler)
                 wp.load_module(newton.solvers.euler.solver_euler, device=self.device)
 
+            wp.set_module_options({"block_dim": 256}, newton.solvers.solver)
             wp.load_module(newton.solvers.solver, device=self.device)
             wp.load_module(device=self.device)
             with wp.ScopedCapture(device=self.device, force_module_load=False) as capture:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Whenever graph capture is involved, we need to be careful about making sure the modules are preloaded since they cannot be dynamically loaded when the CUDA driver is older than 12.3.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
