### PR TITLE
Rename example argument names to use hyphens instead of underscores

### DIFF
--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -357,12 +357,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_anymal_c_walk.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=10000, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=10000, help="Total number of frames.")
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -335,18 +335,18 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_anymal_c_walk_on_sand.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=10000, help="Total number of frames.")
-    parser.add_argument("--voxel_size", "-dx", type=float, default=0.03)
-    parser.add_argument("--particles_per_cell", "-ppc", type=float, default=3.0)
-    parser.add_argument("--sand_friction", "-mu", type=float, default=0.48)
+    parser.add_argument("--num-frames", type=int, default=10000, help="Total number of frames.")
+    parser.add_argument("--voxel-size", "-dx", type=float, default=0.03)
+    parser.add_argument("--particles-per-cell", "-ppc", type=float, default=3.0)
+    parser.add_argument("--sand-friction", "-mu", type=float, default=0.48)
     parser.add_argument("--tolerance", "-tol", type=float, default=1.0e-5)
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction)
-    parser.add_argument("--dynamic_grid", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--dynamic-grid", action=argparse.BooleanOptionalAction, default=True)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_cartpole.py
+++ b/newton/examples/example_cartpole.py
@@ -120,14 +120,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_cartpole.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=1200, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=100, help="Total number of simulated environments.")
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=100, help="Total number of simulated environments.")
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_cloth_bending.py
+++ b/newton/examples/example_cloth_bending.py
@@ -152,12 +152,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_cloth_bending.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=300, help="Total number of frames.")
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_cloth_hanging.py
+++ b/newton/examples/example_cloth_hanging.py
@@ -202,12 +202,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_cloth_hanging.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=300, help="Total number of frames.")
     parser.add_argument(
         "--solver",
         help="Type of solver",

--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -304,12 +304,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_cloth_self_contact.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=300, help="Total number of frames.")
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -123,7 +123,7 @@ def apply_rotation(
 
 
 class Example:
-    def __init__(self, stage_path="example_cloth_self_contact.usd", num_frames=600):
+    def __init__(self, stage_path="example_cloth_self_contact.usd", num_frames=300):
         fps = 60
         self.frame_dt = 1.0 / fps
         # must be an even number when using CUDA Graph

--- a/newton/examples/example_cloth_style3d.py
+++ b/newton/examples/example_cloth_style3d.py
@@ -193,12 +193,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_cloth_style3d.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=3000, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=3000, help="Total number of frames.")
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_cloth_style3d.py
+++ b/newton/examples/example_cloth_style3d.py
@@ -27,7 +27,7 @@ from newton.geometry import PARTICLE_FLAG_ACTIVE, Mesh
 
 
 class Example:
-    def __init__(self, stage_path="example_cloth_style3d.usd", num_frames=600):
+    def __init__(self, stage_path="example_cloth_style3d.usd", num_frames=3000):
         fps = 60
         self.frame_dt = 1.0 / fps
         # must be an even number when using CUDA Graph
@@ -178,7 +178,7 @@ class Example:
             self.render()
 
             if self.renderer is None:
-                print(f"[{frame_idx:4d}/{args.num_frames}]")
+                print(f"[{frame_idx:4d}/{self.num_frames}]")
 
     def render(self):
         if self.renderer is not None:

--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -174,20 +174,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_g1.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=12000, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=1, help="Total number of simulated environments.")
+    parser.add_argument("--num-frames", type=int, default=12000, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=1, help="Total number of simulated environments.")
     parser.add_argument(
-        "--show_mujoco_viewer",
+        "--show-mujoco-viewer",
         type=bool,
         default=False,
         help="Show MuJoCo viewer next to Newton renderer if MuJoCoSolver is used.",
     )
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -183,9 +183,9 @@ if __name__ == "__main__":
     parser.add_argument("--num-envs", type=int, default=1, help="Total number of simulated environments.")
     parser.add_argument(
         "--show-mujoco-viewer",
-        type=bool,
         default=False,
-        help="Show MuJoCo viewer next to Newton renderer if MuJoCoSolver is used.",
+        action=argparse.BooleanOptionalAction,
+        help="Toggle MuJoCo viewer next to Newton renderer when MuJoCoSolver is active.",
     )
     parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 

--- a/newton/examples/example_humanoid.py
+++ b/newton/examples/example_humanoid.py
@@ -133,14 +133,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_humanoid.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=12000, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=9, help="Total number of simulated environments.")
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--num-frames", type=int, default=12000, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=9, help="Total number of simulated environments.")
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_mpm_granular.py
+++ b/newton/examples/example_mpm_granular.py
@@ -235,28 +235,28 @@ if __name__ == "__main__":
 
     parser.add_argument("--collider", type=str)
 
-    parser.add_argument("--emit_lo", type=float, nargs=3, default=[-1, 0, -1])
-    parser.add_argument("--emit_hi", type=float, nargs=3, default=[1, 2, 1])
+    parser.add_argument("--emit-lo", type=float, nargs=3, default=[-1, 0, -1])
+    parser.add_argument("--emit-hi", type=float, nargs=3, default=[1, 2, 1])
     parser.add_argument("--gravity", type=float, nargs=3, default=[0, -10, 0])
     parser.add_argument("--fps", type=float, default=60.0)
     parser.add_argument("--substeps", type=int, default=1)
 
-    parser.add_argument("--max_fraction", type=float, default=1.0)
+    parser.add_argument("--max-fraction", type=float, default=1.0)
 
     parser.add_argument("--compliance", type=float, default=0.0)
