### PR TITLE
Add artifact saving step to AWS GPU test workflows

### DIFF
--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -67,7 +67,8 @@ jobs:
             echo "--------------------------------------------------------------------------------" >&2
           fi
 
-  run-unit-tests-on-aws:
+  aws-unit-tests-pr:
+    name: Run GPU Unit Tests on AWS EC2 (Pull Request)
     if: github.repository == 'newton-physics/newton'
     needs: check-author-membership
     environment:
@@ -324,7 +325,7 @@ jobs:
     # main job's runner fails unexpectedly. This prevents orphaned EC2 instances.
     name: Cleanup EC2 Instance
     runs-on: ubuntu-latest
-    needs: run-unit-tests-on-aws
+    needs: aws-unit-tests-pr
     if: always() && github.repository == 'newton-physics/newton'
     permissions:
       id-token: write

--- a/.github/workflows/push_aws_gpu_tests.yml
+++ b/.github/workflows/push_aws_gpu_tests.yml
@@ -20,7 +20,8 @@ on:
       - ".gitignore"
 
 jobs:
-  run-unit-tests-on-aws:
+  aws-unit-tests-push:
+    name: Run GPU Unit Tests on AWS EC2 (Push)
     if: github.repository == 'newton-physics/newton'
     runs-on: ubuntu-latest
     timeout-minutes: 75
@@ -272,7 +273,7 @@ jobs:
     # main job's runner fails unexpectedly. This prevents orphaned EC2 instances.
     name: Cleanup EC2 Instance
     runs-on: ubuntu-latest
-    needs: run-unit-tests-on-aws
+    needs: aws-unit-tests-push
     if: always() && github.repository == 'newton-physics/newton'
     permissions:
       id-token: write


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This update introduces a step to save test artifacts in both the PR and push AWS GPU test workflows.

While the artifacts are already saved to S3 (temporarily), most developers are unable to retrieve these files themselves. By using the GitHub action to upload these as artifacts to GitHub storage, we can solve this problem.

Also rename some job names in the AWS workflow files for uniqueness.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added steps to save test artifacts (such as test reports and logs) in GitHub Actions workflows for later retrieval.
  * Renamed AWS GPU unit test jobs for clearer identification in workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->