### PR TITLE
Add mesh approximation methods, `physics:approximation` handling in USD importer

### DIFF
--- a/docs/generated/core/newton.Mesh.rst
+++ b/docs/generated/core/newton.Mesh.rst
@@ -18,7 +18,6 @@
       ~Mesh.__init__
       ~Mesh.compute_convex_hull
       ~Mesh.finalize
-      ~Mesh.set_convex_hull
    
    
 

--- a/docs/generated/core/newton.ModelBuilder.rst
+++ b/docs/generated/core/newton.ModelBuilder.rst
@@ -49,6 +49,7 @@
       ~ModelBuilder.add_tetrahedron
       ~ModelBuilder.add_triangle
       ~ModelBuilder.add_triangles
+      ~ModelBuilder.approximate_meshes
       ~ModelBuilder.collapse_fixed_joints
       ~ModelBuilder.color
       ~ModelBuilder.finalize

--- a/docs/generated/renderers/newton.utils.SimRendererOpenGL.rst
+++ b/docs/generated/renderers/newton.utils.SimRendererOpenGL.rst
@@ -18,7 +18,12 @@
    
       ~SimRendererOpenGL.__init__
       ~SimRendererOpenGL.compute_projection_matrix
+      ~SimRendererOpenGL.get_new_color
       ~SimRendererOpenGL.get_pixels
+      ~SimRendererOpenGL.populate
+      ~SimRendererOpenGL.populate_bodies
+      ~SimRendererOpenGL.populate_joints
+      ~SimRendererOpenGL.populate_shapes
       ~SimRendererOpenGL.render
       ~SimRendererOpenGL.render_arrow
       ~SimRendererOpenGL.render_box
@@ -30,6 +35,8 @@
       ~SimRendererOpenGL.render_line_list
       ~SimRendererOpenGL.render_line_strip
       ~SimRendererOpenGL.render_mesh
+      ~SimRendererOpenGL.render_muscles
+      ~SimRendererOpenGL.render_particles_and_springs
       ~SimRendererOpenGL.render_plane
       ~SimRendererOpenGL.render_points
       ~SimRendererOpenGL.render_ref

--- a/docs/generated/renderers/newton.utils.SimRendererUsd.rst
+++ b/docs/generated/renderers/newton.utils.SimRendererUsd.rst
@@ -17,6 +17,11 @@
    .. autosummary::
    
       ~SimRendererUsd.__init__
+      ~SimRendererUsd.get_new_color
+      ~SimRendererUsd.populate
+      ~SimRendererUsd.populate_bodies
+      ~SimRendererUsd.populate_joints
+      ~SimRendererUsd.populate_shapes
       ~SimRendererUsd.render
       ~SimRendererUsd.render_box
       ~SimRendererUsd.render_capsule
@@ -24,6 +29,8 @@
       ~SimRendererUsd.render_contacts
       ~SimRendererUsd.render_cylinder
       ~SimRendererUsd.render_line_list
+      ~SimRendererUsd.render_muscles
+      ~SimRendererUsd.render_particles_and_springs
       ~SimRendererUsd.render_plane
       ~SimRendererUsd.render_sphere
    

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -17,7 +17,6 @@ import os
 import unittest
 
 import numpy as np
-import warp as wp
 
 import newton
 from newton.tests.unittest_utils import USD_AVAILABLE, get_test_devices
