### PR TITLE
Intentionally break a test

### DIFF
--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -221,7 +221,7 @@ class TestModel(unittest.TestCase):
             )
 
         self.assertEqual(
-            np.sum(np.array(builder.edge_indices) == -1),
+            np.sum(np.array(builder.edge_indices) == 1),
             builder_open_edge_count + num_envs * env_builder_open_edge_count,
             "builder does not have the expected number of open edges",
         )


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test to change the condition for counting open edges, ensuring more accurate validation of edge states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->