### PR TITLE
Add PyTorch to `--extra cu12`, fix Anymal Sand example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version-file: ".python-version"
       - name: Run Tests
-        run: uv run --all-extras -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
+        run: uv run --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ linting:
     - when: manual # If not auto-triggered, allow any pipeline to run this job manually
       allow_failure: true
   script:
-    - uv run --extra cu128 --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
+    - uv run --extra cu12 --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
 
 linux-x86_64 test:
   image: ghcr.io/astral-sh/uv:bookworm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ linting:
     - when: manual # If not auto-triggered, allow any pipeline to run this job manually
       allow_failure: true
   script:
-    - uv run --all-extras -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
+    - uv run --extra cu128 --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
 
 linux-x86_64 test:
   image: ghcr.io/astral-sh/uv:bookworm

--- a/docs/development-guide.rst
+++ b/docs/development-guide.rst
@@ -46,7 +46,7 @@ Run basic examples:
     uv run newton/examples/example_quadruped.py
 
     # An example that requires extras
-    uv run --all-extras newton/examples/example_humanoid.py
+    uv run --extra dev newton/examples/example_humanoid.py
 
 When using uv, the `lockfile <https://docs.astral.sh/uv/concepts/projects/layout/#the-lockfile>`__
 (``uv.lock``) is used to resolve project dependencies
@@ -141,7 +141,7 @@ Pass ``--help`` to either runner to see all available flags.
         .. code-block:: console
 
             # install all extras and run tests
-            uv run --all-extras -m newton.tests
+            uv run --extra dev -m newton.tests
 
     .. tab-item:: venv
         :sync: venv
@@ -164,7 +164,7 @@ To generate a coverage report:
         .. code-block:: console
             
             # append the coverage flags:
-            uv run --all-extras -m newton.tests --coverage --coverage-html htmlcov
+            uv run --extra dev -m newton.tests --coverage --coverage-html htmlcov
 
     .. tab-item:: venv
         :sync: venv

--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -19,7 +19,7 @@
 # Shows how to control Anymal C with a pretrained policy.
 #
 # Example usage:
-# uv run --extra cu128 newton/examples/example_anymal_c_walk.py
+# uv run --extra cu12 newton/examples/example_anymal_c_walk.py
 #
 ###########################################################################
 

--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -18,11 +18,12 @@
 #
 # Shows how to control Anymal C with a pretrained policy.
 #
-# Run the script with the --with option to temporarily add the PyTorch dependency for its execution:
-# uv run --with torch newton/examples/example_anymal_c_walk.py
+# Example usage:
+# uv run --extra cu128 newton/examples/example_anymal_c_walk.py
 #
 ###########################################################################
 
+import sys
 
 import numpy as np
 import torch
@@ -30,6 +31,7 @@ import warp as wp
 
 import newton
 import newton.examples
+import newton.solvers.euler.kernels  # For graph capture on CUDA <12.3
 import newton.utils
 from newton.sim import Control, State
 
@@ -174,11 +176,7 @@ class AnymalController:
             device=self.device,
         )
 
-    def compute_observations(
-        self,
-        state: State,
-        observations: wp.array,
-    ):
+    def compute_observations(self, state: State, observations: wp.array):
         wp.launch(
             compute_observations_anymal,
             dim=self.num_envs,
@@ -216,14 +214,14 @@ class AnymalController:
             device=self.model.device,
         )
 
-    def get_control(self, state: State, control: Control):
+    def get_control(self, state: State):
         self.compute_observations(state, self.obs_buf)
         obs_torch = wp.to_torch(self.obs_buf).detach()
         self.ctrl = wp.array(torch.clamp(self.policy_model(obs_torch).detach(), -1, 1), dtype=float)
 
 
 class Example:
-    def __init__(self, stage_path="example_quadruped.usd"):
+    def __init__(self, stage_path="example_anymal_c_walk.usd", headless=False):
         self.device = wp.get_device()
         builder = newton.ModelBuilder(up_axis=newton.Axis.Y)
         builder.default_joint_cfg = newton.ModelBuilder.JointDofConfig(
@@ -304,7 +302,7 @@ class Example:
         # fmt: on
 
         self.solver = newton.solvers.FeatherstoneSolver(self.model)
-        self.renderer = newton.utils.SimRendererOpenGL(self.model, stage_path)
+        self.renderer = None if headless else newton.utils.SimRendererOpenGL(self.model, stage_path)
 
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
@@ -313,10 +311,13 @@ class Example:
         newton.sim.eval_fk(self.model, self.state_0.joint_q, self.state_0.joint_qd, self.state_0)
 
         self.controller = AnymalController(self.model, self.device)
+        self.controller.get_control(self.state_0)
 
         self.use_cuda_graph = self.device.is_cuda and wp.is_mempool_enabled(wp.get_device())
         if self.use_cuda_graph:
-            self.controller.get_control(self.state_0, self.control)
+            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
+            wp.load_module(newton.solvers.euler.kernels, device=wp.get_device())
+
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph
@@ -337,7 +338,7 @@ class Example:
                 wp.capture_launch(self.graph)
             else:
                 self.simulate()
-            self.controller.get_control(self.state_0, self.control)
+            self.controller.get_control(self.state_0)
         self.sim_time += self.frame_dt
 
     def render(self):
@@ -358,15 +359,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "--stage_path",
         type=lambda x: None if x == "None" else str(x),
-        default="example_quadruped.usd",
+        default="example_anymal_c_walk.usd",
         help="Path to the output USD file.",
     )
     parser.add_argument("--num_frames", type=int, default=10000, help="Total number of frames.")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 
+    if wp.get_device(args.device).is_cpu:
+        print("Error: This example requires a GPU device.")
+        sys.exit(1)
+
     with wp.ScopedDevice(args.device):
-        example = Example(stage_path=args.stage_path)
+        example = Example(stage_path=args.stage_path, headless=args.headless)
 
         for _ in range(args.num_frames):
             example.step()

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -19,7 +19,7 @@
 # Shows Anymal C with a pretrained policy coupled with implicit mpm sand.
 #
 # Example usage:
-# uv run --extra cu128 newton/examples/example_anymal_c_walk_on_sand.py
+# uv run --extra cu12 newton/examples/example_anymal_c_walk_on_sand.py
 ###########################################################################
 
 import sys

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -18,12 +18,19 @@
 #
 # Shows Anymal C with a pretrained policy coupled with implicit mpm sand.
 #
+# Example usage:
+# uv run --extra cu128 newton/examples/example_anymal_c_walk_on_sand.py
 ###########################################################################
+
+import sys
 
 import numpy as np
 import warp as wp
 
 import newton
+import newton.solvers.euler.kernels  # For graph capture on CUDA <12.3
+import newton.solvers.euler.particles  # For graph capture on CUDA <12.3
+import newton.solvers.solver  # For graph capture on CUDA <12.3
 import newton.utils
 from newton.examples.example_anymal_c_walk import AnymalController
 from newton.solvers.implicit_mpm import ImplicitMPMSolver
