### PR TITLE
Ensure `wp.ScopedCapture()` happens on the right device

### DIFF
--- a/newton/tests/test_rigid_contact.py
+++ b/newton/tests/test_rigid_contact.py
@@ -66,7 +66,7 @@ def test_spheres_on_plane(test: TestRigidContact, device, solver_fn):
         # ensure data is allocated and modules are loaded before graph capture
         # in case of an earlier CUDA version
         simulate(solver, model, state_0, state_1, control, sim_dt, substeps)
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(device) as capture:
             simulate(solver, model, state_0, state_1, control, sim_dt, substeps)
         graph = capture.graph
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

I noticed when testing on a multi-GPU system that all these tests fail on the second GPU. It seems that the `wp.ScopedCapture()` was not targeting the intended device.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
