### PR TITLE
fix model attribute frequency

### DIFF
--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -494,6 +494,9 @@ class ModelBuilder:
             separate_collision_group (bool): if True, the shapes from the articulations in `builder` will all be put into a single new collision group, otherwise, only the shapes in collision group > -1 will be moved to a new group.
         """
 
+        if builder.up_axis != self.up_axis:
+            raise ValueError("Cannot add a builder with a different up axis.")
+
         # explicitly resolve the transform multiplication function to avoid
         # repeatedly resolving builtin overloads during shape transformation
         transform_mul_cfunc = wp.context.runtime.core.wp_builtin_mul_transformf_transformf
@@ -675,9 +678,6 @@ class ModelBuilder:
 
         self.joint_dof_count += builder.joint_dof_count
         self.joint_coord_count += builder.joint_coord_count
-
-        self.up_axis = builder.up_axis
-        self.gravity = builder.gravity
 
         if update_num_env_count:
             self.num_envs += 1

--- a/newton/sim/model.py
+++ b/newton/sim/model.py
@@ -348,6 +348,9 @@ class Model:
         self.attribute_frequency["joint_limit_upper"] = "joint_dof"
         self.attribute_frequency["joint_limit_ke"] = "joint_dof"
         self.attribute_frequency["joint_limit_kd"] = "joint_dof"
+        self.attribute_frequency["joint_effort_limit"] = "joint_dof"
+        self.attribute_frequency["joint_friction"] = "joint_dof"
+        self.attribute_frequency["joint_velocity_limit"] = "joint_dof"
 
         # attributes per shape
         self.attribute_frequency["shape_transform"] = "shape"

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -708,6 +708,7 @@ def update_geom_properties_kernel(
     shape_type: wp.array(dtype=wp.int32),
     shape_body: wp.array(dtype=wp.int32),
     to_newton_shape_index: wp.array(dtype=wp.int32),
+    shape_incoming_xform: wp.array(dtype=wp.transform),
     up_axis: int,
     torsional_friction: float,
     rolling_friction: float,
@@ -755,15 +756,18 @@ def update_geom_properties_kernel(
     geom_size[worldid, geom_idx] = shape_size[shape_idx]
 
     # update position and orientation
-    pos = wp.vec3f(shape_transform[shape_idx].p)
-    quat = shape_transform[shape_idx].q
+    tf = shape_transform[shape_idx]
+    incoming_xform = shape_incoming_xform[shape_idx]
+    tf = incoming_xform * tf
+    pos = tf.p
+    quat = tf.q
     # get shape type and body
     stype = shape_type[shape_idx]
     body_idx = shape_body[shape_idx]
     # apply shape-specific rotations (matching add_geoms logic)
     if stype == wp.static(newton.GEO_CAPSULE) or stype == wp.static(newton.GEO_CYLINDER):
         # MuJoCo aligns these shapes with the z-axis, Warp uses the y-axis
-        rot_y2z = wp.static(wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), wp.pi * 0.5))
+        rot_y2z = wp.static(wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), -wp.pi * 0.5))
         quat = quat * rot_y2z
     # special handling for static geoms with Z-up axis (matching add_geoms logic)
     if up_axis == 2 and body_idx == -1:
@@ -1370,6 +1374,8 @@ class MuJoCoSolver(SolverBase):
         body_mapping = {-1: 0}
         # mapping from Newton shape id to MuJoCo geom id
         shape_mapping = {}
+        # mapping from Newton shape id to incoming transform
+        shape_incoming_xform = np.tile(np.array(wp.transform_identity()), (model.shape_count, 1))
 
         # ensure unique names
         body_names = {}
@@ -1489,6 +1495,7 @@ class MuJoCoSolver(SolverBase):
                     tf: wp.transform = incoming_xform * tf
                     q = tf.q
                     p = tf.p
+                    shape_incoming_xform[shape] = incoming_xform
                 if stype in (newton.GEO_CAPSULE, newton.GEO_CYLINDER):
                     # mujoco aligns these shapes with the z-axis, Warp uses the y-axis
                     q = q * rot_y2z
@@ -1811,6 +1818,7 @@ class MuJoCoSolver(SolverBase):
                 for geom_idx, shape_idx in reverse_shape_mapping.items():
                     to_newton_shape_array[geom_idx] = shape_idx
             model.to_newton_shape_index = wp.array(to_newton_shape_array, dtype=wp.int32)  # pyright: ignore[reportAttributeAccessIssue]
+            model.shape_incoming_xform = wp.array(shape_incoming_xform, dtype=wp.transform)  # pyright: ignore[reportAttributeAccessIssue]
 
             self.mjw_model = mujoco_warp.put_model(self.mj_model)
             self.mjw_model.opt.graph_conditional = newton.utils.check_conditional_graph_support()
@@ -1831,7 +1839,6 @@ class MuJoCoSolver(SolverBase):
                 | newton.sim.NOTIFY_FLAG_DOF_PROPERTIES
             )
 
-            # TODO: Also update shape properties once during initialization
             if model.shape_materials.mu is not None:
                 flags |= newton.sim.NOTIFY_FLAG_SHAPE_PROPERTIES
             self.notify_model_changed(flags)
@@ -2045,6 +2052,7 @@ class MuJoCoSolver(SolverBase):
                 self.model.shape_geo.type,
                 self.model.shape_body,
                 self.model.to_newton_shape_index,
+                self.model.shape_incoming_xform,
                 self.model.up_axis,
                 self.model.rigid_contact_torsional_friction,
                 self.model.rigid_contact_rolling_friction,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -660,6 +660,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         shape_sizes = self.model.shape_geo.scale.numpy()
         shape_transforms = self.model.shape_transform.numpy()
         shape_bodies = self.model.shape_body.numpy()
+        shape_incoming_xform = self.model.shape_incoming_xform.numpy()
 
         # Get all property arrays from MuJoCo
         geom_friction = solver.mjw_model.geom_friction.numpy()
@@ -758,16 +759,18 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 actual_quat = geom_quat[world_idx, geom_idx]
 
                 # Get expected transform from Newton
-                shape_transform = shape_transforms[shape_idx]
-                expected_pos = wp.vec3(*shape_transform[:3])
-                expected_quat = wp.quat(*shape_transform[3:])
+                incoming_xform = wp.transform(*shape_incoming_xform[shape_idx])
+                # account for incoming transform due to joint child transform
+                shape_transform = incoming_xform * wp.transform(*shape_transforms[shape_idx])
+                expected_pos = wp.vec3(*shape_transform.p)
+                expected_quat = wp.quat(*shape_transform.q)
 
                 # Apply shape-specific rotations (matching update_geom_properties_kernel logic)
                 shape_body = shape_bodies[shape_idx]
 
                 # Capsules and cylinders need rotation from Y-axis to Z-axis
                 if shape_type in (newton.GEO_CAPSULE, newton.GEO_CYLINDER):
-                    rot_y2z = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), wp.pi * 0.5)
+                    rot_y2z = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), -wp.pi * 0.5)
                     expected_quat = expected_quat * rot_y2z
 
                 # Special handling for static geoms with Z-up axis
@@ -819,6 +822,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         # Get mappings
         to_newton_shape_index = self.model.to_newton_shape_index.numpy()
         shape_types = self.model.shape_geo.type.numpy()
+        shape_incoming_xform = self.model.shape_incoming_xform.numpy()
         num_geoms = solver.mj_model.ngeom
 
         # Run an initial simulation step
@@ -978,15 +982,17 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
 
                 # Verify 5: Position and orientation updated
                 # Compute expected values based on new transforms
-                expected_pos = wp.vec3(*new_transforms[shape_idx].p)
-                expected_quat = new_transforms[shape_idx].q
+                incoming_xform = wp.transform(*shape_incoming_xform[shape_idx])
+                new_transform = incoming_xform * wp.transform(*new_transforms[shape_idx])
+                expected_pos = new_transform.p
+                expected_quat = new_transform.q
 
                 # Apply same transformations as in the kernel
                 shape_body = self.model.shape_body.numpy()[shape_idx]
 
                 # Capsules and cylinders need rotation from Y-axis to Z-axis
                 if shape_type in (newton.GEO_CAPSULE, newton.GEO_CYLINDER):
-                    rot_y2z = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), wp.pi * 0.5)
+                    rot_y2z = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), -wp.pi * 0.5)
                     expected_quat = expected_quat * rot_y2z
 
                 # Special handling for static geoms with Z-up axis


### PR DESCRIPTION
## Description

Adds missing entries in the Newton.Model attribute frequency dict.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