@@ -56,7 +63,7 @@ def update_collider_mesh(
 class Example:
     def __init__(
         self,
-        stage_path="example_anymal_c_walk_in_sand.usd",
+        stage_path="example_anymal_c_walk_on_sand.usd",
         voxel_size=0.05,
         particles_per_cell=3,
         tolerance=1.0e-5,
@@ -202,9 +209,15 @@ class Example:
 
         self.control = self.model.control()
         self.controller = AnymalController(self.model, self.device)
+        self.controller.get_control(self.state_0)
 
         self.use_cuda_graph = self.device.is_cuda and wp.is_mempool_enabled(wp.get_device())
         if self.use_cuda_graph:
+            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
+            wp.load_module(newton.solvers.euler.kernels, device=wp.get_device())
+            wp.load_module(newton.solvers.euler.particles, device=wp.get_device())
+            wp.load_module(newton.solvers.solver, device=wp.get_device())
+
             with wp.ScopedCapture() as capture:
                 self.simulate_robot()
             self.robot_graph = capture.graph
@@ -215,6 +228,7 @@ class Example:
         self.contacts = self.model.collide(self.state_0, rigid_contact_margin=0.1)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
+            self.controller.assign_control(self.control, self.state_0)
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 
@@ -231,7 +245,7 @@ class Example:
                 self.simulate_robot()
 
             self.simulate_sand()
-            self.controller.get_control(self.state_0, self.control)
+            self.controller.get_control(self.state_0)
 
         self.sim_time += self.frame_dt
 
@@ -320,6 +334,12 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
+    parser.add_argument(
+        "--stage_path",
+        type=lambda x: None if x == "None" else str(x),
+        default="example_anymal_c_walk_on_sand.usd",
+        help="Path to the output USD file.",
+    )
     parser.add_argument("--num_frames", type=int, default=10000, help="Total number of frames.")
     parser.add_argument("--voxel_size", "-dx", type=float, default=0.03)
     parser.add_argument("--particles_per_cell", "-ppc", type=float, default=3.0)
@@ -329,6 +349,10 @@ if __name__ == "__main__":
     parser.add_argument("--dynamic_grid", action=argparse.BooleanOptionalAction, default=True)
 
     args = parser.parse_known_args()[0]
+
+    if wp.get_device(args.device).is_cpu:
+        print("Error: This example requires a GPU device.")
+        sys.exit(1)
 
     with wp.ScopedDevice(args.device):
         example = Example(

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -98,6 +98,19 @@ def add_example_test(
         else:
             options = _merge_options(test_options, test_options_cpu)
 
+        # Mark the test as skipped if Torch is not installed but required
+        torch_required = options.pop("torch_required", False)
+        if torch_required:
+            try:
+                import torch  # noqa: PLC0415
+
+                if wp.get_device(device).is_cuda and not torch.cuda.is_available():
+                    # Ensure torch has CUDA support
+                    test.skipTest("Torch not compiled with CUDA support")
+
+            except Exception as e:
+                test.skipTest(f"{e}")
+
         # Mark the test as skipped if USD is not installed but required
         usd_required = options.pop("usd_required", False)
         if usd_required and not USD_AVAILABLE:
@@ -269,6 +282,18 @@ add_example_test(
     devices=test_devices,
     test_options={"stage_path": "None", "num_frames": 300},
     test_options_cpu={"num_frames": 2},
+)
+add_example_test(
+    TestAdvancedRobotExamples,
+    name="example_anymal_c_walk",
+    devices=cuda_test_devices,
+    test_options={"stage_path": "None", "num_frames": 200, "headless": True, "torch_required": True},
+)
+add_example_test(
+    TestAdvancedRobotExamples,
+    name="example_anymal_c_walk_on_sand",
+    devices=cuda_test_devices,
+    test_options={"stage_path": "None", "num_frames": 100, "headless": True, "torch_required": True},
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ docs = [
     "sphinx-design<=0.6.1",
     "sphinx-tabs>=3.3.0",
 ]
-cu128 = ["torch>=2.7.0"]
+cu12 = ["torch>=2.7.0"]
 
 [tool.hatch.version]
 path = "newton/_version.py"
@@ -74,9 +74,7 @@ explicit = true
 mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp" }
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
-torch = [
-    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
+torch = [{ index = "pytorch-cu128", extra = "cu12" }]
 
 [[tool.uv.index]]
 name = "mujoco"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = ["warp-lang>=1.7.0.dev20250625"]
 
 [project.optional-dependencies]
 dev = [
-    "coverage[toml]>=7.8.0",
     "mujoco-warp>=3.2.7",
     "usd-core>=25.5 ; platform_machine != 'aarch64'",
     "pycollada>=0.9",
@@ -53,6 +52,7 @@ docs = [
     "sphinx-design<=0.6.1",
     "sphinx-tabs>=3.3.0",
 ]
+cu128 = ["torch>=2.7.0"]
 
 [tool.hatch.version]
 path = "newton/_version.py"
@@ -65,10 +65,18 @@ name = "nvidia"
 url = "https://pypi.nvidia.com"
 explicit = true
 
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
 [tool.uv.sources]
 mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp" }
 warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
 mujoco = { index = "mujoco" }
+torch = [
+    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
 
 [[tool.uv.index]]
 name = "mujoco"
@@ -76,16 +84,7 @@ url = "https://py.mujoco.org"
 explicit = true
 
 [dependency-groups]
-dev = [
-    "coverage[toml]>=7.8.0",
-    "mujoco-warp>=3.2.7",
-    "usd-core>=25.5 ; platform_machine != 'aarch64'",
-    "pycollada>=0.9",
-    "pyglet>=2.1.6",
-    "trimesh>=4.6.8",
-    "matplotlib>=3.9.4",
-    "gitpython>=3.1.44",
-]
+dev = ["coverage[toml]>=7.8.0"]
 
 [tool.ruff]
 cache-dir = ".cache/ruff"

--- a/uv.lock
+++ b/uv.lock
@@ -2,13 +2,37 @@ version = 1
 revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
+conflicts = [[
+    { package = "newton-physics", extra = "cpu" },
+    { package = "newton-physics", extra = "cu128" },
+]]
 
 [[package]]
 name = "absl-py"
@@ -36,8 +60,13 @@ name = "alabaster"
 version = "0.7.16"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
 wheels = [
@@ -49,10 +78,25 @@ name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
 wheels = [
@@ -64,21 +108,21 @@ name = "alphashape"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "click-log" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "rtree" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "trimesh" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/83/67ff905694df5b34a777123b59fdfd05998d5a31766f188aafbf5b340055/alphashape-1.3.1.tar.gz", hash = "sha256:7a27340afc5f8ed301577acec46bb0cf2bada5410045f7289142e735ef6977ec", size = 26316, upload-time = "2021-04-16T17:47:19.486Z" }
@@ -196,11 +240,16 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "(python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -212,13 +261,28 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "(python_full_version >= '3.10' and sys_platform == 'win32') or (python_full_version < '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -230,8 +294,8 @@ name = "click-log"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/32/228be4f971e4bd556c33d52a22682bfe318ffe57a1ddb7a546f347a90260/click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975", size = 9985, upload-time = "2022-03-13T11:10:15.262Z" }
 wheels = [
@@ -252,11 +316,16 @@ name = "contourpy"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -331,14 +400,29 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -476,7 +560,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 
 [[package]]
@@ -502,8 +586,13 @@ name = "etils"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/fa/8637c95271dd9eed00e258184295dd00ba163bb8924ba3be978ec89f093f/etils-1.5.2.tar.gz", hash = "sha256:ba6a3e1aff95c769130776aa176c11540637f5dd881f3b79172a5149b6b1c446", size = 87021, upload-time = "2023-10-24T12:22:58.996Z" }
 wheels = [
@@ -512,10 +601,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version < '3.10'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "fsspec", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 
 [[package]]
@@ -523,10 +612,25 @@ name = "etils"
 version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/12/1cc11e88a0201280ff389bc4076df7c3432e39d9f22cba8b71aa263f67b8/etils-1.12.2.tar.gz", hash = "sha256:c6b9e1f0ce66d1bbf54f99201b08a60ba396d3446d9eb18d4bc39b26a2e1a5ee", size = 104711, upload-time = "2025-03-10T15:14:13.671Z" }
 wheels = [
@@ -535,10 +639,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version >= '3.10'" },
-    { name = "importlib-resources", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "zipp", marker = "python_full_version >= '3.10'" },
+    { name = "fsspec", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "importlib-resources", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "zipp", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 
 [[package]]
@@ -546,9 +650,9 @@ name = "fast-simplification"
 version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/98/1e10c12ac539826e81902952175961f2717f188b1e2276949e687a88c91c/fast_simplification-0.1.11.tar.gz", hash = "sha256:deba1bd719b372e375ed38cbfcc47d98e9e3e41405c470d10efdae3a2b676d3d", size = 26334, upload-time = "2025-05-07T15:53:15.825Z" }
 wheels = [
@@ -572,6 +676,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/45/7e/954b4a99dda9b4d611ff752aed9d35fc9554acafbdc2a6e3c41ca695ee6e/fast_simplification-0.1.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f40bdec940180af2a9bf6f5894cd9203dbc55b8182c485f8a0deb7bae13b86ee", size = 242641, upload-time = "2025-05-07T15:53:09.804Z" },
     { url = "https://files.pythonhosted.org/packages/95/1d/44cab05fc9a71627b606598f2cde63c4e2adafc6c907ce5b8a43bfc71a87/fast_simplification-0.1.11-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4c2172e1e0f77777b76e5425c2a1117bad7d24606cb3f66ce2efb2af7817ee6", size = 1699320, upload-time = "2025-05-07T15:53:11.656Z" },
     { url = "https://files.pythonhosted.org/packages/c8/48/50fbef14f15c724fb1fa92a076d2222d7a7464214996d89aad5863515b17/fast_simplification-0.1.11-cp39-cp39-win_amd64.whl", hash = "sha256:5fe79aee0b5371627d7cf8510ac91f25f318b940e7ef2a82ecff68501f2b6356", size = 213398, upload-time = "2025-05-07T15:53:13.885Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
 ]
 
 [[package]]
@@ -695,7 +808,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -707,7 +820,7 @@ name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -731,8 +844,13 @@ name = "kiwisolver"
 version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/4d/2255e1c76304cbd60b48cee302b66d1dde4468dc5b1160e4b7cb43778f2a/kiwisolver-1.4.7.tar.gz", hash = "sha256:9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60", size = 97286, upload-time = "2024-09-04T09:39:44.302Z" }
 wheels = [
@@ -835,10 +953,25 @@ name = "kiwisolver"
 version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/59/7c91426a8ac292e1cdd53a63b6d9439abd573c875c3f92c146767dd33faf/kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e", size = 97538, upload-time = "2024-12-24T18:30:51.519Z" }
 wheels = [
@@ -1008,20 +1141,25 @@ name = "matplotlib"
 version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "cycler", marker = "python_full_version < '3.10'" },
-    { name = "fonttools", marker = "python_full_version < '3.10'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pillow", marker = "python_full_version < '3.10'" },
-    { name = "pyparsing", marker = "python_full_version < '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "cycler", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "fonttools", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "packaging", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pillow", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pyparsing", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -1072,22 +1210,37 @@ name = "matplotlib"
 version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "cycler", marker = "python_full_version >= '3.10'" },
-    { name = "fonttools", marker = "python_full_version >= '3.10'" },
-    { name = "kiwisolver", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pillow", marker = "python_full_version >= '3.10'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "cycler", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "fonttools", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "kiwisolver", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "packaging", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pillow", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pyparsing", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/91/d49359a21893183ed2a5b6c76bec40e0b1dcbf8ca148f864d134897cfc75/matplotlib-3.10.3.tar.gz", hash = "sha256:2f82d2c5bb7ae93aaaa4cd42aca65d76ce6376f83304fa3a630b569aca274df0", size = 34799811, upload-time = "2025-05-08T19:10:54.39Z" }
 wheels = [
@@ -1148,17 +1301,26 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mujoco"
 version = "3.3.4.dev775632047"
 source = { registry = "https://py.mujoco.org/" }
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
-    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10'" },
+    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "glfw" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "pyopengl" },
 ]
 wheels = [
@@ -1190,14 +1352,14 @@ version = "0.0.1"
 source = { git = "https://github.com/google-deepmind/mujoco_warp#8e1b3b0ffb1ab6b9df3123b136bd30837fc31eab" }
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
-    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10'" },
+    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "mujoco" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 
 [[package]]
@@ -1205,16 +1367,21 @@ name = "myst-parser"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "docutils", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "jinja2", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "markdown-it-py", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pyyaml", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
 wheels = [
@@ -1226,19 +1393,34 @@ name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "docutils", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "jinja2", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "markdown-it-py", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1250,8 +1432,13 @@ name = "networkx"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/80/a84676339aaae2f1cfdf9f418701dd634aef9cc76f708ef55c36ff39c3ca/networkx-3.2.1.tar.gz", hash = "sha256:9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6", size = 2073928, upload-time = "2023-10-28T08:41:39.364Z" }
 wheels = [
@@ -1263,8 +1450,13 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1276,8 +1468,18 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -1288,36 +1490,39 @@ wheels = [
 name = "newton-physics"
 source = { editable = "." }
 dependencies = [
-    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 
 [package.optional-dependencies]
+cu128 = [
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+]
 dev = [
     { name = "alphashape" },
-    { name = "coverage", extra = ["toml"] },
     { name = "fast-simplification" },
     { name = "gitpython" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
     { name = "pycollada" },
     { name = "pyglet" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "tqdm" },
     { name = "trimesh" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64'" },
+    { name = "usd-core", marker = "platform_machine != 'aarch64' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 docs = [
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "pydata-sphinx-theme" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-tabs" },
@@ -1327,20 +1532,11 @@ docs = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage", extra = ["toml"] },
-    { name = "gitpython" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mujoco-warp" },
-    { name = "pycollada" },
-    { name = "pyglet" },
-    { name = "trimesh" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64'" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "alphashape", marker = "extra == 'dev'", specifier = ">=1.3.1" },
-    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.8.0" },
     { name = "fast-simplification", marker = "extra == 'dev'", specifier = ">=0.1.11" },
     { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.44" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.9.4" },
@@ -1356,33 +1552,31 @@ requires-dist = [
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = "<=0.6.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.3.0" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0.0" },
+    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu128') or (sys_platform == 'win32' and extra == 'cu128')", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'cu128'", specifier = ">=2.7.0" },
     { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.67.1" },
     { name = "trimesh", marker = "extra == 'dev'", specifier = ">=4.6.8" },
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'dev'", specifier = ">=25.5" },
     { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250625", index = "https://pypi.nvidia.com/" },
     { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250625" },
 ]
-provides-extras = ["dev", "docs"]
+provides-extras = ["cu128", "dev", "docs"]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "coverage", extras = ["toml"], specifier = ">=7.8.0" },
-    { name = "gitpython", specifier = ">=3.1.44" },
-    { name = "matplotlib", specifier = ">=3.9.4" },
-    { name = "mujoco-warp", git = "https://github.com/google-deepmind/mujoco_warp" },
-    { name = "pycollada", specifier = ">=0.9" },
-    { name = "pyglet", specifier = ">=2.1.6" },
-    { name = "trimesh", specifier = ">=4.6.8" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64'", specifier = ">=25.5" },
-]
+dev = [{ name = "coverage", extras = ["toml"], specifier = ">=7.8.0" }]
 
 [[package]]
 name = "numpy"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
 wheels = [
@@ -1437,8 +1631,13 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1503,8 +1702,18 @@ name = "numpy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz", hash = "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b", size = 20390372, upload-time = "2025-06-21T12:28:33.469Z" }
 wheels = [
@@ -1558,6 +1767,158 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/ee/89bedf69c36ace1ac8f59e97811c1f5031e179a37e4821c3a230bf750142/numpy-2.3.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c6e0bf9d1a2f50d2b65a7cf56db37c095af17b59f6c132396f7c6d5dd76484df", size = 14399010, upload-time = "2025-06-21T12:26:54.086Z" },
     { url = "https://files.pythonhosted.org/packages/15/08/e00e7070ede29b2b176165eba18d6f9784d5349be3c0c1218338e79c27fd/numpy-2.3.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:eabd7e8740d494ce2b4ea0ff05afa1b7b291e978c0ae075487c51e8bd93c0c68", size = 16752042, upload-time = "2025-06-21T12:27:19.018Z" },
     { url = "https://files.pythonhosted.org/packages/48/6b/1c6b515a83d5564b1698a61efa245727c8feecf308f4091f565988519d20/numpy-2.3.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:e610832418a2bc09d974cc9fecebfa51e9532d6190223bc5ef6a7402ebf3b5cb", size = 12927246, upload-time = "2025-06-21T12:27:38.618Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.3.14"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/63/684a6f72f52671ea222c12ecde9bdf748a0ba025e2ad3ec374e466c26eb6/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:93a4e0e386cc7f6e56c822531396de8170ed17068a1e18f987574895044cd8c3", size = 604900717, upload-time = "2025-01-23T17:52:55.486Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/4b01f10069e23c641f116c62fc31e31e8dc361a153175d81561d15c8143b/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:3f0e05e7293598cf61933258b73e66a160c27d59c4422670bf0b79348c04be44", size = 609620630, upload-time = "2025-01-23T17:55:00.753Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/54/fbfa3315b936d3358517f7da5f9f2557c279bf210e5261f0cf66cc0f9832/nvidia_cublas_cu12-12.8.3.14-py3-none-win_amd64.whl", hash = "sha256:9ae5eae500aead01fc4bdfc458209df638b1a3551557ce11a78eea9ece602ae9", size = 578387959, upload-time = "2025-01-23T18:08:00.662Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.57"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/53/458956a65283c55c22ba40a65745bbe9ff20c10b68ea241bc575e20c0465/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff154211724fd824e758ce176b66007b558eea19c9a5135fc991827ee147e317", size = 9526469, upload-time = "2025-01-23T17:47:33.104Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6f/3683ecf4e38931971946777d231c2df00dd5c1c4c2c914c42ad8f9f4dca6/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e0b2eb847de260739bee4a3f66fac31378f4ff49538ff527a38a01a9a39f950", size = 10237547, upload-time = "2025-01-23T17:47:56.863Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2a/cabe033045427beb042b70b394ac3fd7cfefe157c965268824011b16af67/nvidia_cuda_cupti_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:bbed719c52a476958a74cfc42f2b95a3fd6b3fd94eb40134acc4601feb4acac3", size = 7002337, upload-time = "2025-01-23T18:04:35.34Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.61"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/22/32029d4583f7b19cfe75c84399cbcfd23f2aaf41c66fc8db4da460104fff/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a0fa9c2a21583105550ebd871bd76e2037205d56f33f128e69f6d2a55e0af9ed", size = 88024585, upload-time = "2025-01-23T17:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/98/29f98d57fc40d6646337e942d37509c6d5f8abe29012671f7a6eb9978ebe/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b1f376bf58111ca73dde4fd4df89a462b164602e074a76a2c29c121ca478dcd4", size = 43097015, upload-time = "2025-01-23T17:49:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/052d05aa068e4752415ad03bac58e852ea8bc17c9321e08546b3f261e47e/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:9c8887bf5e5dffc441018ba8c5dc59952372a6f4806819e8c1f03d62637dbeea", size = 73567440, upload-time = "2025-01-23T18:05:51.036Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.57"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/9d/e77ec4227e70c6006195bdf410370f2d0e5abfa2dc0d1d315cacd57c5c88/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:534ccebd967b6a44292678fa5da4f00666029cb2ed07a79515ea41ef31fe3ec7", size = 965264, upload-time = "2025-01-23T17:47:11.759Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/0e1ef31f4753a44084310ba1a7f0abaf977ccd810a604035abb43421c057/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75342e28567340b7428ce79a5d6bb6ca5ff9d07b69e7ce00d2c7b4dc23eff0be", size = 954762, upload-time = "2025-01-23T17:47:22.21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/52508c74bee2a3de8d59c6fd9af4ca2f216052fa2bc916da3a6a7bb998af/nvidia_cuda_runtime_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:89be637e3ee967323865b85e0f147d75f9a5bd98360befa37481b02dd57af8f5", size = 944309, upload-time = "2025-01-23T18:04:23.143Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.7.1.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/2e/ec5dda717eeb1de3afbbbb611ca556f9d6d057470759c6abd36d72f0063b/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:848a61d40ef3b32bd4e1fadb599f0cf04a4b942fbe5fb3be572ad75f9b8c53ef", size = 725862213, upload-time = "2025-02-06T22:14:57.169Z" },
+    { url = "https://files.pythonhosted.org/packages/25/dc/dc825c4b1c83b538e207e34f48f86063c88deaa35d46c651c7c181364ba2/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:6d011159a158f3cfc47bf851aea79e31bcff60d530b70ef70474c84cac484d07", size = 726851421, upload-time = "2025-02-06T22:18:29.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ea/636cda41b3865caa0d43c34f558167304acde3d2c5f6c54c00a550e69ecd/nvidia_cudnn_cu12-9.7.1.26-py3-none-win_amd64.whl", hash = "sha256:7b805b9a4cf9f3da7c5f4ea4a9dff7baf62d1a612d6154a7e0d2ea51ed296241", size = 715962100, upload-time = "2025-02-06T22:21:32.431Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/95/6157cb45a49f5090a470de42353a22a0ed5b13077886dca891b4b0e350fe/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68509dcd7e3306e69d0e2d8a6d21c8b25ed62e6df8aac192ce752f17677398b5", size = 193108626, upload-time = "2025-01-23T17:55:49.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/26/b53c493c38dccb1f1a42e1a21dc12cba2a77fbe36c652f7726d9ec4aba28/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da650080ab79fcdf7a4b06aa1b460e99860646b176a43f6208099bdc17836b6a", size = 193118795, upload-time = "2025-01-23T17:56:30.536Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f3/f6248aa119c2726b1bdd02d472332cae274133bd32ca5fa8822efb0c308c/nvidia_cufft_cu12-11.3.3.41-py3-none-win_amd64.whl", hash = "sha256:f9760612886786601d27a0993bb29ce1f757e6b8b173499d0ecfa850d31b50f8", size = 192216738, upload-time = "2025-01-23T18:08:51.102Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.0.11"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/9c/1f3264d0a84c8a031487fb7f59780fc78fa6f1c97776233956780e3dc3ac/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:483f434c541806936b98366f6d33caef5440572de8ddf38d453213729da3e7d4", size = 1197801, upload-time = "2025-01-23T17:57:07.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/80/f6a0fc90ab6fa4ac916f3643e5b620fd19724626c59ae83b74f5efef0349/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:2acbee65dc2eaf58331f0798c5e6bcdd790c4acb26347530297e63528c9eba5d", size = 1120660, upload-time = "2025-01-23T17:56:56.608Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.55"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/13/bbcf48e2f8a6a9adef58f130bc968810528a4e66bbbe62fad335241e699f/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6bb90c044fa9b07cedae2ef29077c4cf851fb6fdd6d862102321f359dca81e9", size = 63623836, upload-time = "2025-01-23T17:57:22.319Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/fc/7be5d0082507269bb04ac07cc614c84b78749efb96e8cf4100a8a1178e98/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8387d974240c91f6a60b761b83d4b2f9b938b7e0b9617bae0f0dafe4f5c36b86", size = 63618038, upload-time = "2025-01-23T17:57:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f0/91252f3cffe3f3c233a8e17262c21b41534652edfe783c1e58ea1c92c115/nvidia_curand_cu12-10.3.9.55-py3-none-win_amd64.whl", hash = "sha256:570d82475fe7f3d8ed01ffbe3b71796301e0e24c98762ca018ff8ce4f5418e1f", size = 62761446, upload-time = "2025-01-23T18:09:21.663Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.2.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/ce/4214a892e804b20bf66d04f04a473006fc2d3dac158160ef85f1bc906639/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:0fd9e98246f43c15bee5561147ad235dfdf2d037f5d07c9d41af3f7f72feb7cc", size = 260094827, upload-time = "2025-01-23T17:58:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/953675873a136d96bb12f93b49ba045d1107bc94d2551c52b12fa6c7dec3/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4d1354102f1e922cee9db51920dba9e2559877cf6ff5ad03a00d853adafb191b", size = 260373342, upload-time = "2025-01-23T17:58:56.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/e0e6f8b7aecd13e0f9e937d116fb3211329a0a92b9bea9624b1368de307a/nvidia_cusolver_cu12-11.7.2.55-py3-none-win_amd64.whl", hash = "sha256:a5a516c55da5c5aba98420d9bc9bcab18245f21ec87338cc1f930eb18dd411ac", size = 249600787, upload-time = "2025-01-23T18:10:07.641Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.7.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/a2/313db0453087f5324a5900380ca2e57e050c8de76f407b5e11383dc762ae/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d869c6146ca80f4305b62e02d924b4aaced936f8173e3cef536a67eed2a91af1", size = 291963692, upload-time = "2025-01-23T17:59:40.325Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ab/31e8149c66213b846c082a3b41b1365b831f41191f9f40c6ddbc8a7d550e/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c1b61eb8c85257ea07e9354606b26397612627fdcd327bfd91ccf6155e7c86d", size = 292064180, upload-time = "2025-01-23T18:00:23.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/48/64b01653919a3d1d9b5117c156806ab0db8312c7496ff646477a5c1545bf/nvidia_cusparse_cu12-12.5.7.53-py3-none-win_amd64.whl", hash = "sha256:82c201d6781bacf6bb7c654f0446728d0fe596dfdd82ef4a04c204ce3e107441", size = 288767123, upload-time = "2025-01-23T18:11:01.543Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/da/4de092c61c6dea1fc9c936e69308a02531d122e12f1f649825934ad651b5/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1", size = 156402859, upload-time = "2024-10-16T02:23:17.184Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/9e1e394a02a06f694be2c97bbe47288bb7c90ea84c7e9cf88f7b28afe165/nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7", size = 155595972, upload-time = "2024-10-15T22:58:35.426Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.26.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/5b/ca2f213f637305633814ae8c36b153220e40a07ea001966dcd87391f3acb/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522", size = 291671495, upload-time = "2025-03-13T00:30:07.805Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ca/f42388aed0fddd64ade7493dbba36e1f534d4e6fdbdd355c6a90030ae028/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6", size = 201319755, upload-time = "2025-03-13T00:29:55.296Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.61"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/f8/9d85593582bd99b8d7c65634d2304780aefade049b2b94d96e44084be90b/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17", size = 39243473, upload-time = "2025-01-23T18:03:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/af/53/698f3758f48c5fcb1112721e40cc6714da3980d3c7e93bae5b29dafa9857/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b80ecab31085dda3ce3b41d043be0ec739216c3fc633b8abe212d5a30026df0", size = 38374634, upload-time = "2025-01-23T18:02:35.812Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c6/0d1b2bfeb2ef42c06db0570c4d081e5cde4450b54c09e43165126cfe6ff6/nvidia_nvjitlink_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:1166a964d25fdc0eae497574d38824305195a5283324a21ccb0ce0c802cbf41c", size = 268514099, upload-time = "2025-01-23T18:12:33.874Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.55"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/e8/ae6ecbdade8bb9174d75db2b302c57c1c27d9277d6531c62aafde5fb32a3/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c38405335fbc0f0bf363eaeaeb476e8dfa8bae82fada41d25ace458b9ba9f3db", size = 91103, upload-time = "2025-01-23T17:50:24.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/cd/0e8c51b2ae3a58f054f2e7fe91b82d201abfb30167f2431e9bd92d532f42/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dd0780f1a55c21d8e06a743de5bd95653de630decfff40621dbde78cc307102", size = 89896, upload-time = "2025-01-23T17:50:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/84d46e62bfde46dd20cfb041e0bb5c2ec454fd6a384696e7fa3463c5bb59/nvidia_nvtx_cu12-12.8.55-py3-none-win_amd64.whl", hash = "sha256:9022681677aef1313458f88353ad9c0d2fbbe6402d6b07c9f00ba0e3ca8774d3", size = 56435, upload-time = "2025-01-23T18:06:06.268Z" },
 ]
 
 [[package]]
@@ -1662,9 +2023,9 @@ name = "pycollada"
 version = "0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/6b/caadd3d65fde5a6a5a33e608183d5a52525a41e2c44f479a99620413a661/pycollada-0.9.tar.gz", hash = "sha256:824f6e809e510d649b5984a6ea8e614ce5cf270c81eab6fbeaaf0ae71de6a6af", size = 109666, upload-time = "2025-02-16T22:59:04.849Z" }
@@ -1679,9 +2040,9 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "docutils" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/20/bb50f9de3a6de69e6abd6b087b52fa2418a0418b19597601605f855ad044/pydata_sphinx_theme-0.16.1.tar.gz", hash = "sha256:a08b7f0b7f70387219dc659bff0893a7554d5eb39b59d3b8ef37b8401b7642d7", size = 2412693, upload-time = "2024-12-17T10:53:39.537Z" }
@@ -1836,11 +2197,16 @@ name = "scipy"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -1875,11 +2241,16 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1935,11 +2306,21 @@ name = "scipy"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/18/b06a83f0c5ee8cddbde5e3f3d0bb9b702abfa5136ef6d4620ff67df7eee5/scipy-1.16.0.tar.gz", hash = "sha256:b5ef54021e832869c8cfb03bc3bf20366cbcd426e02a58e8a58d7584dfbb8f62", size = 30581216, upload-time = "2025-06-22T16:27:55.782Z" }
 wheels = [
@@ -1982,15 +2363,29 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
 name = "shapely"
 version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/c0/a911d1fd765d07a2b6769ce155219a281bfbe311584ebe97340d75c5bdb1/shapely-2.0.7.tar.gz", hash = "sha256:28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5", size = 283413, upload-time = "2025-01-31T01:10:20.787Z" }
 wheels = [
@@ -2031,14 +2426,29 @@ name = "shapely"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/3c/2da625233f4e605155926566c0e7ea8dda361877f48e8b1655e53456f252/shapely-2.1.1.tar.gz", hash = "sha256:500621967f2ffe9642454808009044c21e5b35db89ce69f8a2042c2ffd0e2772", size = 315422, upload-time = "2025-05-19T11:04:41.265Z" }
 wheels = [
@@ -2125,28 +2535,33 @@ name = "sphinx"
 version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "babel", marker = "python_full_version < '3.10'" },
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "imagesize", marker = "python_full_version < '3.10'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "requests", marker = "python_full_version < '3.10'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "babel", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "(python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "docutils", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "imagesize", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "jinja2", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "packaging", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pygments", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "requests", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "tomli", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
 wheels = [
@@ -2158,27 +2573,32 @@ name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "babel", marker = "python_full_version == '3.10.*'" },
-    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version == '3.10.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.10.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.10.*'" },
-    { name = "packaging", marker = "python_full_version == '3.10.*'" },
-    { name = "pygments", marker = "python_full_version == '3.10.*'" },
-    { name = "requests", marker = "python_full_version == '3.10.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.10.*'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "babel", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "(python_full_version == '3.10.*' and sys_platform == 'win32') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "docutils", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "imagesize", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "jinja2", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "packaging", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pygments", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "requests", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "tomli", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2190,27 +2610,37 @@ name = "sphinx"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "babel", marker = "python_full_version >= '3.11'" },
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.11'" },
-    { name = "imagesize", marker = "python_full_version >= '3.11'" },
-    { name = "jinja2", marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "requests", marker = "python_full_version >= '3.11'" },
-    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
+    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "babel", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "docutils", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "imagesize", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "jinja2", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "requests", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
@@ -2222,9 +2652,9 @@ name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
@@ -2236,9 +2666,9 @@ name = "sphinx-design"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -2252,9 +2682,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/53/a9a91995cb365e589f413b77fc75f1c0e9b4ac61bfa8da52a779ad855cc0/sphinx-tabs-3.4.7.tar.gz", hash = "sha256:991ad4a424ff54119799ba1491701aa8130dd43509474aef45a81c42d889784d", size = 15891, upload-time = "2024-10-08T13:37:27.887Z" }
 wheels = [
@@ -2303,9 +2733,9 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/69/bf039237ad260073e8c02f820b3e00dc34f3a2de20aff7861e6b19d2f8c5/sphinxcontrib_mermaid-1.0.0.tar.gz", hash = "sha256:2e8ab67d3e1e2816663f9347d026a8dee4a858acdd4ad32dd1c808893db88146", size = 15153, upload-time = "2024-10-12T16:33:03.863Z" }
 wheels = [
@@ -2328,6 +2758,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -2370,11 +2812,120 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/27/2e06cb52adf89fe6e020963529d17ed51532fc73c1e6d1b18420ef03338c/torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a103b5d782af5bd119b81dbcc7ffc6fa09904c423ff8db397a1e6ea8fd71508f", size = 99089441, upload-time = "2025-06-04T17:38:48.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7c/0a5b3aee977596459ec45be2220370fde8e017f651fecc40522fd478cb1e/torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fe955951bdf32d182ee8ead6c3186ad54781492bf03d547d31771a01b3d6fb7d", size = 821154516, upload-time = "2025-06-04T17:36:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/3d709cfc5e15995fb3fe7a6b564ce42280d3a55676dad672205e94f34ac9/torch-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:885453d6fba67d9991132143bf7fa06b79b24352f4506fd4d10b309f53454162", size = 216093147, upload-time = "2025-06-04T17:39:38.132Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f6/5da3918414e07da9866ecb9330fe6ffdebe15cb9a4c5ada7d4b6e0a6654d/torch-2.7.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:d72acfdb86cee2a32c0ce0101606f3758f0d8bb5f8f31e7920dc2809e963aa7c", size = 68630914, upload-time = "2025-06-04T17:39:31.162Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/2eae3494e3d375533034a8e8cf0ba163363e996d85f0629441fa9d9843fe/torch-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:236f501f2e383f1cb861337bdf057712182f910f10aeaf509065d54d339e49b2", size = 99093039, upload-time = "2025-06-04T17:39:06.963Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/94/34b80bd172d0072c9979708ccd279c2da2f55c3ef318eceec276ab9544a4/torch-2.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:06eea61f859436622e78dd0cdd51dbc8f8c6d76917a9cf0555a333f9eac31ec1", size = 821174704, upload-time = "2025-06-04T17:37:03.799Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9e/acf04ff375b0b49a45511c55d188bcea5c942da2aaf293096676110086d1/torch-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:8273145a2e0a3c6f9fd2ac36762d6ee89c26d430e612b95a99885df083b04e52", size = 216095937, upload-time = "2025-06-04T17:39:24.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/2b/d36d57c66ff031f93b4fa432e86802f84991477e522adcdffd314454326b/torch-2.7.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:aea4fc1bf433d12843eb2c6b2204861f43d8364597697074c8d38ae2507f8730", size = 68640034, upload-time = "2025-06-04T17:39:17.989Z" },
+    { url = "https://files.pythonhosted.org/packages/87/93/fb505a5022a2e908d81fe9a5e0aa84c86c0d5f408173be71c6018836f34e/torch-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ea1e518df4c9de73af7e8a720770f3628e7f667280bce2be7a16292697e3fa", size = 98948276, upload-time = "2025-06-04T17:39:12.852Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7e/67c3fe2b8c33f40af06326a3d6ae7776b3e3a01daa8f71d125d78594d874/torch-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c33360cfc2edd976c2633b3b66c769bdcbbf0e0b6550606d188431c81e7dd1fc", size = 821025792, upload-time = "2025-06-04T17:34:58.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/37/a37495502bc7a23bf34f89584fa5a78e25bae7b8da513bc1b8f97afb7009/torch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8bf6e1856ddd1807e79dc57e54d3335f2b62e6f316ed13ed3ecfe1fc1df3d8b", size = 216050349, upload-time = "2025-06-04T17:38:59.709Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/04b77281c730bb13460628e518c52721257814ac6c298acd25757f6a175c/torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb", size = 68645146, upload-time = "2025-06-04T17:38:52.97Z" },
+    { url = "https://files.pythonhosted.org/packages/66/81/e48c9edb655ee8eb8c2a6026abdb6f8d2146abd1f150979ede807bb75dcb/torch-2.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:03563603d931e70722dce0e11999d53aa80a375a3d78e6b39b9f6805ea0a8d28", size = 98946649, upload-time = "2025-06-04T17:38:43.031Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/24/efe2f520d75274fc06b695c616415a1e8a1021d87a13c68ff9dce733d088/torch-2.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d632f5417b6980f61404a125b999ca6ebd0b8b4bbdbb5fbbba44374ab619a412", size = 821033192, upload-time = "2025-06-04T17:38:09.146Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d9/9c24d230333ff4e9b6807274f6f8d52a864210b52ec794c5def7925f4495/torch-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:23660443e13995ee93e3d844786701ea4ca69f337027b05182f5ba053ce43b38", size = 216055668, upload-time = "2025-06-04T17:38:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/e086ee36ddcef9299f6e708d3b6c8487c1651787bb9ee2939eb2a7f74911/torch-2.7.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585", size = 68925988, upload-time = "2025-06-04T17:38:29.273Z" },
+    { url = "https://files.pythonhosted.org/packages/69/6a/67090dcfe1cf9048448b31555af6efb149f7afa0a310a366adbdada32105/torch-2.7.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e08d7e6f21a617fe38eeb46dd2213ded43f27c072e9165dc27300c9ef9570934", size = 99028857, upload-time = "2025-06-04T17:37:50.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/48b988870823d1cc381f15ec4e70ed3d65e043f43f919329b0045ae83529/torch-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:30207f672328a42df4f2174b8f426f354b2baa0b7cca3a0adb3d6ab5daf00dc8", size = 821098066, upload-time = "2025-06-04T17:37:33.939Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/eb/10050d61c9d5140c5dc04a89ed3257ef1a6b93e49dd91b95363d757071e0/torch-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:79042feca1c634aaf6603fe6feea8c6b30dfa140a6bbc0b973e2260c7e79a22e", size = 216336310, upload-time = "2025-06-04T17:36:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/beb45cdf5c4fc3ebe282bf5eafc8dfd925ead7299b3c97491900fe5ed844/torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946", size = 68645708, upload-time = "2025-06-04T17:34:39.852Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8a/7db5ed2696e9d67dbc7f8df02d0bc1680b68a0552a3c07ea2d1795fb3f19/torch-2.7.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e0d81e9a12764b6f3879a866607c8ae93113cbcad57ce01ebde63eb48a576369", size = 99140587, upload-time = "2025-06-04T17:36:46.282Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7b/62bedf718e6100c6d1d53fbdb7e56cb7ad80912a57f2bc7f4f1f289988f1/torch-2.7.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8394833c44484547ed4a47162318337b88c97acdb3273d85ea06e03ffff44998", size = 821146689, upload-time = "2025-06-04T17:35:47.69Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e3/80230d0eec3a4dd1b5d2b423e663026452ac8ffb64aeac1619febc1b4ac7/torch-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:df41989d9300e6e3c19ec9f56f856187a6ef060c3662fe54f4b6baf1fc90bd19", size = 215987480, upload-time = "2025-06-04T17:35:19.335Z" },
+    { url = "https://files.pythonhosted.org/packages/62/77/6391214d084a85aeb099d520420d39f405928b6a5f27a3f1a453c27c5173/torch-2.7.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:a737b5edd1c44a5c1ece2e9f3d00df9d1b3fb9541138bee56d83d38293fb6c9d", size = 68630146, upload-time = "2025-06-04T17:35:26.434Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.7.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.11' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:aca3472608e3c92df5166537595687b53a6c997082478b372427b043dbed98d0" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d6c3cba198dc93f93422a8545f48a6697890366e4b9701f54351fc27e2304bd3" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:5174f02de8ca14df87c8e333c4c39cf3ce93a323c9d470d690301d110a053b3c" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a0954c54fd7cb9f45beab1272dece2a05b0e77023c1da33ba32a7919661260f" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c301dc280458afd95450af794924c98fe07522dd148ff384739b810e3e3179f2" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:138c66dcd0ed2f07aafba3ed8b7958e2bed893694990e0b4b55b6b2b4a336aa6" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:268e54db9f0bc2b7b9eb089852d3e592c2dea2facc3db494100c3d3b796549fa" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0b64f7d0a6f2a739ed052ba959f7b67c677028c9566ce51997f9f90fe573ddaa" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:2bb8c05d48ba815b316879a18195d53a6472a03e297d971e916753f8e1053d30" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d56d29a6ad7758ba5173cc2b0c51c93e126e2b0a918e874101dc66545283967f" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9560425f9ea1af1791507e8ca70d5b9ecf62fed7ca226a95fcd58d0eb2cca78f" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:500ad5b670483f62d4052e41948a3fb19e8c8de65b99f8d418d879cbb15a82d6" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f112465fdf42eb1297c6dddda1a8b7f411914428b704e1b8a47870c52e290909" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c355db49c218ada70321d5c5c9bb3077312738b99113c8f3723ef596b554a7b9" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:e27e5f7e74179fb5d814a0412e5026e4b50c9e0081e9050bc4c28c992a276eb1" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:01d4745b4289d8a238c1741cae9920241fb1be199108c83002c661fc3e4d60da" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:738ac9b3ad79e62a21256e3d250cee858de955f93f89fab114da8d1919347d06" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp39-cp39-win_amd64.whl", hash = "sha256:9eadb0a49ae383b2d20e059b8614485cf216f3ebd13c4f401daa917e9979254b" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -2386,13 +2937,29 @@ name = "trimesh"
 version = "4.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/fb/b3d8fb188a1ec7df337df9e2fd5dea672c8806860677a7a6ef26b123865f/trimesh-4.6.12.tar.gz", hash = "sha256:cf8ad4a5c2d9b0277f34d999a077aa9331c465040c402774e1455054a6c20e67", size = 803682, upload-time = "2025-06-11T22:23:54.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/fa/3dc02004746b7708f3c206e6363da1dcdaed764f24a89fc3462ac2e01f2f/trimesh-4.6.12-py3-none-any.whl", hash = "sha256:71e71d1e698d2ffb73e60b461836352669974082fa7970807660bcd81de8aa30", size = 711977, upload-time = "2025-06-11T22:23:50.905Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/a9/549e51e9b1b2c9b854fd761a1d23df0ba2fbc60bd0c13b489ffa518cfcb7/triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e", size = 155600257, upload-time = "2025-05-29T23:39:36.085Z" },
+    { url = "https://files.pythonhosted.org/packages/21/2f/3e56ea7b58f80ff68899b1dbe810ff257c9d177d288c6b0f55bf2fe4eb50/triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b", size = 155689937, upload-time = "2025-05-29T23:39:44.182Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5f/950fb373bf9c01ad4eb5a8cd5eaf32cdf9e238c02f9293557a2129b9c4ac/triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43", size = 155669138, upload-time = "2025-05-29T23:39:51.771Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1f/dfb531f90a2d367d914adfee771babbd3f1a5b26c3f5fbc458dee21daa78/triton-3.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b89d846b5a4198317fec27a5d3a609ea96b6d557ff44b56c23176546023c4240", size = 155673035, upload-time = "2025-05-29T23:40:02.468Z" },
+    { url = "https://files.pythonhosted.org/packages/28/71/bd20ffcb7a64c753dc2463489a61bf69d531f308e390ad06390268c4ea04/triton-3.3.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3198adb9d78b77818a5388bff89fa72ff36f9da0bc689db2f0a651a67ce6a42", size = 155735832, upload-time = "2025-05-29T23:40:10.522Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/ac4d50af22f594c4cb7c84fd2ad5ba1e0c03e2a83fe3483ddd79edcd7ec7/triton-3.3.1-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f6139aeb04a146b0b8e0fbbd89ad1e65861c57cfed881f21d62d3cb94a36bab7", size = 155596799, upload-time = "2025-05-29T23:40:18.949Z" },
 ]
 
 [[package]]
@@ -2437,17 +3004,28 @@ name = "warp-lang"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'darwin') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'darwin') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/eb/bef2bf8404186115be15cd015c11ab356228410514c9878ad1a8b405b9a7/warp_lang-1.7.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:3825d7ddeb1c733812ff00cce12febcd7fb80b20c413b17e3517dc67b9d5b5ee", size = 45180599, upload-time = "2025-05-31T20:36:08.153Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/81/49be6af5701f21582b8b41ffb9c159bcf63606b83a7134f3906e670fa990/warp_lang-1.7.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:44ea71528d667b4a6b851767d2ccceee3c81a49956798122004aefd95e614a6f", size = 126571159, upload-time = "2025-05-31T20:36:14.246Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/56/3c004907c5322157b3e5dc6534f3d12ff55fbba0f2458bf8af6d767d0485/warp_lang-1.7.2-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e966450620d6c7a091417d9368528ed1ddf8e819304c84d12e0c440b2e47ef79", size = 127496325, upload-time = "2025-05-31T20:36:22.539Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/455ffdfd0e0aefcf7da0b90ec567329ca01c01e2c5cfafee207799efa627/warp_lang-1.7.2-py3-none-win_amd64.whl", hash = "sha256:a68dd8a4493670aa02ec12c4eb724d4ee9f54e47fa332333fb863a696fe4b40b", size = 108800535, upload-time = "2025-05-31T20:36:28.975Z" },
 ]
 
 [[package]]
@@ -2455,14 +3033,26 @@ name = "warp-lang"
 version = "1.8.0.dev20250625"
 source = { registry = "https://pypi.nvidia.com/" }
 resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform != 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin'",
-    "python_full_version < '3.10' and sys_platform != 'darwin'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'darwin'" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform != 'darwin') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform != 'darwin') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
 ]
 wheels = [
     { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce042da8e85f62acd0f8e1b61b18c02193c078581df5d9317ffd8310b386c9ce" },

--- a/uv.lock
+++ b/uv.lock
@@ -1365,9 +1365,8 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-cu128 = [
-    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+cu12 = [
+    { name = "torch" },
 ]
 dev = [
     { name = "alphashape" },
@@ -1422,15 +1421,14 @@ requires-dist = [
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = "<=0.6.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.3.0" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0.0" },
-    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cu128') or (sys_platform == 'win32' and extra == 'cu128')", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'cu128'", specifier = ">=2.7.0" },
+    { name = "torch", marker = "extra == 'cu12'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "newton-physics", extra = "cu12" } },
     { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.67.1" },
     { name = "trimesh", marker = "extra == 'dev'", specifier = ">=4.6.8" },
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'dev'", specifier = ">=25.5" },
     { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250625", index = "https://pypi.nvidia.com/" },
     { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250625" },
 ]
-provides-extras = ["cu128", "dev", "docs"]
+provides-extras = ["cu12", "dev", "docs"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "coverage", extras = ["toml"], specifier = ">=7.8.0" }]
@@ -2629,55 +2627,15 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.7.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.10' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/f6/5da3918414e07da9866ecb9330fe6ffdebe15cb9a4c5ada7d4b6e0a6654d/torch-2.7.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:d72acfdb86cee2a32c0ce0101606f3758f0d8bb5f8f31e7920dc2809e963aa7c", size = 68630914, upload-time = "2025-06-04T17:39:31.162Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/2b/d36d57c66ff031f93b4fa432e86802f84991477e522adcdffd314454326b/torch-2.7.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:aea4fc1bf433d12843eb2c6b2204861f43d8364597697074c8d38ae2507f8730", size = 68640034, upload-time = "2025-06-04T17:39:17.989Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/60/04b77281c730bb13460628e518c52721257814ac6c298acd25757f6a175c/torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb", size = 68645146, upload-time = "2025-06-04T17:38:52.97Z" },
-    { url = "https://files.pythonhosted.org/packages/95/bf/e086ee36ddcef9299f6e708d3b6c8487c1651787bb9ee2939eb2a7f74911/torch-2.7.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585", size = 68925988, upload-time = "2025-06-04T17:38:29.273Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/29/beb45cdf5c4fc3ebe282bf5eafc8dfd925ead7299b3c97491900fe5ed844/torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946", size = 68645708, upload-time = "2025-06-04T17:34:39.852Z" },
-    { url = "https://files.pythonhosted.org/packages/62/77/6391214d084a85aeb099d520420d39f405928b6a5f27a3f1a453c27c5173/torch-2.7.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:a737b5edd1c44a5c1ece2e9f3d00df9d1b3fb9541138bee56d83d38293fb6c9d", size = 68630146, upload-time = "2025-06-04T17:35:26.434Z" },
-]
-
-[[package]]
-name = "torch"
 version = "2.7.1+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
-resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
-    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
-]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2692,10 +2650,10 @@ dependencies = [
     { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
+    { name = "sympy" },
     { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:aca3472608e3c92df5166537595687b53a6c997082478b372427b043dbed98d0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2,45 +2,27 @@ version = 1
 revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
-conflicts = [[
-    { package = "newton-physics", extra = "cpu" },
-    { package = "newton-physics", extra = "cu128" },
-]]
 
 [[package]]
 name = "absl-py"
-version = "2.3.0"
+version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/15/18693af986560a5c3cc0b84a8046b536ffb2cdb536e03cce897f2759e284/absl_py-2.3.0.tar.gz", hash = "sha256:d96fda5c884f1b22178852f30ffa85766d50b99e00775ea626c23304f582fc4f", size = 116400, upload-time = "2025-05-27T09:15:50.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/2a/c93173ffa1b39c1d0395b7e842bbdc62e556ca9d8d3b5572926f3e4ca752/absl_py-2.3.1.tar.gz", hash = "sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9", size = 116588, upload-time = "2025-07-03T09:31:44.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/04/9d75e1d3bb4ab8ec67ff10919476ccdee06c098bcfcf3a352da5f985171d/absl_py-2.3.0-py3-none-any.whl", hash = "sha256:9824a48b654a306168f63e0d97714665f8490b8d89ec7bf2efc24bf67cf579b3", size = 135657, upload-time = "2025-05-27T09:15:48.742Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/aa/ba0014cc4659328dc818a28827be78e6d97312ab0cb98105a770924dc11e/absl_py-2.3.1-py3-none-any.whl", hash = "sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d", size = 135811, upload-time = "2025-07-03T09:31:42.253Z" },
 ]
 
 [[package]]
@@ -60,13 +42,9 @@ name = "alabaster"
 version = "0.7.16"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
 wheels = [
@@ -78,25 +56,15 @@ name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
 wheels = [
@@ -108,21 +76,21 @@ name = "alphashape"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "click-log" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "rtree" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "trimesh" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/83/67ff905694df5b34a777123b59fdfd05998d5a31766f188aafbf5b340055/alphashape-1.3.1.tar.gz", hash = "sha256:7a27340afc5f8ed301577acec46bb0cf2bada5410045f7289142e735ef6977ec", size = 26316, upload-time = "2021-04-16T17:47:19.486Z" }
@@ -240,16 +208,12 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -261,28 +225,18 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "colorama", marker = "(python_full_version >= '3.10' and sys_platform == 'win32') or (python_full_version < '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -294,8 +248,8 @@ name = "click-log"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/32/228be4f971e4bd556c33d52a22682bfe318ffe57a1ddb7a546f347a90260/click-log-0.4.0.tar.gz", hash = "sha256:3970f8570ac54491237bcdb3d8ab5e3eef6c057df29f8c3d1151a51a9c23b975", size = 9985, upload-time = "2022-03-13T11:10:15.262Z" }
 wheels = [
@@ -316,16 +270,12 @@ name = "contourpy"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -400,29 +350,19 @@ name = "contourpy"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -486,81 +426,81 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.9.1"
+version = "7.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/e0/98670a80884f64578f0c22cd70c5e81a6e07b08167721c7487b4d70a7ca0/coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec", size = 813650, upload-time = "2025-06-13T13:02:28.627Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/b7/c0465ca253df10a9e8dae0692a4ae6e9726d245390aaef92360e1d6d3832/coverage-7.9.2.tar.gz", hash = "sha256:997024fa51e3290264ffd7492ec97d0690293ccd2b45a6cd7d82d945a4a80c8b", size = 813556, upload-time = "2025-07-03T10:54:15.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/78/1c1c5ec58f16817c09cbacb39783c3655d54a221b6552f47ff5ac9297603/coverage-7.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca", size = 212028, upload-time = "2025-06-13T13:00:29.293Z" },
-    { url = "https://files.pythonhosted.org/packages/98/db/e91b9076f3a888e3b4ad7972ea3842297a52cc52e73fd1e529856e473510/coverage-7.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509", size = 212420, upload-time = "2025-06-13T13:00:34.027Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/d0/2b3733412954576b0aea0a16c3b6b8fbe95eb975d8bfa10b07359ead4252/coverage-7.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b", size = 241529, upload-time = "2025-06-13T13:00:35.786Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/00/5e2e5ae2e750a872226a68e984d4d3f3563cb01d1afb449a17aa819bc2c4/coverage-7.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3", size = 239403, upload-time = "2025-06-13T13:00:37.399Z" },
-    { url = "https://files.pythonhosted.org/packages/37/3b/a2c27736035156b0a7c20683afe7df498480c0dfdf503b8c878a21b6d7fb/coverage-7.9.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3", size = 240548, upload-time = "2025-06-13T13:00:39.647Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f5/13d5fc074c3c0e0dc80422d9535814abf190f1254d7c3451590dc4f8b18c/coverage-7.9.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5", size = 240459, upload-time = "2025-06-13T13:00:40.934Z" },
-    { url = "https://files.pythonhosted.org/packages/36/24/24b9676ea06102df824c4a56ffd13dc9da7904478db519efa877d16527d5/coverage-7.9.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187", size = 239128, upload-time = "2025-06-13T13:00:42.343Z" },
-    { url = "https://files.pythonhosted.org/packages/be/05/242b7a7d491b369ac5fee7908a6e5ba42b3030450f3ad62c645b40c23e0e/coverage-7.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce", size = 239402, upload-time = "2025-06-13T13:00:43.634Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e0/4de7f87192fa65c9c8fbaeb75507e124f82396b71de1797da5602898be32/coverage-7.9.1-cp310-cp310-win32.whl", hash = "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70", size = 214518, upload-time = "2025-06-13T13:00:45.622Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ab/5e4e2fe458907d2a65fab62c773671cfc5ac704f1e7a9ddd91996f66e3c2/coverage-7.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe", size = 215436, upload-time = "2025-06-13T13:00:47.245Z" },
-    { url = "https://files.pythonhosted.org/packages/60/34/fa69372a07d0903a78ac103422ad34db72281c9fc625eba94ac1185da66f/coverage-7.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582", size = 212146, upload-time = "2025-06-13T13:00:48.496Z" },
-    { url = "https://files.pythonhosted.org/packages/27/f0/da1894915d2767f093f081c42afeba18e760f12fdd7a2f4acbe00564d767/coverage-7.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86", size = 212536, upload-time = "2025-06-13T13:00:51.535Z" },
-    { url = "https://files.pythonhosted.org/packages/10/d5/3fc33b06e41e390f88eef111226a24e4504d216ab8e5d1a7089aa5a3c87a/coverage-7.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed", size = 245092, upload-time = "2025-06-13T13:00:52.883Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/39/7aa901c14977aba637b78e95800edf77f29f5a380d29768c5b66f258305b/coverage-7.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d", size = 242806, upload-time = "2025-06-13T13:00:54.571Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fc/30e5cfeaf560b1fc1989227adedc11019ce4bb7cce59d65db34fe0c2d963/coverage-7.9.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338", size = 244610, upload-time = "2025-06-13T13:00:56.932Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/15/cca62b13f39650bc87b2b92bb03bce7f0e79dd0bf2c7529e9fc7393e4d60/coverage-7.9.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875", size = 244257, upload-time = "2025-06-13T13:00:58.545Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1a/c0f2abe92c29e1464dbd0ff9d56cb6c88ae2b9e21becdb38bea31fcb2f6c/coverage-7.9.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250", size = 242309, upload-time = "2025-06-13T13:00:59.836Z" },
-    { url = "https://files.pythonhosted.org/packages/57/8d/c6fd70848bd9bf88fa90df2af5636589a8126d2170f3aade21ed53f2b67a/coverage-7.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c", size = 242898, upload-time = "2025-06-13T13:01:02.506Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/9e/6ca46c7bff4675f09a66fe2797cd1ad6a24f14c9c7c3b3ebe0470a6e30b8/coverage-7.9.1-cp311-cp311-win32.whl", hash = "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32", size = 214561, upload-time = "2025-06-13T13:01:04.012Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/30/166978c6302010742dabcdc425fa0f938fa5a800908e39aff37a7a876a13/coverage-7.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125", size = 215493, upload-time = "2025-06-13T13:01:05.702Z" },
-    { url = "https://files.pythonhosted.org/packages/60/07/a6d2342cd80a5be9f0eeab115bc5ebb3917b4a64c2953534273cf9bc7ae6/coverage-7.9.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e", size = 213869, upload-time = "2025-06-13T13:01:09.345Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d9/7f66eb0a8f2fce222de7bdc2046ec41cb31fe33fb55a330037833fb88afc/coverage-7.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626", size = 212336, upload-time = "2025-06-13T13:01:10.909Z" },
-    { url = "https://files.pythonhosted.org/packages/20/20/e07cb920ef3addf20f052ee3d54906e57407b6aeee3227a9c91eea38a665/coverage-7.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb", size = 212571, upload-time = "2025-06-13T13:01:12.518Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f8/96f155de7e9e248ca9c8ff1a40a521d944ba48bec65352da9be2463745bf/coverage-7.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300", size = 246377, upload-time = "2025-06-13T13:01:14.87Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/cf/1d783bd05b7bca5c10ded5f946068909372e94615a4416afadfe3f63492d/coverage-7.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8", size = 243394, upload-time = "2025-06-13T13:01:16.23Z" },
-    { url = "https://files.pythonhosted.org/packages/02/dd/e7b20afd35b0a1abea09fb3998e1abc9f9bd953bee548f235aebd2b11401/coverage-7.9.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5", size = 245586, upload-time = "2025-06-13T13:01:17.532Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/38/b30b0006fea9d617d1cb8e43b1bc9a96af11eff42b87eb8c716cf4d37469/coverage-7.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd", size = 245396, upload-time = "2025-06-13T13:01:19.164Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e4/4d8ec1dc826e16791f3daf1b50943e8e7e1eb70e8efa7abb03936ff48418/coverage-7.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898", size = 243577, upload-time = "2025-06-13T13:01:22.433Z" },
-    { url = "https://files.pythonhosted.org/packages/25/f4/b0e96c5c38e6e40ef465c4bc7f138863e2909c00e54a331da335faf0d81a/coverage-7.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d", size = 244809, upload-time = "2025-06-13T13:01:24.143Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/65/27e0a1fa5e2e5079bdca4521be2f5dabf516f94e29a0defed35ac2382eb2/coverage-7.9.1-cp312-cp312-win32.whl", hash = "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74", size = 214724, upload-time = "2025-06-13T13:01:25.435Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/a8/d5b128633fd1a5e0401a4160d02fa15986209a9e47717174f99dc2f7166d/coverage-7.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e", size = 215535, upload-time = "2025-06-13T13:01:27.861Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/37/84bba9d2afabc3611f3e4325ee2c6a47cd449b580d4a606b240ce5a6f9bf/coverage-7.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342", size = 213904, upload-time = "2025-06-13T13:01:29.202Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a7/a027970c991ca90f24e968999f7d509332daf6b8c3533d68633930aaebac/coverage-7.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631", size = 212358, upload-time = "2025-06-13T13:01:30.909Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/48/6aaed3651ae83b231556750280682528fea8ac7f1232834573472d83e459/coverage-7.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f", size = 212620, upload-time = "2025-06-13T13:01:32.256Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/2a/f4b613f3b44d8b9f144847c89151992b2b6b79cbc506dee89ad0c35f209d/coverage-7.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd", size = 245788, upload-time = "2025-06-13T13:01:33.948Z" },
-    { url = "https://files.pythonhosted.org/packages/04/d2/de4fdc03af5e4e035ef420ed26a703c6ad3d7a07aff2e959eb84e3b19ca8/coverage-7.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86", size = 243001, upload-time = "2025-06-13T13:01:35.285Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e8/eed18aa5583b0423ab7f04e34659e51101135c41cd1dcb33ac1d7013a6d6/coverage-7.9.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43", size = 244985, upload-time = "2025-06-13T13:01:36.712Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f8/ae9e5cce8885728c934eaa58ebfa8281d488ef2afa81c3dbc8ee9e6d80db/coverage-7.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1", size = 245152, upload-time = "2025-06-13T13:01:39.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/c8/272c01ae792bb3af9b30fac14d71d63371db227980682836ec388e2c57c0/coverage-7.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751", size = 243123, upload-time = "2025-06-13T13:01:40.727Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d0/2819a1e3086143c094ab446e3bdf07138527a7b88cb235c488e78150ba7a/coverage-7.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67", size = 244506, upload-time = "2025-06-13T13:01:42.184Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/4e/9f6117b89152df7b6112f65c7a4ed1f2f5ec8e60c4be8f351d91e7acc848/coverage-7.9.1-cp313-cp313-win32.whl", hash = "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643", size = 214766, upload-time = "2025-06-13T13:01:44.482Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0f/4b59f7c93b52c2c4ce7387c5a4e135e49891bb3b7408dcc98fe44033bbe0/coverage-7.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a", size = 215568, upload-time = "2025-06-13T13:01:45.772Z" },
-    { url = "https://files.pythonhosted.org/packages/09/1e/9679826336f8c67b9c39a359352882b24a8a7aee48d4c9cad08d38d7510f/coverage-7.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d", size = 213939, upload-time = "2025-06-13T13:01:47.087Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/5b/5c6b4e7a407359a2e3b27bf9c8a7b658127975def62077d441b93a30dbe8/coverage-7.9.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0", size = 213079, upload-time = "2025-06-13T13:01:48.554Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/22/1e2e07279fd2fd97ae26c01cc2186e2258850e9ec125ae87184225662e89/coverage-7.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d", size = 213299, upload-time = "2025-06-13T13:01:49.997Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c0/4c5125a4b69d66b8c85986d3321520f628756cf524af810baab0790c7647/coverage-7.9.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f", size = 256535, upload-time = "2025-06-13T13:01:51.314Z" },
-    { url = "https://files.pythonhosted.org/packages/81/8b/e36a04889dda9960be4263e95e777e7b46f1bb4fc32202612c130a20c4da/coverage-7.9.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029", size = 252756, upload-time = "2025-06-13T13:01:54.403Z" },
-    { url = "https://files.pythonhosted.org/packages/98/82/be04eff8083a09a4622ecd0e1f31a2c563dbea3ed848069e7b0445043a70/coverage-7.9.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece", size = 254912, upload-time = "2025-06-13T13:01:56.769Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/25/c26610a2c7f018508a5ab958e5b3202d900422cf7cdca7670b6b8ca4e8df/coverage-7.9.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683", size = 256144, upload-time = "2025-06-13T13:01:58.19Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/8b/fb9425c4684066c79e863f1e6e7ecebb49e3a64d9f7f7860ef1688c56f4a/coverage-7.9.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f", size = 254257, upload-time = "2025-06-13T13:01:59.645Z" },
-    { url = "https://files.pythonhosted.org/packages/93/df/27b882f54157fc1131e0e215b0da3b8d608d9b8ef79a045280118a8f98fe/coverage-7.9.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10", size = 255094, upload-time = "2025-06-13T13:02:01.37Z" },
-    { url = "https://files.pythonhosted.org/packages/41/5f/cad1c3dbed8b3ee9e16fa832afe365b4e3eeab1fb6edb65ebbf745eabc92/coverage-7.9.1-cp313-cp313t-win32.whl", hash = "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363", size = 215437, upload-time = "2025-06-13T13:02:02.905Z" },
-    { url = "https://files.pythonhosted.org/packages/99/4d/fad293bf081c0e43331ca745ff63673badc20afea2104b431cdd8c278b4c/coverage-7.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7", size = 216605, upload-time = "2025-06-13T13:02:05.638Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/56/4ee027d5965fc7fc126d7ec1187529cc30cc7d740846e1ecb5e92d31b224/coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c", size = 214392, upload-time = "2025-06-13T13:02:07.642Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d6/c41dd9b02bf16ec001aaf1cbef665537606899a3db1094e78f5ae17540ca/coverage-7.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951", size = 212029, upload-time = "2025-06-13T13:02:09.058Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/c0/40420d81d731f84c3916dcdf0506b3e6c6570817bff2576b83f780914ae6/coverage-7.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58", size = 212407, upload-time = "2025-06-13T13:02:11.151Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/87/f0db7d62d0e09f14d6d2f6ae8c7274a2f09edf74895a34b412a0601e375a/coverage-7.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71", size = 241160, upload-time = "2025-06-13T13:02:12.864Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/b7/3337c064f058a5d7696c4867159651a5b5fb01a5202bcf37362f0c51400e/coverage-7.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55", size = 239027, upload-time = "2025-06-13T13:02:14.294Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/a9/5898a283f66d1bd413c32c2e0e05408196fd4f37e206e2b06c6e0c626e0e/coverage-7.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b", size = 240145, upload-time = "2025-06-13T13:02:15.745Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/33/d96e3350078a3c423c549cb5b2ba970de24c5257954d3e4066e2b2152d30/coverage-7.9.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7", size = 239871, upload-time = "2025-06-13T13:02:17.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/6e/6fb946072455f71a820cac144d49d11747a0f1a21038060a68d2d0200499/coverage-7.9.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385", size = 238122, upload-time = "2025-06-13T13:02:18.849Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5c/bc43f25c8586840ce25a796a8111acf6a2b5f0909ba89a10d41ccff3920d/coverage-7.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed", size = 239058, upload-time = "2025-06-13T13:02:21.423Z" },
-    { url = "https://files.pythonhosted.org/packages/11/d8/ce2007418dd7fd00ff8c8b898bb150bb4bac2d6a86df05d7b88a07ff595f/coverage-7.9.1-cp39-cp39-win32.whl", hash = "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d", size = 214532, upload-time = "2025-06-13T13:02:22.857Z" },
-    { url = "https://files.pythonhosted.org/packages/20/21/334e76fa246e92e6d69cab217f7c8a70ae0cc8f01438bd0544103f29528e/coverage-7.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244", size = 215439, upload-time = "2025-06-13T13:02:24.268Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/e5/c723545c3fd3204ebde3b4cc4b927dce709d3b6dc577754bb57f63ca4a4a/coverage-7.9.1-pp39.pp310.pp311-none-any.whl", hash = "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514", size = 204009, upload-time = "2025-06-13T13:02:25.787Z" },
-    { url = "https://files.pythonhosted.org/packages/08/b8/7ddd1e8ba9701dea08ce22029917140e6f66a859427406579fd8d0ca7274/coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c", size = 204000, upload-time = "2025-06-13T13:02:27.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0d/5c2114fd776c207bd55068ae8dc1bef63ecd1b767b3389984a8e58f2b926/coverage-7.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:66283a192a14a3854b2e7f3418d7db05cdf411012ab7ff5db98ff3b181e1f912", size = 212039, upload-time = "2025-07-03T10:52:38.955Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ad/dc51f40492dc2d5fcd31bb44577bc0cc8920757d6bc5d3e4293146524ef9/coverage-7.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4e01d138540ef34fcf35c1aa24d06c3de2a4cffa349e29a10056544f35cca15f", size = 212428, upload-time = "2025-07-03T10:52:41.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a3/55cb3ff1b36f00df04439c3993d8529193cdf165a2467bf1402539070f16/coverage-7.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f22627c1fe2745ee98d3ab87679ca73a97e75ca75eb5faee48660d060875465f", size = 241534, upload-time = "2025-07-03T10:52:42.956Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/c9/a8410b91b6be4f6e9c2e9f0dce93749b6b40b751d7065b4410bf89cb654b/coverage-7.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b1c2d8363247b46bd51f393f86c94096e64a1cf6906803fa8d5a9d03784bdbf", size = 239408, upload-time = "2025-07-03T10:52:44.199Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c4/6f3e56d467c612b9070ae71d5d3b114c0b899b5788e1ca3c93068ccb7018/coverage-7.9.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c10c882b114faf82dbd33e876d0cbd5e1d1ebc0d2a74ceef642c6152f3f4d547", size = 240552, upload-time = "2025-07-03T10:52:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/20/04eda789d15af1ce79bce5cc5fd64057c3a0ac08fd0576377a3096c24663/coverage-7.9.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:de3c0378bdf7066c3988d66cd5232d161e933b87103b014ab1b0b4676098fa45", size = 240464, upload-time = "2025-07-03T10:52:46.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5a/217b32c94cc1a0b90f253514815332d08ec0812194a1ce9cca97dda1cd20/coverage-7.9.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1e2f097eae0e5991e7623958a24ced3282676c93c013dde41399ff63e230fcf2", size = 239134, upload-time = "2025-07-03T10:52:48.149Z" },
+    { url = "https://files.pythonhosted.org/packages/34/73/1d019c48f413465eb5d3b6898b6279e87141c80049f7dbf73fd020138549/coverage-7.9.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28dc1f67e83a14e7079b6cea4d314bc8b24d1aed42d3582ff89c0295f09b181e", size = 239405, upload-time = "2025-07-03T10:52:49.687Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6c/a2beca7aa2595dad0c0d3f350382c381c92400efe5261e2631f734a0e3fe/coverage-7.9.2-cp310-cp310-win32.whl", hash = "sha256:bf7d773da6af9e10dbddacbf4e5cab13d06d0ed93561d44dae0188a42c65be7e", size = 214519, upload-time = "2025-07-03T10:52:51.036Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c8/91e5e4a21f9a51e2c7cdd86e587ae01a4fcff06fc3fa8cde4d6f7cf68df4/coverage-7.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:0c0378ba787681ab1897f7c89b415bd56b0b2d9a47e5a3d8dc0ea55aac118d6c", size = 215400, upload-time = "2025-07-03T10:52:52.313Z" },
+    { url = "https://files.pythonhosted.org/packages/39/40/916786453bcfafa4c788abee4ccd6f592b5b5eca0cd61a32a4e5a7ef6e02/coverage-7.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a7a56a2964a9687b6aba5b5ced6971af308ef6f79a91043c05dd4ee3ebc3e9ba", size = 212152, upload-time = "2025-07-03T10:52:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/66/cc13bae303284b546a030762957322bbbff1ee6b6cb8dc70a40f8a78512f/coverage-7.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:123d589f32c11d9be7fe2e66d823a236fe759b0096f5db3fb1b75b2fa414a4fa", size = 212540, upload-time = "2025-07-03T10:52:55.196Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3c/d56a764b2e5a3d43257c36af4a62c379df44636817bb5f89265de4bf8bd7/coverage-7.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:333b2e0ca576a7dbd66e85ab402e35c03b0b22f525eed82681c4b866e2e2653a", size = 245097, upload-time = "2025-07-03T10:52:56.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/46/bd064ea8b3c94eb4ca5d90e34d15b806cba091ffb2b8e89a0d7066c45791/coverage-7.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:326802760da234baf9f2f85a39e4a4b5861b94f6c8d95251f699e4f73b1835dc", size = 242812, upload-time = "2025-07-03T10:52:57.842Z" },
+    { url = "https://files.pythonhosted.org/packages/43/02/d91992c2b29bc7afb729463bc918ebe5f361be7f1daae93375a5759d1e28/coverage-7.9.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19e7be4cfec248df38ce40968c95d3952fbffd57b400d4b9bb580f28179556d2", size = 244617, upload-time = "2025-07-03T10:52:59.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4f/8fadff6bf56595a16d2d6e33415841b0163ac660873ed9a4e9046194f779/coverage-7.9.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0b4a4cb73b9f2b891c1788711408ef9707666501ba23684387277ededab1097c", size = 244263, upload-time = "2025-07-03T10:53:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/d2/e0be7446a2bba11739edb9f9ba4eff30b30d8257370e237418eb44a14d11/coverage-7.9.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2c8937fa16c8c9fbbd9f118588756e7bcdc7e16a470766a9aef912dd3f117dbd", size = 242314, upload-time = "2025-07-03T10:53:01.932Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7d/dcbac9345000121b8b57a3094c2dfcf1ccc52d8a14a40c1d4bc89f936f80/coverage-7.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:42da2280c4d30c57a9b578bafd1d4494fa6c056d4c419d9689e66d775539be74", size = 242904, upload-time = "2025-07-03T10:53:03.478Z" },
+    { url = "https://files.pythonhosted.org/packages/41/58/11e8db0a0c0510cf31bbbdc8caf5d74a358b696302a45948d7c768dfd1cf/coverage-7.9.2-cp311-cp311-win32.whl", hash = "sha256:14fa8d3da147f5fdf9d298cacc18791818f3f1a9f542c8958b80c228320e90c6", size = 214553, upload-time = "2025-07-03T10:53:05.174Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7d/751794ec8907a15e257136e48dc1021b1f671220ecccfd6c4eaf30802714/coverage-7.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:549cab4892fc82004f9739963163fd3aac7a7b0df430669b75b86d293d2df2a7", size = 215441, upload-time = "2025-07-03T10:53:06.472Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5b/34abcedf7b946c1c9e15b44f326cb5b0da852885312b30e916f674913428/coverage-7.9.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2667a2b913e307f06aa4e5677f01a9746cd08e4b35e14ebcde6420a9ebb4c62", size = 213873, upload-time = "2025-07-03T10:53:07.699Z" },
+    { url = "https://files.pythonhosted.org/packages/53/d7/7deefc6fd4f0f1d4c58051f4004e366afc9e7ab60217ac393f247a1de70a/coverage-7.9.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ae9eb07f1cfacd9cfe8eaee6f4ff4b8a289a668c39c165cd0c8548484920ffc0", size = 212344, upload-time = "2025-07-03T10:53:09.3Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0c/ee03c95d32be4d519e6a02e601267769ce2e9a91fc8faa1b540e3626c680/coverage-7.9.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9ce85551f9a1119f02adc46d3014b5ee3f765deac166acf20dbb851ceb79b6f3", size = 212580, upload-time = "2025-07-03T10:53:11.52Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9f/826fa4b544b27620086211b87a52ca67592622e1f3af9e0a62c87aea153a/coverage-7.9.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8f6389ac977c5fb322e0e38885fbbf901743f79d47f50db706e7644dcdcb6e1", size = 246383, upload-time = "2025-07-03T10:53:13.134Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b3/4477aafe2a546427b58b9c540665feff874f4db651f4d3cb21b308b3a6d2/coverage-7.9.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff0d9eae8cdfcd58fe7893b88993723583a6ce4dfbfd9f29e001922544f95615", size = 243400, upload-time = "2025-07-03T10:53:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/c2/efffa43778490c226d9d434827702f2dfbc8041d79101a795f11cbb2cf1e/coverage-7.9.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fae939811e14e53ed8a9818dad51d434a41ee09df9305663735f2e2d2d7d959b", size = 245591, upload-time = "2025-07-03T10:53:15.872Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e7/a59888e882c9a5f0192d8627a30ae57910d5d449c80229b55e7643c078c4/coverage-7.9.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:31991156251ec202c798501e0a42bbdf2169dcb0f137b1f5c0f4267f3fc68ef9", size = 245402, upload-time = "2025-07-03T10:53:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a5/72fcd653ae3d214927edc100ce67440ed8a0a1e3576b8d5e6d066ed239db/coverage-7.9.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d0d67963f9cbfc7c7f96d4ac74ed60ecbebd2ea6eeb51887af0f8dce205e545f", size = 243583, upload-time = "2025-07-03T10:53:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f5/84e70e4df28f4a131d580d7d510aa1ffd95037293da66fd20d446090a13b/coverage-7.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:49b752a2858b10580969ec6af6f090a9a440a64a301ac1528d7ca5f7ed497f4d", size = 244815, upload-time = "2025-07-03T10:53:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e7/d73d7cbdbd09fdcf4642655ae843ad403d9cbda55d725721965f3580a314/coverage-7.9.2-cp312-cp312-win32.whl", hash = "sha256:88d7598b8ee130f32f8a43198ee02edd16d7f77692fa056cb779616bbea1b355", size = 214719, upload-time = "2025-07-03T10:53:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d6/7486dcc3474e2e6ad26a2af2db7e7c162ccd889c4c68fa14ea8ec189c9e9/coverage-7.9.2-cp312-cp312-win_amd64.whl", hash = "sha256:9dfb070f830739ee49d7c83e4941cc767e503e4394fdecb3b54bfdac1d7662c0", size = 215509, upload-time = "2025-07-03T10:53:22.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/34/0439f1ae2593b0346164d907cdf96a529b40b7721a45fdcf8b03c95fcd90/coverage-7.9.2-cp312-cp312-win_arm64.whl", hash = "sha256:4e2c058aef613e79df00e86b6d42a641c877211384ce5bd07585ed7ba71ab31b", size = 213910, upload-time = "2025-07-03T10:53:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/94/9d/7a8edf7acbcaa5e5c489a646226bed9591ee1c5e6a84733c0140e9ce1ae1/coverage-7.9.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:985abe7f242e0d7bba228ab01070fde1d6c8fa12f142e43debe9ed1dde686038", size = 212367, upload-time = "2025-07-03T10:53:25.811Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9e/5cd6f130150712301f7e40fb5865c1bc27b97689ec57297e568d972eec3c/coverage-7.9.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82c3939264a76d44fde7f213924021ed31f55ef28111a19649fec90c0f109e6d", size = 212632, upload-time = "2025-07-03T10:53:27.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/de/6287a2c2036f9fd991c61cefa8c64e57390e30c894ad3aa52fac4c1e14a8/coverage-7.9.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae5d563e970dbe04382f736ec214ef48103d1b875967c89d83c6e3f21706d5b3", size = 245793, upload-time = "2025-07-03T10:53:28.408Z" },
+    { url = "https://files.pythonhosted.org/packages/06/cc/9b5a9961d8160e3cb0b558c71f8051fe08aa2dd4b502ee937225da564ed1/coverage-7.9.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdd612e59baed2a93c8843c9a7cb902260f181370f1d772f4842987535071d14", size = 243006, upload-time = "2025-07-03T10:53:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d9/4616b787d9f597d6443f5588619c1c9f659e1f5fc9eebf63699eb6d34b78/coverage-7.9.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:256ea87cb2a1ed992bcdfc349d8042dcea1b80436f4ddf6e246d6bee4b5d73b6", size = 244990, upload-time = "2025-07-03T10:53:31.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/83/801cdc10f137b2d02b005a761661649ffa60eb173dcdaeb77f571e4dc192/coverage-7.9.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f44ae036b63c8ea432f610534a2668b0c3aee810e7037ab9d8ff6883de480f5b", size = 245157, upload-time = "2025-07-03T10:53:32.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a4/41911ed7e9d3ceb0ffb019e7635468df7499f5cc3edca5f7dfc078e9c5ec/coverage-7.9.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:82d76ad87c932935417a19b10cfe7abb15fd3f923cfe47dbdaa74ef4e503752d", size = 243128, upload-time = "2025-07-03T10:53:34.009Z" },
+    { url = "https://files.pythonhosted.org/packages/10/41/344543b71d31ac9cb00a664d5d0c9ef134a0fe87cb7d8430003b20fa0b7d/coverage-7.9.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:619317bb86de4193debc712b9e59d5cffd91dc1d178627ab2a77b9870deb2868", size = 244511, upload-time = "2025-07-03T10:53:35.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/81/3b68c77e4812105e2a060f6946ba9e6f898ddcdc0d2bfc8b4b152a9ae522/coverage-7.9.2-cp313-cp313-win32.whl", hash = "sha256:0a07757de9feb1dfafd16ab651e0f628fd7ce551604d1bf23e47e1ddca93f08a", size = 214765, upload-time = "2025-07-03T10:53:36.787Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a2/7fac400f6a346bb1a4004eb2a76fbff0e242cd48926a2ce37a22a6a1d917/coverage-7.9.2-cp313-cp313-win_amd64.whl", hash = "sha256:115db3d1f4d3f35f5bb021e270edd85011934ff97c8797216b62f461dd69374b", size = 215536, upload-time = "2025-07-03T10:53:38.188Z" },
+    { url = "https://files.pythonhosted.org/packages/08/47/2c6c215452b4f90d87017e61ea0fd9e0486bb734cb515e3de56e2c32075f/coverage-7.9.2-cp313-cp313-win_arm64.whl", hash = "sha256:48f82f889c80af8b2a7bb6e158d95a3fbec6a3453a1004d04e4f3b5945a02694", size = 213943, upload-time = "2025-07-03T10:53:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/46/e211e942b22d6af5e0f323faa8a9bc7c447a1cf1923b64c47523f36ed488/coverage-7.9.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:55a28954545f9d2f96870b40f6c3386a59ba8ed50caf2d949676dac3ecab99f5", size = 213088, upload-time = "2025-07-03T10:53:40.874Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/2f/762551f97e124442eccd907bf8b0de54348635b8866a73567eb4e6417acf/coverage-7.9.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cdef6504637731a63c133bb2e6f0f0214e2748495ec15fe42d1e219d1b133f0b", size = 213298, upload-time = "2025-07-03T10:53:42.218Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b7/76d2d132b7baf7360ed69be0bcab968f151fa31abe6d067f0384439d9edb/coverage-7.9.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcd5ebe66c7a97273d5d2ddd4ad0ed2e706b39630ed4b53e713d360626c3dbb3", size = 256541, upload-time = "2025-07-03T10:53:43.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/392b219837d7ad47d8e5974ce5f8dc3deb9f99a53b3bd4d123602f960c81/coverage-7.9.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9303aed20872d7a3c9cb39c5d2b9bdbe44e3a9a1aecb52920f7e7495410dfab8", size = 252761, upload-time = "2025-07-03T10:53:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/77/4256d3577fe1b0daa8d3836a1ebe68eaa07dd2cbaf20cf5ab1115d6949d4/coverage-7.9.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc18ea9e417a04d1920a9a76fe9ebd2f43ca505b81994598482f938d5c315f46", size = 254917, upload-time = "2025-07-03T10:53:46.931Z" },
+    { url = "https://files.pythonhosted.org/packages/53/99/fc1a008eef1805e1ddb123cf17af864743354479ea5129a8f838c433cc2c/coverage-7.9.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6406cff19880aaaadc932152242523e892faff224da29e241ce2fca329866584", size = 256147, upload-time = "2025-07-03T10:53:48.289Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c0/f63bf667e18b7f88c2bdb3160870e277c4874ced87e21426128d70aa741f/coverage-7.9.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:2d0d4f6ecdf37fcc19c88fec3e2277d5dee740fb51ffdd69b9579b8c31e4232e", size = 254261, upload-time = "2025-07-03T10:53:49.99Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/32/37dd1c42ce3016ff8ec9e4b607650d2e34845c0585d3518b2a93b4830c1a/coverage-7.9.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c33624f50cf8de418ab2b4d6ca9eda96dc45b2c4231336bac91454520e8d1fac", size = 255099, upload-time = "2025-07-03T10:53:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/da/2e/af6b86f7c95441ce82f035b3affe1cd147f727bbd92f563be35e2d585683/coverage-7.9.2-cp313-cp313t-win32.whl", hash = "sha256:1df6b76e737c6a92210eebcb2390af59a141f9e9430210595251fbaf02d46926", size = 215440, upload-time = "2025-07-03T10:53:52.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bb/8a785d91b308867f6b2e36e41c569b367c00b70c17f54b13ac29bcd2d8c8/coverage-7.9.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f5fd54310b92741ebe00d9c0d1d7b2b27463952c022da6d47c175d246a98d1bd", size = 216537, upload-time = "2025-07-03T10:53:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a0/a6bffb5e0f41a47279fd45a8f3155bf193f77990ae1c30f9c224b61cacb0/coverage-7.9.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c48c2375287108c887ee87d13b4070a381c6537d30e8487b24ec721bf2a781cb", size = 214398, upload-time = "2025-07-03T10:53:56.715Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ab/b4b06662ccaa00ca7bbee967b7035a33a58b41efb92d8c89a6c523a2ccd5/coverage-7.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddc39510ac922a5c4c27849b739f875d3e1d9e590d1e7b64c98dadf037a16cce", size = 212037, upload-time = "2025-07-03T10:53:58.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/5e/04619995657acc898d15bfad42b510344b3a74d4d5bc34f2e279d46c781c/coverage-7.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a535c0c7364acd55229749c2b3e5eebf141865de3a8f697076a3291985f02d30", size = 212412, upload-time = "2025-07-03T10:53:59.451Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e7/1465710224dc6d31c534e7714cbd907210622a044adc81c810e72eea873f/coverage-7.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df0f9ef28e0f20c767ccdccfc5ae5f83a6f4a2fbdfbcbcc8487a8a78771168c8", size = 241164, upload-time = "2025-07-03T10:54:00.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f2/44c6fbd2794afeb9ab6c0a14d3c088ab1dae3dff3df2624609981237bbb4/coverage-7.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f3da12e0ccbcb348969221d29441ac714bbddc4d74e13923d3d5a7a0bebef7a", size = 239032, upload-time = "2025-07-03T10:54:02.25Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d2/7a79845429c0aa2e6788bc45c26a2e3052fa91082c9ea1dea56fb531952c/coverage-7.9.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a17eaf46f56ae0f870f14a3cbc2e4632fe3771eab7f687eda1ee59b73d09fe4", size = 240148, upload-time = "2025-07-03T10:54:03.618Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/7d/2731d1b4c9c672d82d30d218224dfc62939cf3800bc8aba0258fefb191f5/coverage-7.9.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:669135a9d25df55d1ed56a11bf555f37c922cf08d80799d4f65d77d7d6123fcf", size = 239875, upload-time = "2025-07-03T10:54:05.022Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/83/685958715429a9da09cf172c15750ca5c795dd7259466f2645403696557b/coverage-7.9.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9d3a700304d01a627df9db4322dc082a0ce1e8fc74ac238e2af39ced4c083193", size = 238127, upload-time = "2025-07-03T10:54:06.366Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/161a4313308b3783126790adfae1970adbe4886fda8788792e435249910a/coverage-7.9.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:71ae8b53855644a0b1579d4041304ddc9995c7b21c8a1f16753c4d8903b4dfed", size = 239064, upload-time = "2025-07-03T10:54:07.878Z" },
+    { url = "https://files.pythonhosted.org/packages/17/14/fe33f41b2e80811021de059621f44c01ebe4d6b08bdb82d54a514488e933/coverage-7.9.2-cp39-cp39-win32.whl", hash = "sha256:dd7a57b33b5cf27acb491e890720af45db05589a80c1ffc798462a765be6d4d7", size = 214522, upload-time = "2025-07-03T10:54:09.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/30/63d850ec31b5c6f6a7b4e853016375b846258300320eda29376e2786ceeb/coverage-7.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f65bb452e579d5540c8b37ec105dd54d8b9307b07bcaa186818c104ffda22441", size = 215419, upload-time = "2025-07-03T10:54:10.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/85/f8bbefac27d286386961c25515431482a425967e23d3698b75a250872924/coverage-7.9.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:8a1166db2fb62473285bcb092f586e081e92656c7dfa8e9f62b4d39d7e6b5050", size = 204013, upload-time = "2025-07-03T10:54:12.084Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/38/bbe2e63902847cf79036ecc75550d0698af31c91c7575352eb25190d0fb3/coverage-7.9.2-py3-none-any.whl", hash = "sha256:e425cd5b00f6fc0ed7cdbd766c70be8baab4b7839e4d4fe5fac48581dd968ea4", size = 204005, upload-time = "2025-07-03T10:54:13.491Z" },
 ]
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -586,13 +526,9 @@ name = "etils"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/fa/8637c95271dd9eed00e258184295dd00ba163bb8924ba3be978ec89f093f/etils-1.5.2.tar.gz", hash = "sha256:ba6a3e1aff95c769130776aa176c11540637f5dd881f3b79172a5149b6b1c446", size = 87021, upload-time = "2023-10-24T12:22:58.996Z" }
 wheels = [
@@ -601,10 +537,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "fsspec", marker = "python_full_version < '3.10'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -612,25 +548,15 @@ name = "etils"
 version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/12/1cc11e88a0201280ff389bc4076df7c3432e39d9f22cba8b71aa263f67b8/etils-1.12.2.tar.gz", hash = "sha256:c6b9e1f0ce66d1bbf54f99201b08a60ba396d3446d9eb18d4bc39b26a2e1a5ee", size = 104711, upload-time = "2025-03-10T15:14:13.671Z" }
 wheels = [
@@ -639,10 +565,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "importlib-resources", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "zipp", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "fsspec", marker = "python_full_version >= '3.10'" },
+    { name = "importlib-resources", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "zipp", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -650,9 +576,9 @@ name = "fast-simplification"
 version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/98/1e10c12ac539826e81902952175961f2717f188b1e2276949e687a88c91c/fast_simplification-0.1.11.tar.gz", hash = "sha256:deba1bd719b372e375ed38cbfcc47d98e9e3e41405c470d10efdae3a2b676d3d", size = 26334, upload-time = "2025-05-07T15:53:15.825Z" }
 wheels = [
@@ -689,51 +615,51 @@ wheels = [
 
 [[package]]
 name = "fonttools"
-version = "4.58.4"
+version = "4.58.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/5a/1124b2c8cb3a8015faf552e92714040bcdbc145dfa29928891b02d147a18/fonttools-4.58.4.tar.gz", hash = "sha256:928a8009b9884ed3aae17724b960987575155ca23c6f0b8146e400cc9e0d44ba", size = 3525026, upload-time = "2025-06-13T17:25:15.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/97/5735503e58d3816b0989955ef9b2df07e4c99b246469bd8b3823a14095da/fonttools-4.58.5.tar.gz", hash = "sha256:b2a35b0a19f1837284b3a23dd64fd7761b8911d50911ecd2bdbaf5b2d1b5df9c", size = 3526243, upload-time = "2025-07-03T14:04:47.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/86/d22c24caa574449b56e994ed1a96d23b23af85557fb62a92df96439d3f6c/fonttools-4.58.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:834542f13fee7625ad753b2db035edb674b07522fcbdd0ed9e9a9e2a1034467f", size = 2748349, upload-time = "2025-06-13T17:23:49.179Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b8/384aca93856def00e7de30341f1e27f439694857d82c35d74a809c705ed0/fonttools-4.58.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2e6c61ce330142525296170cd65666e46121fc0d44383cbbcfa39cf8f58383df", size = 2318565, upload-time = "2025-06-13T17:23:52.144Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/f2/273edfdc8d9db89ecfbbf659bd894f7e07b6d53448b19837a4bdba148d17/fonttools-4.58.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9c75f8faa29579c0fbf29b56ae6a3660c6c025f3b671803cb6a9caa7e4e3a98", size = 4838855, upload-time = "2025-06-13T17:23:54.039Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fa/403703548c093c30b52ab37e109b369558afa221130e67f06bef7513f28a/fonttools-4.58.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:88dedcedbd5549e35b2ea3db3de02579c27e62e51af56779c021e7b33caadd0e", size = 4767637, upload-time = "2025-06-13T17:23:56.17Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/a8/3380e1e0bff6defb0f81c9abf274a5b4a0f30bc8cab4fd4e346c6f923b4c/fonttools-4.58.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ae80a895adab43586f4da1521d58fd4f4377cef322ee0cc205abcefa3a5effc3", size = 4819397, upload-time = "2025-06-13T17:23:58.263Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1b/99e47eb17a8ca51d808622a4658584fa8f340857438a4e9d7ac326d4a041/fonttools-4.58.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0d3acc7f0d151da116e87a182aefb569cf0a3c8e0fd4c9cd0a7c1e7d3e7adb26", size = 4926641, upload-time = "2025-06-13T17:24:00.368Z" },
-    { url = "https://files.pythonhosted.org/packages/31/75/415254408f038e35b36c8525fc31feb8561f98445688dd2267c23eafd7a2/fonttools-4.58.4-cp310-cp310-win32.whl", hash = "sha256:1244f69686008e7e8d2581d9f37eef330a73fee3843f1107993eb82c9d306577", size = 2201917, upload-time = "2025-06-13T17:24:02.587Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/f019a15ed2946317c5318e1bcc8876f8a54a313848604ad1d4cfc4c07916/fonttools-4.58.4-cp310-cp310-win_amd64.whl", hash = "sha256:2a66c0af8a01eb2b78645af60f3b787de5fe5eb1fd8348163715b80bdbfbde1f", size = 2246327, upload-time = "2025-06-13T17:24:04.087Z" },
-    { url = "https://files.pythonhosted.org/packages/17/7b/cc6e9bb41bab223bd2dc70ba0b21386b85f604e27f4c3206b4205085a2ab/fonttools-4.58.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a3841991c9ee2dc0562eb7f23d333d34ce81e8e27c903846f0487da21e0028eb", size = 2768901, upload-time = "2025-06-13T17:24:05.901Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/15/98d75df9f2b4e7605f3260359ad6e18e027c11fa549f74fce567270ac891/fonttools-4.58.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c98f91b6a9604e7ffb5ece6ea346fa617f967c2c0944228801246ed56084664", size = 2328696, upload-time = "2025-06-13T17:24:09.18Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c8/dc92b80f5452c9c40164e01b3f78f04b835a00e673bd9355ca257008ff61/fonttools-4.58.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab9f891eb687ddf6a4e5f82901e00f992e18012ca97ab7acd15f13632acd14c1", size = 5018830, upload-time = "2025-06-13T17:24:11.282Z" },
-    { url = "https://files.pythonhosted.org/packages/19/48/8322cf177680505d6b0b6062e204f01860cb573466a88077a9b795cb70e8/fonttools-4.58.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:891c5771e8f0094b7c0dc90eda8fc75e72930b32581418f2c285a9feedfd9a68", size = 4960922, upload-time = "2025-06-13T17:24:14.9Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e0/2aff149ed7eb0916de36da513d473c6fff574a7146891ce42de914899395/fonttools-4.58.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:43ba4d9646045c375d22e3473b7d82b18b31ee2ac715cd94220ffab7bc2d5c1d", size = 4997135, upload-time = "2025-06-13T17:24:16.959Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/6f/4d9829b29a64a2e63a121cb11ecb1b6a9524086eef3e35470949837a1692/fonttools-4.58.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33d19f16e6d2ffd6669bda574a6589941f6c99a8d5cfb9f464038244c71555de", size = 5108701, upload-time = "2025-06-13T17:24:18.849Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/1e/2d656ddd1b0cd0d222f44b2d008052c2689e66b702b9af1cd8903ddce319/fonttools-4.58.4-cp311-cp311-win32.whl", hash = "sha256:b59e5109b907da19dc9df1287454821a34a75f2632a491dd406e46ff432c2a24", size = 2200177, upload-time = "2025-06-13T17:24:20.823Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/83/ba71ad053fddf4157cb0697c8da8eff6718d059f2a22986fa5f312b49c92/fonttools-4.58.4-cp311-cp311-win_amd64.whl", hash = "sha256:3d471a5b567a0d1648f2e148c9a8bcf00d9ac76eb89e976d9976582044cc2509", size = 2247892, upload-time = "2025-06-13T17:24:22.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/3c/1d1792bfe91ef46f22a3d23b4deb514c325e73c17d4f196b385b5e2faf1c/fonttools-4.58.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:462211c0f37a278494e74267a994f6be9a2023d0557aaa9ecbcbfce0f403b5a6", size = 2754082, upload-time = "2025-06-13T17:24:24.862Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/1f/2b261689c901a1c3bc57a6690b0b9fc21a9a93a8b0c83aae911d3149f34e/fonttools-4.58.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c7a12fb6f769165547f00fcaa8d0df9517603ae7e04b625e5acb8639809b82d", size = 2321677, upload-time = "2025-06-13T17:24:26.815Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/6b/4607add1755a1e6581ae1fc0c9a640648e0d9cdd6591cc2d581c2e07b8c3/fonttools-4.58.4-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d42c63020a922154add0a326388a60a55504629edc3274bc273cd3806b4659f", size = 4896354, upload-time = "2025-06-13T17:24:28.428Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/95/34b4f483643d0cb11a1f830b72c03fdd18dbd3792d77a2eb2e130a96fada/fonttools-4.58.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f2b4e6fd45edc6805f5f2c355590b092ffc7e10a945bd6a569fc66c1d2ae7aa", size = 4941633, upload-time = "2025-06-13T17:24:30.568Z" },
-    { url = "https://files.pythonhosted.org/packages/81/ac/9bafbdb7694059c960de523e643fa5a61dd2f698f3f72c0ca18ae99257c7/fonttools-4.58.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f155b927f6efb1213a79334e4cb9904d1e18973376ffc17a0d7cd43d31981f1e", size = 4886170, upload-time = "2025-06-13T17:24:32.724Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/44/a3a3b70d5709405f7525bb7cb497b4e46151e0c02e3c8a0e40e5e9fe030b/fonttools-4.58.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e38f687d5de97c7fb7da3e58169fb5ba349e464e141f83c3c2e2beb91d317816", size = 5037851, upload-time = "2025-06-13T17:24:35.034Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cb/e8923d197c78969454eb876a4a55a07b59c9c4c46598f02b02411dc3b45c/fonttools-4.58.4-cp312-cp312-win32.whl", hash = "sha256:636c073b4da9db053aa683db99580cac0f7c213a953b678f69acbca3443c12cc", size = 2187428, upload-time = "2025-06-13T17:24:36.996Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e6/fe50183b1a0e1018e7487ee740fa8bb127b9f5075a41e20d017201e8ab14/fonttools-4.58.4-cp312-cp312-win_amd64.whl", hash = "sha256:82e8470535743409b30913ba2822e20077acf9ea70acec40b10fcf5671dceb58", size = 2236649, upload-time = "2025-06-13T17:24:38.985Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/4f/c05cab5fc1a4293e6bc535c6cb272607155a0517700f5418a4165b7f9ec8/fonttools-4.58.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5f4a64846495c543796fa59b90b7a7a9dff6839bd852741ab35a71994d685c6d", size = 2745197, upload-time = "2025-06-13T17:24:40.645Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d3/49211b1f96ae49308f4f78ca7664742377a6867f00f704cdb31b57e4b432/fonttools-4.58.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e80661793a5d4d7ad132a2aa1eae2e160fbdbb50831a0edf37c7c63b2ed36574", size = 2317272, upload-time = "2025-06-13T17:24:43.428Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/11/c9972e46a6abd752a40a46960e431c795ad1f306775fc1f9e8c3081a1274/fonttools-4.58.4-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe5807fc64e4ba5130f1974c045a6e8d795f3b7fb6debfa511d1773290dbb76b", size = 4877184, upload-time = "2025-06-13T17:24:45.527Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/24/5017c01c9ef8df572cc9eaf9f12be83ad8ed722ff6dc67991d3d752956e4/fonttools-4.58.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b610b9bef841cb8f4b50472494158b1e347d15cad56eac414c722eda695a6cfd", size = 4939445, upload-time = "2025-06-13T17:24:47.647Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b0/538cc4d0284b5a8826b4abed93a69db52e358525d4b55c47c8cef3669767/fonttools-4.58.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2daa7f0e213c38f05f054eb5e1730bd0424aebddbeac094489ea1585807dd187", size = 4878800, upload-time = "2025-06-13T17:24:49.766Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/9b/a891446b7a8250e65bffceb248508587958a94db467ffd33972723ab86c9/fonttools-4.58.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66cccb6c0b944496b7f26450e9a66e997739c513ffaac728d24930df2fd9d35b", size = 5021259, upload-time = "2025-06-13T17:24:51.754Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b2/c4d2872cff3ace3ddd1388bf15b76a1d8d5313f0a61f234e9aed287e674d/fonttools-4.58.4-cp313-cp313-win32.whl", hash = "sha256:94d2aebb5ca59a5107825520fde596e344652c1f18170ef01dacbe48fa60c889", size = 2185824, upload-time = "2025-06-13T17:24:54.324Z" },
-    { url = "https://files.pythonhosted.org/packages/98/57/cddf8bcc911d4f47dfca1956c1e3aeeb9f7c9b8e88b2a312fe8c22714e0b/fonttools-4.58.4-cp313-cp313-win_amd64.whl", hash = "sha256:b554bd6e80bba582fd326ddab296e563c20c64dca816d5e30489760e0c41529f", size = 2236382, upload-time = "2025-06-13T17:24:56.291Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/787d70ba4cb831706fa587c56ee472a88ebc28752be660f4b58e598af6fc/fonttools-4.58.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ca773fe7812e4e1197ee4e63b9691e89650ab55f679e12ac86052d2fe0d152cd", size = 2754537, upload-time = "2025-06-13T17:24:57.851Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a5/ccb7ef1b8ab4bbf48f7753b6df512b61e73af82cd27aa486a03d6afb8635/fonttools-4.58.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e31289101221910f44245472e02b1a2f7d671c6d06a45c07b354ecb25829ad92", size = 2321715, upload-time = "2025-06-13T17:24:59.863Z" },
-    { url = "https://files.pythonhosted.org/packages/20/5c/b361a7eae95950afaadb7049f55b214b619cb5368086cb3253726fe0c478/fonttools-4.58.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c9e3c01475bb9602cb617f69f02c4ba7ab7784d93f0b0d685e84286f4c1a10", size = 4819004, upload-time = "2025-06-13T17:25:01.591Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2f/3006fbb1f57704cd60af82fb8127788cfb102f12d39c39fb5996af595cf3/fonttools-4.58.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e00a826f2bc745a010341ac102082fe5e3fb9f0861b90ed9ff32277598813711", size = 4749072, upload-time = "2025-06-13T17:25:03.334Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/42/ea79e2c3d5e4441e4508d6456b268a7de275452f3dba3a13fc9d73f3e03d/fonttools-4.58.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:bc75e72e9d2a4ad0935c59713bd38679d51c6fefab1eadde80e3ed4c2a11ea84", size = 4802023, upload-time = "2025-06-13T17:25:05.486Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/70/90a196f57faa2bcd1485710c6d08eedceca500cdf2166640b3478e72072c/fonttools-4.58.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f57a795e540059ce3de68508acfaaf177899b39c36ef0a2833b2308db98c71f1", size = 4911103, upload-time = "2025-06-13T17:25:07.505Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3f/a7d38e606e98701dbcb6198406c8b554a77ed06c5b21e425251813fd3775/fonttools-4.58.4-cp39-cp39-win32.whl", hash = "sha256:a7d04f64c88b48ede655abcf76f2b2952f04933567884d99be7c89e0a4495131", size = 1471393, upload-time = "2025-06-13T17:25:09.587Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6e/08158deaebeb5b0c7a0fb251ca6827defb5f5159958a23ba427e0b677e95/fonttools-4.58.4-cp39-cp39-win_amd64.whl", hash = "sha256:5a8bc5dfd425c89b1c38380bc138787b0a830f761b82b37139aa080915503b69", size = 1515901, upload-time = "2025-06-13T17:25:11.336Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/2f/c536b5b9bb3c071e91d536a4d11f969e911dbb6b227939f4c5b0bca090df/fonttools-4.58.4-py3-none-any.whl", hash = "sha256:a10ce13a13f26cbb9f37512a4346bb437ad7e002ff6fa966a7ce7ff5ac3528bd", size = 1114660, upload-time = "2025-06-13T17:25:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/d2a50d9e9e9f01491993acd557051a05b0bbe57eb47710c6381dca741ac9/fonttools-4.58.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d500d399aa4e92d969a0d21052696fa762385bb23c3e733703af4a195ad9f34c", size = 2749015, upload-time = "2025-07-03T14:03:15.683Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/8f9a4781f79042b2efb68a1636b9013c54f80311dbbc05e6a4bacdaf7661/fonttools-4.58.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b00530b84f87792891874938bd42f47af2f7f4c2a1d70466e6eb7166577853ab", size = 2319224, upload-time = "2025-07-03T14:03:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/51/87/dddb6c9b4af1f49b100e3ec84d45c769947fd8e58943d35a58f27aa017b0/fonttools-4.58.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5579fb3744dfec151b5c29b35857df83e01f06fe446e8c2ebaf1effd7e6cdce", size = 4839510, upload-time = "2025-07-03T14:03:22.785Z" },
+    { url = "https://files.pythonhosted.org/packages/30/57/63fd49a3328e39e3f8868dd0b0f00370f4f40c4bd44a8478efad3338ebd9/fonttools-4.58.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adf440deecfcc2390998e649156e3bdd0b615863228c484732dc06ac04f57385", size = 4768294, upload-time = "2025-07-03T14:03:24.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/1a/e943dfecf56b48d7e684be7c37749c48560461d14f480b4e7c42285976ce/fonttools-4.58.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a81769fc4d473c808310c9ed91fbe01b67f615e3196fb9773e093939f59e6783", size = 4820057, upload-time = "2025-07-03T14:03:26.939Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/04e9dd0b711ca720f5473adde9325941c73faf947b771ea21fac9e3613c3/fonttools-4.58.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0162a6a37b0ca70d8505311d541e291cd6cab54d1a986ae3d2686c56c0581e8f", size = 4927299, upload-time = "2025-07-03T14:03:29.136Z" },
+    { url = "https://files.pythonhosted.org/packages/80/82/9d36a24c47ae4b93377332343b4f018c965e9c4835bbebaed951f99784d0/fonttools-4.58.5-cp310-cp310-win32.whl", hash = "sha256:1cde303422198fdc7f502dbdf1bf65306166cdb9446debd6c7fb826b4d66a530", size = 2203042, upload-time = "2025-07-03T14:03:31.139Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d1/c2c3582d575ef901cad6cfbe77aa5396debd652f51bf32b6963245f00dfa/fonttools-4.58.5-cp310-cp310-win_amd64.whl", hash = "sha256:75cf8c2812c898dd3d70d62b2b768df4eeb524a83fb987a512ddb3863d6a8c54", size = 2247338, upload-time = "2025-07-03T14:03:33.24Z" },
+    { url = "https://files.pythonhosted.org/packages/14/50/26c683bf6f30dcbde6955c8e07ec6af23764aab86ff06b36383654ab6739/fonttools-4.58.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cda226253bf14c559bc5a17c570d46abd70315c9a687d91c0e01147f87736182", size = 2769557, upload-time = "2025-07-03T14:03:35.383Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/00/c3c75fb6196b9ff9988e6a82319ae23f4ae7098e1c01e2408e58d2e7d9c7/fonttools-4.58.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:83a96e4a4e65efd6c098da549ec34f328f08963acd2d7bc910ceba01d2dc73e6", size = 2329367, upload-time = "2025-07-03T14:03:37.322Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e9/6946366c8e88650c199da9b284559de5d47a6e66ed6d175a166953347959/fonttools-4.58.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d172b92dff59ef8929b4452d5a7b19b8e92081aa87bfb2d82b03b1ff14fc667", size = 5019491, upload-time = "2025-07-03T14:03:39.759Z" },
+    { url = "https://files.pythonhosted.org/packages/76/12/2f3f7d09bba7a93bd48dcb54b170fba665f0b7e80e959ac831b907d40785/fonttools-4.58.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0bfddfd09aafbbfb3bd98ae67415fbe51eccd614c17db0c8844fe724fbc5d43d", size = 4961579, upload-time = "2025-07-03T14:03:41.611Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/95/87e84071189e51c714074646dfac8275b2e9c6b2b118600529cc74f7451e/fonttools-4.58.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cfde5045f1bc92ad11b4b7551807564045a1b38cb037eb3c2bc4e737cd3a8d0f", size = 4997792, upload-time = "2025-07-03T14:03:44.529Z" },
+    { url = "https://files.pythonhosted.org/packages/73/47/5c4df7473ecbeb8aa4e01373e4f614ca33f53227fe13ae673c6d5ca99be7/fonttools-4.58.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3515ac47a9a5ac025d2899d195198314023d89492340ba86e4ba79451f7518a8", size = 5109361, upload-time = "2025-07-03T14:03:46.693Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/31406853c570210232b845e08e5a566e15495910790381566ffdbdc7f9a2/fonttools-4.58.5-cp311-cp311-win32.whl", hash = "sha256:9f7e2ab9c10b6811b4f12a0768661325a48e664ec0a0530232c1605896a598db", size = 2201369, upload-time = "2025-07-03T14:03:48.885Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/ac0facb57962cef53a5734d0be5d2f2936e55aa5c62647c38ca3497263d8/fonttools-4.58.5-cp311-cp311-win_amd64.whl", hash = "sha256:126c16ec4a672c9cb5c1c255dc438d15436b470afc8e9cac25a2d39dd2dc26eb", size = 2249021, upload-time = "2025-07-03T14:03:51.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/68/66b498ee66f3e7e92fd68476c2509508082b7f57d68c0cdb4b8573f44331/fonttools-4.58.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c3af3fefaafb570a03051a0d6899b8374dcf8e6a4560e42575843aef33bdbad6", size = 2754751, upload-time = "2025-07-03T14:03:52.976Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/edbc14b79290980c3944a1f43098624bc8965f534964aa03d52041f24cb4/fonttools-4.58.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:688137789dbd44e8757ad77b49a771539d8069195ffa9a8bcf18176e90bbd86d", size = 2322342, upload-time = "2025-07-03T14:03:54.957Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d7/3c87cf147185d91c2e946460a5cf68c236427b4a23ab96793ccb7d8017c9/fonttools-4.58.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af65836cf84cd7cb882d0b353bdc73643a497ce23b7414c26499bb8128ca1af", size = 4897011, upload-time = "2025-07-03T14:03:56.829Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d6/fbb44cc85d4195fe54356658bd9f934328b4f74ae14addd90b4b5558b5c9/fonttools-4.58.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2d79cfeb456bf438cb9fb87437634d4d6f228f27572ca5c5355e58472d5519d", size = 4942291, upload-time = "2025-07-03T14:03:59.204Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c8/453f82e21aedf25cdc2ae619c03a73512398cec9bd8b6c3b1c571e0b6632/fonttools-4.58.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0feac9dda9a48a7a342a593f35d50a5cee2dbd27a03a4c4a5192834a4853b204", size = 4886824, upload-time = "2025-07-03T14:04:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/40/54/e9190001b8e22d123f78925b2f508c866d9d18531694b979277ad45d59b0/fonttools-4.58.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36555230e168511e83ad8637232268649634b8dfff6ef58f46e1ebc057a041ad", size = 5038510, upload-time = "2025-07-03T14:04:03.917Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/9c/07cdad4774841a6304aabae939f8cbb9538cb1d8e97f5016b334da98e73a/fonttools-4.58.5-cp312-cp312-win32.whl", hash = "sha256:26ec05319353842d127bd02516eacb25b97ca83966e40e9ad6fab85cab0576f4", size = 2188459, upload-time = "2025-07-03T14:04:06.103Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4d/1eaaad22781d55f49d1b184563842172aeb6a4fe53c029e503be81114314/fonttools-4.58.5-cp312-cp312-win_amd64.whl", hash = "sha256:778a632e538f82c1920579c0c01566a8f83dc24470c96efbf2fbac698907f569", size = 2236565, upload-time = "2025-07-03T14:04:08.27Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ee/764dd8b99891f815241f449345863cfed9e546923d9cef463f37fd1d7168/fonttools-4.58.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f4b6f1360da13cecc88c0d60716145b31e1015fbe6a59e32f73a4404e2ea92cf", size = 2745867, upload-time = "2025-07-03T14:04:10.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/23/8fef484c02fef55e226dfeac4339a015c5480b6a496064058491759ac71e/fonttools-4.58.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4a036822e915692aa2c03e2decc60f49a8190f8111b639c947a4f4e5774d0d7a", size = 2317933, upload-time = "2025-07-03T14:04:12.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/47/f92b135864fa777e11ad68420bf89446c91a572fe2782745586f8e6aac0c/fonttools-4.58.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6d7709fcf4577b0f294ee6327088884ca95046e1eccde87c53bbba4d5008541", size = 4877844, upload-time = "2025-07-03T14:04:14.58Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/65/6c1a83511d8ac32411930495645edb3f8dfabebcb78f08cf6009ba2585ec/fonttools-4.58.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9b5099ca99b79d6d67162778b1b1616fc0e1de02c1a178248a0da8d78a33852", size = 4940106, upload-time = "2025-07-03T14:04:16.563Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/90/df8eb77d6cf266cbbba01866a1349a3e9121e0a63002cf8d6754e994f755/fonttools-4.58.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3f2c05a8d82a4d15aebfdb3506e90793aea16e0302cec385134dd960647a36c0", size = 4879458, upload-time = "2025-07-03T14:04:19.584Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b1/e32f8de51b7afcfea6ad62780da2fa73212c43a32cd8cafcc852189d7949/fonttools-4.58.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:79f0c4b1cc63839b61deeac646d8dba46f8ed40332c2ac1b9997281462c2e4ba", size = 5021917, upload-time = "2025-07-03T14:04:21.736Z" },
+    { url = "https://files.pythonhosted.org/packages/89/72/578aa7fe32918dd763c62f447aaed672d665ee10e3eeb1725f4d6493fe96/fonttools-4.58.5-cp313-cp313-win32.whl", hash = "sha256:a1a9a2c462760976882131cbab7d63407813413a2d32cd699e86a1ff22bf7aa5", size = 2186827, upload-time = "2025-07-03T14:04:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/71/a3/21e921b16cb9c029d3308e0cb79c9a937e9ff1fc1ee28c2419f0957b9e7c/fonttools-4.58.5-cp313-cp313-win_amd64.whl", hash = "sha256:bca61b14031a4b7dc87e14bf6ca34c275f8e4b9f7a37bc2fe746b532a924cf30", size = 2235706, upload-time = "2025-07-03T14:04:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/76/170fb1bbe5e846500bf9715a68d6c5510a68c2f6fbba7a0f406cb2cc09a3/fonttools-4.58.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:082410bc40014db55be5457836043f0dd1e6b3817c7d11a0aeb44eaa862890af", size = 2755197, upload-time = "2025-07-03T14:04:28.308Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4e/1408d99d6f849d9f88800d062267b2a14ffac4ee782c1242fe2334b08eb5/fonttools-4.58.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0b0983be58d8c8acb11161fdd3b43d64015cef8c3d65ad9289a252243b236128", size = 2322376, upload-time = "2025-07-03T14:04:30.053Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d9/9cd095d3aa3a1b42a9f9d9f12ad77cae1637a49ca41933464b87dfd99101/fonttools-4.58.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5a0e28fb6abc31ba45a2d11dc2fe826e5a074013d13b7b447b441e8236e5f1c", size = 4819660, upload-time = "2025-07-03T14:04:32.494Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b9/d7489c4c30cadba207919126a0b8657ca653d3a275589561341f84ed8855/fonttools-4.58.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d506652abc285934ee949a5f3a952c5d52a09257bc2ba44a92db3ec2804c76fe", size = 4749728, upload-time = "2025-07-03T14:04:34.532Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/03/cd03bc4e62af9d2b783a4e6b815ebb4b1aff22f10c2169522297f323454e/fonttools-4.58.5-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9e2d71676025dd74a21d682be36d4846aa03644c619f2c2d695a11a7262433f6", size = 4802679, upload-time = "2025-07-03T14:04:36.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8c/afe474eb489b9abd7785b2a12668faede78dabd52c391bb5f4cd0e9db67c/fonttools-4.58.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb46a73759efc8a7eca40203843241cd3c79aa983ed7f7515548ed3d82073761", size = 4911759, upload-time = "2025-07-03T14:04:38.96Z" },
+    { url = "https://files.pythonhosted.org/packages/be/aa/0d1f16a48b4db6bf7f61193ebe666c8d49c7c36364baa604530835be8898/fonttools-4.58.5-cp39-cp39-win32.whl", hash = "sha256:bf09f14d73a18c62eb9ad1cac98a37569241ba3cd5789cc578286c128cc29f7f", size = 1472353, upload-time = "2025-07-03T14:04:41.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/78cf284e22254c20d673103a9d8c28a9bab6c56d927ca19dbe95bffd9ccd/fonttools-4.58.5-cp39-cp39-win_amd64.whl", hash = "sha256:8ddb7c0c3e91b187acc1bed31857376926569a18a348ac58d6a71eb8a6b22393", size = 1517191, upload-time = "2025-07-03T14:04:43.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1d85a1996b6188cd2713230e002d79a6f3a289bb17cef600cba385848b72/fonttools-4.58.5-py3-none-any.whl", hash = "sha256:e48a487ed24d9b611c5c4b25db1e50e69e9854ca2670e39a3486ffcd98863ec4", size = 1115318, upload-time = "2025-07-03T14:04:45.378Z" },
 ]
 
 [[package]]
@@ -808,7 +734,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -820,7 +746,7 @@ name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
@@ -844,13 +770,9 @@ name = "kiwisolver"
 version = "1.4.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/4d/2255e1c76304cbd60b48cee302b66d1dde4468dc5b1160e4b7cb43778f2a/kiwisolver-1.4.7.tar.gz", hash = "sha256:9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60", size = 97286, upload-time = "2024-09-04T09:39:44.302Z" }
 wheels = [
@@ -953,25 +875,15 @@ name = "kiwisolver"
 version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/59/7c91426a8ac292e1cdd53a63b6d9439abd573c875c3f92c146767dd33faf/kiwisolver-1.4.8.tar.gz", hash = "sha256:23d5f023bdc8c7e54eb65f03ca5d5bb25b601eac4d7f1a042888a1f45237987e", size = 97538, upload-time = "2024-12-24T18:30:51.519Z" }
 wheels = [
@@ -1141,25 +1053,21 @@ name = "matplotlib"
 version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "cycler", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "fonttools", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "importlib-resources", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "packaging", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pillow", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pyparsing", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "python-dateutil", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cycler", marker = "python_full_version < '3.10'" },
+    { name = "fonttools", marker = "python_full_version < '3.10'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pillow", marker = "python_full_version < '3.10'" },
+    { name = "pyparsing", marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -1210,37 +1118,27 @@ name = "matplotlib"
 version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "cycler", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "fonttools", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "kiwisolver", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "packaging", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pillow", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pyparsing", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "cycler", marker = "python_full_version >= '3.10'" },
+    { name = "fonttools", marker = "python_full_version >= '3.10'" },
+    { name = "kiwisolver", version = "1.4.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pillow", marker = "python_full_version >= '3.10'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/91/d49359a21893183ed2a5b6c76bec40e0b1dcbf8ca148f864d134897cfc75/matplotlib-3.10.3.tar.gz", hash = "sha256:2f82d2c5bb7ae93aaaa4cd42aca65d76ce6376f83304fa3a630b569aca274df0", size = 34799811, upload-time = "2025-05-08T19:10:54.39Z" }
 wheels = [
@@ -1311,39 +1209,39 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.3.4.dev775632047"
+version = "3.3.4.dev778924297"
 source = { registry = "https://py.mujoco.org/" }
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
+    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10'" },
     { name = "glfw" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pyopengl" },
 ]
 wheels = [
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp310-cp310-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp311-cp311-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp312-cp312-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp313-cp313-win_amd64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-macosx_11_0_universal2.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev775632047-cp39-cp39-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp310-cp310-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp310-cp310-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp311-cp311-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp311-cp311-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp312-cp312-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp312-cp312-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp313-cp313-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp313-cp313-win_amd64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp39-cp39-macosx_11_0_universal2.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
+    { url = "https://py.mujoco.org/mujoco/mujoco-3.3.4.dev778924297-cp39-cp39-win_amd64.whl" },
 ]
 
 [[package]]
@@ -1352,14 +1250,14 @@ version = "0.0.1"
 source = { git = "https://github.com/google-deepmind/mujoco_warp#8e1b3b0ffb1ab6b9df3123b136bd30837fc31eab" }
 dependencies = [
     { name = "absl-py" },
-    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },
+    { name = "etils", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.10'" },
     { name = "mujoco" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "warp-lang", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "warp-lang", version = "1.9.0.dev20250703", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -1367,21 +1265,17 @@ name = "myst-parser"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "jinja2", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "markdown-it-py", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "mdit-py-plugins", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pyyaml", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "docutils", marker = "python_full_version < '3.10'" },
+    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.10'" },
+    { name = "pyyaml", marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
 wheels = [
@@ -1393,34 +1287,24 @@ name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "jinja2", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "mdit-py-plugins", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "docutils", marker = "python_full_version >= '3.10'" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
@@ -1432,13 +1316,9 @@ name = "networkx"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/80/a84676339aaae2f1cfdf9f418701dd634aef9cc76f708ef55c36ff39c3ca/networkx-3.2.1.tar.gz", hash = "sha256:9f1bb5cf3409bf324e0a722c20bdb4c20ee39bf1c30ce8ae499c8502b0b5e0c6", size = 2073928, upload-time = "2023-10-28T08:41:39.364Z" }
 wheels = [
@@ -1450,13 +1330,9 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -1468,18 +1344,12 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -1490,39 +1360,39 @@ wheels = [
 name = "newton-physics"
 source = { editable = "." }
 dependencies = [
-    { name = "warp-lang", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "warp-lang", version = "1.8.0.dev20250625", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "warp-lang", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "warp-lang", version = "1.9.0.dev20250703", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
 cu128 = [
-    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 dev = [
     { name = "alphashape" },
     { name = "fast-simplification" },
     { name = "gitpython" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib", version = "3.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
     { name = "pycollada" },
     { name = "pyglet" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
     { name = "trimesh" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "usd-core", marker = "platform_machine != 'aarch64'" },
 ]
 docs = [
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydata-sphinx-theme" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-tabs" },
@@ -1570,13 +1440,9 @@ name = "numpy"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
 wheels = [
@@ -1631,13 +1497,9 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -1702,18 +1564,12 @@ name = "numpy"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz", hash = "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b", size = 20390372, upload-time = "2025-06-21T12:28:33.469Z" }
 wheels = [
@@ -1774,9 +1630,7 @@ name = "nvidia-cublas-cu12"
 version = "12.8.3.14"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/63/684a6f72f52671ea222c12ecde9bdf748a0ba025e2ad3ec374e466c26eb6/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:93a4e0e386cc7f6e56c822531396de8170ed17068a1e18f987574895044cd8c3", size = 604900717, upload-time = "2025-01-23T17:52:55.486Z" },
     { url = "https://files.pythonhosted.org/packages/82/df/4b01f10069e23c641f116c62fc31e31e8dc361a153175d81561d15c8143b/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:3f0e05e7293598cf61933258b73e66a160c27d59c4422670bf0b79348c04be44", size = 609620630, upload-time = "2025-01-23T17:55:00.753Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/54/fbfa3315b936d3358517f7da5f9f2557c279bf210e5261f0cf66cc0f9832/nvidia_cublas_cu12-12.8.3.14-py3-none-win_amd64.whl", hash = "sha256:9ae5eae500aead01fc4bdfc458209df638b1a3551557ce11a78eea9ece602ae9", size = 578387959, upload-time = "2025-01-23T18:08:00.662Z" },
 ]
 
 [[package]]
@@ -1784,9 +1638,7 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.8.57"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/53/458956a65283c55c22ba40a65745bbe9ff20c10b68ea241bc575e20c0465/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff154211724fd824e758ce176b66007b558eea19c9a5135fc991827ee147e317", size = 9526469, upload-time = "2025-01-23T17:47:33.104Z" },
     { url = "https://files.pythonhosted.org/packages/39/6f/3683ecf4e38931971946777d231c2df00dd5c1c4c2c914c42ad8f9f4dca6/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e0b2eb847de260739bee4a3f66fac31378f4ff49538ff527a38a01a9a39f950", size = 10237547, upload-time = "2025-01-23T17:47:56.863Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/2a/cabe033045427beb042b70b394ac3fd7cfefe157c965268824011b16af67/nvidia_cuda_cupti_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:bbed719c52a476958a74cfc42f2b95a3fd6b3fd94eb40134acc4601feb4acac3", size = 7002337, upload-time = "2025-01-23T18:04:35.34Z" },
 ]
 
 [[package]]
@@ -1795,8 +1647,6 @@ version = "12.8.61"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/22/32029d4583f7b19cfe75c84399cbcfd23f2aaf41c66fc8db4da460104fff/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a0fa9c2a21583105550ebd871bd76e2037205d56f33f128e69f6d2a55e0af9ed", size = 88024585, upload-time = "2025-01-23T17:50:10.722Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/98/29f98d57fc40d6646337e942d37509c6d5f8abe29012671f7a6eb9978ebe/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b1f376bf58111ca73dde4fd4df89a462b164602e074a76a2c29c121ca478dcd4", size = 43097015, upload-time = "2025-01-23T17:49:44.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5b/052d05aa068e4752415ad03bac58e852ea8bc17c9321e08546b3f261e47e/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:9c8887bf5e5dffc441018ba8c5dc59952372a6f4806819e8c1f03d62637dbeea", size = 73567440, upload-time = "2025-01-23T18:05:51.036Z" },
 ]
 
 [[package]]
@@ -1804,9 +1654,7 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.8.57"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/9d/e77ec4227e70c6006195bdf410370f2d0e5abfa2dc0d1d315cacd57c5c88/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:534ccebd967b6a44292678fa5da4f00666029cb2ed07a79515ea41ef31fe3ec7", size = 965264, upload-time = "2025-01-23T17:47:11.759Z" },
     { url = "https://files.pythonhosted.org/packages/16/f6/0e1ef31f4753a44084310ba1a7f0abaf977ccd810a604035abb43421c057/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75342e28567340b7428ce79a5d6bb6ca5ff9d07b69e7ce00d2c7b4dc23eff0be", size = 954762, upload-time = "2025-01-23T17:47:22.21Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ee/52508c74bee2a3de8d59c6fd9af4ca2f216052fa2bc916da3a6a7bb998af/nvidia_cuda_runtime_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:89be637e3ee967323865b85e0f147d75f9a5bd98360befa37481b02dd57af8f5", size = 944309, upload-time = "2025-01-23T18:04:23.143Z" },
 ]
 
 [[package]]
@@ -1817,9 +1665,7 @@ dependencies = [
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/2e/ec5dda717eeb1de3afbbbb611ca556f9d6d057470759c6abd36d72f0063b/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:848a61d40ef3b32bd4e1fadb599f0cf04a4b942fbe5fb3be572ad75f9b8c53ef", size = 725862213, upload-time = "2025-02-06T22:14:57.169Z" },
     { url = "https://files.pythonhosted.org/packages/25/dc/dc825c4b1c83b538e207e34f48f86063c88deaa35d46c651c7c181364ba2/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:6d011159a158f3cfc47bf851aea79e31bcff60d530b70ef70474c84cac484d07", size = 726851421, upload-time = "2025-02-06T22:18:29.812Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ea/636cda41b3865caa0d43c34f558167304acde3d2c5f6c54c00a550e69ecd/nvidia_cudnn_cu12-9.7.1.26-py3-none-win_amd64.whl", hash = "sha256:7b805b9a4cf9f3da7c5f4ea4a9dff7baf62d1a612d6154a7e0d2ea51ed296241", size = 715962100, upload-time = "2025-02-06T22:21:32.431Z" },
 ]
 
 [[package]]
@@ -1830,9 +1676,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/95/6157cb45a49f5090a470de42353a22a0ed5b13077886dca891b4b0e350fe/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68509dcd7e3306e69d0e2d8a6d21c8b25ed62e6df8aac192ce752f17677398b5", size = 193108626, upload-time = "2025-01-23T17:55:49.192Z" },
     { url = "https://files.pythonhosted.org/packages/ac/26/b53c493c38dccb1f1a42e1a21dc12cba2a77fbe36c652f7726d9ec4aba28/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da650080ab79fcdf7a4b06aa1b460e99860646b176a43f6208099bdc17836b6a", size = 193118795, upload-time = "2025-01-23T17:56:30.536Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f3/f6248aa119c2726b1bdd02d472332cae274133bd32ca5fa8822efb0c308c/nvidia_cufft_cu12-11.3.3.41-py3-none-win_amd64.whl", hash = "sha256:f9760612886786601d27a0993bb29ce1f757e6b8b173499d0ecfa850d31b50f8", size = 192216738, upload-time = "2025-01-23T18:08:51.102Z" },
 ]
 
 [[package]]
@@ -1841,7 +1685,6 @@ version = "1.13.0.11"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/9c/1f3264d0a84c8a031487fb7f59780fc78fa6f1c97776233956780e3dc3ac/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:483f434c541806936b98366f6d33caef5440572de8ddf38d453213729da3e7d4", size = 1197801, upload-time = "2025-01-23T17:57:07.247Z" },
-    { url = "https://files.pythonhosted.org/packages/35/80/f6a0fc90ab6fa4ac916f3643e5b620fd19724626c59ae83b74f5efef0349/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:2acbee65dc2eaf58331f0798c5e6bcdd790c4acb26347530297e63528c9eba5d", size = 1120660, upload-time = "2025-01-23T17:56:56.608Z" },
 ]
 
 [[package]]
@@ -1849,9 +1692,7 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.55"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/13/bbcf48e2f8a6a9adef58f130bc968810528a4e66bbbe62fad335241e699f/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6bb90c044fa9b07cedae2ef29077c4cf851fb6fdd6d862102321f359dca81e9", size = 63623836, upload-time = "2025-01-23T17:57:22.319Z" },
     { url = "https://files.pythonhosted.org/packages/bd/fc/7be5d0082507269bb04ac07cc614c84b78749efb96e8cf4100a8a1178e98/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8387d974240c91f6a60b761b83d4b2f9b938b7e0b9617bae0f0dafe4f5c36b86", size = 63618038, upload-time = "2025-01-23T17:57:41.838Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f0/91252f3cffe3f3c233a8e17262c21b41534652edfe783c1e58ea1c92c115/nvidia_curand_cu12-10.3.9.55-py3-none-win_amd64.whl", hash = "sha256:570d82475fe7f3d8ed01ffbe3b71796301e0e24c98762ca018ff8ce4f5418e1f", size = 62761446, upload-time = "2025-01-23T18:09:21.663Z" },
 ]
 
 [[package]]
@@ -1864,9 +1705,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/ce/4214a892e804b20bf66d04f04a473006fc2d3dac158160ef85f1bc906639/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:0fd9e98246f43c15bee5561147ad235dfdf2d037f5d07c9d41af3f7f72feb7cc", size = 260094827, upload-time = "2025-01-23T17:58:17.586Z" },
     { url = "https://files.pythonhosted.org/packages/c2/08/953675873a136d96bb12f93b49ba045d1107bc94d2551c52b12fa6c7dec3/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4d1354102f1e922cee9db51920dba9e2559877cf6ff5ad03a00d853adafb191b", size = 260373342, upload-time = "2025-01-23T17:58:56.406Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f9/e0e6f8b7aecd13e0f9e937d116fb3211329a0a92b9bea9624b1368de307a/nvidia_cusolver_cu12-11.7.2.55-py3-none-win_amd64.whl", hash = "sha256:a5a516c55da5c5aba98420d9bc9bcab18245f21ec87338cc1f930eb18dd411ac", size = 249600787, upload-time = "2025-01-23T18:10:07.641Z" },
 ]
 
 [[package]]
@@ -1877,9 +1716,7 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/a2/313db0453087f5324a5900380ca2e57e050c8de76f407b5e11383dc762ae/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d869c6146ca80f4305b62e02d924b4aaced936f8173e3cef536a67eed2a91af1", size = 291963692, upload-time = "2025-01-23T17:59:40.325Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ab/31e8149c66213b846c082a3b41b1365b831f41191f9f40c6ddbc8a7d550e/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c1b61eb8c85257ea07e9354606b26397612627fdcd327bfd91ccf6155e7c86d", size = 292064180, upload-time = "2025-01-23T18:00:23.233Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/48/64b01653919a3d1d9b5117c156806ab0db8312c7496ff646477a5c1545bf/nvidia_cusparse_cu12-12.5.7.53-py3-none-win_amd64.whl", hash = "sha256:82c201d6781bacf6bb7c654f0446728d0fe596dfdd82ef4a04c204ce3e107441", size = 288767123, upload-time = "2025-01-23T18:11:01.543Z" },
 ]
 
 [[package]]
@@ -1887,9 +1724,7 @@ name = "nvidia-cusparselt-cu12"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/da/4de092c61c6dea1fc9c936e69308a02531d122e12f1f649825934ad651b5/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1", size = 156402859, upload-time = "2024-10-16T02:23:17.184Z" },
     { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
-    { url = "https://files.pythonhosted.org/packages/46/3e/9e1e394a02a06f694be2c97bbe47288bb7c90ea84c7e9cf88f7b28afe165/nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7", size = 155595972, upload-time = "2024-10-15T22:58:35.426Z" },
 ]
 
 [[package]]
@@ -1897,7 +1732,6 @@ name = "nvidia-nccl-cu12"
 version = "2.26.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/5b/ca2f213f637305633814ae8c36b153220e40a07ea001966dcd87391f3acb/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522", size = 291671495, upload-time = "2025-03-13T00:30:07.805Z" },
     { url = "https://files.pythonhosted.org/packages/67/ca/f42388aed0fddd64ade7493dbba36e1f534d4e6fdbdd355c6a90030ae028/nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6", size = 201319755, upload-time = "2025-03-13T00:29:55.296Z" },
 ]
 
@@ -1907,8 +1741,6 @@ version = "12.8.61"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/f8/9d85593582bd99b8d7c65634d2304780aefade049b2b94d96e44084be90b/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17", size = 39243473, upload-time = "2025-01-23T18:03:03.509Z" },
-    { url = "https://files.pythonhosted.org/packages/af/53/698f3758f48c5fcb1112721e40cc6714da3980d3c7e93bae5b29dafa9857/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b80ecab31085dda3ce3b41d043be0ec739216c3fc633b8abe212d5a30026df0", size = 38374634, upload-time = "2025-01-23T18:02:35.812Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c6/0d1b2bfeb2ef42c06db0570c4d081e5cde4450b54c09e43165126cfe6ff6/nvidia_nvjitlink_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:1166a964d25fdc0eae497574d38824305195a5283324a21ccb0ce0c802cbf41c", size = 268514099, upload-time = "2025-01-23T18:12:33.874Z" },
 ]
 
 [[package]]
@@ -1916,9 +1748,7 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.55"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/e8/ae6ecbdade8bb9174d75db2b302c57c1c27d9277d6531c62aafde5fb32a3/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c38405335fbc0f0bf363eaeaeb476e8dfa8bae82fada41d25ace458b9ba9f3db", size = 91103, upload-time = "2025-01-23T17:50:24.664Z" },
     { url = "https://files.pythonhosted.org/packages/8d/cd/0e8c51b2ae3a58f054f2e7fe91b82d201abfb30167f2431e9bd92d532f42/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dd0780f1a55c21d8e06a743de5bd95653de630decfff40621dbde78cc307102", size = 89896, upload-time = "2025-01-23T17:50:44.487Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/14/84d46e62bfde46dd20cfb041e0bb5c2ec454fd6a384696e7fa3463c5bb59/nvidia_nvtx_cu12-12.8.55-py3-none-win_amd64.whl", hash = "sha256:9022681677aef1313458f88353ad9c0d2fbbe6402d6b07c9f00ba0e3ca8774d3", size = 56435, upload-time = "2025-01-23T18:06:06.268Z" },
 ]
 
 [[package]]
@@ -1932,103 +1762,131 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "11.2.1"
+version = "11.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz", hash = "sha256:a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6", size = 47026707, upload-time = "2025-04-12T17:50:03.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/8b/b158ad57ed44d3cc54db8d68ad7c0a58b8fc0e4c7a3f995f9d62d5b464a1/pillow-11.2.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:d57a75d53922fc20c165016a20d9c44f73305e67c351bbc60d1adaf662e74047", size = 3198442, upload-time = "2025-04-12T17:47:10.666Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f8/bb5d956142f86c2d6cc36704943fa761f2d2e4c48b7436fd0a85c20f1713/pillow-11.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:127bf6ac4a5b58b3d32fc8289656f77f80567d65660bc46f72c0d77e6600cc95", size = 3030553, upload-time = "2025-04-12T17:47:13.153Z" },
-    { url = "https://files.pythonhosted.org/packages/22/7f/0e413bb3e2aa797b9ca2c5c38cb2e2e45d88654e5b12da91ad446964cfae/pillow-11.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ba4be812c7a40280629e55ae0b14a0aafa150dd6451297562e1764808bbe61", size = 4405503, upload-time = "2025-04-12T17:47:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/b4/cc647f4d13f3eb837d3065824aa58b9bcf10821f029dc79955ee43f793bd/pillow-11.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8bd62331e5032bc396a93609982a9ab6b411c05078a52f5fe3cc59234a3abd1", size = 4490648, upload-time = "2025-04-12T17:47:17.37Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/6f/240b772a3b35cdd7384166461567aa6713799b4e78d180c555bd284844ea/pillow-11.2.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:562d11134c97a62fe3af29581f083033179f7ff435f78392565a1ad2d1c2c45c", size = 4508937, upload-time = "2025-04-12T17:47:19.066Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/5e/7ca9c815ade5fdca18853db86d812f2f188212792780208bdb37a0a6aef4/pillow-11.2.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c97209e85b5be259994eb5b69ff50c5d20cca0f458ef9abd835e262d9d88b39d", size = 4599802, upload-time = "2025-04-12T17:47:21.404Z" },
-    { url = "https://files.pythonhosted.org/packages/02/81/c3d9d38ce0c4878a77245d4cf2c46d45a4ad0f93000227910a46caff52f3/pillow-11.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0c3e6d0f59171dfa2e25d7116217543310908dfa2770aa64b8f87605f8cacc97", size = 4576717, upload-time = "2025-04-12T17:47:23.571Z" },
-    { url = "https://files.pythonhosted.org/packages/42/49/52b719b89ac7da3185b8d29c94d0e6aec8140059e3d8adcaa46da3751180/pillow-11.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc1c3bc53befb6096b84165956e886b1729634a799e9d6329a0c512ab651e579", size = 4654874, upload-time = "2025-04-12T17:47:25.783Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0b/ede75063ba6023798267023dc0d0401f13695d228194d2242d5a7ba2f964/pillow-11.2.1-cp310-cp310-win32.whl", hash = "sha256:312c77b7f07ab2139924d2639860e084ec2a13e72af54d4f08ac843a5fc9c79d", size = 2331717, upload-time = "2025-04-12T17:47:28.922Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/3c/9831da3edea527c2ed9a09f31a2c04e77cd705847f13b69ca60269eec370/pillow-11.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:9bc7ae48b8057a611e5fe9f853baa88093b9a76303937449397899385da06fad", size = 2676204, upload-time = "2025-04-12T17:47:31.283Z" },
-    { url = "https://files.pythonhosted.org/packages/01/97/1f66ff8a1503d8cbfc5bae4dc99d54c6ec1e22ad2b946241365320caabc2/pillow-11.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:2728567e249cdd939f6cc3d1f049595c66e4187f3c34078cbc0a7d21c47482d2", size = 2414767, upload-time = "2025-04-12T17:47:34.655Z" },
-    { url = "https://files.pythonhosted.org/packages/68/08/3fbf4b98924c73037a8e8b4c2c774784805e0fb4ebca6c5bb60795c40125/pillow-11.2.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:35ca289f712ccfc699508c4658a1d14652e8033e9b69839edf83cbdd0ba39e70", size = 3198450, upload-time = "2025-04-12T17:47:37.135Z" },
-    { url = "https://files.pythonhosted.org/packages/84/92/6505b1af3d2849d5e714fc75ba9e69b7255c05ee42383a35a4d58f576b16/pillow-11.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0409af9f829f87a2dfb7e259f78f317a5351f2045158be321fd135973fff7bf", size = 3030550, upload-time = "2025-04-12T17:47:39.345Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/8c/ac2f99d2a70ff966bc7eb13dacacfaab57c0549b2ffb351b6537c7840b12/pillow-11.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4e5c5edee874dce4f653dbe59db7c73a600119fbea8d31f53423586ee2aafd7", size = 4415018, upload-time = "2025-04-12T17:47:41.128Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e3/0a58b5d838687f40891fff9cbaf8669f90c96b64dc8f91f87894413856c6/pillow-11.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b93a07e76d13bff9444f1a029e0af2964e654bfc2e2c2d46bfd080df5ad5f3d8", size = 4498006, upload-time = "2025-04-12T17:47:42.912Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f5/6ba14718135f08fbfa33308efe027dd02b781d3f1d5c471444a395933aac/pillow-11.2.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e6def7eed9e7fa90fde255afaf08060dc4b343bbe524a8f69bdd2a2f0018f600", size = 4517773, upload-time = "2025-04-12T17:47:44.611Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f2/805ad600fc59ebe4f1ba6129cd3a75fb0da126975c8579b8f57abeb61e80/pillow-11.2.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8f4f3724c068be008c08257207210c138d5f3731af6c155a81c2b09a9eb3a788", size = 4607069, upload-time = "2025-04-12T17:47:46.46Z" },
-    { url = "https://files.pythonhosted.org/packages/71/6b/4ef8a288b4bb2e0180cba13ca0a519fa27aa982875882392b65131401099/pillow-11.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a0a6709b47019dff32e678bc12c63008311b82b9327613f534e496dacaefb71e", size = 4583460, upload-time = "2025-04-12T17:47:49.255Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/f29c705a09cbc9e2a456590816e5c234382ae5d32584f451c3eb41a62062/pillow-11.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f6b0c664ccb879109ee3ca702a9272d877f4fcd21e5eb63c26422fd6e415365e", size = 4661304, upload-time = "2025-04-12T17:47:51.067Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/1a/c8217b6f2f73794a5e219fbad087701f412337ae6dbb956db37d69a9bc43/pillow-11.2.1-cp311-cp311-win32.whl", hash = "sha256:cc5d875d56e49f112b6def6813c4e3d3036d269c008bf8aef72cd08d20ca6df6", size = 2331809, upload-time = "2025-04-12T17:47:54.425Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/72/25a8f40170dc262e86e90f37cb72cb3de5e307f75bf4b02535a61afcd519/pillow-11.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:0f5c7eda47bf8e3c8a283762cab94e496ba977a420868cb819159980b6709193", size = 2676338, upload-time = "2025-04-12T17:47:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9e/76825e39efee61efea258b479391ca77d64dbd9e5804e4ad0fa453b4ba55/pillow-11.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:4d375eb838755f2528ac8cbc926c3e31cc49ca4ad0cf79cff48b20e30634a4a7", size = 2414918, upload-time = "2025-04-12T17:47:58.217Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/40/052610b15a1b8961f52537cc8326ca6a881408bc2bdad0d852edeb6ed33b/pillow-11.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:78afba22027b4accef10dbd5eed84425930ba41b3ea0a86fa8d20baaf19d807f", size = 3190185, upload-time = "2025-04-12T17:48:00.417Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/7e/b86dbd35a5f938632093dc40d1682874c33dcfe832558fc80ca56bfcb774/pillow-11.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78092232a4ab376a35d68c4e6d5e00dfd73454bd12b230420025fbe178ee3b0b", size = 3030306, upload-time = "2025-04-12T17:48:02.391Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/5c/467a161f9ed53e5eab51a42923c33051bf8d1a2af4626ac04f5166e58e0c/pillow-11.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25a5f306095c6780c52e6bbb6109624b95c5b18e40aab1c3041da3e9e0cd3e2d", size = 4416121, upload-time = "2025-04-12T17:48:04.554Z" },
-    { url = "https://files.pythonhosted.org/packages/62/73/972b7742e38ae0e2ac76ab137ca6005dcf877480da0d9d61d93b613065b4/pillow-11.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c7b29dbd4281923a2bfe562acb734cee96bbb129e96e6972d315ed9f232bef4", size = 4501707, upload-time = "2025-04-12T17:48:06.831Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/3a/427e4cb0b9e177efbc1a84798ed20498c4f233abde003c06d2650a6d60cb/pillow-11.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3e645b020f3209a0181a418bffe7b4a93171eef6c4ef6cc20980b30bebf17b7d", size = 4522921, upload-time = "2025-04-12T17:48:09.229Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7c/d8b1330458e4d2f3f45d9508796d7caf0c0d3764c00c823d10f6f1a3b76d/pillow-11.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2dbea1012ccb784a65349f57bbc93730b96e85b42e9bf7b01ef40443db720b4", size = 4612523, upload-time = "2025-04-12T17:48:11.631Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2f/65738384e0b1acf451de5a573d8153fe84103772d139e1e0bdf1596be2ea/pillow-11.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:da3104c57bbd72948d75f6a9389e6727d2ab6333c3617f0a89d72d4940aa0443", size = 4587836, upload-time = "2025-04-12T17:48:13.592Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c5/e795c9f2ddf3debb2dedd0df889f2fe4b053308bb59a3cc02a0cd144d641/pillow-11.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:598174aef4589af795f66f9caab87ba4ff860ce08cd5bb447c6fc553ffee603c", size = 4669390, upload-time = "2025-04-12T17:48:15.938Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ae/ca0099a3995976a9fce2f423166f7bff9b12244afdc7520f6ed38911539a/pillow-11.2.1-cp312-cp312-win32.whl", hash = "sha256:1d535df14716e7f8776b9e7fee118576d65572b4aad3ed639be9e4fa88a1cad3", size = 2332309, upload-time = "2025-04-12T17:48:17.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/18/24bff2ad716257fc03da964c5e8f05d9790a779a8895d6566e493ccf0189/pillow-11.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:14e33b28bf17c7a38eede290f77db7c664e4eb01f7869e37fa98a5aa95978941", size = 2676768, upload-time = "2025-04-12T17:48:19.655Z" },
-    { url = "https://files.pythonhosted.org/packages/da/bb/e8d656c9543276517ee40184aaa39dcb41e683bca121022f9323ae11b39d/pillow-11.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:21e1470ac9e5739ff880c211fc3af01e3ae505859392bf65458c224d0bf283eb", size = 2415087, upload-time = "2025-04-12T17:48:21.991Z" },
-    { url = "https://files.pythonhosted.org/packages/36/9c/447528ee3776e7ab8897fe33697a7ff3f0475bb490c5ac1456a03dc57956/pillow-11.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fdec757fea0b793056419bca3e9932eb2b0ceec90ef4813ea4c1e072c389eb28", size = 3190098, upload-time = "2025-04-12T17:48:23.915Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/09/29d5cd052f7566a63e5b506fac9c60526e9ecc553825551333e1e18a4858/pillow-11.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b0e130705d568e2f43a17bcbe74d90958e8a16263868a12c3e0d9c8162690830", size = 3030166, upload-time = "2025-04-12T17:48:25.738Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5d/446ee132ad35e7600652133f9c2840b4799bbd8e4adba881284860da0a36/pillow-11.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bdb5e09068332578214cadd9c05e3d64d99e0e87591be22a324bdbc18925be0", size = 4408674, upload-time = "2025-04-12T17:48:27.908Z" },
-    { url = "https://files.pythonhosted.org/packages/69/5f/cbe509c0ddf91cc3a03bbacf40e5c2339c4912d16458fcb797bb47bcb269/pillow-11.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d189ba1bebfbc0c0e529159631ec72bb9e9bc041f01ec6d3233d6d82eb823bc1", size = 4496005, upload-time = "2025-04-12T17:48:29.888Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b3/dd4338d8fb8a5f312021f2977fb8198a1184893f9b00b02b75d565c33b51/pillow-11.2.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:191955c55d8a712fab8934a42bfefbf99dd0b5875078240943f913bb66d46d9f", size = 4518707, upload-time = "2025-04-12T17:48:31.874Z" },
-    { url = "https://files.pythonhosted.org/packages/13/eb/2552ecebc0b887f539111c2cd241f538b8ff5891b8903dfe672e997529be/pillow-11.2.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad275964d52e2243430472fc5d2c2334b4fc3ff9c16cb0a19254e25efa03a155", size = 4610008, upload-time = "2025-04-12T17:48:34.422Z" },
-    { url = "https://files.pythonhosted.org/packages/72/d1/924ce51bea494cb6e7959522d69d7b1c7e74f6821d84c63c3dc430cbbf3b/pillow-11.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:750f96efe0597382660d8b53e90dd1dd44568a8edb51cb7f9d5d918b80d4de14", size = 4585420, upload-time = "2025-04-12T17:48:37.641Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ab/8f81312d255d713b99ca37479a4cb4b0f48195e530cdc1611990eb8fd04b/pillow-11.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fe15238d3798788d00716637b3d4e7bb6bde18b26e5d08335a96e88564a36b6b", size = 4667655, upload-time = "2025-04-12T17:48:39.652Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/8f2e9d2dc3d308dfd137a07fe1cc478df0a23d42a6c4093b087e738e4827/pillow-11.2.1-cp313-cp313-win32.whl", hash = "sha256:3fe735ced9a607fee4f481423a9c36701a39719252a9bb251679635f99d0f7d2", size = 2332329, upload-time = "2025-04-12T17:48:41.765Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ec/1179083b8d6067a613e4d595359b5fdea65d0a3b7ad623fee906e1b3c4d2/pillow-11.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:74ee3d7ecb3f3c05459ba95eed5efa28d6092d751ce9bf20e3e253a4e497e691", size = 2676388, upload-time = "2025-04-12T17:48:43.625Z" },
-    { url = "https://files.pythonhosted.org/packages/23/f1/2fc1e1e294de897df39fa8622d829b8828ddad938b0eaea256d65b84dd72/pillow-11.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:5119225c622403afb4b44bad4c1ca6c1f98eed79db8d3bc6e4e160fc6339d66c", size = 2414950, upload-time = "2025-04-12T17:48:45.475Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/3e/c328c48b3f0ead7bab765a84b4977acb29f101d10e4ef57a5e3400447c03/pillow-11.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8ce2e8411c7aaef53e6bb29fe98f28cd4fbd9a1d9be2eeea434331aac0536b22", size = 3192759, upload-time = "2025-04-12T17:48:47.866Z" },
-    { url = "https://files.pythonhosted.org/packages/18/0e/1c68532d833fc8b9f404d3a642991441d9058eccd5606eab31617f29b6d4/pillow-11.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ee66787e095127116d91dea2143db65c7bb1e232f617aa5957c0d9d2a3f23a7", size = 3033284, upload-time = "2025-04-12T17:48:50.189Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/cb/6faf3fb1e7705fd2db74e070f3bf6f88693601b0ed8e81049a8266de4754/pillow-11.2.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9622e3b6c1d8b551b6e6f21873bdcc55762b4b2126633014cea1803368a9aa16", size = 4445826, upload-time = "2025-04-12T17:48:52.346Z" },
-    { url = "https://files.pythonhosted.org/packages/07/94/8be03d50b70ca47fb434a358919d6a8d6580f282bbb7af7e4aa40103461d/pillow-11.2.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63b5dff3a68f371ea06025a1a6966c9a1e1ee452fc8020c2cd0ea41b83e9037b", size = 4527329, upload-time = "2025-04-12T17:48:54.403Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/a4/bfe78777076dc405e3bd2080bc32da5ab3945b5a25dc5d8acaa9de64a162/pillow-11.2.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:31df6e2d3d8fc99f993fd253e97fae451a8db2e7207acf97859732273e108406", size = 4549049, upload-time = "2025-04-12T17:48:56.383Z" },
-    { url = "https://files.pythonhosted.org/packages/65/4d/eaf9068dc687c24979e977ce5677e253624bd8b616b286f543f0c1b91662/pillow-11.2.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:062b7a42d672c45a70fa1f8b43d1d38ff76b63421cbbe7f88146b39e8a558d91", size = 4635408, upload-time = "2025-04-12T17:48:58.782Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/26/0fd443365d9c63bc79feb219f97d935cd4b93af28353cba78d8e77b61719/pillow-11.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4eb92eca2711ef8be42fd3f67533765d9fd043b8c80db204f16c8ea62ee1a751", size = 4614863, upload-time = "2025-04-12T17:49:00.709Z" },
-    { url = "https://files.pythonhosted.org/packages/49/65/dca4d2506be482c2c6641cacdba5c602bc76d8ceb618fd37de855653a419/pillow-11.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f91ebf30830a48c825590aede79376cb40f110b387c17ee9bd59932c961044f9", size = 4692938, upload-time = "2025-04-12T17:49:02.946Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/92/1ca0c3f09233bd7decf8f7105a1c4e3162fb9142128c74adad0fb361b7eb/pillow-11.2.1-cp313-cp313t-win32.whl", hash = "sha256:e0b55f27f584ed623221cfe995c912c61606be8513bfa0e07d2c674b4516d9dd", size = 2335774, upload-time = "2025-04-12T17:49:04.889Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ac/77525347cb43b83ae905ffe257bbe2cc6fd23acb9796639a1f56aa59d191/pillow-11.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:36d6b82164c39ce5482f649b437382c0fb2395eabc1e2b1702a6deb8ad647d6e", size = 2681895, upload-time = "2025-04-12T17:49:06.635Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/32dc030cfa91ca0fc52baebbba2e009bb001122a1daa8b6a79ad830b38d3/pillow-11.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:225c832a13326e34f212d2072982bb1adb210e0cc0b153e688743018c94a2681", size = 2417234, upload-time = "2025-04-12T17:49:08.399Z" },
-    { url = "https://files.pythonhosted.org/packages/21/3a/c1835d1c7cf83559e95b4f4ed07ab0bb7acc689712adfce406b3f456e9fd/pillow-11.2.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:7491cf8a79b8eb867d419648fff2f83cb0b3891c8b36da92cc7f1931d46108c8", size = 3198391, upload-time = "2025-04-12T17:49:10.122Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/4d/dcb7a9af3fc1e8653267c38ed622605d9d1793349274b3ef7af06457e257/pillow-11.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b02d8f9cb83c52578a0b4beadba92e37d83a4ef11570a8688bbf43f4ca50909", size = 3030573, upload-time = "2025-04-12T17:49:11.938Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/29/530ca098c1a1eb31d4e163d317d0e24e6d2ead907991c69ca5b663de1bc5/pillow-11.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:014ca0050c85003620526b0ac1ac53f56fc93af128f7546623cc8e31875ab928", size = 4398677, upload-time = "2025-04-12T17:49:13.861Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/ee/0e5e51db34de1690264e5f30dcd25328c540aa11d50a3bc0b540e2a445b6/pillow-11.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3692b68c87096ac6308296d96354eddd25f98740c9d2ab54e1549d6c8aea9d79", size = 4484986, upload-time = "2025-04-12T17:49:15.948Z" },
-    { url = "https://files.pythonhosted.org/packages/93/7d/bc723b41ce3d2c28532c47678ec988974f731b5c6fadd5b3a4fba9015e4f/pillow-11.2.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:f781dcb0bc9929adc77bad571b8621ecb1e4cdef86e940fe2e5b5ee24fd33b35", size = 4501897, upload-time = "2025-04-12T17:49:17.839Z" },
-    { url = "https://files.pythonhosted.org/packages/be/0b/532e31abc7389617ddff12551af625a9b03cd61d2989fa595e43c470ec67/pillow-11.2.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:2b490402c96f907a166615e9a5afacf2519e28295f157ec3a2bb9bd57de638cb", size = 4592618, upload-time = "2025-04-12T17:49:19.7Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f0/21ed6499a6216fef753e2e2254a19d08bff3747108ba042422383f3e9faa/pillow-11.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dd6b20b93b3ccc9c1b597999209e4bc5cf2853f9ee66e3fc9a400a78733ffc9a", size = 4570493, upload-time = "2025-04-12T17:49:21.703Z" },
-    { url = "https://files.pythonhosted.org/packages/68/de/17004ddb8ab855573fe1127ab0168d11378cdfe4a7ee2a792a70ff2e9ba7/pillow-11.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:4b835d89c08a6c2ee7781b8dd0a30209a8012b5f09c0a665b65b0eb3560b6f36", size = 4647748, upload-time = "2025-04-12T17:49:23.579Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/23/82ecb486384bb3578115c509d4a00bb52f463ee700a5ca1be53da3c88c19/pillow-11.2.1-cp39-cp39-win32.whl", hash = "sha256:b10428b3416d4f9c61f94b494681280be7686bda15898a3a9e08eb66a6d92d67", size = 2331731, upload-time = "2025-04-12T17:49:25.58Z" },
-    { url = "https://files.pythonhosted.org/packages/58/bb/87efd58b3689537a623d44dbb2550ef0bb5ff6a62769707a0fe8b1a7bdeb/pillow-11.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:6ebce70c3f486acf7591a3d73431fa504a4e18a9b97ff27f5f47b7368e4b9dd1", size = 2676346, upload-time = "2025-04-12T17:49:27.342Z" },
-    { url = "https://files.pythonhosted.org/packages/80/08/dc268475b22887b816e5dcfae31bce897f524b4646bab130c2142c9b2400/pillow-11.2.1-cp39-cp39-win_arm64.whl", hash = "sha256:c27476257b2fdcd7872d54cfd119b3a9ce4610fb85c8e32b70b42e3680a29a1e", size = 2414623, upload-time = "2025-04-12T17:49:29.139Z" },
-    { url = "https://files.pythonhosted.org/packages/33/49/c8c21e4255b4f4a2c0c68ac18125d7f5460b109acc6dfdef1a24f9b960ef/pillow-11.2.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:9b7b0d4fd2635f54ad82785d56bc0d94f147096493a79985d0ab57aedd563156", size = 3181727, upload-time = "2025-04-12T17:49:31.898Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f1/f7255c0838f8c1ef6d55b625cfb286835c17e8136ce4351c5577d02c443b/pillow-11.2.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:aa442755e31c64037aa7c1cb186e0b369f8416c567381852c63444dd666fb772", size = 2999833, upload-time = "2025-04-12T17:49:34.2Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/57/9968114457bd131063da98d87790d080366218f64fa2943b65ac6739abb3/pillow-11.2.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0d3348c95b766f54b76116d53d4cb171b52992a1027e7ca50c81b43b9d9e363", size = 3437472, upload-time = "2025-04-12T17:49:36.294Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1b/e35d8a158e21372ecc48aac9c453518cfe23907bb82f950d6e1c72811eb0/pillow-11.2.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85d27ea4c889342f7e35f6d56e7e1cb345632ad592e8c51b693d7b7556043ce0", size = 3459976, upload-time = "2025-04-12T17:49:38.988Z" },
-    { url = "https://files.pythonhosted.org/packages/26/da/2c11d03b765efff0ccc473f1c4186dc2770110464f2177efaed9cf6fae01/pillow-11.2.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bf2c33d6791c598142f00c9c4c7d47f6476731c31081331664eb26d6ab583e01", size = 3527133, upload-time = "2025-04-12T17:49:40.985Z" },
-    { url = "https://files.pythonhosted.org/packages/79/1a/4e85bd7cadf78412c2a3069249a09c32ef3323650fd3005c97cca7aa21df/pillow-11.2.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e616e7154c37669fc1dfc14584f11e284e05d1c650e1c0f972f281c4ccc53193", size = 3571555, upload-time = "2025-04-12T17:49:42.964Z" },
-    { url = "https://files.pythonhosted.org/packages/69/03/239939915216de1e95e0ce2334bf17a7870ae185eb390fab6d706aadbfc0/pillow-11.2.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:39ad2e0f424394e3aebc40168845fee52df1394a4673a6ee512d840d14ab3013", size = 2674713, upload-time = "2025-04-12T17:49:44.944Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/ad/2613c04633c7257d9481ab21d6b5364b59fc5d75faafd7cb8693523945a3/pillow-11.2.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:80f1df8dbe9572b4b7abdfa17eb5d78dd620b1d55d9e25f834efdbee872d3aed", size = 3181734, upload-time = "2025-04-12T17:49:46.789Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/fd/dcdda4471ed667de57bb5405bb42d751e6cfdd4011a12c248b455c778e03/pillow-11.2.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ea926cfbc3957090becbcbbb65ad177161a2ff2ad578b5a6ec9bb1e1cd78753c", size = 2999841, upload-time = "2025-04-12T17:49:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/89/8a2536e95e77432833f0db6fd72a8d310c8e4272a04461fb833eb021bf94/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:738db0e0941ca0376804d4de6a782c005245264edaa253ffce24e5a15cbdc7bd", size = 3437470, upload-time = "2025-04-12T17:49:50.831Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/8f/abd47b73c60712f88e9eda32baced7bfc3e9bd6a7619bb64b93acff28c3e/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9db98ab6565c69082ec9b0d4e40dd9f6181dab0dd236d26f7a50b8b9bfbd5076", size = 3460013, upload-time = "2025-04-12T17:49:53.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/20/5c0a0aa83b213b7a07ec01e71a3d6ea2cf4ad1d2c686cc0168173b6089e7/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:036e53f4170e270ddb8797d4c590e6dd14d28e15c7da375c18978045f7e6c37b", size = 3527165, upload-time = "2025-04-12T17:49:55.164Z" },
-    { url = "https://files.pythonhosted.org/packages/58/0e/2abab98a72202d91146abc839e10c14f7cf36166f12838ea0c4db3ca6ecb/pillow-11.2.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:14f73f7c291279bd65fda51ee87affd7c1e097709f7fdd0188957a16c264601f", size = 3571586, upload-time = "2025-04-12T17:49:57.171Z" },
-    { url = "https://files.pythonhosted.org/packages/21/2c/5e05f58658cf49b6667762cca03d6e7d85cededde2caf2ab37b81f80e574/pillow-11.2.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:208653868d5c9ecc2b327f9b9ef34e0e42a4cdd172c2988fd81d62d2bc9bc044", size = 2674751, upload-time = "2025-04-12T17:49:59.628Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554, upload-time = "2025-07-01T09:13:39.342Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548, upload-time = "2025-07-01T09:13:41.835Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742, upload-time = "2025-07-03T13:09:47.439Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087, upload-time = "2025-07-03T13:09:51.796Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350, upload-time = "2025-07-01T09:13:43.865Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840, upload-time = "2025-07-01T09:13:46.161Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005, upload-time = "2025-07-01T09:13:47.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372, upload-time = "2025-07-01T09:13:52.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090, upload-time = "2025-07-01T09:13:53.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988, upload-time = "2025-07-01T09:13:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899, upload-time = "2025-07-01T09:13:57.497Z" },
+    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531, upload-time = "2025-07-01T09:13:59.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560, upload-time = "2025-07-01T09:14:01.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978, upload-time = "2025-07-03T13:09:55.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168, upload-time = "2025-07-03T13:10:00.37Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053, upload-time = "2025-07-01T09:14:04.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273, upload-time = "2025-07-01T09:14:06.235Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043, upload-time = "2025-07-01T09:14:07.978Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516, upload-time = "2025-07-01T09:14:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768, upload-time = "2025-07-01T09:14:11.921Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055, upload-time = "2025-07-01T09:14:13.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079, upload-time = "2025-07-01T09:14:15.268Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
+    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
+    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328, upload-time = "2025-07-01T09:14:35.276Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652, upload-time = "2025-07-01T09:14:37.203Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443, upload-time = "2025-07-01T09:14:39.344Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474, upload-time = "2025-07-01T09:14:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038, upload-time = "2025-07-01T09:14:44.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407, upload-time = "2025-07-03T13:10:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094, upload-time = "2025-07-03T13:10:21.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503, upload-time = "2025-07-01T09:14:45.698Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574, upload-time = "2025-07-01T09:14:47.415Z" },
+    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060, upload-time = "2025-07-01T09:14:49.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407, upload-time = "2025-07-01T09:14:51.962Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841, upload-time = "2025-07-01T09:14:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450, upload-time = "2025-07-01T09:14:56.436Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055, upload-time = "2025-07-01T09:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110, upload-time = "2025-07-01T09:14:59.79Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547, upload-time = "2025-07-01T09:15:01.648Z" },
+    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554, upload-time = "2025-07-03T13:10:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132, upload-time = "2025-07-03T13:10:33.01Z" },
+    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001, upload-time = "2025-07-01T09:15:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814, upload-time = "2025-07-01T09:15:05.655Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124, upload-time = "2025-07-01T09:15:07.358Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186, upload-time = "2025-07-01T09:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546, upload-time = "2025-07-01T09:15:11.311Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102, upload-time = "2025-07-01T09:15:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803, upload-time = "2025-07-01T09:15:15.695Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520, upload-time = "2025-07-01T09:15:17.429Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116, upload-time = "2025-07-01T09:15:19.423Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597, upload-time = "2025-07-03T13:10:38.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246, upload-time = "2025-07-03T13:10:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336, upload-time = "2025-07-01T09:15:21.237Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699, upload-time = "2025-07-01T09:15:23.186Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789, upload-time = "2025-07-01T09:15:25.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386, upload-time = "2025-07-01T09:15:27.378Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911, upload-time = "2025-07-01T09:15:29.294Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383, upload-time = "2025-07-01T09:15:31.128Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385, upload-time = "2025-07-01T09:15:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129, upload-time = "2025-07-01T09:15:35.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580, upload-time = "2025-07-01T09:15:37.114Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860, upload-time = "2025-07-03T13:10:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694, upload-time = "2025-07-03T13:10:56.432Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888, upload-time = "2025-07-01T09:15:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330, upload-time = "2025-07-01T09:15:41.269Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089, upload-time = "2025-07-01T09:15:43.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206, upload-time = "2025-07-01T09:15:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370, upload-time = "2025-07-01T09:15:46.673Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500, upload-time = "2025-07-01T09:15:48.512Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835, upload-time = "2025-07-01T09:15:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8e/9c089f01677d1264ab8648352dcb7773f37da6ad002542760c80107da816/pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f", size = 5316478, upload-time = "2025-07-01T09:15:52.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a9/5749930caf674695867eb56a581e78eb5f524b7583ff10b01b6e5048acb3/pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081", size = 4686522, upload-time = "2025-07-01T09:15:54.162Z" },
+    { url = "https://files.pythonhosted.org/packages/43/46/0b85b763eb292b691030795f9f6bb6fcaf8948c39413c81696a01c3577f7/pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4", size = 5853376, upload-time = "2025-07-03T13:11:01.066Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/1a230ec0067243cbd60bc2dad5dc3ab46a8a41e21c15f5c9b52b26873069/pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc", size = 7626020, upload-time = "2025-07-03T13:11:06.479Z" },
+    { url = "https://files.pythonhosted.org/packages/63/dd/f296c27ffba447bfad76c6a0c44c1ea97a90cb9472b9304c94a732e8dbfb/pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06", size = 5956732, upload-time = "2025-07-01T09:15:56.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a0/98a3630f0b57f77bae67716562513d3032ae70414fcaf02750279c389a9e/pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a", size = 6624404, upload-time = "2025-07-01T09:15:58.245Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e6/83dfba5646a290edd9a21964da07674409e410579c341fc5b8f7abd81620/pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978", size = 6067760, upload-time = "2025-07-01T09:16:00.003Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/41/15ab268fe6ee9a2bc7391e2bbb20a98d3974304ab1a406a992dcb297a370/pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d", size = 6700534, upload-time = "2025-07-01T09:16:02.29Z" },
+    { url = "https://files.pythonhosted.org/packages/64/79/6d4f638b288300bed727ff29f2a3cb63db054b33518a95f27724915e3fbc/pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71", size = 6277091, upload-time = "2025-07-01T09:16:04.4Z" },
+    { url = "https://files.pythonhosted.org/packages/46/05/4106422f45a05716fd34ed21763f8ec182e8ea00af6e9cb05b93a247361a/pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada", size = 6986091, upload-time = "2025-07-01T09:16:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/287fd55c2c12761d0591549d48885187579b7c257bef0c6660755b0b59ae/pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb", size = 2422632, upload-time = "2025-07-01T09:16:08.142Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556, upload-time = "2025-07-01T09:16:09.961Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625, upload-time = "2025-07-01T09:16:11.913Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207, upload-time = "2025-07-03T13:11:10.201Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939, upload-time = "2025-07-03T13:11:15.68Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166, upload-time = "2025-07-01T09:16:13.74Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482, upload-time = "2025-07-01T09:16:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596, upload-time = "2025-07-01T09:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566, upload-time = "2025-07-01T09:16:19.801Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618, upload-time = "2025-07-01T09:16:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248, upload-time = "2025-07-03T13:11:20.738Z" },
+    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963, upload-time = "2025-07-03T13:11:26.283Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
 ]
 
 [[package]]
 name = "pycollada"
-version = "0.9"
+version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/6b/caadd3d65fde5a6a5a33e608183d5a52525a41e2c44f479a99620413a661/pycollada-0.9.tar.gz", hash = "sha256:824f6e809e510d649b5984a6ea8e614ce5cf270c81eab6fbeaaf0ae71de6a6af", size = 109666, upload-time = "2025-02-16T22:59:04.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/13/21debba42c0c255acba29f42af8785ecad656948d30fde5302d5e4494d1c/pycollada-0.9.2.tar.gz", hash = "sha256:7ca12267be0a2b93e495d6036e6b274023a9457ded641954eb0c470efe153d6e", size = 109972, upload-time = "2025-06-30T16:23:48.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/75/04e83be415fc67fa29d2447eb3248ea3bb79c2243be3f2fdfcca3699ce8b/pycollada-0.9.2-py3-none-any.whl", hash = "sha256:12fbeef6461688b6b3775c50196a2bb5f8813c0d39923a5a49681a75eb4622c9", size = 128399, upload-time = "2025-06-30T16:23:47.327Z" },
+]
 
 [[package]]
 name = "pydata-sphinx-theme"
@@ -2040,9 +1898,9 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "docutils" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/20/bb50f9de3a6de69e6abd6b087b52fa2418a0418b19597601605f855ad044/pydata_sphinx_theme-0.16.1.tar.gz", hash = "sha256:a08b7f0b7f70387219dc659bff0893a7554d5eb39b59d3b8ef37b8401b7642d7", size = 2412693, upload-time = "2024-12-17T10:53:39.537Z" }
@@ -2197,16 +2055,12 @@ name = "scipy"
 version = "1.13.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -2241,16 +2095,12 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2306,21 +2156,15 @@ name = "scipy"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/18/b06a83f0c5ee8cddbde5e3f3d0bb9b702abfa5136ef6d4620ff67df7eee5/scipy-1.16.0.tar.gz", hash = "sha256:b5ef54021e832869c8cfb03bc3bf20366cbcd426e02a58e8a58d7584dfbb8f62", size = 30581216, upload-time = "2025-06-22T16:27:55.782Z" }
 wheels = [
@@ -2376,16 +2220,12 @@ name = "shapely"
 version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/c0/a911d1fd765d07a2b6769ce155219a281bfbe311584ebe97340d75c5bdb1/shapely-2.0.7.tar.gz", hash = "sha256:28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5", size = 283413, upload-time = "2025-01-31T01:10:20.787Z" }
 wheels = [
@@ -2426,29 +2266,19 @@ name = "shapely"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/3c/2da625233f4e605155926566c0e7ea8dda361877f48e8b1655e53456f252/shapely-2.1.1.tar.gz", hash = "sha256:500621967f2ffe9642454808009044c21e5b35db89ce69f8a2042c2ffd0e2772", size = 315422, upload-time = "2025-05-19T11:04:41.265Z" }
 wheels = [
@@ -2535,33 +2365,29 @@ name = "sphinx"
 version = "7.4.7"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "babel", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "colorama", marker = "(python_full_version < '3.10' and sys_platform == 'win32') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "docutils", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "imagesize", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "jinja2", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "packaging", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pygments", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "requests", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "tomli", marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "babel", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.10'" },
+    { name = "imagesize", marker = "python_full_version < '3.10'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "requests", marker = "python_full_version < '3.10'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.10'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
 wheels = [
@@ -2573,32 +2399,28 @@ name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "babel", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "colorama", marker = "(python_full_version == '3.10.*' and sys_platform == 'win32') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "docutils", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "imagesize", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "jinja2", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "packaging", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pygments", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "requests", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "tomli", marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "babel", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version == '3.10.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.10.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.10.*'" },
+    { name = "packaging", marker = "python_full_version == '3.10.*'" },
+    { name = "pygments", marker = "python_full_version == '3.10.*'" },
+    { name = "requests", marker = "python_full_version == '3.10.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.10.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.10.*'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -2610,37 +2432,31 @@ name = "sphinx"
 version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "babel", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "docutils", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "imagesize", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "jinja2", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "requests", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "roman-numerals-py", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
@@ -2652,9 +2468,9 @@ name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
@@ -2666,9 +2482,9 @@ name = "sphinx-design"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -2682,9 +2498,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/53/a9a91995cb365e589f413b77fc75f1c0e9b4ac61bfa8da52a779ad855cc0/sphinx-tabs-3.4.7.tar.gz", hash = "sha256:991ad4a424ff54119799ba1491701aa8130dd43509474aef45a81c42d889784d", size = 15891, upload-time = "2024-10-08T13:37:27.887Z" }
 wheels = [
@@ -2733,9 +2549,9 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/69/bf039237ad260073e8c02f820b3e00dc34f3a2de20aff7861e6b19d2f8c5/sphinxcontrib_mermaid-1.0.0.tar.gz", hash = "sha256:2e8ab67d3e1e2816663f9347d026a8dee4a858acdd4ad32dd1c808893db88146", size = 15153, upload-time = "2024-10-12T16:33:03.863Z" }
 wheels = [
@@ -2829,37 +2645,19 @@ dependencies = [
     { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "setuptools", marker = "python_full_version >= '3.12' and sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/27/2e06cb52adf89fe6e020963529d17ed51532fc73c1e6d1b18420ef03338c/torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a103b5d782af5bd119b81dbcc7ffc6fa09904c423ff8db397a1e6ea8fd71508f", size = 99089441, upload-time = "2025-06-04T17:38:48.268Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7c/0a5b3aee977596459ec45be2220370fde8e017f651fecc40522fd478cb1e/torch-2.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:fe955951bdf32d182ee8ead6c3186ad54781492bf03d547d31771a01b3d6fb7d", size = 821154516, upload-time = "2025-06-04T17:36:28.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/91/3d709cfc5e15995fb3fe7a6b564ce42280d3a55676dad672205e94f34ac9/torch-2.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:885453d6fba67d9991132143bf7fa06b79b24352f4506fd4d10b309f53454162", size = 216093147, upload-time = "2025-06-04T17:39:38.132Z" },
     { url = "https://files.pythonhosted.org/packages/92/f6/5da3918414e07da9866ecb9330fe6ffdebe15cb9a4c5ada7d4b6e0a6654d/torch-2.7.1-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:d72acfdb86cee2a32c0ce0101606f3758f0d8bb5f8f31e7920dc2809e963aa7c", size = 68630914, upload-time = "2025-06-04T17:39:31.162Z" },
-    { url = "https://files.pythonhosted.org/packages/11/56/2eae3494e3d375533034a8e8cf0ba163363e996d85f0629441fa9d9843fe/torch-2.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:236f501f2e383f1cb861337bdf057712182f910f10aeaf509065d54d339e49b2", size = 99093039, upload-time = "2025-06-04T17:39:06.963Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/94/34b80bd172d0072c9979708ccd279c2da2f55c3ef318eceec276ab9544a4/torch-2.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:06eea61f859436622e78dd0cdd51dbc8f8c6d76917a9cf0555a333f9eac31ec1", size = 821174704, upload-time = "2025-06-04T17:37:03.799Z" },
-    { url = "https://files.pythonhosted.org/packages/50/9e/acf04ff375b0b49a45511c55d188bcea5c942da2aaf293096676110086d1/torch-2.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:8273145a2e0a3c6f9fd2ac36762d6ee89c26d430e612b95a99885df083b04e52", size = 216095937, upload-time = "2025-06-04T17:39:24.83Z" },
     { url = "https://files.pythonhosted.org/packages/5b/2b/d36d57c66ff031f93b4fa432e86802f84991477e522adcdffd314454326b/torch-2.7.1-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:aea4fc1bf433d12843eb2c6b2204861f43d8364597697074c8d38ae2507f8730", size = 68640034, upload-time = "2025-06-04T17:39:17.989Z" },
-    { url = "https://files.pythonhosted.org/packages/87/93/fb505a5022a2e908d81fe9a5e0aa84c86c0d5f408173be71c6018836f34e/torch-2.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ea1e518df4c9de73af7e8a720770f3628e7f667280bce2be7a16292697e3fa", size = 98948276, upload-time = "2025-06-04T17:39:12.852Z" },
-    { url = "https://files.pythonhosted.org/packages/56/7e/67c3fe2b8c33f40af06326a3d6ae7776b3e3a01daa8f71d125d78594d874/torch-2.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c33360cfc2edd976c2633b3b66c769bdcbbf0e0b6550606d188431c81e7dd1fc", size = 821025792, upload-time = "2025-06-04T17:34:58.747Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/37/a37495502bc7a23bf34f89584fa5a78e25bae7b8da513bc1b8f97afb7009/torch-2.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8bf6e1856ddd1807e79dc57e54d3335f2b62e6f316ed13ed3ecfe1fc1df3d8b", size = 216050349, upload-time = "2025-06-04T17:38:59.709Z" },
     { url = "https://files.pythonhosted.org/packages/3a/60/04b77281c730bb13460628e518c52721257814ac6c298acd25757f6a175c/torch-2.7.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:787687087412c4bd68d315e39bc1223f08aae1d16a9e9771d95eabbb04ae98fb", size = 68645146, upload-time = "2025-06-04T17:38:52.97Z" },
-    { url = "https://files.pythonhosted.org/packages/66/81/e48c9edb655ee8eb8c2a6026abdb6f8d2146abd1f150979ede807bb75dcb/torch-2.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:03563603d931e70722dce0e11999d53aa80a375a3d78e6b39b9f6805ea0a8d28", size = 98946649, upload-time = "2025-06-04T17:38:43.031Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/24/efe2f520d75274fc06b695c616415a1e8a1021d87a13c68ff9dce733d088/torch-2.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d632f5417b6980f61404a125b999ca6ebd0b8b4bbdbb5fbbba44374ab619a412", size = 821033192, upload-time = "2025-06-04T17:38:09.146Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d9/9c24d230333ff4e9b6807274f6f8d52a864210b52ec794c5def7925f4495/torch-2.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:23660443e13995ee93e3d844786701ea4ca69f337027b05182f5ba053ce43b38", size = 216055668, upload-time = "2025-06-04T17:38:36.253Z" },
     { url = "https://files.pythonhosted.org/packages/95/bf/e086ee36ddcef9299f6e708d3b6c8487c1651787bb9ee2939eb2a7f74911/torch-2.7.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0da4f4dba9f65d0d203794e619fe7ca3247a55ffdcbd17ae8fb83c8b2dc9b585", size = 68925988, upload-time = "2025-06-04T17:38:29.273Z" },
-    { url = "https://files.pythonhosted.org/packages/69/6a/67090dcfe1cf9048448b31555af6efb149f7afa0a310a366adbdada32105/torch-2.7.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e08d7e6f21a617fe38eeb46dd2213ded43f27c072e9165dc27300c9ef9570934", size = 99028857, upload-time = "2025-06-04T17:37:50.956Z" },
-    { url = "https://files.pythonhosted.org/packages/90/1c/48b988870823d1cc381f15ec4e70ed3d65e043f43f919329b0045ae83529/torch-2.7.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:30207f672328a42df4f2174b8f426f354b2baa0b7cca3a0adb3d6ab5daf00dc8", size = 821098066, upload-time = "2025-06-04T17:37:33.939Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/eb/10050d61c9d5140c5dc04a89ed3257ef1a6b93e49dd91b95363d757071e0/torch-2.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:79042feca1c634aaf6603fe6feea8c6b30dfa140a6bbc0b973e2260c7e79a22e", size = 216336310, upload-time = "2025-06-04T17:36:09.862Z" },
     { url = "https://files.pythonhosted.org/packages/b1/29/beb45cdf5c4fc3ebe282bf5eafc8dfd925ead7299b3c97491900fe5ed844/torch-2.7.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:988b0cbc4333618a1056d2ebad9eb10089637b659eb645434d0809d8d937b946", size = 68645708, upload-time = "2025-06-04T17:34:39.852Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8a/7db5ed2696e9d67dbc7f8df02d0bc1680b68a0552a3c07ea2d1795fb3f19/torch-2.7.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:e0d81e9a12764b6f3879a866607c8ae93113cbcad57ce01ebde63eb48a576369", size = 99140587, upload-time = "2025-06-04T17:36:46.282Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7b/62bedf718e6100c6d1d53fbdb7e56cb7ad80912a57f2bc7f4f1f289988f1/torch-2.7.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8394833c44484547ed4a47162318337b88c97acdb3273d85ea06e03ffff44998", size = 821146689, upload-time = "2025-06-04T17:35:47.69Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/e3/80230d0eec3a4dd1b5d2b423e663026452ac8ffb64aeac1619febc1b4ac7/torch-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:df41989d9300e6e3c19ec9f56f856187a6ef060c3662fe54f4b6baf1fc90bd19", size = 215987480, upload-time = "2025-06-04T17:35:19.335Z" },
     { url = "https://files.pythonhosted.org/packages/62/77/6391214d084a85aeb099d520420d39f405928b6a5f27a3f1a453c27c5173/torch-2.7.1-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:a737b5edd1c44a5c1ece2e9f3d00df9d1b3fb9541138bee56d83d38293fb6c9d", size = 68630146, upload-time = "2025-06-04T17:35:26.434Z" },
 ]
 
@@ -2877,9 +2675,9 @@ dependencies = [
     { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.11' and sys_platform == 'win32' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'linux' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'win32' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
     { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -2925,7 +2723,7 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -2934,16 +2732,16 @@ wheels = [
 
 [[package]]
 name = "trimesh"
-version = "4.6.12"
+version = "4.6.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/fb/b3d8fb188a1ec7df337df9e2fd5dea672c8806860677a7a6ef26b123865f/trimesh-4.6.12.tar.gz", hash = "sha256:cf8ad4a5c2d9b0277f34d999a077aa9331c465040c402774e1455054a6c20e67", size = 803682, upload-time = "2025-06-11T22:23:54.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c2/b97f9fea123b608d0027abb3bb87cfbecfb974ad8f1f034641e5fe4f0312/trimesh-4.6.13.tar.gz", hash = "sha256:2950dd6c3c9c9948a652f7a2966319b47130467bbbf447b254e02b9d90c94f14", size = 804497, upload-time = "2025-06-27T18:34:27.839Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/fa/3dc02004746b7708f3c206e6363da1dcdaed764f24a89fc3462ac2e01f2f/trimesh-4.6.12-py3-none-any.whl", hash = "sha256:71e71d1e698d2ffb73e60b461836352669974082fa7970807660bcd81de8aa30", size = 711977, upload-time = "2025-06-11T22:23:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2f/03e3829bf98fdf77b8669174957f47e8a977385ffd2c810e818a603a32ca/trimesh-4.6.13-py3-none-any.whl", hash = "sha256:b20b4c3ff03d185ec5b2b0e3adce6e75d8d73508861f2c1be3e40ab47cf18fee", size = 712440, upload-time = "2025-06-27T18:34:24.768Z" },
 ]
 
 [[package]]
@@ -3001,63 +2799,46 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.7.2"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform == 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.10.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.10' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform == 'darwin') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform == 'darwin') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/eb/bef2bf8404186115be15cd015c11ab356228410514c9878ad1a8b405b9a7/warp_lang-1.7.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:3825d7ddeb1c733812ff00cce12febcd7fb80b20c413b17e3517dc67b9d5b5ee", size = 45180599, upload-time = "2025-05-31T20:36:08.153Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/81/49be6af5701f21582b8b41ffb9c159bcf63606b83a7134f3906e670fa990/warp_lang-1.7.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:44ea71528d667b4a6b851767d2ccceee3c81a49956798122004aefd95e614a6f", size = 126571159, upload-time = "2025-05-31T20:36:14.246Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/56/3c004907c5322157b3e5dc6534f3d12ff55fbba0f2458bf8af6d767d0485/warp_lang-1.7.2-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e966450620d6c7a091417d9368528ed1ddf8e819304c84d12e0c440b2e47ef79", size = 127496325, upload-time = "2025-05-31T20:36:22.539Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/2f/455ffdfd0e0aefcf7da0b90ec567329ca01c01e2c5cfafee207799efa627/warp_lang-1.7.2-py3-none-win_amd64.whl", hash = "sha256:a68dd8a4493670aa02ec12c4eb724d4ee9f54e47fa332333fb863a696fe4b40b", size = 108800535, upload-time = "2025-05-31T20:36:28.975Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/27cbc1339c34b3d18dfee86c050b2be42781ed30f131d97e80522926e02a/warp_lang-1.8.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:1be62e7b3e8019ccccc00916c2798afc6c4bfce17d1d6025dc8ef5c790e42c1d", size = 45316553, upload-time = "2025-07-01T18:31:57.85Z" },
 ]
 
 [[package]]
 name = "warp-lang"
-version = "1.8.0.dev20250625"
+version = "1.9.0.dev20250703"
 source = { registry = "https://pypi.nvidia.com/" }
 resolution-markers = [
-    "(python_full_version >= '3.12' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version >= '3.12' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.11.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.11.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version == '3.10.*' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version == '3.10.*' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "(python_full_version < '3.10' and sys_platform == 'linux' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (python_full_version < '3.10' and sys_platform == 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.12' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version >= '3.11' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version == '3.10.*' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
-    "python_full_version < '3.10' and sys_platform != 'darwin' and extra != 'extra-14-newton-physics-cpu' and extra != 'extra-14-newton-physics-cu128'",
+    "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
+    "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.10.*' and sys_platform == 'linux') or (python_full_version == '3.10.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.10' and sys_platform == 'linux') or (python_full_version < '3.10' and sys_platform == 'win32')",
+    "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.10' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.10' and sys_platform != 'darwin') or (python_full_version >= '3.10' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.10.*' and sys_platform != 'darwin') or (python_full_version != '3.10.*' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
-    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'darwin') or (python_full_version < '3.11' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128') or (sys_platform == 'darwin' and extra == 'extra-14-newton-physics-cpu' and extra == 'extra-14-newton-physics-cu128')" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce042da8e85f62acd0f8e1b61b18c02193c078581df5d9317ffd8310b386c9ce" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e6850770d6f6a51dc2794e0daff18fd988b0c8e9057ae4fcdce6d2ea5b482417" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.8.0.dev20250625-py3-none-win_amd64.whl", hash = "sha256:b6b8811b695aae3ecb262c545852ee0371c2210f5753338650e0caede8342bd3" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250703-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:73ea2325a474ed5b88f3910a0ef73e112b523e87aba722bfa5a0d2efe5b64958" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250703-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d589e151409fcdbb6a2e3949036119d11f1c4850a976f220bbca6e1b521cc1fe" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250703-py3-none-win_amd64.whl", hash = "sha256:2436d7b559801de9e7aba07d7f93f269e5cae4caf5babb00812ab97c74ba1422" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

- Add a PyTorch dependency. This can be installed by running `uv run --extra cu128 name_of_script.py`
- Test the Anymal examples (GPU testing only due to how the examples were written)
- Early-out if the Anymal examples is run on the CPU
- Apply fix from #318 to the sand example
- Clean up uv dependency group usage
- Mass-update of dependencies in the `uv.lock` file
- Update documentation to avoid `--all-extras` (too heavy-handed, especially with the PyTorch extra)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
