### PR TITLE
Remove forward-loading of modules

### DIFF
--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -31,7 +31,6 @@ import warp as wp
 
 import newton
 import newton.examples
-import newton.solvers.euler.kernels  # For graph capture on CUDA <12.3
 import newton.utils
 from newton.sim import Control, State
 
@@ -315,9 +314,6 @@ class Example:
 
         self.use_cuda_graph = self.device.is_cuda and wp.is_mempool_enabled(wp.get_device())
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.load_module(newton.solvers.euler.kernels, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.simulate()
             self.graph = capture.graph

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -28,9 +28,6 @@ import numpy as np
 import warp as wp
 
 import newton
-import newton.solvers.euler.kernels  # For graph capture on CUDA <12.3
-import newton.solvers.euler.particles  # For graph capture on CUDA <12.3
-import newton.solvers.solver  # For graph capture on CUDA <12.3
 import newton.utils
 from newton.examples.example_anymal_c_walk import AnymalController
 from newton.solvers.implicit_mpm import ImplicitMPMSolver
@@ -213,11 +210,6 @@ class Example:
 
         self.use_cuda_graph = self.device.is_cuda and wp.is_mempool_enabled(wp.get_device())
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.load_module(newton.solvers.euler.kernels, device=wp.get_device())
-            wp.load_module(newton.solvers.euler.particles, device=wp.get_device())
-            wp.load_module(newton.solvers.solver, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.simulate_robot()
             self.robot_graph = capture.graph

--- a/newton/examples/example_cloth_bending.py
+++ b/newton/examples/example_cloth_bending.py
@@ -29,8 +29,6 @@ from pxr import Usd, UsdGeom
 
 import newton
 import newton.examples
-import newton.geometry.kernels
-import newton.solvers.vbd.solver_vbd
 import newton.utils
 
 
@@ -106,12 +104,6 @@ class Example:
 
         self.cuda_graph = None
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.set_module_options({"block_dim": 256}, newton.solvers.vbd.solver_vbd)
-            wp.load_module(newton.solvers.vbd.solver_vbd, device=wp.get_device())
-            wp.set_module_options({"block_dim": 16}, newton.geometry.kernels)
-            wp.load_module(newton.geometry.kernels, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.simulate_substeps()
             self.cuda_graph = capture.graph

--- a/newton/examples/example_cloth_hanging.py
+++ b/newton/examples/example_cloth_hanging.py
@@ -26,8 +26,6 @@ from enum import Enum
 import warp as wp
 
 import newton
-import newton.geometry.kernels
-import newton.solvers.vbd.solver_vbd
 import newton.utils
 
 
@@ -155,13 +153,6 @@ class Example:
 
         self.cuda_graph = None
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            if self.solver_type == SolverType.VBD:
-                wp.set_module_options({"block_dim": 256}, newton.solvers.vbd.solver_vbd)
-                wp.load_module(newton.solvers.vbd.solver_vbd, device=wp.get_device())
-            wp.set_module_options({"block_dim": 256}, newton.geometry.kernels)
-            wp.load_module(newton.geometry.kernels, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.simulate_substeps()
             self.cuda_graph = capture.graph

--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -31,8 +31,6 @@ import warp.examples
 from pxr import Usd, UsdGeom
 
 import newton
-import newton.geometry.kernels
-import newton.solvers.vbd.solver_vbd
 import newton.utils
 from newton.geometry import PARTICLE_FLAG_ACTIVE
 
@@ -234,12 +232,6 @@ class Example:
 
         self.cuda_graph = None
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.set_module_options({"block_dim": 256}, newton.solvers.vbd.solver_vbd)
-            wp.load_module(newton.solvers.vbd.solver_vbd, device=wp.get_device())
-            wp.set_module_options({"block_dim": 16}, newton.geometry.kernels)
-            wp.load_module(newton.geometry.kernels, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.simulate_substeps()
             self.cuda_graph = capture.graph

--- a/newton/examples/example_cloth_style3d.py
+++ b/newton/examples/example_cloth_style3d.py
@@ -20,8 +20,6 @@ from pxr import Usd, UsdGeom
 
 import newton
 import newton.examples
-import newton.solvers.style3d.kernels
-import newton.solvers.style3d.linear_solver
 import newton.utils
 from newton.geometry import PARTICLE_FLAG_ACTIVE, Mesh
 
@@ -148,10 +146,6 @@ class Example:
 
         self.cuda_graph = None
         if self.use_cuda_graph:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.load_module(newton.solvers.style3d.kernels, device=wp.get_device())
-            wp.load_module(newton.solvers.style3d.linear_solver, device=wp.get_device())
-
             with wp.ScopedCapture() as capture:
                 self.integrate_frame_substeps()
             self.cuda_graph = capture.graph

--- a/newton/examples/example_robot_manipulating_cloth.py
+++ b/newton/examples/example_robot_manipulating_cloth.py
@@ -33,10 +33,6 @@ from pxr import Usd, UsdGeom
 
 import newton
 import newton.examples
-import newton.geometry.kernels
-import newton.sim.articulation
-import newton.solvers.euler.kernels
-import newton.solvers.vbd.solver_vbd
 import newton.utils
 from newton.sim import Model, ModelBuilder, State, eval_fk
 from newton.solvers import FeatherstoneSolver, VBDSolver
@@ -357,15 +353,6 @@ class Example:
         self.initial_pose = self.model.joint_q.numpy()
 
     def capture_cuda_graph(self):
-        if self.cuda_graph is None:
-            # Initial graph launch, load modules (necessary for drivers prior to CUDA 12.3)
-            wp.load_module(newton.solvers.euler.kernels, device=wp.get_device())
-            wp.load_module(newton.sim.articulation, device=wp.get_device())
-            wp.set_module_options({"block_dim": 16}, newton.geometry.kernels)
-            wp.load_module(newton.geometry.kernels, device=wp.get_device())
-            wp.set_module_options({"block_dim": 256}, newton.solvers.vbd.solver_vbd)
-            wp.load_module(newton.solvers.vbd.solver_vbd, device=wp.get_device())
-
         if self.use_cuda_graph:
             with wp.ScopedCapture() as capture:
                 self.integrate_frame()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Newton will no longer technically  support CUDA drivers older than 545, so we can get rid of these workarounds.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified CUDA graph initialization in multiple simulation examples and tests by removing explicit module imports and manual module loading steps.
  * CUDA graph capture logic remains unchanged, now relying on implicit module handling for improved maintainability.

* **Chores**
  * Cleaned up unused import statements across several example scripts and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->