### PR TITLE
Add inverse kinematics module with interactive and benchmark examples

### DIFF
--- a/newton/examples/example_ik_benchmark.py
+++ b/newton/examples/example_ik_benchmark.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from functools import lru_cache, partial
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.sim.ik as ik
+import newton.utils
+
+
+@dataclass(frozen=True)
+class RobotCfg:
+    asset: str
+    file: Path
+    parser: Callable[..., None]
+    ee_names: tuple[str, ...]
+    ee_links: tuple[int, ...]
+    seeds: int
+    sub_batch_size: int
+    lambda_factor: float
+
+
+ROBOTS: dict[str, RobotCfg] = {
+    "h1": RobotCfg(
+        asset="h1_description",
+        file=Path("mjcf/h1.xml"),
+        parser=newton.utils.parse_mjcf,
+        ee_names=("left_hand", "right_hand", "left_foot", "right_foot"),
+        ee_links=(15, 19, 5, 10),
+        seeds=256,
+        sub_batch_size=25,
+        lambda_factor=2.0,
+    ),
+    "franka": RobotCfg(
+        asset="franka_description",
+        file=Path("urdfs/fr3.urdf"),
+        parser=partial(newton.utils.parse_urdf, scale=1.0),
+        ee_names=("ee",),
+        ee_links=(9,),
+        seeds=64,
+        sub_batch_size=1000,
+        lambda_factor=4.0,
+    ),
+}
+
+
+@lru_cache(maxsize=64)
+def _roberts_root(dim: int) -> float:
+    x = 1.5
+    for _ in range(20):
+        f = x ** (dim + 1) - x - 1.0
+        df = (dim + 1) * x**dim - 1.0
+        x_next = x - f / df
+        if abs(x_next - x) < 1.0e-12:
+            break
+        x = x_next
+    return x
+
+
+@wp.kernel
+def _pick_best(costs: wp.array(dtype=float), n_seeds: int, best: wp.array(dtype=int)):
+    q = wp.tid()
+    base = q * n_seeds
+    best_cost = float(1.0e30)
+    best_seed = int(0)
+    for s in range(n_seeds):
+        c = costs[base + s]
+        if c < best_cost:
+            best_cost, best_seed = c, s
+    best[q] = best_seed
+
+
+@wp.kernel
+def _scatter_winner(
+    src: wp.array2d(dtype=float),
+    winners: wp.array2d(dtype=float),
+    best: wp.array(dtype=int),
+    offs: wp.array(dtype=int),
+    n_seeds: int,
+    n_coords: int,
+):
+    sb_start = offs[0]
+    q = wp.tid()
+    src_idx = q * n_seeds + best[q]
+    for d in range(n_coords):
+        winners[sb_start + q, d] = src[src_idx, d]
+
+
+class Example:
+    def __init__(self, robot="h1", batch_sizes=(1, 10, 100, 1_000, 2_000), repeats=3):
+        self.robot_name = robot
+        self.batch_sizes = batch_sizes
+        self.repeats = repeats
+
+        self.iterations = 16
+        self.step_size = 1.0
+        self.pos_thresh_m = 5e-3
+        self.ori_thresh_rad = 0.05
+
+        self.device = "cuda" if wp.get_preferred_device().is_cuda else "cpu"
+        wp.set_device(self.device)
+
+        self.cfg = ROBOTS[robot]
+        self.model = self._create_robot()
+        self.n_coords = self.model.joint_coord_count
+
+        self.results = []
+        self.rng = np.random.default_rng()
+
+    def _create_robot(self) -> newton.Model:
+        builder = newton.ModelBuilder()
+        builder.num_rigid_contacts_per_env = 0
+        builder.default_shape_cfg.density = 100.0
+
+        asset_path = newton.utils.download_asset(self.cfg.asset) / self.cfg.file
+        self.cfg.parser(asset_path, builder, floating=False)
+
+        model = builder.finalize(requires_grad=False)
+        return model
+
+    def _roberts_sequence(self, n: int, dim: int) -> np.ndarray:
+        r = _roberts_root(dim)
+        basis = 1.0 - 1.0 / r ** (1 + np.arange(dim))
+        return ((np.arange(n)[:, None] * basis) % 1.0).astype(np.float32)
+
+    def _random_solutions(self, n: int) -> np.ndarray:
+        lower = self.model.joint_limit_lower.numpy()[: self.n_coords]
+        upper = self.model.joint_limit_upper.numpy()[: self.n_coords]
+        span = upper - lower
+
+        mask = np.abs(span) > 1e5
+        span[mask] = 0.0
+
+        q = self.rng.random((n, self.n_coords)) * span + lower
+        q[:, mask] = 0.0
+        return q.astype(np.float32)
+
+    def _build_ik_solver(self, max_problems: int):
+        n_residuals = len(self.cfg.ee_links) * 6 + self.n_coords
+
+        zero_pos = [wp.zeros(max_problems, dtype=wp.vec3) for _ in self.cfg.ee_links]
+        zero_rot = [wp.zeros(max_problems, dtype=wp.vec4) for _ in self.cfg.ee_links]
+
+        objectives = []
+
+        for ee, link in enumerate(self.cfg.ee_links):
+            objectives.append(ik.PositionObjective(link, wp.vec3(), zero_pos[ee], max_problems, n_residuals, ee * 3))
+
+        for ee, link in enumerate(self.cfg.ee_links):
+            objectives.append(
+                ik.RotationObjective(
+                    link,
+                    wp.quat_identity(),
+                    zero_rot[ee],
+                    max_problems,
+                    n_residuals,
+                    len(self.cfg.ee_links) * 3 + ee * 3,
+                )
+            )
+
+        objectives.append(
+            ik.JointLimitObjective(
+                self.model.joint_limit_lower,
+                self.model.joint_limit_upper,
+                max_problems,
+                n_residuals,
+                len(self.cfg.ee_links) * 6,
+                1.0,
+            )
+        )
+
+        q0 = wp.zeros((max_problems, self.n_coords), dtype=wp.float32)
+
+        solver = ik.IKSolver(
+            self.model,
+            q0,
+            objectives,
+            lambda_factor=self.cfg.lambda_factor,
+            jacobian_mode=ik.JacobianMode.ANALYTIC,
+        )
+        return (
+            solver,
+            objectives[: len(self.cfg.ee_links)],
+            objectives[len(self.cfg.ee_links) : 2 * len(self.cfg.ee_links)],
+        )
+
+    def _fk_targets(self, q_batch: np.ndarray):
+        state = self.model.state()
+        pos, rot = [], []
+        for q in q_batch:
+            wp.copy(self.model.joint_q, wp.array(q, dtype=wp.float32))
+            newton.sim.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, state)
+            body_q = state.body_q.numpy()
+            pos.append(body_q[self.cfg.ee_links, :3])
+            rot.append(body_q[self.cfg.ee_links, 3:7])
+        return np.stack(pos), np.stack(rot)
+
+    def _eval_winners(self, solver, q_best, tgt_pos, tgt_rot):
+        sb_size = q_best.shape[0]
+
+        solver._fk_two_pass(
+            self.model,
+            wp.array(q_best, dtype=wp.float32),
+            solver.body_q,
+            solver.X_local,
+            sb_size,
+        )
+        wp.synchronize()
+
+        bq = solver.body_q.numpy()[:sb_size]
+        ee = np.asarray(self.cfg.ee_links)
+
+        pos_err = np.linalg.norm(bq[:, ee, :3] - tgt_pos, axis=-1).max(axis=-1)
+
+        def _qmul(a, b):
+            w1, x1, y1, z1 = np.moveaxis(a, -1, 0)
+            w2, x2, y2, z2 = np.moveaxis(b, -1, 0)
+            return np.stack(
+                (
+                    w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+                    w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+                    w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+                    w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+                ),
+                axis=-1,
+            )
+
+        tgt_conj = np.concatenate([tgt_rot[..., :1], -tgt_rot[..., 1:]], axis=-1)
+        rel = _qmul(tgt_conj, bq[:, ee, 3:7])
+        rot_err = (2 * np.arctan2(np.linalg.norm(rel[..., 1:], axis=-1), np.abs(rel[..., 0]))).max(axis=-1)
+
+        success = (pos_err < self.pos_thresh_m) & (rot_err < self.ori_thresh_rad)
+        return pos_err, rot_err, success
+
+    def run(self):
+        for batch in self.batch_sizes:
+            sub = min(self.cfg.sub_batch_size, batch)
+            max_problems = sub * self.cfg.seeds
+
+            solver, pos_obj, rot_obj = self._build_ik_solver(max_problems)
+
+            winners_d = wp.zeros((batch, self.n_coords), dtype=wp.float32, device=self.device)
+            best_d = wp.zeros(sub, dtype=int, device=self.device)
+            off_d = wp.zeros(1, dtype=int, device=self.device)
+
+            solver.solve(self.iterations, self.step_size)
+
+            with wp.ScopedCapture() as cap:
+                solver.solve(self.iterations, self.step_size)
+                wp.launch(_pick_best, dim=sub, inputs=[solver.costs, self.cfg.seeds, best_d], device=self.device)
+                wp.launch(
+                    _scatter_winner,
+                    dim=sub,
+                    inputs=[solver.joint_q, winners_d, best_d, off_d, self.cfg.seeds, self.n_coords],
+                    device=self.device,
+                )
+            solve_graph = cap.graph
+
+            q_gt = self._random_solutions(batch)
+            tgt_p, tgt_r = self._fk_targets(q_gt)
+
+            span = (
+                self.model.joint_limit_upper.numpy()[: self.n_coords]
+                - self.model.joint_limit_lower.numpy()[: self.n_coords]
+            )
+            base = (
+                self._roberts_sequence(self.cfg.seeds, self.n_coords) * span
+                + self.model.joint_limit_lower.numpy()[: self.n_coords]
+            ).astype(np.float32)
+            starts = np.tile(base, (sub, 1))
+
+            scratch_p = np.empty((max_problems, 3), np.float32)
+            scratch_r = np.empty((max_problems, 4), np.float32)
+
+            times = []
+
+            for _ in range(self.repeats):
+                wp.synchronize()
+                t0 = time.perf_counter()
+
+                for sb_start in range(0, batch, sub):
+                    sb_size = min(sub, batch - sb_start)
+                    active = sb_size * self.cfg.seeds
+
+                    for ee in range(len(self.cfg.ee_names)):
+                        scratch_p[:active] = np.repeat(tgt_p[sb_start : sb_start + sb_size, ee], self.cfg.seeds, axis=0)
+                        pos_obj[ee].set_target_positions(wp.array(scratch_p, dtype=wp.vec3))
+
+                        scratch_r[:active] = np.repeat(tgt_r[sb_start : sb_start + sb_size, ee], self.cfg.seeds, axis=0)
+                        rot_obj[ee].set_target_rotations(wp.array(scratch_r, dtype=wp.vec4))
+
+                    wp.copy(
+                        solver.joint_q,
+                        wp.array(
+                            starts,
+                            dtype=wp.float32,
+                        ),
+                    )
+
+                    off_d.fill_(sb_start)
+                    wp.capture_launch(solve_graph)
+
+                wp.synchronize()
+                times.append(time.perf_counter() - t0)
+
+            q_best = winners_d.numpy()
+            pos_e, rot_e, succ = [], [], []
+
+            for sb_start in range(0, batch, sub):
+                sb_size = min(sub, batch - sb_start)
+                p, r, s = self._eval_winners(
+                    solver,
+                    q_best[sb_start : sb_start + sb_size],
+                    tgt_p[sb_start : sb_start + sb_size],
+                    tgt_r[sb_start : sb_start + sb_size],
+                )
+                pos_e.append(p)
+                rot_e.append(r)
+                succ.append(s)
+
+            pos_e = np.concatenate(pos_e)
+            rot_e = np.concatenate(rot_e)
+            succ = np.concatenate(succ)
+
+            last_t_ms = times[-1] * 1_000.0
+            if succ.any():
+                pos_98 = np.percentile(pos_e[succ], 98) * 1_000.0
+                rot_98 = np.percentile(rot_e[succ], 98)
+            else:
+                pos_98 = rot_98 = float("nan")
+
+            self.results.append([self.cfg.file.name, batch, last_t_ms, succ.mean() * 100, pos_98, rot_98])
+
+    def print_results(self):
+        def _border(widths, sep="+", glyph="-"):
+            return sep + sep.join(glyph * w for w in widths) + sep
+
+        def _row(cells, widths, aligns):
+            pad = {"l": str.ljust, "r": str.rjust}
+            padded = [f" {pad[a](txt, w - 2)} " for txt, w, a in zip(cells, widths, aligns)]
+            return "|" + "|".join(padded) + "|"
+
+        header = (
+            "",
+            "robot",
+            "batch",
+            "newton-time (ms)",
+            "newton-success (%)",
+            "newton-pos-err (mm)",
+            "newton-ori-err (rad)",
+        )
+        rows = [
+            [
+                str(i),
+                r,
+                str(b),
+                f"{t:.6g}",
+                f"{s:.3f}",
+                "nan" if np.isnan(pe) else f"{pe:.6g}",
+                "nan" if np.isnan(oe) else f"{oe:.6g}",
+            ]
+            for i, (r, b, t, s, pe, oe) in enumerate(self.results)
+        ]
+
+        widths = [max(len(cell) for cell in col) + 2 for col in zip(*([header, *rows]))]
+
+        print("\nReported errors are 98-percentile of successful solves\n")
+        print(_border(widths))
+        print(_row(header, widths, ["l"] * len(header)))
+        print(_border(widths, "+", "="))
+        for row in rows:
+            print(_row(row, widths, ["r", "l", "r", "r", "r", "r", "r"]))
+            print(_border(widths))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--robot",
+        type=str,
+        default="h1",
+        choices=ROBOTS.keys(),
+        help="Robot model to benchmark",
+    )
+    args = parser.parse_args()
+
+    example = Example(robot=args.robot, repeats=3)
+    example.run()
+    example.print_results()
+
+
+if __name__ == "__main__":
+    main()