-    parser.add_argument("--poisson_ratio", "-nu", type=float, default=0.3)
-    parser.add_argument("--friction_coeff", "-mu", type=float, default=0.48)
-    parser.add_argument("--yield_stress", "-ys", type=float, default=0.0)
-    parser.add_argument("--compression_yield_stress", "-cys", type=float, default=1.0e8)
-    parser.add_argument("--stretching_yield_stress", "-sys", type=float, default=1.0e8)
+    parser.add_argument("--poisson-ratio", "-nu", type=float, default=0.3)
+    parser.add_argument("--friction-coeff", "-mu", type=float, default=0.48)
+    parser.add_argument("--yield-stress", "-ys", type=float, default=0.0)
+    parser.add_argument("--compression-yield-stress", "-cys", type=float, default=1.0e8)
+    parser.add_argument("--stretching-yield-stress", "-sys", type=float, default=1.0e8)
     parser.add_argument("--unilateral", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--dynamic_grid", action=argparse.BooleanOptionalAction, default=True)
-    parser.add_argument("--gauss_seidel", "-gs", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--dynamic-grid", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--gauss-seidel", "-gs", action=argparse.BooleanOptionalAction, default=True)
 
-    parser.add_argument("--max_iterations", "-it", type=int, default=250)
+    parser.add_argument("--max-iterations", "-it", type=int, default=250)
     parser.add_argument("--tolerance", "-tol", type=float, default=1.0e-5)
-    parser.add_argument("--voxel_size", "-dx", type=float, default=0.1)
-    parser.add_argument("--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument("--voxel-size", "-dx", type=float, default=0.1)
+    parser.add_argument("--num-frames", type=int, default=300, help="Total number of frames.")
     parser.add_argument("--headless", action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]

--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -133,13 +133,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_quadruped.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=30000, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=100, help="Total number of simulated environments.")
+    parser.add_argument("--num-frames", type=int, default=30000, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=100, help="Total number of simulated environments.")
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -599,13 +599,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_robot_manipulating_cloth.usd",
         help="Path to the output USD file.",
     )
     parser.add_argument(
-        "--num_frames",
+        "--num-frames",
         type=lambda x: None if x == "None" else int(x),
         default=None,
         help="Total number of frames. If None, the number of frames will be determined automatically.",

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -317,14 +317,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_selection_ant.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=1200, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=16, help="Total number of simulated environments.")
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=16, help="Total number of simulated environments.")
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -72,7 +72,7 @@ def random_forces_kernel(dof_forces: wp.array2d(dtype=float), seed: int, num_env
 
 
 class Example:
-    def __init__(self, stage_path=None, num_envs=8, use_cuda_graph=True):
+    def __init__(self, stage_path=None, num_envs=16, use_cuda_graph=True):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z

--- a/newton/examples/example_selection_cartpole.py
+++ b/newton/examples/example_selection_cartpole.py
@@ -45,7 +45,7 @@ def apply_forces_kernel(joint_q: wp.array2d(dtype=float), joint_f: wp.array2d(dt
 
 
 class Example:
-    def __init__(self, stage_path=None, num_envs=8, use_cuda_graph=True):
+    def __init__(self, stage_path=None, num_envs=16, use_cuda_graph=True):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z

--- a/newton/examples/example_selection_cartpole.py
+++ b/newton/examples/example_selection_cartpole.py
@@ -192,14 +192,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_selection_cartpole.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=12000, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=16, help="Total number of simulated environments.")
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--num-frames", type=int, default=12000, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=16, help="Total number of simulated environments.")
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_selection_materials.py
+++ b/newton/examples/example_selection_materials.py
@@ -261,14 +261,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
         default="example_selection_ant.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=1200, help="Total number of frames.")
-    parser.add_argument("--num_envs", type=int, default=16, help="Total number of simulated environments.")
-    parser.add_argument("--use_cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")
+    parser.add_argument("--num-envs", type=int, default=16, help="Total number of simulated environments.")
+    parser.add_argument("--use-cuda_graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_selection_materials.py
+++ b/newton/examples/example_selection_materials.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")
     parser.add_argument("--num-envs", type=int, default=16, help="Total number of simulated environments.")
-    parser.add_argument("--use-cuda_graph", default=True, action=argparse.BooleanOptionalAction)
+    parser.add_argument("--use-cuda-graph", default=True, action=argparse.BooleanOptionalAction)
 
     args = parser.parse_known_args()[0]
 

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -58,10 +58,10 @@ def _build_command_line_options(test_options: dict[str, Any]) -> list:
         if key == "headless" and value:
             additional_options.extend(["--headless"])
         elif key == "use_cuda_graph" and not value:
-            additional_options.extend(["--no-use_cuda_graph"])
+            additional_options.extend(["--no-use-cuda-graph"])
         else:
             # Just add --key value
-            additional_options.extend(["--" + key, str(value)])
+            additional_options.extend(["--" + key.replace("_", "-"), str(value)])
 
     return additional_options
 
@@ -151,7 +151,7 @@ def add_example_test(
         )
 
         if stage_path:
-            command.extend(["--stage_path", stage_path])
+            command.extend(["--stage-path", stage_path])
             try:
                 os.remove(stage_path)
             except OSError:

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -57,8 +57,9 @@ def _build_command_line_options(test_options: dict[str, Any]) -> list:
     for key, value in test_options.items():
         if key == "headless" and value:
             additional_options.extend(["--headless"])
-        elif key == "use_cuda_graph" and not value:
-            additional_options.extend(["--no-use-cuda-graph"])
+        elif isinstance(value, bool):
+            # Fallback for other booleans
+            additional_options.append(f"--{'no-' if not value else ''}{key.replace('_', '-')}")
         else:
             # Just add --key value
             additional_options.extend(["--" + key.replace("_", "-"), str(value)])


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This aligns us with the norm for argparse-based command line parameters.

Some examples were cleaned up as well, e.g. consistency with the `__init__()` defaults and argparse defaults.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