@@ -157,5 +156,5 @@ class TestImportUsd(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    wp.clear_kernel_cache()
+    # wp.clear_kernel_cache()
     unittest.main(verbosity=2, failfast=True)

--- a/newton/utils/__init__.py
+++ b/newton/utils/__init__.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
-import os
-
 import warp as wp
 from warp.context import assert_conditional_graph_support
 
@@ -113,34 +110,6 @@ def check_conditional_graph_support():
     return True
 
 
-@contextlib.contextmanager
-def silence_stdio():
-    """
-    Redirect *both* Python-level and C-level stdout/stderr to os.devnull
-    for the duration of the with-block.
-    """
-    devnull = open(os.devnull, "w")
-    # Duplicate the real fds so we can restore them later
-    old_stdout_fd = os.dup(1)
-    old_stderr_fd = os.dup(2)
-
-    try:
-        # Point fds 1 and 2 at /dev/null
-        os.dup2(devnull.fileno(), 1)
-        os.dup2(devnull.fileno(), 2)
-
-        # Also patch the Python objects that wrap those fds
-        with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
-            yield
-    finally:
-        # Restore original fds
-        os.dup2(old_stdout_fd, 1)
-        os.dup2(old_stderr_fd, 2)
-        os.close(old_stdout_fd)
-        os.close(old_stderr_fd)
-        devnull.close()
-
-
 __all__ = [
     "SimRenderer",
     "SimRendererOpenGL",
@@ -154,7 +123,6 @@ __all__ = [
     "parse_mjcf",
     "parse_urdf",
     "parse_usd",
-    "silence_stdio",
     "smooth_max",
     "smooth_min",
     "topological_sort",

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -49,6 +49,7 @@ def parse_usd(
     root_path: str = "/",
     joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
     bodies_follow_joint_ordering: bool = True,
+    skip_mesh_approximation: bool = False,
 ) -> dict[str, Any]:
     """
     Parses a Universal Scene Description (USD) stage containing UsdPhysics schema definitions for rigid-body articulations and adds the bodies, shapes and joints to the given ModelBuilder.
@@ -74,6 +75,7 @@ def parse_usd(
         root_path (str): The USD path to import, defaults to "/".
         joint_ordering (str): The ordering of the joints in the simulation. Can be either "bfs" or "dfs" for breadth-first or depth-first search, or ``None`` to keep joints in the order in which they appear in the USD. Default is "dfs".
         bodies_follow_joint_ordering (bool): If True, the bodies are added to the builder in the same order as the joints (parent then child body). Otherwise, bodies are added in the order they appear in the USD. Default is True.
+        skip_mesh_approximation (bool): If True, mesh approximation is skipped. Otherwise, meshes are approximated according to the ``physics:approximation`` attribute defined on the UsdPhysicsMeshCollisionAPI (if it is defined). Default is False.
 
     Returns:
         dict: Dictionary with the following entries:
@@ -123,6 +125,17 @@ def parse_usd(
 
     # load shape defaults
     default_shape_density = builder.default_shape_cfg.density
+
+    # mapping from physics:approximation attribute (lower case) to remeshing method
+    approximation_to_remeshing_method = {
+        "convexdecomposition": "coacd",
+        "convexhull": "convex_hull",
+        "boundingsphere": "bounding_sphere",
+        "boundingcube": "bounding_box",
+        "meshSimplification": "quadratic",
+    }
+    # mapping from remeshing method to a list of shape indices
+    remeshing_queue = {}
 
     def get_attribute(prim, name):
         return prim.GetAttribute(name)
@@ -914,6 +927,20 @@ def parse_usd(
                         mesh=m,
                         **shape_params,
                     )
+                    if not skip_mesh_approximation:
+                        approximation = parse_generic(prim, "physics:approximation", None)
+                        if approximation is not None:
+                            remeshing_method = approximation_to_remeshing_method.get(approximation.lower(), None)
+                            if remeshing_method is None:
+                                if verbose:
+                                    print(
+                                        f"Warning: Unknown physics:approximation attribute '{approximation}' on shape at '{path}'."
+                                    )
+                            else:
+                                if remeshing_method not in remeshing_queue:
+                                    remeshing_queue[remeshing_method] = []
+                                remeshing_queue[remeshing_method].append(shape_id)
+
                 elif key == UsdPhysics.ObjectType.PlaneShape:
                     # Warp uses +Z convention for planes
                     if shape_spec.axis != UsdPhysics.Axis.Z:
@@ -939,7 +966,12 @@ def parse_usd(
                 if "PhysicsCollisionAPI" not in schemas or not parse_generic(prim, "physics:collisionEnabled", True):
                     # print("no_collision_shapes : ", prim)
                     no_collision_shapes.add(shape_id)
+                    builder.shape_flags[shape_id] &= ~newton.SHAPE_FLAG_COLLIDE_SHAPES
             # print(path_shape_map)
+
+    # approximate meshes
+    for remeshing_method, shape_ids in remeshing_queue.items():
+        builder.approximate_meshes(method=remeshing_method, shape_indices=shape_ids)
 
     # apply collision filters now that we have added all shapes
     for path1, path2 in path_collision_filters:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* `parse_usd()` now considers the [`physics:approximation` attribute](https://openusd.org/dev/api/class_usd_physics_mesh_collision_a_p_i.html#a10cf1418c11bf2668496aae60f05bbac)
* Add `ModelBuilder.approximate_meshes()` to support all USD approximation methods (and other remeshing algorithms)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
