### PR TITLE
Reenable GitLab jobs with R570 drivers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ variables:
 
 workflow:
   rules:
-    - when: never # TODO: Disabled until CUDA 12.3+ runners are available
     - if: $CI_PROJECT_ROOT_NAMESPACE != "omniverse" # Prevent pipelines that can't access the runners
       when: never
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
@@ -107,19 +106,22 @@ linting:
 linux-x86_64 test:
   image: ghcr.io/astral-sh/uv:bookworm
   extends:
-    - .omni_nvks_gpu
     - .test_common
+  tags:
+    - lnx-x86_64-gpu-1x-570.158.01
 
-windows-x86_64 test:
+# TODO: mujoco load dll often fails on Windows, disabling
+.windows-x86_64 test:
   extends:
-    - .runner-test-windows-x86_64-gpu
     - .test_common
   needs: []
   before_script:
     - powershell -ExecutionPolicy ByPass -c {$env:UV_INSTALL_DIR = "${env:CI_PROJECT_DIR}\uv-install";irm https://astral.sh/uv/install.ps1 | iex}
     - $env:Path = "${env:CI_PROJECT_DIR}\uv-install;$env:Path"
     - uv venv --managed-python
-  allow_failure: true # TODO: mujoco load dll often fails on Windows
+  allow_failure: true
+  tags:
+    - win-x86_64-gpu-1x-573.42
 
 # --- Stage: Build ---
 build_package:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline configuration to adjust runner selection and job activation for test stages.
  * Improved environment setup for Windows test jobs and marked them as allowed to fail.
  * Removed outdated workflow rules related to CUDA runner availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->