### PR TITLE
Minor updates to examples and testing

### DIFF
--- a/newton/examples/example_rigid_force.py
+++ b/newton/examples/example_rigid_force.py
@@ -21,13 +21,15 @@
 #
 ###########################################################################
 
+from __future__ import annotations
+
 import warp as wp
 
 import newton
 
 
 class Example:
-    def __init__(self, stage_path="example_rigid_force.usd", headless=False):
+    def __init__(self, stage_path: str | None = "example_rigid_force.usd", headless: bool = False):
         fps = 60
         self.frame_dt = 1.0 / fps
         self.sim_substeps = 5
@@ -69,11 +71,7 @@ class Example:
             self.state_0.clear_forces()
             self.state_1.clear_forces()
 
-            self.state_0.body_f.assign(
-                [
-                    [0.0, 0.0, -7000.0, 0.0, 0.0, 0.0],
-                ]
-            )
+            self.state_0.body_f.assign([[0.0, 0.0, -7000.0, 0.0, 0.0, 0.0]])
 
             self.solver.step(self.state_0, self.state_1, None, self.contacts, self.sim_dt)
 
@@ -114,7 +112,7 @@ if __name__ == "__main__":
         "--headless",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="Toggles the opening of an interactive window to play back animations in real time. Ignores --num_frames if used.",
+        help="Toggles the opening of an interactive window to play back animations in real time. Ignores --num-frames if used.",
     )
 
     args = parser.parse_known_args()[0]

--- a/newton/examples/example_rigid_force.py
+++ b/newton/examples/example_rigid_force.py
@@ -27,7 +27,7 @@ import newton
 
 
 class Example:
-    def __init__(self, stage_path="example_rigid_force.usda", use_opengl=False):
+    def __init__(self, stage_path="example_rigid_force.usd", headless=False):
         fps = 60
         self.frame_dt = 1.0 / fps
         self.sim_substeps = 5
@@ -48,7 +48,7 @@ class Example:
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
 
-        if use_opengl:
+        if not headless:
             self.renderer = newton.utils.SimRendererOpenGL(self.model, stage_path)
         elif stage_path:
             self.renderer = newton.utils.SimRendererUsd(self.model, stage_path)
@@ -104,24 +104,25 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument(
-        "--stage_path",
+        "--stage-path",
         type=lambda x: None if x == "None" else str(x),
-        default="example_rigid_force.usda",
+        default="example_rigid_force.usd",
         help="Path to the output USD file.",
     )
