### PR TITLE
fix: walk for anymal on sand

### DIFF
--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -92,7 +92,7 @@ class Example:
         fps = 60
         self.frame_dt = 1.0e0 / fps
 
-        self.sim_substeps = 6
+        self.sim_substeps = 10
         self.sim_dt = self.frame_dt / self.sim_substeps
 
         builder.joint_q[:3] = [
@@ -205,6 +205,7 @@ class Example:
 
         self.use_cuda_graph = self.device.is_cuda and wp.is_mempool_enabled(wp.get_device())
         if self.use_cuda_graph:
+            self.controller.get_control(self.state_0, self.control)
             with wp.ScopedCapture() as capture:
                 self.simulate_robot()
             self.robot_graph = capture.graph
@@ -215,6 +216,7 @@ class Example:
         self.contacts = self.model.collide(self.state_0, rigid_contact_margin=0.1)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
+            self.controller.assign_control(self.control, self.state_0)
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
 


### PR DESCRIPTION
## Description

Fixes walk for anymal on sand. (#354 )

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
