### PR TITLE
Anymal: run PD control at a higher frequency

### DIFF
--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -17,6 +17,8 @@
 # Example Anymal C walk
 #
 # Shows how to control Anymal C with a pretrained policy.
+#
+# Run the script with the --with option to temporarily add the PyTorch dependency for its execution:
 # uv run --with torch newton/examples/example_anymal_c_walk.py
 #
 ###########################################################################


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

The anymal was falling because the force was updated only every n sim_substeps. However, policy should be inferred every n sim_substeps, but PD should run at a higher frequency, every sim_substep

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