--- a/newton/examples/example_ik_interactive.py
+++ b/newton/examples/example_ik_interactive.py
@@ -1,0 +1,527 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.examples
+import newton.sim.ik as ik
+import newton.utils
+from newton.sim import eval_fk
+from newton.utils.gizmo import GizmoSystem
+
+# -------------------------------------------------------------------------
+# Utility classes
+# -------------------------------------------------------------------------
+
+
+class FrameAlignedHandler:
+    """Buffers GUI events and forwards the *latest* one once per render frame."""
+
+    def __init__(self, handler: Callable, consume_ret: Callable[..., bool] | None = None):
+        self._handler = handler
+        self._consume_ret = consume_ret or (lambda *_: False)
+        self._pending: tuple | None = None
+
+    def __call__(self, *args):
+        self._pending = args
+        return self._consume_ret(*args)
+
+    def flush(self):
+        if self._pending is None:
+            return
+        self._handler(*self._pending)
+        self._pending = None
+
+
+# -------------------------------------------------------------------------
+# Example
+# -------------------------------------------------------------------------
+
+
+class Example:
+    """Interactive inverse-kinematics playground for a batch of H1 robots."""
+
+    END_EFFECTOR_NAMES = ("left_hand", "right_hand", "left_foot", "right_foot")
+
+    # -----------------------------------------------------------------
+    # Construction
+    # -----------------------------------------------------------------
+
+    def __init__(
+        self,
+        stage_path: str | None = "example_h1_ik_interactive.usd",
+        num_envs: int = 4,
+        tie_targets: bool = True,
+        ik_iters: int = 20,
+    ):
+        self.stage_path = stage_path
+        self.num_envs = num_envs
+        self.tie_targets = tie_targets
+        self.ik_iters = ik_iters
+
+        # timings ------------------------------------------------------
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_time = 0.0
+
+        # model(s) -----------------------------------------------------
+        (
+            self.model,
+            self.num_links,
+            self.ee_link_indices,
+            self.ee_link_offsets,
+            self.num_coords,
+            self.env_offsets,
+        ) = self._build_model(num_envs)
+
+        # dedicated 1-env model for IK
+        self.singleton_model, *_ = self._build_model(1)
+
+        # simulation state --------------------------------------------
+        self.state = self.model.state()
+        self.joint_q = wp.zeros((num_envs, self.singleton_model.joint_coord_count), dtype=wp.float32)
+
+        # target buffers ----------------------------------------------
+        self.target_positions, self.target_rotations = self._initialize_targets()
+        (
+            self.position_objectives,
+            self.rotation_objectives,
+            total_residuals,
+        ) = self._create_objectives()
+
+        # joint limits -------------------------------------------------
+        joint_limit_objective = ik.JointLimitObjective(
+            joint_limit_lower=self.singleton_model.joint_limit_lower,
+            joint_limit_upper=self.singleton_model.joint_limit_upper,
+            n_problems=num_envs,
+            total_residuals=total_residuals,
+            residual_offset=len(self.END_EFFECTOR_NAMES) * 3 * 2,
+            weight=0.1,
+        )
+
+        # IK solver ----------------------------------------------------
+        self.ik_solver = ik.IKSolver(
+            model=self.singleton_model,
+            joint_q=self.joint_q,
+            objectives=self.position_objectives + self.rotation_objectives + [joint_limit_objective],
+            lambda_initial=0.1,
+            jacobian_mode=ik.JacobianMode.ANALYTIC,
+        )
+
+        # renderer & gizmos -------------------------------------------
+        self.renderer = None
+        if stage_path:
+            self.renderer = newton.utils.SimRendererOpenGL(path=stage_path, model=self.model, scaling=1.0)
+            self._setup_gizmos()
+
+        # warm-up + CUDA graph ----------------------------------------
+        self.use_cuda_graph = wp.get_device().is_cuda
+        self.ik_solver.solve(iterations=ik_iters)  # JIT & cache
+        if self.use_cuda_graph:
+            with wp.ScopedCapture() as capture:
+                self.ik_solver.solve(iterations=ik_iters)
+                wp.copy(self.model.joint_q, self.joint_q.flatten())
+            self.graph = capture.graph
+
+    # -----------------------------------------------------------------
+    # Model construction helpers
+    # -----------------------------------------------------------------
+
+    @staticmethod
+    def _build_model(num_envs: int):
+        """Return (`model`, `num_links`, `ee_indices`, `ee_offsets`, `n_coords`, `env_offsets`)."""
+        articulation_builder = newton.ModelBuilder()
+        articulation_builder.default_shape_cfg.density = 100.0
+        articulation_builder.default_joint_cfg.armature = 0.1
+        articulation_builder.default_body_armature = 0.1
+
+        newton.utils.parse_mjcf(
+            newton.utils.download_asset("h1_description") / "mjcf/h1_with_hand.xml",
+            articulation_builder,
+            floating=False,
+        )
+
+        # initial joint angles (same as original script) --------------
+        initial_joint_positions = [
+            0.0,
+            0.0,
+            -0.3,
+            0.6,
+            -0.3,  # left leg
+            0.0,
+            0.0,
+            -0.3,
+            0.6,
+            -0.3,  # right leg
+            0.0,  # torso pitch
+            0.0,
+            0.0,
+            0.0,
+            -0.5,  # left arm
+            0.0,
+            -0.3,
+            0.0,
+            -0.8,  # right arm
+        ]
+        joint_mapping = [
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            35,
+            36,
+            37,
+            38,
+        ]
+        for joint_idx, value in zip(joint_mapping, initial_joint_positions):
+            articulation_builder.joint_q[joint_idx - 7] = value
+
+        articulation_builder.joint_q[22 - 7] = 0.0  # left_hand_joint
+        articulation_builder.joint_q[39 - 7] = 0.0  # right_hand_joint
+
+        # zero all finger joints
+        for i in range(23, 35):
+            articulation_builder.joint_q[i - 7] = 0.0
+        for i in range(40, 52):
+            articulation_builder.joint_q[i - 7] = 0.0
+
+        # wrap into batched ModelBuilder ------------------------------
+        builder = newton.ModelBuilder()
+        builder.num_rigid_contacts_per_env = 0
+
+        env_offsets = newton.examples.compute_env_offsets(num_envs, env_offset=(-1.0, -2.0, 0.0))
+
+        for pos in env_offsets:
+            builder.add_builder(articulation_builder, xform=wp.transform(pos, wp.quat_identity()))
+
+        builder.add_ground_plane()
+        model = builder.finalize(requires_grad=True)
+
+        ee_link_indices = [16, 33, 5, 10]  # hands & ankles
+        ee_link_offsets = [wp.vec3()] * 4
+
+        return (
+            model,
+            len(articulation_builder.body_q),
+            ee_link_indices,
+            ee_link_offsets,
+            len(articulation_builder.joint_q),
+            env_offsets,
+        )
+
+    # -----------------------------------------------------------------
+    # Targets & Objectives
+    # -----------------------------------------------------------------
+
+    def _initialize_targets(self):
+        """Compute initial local-frame targets from current FK."""
+        eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state, None)
+
+        num_ees = len(self.END_EFFECTOR_NAMES)
+        tgt_pos = np.zeros((self.num_envs, num_ees, 3), dtype=np.float32)
+        tgt_rot = np.zeros((self.num_envs, num_ees, 4), dtype=np.float32)
+
+        body_q_np = self.state.body_q.numpy()
+        for env in range(self.num_envs):
+            base = env * self.num_links
+            for ee_idx, link_idx in enumerate(self.ee_link_indices):
+                tf = body_q_np[base + link_idx]
+                world_pos = wp.transform_point(wp.transform(tf[:3], wp.quat(*tf[3:])), self.ee_link_offsets[ee_idx])
+                tgt_pos[env, ee_idx] = np.array(world_pos) - self.env_offsets[env]  # ← LOCAL!
+                quat = tf[3:7] / np.linalg.norm(tf[3:7])
+                tgt_rot[env, ee_idx] = quat
+        return tgt_pos, tgt_rot
+
+    def _create_objectives(self):
+        num_ees = len(self.END_EFFECTOR_NAMES)
+        total_residuals = num_ees * 3 * 2 + self.num_coords
+
+        position_objectives, rotation_objectives = [], []
+        self.position_target_arrays, self.rotation_target_arrays = [], []
+
+        for ee_idx in range(num_ees):
+            pos_wp = wp.array(self.target_positions[:, ee_idx], dtype=wp.vec3)
+            rot_wp = wp.array(self.target_rotations[:, ee_idx], dtype=wp.vec4)
+            self.position_target_arrays.append(pos_wp)
+            self.rotation_target_arrays.append(rot_wp)
+
+        # position objectives -----------------------------------------
+        for ee_idx, (link_idx, offset) in enumerate(zip(self.ee_link_indices, self.ee_link_offsets)):
+            obj = ik.PositionObjective(
+                link_index=link_idx,
+                link_offset=offset,
+                target_positions=self.position_target_arrays[ee_idx],
+                n_problems=self.num_envs,
+                total_residuals=total_residuals,
+                residual_offset=ee_idx * 3,
+            )
+            position_objectives.append(obj)
+
+        # rotation objectives -----------------------------------------
+        for ee_idx, link_idx in enumerate(self.ee_link_indices):
+            obj = ik.RotationObjective(
+                link_index=link_idx,
+                link_offset_rotation=wp.quat_identity(),
+                target_rotations=self.rotation_target_arrays[ee_idx],
+                n_problems=self.num_envs,
+                total_residuals=total_residuals,
+                residual_offset=num_ees * 3 + ee_idx * 3,
+            )
+            rotation_objectives.append(obj)
+
+        return position_objectives, rotation_objectives, total_residuals
+
+    # -----------------------------------------------------------------
+    # Gizmos & mouse interaction
+    # -----------------------------------------------------------------
+
+    GIZMO_OFFSET_DISTANCE = 0.3
+    GIZMO_OFFSETS = (
+        np.array([0.0, GIZMO_OFFSET_DISTANCE, 0.0], dtype=np.float32),
+        np.array([0.0, -GIZMO_OFFSET_DISTANCE, 0.0], dtype=np.float32),
+        np.array([0.0, GIZMO_OFFSET_DISTANCE, 0.0], dtype=np.float32),
+        np.array([0.0, -GIZMO_OFFSET_DISTANCE, 0.0], dtype=np.float32),
+    )
+
+    def _setup_gizmos(self):
+        self.gizmo_system = GizmoSystem(self.renderer, scale_factor=0.15, rotation_sensitivity=1.0)
+        self.gizmo_system.set_callbacks(
+            position_callback=self._on_position_dragged,
+            rotation_callback=self._on_rotation_dragged,
+        )
+
+        if self.tie_targets:
+            for ee_idx in range(len(self.END_EFFECTOR_NAMES)):
+                world_pos = self._local_to_world(0, self.target_positions[0, ee_idx])
+                self.gizmo_system.create_target(
+                    ee_idx,
+                    world_pos,
+                    self.target_rotations[0, ee_idx],
+                    self.GIZMO_OFFSETS[ee_idx],
+                )
+        else:
+            for env in range(self.num_envs):
+                for ee_idx in range(len(self.END_EFFECTOR_NAMES)):
+                    gid = env * len(self.END_EFFECTOR_NAMES) + ee_idx
+                    world_pos = self._local_to_world(env, self.target_positions[env, ee_idx])
+                    self.gizmo_system.create_target(
+                        gid,
+                        world_pos,
+                        self.target_rotations[env, ee_idx],
+                        self.GIZMO_OFFSETS[ee_idx],
+                    )
+        self.gizmo_system.finalize()
+
+        # frame-aligned wrappers --------------------------------------
+        self._mouse_press_handler = FrameAlignedHandler(self.gizmo_system.on_mouse_press)
+        self._mouse_drag_handler = FrameAlignedHandler(
+            self.gizmo_system.on_mouse_drag,
+            consume_ret=lambda *_: self.gizmo_system.drag_state is not None,
+        )
+        self._mouse_release_handler = FrameAlignedHandler(self.gizmo_system.on_mouse_release)
+
+        # register pyglet callbacks
+        self.renderer.window.push_handlers(on_mouse_press=self._mouse_press_handler)
+        self.renderer.window.push_handlers(on_mouse_drag=self._mouse_drag_handler)
+        self.renderer.window.push_handlers(on_mouse_release=self._mouse_release_handler)
+
+        # tied-target drag bookkeeping
+        if self.tie_targets:
+            self._drag_start_positions = None
+            self._drag_start_rotations = None
+            self._is_dragging_pos = False
+            self._is_dragging_rot = False
+            self._last_drag_id: int | None = None
+
+    # coordinate helpers ----------------------------------------------
+
+    def _local_to_world(self, env_idx: int, local_pos: np.ndarray):
+        return local_pos + self.env_offsets[env_idx]
+
+    # snapshot helpers for tied drag ----------------------------------
+
+    def _capture_drag_start(self):
+        self._drag_start_positions = np.copy(self.target_positions)
+        self._drag_start_rotations = np.copy(self.target_rotations)
+
+    # callbacks -------------------------------------------------------
+
+    def _on_position_dragged(self, global_id: int, new_world_pos: np.ndarray):
+        env = global_id // len(self.END_EFFECTOR_NAMES)
+        ee = global_id % len(self.END_EFFECTOR_NAMES)
+        local_pos = new_world_pos - self.env_offsets[env]
+
+        if self.tie_targets:
+            if not self._is_dragging_pos or self._last_drag_id != global_id:
+                self._capture_drag_start()
+                self._is_dragging_pos = True
+                self._last_drag_id = global_id
+
+            delta = local_pos - self._drag_start_positions[env, ee]
+            new_local_targets = self._drag_start_positions[:, ee] + delta
+            self.target_positions[:, ee] = new_local_targets
+            self.position_objectives[ee].set_target_positions(wp.array(new_local_targets, dtype=wp.vec3))
+            self._is_dragging_pos = False
+        else:
+            self.target_positions[env, ee] = local_pos
+            self.position_objectives[ee].set_target_position(env, wp.vec3(*local_pos))
+
+        self._solve()
+
+    def _on_rotation_dragged(self, global_id: int, new_q: np.ndarray):
+        num_ees = len(self.END_EFFECTOR_NAMES)
+        env = global_id // num_ees
+        ee = global_id % num_ees
+
+        new_q = new_q / np.linalg.norm(new_q)
+
+        if self.tie_targets:
+            # start of a new drag?
+            if (not self._is_dragging_rot) or (self._last_drag_id != global_id):
+                self._drag_start_rotations = np.copy(self.target_rotations)
+                self._is_dragging_rot = True
+                self._last_drag_id = global_id
+
+            # delta = new * conj(initial)
+            q0 = self._drag_start_rotations[env, ee]
+            conj = np.array([-q0[0], -q0[1], -q0[2], q0[3]], dtype=np.float32)
+
+            delta = np.array(
+                [
+                    new_q[3] * conj[0] + new_q[0] * conj[3] + new_q[1] * conj[2] - new_q[2] * conj[1],
+                    new_q[3] * conj[1] - new_q[0] * conj[2] + new_q[1] * conj[3] + new_q[2] * conj[0],
+                    new_q[3] * conj[2] + new_q[0] * conj[1] - new_q[1] * conj[0] + new_q[2] * conj[3],
+                    new_q[3] * conj[3] - new_q[0] * conj[0] - new_q[1] * conj[1] - new_q[2] * conj[2],
+                ],
+                dtype=np.float32,
+            )
+            delta /= np.linalg.norm(delta)
+
+            # apply the same delta to every env's stored initial rotation
+            initial = self._drag_start_rotations[:, ee]  # shape (num_envs, 4)
+            q1, q2 = delta, initial  # aliases to match original math
+
+            updated = np.zeros_like(initial)
+            updated[:, 0] = q1[3] * q2[:, 0] + q1[0] * q2[:, 3] + q1[1] * q2[:, 2] - q1[2] * q2[:, 1]
+            updated[:, 1] = q1[3] * q2[:, 1] - q1[0] * q2[:, 2] + q1[1] * q2[:, 3] + q1[2] * q2[:, 0]
+            updated[:, 2] = q1[3] * q2[:, 2] + q1[0] * q2[:, 1] - q1[1] * q2[:, 0] + q1[2] * q2[:, 3]
+            updated[:, 3] = q1[3] * q2[:, 3] - q1[0] * q2[:, 0] - q1[1] * q2[:, 1] - q1[2] * q2[:, 2]
+
+            # normalise all rows (protects against numeric drift)
+            updated /= np.linalg.norm(updated, axis=1, keepdims=True)
+
+            self.target_rotations[:, ee] = updated
+            self.rotation_objectives[ee].set_target_rotations(wp.array(updated, dtype=wp.vec4))
+
+            self._is_dragging_rot = False
+        else:
+            # untied mode: update only this environment
+            self.target_rotations[env, ee] = new_q
+            self.rotation_objectives[ee].set_target_rotation(env, wp.vec4(*new_q))
+
+        # re-solve IK
+        self._solve()
+
+    # -----------------------------------------------------------------
+    # Solve / render / run
+    # -----------------------------------------------------------------
+
+    def _solve(self):
+        with wp.ScopedTimer("solve", synchronize=True):
+            if self.use_cuda_graph:
+                wp.capture_launch(self.graph)
+            else:
+                self.ik_solver.solve(iterations=self.ik_iters)
+                wp.copy(self.model.joint_q, self.joint_q.flatten())
+
+    def _render_frame(self):
+        if self.renderer is None:
+            return
+
+        self.renderer.begin_frame(self.sim_time)
+        eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state, None)
+        self.renderer.render(self.state)
+        self.renderer.end_frame()
+
+    def run(self):
+        # initial solve so joints match targets before first frame
+        if not self.use_cuda_graph:
+            self.ik_solver.solve(iterations=self.ik_iters)
+
+        while self.renderer.is_running():
+            self.sim_time += self.frame_dt
+
+            # process any pending GUI events
+            self._mouse_press_handler.flush()
+            self._mouse_drag_handler.flush()
+            self._mouse_release_handler.flush()
+
+            self._render_frame()
+
+        self.renderer.close()
+
+
+# -------------------------------------------------------------------------
+# main()
+# -------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
+    parser.add_argument(
+        "--stage_path",
+        type=lambda x: None if x == "None" else str(x),
+        default="example_h1_ik_interactive.usd",
+        help="Path of the output USD.",
+    )
+    parser.add_argument("--num_envs", type=int, default=4, help="Number of parallel environments.")
+    parser.add_argument(
+        "--tie_targets",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Tie all envs together so dragging one EE moves the others.",
+    )
+    args = parser.parse_known_args()[0]
+
+    with wp.ScopedDevice(args.device):
+        example = Example(
+            stage_path=args.stage_path,
+            num_envs=args.num_envs,
+            tie_targets=args.tie_targets,
+        )
+        example.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/newton/sim/ik.py
+++ b/newton/sim/ik.py
@@ -1,0 +1,1616 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import ClassVar
+
+import numpy as np
+import warp as wp
+
+from .articulation import eval_single_articulation_fk
+from .joints import (
+    JOINT_FIXED,
+    JOINT_PRISMATIC,
+    JOINT_REVOLUTE,
+)
+
+
+class JacobianMode(Enum):
+    AUTODIFF = "autodiff"
+    ANALYTIC = "analytic"
+    MIXED = "mixed"
+
+
+class IKSolver:
+    """
+    Modular inverse-kinematics solver.
+
+    The solver uses an adaptive Levenberg-Marquardt loop and supports
+    three Jacobian back-ends:
+
+    * **AUTODIFF**   — Warp's reverse-mode autodiff for every objective
+    * **ANALYTIC**   — objective-specific analytic Jacobians only
+    * **MIXED**      — analytic where available, autodiff fallback elsewhere
+
+    Parameters
+    ----------
+    model : newton.Model
+        Singleton articulation shared by _all_ problems.
+    joint_q : wp.array2d[float32] shape (n_problems, model.joint_coord_count)
+        Initial joint coordinates, one row per problem.
+        **Modified in place.**
+    objectives : Sequence[IKObjective]
+        Ordered list of objectives shared by _all_ problems.
+        Each `IKObjective` instance can carry arrays of per-problem
+        parameters (e.g. an array of target positions of length `n_problems`).
+    jacobian_mode : JacobianMode, default JacobianMode.AUTODIFF
+        Backend used in `compute_jacobian`.
+    lambda_initial : float, default 0.1
+        Initial LM damping per problem.
+    lambda_factor : float, default 2.0
+        Multiplicative update factor for λ.
+    lambda_min : float, default 1e-5
+        Lower clamp for λ.
+    lambda_max : float, default 1e10
+        Upper clamp for λ.
+    rho_min : float, default 1e-3
+        Acceptance threshold on predicted vs. actual reduction.
+
+    Batch structure
+    ------
+    The solver handles a batch of independent IK problems that all reference the same
+    articulation (`model`) and the same list of objective objects.
+    What varies from problem to problem are (1) the corresponding row in `joint_q`, and
+    (2) any per-problem data stored internally by the objectives, e.g., an array
+    of target positions. Nothing else is duplicated.
+
+    - Shared across problems: `model`, `objectives`
+    - Per-problem data: each row of `joint_q`, objective parameters (e.g. targets)
+
+
+    Supported joint types
+    ------
+    ANALYTIC and MIXED modes currently only support models with revolute, prismatic, and fixed joints.
+    For more complex joint types (e.g., free, ball, D6), use AUTODIFF mode.
+    Velocity-space optimization is planned for broader analytic support in future updates.
+    """
+
+    TILE_N_COORDS = None
+    TILE_N_RESIDUALS = None
+    _cache: ClassVar[dict[tuple[int, int], type]] = {}
+
+    def __new__(cls, model, joint_q, objectives, *a, **kw):
+        n_coords = model.joint_coord_count
+        n_residuals = sum(o.residual_dim() for o in objectives)
+        arch = model.device.arch
+        key = (n_coords, n_residuals, arch)
+
+        spec_cls = cls._cache.get(key)
+        if spec_cls is None:
+            spec_cls = cls._build_specialised(key)
+            cls._cache[key] = spec_cls
+
+        return super().__new__(spec_cls)
+
+    def __init__(
+        self,
+        model,
+        joint_q,
+        objectives,
+        lambda_initial=0.1,
+        jacobian_mode=JacobianMode.AUTODIFF,
+        lambda_factor=2.0,
+        lambda_min=1e-5,
+        lambda_max=1e10,
+        rho_min=1e-3,
+    ):
+        """
+        Construct a batch IK solver.
+
+        See class doc-string for parameter semantics.
+        """
+
+        self.model = model
+        self.device = model.device
+        self.n_problems, self.n_coords = joint_q.shape
+        self.n_dofs = model.joint_dof_count
+        self.n_residuals = sum(o.residual_dim() for o in objectives)
+        assert self.n_coords == model.joint_coord_count, (
+            f"Coordinate count mismatch: expected {model.joint_coord_count}, got {self.n_coords}"
+        )
+
+        self.objectives = objectives
+        self.jacobian_mode = jacobian_mode
+
+        if self.jacobian_mode in (JacobianMode.ANALYTIC, JacobianMode.MIXED):
+            joint_types = set(self.model.joint_type.numpy())
+            supported = {JOINT_REVOLUTE, JOINT_PRISMATIC, JOINT_FIXED}
+            unsupported = joint_types - supported
+            if unsupported:
+                raise ValueError(
+                    f"Analytic/Mixed Jacobians currently only support revolute, prismatic, and fixed joints. "
+                    f"Unsupported types found: {unsupported}. Use AUTODIFF mode as a workaround."
+                )
+
+        self.lambda_initial = lambda_initial
+        self.lambda_factor = lambda_factor
+        self.lambda_min = lambda_min
+        self.lambda_max = lambda_max
+        self.rho_min = rho_min
+
+        if self.TILE_N_COORDS is not None:
+            assert self.n_coords == self.TILE_N_COORDS
+        if self.TILE_N_RESIDUALS is not None:
+            assert self.n_residuals == self.TILE_N_RESIDUALS
+
+        grad = jacobian_mode in (JacobianMode.AUTODIFF, JacobianMode.MIXED)
+
+        self.joint_q = joint_q
+        self.joint_qd = wp.zeros((self.n_problems, self.n_dofs), dtype=wp.float32, device=self.device)
+        self.body_q = wp.zeros(
+            (self.n_problems, model.body_count), dtype=wp.transform, requires_grad=grad, device=self.device
+        )
+        if grad:
+            self.body_qd = wp.zeros((self.n_problems, model.body_count), dtype=wp.spatial_vector, device=self.device)
+
+        self.residuals = wp.zeros(
+            (self.n_problems, self.n_residuals), dtype=wp.float32, requires_grad=grad, device=self.device
+        )
+        self.jacobian = wp.zeros(
+            (self.n_problems, self.n_residuals, self.n_coords), dtype=wp.float32, device=self.device
+        )
+        self.delta_q = wp.zeros((self.n_problems, self.n_coords), dtype=wp.float32, device=self.device)
+        self.residuals_3d = wp.zeros((self.n_problems, self.n_residuals, 1), dtype=wp.float32, device=self.device)
+        self.residuals_proposed = wp.zeros_like(self.residuals, device=self.device)
+        self.joint_q_proposed = wp.zeros_like(self.joint_q, device=self.device)
+        self.costs = wp.zeros(self.n_problems, dtype=wp.float32, device=self.device)
+        self.costs_proposed = wp.zeros_like(self.costs, device=self.device)
+        self.lambda_values = wp.zeros(self.n_problems, dtype=wp.float32, device=self.device)
+        self.accept_flags = wp.zeros(self.n_problems, dtype=wp.int32, device=self.device)
+        self.pred_reduction = wp.zeros(self.n_problems, dtype=wp.float32, device=self.device)
+
+        self.tape = wp.Tape() if grad else None
+
+        if jacobian_mode != JacobianMode.AUTODIFF and any(o.supports_analytic() for o in objectives):
+            self.joint_S_s = wp.zeros((self.n_problems, self.n_dofs), dtype=wp.spatial_vector, device=self.device)
+        self.X_local = wp.zeros((self.n_problems, model.joint_count), dtype=wp.transform, device=self.device)
+
+        off = 0
+        self.residual_offsets = []
+        for o in objectives:
+            self.residual_offsets.append(off)
+            off += o.residual_dim()
+
+        self._init_objectives()
+        self._init_cuda_streams()
+
+    def _init_objectives(self):
+        """Allocate any per-objective buffers that must live on `self.device`."""
+        for obj in self.objectives:
+            obj.bind_device(self.device)
+            if self.jacobian_mode == JacobianMode.MIXED:
+                mode = JacobianMode.ANALYTIC if obj.supports_analytic() else JacobianMode.AUTODIFF
+            else:
+                mode = self.jacobian_mode
+            obj.init_buffers(model=self.model, jacobian_mode=mode)
+
+    def _init_cuda_streams(self):
+        """Allocate per-objective Warp streams and sync events."""
+        self.objective_streams = []
+        self.sync_events = []
+
+        if self.device.is_cuda:
+            for _ in range(len(self.objectives)):
+                stream = wp.Stream(self.device)
+                event = wp.Event(self.device)
+                self.objective_streams.append(stream)
+                self.sync_events.append(event)
+        else:
+            self.objective_streams = [None] * len(self.objectives)
+            self.sync_events = [None] * len(self.objectives)
+
+    def _parallel_for_objectives(self, fn, *extra):
+        """Run <fn(obj, offset, *extra)> across objectives on parallel CUDA streams."""
+        if self.device.is_cuda:
+            main = wp.get_stream(self.device)
+            init_evt = main.record_event()
+            for obj, offset, obj_stream, sync_event in zip(
+                self.objectives, self.residual_offsets, self.objective_streams, self.sync_events
+            ):
+                obj_stream.wait_event(init_evt)
+                with wp.ScopedStream(obj_stream):
+                    fn(obj, offset, *extra)
+                obj_stream.record_event(sync_event)
+            for sync_event in self.sync_events:
+                main.wait_event(sync_event)
+        else:
+            for obj, offset in zip(self.objectives, self.residual_offsets):
+                fn(obj, offset, *extra)
+
+    def solve(self, iterations=10, step_size=1.0):
+        """
+        Run the Levenberg-Marquardt loop.
+
+        Parameters
+        ----------
+        iterations : int, default 10
+            Maximum number of outer iterations.
+        step_size : float, default 1.0
+            Multiplicative scale on deltaq before applying the proposal.
+
+        Side-effects
+        ------------
+        Updates `self.joint_q` in-place with the converged coordinates.
+        """
+        self.lambda_values.fill_(self.lambda_initial)
+        for i in range(iterations):
+            self._step(step_size=step_size, iteration=i)
+
+    def compute_residuals(self, joint_q=None, output_residuals=None):
+        joint_q = joint_q or self.joint_q
+        output_residuals = output_residuals or self.residuals
+
+        if self.jacobian_mode in [JacobianMode.AUTODIFF, JacobianMode.MIXED]:
+            _eval_fk_batched(self.model, joint_q, self.joint_qd, self.body_q, self.body_qd)
+        else:
+            self._fk_two_pass(self.model, joint_q, self.body_q, self.X_local, self.n_problems)
+
+        output_residuals.zero_()
+
+        def _do(obj, off, body_q, joint_q, model, output_residuals):
+            obj.compute_residuals(body_q, joint_q, model, output_residuals, off)
+
+        self._parallel_for_objectives(_do, self.body_q, joint_q, self.model, output_residuals)
+
+        return output_residuals
+
+    def compute_jacobian(self):
+        self.jacobian.zero_()
+
+        if self.jacobian_mode == JacobianMode.AUTODIFF:
+            self.tape.reset()
+            with self.tape:
+                residuals_2d = self.compute_residuals(self.joint_q)
+                current_residuals_wp = residuals_2d.flatten()
+
+            self.tape.outputs = [current_residuals_wp]
+
+            for obj, offset in zip(self.objectives, self.residual_offsets):
+                obj.compute_jacobian_autodiff(self.tape, self.model, self.jacobian, offset, self.joint_q)
+                self.tape.zero()
+
+        elif self.jacobian_mode == JacobianMode.ANALYTIC:
+            n_joints = self.model.joint_count
+
+            wp.launch(
+                self._compute_motion_subspace_2d,
+                dim=self.n_problems * n_joints,
+                inputs=[
+                    self.n_problems,
+                    self.model.joint_type,
+                    self.model.joint_parent,
+                    self.model.joint_qd_start,
+                    self.joint_qd,
+                    self.model.joint_axis,
+                    self.model.joint_dof_dim,
+                    self.body_q,
+                    self.model.joint_X_p,
+                ],
+                outputs=[
+                    self.joint_S_s,
+                ],
+                device=self.device,
+            )
+
+            def _do_analytic(obj, off, body_q, q, model, jac, joint_S_s):
+                if obj.supports_analytic():
+                    obj.compute_jacobian_analytic(body_q, q, model, jac, joint_S_s, off)
+                else:
+                    raise ValueError(f"Objective {type(obj).__name__} does not support analytic Jacobian")
+
+            self._parallel_for_objectives(
+                _do_analytic, self.body_q, self.joint_q, self.model, self.jacobian, self.joint_S_s
+            )
+
+        elif self.jacobian_mode == JacobianMode.MIXED:
+            self.tape.reset()
+            need_autodiff = any(not obj.supports_analytic() for obj in self.objectives)
+            need_analytic = any(obj.supports_analytic() for obj in self.objectives)
+
+            if need_autodiff:
+                with self.tape:
+                    residuals_2d = self.compute_residuals(self.joint_q)
+                    current_residuals_wp = residuals_2d.flatten()
+                self.tape.outputs = [current_residuals_wp]
+
+            if need_analytic:
+                n_joints = self.model.joint_count
+                wp.launch(
+                    self._compute_motion_subspace_2d,
+                    dim=self.n_problems * n_joints,
+                    inputs=[
+                        self.n_problems,
+                        self.model.joint_type,
+                        self.model.joint_parent,
+                        self.model.joint_qd_start,
+                        self.joint_qd,
+                        self.model.joint_axis,
+                        self.model.joint_dof_dim,
+                        self.body_q,
+                        self.model.joint_X_p,
+                    ],
+                    outputs=[
+                        self.joint_S_s,
+                    ],
+                    device=self.device,
+                )
+
+            for obj, offset in zip(self.objectives, self.residual_offsets):
+                if obj.supports_analytic():
+                    obj.compute_jacobian_analytic(
+                        self.body_q, self.joint_q, self.model, self.jacobian, self.joint_S_s, offset
+                    )
+                else:
+                    obj.compute_jacobian_autodiff(self.tape, self.model, self.jacobian, offset, self.joint_q)
+
+        return self.jacobian
+
+    def _step(self, step_size=1.0, iteration=0):
+        """Execute one Levenberg-Marquardt iteration with adaptive damping."""
+        if iteration == 0:
+            self.compute_residuals()
+        wp.launch(
+            _compute_costs,
+            dim=self.n_problems,
+            inputs=[self.residuals, self.n_residuals],
+            outputs=[self.costs],
+            device=self.device,
+        )
+
+        self.compute_jacobian()
+        residuals_flat = self.residuals.flatten()
+        flat_3d_view = self.residuals_3d.flatten()
+        wp.copy(flat_3d_view, residuals_flat)
+
+        self.delta_q.zero_()
+
+        self._solve_tiled(self.jacobian, self.residuals_3d, self.lambda_values, self.delta_q, self.pred_reduction)
+        total_coords = self.n_problems * self.n_coords
+        wp.launch(
+            _compute_q_proposed,
+            dim=total_coords,
+            inputs=[self.joint_q, self.delta_q, step_size, self.n_coords],
+            outputs=[self.joint_q_proposed],
+            device=self.device,
+        )
+
+        self.compute_residuals(self.joint_q_proposed, self.residuals_proposed)
+        wp.launch(
+            _compute_costs,
+            dim=self.n_problems,
+            inputs=[self.residuals_proposed, self.n_residuals],
+            outputs=[self.costs_proposed],
+            device=self.device,
+        )
+
+        wp.launch(
+            _accept_reject,
+            dim=self.n_problems,
+            inputs=[self.costs, self.costs_proposed, self.pred_reduction, self.rho_min],
+            outputs=[self.accept_flags],
+            device=self.device,
+        )
+
+        wp.launch(
+            _update_lm_state,
+            dim=self.n_problems,
+            inputs=[
+                self.joint_q_proposed,
+                self.residuals_proposed,
+                self.costs_proposed,
+                self.accept_flags,
+                self.n_coords,
+                self.n_residuals,
+                self.lambda_factor,
+                self.lambda_min,
+                self.lambda_max,
+            ],
+            outputs=[self.joint_q, self.residuals, self.costs, self.lambda_values],
+            device=self.device,
+        )
+
+    def _solve_tiled(self, jacobian, residuals, lambda_values, delta_q, pred_reduction):
+        raise NotImplementedError("This method should be overridden by specialized solver")
+
+    @classmethod
+    def _build_specialised(cls, key):
+        """Build a specialized IKSolver subclass with tiled solver for given dimensions."""
+        C, R, _ = key
+
+        @wp.kernel(enable_backward=False, module="unique")
+        def _lm_solve_tiled(
+            jacobians: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+            residuals: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, 1)
+            lambda_values: wp.array1d(dtype=wp.float32),  # (n_problems)
+            # outputs
+            delta_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+            pred_reduction_out: wp.array1d(dtype=wp.float32),  # (n_problems)
+        ):
+            problem_idx = wp.tid()
+
+            RES = _Specialised.TILE_N_RESIDUALS
+            COORD = _Specialised.TILE_N_COORDS
+            J = wp.tile_load(jacobians[problem_idx], shape=(RES, COORD))
+            r = wp.tile_load(residuals[problem_idx], shape=(RES, 1))
+            lam = lambda_values[problem_idx]
+            Jt = wp.tile_transpose(J)
+            JtJ = wp.tile_zeros(shape=(COORD, COORD), dtype=wp.float32)
+            wp.tile_matmul(Jt, J, JtJ)
+
+            diag = wp.tile_zeros(shape=(COORD,), dtype=wp.float32)
+            for i in range(COORD):
+                diag[i] = lam
+            A = wp.tile_diag_add(JtJ, diag)
+            g = wp.tile_zeros(shape=(COORD,), dtype=wp.float32)
+            tmp2d = wp.tile_zeros(shape=(COORD, 1), dtype=wp.float32)
+            wp.tile_matmul(Jt, r, tmp2d)
+            for i in range(COORD):
+                g[i] = tmp2d[i, 0]
+
+            rhs = wp.tile_map(wp.neg, g)
+            L = wp.tile_cholesky(A)
+            delta = wp.tile_cholesky_solve(L, rhs)
+            wp.tile_store(delta_q[problem_idx], delta)
+            lambda_delta = wp.tile_zeros(shape=(COORD,), dtype=wp.float32)
+            for i in range(COORD):
+                lambda_delta[i] = lam * delta[i]
+
+            diff = wp.tile_map(wp.sub, lambda_delta, g)
+            prod = wp.tile_map(wp.mul, delta, diff)
+            red = wp.tile_sum(prod)[0]
+            pred_reduction_out[problem_idx] = 0.5 * red
+
+        # late-import jcalc_motion, jcalc_transform to avoid circular import error
+        from newton.solvers.featherstone.kernels import (  # noqa: PLC0415
+            jcalc_motion,
+            jcalc_transform,
+        )
+
+        @wp.kernel(module="unique")
+        def _compute_motion_subspace_2d(
+            n_problems: int,
+            joint_type: wp.array1d(dtype=wp.int32),  # (n_joints)
+            joint_parent: wp.array1d(dtype=wp.int32),  # (n_joints)
+            joint_qd_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+            joint_qd: wp.array2d(dtype=wp.float32),  # (n_problems, n_joint_dof_count)
+            joint_axis: wp.array1d(dtype=wp.vec3),  # (n_joint_dof_count)
+            joint_dof_dim: wp.array2d(dtype=wp.int32),  # (n_joints, 2)
+            body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+            joint_X_p: wp.array1d(dtype=wp.transform),  # (n_joints)
+            # outputs
+            joint_S_s: wp.array2d(dtype=wp.spatial_vector),  # (n_problems, n_joint_dof_count)
+        ):
+            tid = wp.tid()
+
+            n_joints = len(joint_type)
+            problem_idx = tid / n_joints
+            joint_idx = tid % n_joints
+
+            if problem_idx >= n_problems:
+                return
+
+            type = joint_type[joint_idx]
+            parent = joint_parent[joint_idx]
+            qd_start = joint_qd_start[joint_idx]
+
+            X_pj = joint_X_p[joint_idx]
+            X_wpj = X_pj
+            if parent >= 0:
+                X_wpj = body_q[problem_idx, parent] * X_pj
+
+            lin_axis_count = joint_dof_dim[joint_idx, 0]
+            ang_axis_count = joint_dof_dim[joint_idx, 1]
+
+            joint_qd_1d = joint_qd[problem_idx]
+            S_s_out = joint_S_s[problem_idx]
+
+            jcalc_motion(
+                type,
+                joint_axis,
+                lin_axis_count,
+                ang_axis_count,
+                X_wpj,
+                joint_qd_1d,
+                qd_start,
+                S_s_out,
+            )
+
+        @wp.kernel(module="unique")
+        def _fk_local(
+            joint_type: wp.array1d(dtype=wp.int32),  # (n_joints)
+            joint_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+            joint_q_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+            joint_qd_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+            joint_axis: wp.array1d(dtype=wp.vec3),  # (n_axes)
+            joint_dof_dim: wp.array2d(dtype=wp.int32),  # (n_joints, 2)  → (lin, ang)
+            joint_X_p: wp.array1d(dtype=wp.transform),  # (n_joints)
+            joint_X_c: wp.array1d(dtype=wp.transform),  # (n_joints)
+            joint_count: int,
+            # outputs
+            X_local_out: wp.array2d(dtype=wp.transform),  # (n_problems, n_joints)
+        ):
+            global_joint_idx = wp.tid()
+            problem_idx = global_joint_idx / joint_count
+            local_joint_idx = global_joint_idx % joint_count
+
+            t = joint_type[local_joint_idx]
+            q_start = joint_q_start[local_joint_idx]
+            axis_start = joint_qd_start[local_joint_idx]
+            lin_axes = joint_dof_dim[local_joint_idx, 0]
+            ang_axes = joint_dof_dim[local_joint_idx, 1]
+
+            X_j = jcalc_transform(
+                t,
+                joint_axis,
+                axis_start,
+                lin_axes,
+                ang_axes,
+                joint_q[problem_idx],  # 1-D row slice
+                q_start,
+            )
+
+            X_rel = joint_X_p[local_joint_idx] * X_j * wp.transform_inverse(joint_X_c[local_joint_idx])
+            X_local_out[problem_idx, local_joint_idx] = X_rel
+
+        def _fk_two_pass(model, joint_q, body_q, X_local, n_problems):
+            """Compute forward kinematics using two-pass algorithm.
+
+            Args:
+                model: newton.Model instance
+                joint_q: 2D array [n_problems, joint_coord_count]
+                body_q: 2D array [n_problems, body_count] (output)
+                X_local: 2D array [n_problems, joint_count] (workspace)
+                n_problems: Number of problems
+            """
+            total_joints = n_problems * model.joint_count
+            wp.launch(
+                _fk_local,
+                dim=total_joints,
+                inputs=[
+                    model.joint_type,
+                    joint_q,
+                    model.joint_q_start,
+                    model.joint_qd_start,
+                    model.joint_axis,
+                    model.joint_dof_dim,
+                    model.joint_X_p,
+                    model.joint_X_c,
+                    model.joint_count,
+                ],
+                outputs=[
+                    X_local,
+                ],
+                device=model.device,
+            )
+
+            wp.launch(
+                _fk_accum,
+                dim=total_joints,
+                inputs=[
+                    model.joint_parent,
+                    X_local,
+                    model.joint_count,
+                ],
+                outputs=[
+                    body_q,
+                ],
+                device=model.device,
+            )
+
+        class _Specialised(IKSolver):
+            TILE_N_COORDS = wp.constant(C)
+            TILE_N_RESIDUALS = wp.constant(R)
+            TILE_THREADS = wp.constant(32)
+
+            def _solve_tiled(self, jac, res, lam, dq, pred):
+                wp.launch_tiled(
+                    _lm_solve_tiled,
+                    dim=[self.n_problems],
+                    inputs=[jac, res, lam, dq, pred],
+                    block_dim=self.TILE_THREADS,
+                    device=self.device,
+                )
+
+        _Specialised.__name__ = f"IK_{C}x{R}"
+        _Specialised._compute_motion_subspace_2d = staticmethod(_compute_motion_subspace_2d)
+        _Specialised._fk_two_pass = staticmethod(_fk_two_pass)
+        return _Specialised
+
+
+@wp.kernel
+def _eval_fk_articulation_batched(
+    n_problems: int,
+    articulation_start: wp.array1d(dtype=wp.int32),  # (n_articulations + 1)
+    joint_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    joint_qd: wp.array2d(dtype=wp.float32),  # (n_problems, n_dofs)
+    joint_q_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_qd_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_type: wp.array1d(dtype=wp.int32),  # (n_joints)
+    joint_parent: wp.array1d(dtype=wp.int32),  # (n_joints)
+    joint_child: wp.array1d(dtype=wp.int32),  # (n_joints)
+    joint_X_p: wp.array1d(dtype=wp.transform),  # (n_joints)
+    joint_X_c: wp.array1d(dtype=wp.transform),  # (n_joints)
+    joint_axis: wp.array1d(dtype=wp.vec3),  # (n_dofs)
+    joint_dof_dim: wp.array2d(dtype=int),  # (n_joints, 2)
+    body_com: wp.array1d(dtype=wp.vec3),  # (n_bodies)
+    # outputs
+    body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+    body_qd: wp.array2d(dtype=wp.spatial_vector),  # (n_problems, n_bodies)
+):
+    tid = wp.tid()
+
+    num_articulations = len(articulation_start) - 1
+    problem_idx = tid // num_articulations
+    articulation_idx = tid % num_articulations
+
+    if problem_idx >= n_problems:
+        return
+
+    joint_start = articulation_start[articulation_idx]
+    joint_end = articulation_start[articulation_idx + 1]
+
+    joint_q_slice = joint_q[problem_idx]
+    joint_qd_slice = joint_qd[problem_idx]
+    body_q_slice = body_q[problem_idx]
+    body_qd_slice = body_qd[problem_idx]
+
+    eval_single_articulation_fk(
+        joint_start,
+        joint_end,
+        joint_q_slice,
+        joint_qd_slice,
+        joint_q_start,
+        joint_qd_start,
+        joint_type,
+        joint_parent,
+        joint_child,
+        joint_X_p,
+        joint_X_c,
+        joint_axis,
+        joint_dof_dim,
+        body_com,
+        body_q_slice,
+        body_qd_slice,
+    )
+
+
+def _eval_fk_batched(model, joint_q, joint_qd, body_q, body_qd):
+    """Compute batched forward kinematics."""
+    n_problems = joint_q.shape[0]
+
+    wp.launch(
+        kernel=_eval_fk_articulation_batched,
+        dim=n_problems * model.articulation_count,
+        inputs=[
+            n_problems,
+            model.articulation_start,
+            joint_q,
+            joint_qd,
+            model.joint_q_start,
+            model.joint_qd_start,
+            model.joint_type,
+            model.joint_parent,
+            model.joint_child,
+            model.joint_X_p,
+            model.joint_X_c,
+            model.joint_axis,
+            model.joint_dof_dim,
+            model.body_com,
+        ],
+        outputs=[
+            body_q,
+            body_qd,
+        ],
+        device=model.device,
+    )
+
+
+@wp.kernel
+def _fk_accum(
+    joint_parent: wp.array1d(dtype=wp.int32),  # (n_joints)
+    X_local: wp.array2d(dtype=wp.transform),  # (n_problems, n_joints)
+    joint_count: int,
+    # outputs
+    body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+):
+    global_joint_idx = wp.tid()
+    problem_idx = global_joint_idx / joint_count
+    local_joint_idx = global_joint_idx % joint_count
+
+    Xw = X_local[problem_idx, local_joint_idx]
+    parent = joint_parent[local_joint_idx]
+
+    while parent >= 0:
+        Xp = X_local[problem_idx, parent]
+        Xw = Xp * Xw
+        parent = joint_parent[parent]
+
+    body_q[problem_idx, local_joint_idx] = Xw
+
+
+@wp.kernel
+def _compute_costs(
+    residuals: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+    num_residuals: int,
+    # outputs
+    costs: wp.array1d(dtype=wp.float32),  # (n_problems)
+):
+    problem_idx = wp.tid()
+
+    cost = float(0.0)
+    for i in range(num_residuals):
+        r = residuals[problem_idx, i]
+        cost += r * r
+
+    costs[problem_idx] = cost
+
+
+@wp.kernel
+def _compute_q_proposed(
+    joint_q_current: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    delta_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    step_size: float,
+    n_coords: int,
+    # outputs
+    joint_q_proposed: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+):
+    global_coord_idx = wp.tid()
+
+    problem_idx = global_coord_idx / n_coords
+    coord_idx = global_coord_idx % n_coords
+
+    joint_q_proposed[problem_idx, coord_idx] = (
+        joint_q_current[problem_idx, coord_idx] + step_size * delta_q[problem_idx, coord_idx]
+    )
+
+
+@wp.kernel
+def _accept_reject(
+    cost_curr: wp.array1d(dtype=wp.float32),  # (n_problems)
+    cost_prop: wp.array1d(dtype=wp.float32),  # (n_problems)
+    pred_red: wp.array1d(dtype=wp.float32),  # (n_problems)
+    rho_min: float,
+    # outputs
+    accept: wp.array1d(dtype=wp.int32),  # (n_problems)
+):
+    problem_idx = wp.tid()
+    rho = (cost_curr[problem_idx] - cost_prop[problem_idx]) / (pred_red[problem_idx] + 1e-8)
+    accept[problem_idx] = wp.int32(1) if rho >= rho_min else wp.int32(0)
+
+
+@wp.kernel
+def _update_lm_state(
+    joint_q_proposed: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    residuals_proposed: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+    costs_proposed: wp.array1d(dtype=wp.float32),  # (n_problems)
+    accept_flags: wp.array1d(dtype=wp.int32),  # (n_problems)
+    n_coords: int,
+    num_residuals: int,
+    lambda_factor: float,
+    lambda_min: float,
+    lambda_max: float,
+    # outputs
+    joint_q_current: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    residuals_current: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+    costs: wp.array1d(dtype=wp.float32),  # (n_problems)
+    lambda_values: wp.array1d(dtype=wp.float32),  # (n_problems)
+):
+    problem_idx = wp.tid()
+
+    if accept_flags[problem_idx] == 1:
+        for i in range(n_coords):
+            joint_q_current[problem_idx, i] = joint_q_proposed[problem_idx, i]
+
+        for i in range(num_residuals):
+            residuals_current[problem_idx, i] = residuals_proposed[problem_idx, i]
+
+        costs[problem_idx] = costs_proposed[problem_idx]
+
+        lambda_values[problem_idx] = lambda_values[problem_idx] / lambda_factor
+    else:
+        new_lambda = lambda_values[problem_idx] * lambda_factor
+        lambda_values[problem_idx] = wp.clamp(new_lambda, lambda_min, lambda_max)
+
+
+class IKObjective:
+    def residual_dim(self):
+        raise NotImplementedError
+
+    def compute_residuals(self, body_q, joint_q, model, residuals, start_idx):
+        raise NotImplementedError
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx, joint_q):
+        raise NotImplementedError
+
+    def supports_analytic(self):
+        return False
+
+    def bind_device(self, device):
+        self.device = device
+
+    def init_buffers(self, model, jacobian_mode):
+        pass
+
+    def compute_jacobian_analytic(self, body_q, joint_q, model, jacobian, joint_S_s, start_idx):
+        pass
+
+
+@wp.kernel
+def _pos_residuals(
+    body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+    target_pos: wp.array1d(dtype=wp.vec3),  # (n_problems)
+    link_index: int,
+    link_offset: wp.vec3,
+    start_idx: int,
+    weight: float,
+    # outputs
+    residuals: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+):
+    problem_idx = wp.tid()
+
+    body_tf = body_q[problem_idx, link_index]
+    ee_pos = wp.transform_point(body_tf, link_offset)
+
+    error = target_pos[problem_idx] - ee_pos
+    residuals[problem_idx, start_idx + 0] = weight * error[0]
+    residuals[problem_idx, start_idx + 1] = weight * error[1]
+    residuals[problem_idx, start_idx + 2] = weight * error[2]
+
+
+@wp.kernel
+def _pos_jac_fill(
+    q_grad: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    n_coords: int,
+    start_idx: int,
+    component: int,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    problem_idx = wp.tid()
+
+    residual_idx = start_idx + component
+
+    for j in range(n_coords):
+        jacobian[problem_idx, residual_idx, j] = q_grad[problem_idx, j]
+
+
+@wp.kernel
+def _update_position_target(
+    problem_idx: int,
+    new_position: wp.vec3,
+    # outputs
+    target_array: wp.array1d(dtype=wp.vec3),  # (n_problems)
+):
+    target_array[problem_idx] = new_position
+
+
+@wp.kernel
+def _update_position_targets(
+    new_positions: wp.array1d(dtype=wp.vec3),  # (n_problems)
+    # outputs
+    target_array: wp.array1d(dtype=wp.vec3),  # (n_problems)
+):
+    problem_idx = wp.tid()
+    target_array[problem_idx] = new_positions[problem_idx]
+
+
+@wp.kernel
+def _pos_jac_analytic(
+    link_index: int,
+    link_offset: wp.vec3,
+    joint_child: wp.array1d(dtype=wp.int32),  # (n_joints)
+    coord_to_joint: wp.array1d(dtype=wp.int32),  # (n_coords)
+    affects_coord: wp.array1d(dtype=wp.uint8),  # (n_coords)
+    joint_qd_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_q_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_type: wp.array1d(dtype=wp.int32),  # (n_joints)
+    joint_S_s: wp.array2d(dtype=wp.spatial_vector),  # (n_problems, n_dofs)
+    body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+    start_idx: int,
+    n_coords: int,
+    weight: float,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    global_coord = wp.tid()
+
+    problem_idx = global_coord // n_coords
+    coord_idx = global_coord % n_coords
+
+    if affects_coord[coord_idx] == 0:
+        return
+
+    joint_idx = coord_to_joint[coord_idx]
+
+    joint_coord_start = joint_q_start[joint_idx]
+    joint_coord_end = joint_q_start[joint_idx + 1]
+    local_coord = coord_idx - joint_coord_start
+
+    body_tf = body_q[problem_idx, link_index]
+
+    rot_w = wp.quat(body_tf[3], body_tf[4], body_tf[5], body_tf[6])
+    pos_w = wp.vec3(body_tf[0], body_tf[1], body_tf[2])
+    ee_pos_world = pos_w + wp.quat_rotate(rot_w, link_offset)
+
+    col = coord_idx
+
+    # General twist-based Jacobian (supports revolute/prismatic/fixed only)
+    dof_start = joint_qd_start[joint_idx]
+    dof_local = local_coord
+    dof = dof_start + dof_local
+
+    if dof >= dof_start and dof < dof_start + (joint_coord_end - joint_coord_start):
+        S = joint_S_s[problem_idx, dof]
+        omega = wp.vec3(S[0], S[1], S[2])
+        v_orig = wp.vec3(S[3], S[4], S[5])
+
+    v_ee = v_orig + wp.cross(omega, ee_pos_world)
+
+    jacobian[problem_idx, start_idx + 0, col] = -weight * v_ee[0]
+    jacobian[problem_idx, start_idx + 1, col] = -weight * v_ee[1]
+    jacobian[problem_idx, start_idx + 2, col] = -weight * v_ee[2]
+
+
+class PositionObjective(IKObjective):
+    """
+    End-effector positional target for one link.
+
+    Parameters
+    ----------
+    link_index : int
+        Body index whose frame defines the end-effector.
+    link_offset : wp.vec3
+        Offset from the body frame (local coordinates).
+    target_positions : wp.array(dtype=wp.vec3)
+        One target position per problem.
+    n_problems : int
+        Number of parallel IK problems.
+    total_residuals : int
+        Global residual vector length (for autodiff bookkeeping).
+    residual_offset : int
+        Starting index of this objective inside the residual vector.
+    weight : float, default 1.0
+        Scalar weight multiplying both residual and Jacobian rows.
+    """
+
+    def __init__(
+        self, link_index, link_offset, target_positions, n_problems, total_residuals, residual_offset, weight=1.0
+    ):
+        self.link_index = link_index
+        self.link_offset = link_offset
+        self.target_positions = target_positions
+        self.n_problems = n_problems
+        self.weight = weight
+        self.total_residuals = total_residuals
+        self.residual_offset = residual_offset
+
+        self.body_to_joint = None
+        self.coord_to_joint = None
+        self.affects_coord = None
+
+    def init_buffers(self, model, jacobian_mode):
+        """Precompute lookup tables for analytic jacobian computation."""
+        if jacobian_mode == JacobianMode.ANALYTIC:
+            links_per_problem = model.body_count
+            n_coords = model.joint_coord_count
+
+            joint_child_np = model.joint_child.numpy()
+            body_to_joint_np = np.full(links_per_problem, -1, np.int32)
+
+            for j in range(model.joint_count):
+                child = joint_child_np[j]
+                if child != -1:
+                    body_to_joint_np[child] = j
+
+            self.body_to_joint = wp.array(body_to_joint_np, dtype=wp.int32, device=self.device)
+
+            coord_to_joint_np = np.empty(n_coords, dtype=np.int32)
+            joint_q_start_np = model.joint_q_start.numpy()
+
+            for j in range(len(joint_q_start_np) - 1):
+                start, end = joint_q_start_np[j : j + 2]
+                coord_to_joint_np[start:end] = j
+
+            self.coord_to_joint = wp.array(coord_to_joint_np, dtype=wp.int32, device=self.device)
+
+            ancestors = np.zeros(len(joint_q_start_np) - 1, dtype=bool)
+            joint_parent_np = model.joint_parent.numpy()
+            body = self.link_index
+            while body != -1:
+                j = body_to_joint_np[body]
+                if j != -1:
+                    ancestors[j] = True
+                body = joint_parent_np[j] if j != -1 else -1
+
+            affects_coord_np = ancestors[coord_to_joint_np]
+            self.affects_coord = wp.array(affects_coord_np.astype(np.uint8), device=self.device)
+        elif jacobian_mode == JacobianMode.AUTODIFF:
+            self.e_arrays = []
+            for component in range(3):
+                e = np.zeros((self.n_problems, self.total_residuals), dtype=np.float32)
+                for prob_idx in range(self.n_problems):
+                    e[prob_idx, self.residual_offset + component] = 1.0
+                self.e_arrays.append(wp.array(e.flatten(), dtype=wp.float32, device=self.device))
+
+    def supports_analytic(self):
+        return True
+
+    def set_target_position(self, problem_idx, new_position):
+        wp.launch(
+            _update_position_target,
+            dim=1,
+            inputs=[problem_idx, new_position],
+            outputs=[self.target_positions],
+            device=self.device,
+        )
+
+    def set_target_positions(self, new_positions):
+        wp.launch(
+            _update_position_targets,
+            dim=self.n_problems,
+            inputs=[new_positions],
+            outputs=[self.target_positions],
+            device=self.device,
+        )
+
+    def residual_dim(self):
+        return 3
+
+    def compute_residuals(self, body_q, joint_q, model, residuals, start_idx):
+        wp.launch(
+            _pos_residuals,
+            dim=self.n_problems,
+            inputs=[
+                body_q,
+                self.target_positions,
+                self.link_index,
+                self.link_offset,
+                start_idx,
+                self.weight,
+            ],
+            outputs=[residuals],
+            device=self.device,
+        )
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx, joint_q):
+        for component in range(3):
+            tape.backward(grads={tape.outputs[0]: self.e_arrays[component].flatten()})
+
+            q_grad = tape.gradients[joint_q]
+
+            n_coords = model.joint_coord_count
+
+            wp.launch(
+                _pos_jac_fill,
+                dim=self.n_problems,
+                inputs=[
+                    q_grad,
+                    n_coords,
+                    start_idx,
+                    component,
+                ],
+                outputs=[
+                    jacobian,
+                ],
+                device=self.device,
+            )
+
+            tape.zero()
+
+    def compute_jacobian_analytic(self, body_q, joint_q, model, jacobian, joint_S_s, start_idx):
+        n_coords = model.joint_coord_count
+
+        wp.launch(
+            _pos_jac_analytic,
+            dim=self.n_problems * n_coords,
+            inputs=[
+                self.link_index,
+                self.link_offset,
+                model.joint_child,
+                self.coord_to_joint,
+                self.affects_coord,
+                model.joint_qd_start,
+                model.joint_q_start,
+                model.joint_type,
+                joint_S_s,
+                body_q,
+                start_idx,
+                n_coords,
+                self.weight,
+            ],
+            outputs=[
+                jacobian,
+            ],
+            device=self.device,
+        )
+
+
+@wp.kernel
+def _limit_residuals(
+    joint_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    joint_limit_lower: wp.array1d(dtype=wp.float32),  # (n_coords)
+    joint_limit_upper: wp.array1d(dtype=wp.float32),  # (n_coords)
+    n_coords: int,
+    weight: float,
+    start_idx: int,
+    # outputs
+    residuals: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+):
+    global_coord_idx = wp.tid()
+    problem_idx = global_coord_idx / n_coords
+    coord_idx = global_coord_idx % n_coords
+
+    q = joint_q[problem_idx, coord_idx]
+    lower = joint_limit_lower[coord_idx]
+    upper = joint_limit_upper[coord_idx]
+
+    upper_violation = wp.max(0.0, q - upper)
+    lower_violation = wp.max(0.0, lower - q)
+
+    residuals[problem_idx, start_idx + coord_idx] = weight * (upper_violation + lower_violation)
+
+
+@wp.kernel
+def _limit_jac_fill(
+    q_grad: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    n_coords: int,
+    start_idx: int,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    global_coord_idx = wp.tid()
+    problem_idx = global_coord_idx / n_coords
+    coord_idx = global_coord_idx % n_coords
+
+    residual_idx = start_idx + coord_idx
+
+    jacobian[problem_idx, residual_idx, coord_idx] = q_grad[problem_idx, coord_idx]
+
+
+@wp.kernel
+def _limit_jac_analytic(
+    joint_q: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    joint_limit_lower: wp.array1d(dtype=wp.float32),  # (n_coords)
+    joint_limit_upper: wp.array1d(dtype=wp.float32),  # (n_coords)
+    n_coords: int,
+    start_idx: int,
+    weight: float,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    global_coord_idx = wp.tid()
+    problem_idx = global_coord_idx / n_coords
+    coord_idx = global_coord_idx % n_coords
+
+    q = joint_q[problem_idx, coord_idx]
+    lower = joint_limit_lower[coord_idx]
+    upper = joint_limit_upper[coord_idx]
+
+    grad = float(0.0)
+    if q >= upper:
+        grad = weight
+    elif q <= lower:
+        grad = -weight
+
+    residual_idx = start_idx + coord_idx
+    jacobian[problem_idx, residual_idx, coord_idx] = grad
+
+
+class JointLimitObjective(IKObjective):
+    """
+    Joint limit constraint objective.
+
+    Parameters
+    ----------
+    joint_limit_lower : wp.array(dtype=float)
+        Lower bounds for each joint coordinate.
+    joint_limit_upper : wp.array(dtype=float)
+        Upper bounds for each joint coordinate.
+    n_problems : int, optional
+        Number of parallel IK problems.
+    total_residuals : int, optional
+        Global residual vector length (for autodiff bookkeeping).
+    residual_offset : int, optional
+        Starting index of this objective inside the residual vector.
+    weight : float, default 0.1
+        Scalar weight for limit violation penalty.
+    """
+
+    def __init__(
+        self,
+        joint_limit_lower,
+        joint_limit_upper,
+        n_problems,
+        total_residuals,
+        residual_offset,
+        weight=0.1,
+    ):
+        self.joint_limit_lower = joint_limit_lower
+        self.joint_limit_upper = joint_limit_upper
+        self.e_array = None
+        self.n_problems = n_problems
+        self.total_residuals = total_residuals
+        self.residual_offset = residual_offset
+        self.weight = weight
+
+        self.n_coords = len(joint_limit_lower)
+
+    def init_buffers(self, model, jacobian_mode):
+        if jacobian_mode == JacobianMode.AUTODIFF:
+            e = np.zeros((self.n_problems, self.total_residuals), dtype=np.float32)
+            for prob_idx in range(self.n_problems):
+                for coord_idx in range(self.n_coords):
+                    e[prob_idx, self.residual_offset + coord_idx] = 1.0
+            self.e_array = wp.array(e.flatten(), dtype=wp.float32, device=self.device)
+
+    def supports_analytic(self):
+        return True
+
+    def residual_dim(self):
+        return self.n_coords
+
+    def compute_residuals(self, body_q, joint_q, model, residuals, start_idx):
+        wp.launch(
+            _limit_residuals,
+            dim=self.n_problems * self.n_coords,
+            inputs=[
+                joint_q,
+                self.joint_limit_lower,
+                self.joint_limit_upper,
+                self.n_coords,
+                self.weight,
+                start_idx,
+            ],
+            outputs=[residuals],
+            device=self.device,
+        )
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx, joint_q):
+        tape.backward(grads={tape.outputs[0]: self.e_array})
+
+        q_grad = tape.gradients[joint_q]
+
+        wp.launch(
+            _limit_jac_fill,
+            dim=self.n_problems * self.n_coords,
+            inputs=[
+                q_grad,
+                self.n_coords,
+                start_idx,
+            ],
+            outputs=[jacobian],
+            device=self.device,
+        )
+
+    def compute_jacobian_analytic(self, body_q, joint_q, model, jacobian, joint_S_s, start_idx):
+        wp.launch(
+            _limit_jac_analytic,
+            dim=self.n_problems * self.n_coords,
+            inputs=[
+                joint_q,
+                self.joint_limit_lower,
+                self.joint_limit_upper,
+                self.n_coords,
+                start_idx,
+                self.weight,
+            ],
+            outputs=[jacobian],
+            device=self.device,
+        )
+
+
+@wp.kernel
+def _rot_residuals(
+    body_q: wp.array2d(dtype=wp.transform),  # (n_problems, n_bodies)
+    target_rot: wp.array1d(dtype=wp.vec4),  # (n_problems)
+    link_index: int,
+    link_offset_rotation: wp.quat,
+    start_idx: int,
+    weight: float,
+    # outputs
+    residuals: wp.array2d(dtype=wp.float32),  # (n_problems, n_residuals)
+):
+    problem_idx = wp.tid()
+
+    body_tf = body_q[problem_idx, link_index]
+    body_rot = wp.quat(body_tf[3], body_tf[4], body_tf[5], body_tf[6])
+
+    actual_rot = body_rot * link_offset_rotation
+
+    target_quat_vec = target_rot[problem_idx]
+    target_quat = wp.quat(target_quat_vec[0], target_quat_vec[1], target_quat_vec[2], target_quat_vec[3])
+
+    q_err = actual_rot * wp.quat_inverse(target_quat)
+
+    v_norm = wp.sqrt(q_err[0] * q_err[0] + q_err[1] * q_err[1] + q_err[2] * q_err[2])
+
+    angle = 2.0 * wp.atan2(v_norm, q_err[3])
+
+    eps = float(1e-8)
+    axis_angle = wp.vec3(0.0, 0.0, 0.0)
+
+    if v_norm > eps:
+        axis = wp.vec3(q_err[0] / v_norm, q_err[1] / v_norm, q_err[2] / v_norm)
+        axis_angle = axis * angle
+    else:
+        axis_angle = wp.vec3(2.0 * q_err[0], 2.0 * q_err[1], 2.0 * q_err[2])
+
+    residuals[problem_idx, start_idx + 0] = weight * axis_angle[0]
+    residuals[problem_idx, start_idx + 1] = weight * axis_angle[1]
+    residuals[problem_idx, start_idx + 2] = weight * axis_angle[2]
+
+
+@wp.kernel
+def _rot_jac_fill(
+    q_grad: wp.array2d(dtype=wp.float32),  # (n_problems, n_coords)
+    n_coords: int,
+    start_idx: int,
+    component: int,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    problem_idx = wp.tid()
+
+    residual_idx = start_idx + component
+
+    for j in range(n_coords):
+        jacobian[problem_idx, residual_idx, j] = q_grad[problem_idx, j]
+
+
+@wp.kernel
+def _update_rotation_target(
+    problem_idx: int,
+    new_rotation: wp.vec4,
+    # outputs
+    target_array: wp.array1d(dtype=wp.vec4),  # (n_problems)
+):
+    target_array[problem_idx] = new_rotation
+
+
+@wp.kernel
+def _update_rotation_targets(
+    new_rotation: wp.array1d(dtype=wp.vec4),  # (n_problems)
+    # outputs
+    target_array: wp.array1d(dtype=wp.vec4),  # (n_problems)
+):
+    problem_idx = wp.tid()
+    target_array[problem_idx] = new_rotation[problem_idx]
+
+
+@wp.kernel
+def _rot_jac_analytic(
+    coord_to_joint: wp.array1d(dtype=wp.int32),  # (n_coords)
+    affects_coord: wp.array1d(dtype=wp.uint8),  # (n_coords)
+    joint_qd_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_q_start: wp.array1d(dtype=wp.int32),  # (n_joints + 1)
+    joint_S_s: wp.array2d(dtype=wp.spatial_vector),  # (n_problems, n_dofs)
+    start_idx: int,
+    n_coords: int,
+    weight: float,
+    # outputs
+    jacobian: wp.array3d(dtype=wp.float32),  # (n_problems, n_residuals, n_coords)
+):
+    global_coord = wp.tid()
+    problem_idx = global_coord // n_coords
+    coord_idx = global_coord % n_coords
+
+    if affects_coord[coord_idx] == 0:
+        return
+
+    joint_idx = coord_to_joint[coord_idx]
+    if joint_idx < 0:
+        return
+
+    joint_coord_start = joint_q_start[joint_idx]
+
+    # General omega-based Jacobian (supports revolute/prismatic/fixed only)
+    dof_start = joint_qd_start[joint_idx]
+
+    local_coord = coord_idx - joint_coord_start
+    dof = dof_start + local_coord
+
+    S = joint_S_s[problem_idx, dof]
+    omega = wp.vec3(S[0], S[1], S[2])
+
+    col = coord_idx
+    jacobian[problem_idx, start_idx + 0, col] = weight * omega[0]
+    jacobian[problem_idx, start_idx + 1, col] = weight * omega[1]
+    jacobian[problem_idx, start_idx + 2, col] = weight * omega[2]
+
+
+class RotationObjective(IKObjective):
+    """
+    End-effector rotational target for one link.
+
+    Parameters
+    ----------
+    link_index : int
+        Body index whose frame defines the end-effector.
+    link_offset_rotation : wp.quat
+        Rotation offset from the body frame (local coordinates).
+    target_rotations : wp.array(dtype=wp.vec4)
+        One target quaternion per problem (stored as vec4).
+    n_problems : int
+        Number of parallel IK problems.
+    total_residuals : int
+        Global residual vector length (for autodiff bookkeeping).
+    residual_offset : int
+        Starting index of this objective inside the residual vector.
+    weight : float, default 1.0
+        Scalar weight multiplying both residual and Jacobian rows.
+    """
+
+    def __init__(
+        self,
+        link_index,
+        link_offset_rotation,
+        target_rotations,
+        n_problems,
+        total_residuals,
+        residual_offset,
+        weight=1.0,
+    ):
+        self.link_index = link_index
+        self.link_offset_rotation = link_offset_rotation
+        self.target_rotations = target_rotations
+        self.n_problems = n_problems
+        self.weight = weight
+        self.total_residuals = total_residuals
+        self.residual_offset = residual_offset
+
+        self.body_to_joint = None
+        self.coord_to_joint = None
+        self.affects_coord = None
+
+    def init_buffers(self, model, jacobian_mode):
+        """Precompute lookup tables for analytic jacobian computation."""
+        if jacobian_mode == JacobianMode.ANALYTIC:
+            links_per_problem = model.body_count
+            n_coords = model.joint_coord_count
+
+            joint_child_np = model.joint_child.numpy()
+            body_to_joint_np = np.full(links_per_problem, -1, np.int32)
+
+            for j in range(model.joint_count):
+                child = joint_child_np[j]
+                if child != -1:
+                    body_to_joint_np[child] = j
+
+            self.body_to_joint = wp.array(body_to_joint_np, dtype=wp.int32, device=self.device)
+
+            coord_to_joint_np = np.empty(n_coords, dtype=np.int32)
+            joint_q_start_np = model.joint_q_start.numpy()
+
+            for j in range(len(joint_q_start_np) - 1):
+                start, end = joint_q_start_np[j : j + 2]
+                coord_to_joint_np[start:end] = j
+
+            self.coord_to_joint = wp.array(coord_to_joint_np, dtype=wp.int32, device=self.device)
+
+            ancestors = np.zeros(len(joint_q_start_np) - 1, dtype=bool)
+            joint_parent_np = model.joint_parent.numpy()
+            body = self.link_index
+            while body != -1:
+                j = body_to_joint_np[body]
+                if j != -1:
+                    ancestors[j] = True
+                body = joint_parent_np[j] if j != -1 else -1
+
+            affects_coord_np = ancestors[coord_to_joint_np]
+            self.affects_coord = wp.array(affects_coord_np.astype(np.uint8), device=self.device)
+        elif jacobian_mode == JacobianMode.AUTODIFF:
+            self.e_arrays = []
+            for component in range(3):
+                e = np.zeros((self.n_problems, self.total_residuals), dtype=np.float32)
+                for prob_idx in range(self.n_problems):
+                    e[prob_idx, self.residual_offset + component] = 1.0
+                self.e_arrays.append(wp.array(e.flatten(), dtype=wp.float32, device=self.device))
+
+    def supports_analytic(self):
+        return True
+
+    def set_target_rotation(self, problem_idx, new_rotation):
+        wp.launch(
+            _update_rotation_target,
+            dim=1,
+            inputs=[problem_idx, new_rotation],
+            outputs=[self.target_rotations],
+            device=self.device,
+        )
+
+    def set_target_rotations(self, new_rotations):
+        wp.launch(
+            _update_rotation_targets,
+            dim=self.n_problems,
+            inputs=[new_rotations],
+            outputs=[self.target_rotations],
+            device=self.device,
+        )
+
+    def residual_dim(self):
+        return 3
+
+    def compute_residuals(self, body_q, joint_q, model, residuals, start_idx):
+        wp.launch(
+            _rot_residuals,
+            dim=self.n_problems,
+            inputs=[
+                body_q,
+                self.target_rotations,
+                self.link_index,
+                self.link_offset_rotation,
+                start_idx,
+                self.weight,
+            ],
+            outputs=[residuals],
+            device=self.device,
+        )
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx, joint_q):
+        for component in range(3):
+            tape.backward(grads={tape.outputs[0]: self.e_arrays[component].flatten()})
+
+            q_grad = tape.gradients[joint_q]
+
+            n_coords = model.joint_coord_count
+
+            wp.launch(
+                _rot_jac_fill,
+                dim=self.n_problems,
+                inputs=[
+                    q_grad,
+                    n_coords,
+                    start_idx,
+                    component,
+                ],
+                outputs=[
+                    jacobian,
+                ],
+                device=self.device,
+            )
+
+            tape.zero()
+
+    def compute_jacobian_analytic(self, body_q, joint_q, model, jacobian, joint_S_s, start_idx):
+        n_coords = model.joint_coord_count
+
+        wp.launch(
+            _rot_jac_analytic,
+            dim=self.n_problems * n_coords,
+            inputs=[
+                self.coord_to_joint,
+                self.affects_coord,
+                model.joint_qd_start,
+                model.joint_q_start,
+                joint_S_s,
+                start_idx,
+                n_coords,
+                self.weight,
+            ],
+            outputs=[
+                jacobian,
+            ],
+            device=self.device,
+        )

--- a/newton/tests/test_ik.py
+++ b/newton/tests/test_ik.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.sim.ik as ik
+from newton.tests.unittest_utils import add_function_test, assert_np_equal, get_test_devices
+
+# ----------------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------------
+
+
+def _build_two_link_planar(device) -> newton.Model:
+    """Returns a singleton model with one 2-DOF planar arm."""
+    builder = newton.ModelBuilder()
+
+    link1 = builder.add_body(
+        xform=wp.transform([0.5, 0.0, 0.0], wp.quat_identity()),
+        mass=1.0,
+    )
+    builder.add_joint_revolute(
+        parent=-1,
+        child=link1,
+        parent_xform=wp.transform([0.0, 0.0, 0.0], wp.quat_identity()),
+        child_xform=wp.transform([-0.5, 0.0, 0.0], wp.quat_identity()),
+        axis=[0.0, 0.0, 1.0],
+    )
+
+    link2 = builder.add_body(
+        xform=wp.transform([1.5, 0.0, 0.0], wp.quat_identity()),
+        mass=1.0,
+    )
+    builder.add_joint_revolute(
+        parent=link1,
+        child=link2,
+        parent_xform=wp.transform([0.5, 0.0, 0.0], wp.quat_identity()),
+        child_xform=wp.transform([-0.5, 0.0, 0.0], wp.quat_identity()),
+        axis=[0.0, 0.0, 1.0],
+    )
+
+    model = builder.finalize(device=device, requires_grad=True)
+    return model
+
+
+def _fk_end_effector_positions(
+    model: newton.Model, body_q_2d: wp.array, n_problems: int, ee_link_index: int, ee_offset: wp.vec3
+) -> np.ndarray:
+    """Returns an (N,3) array with end-effector world positions for every problem."""
+    positions = np.zeros((n_problems, 3), dtype=np.float32)
+    body_q_np = body_q_2d.numpy()  # shape: [n_problems, model.body_count]
+
+    for prob in range(n_problems):
+        body_tf = body_q_np[prob, ee_link_index]
+        pos = wp.vec3(body_tf[0], body_tf[1], body_tf[2])
+        rot = wp.quat(body_tf[3], body_tf[4], body_tf[5], body_tf[6])
+        ee_world = wp.transform_point(wp.transform(pos, rot), ee_offset)
+        positions[prob] = [ee_world[0], ee_world[1], ee_world[2]]
+    return positions
+
+
+# ----------------------------------------------------------------------------
+# 1.  Convergence tests (one per Jacobian mode)
+# ----------------------------------------------------------------------------
+
+
+def _convergence_test(test, device, mode: ik.JacobianMode):
+    with wp.ScopedDevice(device):
+        n_problems = 3
+        model = _build_two_link_planar(device)
+
+        # Create 2D joint_q array [n_problems, joint_coord_count]
+        requires_grad = mode in [ik.JacobianMode.AUTODIFF, ik.JacobianMode.MIXED]
+        joint_q_2d = wp.zeros((n_problems, model.joint_coord_count), dtype=wp.float32, requires_grad=requires_grad)
+
+        # Create 2D joint_qd array [n_problems, joint_dof_count]
+        joint_qd_2d = wp.zeros((n_problems, model.joint_dof_count), dtype=wp.float32)
+
+        # Create 2D body arrays for output
+        body_q_2d = wp.zeros((n_problems, model.body_count), dtype=wp.transform)
+        body_qd_2d = wp.zeros((n_problems, model.body_count), dtype=wp.spatial_vector)
+
+        # simple reachable XY targets
+        targets = wp.array([[1.5, 1.0, 0.0], [1.5, 1.0, 0.0], [1.5, 1.0, 0.0]], dtype=wp.vec3)
+        ee_link = 1
+        ee_off = wp.vec3(0.5, 0.0, 0.0)
+
+        pos_obj = ik.PositionObjective(
+            link_index=ee_link,
+            link_offset=ee_off,
+            target_positions=targets,
+            n_problems=n_problems,
+            total_residuals=3,
+            residual_offset=0,
+        )
+
+        solver = ik.IKSolver(model, joint_q_2d, [pos_obj], lambda_initial=1e-3, jacobian_mode=mode)
+
+        # Run initial FK
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        initial = _fk_end_effector_positions(model, body_q_2d, n_problems, ee_link, ee_off)
+
+        solver.solve(iterations=40)
+
+        # Run final FK
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        final = _fk_end_effector_positions(model, body_q_2d, n_problems, ee_link, ee_off)
+
+        for prob in range(n_problems):
+            err0 = np.linalg.norm(initial[prob] - targets.numpy()[prob])
+            err1 = np.linalg.norm(final[prob] - targets.numpy()[prob])
+            test.assertLess(err1, err0, f"mode {mode} problem {prob} did not improve")
+            test.assertLess(err1, 1e-4, f"mode {mode} problem {prob} final error too high ({err1:.3f})")
+
+
+def test_convergence_autodiff(test, device):
+    _convergence_test(test, device, ik.JacobianMode.AUTODIFF)
+
+
+def test_convergence_analytic(test, device):
+    _convergence_test(test, device, ik.JacobianMode.ANALYTIC)
+
+
+def test_convergence_mixed(test, device):
+    _convergence_test(test, device, ik.JacobianMode.MIXED)
+
+
+# ----------------------------------------------------------------------------
+# 2.  Jacobian equality helpers
+# ----------------------------------------------------------------------------
+
+
+def _jacobian_compare(test, device, objective_builder):
+    """Build autodiff + analytic solvers for the same objective(s) and compare J."""
+    with wp.ScopedDevice(device):
+        n_problems = 3
+        model = _build_two_link_planar(device)
+
+        # Create 2D joint_q array [n_problems, joint_coord_count]
+        joint_q_2d = wp.zeros((n_problems, model.joint_coord_count), dtype=wp.float32, requires_grad=True)
+
+        objectives = objective_builder(model, n_problems)
+
+        solver_auto = ik.IKSolver(model, joint_q_2d, objectives, jacobian_mode=ik.JacobianMode.AUTODIFF)
+        solver_ana = ik.IKSolver(model, joint_q_2d, objectives, jacobian_mode=ik.JacobianMode.ANALYTIC)
+
+        solver_auto.compute_residuals()
+        solver_ana.compute_residuals()
+
+        J_auto = solver_auto.compute_jacobian().numpy()
+        J_ana = solver_ana.compute_jacobian().numpy()
+
+        assert_np_equal(J_auto, J_ana, tol=1e-4)
+
+
+# ----------------------------------------------------------------------------
+# 2a.  Position Jacobian
+# ----------------------------------------------------------------------------
+
+
+def _pos_objective_builder(model, n_problems):
+    targets = wp.array([[1.5, 0.8, 0.0] for _ in range(n_problems)], dtype=wp.vec3)
+    pos_obj = ik.PositionObjective(
+        link_index=1,
+        link_offset=wp.vec3(0.5, 0.0, 0.0),
+        target_positions=targets,
+        n_problems=n_problems,
+        total_residuals=3,
+        residual_offset=0,
+    )
+    return [pos_obj]
+
+
+def test_position_jacobian_compare(test, device):
+    _jacobian_compare(test, device, _pos_objective_builder)
+
+
+# ----------------------------------------------------------------------------
+# 2b.  Rotation Jacobian
+# ----------------------------------------------------------------------------
+
+
+def _rot_objective_builder(model, n_problems):
+    angles = [math.pi / 6 + prob * math.pi / 8 for prob in range(n_problems)]
+    quats = [[0.0, 0.0, math.sin(a / 2), math.cos(a / 2)] for a in angles]
+    rot_obj = ik.RotationObjective(
+        link_index=1,
+        link_offset_rotation=wp.quat_identity(),
+        target_rotations=wp.array(quats, dtype=wp.vec4),
+        n_problems=n_problems,
+        total_residuals=3,
+        residual_offset=0,
+    )
+    return [rot_obj]
+
+
+def test_rotation_jacobian_compare(test, device):
+    _jacobian_compare(test, device, _rot_objective_builder)
+
+
+# ----------------------------------------------------------------------------
+# 2c.  Joint-limit Jacobian
+# ----------------------------------------------------------------------------
+
+
+def _jl_objective_builder(model, n_problems):
+    # Joint limits for singleton model
+    dof = model.joint_coord_count
+    joint_limit_lower = wp.array([-1.0] * dof, dtype=wp.float32)
+    joint_limit_upper = wp.array([1.0] * dof, dtype=wp.float32)
+
+    jl_obj = ik.JointLimitObjective(
+        joint_limit_lower=joint_limit_lower,
+        joint_limit_upper=joint_limit_upper,
+        n_problems=n_problems,
+        total_residuals=dof,
+        residual_offset=0,
+        weight=0.1,
+    )
+    return [jl_obj]
+
+
+def test_joint_limit_jacobian_compare(test, device):
+    _jacobian_compare(test, device, _jl_objective_builder)
+
+
+# ----------------------------------------------------------------------------
+# 3.  Test-class registration per device
+# ----------------------------------------------------------------------------
+
+devices = get_test_devices()
+
+
+class TestIKModes(unittest.TestCase):
+    pass
+
+
+add_function_test(TestIKModes, "test_convergence_autodiff", test_convergence_autodiff, devices)
+add_function_test(TestIKModes, "test_convergence_analytic", test_convergence_analytic, devices)
+add_function_test(TestIKModes, "test_convergence_mixed", test_convergence_mixed, devices)
+add_function_test(TestIKModes, "test_position_jacobian_compare", test_position_jacobian_compare, devices)
+add_function_test(TestIKModes, "test_rotation_jacobian_compare", test_rotation_jacobian_compare, devices)
+add_function_test(TestIKModes, "test_joint_limit_jacobian_compare", test_joint_limit_jacobian_compare, devices)
+
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2, failfast=True)

--- a/newton/tests/test_ik_fk_kernels.py
+++ b/newton/tests/test_ik_fk_kernels.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.sim.ik as ik
+from newton import JOINT_BALL, JOINT_D6, JOINT_FREE, JOINT_PRISMATIC, JOINT_REVOLUTE
+from newton.tests.unittest_utils import add_function_test, assert_np_equal, get_test_devices
+
+# -----------------------------------------------------------------------------
+# Joint types we want to hit
+# -----------------------------------------------------------------------------
+JOINT_KINDS: list[int] = [
+    JOINT_REVOLUTE,
+    JOINT_PRISMATIC,
+    JOINT_BALL,
+    JOINT_D6,
+    JOINT_FREE,
+]
+
+
+# -----------------------------------------------------------------------------
+# Dummy (no-op) objective, gives R = 1 so IKSolver factory doesn't generate a 0xC solver
+# -----------------------------------------------------------------------------
+
+
+class _NoopObjective(ik.IKObjective):
+    def residual_dim(self):
+        return 1
+
+    def compute_residuals(self, state, model, residuals, start_idx):
+        # write a single zero residual per env so nothing influences FK
+        env = 0  # only 1 env used here
+        residuals[env, start_idx] = 0.0
+
+    def compute_jacobian_autodiff(self, tape, model, jacobian, start_idx):
+        pass
+
+    # keep analytic path trivial too
+    def supports_analytic(self):
+        return True
+
+    def compute_jacobian_analytic(self, state, model, jacobian, joint_S_s, start_idx):
+        pass
+
+
+# -----------------------------------------------------------------------------
+# Small helpers
+# -----------------------------------------------------------------------------
+
+
+def _add_single_joint(builder: newton.ModelBuilder, jt: int) -> None:
+    """
+    Adds one body and connects it to the world (-1) with the joint-type `jt`.
+    Makes every axis a plain JointDofConfig so the helper works for *all*
+    joint kinds we care about in the parity tests.
+    """
+    cfg = newton.ModelBuilder.JointDofConfig  # alias
+    parent_xf = wp.transform((0.1, 0.2, 0.3), wp.quat_from_axis_angle(wp.vec3(0, 1, 0), 0.0))
+    child_xf = wp.transform((-0.05, 0.0, 0.0), wp.quat_from_axis_angle(wp.vec3(1, 0, 0), 0.5))
+
+    # a 0.1-kg cube just so the body exists
+    child = builder.add_body(
+        xform=wp.transform_identity(),
+        mass=0.1,
+        key=f"body_{jt}",
+    )
+    builder.add_shape_box(
+        body=child,
+        xform=wp.transform_identity(),
+        hx=0.05,
+        hy=0.05,
+        hz=0.05,
+    )
+
+    if jt == JOINT_REVOLUTE:
+        builder.add_joint_revolute(
+            parent=-1,
+            child=child,
+            parent_xform=parent_xf,
+            child_xform=child_xf,
+            axis=[0.0, 0.0, 1.0],
+        )
+
+    elif jt == JOINT_PRISMATIC:
+        builder.add_joint_prismatic(
+            parent=-1,
+            child=child,
+            parent_xform=parent_xf,
+            child_xform=child_xf,
+            axis=[1.0, 0.0, 0.0],
+        )
+
+    elif jt == JOINT_BALL:
+        builder.add_joint_ball(
+            parent=-1,
+            child=child,
+            parent_xform=parent_xf,
+            child_xform=child_xf,
+        )
+
+    elif jt == JOINT_D6:
+        builder.add_joint_d6(
+            -1,
+            child,
+            linear_axes=[
+                cfg(axis=newton.Axis.X),
+                cfg(axis=newton.Axis.Y),
+                cfg(axis=newton.Axis.Z),
+            ],
+            angular_axes=[
+                cfg(axis=[1, 0, 0]),
+                cfg(axis=[0, 1, 0]),
+                cfg(axis=[0, 0, 1]),
+            ],
+            parent_xform=parent_xf,
+            child_xform=child_xf,
+        )
+
+    elif jt == JOINT_FREE:
+        builder.add_joint_free(
+            parent=-1,
+            child=child,
+            parent_xform=parent_xf,
+            child_xform=child_xf,
+        )
+
+    else:
+        raise ValueError(f"Unhandled joint type {jt}")
+
+
+def _build_model_for_joint(jt: int, device):
+    builder = newton.ModelBuilder()
+    _add_single_joint(builder, jt)
+    model = builder.finalize(device=device, requires_grad=True)
+    return model
+
+
+def _randomize_joint_q(model: newton.Model, seed: int = 0) -> None:
+    """In-place randomization of the model's joint coordinates.
+
+    Keeps magnitudes modest so FK stays well-conditioned and never
+    violates default limits (±π for angles, ±0.5 m for free-joint
+    translation, quaternion re-normalised).
+    """
+    rng = np.random.default_rng(seed)
+
+    q_np = model.joint_q.numpy()  # view to host buffer
+    for j, jt in enumerate(model.joint_type.numpy()):
+        q0 = model.joint_q_start.numpy()[j]  # first coord idx
+
+        if jt == JOINT_REVOLUTE:
+            q_np[q0] = rng.uniform(-np.pi / 2, np.pi / 2)
+
+        elif jt == JOINT_PRISMATIC:
+            q_np[q0] = rng.uniform(-0.2, 0.2)  # metres
+
+        elif jt == JOINT_BALL:
+            # random small-angle quaternion
+            axis = rng.normal(size=3)
+            axis /= np.linalg.norm(axis) + 1e-8
+            angle = rng.uniform(-np.pi / 6, np.pi / 6)
+            qw = np.cos(angle / 2.0)
+            qv = axis * np.sin(angle / 2.0)
+            q_np[q0 : q0 + 4] = (*qv, qw)
+
+        elif jt == newton.JOINT_D6:
+            # lin X,Y,Z
+            q_np[q0 + 0 : q0 + 3] = rng.uniform(-0.1, 0.1, size=3)
+            # rot XYZ
+            q_np[q0 + 3 : q0 + 6] = rng.uniform(-np.pi / 8, np.pi / 8, size=3)
+
+        elif jt == newton.JOINT_FREE:
+            # translation
+            q_np[q0 + 0 : q0 + 3] = rng.uniform(-0.3, 0.3, size=3)
+            # quaternion
+            axis = rng.normal(size=3)
+            axis /= np.linalg.norm(axis) + 1e-8
+            angle = rng.uniform(-np.pi / 6, np.pi / 6)
+            qw = np.cos(angle / 2.0)
+            qv = axis * np.sin(angle / 2.0)
+            q_np[q0 + 3 : q0 + 7] = (*qv, qw)
+
+    wp.copy(model.joint_q, wp.array(q_np, dtype=wp.float32))
+
+
+# -----------------------------------------------------------------------------
+# Forward-kinematics two-pass vs reference
+# -----------------------------------------------------------------------------
+
+
+def _fk_parity_for_joint(test, device, jt):
+    with wp.ScopedDevice(device):
+        model = _build_model_for_joint(jt, device)
+        _randomize_joint_q(model)
+
+        # reference FK
+        state_ref = model.state()
+        newton.sim.eval_fk(model, model.joint_q, model.joint_qd, state_ref)
+
+        # two-pass FK (via IKSolver helper)
+        joint_q = model.joint_q.reshape((1, model.joint_coord_count))
+        ik_solver = ik.IKSolver(model, joint_q, objectives=[_NoopObjective()], jacobian_mode=ik.JacobianMode.AUTODIFF)
+        ik_solver._fk_two_pass(model, ik_solver.joint_q, ik_solver.body_q, ik_solver.X_local, ik_solver.n_problems)
+
+        assert_np_equal(state_ref.body_q.numpy(), ik_solver.body_q.numpy(), tol=1e-6)
+
+
+def test_fk_two_pass_parity(test, device):
+    for jt in JOINT_KINDS:
+        _fk_parity_for_joint(test, device, jt)
+
+
+# -----------------------------------------------------------------------------
+# Register tests
+# -----------------------------------------------------------------------------
+
+devices = get_test_devices()
+
+
+class TestIKFKKernels(unittest.TestCase):
+    pass
+
+
+add_function_test(TestIKFKKernels, "test_fk_two_pass_parity", test_fk_two_pass_parity, devices)
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2, failfast=True)


