### PR TITLE
Update MuJoCoSolver to check conditional graph support

### DIFF
--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -108,6 +108,9 @@ class Example:
 
         self.solver = newton.solvers.MuJoCoSolver(self.model)
 
+        # TODO: This line is needed or else this example will crash on some systems
+        self.solver.mjw_model.opt.graph_conditional = False
+
         self.renderer = None
         if stage_path:
             self.renderer = newton.utils.SimRendererOpenGL(

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -1775,7 +1775,7 @@ class MuJoCoSolver(SolverBase):
             model.mjc_shape_to_geom = wp.array(shape_to_geom, dtype=wp.int32)  # pyright: ignore[reportAttributeAccessIssue]
 
             self.mjw_model = mujoco_warp.put_model(self.mj_model)
-            self.mjw_model.opt.graph_conditional = True
+            self.mjw_model.opt.graph_conditional = newton.utils.check_conditional_graph_support()
 
             if separate_envs_to_worlds:
                 nworld = model.num_envs

--- a/newton/utils/__init__.py
+++ b/newton/utils/__init__.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import warp as wp
+from warp.context import assert_conditional_graph_support
 
 from .download_assets import clear_git_cache, download_asset
 from .import_mjcf import parse_mjcf
@@ -101,11 +102,20 @@ def vec_abs(a: wp.vec3):
     return wp.vec3(wp.abs(a[0]), wp.abs(a[1]), wp.abs(a[2]))
 
 
+def check_conditional_graph_support():
+    try:
+        assert_conditional_graph_support()
+    except Exception:
+        return False
+    return False
+
+
 __all__ = [
     "SimRenderer",
     "SimRendererOpenGL",
     "SimRendererUsd",
     "boltzmann",
+    "check_conditional_graph_support",
     "clear_git_cache",
     "download_asset",
     "leaky_max",


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

#334 enabled conditional graph nodes, but neglected to check if the driver supported conditional graph nodes. This led to failures in GitLab CI/CD, where the driver is currently at 12.2.

`check_conditional_graph_support()` from `test_conditional_captures.py` in Warp is brought into `newton.utils` as a quick workaround to only use this feature on systems that can support it.

I also found when testing locally that `example_selection_articulations.py` segfaulted unless I disabled conditional graph nodes. This is on driver 570.133.20, which supports conditional graph nodes. I proactively disabled the use of this feature on this example in case others run into it, as it's also exercised in the unit tests.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
