### PR TITLE
Disable GitLab pipeline, update CUDA driver requirements to 545 and newer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ variables:
 
 workflow:
   rules:
+    - when: never # TODO: Disabled until CUDA 12.3+ runners are available
     - if: $CI_PROJECT_ROOT_NAMESPACE != "omniverse" # Prevent pipelines that can't access the runners
       when: never
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'

--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 - Python 3.9 or higher
-- NVIDIA GPU with driver 525 or newer (545 or newer is recommended)
+- NVIDIA GPU with driver 545 or newer (see note below)
 - NVIDIA Warp from nightly build (see ``pyproject.toml`` for the current minimum version)
 
 A local installation of the `CUDA Toolkit <https://developer.nvidia.com/cuda-downloads>`__ is not required for Newton.


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

As discussed, we will make the minimum driver for Newton CUDA R545 for graph-capture reasons.

With the new GPU pipeline on GitHub, we will disable the already failing pipeline on GitLab. This will be reenabled at some point in the future when the runners have a newer driver.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled all pipeline runs in the CI system until CUDA 12.3+ runners are available.

* **Documentation**
  * Updated the minimum required NVIDIA GPU driver version to 545 or newer in the quickstart guide.
  * Added a note explaining driver requirements for Warp kernel compilation during CUDA graph capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->