### PR TITLE
Clarify membership check job to include instructions for changing membership visiblity

### DIFF
--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -41,11 +41,30 @@ jobs:
           echo "Author's association with the repository: ${ASSOCIATION}"
 
           if [[ "${ASSOCIATION}" == "MEMBER" || "${ASSOCIATION}" == "OWNER" || "${ASSOCIATION}" == "COLLABORATOR" ]]; then
-            echo "Author is an organization member or collaborator."
+            echo "Author is a recognized member, owner, or collaborator."
             echo "membership_status=CONFIRMED_MEMBER" >> "$GITHUB_OUTPUT"
           else
-            echo "Author is not an organization member."
+            # Set the output for other jobs to use
             echo "membership_status=NOT_MEMBER" >> "$GITHUB_OUTPUT"
+
+            # Print a message explaining the status and its impact on workflows.
+            echo "--------------------------------------------------------------------------------" >&2
+            echo "Thank you for your contribution!" >&2
+            echo "This is the expected status for community contributors. Certain automated" >&2
+            echo "workflows are reserved for verified organization members." >&2
+            echo "" >&2
+            echo "--------------------------------------------------------------------------------" >&2
+            echo "❓ Are you a member of the 'newton-physics' organization and believe this is an error?" >&2
+            echo "" >&2
+            echo "This can happen if your organization membership is set to 'Private'. To fix this," >&2
+            echo "please make your membership 'Public' to enable all workflow triggers:" >&2
+            echo "" >&2
+            echo "1. Go to the organization's People page: https://github.com/orgs/newton-physics/people" >&2
+            echo "2. Find your username in the list." >&2
+            echo "3. Click the dropdown next to your name and change your visibility from 'Private' to 'Public'." >&2
+            echo "" >&2
+            echo "After updating your visibility, push a new commit to this PR to re-run the check." >&2
+            echo "--------------------------------------------------------------------------------" >&2
           fi
 
   run-unit-tests-on-aws:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Turns out that for a pull request author to be considered a member of the newton-physics org, their membership should be set to the public visibility level.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved feedback for pull request authors who are not organization members by providing a detailed message with instructions on how to update membership visibility and trigger workflow checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->