### PR TITLE
Fix missing model frequency entries

### DIFF
--- a/newton/sim/model.py
+++ b/newton/sim/model.py
@@ -348,6 +348,9 @@ class Model:
         self.attribute_frequency["joint_limit_upper"] = "joint_dof"
         self.attribute_frequency["joint_limit_ke"] = "joint_dof"
         self.attribute_frequency["joint_limit_kd"] = "joint_dof"
+        self.attribute_frequency["joint_effort_limit"] = "joint_dof"
+        self.attribute_frequency["joint_friction"] = "joint_dof"
+        self.attribute_frequency["joint_velocity_limit"] = "joint_dof"
 
         # attributes per shape
         self.attribute_frequency["shape_transform"] = "shape"


### PR DESCRIPTION
## Description

Adds missing entries in the attribute frequency of the newton model.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for joint properties by recognizing "joint_effort_limit", "joint_friction", and "joint_velocity_limit" as per-degree-of-freedom attributes in the model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->