### PR TITLE
Make simrenderer usable without state and model

### DIFF
--- a/newton/utils/render.py
+++ b/newton/utils/render.py
@@ -70,8 +70,8 @@ def CreateSimRenderer(renderer):
 
         def __init__(
             self,
-            model: newton.Model,
-            path: str,
+            model: newton.Model | None = None,
+            path: str = "No path specified",
             scaling: float = 1.0,
             fps: int = 60,
             up_axis: newton.AxisType | None = None,
@@ -91,7 +91,10 @@ def CreateSimRenderer(renderer):
                 **render_kwargs: Additional keyword arguments for the underlying renderer.
             """
             if up_axis is None:
-                up_axis = model.up_axis
+                if model:
+                    up_axis = model.up_axis
+                else:
+                    up_axis = "Y"
             up_axis = newton.Axis.from_any(up_axis)
             super().__init__(path, scaling=scaling, fps=fps, up_axis=str(up_axis), **render_kwargs)
             self.scaling = scaling
@@ -99,7 +102,8 @@ def CreateSimRenderer(renderer):
             self.show_joints = show_joints
             self.show_particles = show_particles
             self._instance_key_count = {}
-            self.populate(model)
+            if model:
+                self.populate(model)
 
             self._contact_points0 = None
             self._contact_points1 = None


### PR DESCRIPTION
## Description
Modularizes the sim renderer such that it can be used by providing method overloads that accept flat arrays as input. This allows the renderer to be used on simulations that don't have a newton model or a newton state at hand which is often the case during early development. The viewer is fully compatible with the previous version. 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
