### PR TITLE
Fix CUDA kernel loading error during graph capture in example_g1.py

### DIFF
--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -138,6 +138,7 @@ class Example:
         )
 
         if self.use_cuda_graph:
+            self.simulate()
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph


### PR DESCRIPTION
## Description

Running example_g1.py with CUDA graph capture enabled results in a CUDA error due to dynamic kernel loading during the capture process.

```
Warp CUDA error 900: operation not permitted when stream is capturing (in function wp_cuda_load_module, /builds/omniverse/warp/warp/native/warp.cu:3938)
Warp CUDA error: Loading module failed
Module mujoco_warp._src.collision_primitive 7dcb9b8 load on device 'cuda:0' took 0.12 ms  (error)
Traceback (most recent call last):
  File "/home/ubuntu/workspaces/newton/newton/examples/example_g1.py", line 142, in __init__
    self.simulate()
  File "/home/ubuntu/workspaces/newton/newton/examples/example_g1.py", line 150, in simulate
    self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
  File "/home/ubuntu/workspaces/newton/newton/solvers/mujoco/solver_mujoco.py", line 902, in step
    self.mujoco_warp.step(self.mjw_model, self.mjw_data)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/warp_util.py", line 98, in wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/forward.py", line 1128, in step
    forward(m, d)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/warp_util.py", line 98, in wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/forward.py", line 1098, in forward
    fwd_position(m, d, factorize=False)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/warp_util.py", line 98, in wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/forward.py", line 539, in fwd_position
    collision_driver.collision(m, d)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/warp_util.py", line 98, in wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/collision_driver.py", line 540, in collision
    narrowphase(m, d)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/collision_driver.py", line 507, in narrowphase
    _narrowphase(m, d)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/collision_driver.py", line 497, in _narrowphase
    primitive_narrowphase(m, d)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/warp_util.py", line 98, in wrapper
    return fn(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/mujoco_warp/_src/collision_primitive.py", line 2620, in primitive_narrowphase
    wp.launch(
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/warp/context.py", line 5868, in launch
    module_exec = kernel.module.load(device, block_dim)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/warp/context.py", line 2376, in load
    raise Exception(f"Failed to load CUDA module '{self.name}'")
Exception: Failed to load CUDA module 'mujoco_warp._src.collision_primitive'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/workspaces/newton/newton/examples/example_g1.py", line 195, in <module>
    example = Example(stage_path=args.stage_path, num_envs=args.num_envs, use_cuda_graph=args.use_cuda_graph)
  File "/home/ubuntu/workspaces/newton/newton/examples/example_g1.py", line 141, in __init__
    with wp.ScopedCapture() as capture:
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/warp/utils.py", line 1516, in __exit__
    self.graph = wp.capture_end(device=self.device, stream=self.stream)
  File "/home/ubuntu/miniconda3/envs/sim45b-lab21/lib/python3.10/site-packages/warp/context.py", line 6397, in capture_end
    raise RuntimeError(f"CUDA graph capture failed. {runtime.get_error_string()}")
RuntimeError: CUDA graph capture failed. Warp CUDA error 900: operation not permitted when stream is capturing (in function wp_cuda_load_module, /builds/omniverse/warp/warp/native/warp.cu:3938)
```

Call simulate() before starting CUDA graph capture to pre-load all required kernels. This prevents dynamic kernel loading during capture and avoids related CUDA errors.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