### PR DESCRIPTION
## Description
Adds a modular inverse kinematics (IK) system to Newton, inspired by [PyRoki](https://pyroki-toolkit.github.io/).

![output](https://github.com/user-attachments/assets/84df6811-6862-480b-ba36-d4671c609213)

**Core features:**
- Levenberg-Marquardt solver leveraging Warp's tile API for cholesky linear solve
(with adaptive damping, step accept/reject logic)
- Analytic Jacobians for speed (option to use autodiff or mix instead)
- Modular objectives: position, rotation, and joint limit objectives included

**API:**
```
import newton.core.ik as ik

ik_solver = ik.IKSolver(
    model=model,
    joint_q=joint_q, # (n_problems, n_coords) 
    objectives=[
        ik.PositionObjective(link_index=16, target_positions=targets, ...),
        ik.RotationObjective(link_index=16, target_rotations=rotations, ...),
        ik.JointLimitObjective(weight=0.1, ...)
    ],
    jacobian_mode=JacobianMode.ANALYTIC # or MIXED/AUTODIFF
)
ik_solver.solve(iterations=10)

```

**Interactive example:**

- `newton/examples/example_ik_interactive.py` - drag gizmos to control H1 robot end-effectors
- Supports "tied controls" mode where dragging one robot controls all environments
- GUI utilities in newton/examples/gizmo_utils.py

**Benchmark example:**

- `newton/examples/example_ik_benchmark.py --robot [franka/h1]`
- Runs many seeds and selects best
- Generates benchmark tables like below

## Benchmarks
Accuracy stats averaged over 2M samples.


### Franka (Simple Arm): 3x Faster, 99.994% Success Rate
Results (98th percentile errors for successful solves)

<table>
  <thead>
    <tr>
      <th rowspan="2">Solver</th>
      <th rowspan="2">Pos&nbsp;Err&nbsp;(mm)</th>
      <th rowspan="2">Ori&nbsp;Err&nbsp;(rad)</th>
      <th rowspan="2">Success&nbsp;(%)</th>
      <th colspan="5">time&nbsp;(ms)&nbsp;for&nbsp;batch&nbsp;size</th>
    </tr>
    <tr>
      <th>b&nbsp;= 1</th>
      <th>b&nbsp;= 10</th>
      <th>b&nbsp;= 100</th>
      <th>b&nbsp;= 1 k</th>
      <th>b&nbsp;= 2 k</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>cuRobo</td>
      <td>0.004482</td>
      <td>6.96e-6</td>
      <td>99.931</td>
      <td>7.952</td>
      <td>7.761</td>
      <td>11.811</td>
      <td>53.965</td>
      <td>85.420</td>
    </tr>
    <tr>
      <td>PyroKI</td>
      <td>0.000624</td>
      <td>6.21e-7</td>
      <td>99.865</td>
      <td>4.634</td>
      <td>5.275</td>
      <td>7.337</td>
      <td>34.851</td>
      <td>78.240</td>
    </tr>
    <tr>
      <td><strong>Newton</strong></td>
      <td><strong>0.000217</strong></td>
      <td><strong>2.60e-7</strong></td>
      <td><strong>99.994</strong></td>
      <td><strong>2.404</strong></td>
      <td><strong>0.977</strong></td>
      <td><strong>2.242</strong></td>
      <td><strong>13.588</strong></td>
      <td><strong>26.193</strong></td>
    </tr>
  </tbody>
</table>

### H1 (Humanoid): 10x Faster, 99.996% Success Rate
Note: Success requires ALL 4 end effectors to reach their targets
Results (98th percentile errors for successful solves)

<table>
  <thead>
    <tr>
      <th rowspan="2">Solver</th>
      <th rowspan="2">Pos&nbsp;Err&nbsp;(mm)</th>
      <th rowspan="2">Ori&nbsp;Err&nbsp;(rad)</th>
      <th rowspan="2">Success&nbsp;(%)</th>
      <th colspan="4">time&nbsp;(ms)&nbsp;for&nbsp;batch&nbsp;size</th>
    </tr>
    <tr>
      <th>b&nbsp;= 1</th>
      <th>b&nbsp;= 10</th>
      <th>b&nbsp;= 100</th>
      <th>b&nbsp;= 1&nbsp;k</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>PyroKI</td>
      <td>0.014312</td>
      <td>7.26e-6</td>
      <td>98.583</td>
      <td>11.599</td>
      <td>20.615</td>
      <td>108.481</td>
      <td>1525.460</td>
    </tr>
    <tr>
      <td><strong>Newton</strong></td>
      <td><strong>0.004949</strong></td>
      <td><strong>4.43e-7</strong></td>
      <td><strong>99.996</strong></td>
      <td><strong>1.809</strong></td>
      <td><strong>3.306</strong></td>
      <td><strong>23.344</strong></td>
      <td><strong>151.591</strong></td>
    </tr>
  </tbody>
</table>

## Limitations
- Analytic jacobians support only FIXED, REVOLUTE and PRISMATIC joints (more to be added soon)

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] I understand that **GitHub** does not perform any GPU testing of this pull request
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a high-performance, GPU-accelerated inverse kinematics (IK) solver supporting multiple Jacobian modes and batch problem solving.
  * Added example scripts for benchmarking IK performance and interactive IK manipulation with 3D visualization and multi-environment batching.
  * Provided configurable robot models, multi-seed initialization, and detailed IK error evaluation and reporting.
  * Enabled user-friendly 3D manipulation of robot end-effectors with optional tied or independent target control across environments.

* **Tests**
  * Added comprehensive unit tests verifying IK solver convergence, Jacobian correctness, and forward kinematics parity across joint types and devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->