### PR TITLE
`aws-gpu-tests.yml` uses `--failfast`, cleanup refactored

### DIFF
--- a/.github/workflows/aws-gpu-tests.yml
+++ b/.github/workflows/aws-gpu-tests.yml
@@ -84,9 +84,17 @@ jobs:
 
           echo "Instance launched with ID: $INSTANCE_ID"
           echo "INSTANCE_ID=$INSTANCE_ID" >> "$GITHUB_ENV"
+          echo "$INSTANCE_ID" > instance_id.txt
 
           echo "Waiting for instance to be running..."
           aws ec2 wait instance-status-ok --instance-ids $INSTANCE_ID
+
+      - name: Upload instance ID artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instance-id-artifact
+          path: instance_id.txt
 
       - name: Generate script to run on instance
         env:
@@ -106,7 +114,7 @@ jobs:
 
           cat << EOF > remote_script.sh
           #!/bin/bash
-          +set -euo pipefail
+          set -euo pipefail
 
           # These are expanded immediately on the GitHub runner
           S3_BUCKET="${S3_BUCKET}"
@@ -160,7 +168,7 @@ jobs:
           fi
 
           echo "Running Newton test suite..."
-          uv run --extra dev --extra cu12 -m newton.tests --junit-report-xml /tmp/rspec.xml --coverage --coverage-xml /tmp/coverage.xml --serial-fallback 2>&1 | tee /tmp/test_output.log
+          uv run --extra dev --extra cu12 -m newton.tests --junit-report-xml /tmp/rspec.xml --coverage --coverage-xml /tmp/coverage.xml --serial-fallback --failfast 2>&1 | tee /tmp/test_output.log
           EOF
 
           # Prepare script to be passed as SSM parameters
@@ -169,6 +177,7 @@ jobs:
 
           # Echo script for debugging
           cat remote_script.sh
+
       - name: Run script on instance
         env:
           S3_BUCKET: ${{ env.AWS_S3_BUCKET }}
@@ -248,18 +257,21 @@ jobs:
           else
             echo "✅ Workflow completed successfully."
           fi
+
       - name: Test Summary
         if: ${{ !cancelled() }}
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:
           paths: "rspec.xml"
           show: "fail"
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706
         with:
           files: ./rspec.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload coverage reports to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d
@@ -269,12 +281,39 @@ jobs:
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Terminate EC2 Instance
-        if: always()
+  cleanup:
+    # This runs as a separate job to ensure cleanup always occurs, even if the
+    # main job's runner fails unexpectedly. This prevents orphaned EC2 instances.
+    name: Cleanup EC2 Instance
+    runs-on: ubuntu-latest
+    needs: run-unit-tests-on-aws
+    if: always()
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download instance ID artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: instance-id-artifact
+          path: .
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+
+      - name: Read instance ID and terminate EC2 Instance
         run: |
-          if [ -n "$INSTANCE_ID" ]; then
-            echo "Terminating instance: $INSTANCE_ID"
-            aws ec2 terminate-instances --instance-ids $INSTANCE_ID
-          else
-            echo "No instance ID file found - instance may not have been launched"
+          if [ ! -f instance_id.txt ]; then
+            echo "Instance ID file not found. Nothing to terminate."
+            exit 0
           fi
+          INSTANCE_ID=$(cat instance_id.txt)
+          if [ -z "$INSTANCE_ID" ]; then
+            echo "Instance ID is empty. Nothing to terminate."
+            exit 0
+          fi
+          echo "Terminating instance: $INSTANCE_ID"
+          aws ec2 terminate-instances --instance-ids $INSTANCE_ID


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

- Unit tests on EC2 use the `--failfast` option so the tests stop running the moment a unit test has failed. The alternative would be running all unit tests and reporting a list of every test that failed, which takes more time.
- Cleanup logic for terminating EC2 instances has been moved back to a separate job to deal with rare instances of runner failure.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of EC2 instance cleanup in GPU test workflows by introducing a dedicated cleanup step to ensure instances are terminated even if previous steps fail.
  * Enhanced workflow formatting and clarity with minor syntax and spacing adjustments.
  * Modified test execution to stop on the first failure for faster feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->