-    parser.add_argument("--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument("--num-frames", type=int, default=300, help="Total number of frames.")
     parser.add_argument(
-        "--opengl",
-        action="store_true",
-        help="Open an interactive window to play back animations in real time. Ignores --num_frames if used.",
+        "--headless",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Toggles the opening of an interactive window to play back animations in real time. Ignores --num_frames if used.",
     )
 
     args = parser.parse_known_args()[0]
 
     with wp.ScopedDevice(args.device):
-        example = Example(stage_path=args.stage_path, use_opengl=args.opengl)
+        example = Example(stage_path=args.stage_path, headless=args.headless)
 
-        if args.opengl:
+        if not args.headless:
             while example.renderer.is_running():
                 example.step()
                 example.render()

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -167,7 +167,7 @@ def compute_body_jacobian(
 class Example:
     def __init__(
         self,
-        stage_path: str = "example_robot_manipulating_cloth.usd",
+        stage_path: str | None = "example_robot_manipulating_cloth.usd",
         num_frames: int | None = None,
     ):
         self.stage_path = stage_path

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -72,7 +72,9 @@ def random_forces_kernel(dof_forces: wp.array2d(dtype=float), seed: int, num_env
 
 
 class Example:
-    def __init__(self, stage_path=None, num_envs=16, use_cuda_graph=True):
+    def __init__(
+        self, stage_path: str | None = "example_selection_articulations.usd", num_envs=16, use_cuda_graph=True
+    ):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z
@@ -316,7 +318,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--stage-path",
         type=lambda x: None if x == "None" else str(x),
-        default="example_selection_ant.usd",
+        default="example_selection_articulations.usd",
         help="Path to the output USD file.",
     )
     parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warp as wp
 
 import newton

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -108,9 +108,6 @@ class Example:
 
         self.solver = newton.solvers.MuJoCoSolver(self.model)
 
-        # TODO: This line is needed or else this example will crash on some systems
-        self.solver.mjw_model.opt.graph_conditional = False
-
         self.renderer = None
         if stage_path:
             self.renderer = newton.utils.SimRendererOpenGL(

--- a/newton/examples/example_selection_cartpole.py
+++ b/newton/examples/example_selection_cartpole.py
@@ -45,7 +45,7 @@ def apply_forces_kernel(joint_q: wp.array2d(dtype=float), joint_f: wp.array2d(dt
 
 
 class Example:
-    def __init__(self, stage_path=None, num_envs=16, use_cuda_graph=True):
+    def __init__(self, stage_path: str | None = "example_selection_cartpole.usd", num_envs=16, use_cuda_graph=True):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z

--- a/newton/examples/example_selection_cartpole.py
+++ b/newton/examples/example_selection_cartpole.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warp as wp
 
 import newton

--- a/newton/examples/example_selection_materials.py
+++ b/newton/examples/example_selection_materials.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import warp as wp
 
 import newton
@@ -52,7 +54,7 @@ def reset_materials_kernel(mu: wp.array2d(dtype=float), seed: int, num_envs: int
 
 
 class Example:
-    def __init__(self, stage_path: str | None = "example_selection_materials.usd", num_envs=8, use_cuda_graph=True):
+    def __init__(self, stage_path: str | None = "example_selection_materials.usd", num_envs=16, use_cuda_graph=True):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z

--- a/newton/examples/example_selection_materials.py
+++ b/newton/examples/example_selection_materials.py
@@ -52,7 +52,7 @@ def reset_materials_kernel(mu: wp.array2d(dtype=float), seed: int, num_envs: int
 
 
 class Example:
-    def __init__(self, stage_path=None, num_envs=8, use_cuda_graph=True):
+    def __init__(self, stage_path: str | None = "example_selection_materials.usd", num_envs=8, use_cuda_graph=True):
         self.num_envs = num_envs
 
         up_axis = newton.Axis.Z
@@ -263,7 +263,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--stage-path",
         type=lambda x: None if x == "None" else str(x),
-        default="example_selection_ant.usd",
+        default="example_selection_materials.usd",
         help="Path to the output USD file.",
     )
     parser.add_argument("--num-frames", type=int, default=1200, help="Total number of frames.")

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -55,10 +55,8 @@ def _build_command_line_options(test_options: dict[str, Any]) -> list:
     additional_options = []
 
     for key, value in test_options.items():
-        if key == "headless" and value:
-            additional_options.extend(["--headless"])
-        elif isinstance(value, bool):
-            # Fallback for other booleans
+        if isinstance(value, bool):
+            # Default behavior expecting argparse.BooleanOptionalAction support
             additional_options.append(f"--{'no-' if not value else ''}{key.replace('_', '-')}")
         else:
             # Just add --key value
@@ -298,6 +296,33 @@ add_example_test(
 )
 
 
+class TestSelectionAPIExamples(unittest.TestCase):
+    pass
+
+
+add_example_test(
+    TestSelectionAPIExamples,
+    name="example_selection_articulations",
+    devices=test_devices,
+    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options_cpu={"num_frames": 10},
+)
+add_example_test(
+    TestSelectionAPIExamples,
+    name="example_selection_cartpole",
+    devices=test_devices,
+    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options_cpu={"num_frames": 10},
+)
+add_example_test(
+    TestSelectionAPIExamples,
+    name="example_selection_materials",
+    devices=test_devices,
+    test_options={"stage_path": "None", "num_frames": 99, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options_cpu={"num_frames": 9},
+)
+
+
 class TestOtherExamples(unittest.TestCase):
     pass
 
@@ -310,25 +335,11 @@ add_example_test(
 )
 add_example_test(
     TestOtherExamples,
-    name="example_selection_articulations",
+    name="example_rigid_force",
     devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
-    test_options_cpu={"num_frames": 10},
+    test_options={"headless": True},
 )
-add_example_test(
-    TestOtherExamples,
-    name="example_selection_cartpole",
-    devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
-    test_options_cpu={"num_frames": 10},
-)
-add_example_test(
-    TestOtherExamples,
-    name="example_selection_materials",
-    devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
-    test_options_cpu={"num_frames": 10},
-)
+
 
 if __name__ == "__main__":
     # force rebuild of all kernels

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -318,8 +318,8 @@ add_example_test(
     TestSelectionAPIExamples,
     name="example_selection_materials",
     devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 99, "use_cuda_graph": supports_load_during_graph_capture},
-    test_options_cpu={"num_frames": 9},
+    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options_cpu={"num_frames": 10},
 )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

- Add testing of `example_rigid_force.py` and update conventions
- Revert disabling of conditional nodes in `newton/examples/example_selection_articulations.py`
- Clean up `test_examples.py` runner
- Clean up examples to consistently set a default `stage_path` in the `Example` class constructor

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
