### PR TITLE
Adds picking support to the OpenGL sim viewer

### DIFF
--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -123,7 +123,7 @@ class Example:
         with wp.ScopedTimer("render"):
             self.renderer.begin_frame(self.sim_time)
             self.renderer.render(self.state_0)
-            self.renderer.render_contacts(self.state_0, self.contacts, contact_point_radius=1e-2)
+            self.renderer.render_contacts(self.state_0.body_q, self.contacts, contact_point_radius=1e-2)
             self.renderer.end_frame()
 
 

--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -104,6 +104,7 @@ class Example:
     def simulate(self):
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
+            self.renderer.apply_picking_force(self.state_0)
             self.contacts = self.model.collide(self.state_0)
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0

--- a/newton/geometry/gjk.py
+++ b/newton/geometry/gjk.py
@@ -66,392 +66,339 @@ class Polytope:
     edges: wp.array(dtype=int)
 
 
-def build_ccd_generic(support_func: Any):
-    """Build a continuous collision detection (CCD) system using a generic support function.
+@wp.func
+def _linear_combine(n: int, coefs: wp.vec4, mat: mat43):
+    v = wp.vec3(0.0)
+    if n == 1:
+        v = coefs[0] * mat[0]
+    elif n == 2:
+        v = coefs[0] * mat[0] + coefs[1] * mat[1]
+    elif n == 3:
+        v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2]
+    else:
+        v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2] + coefs[3] * mat[3]
+    return v
 
-    This function takes a support function as input and returns a collection of helper functions
-    for performing collision detection between geometric primitives. The support function is used
-    to find the furthest point on a geometry in a given direction.
 
-    The support function must have the following signature:
-        def support_func(geom: Any, geom_type: int, dir: wp.vec3) -> tuple[int, wp.vec3]:
-    The type of geom must be a struct that can look as follows:
-        @wp.struct
-        class Geom:
-            pos: wp.vec3
-            rot: wp.mat33
-            normal: wp.vec3
-            size: wp.vec3
-            index: int
-    Note that only the index member is mandatory. All other members can be chosen as needed for
-    the support function.
+@wp.func
+def _almost_equal(v1: wp.vec3, v2: wp.vec3):
+    return wp.abs(v1[0] - v2[0]) < MINVAL and wp.abs(v1[1] - v2[1]) < MINVAL and wp.abs(v1[2] - v2[2]) < MINVAL
 
-    The returned functions implement the GJK (Gilbert-Johnson-Keerthi) and EPA (Expanding Polytope Algorithm)
-    algorithms for computing distances between convex shapes and handling penetration cases.
 
-    Args:
-        support_func: A function that takes a geometry object, geometry type, and direction vector
-            and returns (index, point) where:
-            - index is the index of the support point in the geometry
-            - point is the furthest point on the geometry in the given direction
+@wp.func
+def _subdistance(n: int, simplex: mat43):
+    if n == 4:
+        return _S3D(simplex[0], simplex[1], simplex[2], simplex[3])
+    if n == 3:
+        coordinates3 = _S2D(simplex[0], simplex[1], simplex[2])
+        return wp.vec4(coordinates3[0], coordinates3[1], coordinates3[2], 0.0)
+    if n == 2:
+        coordinates2 = _S1D(simplex[0], simplex[1])
+        return wp.vec4(coordinates2[0], coordinates2[1], 0.0, 0.0)
+    return wp.vec4(1.0, 0.0, 0.0, 0.0)
 
-    Returns:
-        A collection of helper functions including:
-        - _attach_face: Attaches a triangular face to the polytope
-        - _epa_support: Computes support points for EPA algorithm
-        - _linear_combine: Performs linear combination of vertices
-        - _almost_equal: Checks if two vectors are approximately equal
-        - _subdistance: Computes closest point on simplex to origin
-        And other internal functions used by GJK/EPA algorithms.
-    """
 
-    @wp.func
-    def _attach_face(pt: Polytope, idx: int, v1: int, v2: int, v3: int):
-        # compute witness point v
-        r, ret = _project_origin_plane(pt.verts[v3], pt.verts[v2], pt.verts[v1])
-        if ret:
-            return 0.0
+@wp.func
+def _det3(v1: wp.vec3, v2: wp.vec3, v3: wp.vec3):
+    return wp.dot(v1, wp.cross(v2, v3))
 
-        face_verts = wp.vec3i(v1, v2, v3)
-        pt.face_verts[idx] = face_verts
-        pt.face_v[idx] = r
 
-        pt.face_dist2[idx] = wp.dot(r, r)
-        pt.face_index[idx] = -1
-        return pt.face_dist2[idx]
+@wp.func
+def _same_sign(a: float, b: float):
+    if a > 0 and b > 0:
+        return 1
+    if a < 0 and b < 0:
+        return -1
+    return 0
 
-    @wp.func
-    def _epa_support(pt: Polytope, idx: int, geom1: Any, geom2: Any, geom1_type: int, geom2_type: int, dir: wp.vec3):
-        index1, s1 = wp.static(support_func)(geom1, geom1_type, dir)
-        index2, s2 = wp.static(support_func)(geom2, geom2_type, -dir)
 
-        pt.verts[idx] = s1 - s2
-        pt.verts1[idx] = s1
-        pt.verts2[idx] = s2
-        return index1, index2
+@wp.func
+def _project_origin_line(v1: wp.vec3, v2: wp.vec3):
+    diff = v2 - v1
+    scl = -(wp.dot(v2, diff) / wp.dot(diff, diff))
+    return v2 + scl * diff
 
-    @wp.func
-    def _linear_combine(n: int, coefs: wp.vec4, mat: mat43):
-        v = wp.vec3(0.0)
-        if n == 1:
-            v = coefs[0] * mat[0]
-        elif n == 2:
-            v = coefs[0] * mat[0] + coefs[1] * mat[1]
-        elif n == 3:
-            v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2]
-        else:
-            v = coefs[0] * mat[0] + coefs[1] * mat[1] + coefs[2] * mat[2] + coefs[3] * mat[3]
-        return v
 
-    @wp.func
-    def _almost_equal(v1: wp.vec3, v2: wp.vec3):
-        return wp.abs(v1[0] - v2[0]) < MINVAL and wp.abs(v1[1] - v2[1]) < MINVAL and wp.abs(v1[2] - v2[2]) < MINVAL
+@wp.func
+def _project_origin_plane(v1: wp.vec3, v2: wp.vec3, v3: wp.vec3):
+    z = wp.vec3(0.0)
+    diff21 = v2 - v1
+    diff31 = v3 - v1
+    diff32 = v3 - v2
 
-    @wp.func
-    def _subdistance(n: int, simplex: mat43):
-        if n == 4:
-            return _S3D(simplex[0], simplex[1], simplex[2], simplex[3])
-        if n == 3:
-            coordinates3 = _S2D(simplex[0], simplex[1], simplex[2])
-            return wp.vec4(coordinates3[0], coordinates3[1], coordinates3[2], 0.0)
-        if n == 2:
-            coordinates2 = _S1D(simplex[0], simplex[1])
-            return wp.vec4(coordinates2[0], coordinates2[1], 0.0, 0.0)
-        return wp.vec4(1.0, 0.0, 0.0, 0.0)
-
-    @wp.func
-    def _det3(v1: wp.vec3, v2: wp.vec3, v3: wp.vec3):
-        return wp.dot(v1, wp.cross(v2, v3))
-
-    @wp.func
-    def _same_sign(a: float, b: float):
-        if a > 0 and b > 0:
-            return 1
-        if a < 0 and b < 0:
-            return -1
-        return 0
-
-    @wp.func
-    def _project_origin_line(v1: wp.vec3, v2: wp.vec3):
-        diff = v2 - v1
-        scl = -(wp.dot(v2, diff) / wp.dot(diff, diff))
-        return v2 + scl * diff
-
-    @wp.func
-    def _project_origin_plane(v1: wp.vec3, v2: wp.vec3, v3: wp.vec3):
-        z = wp.vec3(0.0)
-        diff21 = v2 - v1
-        diff31 = v3 - v1
-        diff32 = v3 - v2
-
-        # n = (v1 - v2) x (v3 - v2)
-        n = wp.cross(diff32, diff21)
-        nv = wp.dot(n, v2)
-        nn = wp.dot(n, n)
-        if nn == 0:
-            return z, 1
-        if nv != 0 and nn > MINVAL:
-            v = (nv / nn) * n
-            return v, 0
-
-        # n = (v2 - v1) x (v3 - v1)
-        n = wp.cross(diff21, diff31)
-        nv = wp.dot(n, v1)
-        nn = wp.dot(n, n)
-        if nn == 0:
-            return z, 1
-        if nv != 0 and nn > MINVAL:
-            v = (nv / nn) * n
-            return v, 0
-
-        # n = (v1 - v3) x (v2 - v3)
-        n = wp.cross(diff31, diff32)
-        nv = wp.dot(n, v3)
-        nn = wp.dot(n, n)
+    # n = (v1 - v2) x (v3 - v2)
+    n = wp.cross(diff32, diff21)
+    nv = wp.dot(n, v2)
+    nn = wp.dot(n, n)
+    if nn == 0:
+        return z, 1
+    if nv != 0 and nn > MINVAL:
         v = (nv / nn) * n
         return v, 0
 
-    @wp.func
-    def _S3D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3, s4: wp.vec3):
-        #  [[ s1_x, s2_x, s3_x, s4_x ],
-        #   [ s1_y, s2_y, s3_y, s4_y ],
-        #   [ s1_z, s2_z, s3_z, s4_z ],
-        #   [ 1,    1,    1,    1    ]]
-        # we want to solve M*lambda = P, where P = [p_x, p_y, p_z, 1] with [p_x, p_y, p_z] is
-        # the origin projected onto the simplex
+    # n = (v2 - v1) x (v3 - v1)
+    n = wp.cross(diff21, diff31)
+    nv = wp.dot(n, v1)
+    nn = wp.dot(n, n)
+    if nn == 0:
+        return z, 1
+    if nv != 0 and nn > MINVAL:
+        v = (nv / nn) * n
+        return v, 0
 
-        # compute cofactors to find det(M)
-        C41 = -_det3(s2, s3, s4)
-        C42 = _det3(s1, s3, s4)
-        C43 = -_det3(s1, s2, s4)
-        C44 = _det3(s1, s2, s3)
+    # n = (v1 - v3) x (v2 - v3)
+    n = wp.cross(diff31, diff32)
+    nv = wp.dot(n, v3)
+    nn = wp.dot(n, n)
+    v = (nv / nn) * n
+    return v, 0
 
-        # NOTE: m_det = 6*SignVol(simplex) with C4i corresponding to the volume of the 3-simplex
-        # with vertices {s1, s2, s3, 0} - si
-        m_det = C41 + C42 + C43 + C44
 
-        comp1 = _same_sign(m_det, C41)
-        comp2 = _same_sign(m_det, C42)
-        comp3 = _same_sign(m_det, C43)
-        comp4 = _same_sign(m_det, C44)
+@wp.func
+def _S3D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3, s4: wp.vec3):
+    #  [[ s1_x, s2_x, s3_x, s4_x ],
+    #   [ s1_y, s2_y, s3_y, s4_y ],
+    #   [ s1_z, s2_z, s3_z, s4_z ],
+    #   [ 1,    1,    1,    1    ]]
+    # we want to solve M*lambda = P, where P = [p_x, p_y, p_z, 1] with [p_x, p_y, p_z] is
+    # the origin projected onto the simplex
 
-        # if all signs are the same then the origin is inside the simplex
-        if comp1 and comp2 and comp3 and comp4:
-            return wp.vec4(C41 / m_det, C42 / m_det, C43 / m_det, C44 / m_det)
+    # compute cofactors to find det(M)
+    C41 = -_det3(s2, s3, s4)
+    C42 = _det3(s1, s3, s4)
+    C43 = -_det3(s1, s2, s4)
+    C44 = _det3(s1, s2, s3)
 
-        # find the smallest distance, and use the corresponding barycentric coordinates
-        coordinates = wp.vec4(0.0, 0.0, 0.0, 0.0)
-        dmin = FLOAT_MAX
+    # NOTE: m_det = 6*SignVol(simplex) with C4i corresponding to the volume of the 3-simplex
+    # with vertices {s1, s2, s3, 0} - si
+    m_det = C41 + C42 + C43 + C44
 
-        if not comp1:
-            subcoord = _S2D(s2, s3, s4)
-            x = subcoord[0] * s2 + subcoord[1] * s3 + subcoord[2] * s4
-            d = wp.dot(x, x)
-            coordinates[0] = 0.0
-            coordinates[1] = subcoord[0]
+    comp1 = _same_sign(m_det, C41)
+    comp2 = _same_sign(m_det, C42)
+    comp3 = _same_sign(m_det, C43)
+    comp4 = _same_sign(m_det, C44)
+
+    # if all signs are the same then the origin is inside the simplex
+    if comp1 and comp2 and comp3 and comp4:
+        return wp.vec4(C41 / m_det, C42 / m_det, C43 / m_det, C44 / m_det)
+
+    # find the smallest distance, and use the corresponding barycentric coordinates
+    coordinates = wp.vec4(0.0, 0.0, 0.0, 0.0)
+    dmin = FLOAT_MAX
+
+    if not comp1:
+        subcoord = _S2D(s2, s3, s4)
+        x = subcoord[0] * s2 + subcoord[1] * s3 + subcoord[2] * s4
+        d = wp.dot(x, x)
+        coordinates[0] = 0.0
+        coordinates[1] = subcoord[0]
+        coordinates[2] = subcoord[1]
+        coordinates[3] = subcoord[2]
+        dmin = d
+
+    if not comp2:
+        subcoord = _S2D(s1, s3, s4)
+        x = subcoord[0] * s1 + subcoord[1] * s3 + subcoord[2] * s4
+        d = wp.dot(x, x)
+        if d < dmin:
+            coordinates[0] = subcoord[0]
+            coordinates[1] = 0.0
             coordinates[2] = subcoord[1]
             coordinates[3] = subcoord[2]
             dmin = d
 
-        if not comp2:
-            subcoord = _S2D(s1, s3, s4)
-            x = subcoord[0] * s1 + subcoord[1] * s3 + subcoord[2] * s4
-            d = wp.dot(x, x)
-            if d < dmin:
-                coordinates[0] = subcoord[0]
-                coordinates[1] = 0.0
-                coordinates[2] = subcoord[1]
-                coordinates[3] = subcoord[2]
-                dmin = d
+    if not comp3:
+        subcoord = _S2D(s1, s2, s4)
+        x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s4
+        d = wp.dot(x, x)
+        if d < dmin:
+            coordinates[0] = subcoord[0]
+            coordinates[1] = subcoord[1]
+            coordinates[2] = 0.0
+            coordinates[3] = subcoord[2]
+            dmin = d
 
-        if not comp3:
-            subcoord = _S2D(s1, s2, s4)
-            x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s4
-            d = wp.dot(x, x)
-            if d < dmin:
-                coordinates[0] = subcoord[0]
-                coordinates[1] = subcoord[1]
-                coordinates[2] = 0.0
-                coordinates[3] = subcoord[2]
-                dmin = d
+    if not comp4:
+        subcoord = _S2D(s1, s2, s3)
+        x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s3
+        d = wp.dot(x, x)
+        if d < dmin:
+            coordinates[0] = subcoord[0]
+            coordinates[1] = subcoord[1]
+            coordinates[2] = subcoord[2]
+            coordinates[3] = 0.0
+    return coordinates
 
-        if not comp4:
-            subcoord = _S2D(s1, s2, s3)
-            x = subcoord[0] * s1 + subcoord[1] * s2 + subcoord[2] * s3
-            d = wp.dot(x, x)
-            if d < dmin:
-                coordinates[0] = subcoord[0]
-                coordinates[1] = subcoord[1]
-                coordinates[2] = subcoord[2]
-                coordinates[3] = 0.0
-        return coordinates
 
-    @wp.func
-    def _S2D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3):
-        # project origin onto affine hull of the simplex
-        p_o, ret = _project_origin_plane(s1, s2, s3)
-        if ret:
-            v = _S1D(s1, s2)
-            return wp.vec3(v[0], v[1], 0.0)
+@wp.func
+def _S2D(s1: wp.vec3, s2: wp.vec3, s3: wp.vec3):
+    # project origin onto affine hull of the simplex
+    p_o, ret = _project_origin_plane(s1, s2, s3)
+    if ret:
+        v = _S1D(s1, s2)
+        return wp.vec3(v[0], v[1], 0.0)
 
-        # Below are the minors M_i4 of the matrix M given by
-        # [[ s1_x, s2_x, s3_x, s4_x ],
-        #  [ s1_y, s2_y, s3_y, s4_y ],
-        #  [ s1_z, s2_z, s3_z, s4_z ],
-        #  [ 1,    1,    1,    1    ]]
-        M_14 = s2[1] * s3[2] - s2[2] * s3[1] - s1[1] * s3[2] + s1[2] * s3[1] + s1[1] * s2[2] - s1[2] * s2[1]
-        M_24 = s2[0] * s3[2] - s2[2] * s3[0] - s1[0] * s3[2] + s1[2] * s3[0] + s1[0] * s2[2] - s1[2] * s2[0]
-        M_34 = s2[0] * s3[1] - s2[1] * s3[0] - s1[0] * s3[1] + s1[1] * s3[0] + s1[0] * s2[1] - s1[1] * s2[0]
+    # Below are the minors M_i4 of the matrix M given by
+    # [[ s1_x, s2_x, s3_x, s4_x ],
+    #  [ s1_y, s2_y, s3_y, s4_y ],
+    #  [ s1_z, s2_z, s3_z, s4_z ],
+    #  [ 1,    1,    1,    1    ]]
+    M_14 = s2[1] * s3[2] - s2[2] * s3[1] - s1[1] * s3[2] + s1[2] * s3[1] + s1[1] * s2[2] - s1[2] * s2[1]
+    M_24 = s2[0] * s3[2] - s2[2] * s3[0] - s1[0] * s3[2] + s1[2] * s3[0] + s1[0] * s2[2] - s1[2] * s2[0]
+    M_34 = s2[0] * s3[1] - s2[1] * s3[0] - s1[0] * s3[1] + s1[1] * s3[0] + s1[0] * s2[1] - s1[1] * s2[0]
 
-        # exclude the axis with the largest projection of the simplex using the computed minors
-        M_max = 0.0
-        s1_2D = wp.vec2(0.0)
-        s2_2D = wp.vec2(0.0)
-        s3_2D = wp.vec2(0.0)
-        p_o_2D = wp.vec2(0.0)
+    # exclude the axis with the largest projection of the simplex using the computed minors
+    M_max = 0.0
+    s1_2D = wp.vec2(0.0)
+    s2_2D = wp.vec2(0.0)
+    s3_2D = wp.vec2(0.0)
+    p_o_2D = wp.vec2(0.0)
 
-        mu1 = wp.abs(M_14)
-        mu2 = wp.abs(M_24)
-        mu3 = wp.abs(M_34)
+    mu1 = wp.abs(M_14)
+    mu2 = wp.abs(M_24)
+    mu3 = wp.abs(M_34)
 
-        if mu1 >= mu2 and mu1 >= mu3:
-            M_max = M_14
-            s1_2D[0] = s1[1]
-            s1_2D[1] = s1[2]
+    if mu1 >= mu2 and mu1 >= mu3:
+        M_max = M_14
+        s1_2D[0] = s1[1]
+        s1_2D[1] = s1[2]
 
-            s2_2D[0] = s2[1]
-            s2_2D[1] = s2[2]
+        s2_2D[0] = s2[1]
+        s2_2D[1] = s2[2]
 
-            s3_2D[0] = s3[1]
-            s3_2D[1] = s3[2]
+        s3_2D[0] = s3[1]
+        s3_2D[1] = s3[2]
 
-            p_o_2D[0] = p_o[1]
-            p_o_2D[1] = p_o[2]
-        elif mu2 >= mu3:
-            M_max = M_24
-            s1_2D[0] = s1[0]
-            s1_2D[1] = s1[2]
+        p_o_2D[0] = p_o[1]
+        p_o_2D[1] = p_o[2]
+    elif mu2 >= mu3:
+        M_max = M_24
+        s1_2D[0] = s1[0]
+        s1_2D[1] = s1[2]
 
-            s2_2D[0] = s2[0]
-            s2_2D[1] = s2[2]
+        s2_2D[0] = s2[0]
+        s2_2D[1] = s2[2]
 
-            s3_2D[0] = s3[0]
-            s3_2D[1] = s3[2]
+        s3_2D[0] = s3[0]
+        s3_2D[1] = s3[2]
 
-            p_o_2D[0] = p_o[0]
-            p_o_2D[1] = p_o[2]
-        else:
-            M_max = M_34
-            s1_2D[0] = s1[0]
-            s1_2D[1] = s1[1]
+        p_o_2D[0] = p_o[0]
+        p_o_2D[1] = p_o[2]
+    else:
+        M_max = M_34
+        s1_2D[0] = s1[0]
+        s1_2D[1] = s1[1]
 
-            s2_2D[0] = s2[0]
-            s2_2D[1] = s2[1]
+        s2_2D[0] = s2[0]
+        s2_2D[1] = s2[1]
 
-            s3_2D[0] = s3[0]
-            s3_2D[1] = s3[1]
+        s3_2D[0] = s3[0]
+        s3_2D[1] = s3[1]
 
-            p_o_2D[0] = p_o[0]
-            p_o_2D[1] = p_o[1]
+        p_o_2D[0] = p_o[0]
+        p_o_2D[1] = p_o[1]
 
-        # compute the cofactors C3i of the following matrix:
-        # [[ s1_2D[0] - p_o_2D[0], s2_2D[0] - p_o_2D[0], s3_2D[0] - p_o_2D[0] ],
-        #  [ s1_2D[1] - p_o_2D[1], s2_2D[1] - p_o_2D[1], s3_2D[1] - p_o_2D[1] ],
-        #  [ 1,                    1,                    1                    ]]
+    # compute the cofactors C3i of the following matrix:
+    # [[ s1_2D[0] - p_o_2D[0], s2_2D[0] - p_o_2D[0], s3_2D[0] - p_o_2D[0] ],
+    #  [ s1_2D[1] - p_o_2D[1], s2_2D[1] - p_o_2D[1], s3_2D[1] - p_o_2D[1] ],
+    #  [ 1,                    1,                    1                    ]]
 
-        # C31 corresponds to the signed area of 2-simplex: (p_o_2D, s2_2D, s3_2D)
-        C31 = (
-            p_o_2D[0] * s2_2D[1]
-            + p_o_2D[1] * s3_2D[0]
-            + s2_2D[0] * s3_2D[1]
-            - p_o_2D[0] * s3_2D[1]
-            - p_o_2D[1] * s2_2D[0]
-            - s3_2D[0] * s2_2D[1]
-        )
+    # C31 corresponds to the signed area of 2-simplex: (p_o_2D, s2_2D, s3_2D)
+    C31 = (
+        p_o_2D[0] * s2_2D[1]
+        + p_o_2D[1] * s3_2D[0]
+        + s2_2D[0] * s3_2D[1]
+        - p_o_2D[0] * s3_2D[1]
+        - p_o_2D[1] * s2_2D[0]
+        - s3_2D[0] * s2_2D[1]
+    )
 
-        # C32 corresponds to the signed area of 2-simplex: (_po_2D, s1_2D, s3_2D)
-        C32 = (
-            p_o_2D[0] * s3_2D[1]
-            + p_o_2D[1] * s1_2D[0]
-            + s3_2D[0] * s1_2D[1]
-            - p_o_2D[0] * s1_2D[1]
-            - p_o_2D[1] * s3_2D[0]
-            - s1_2D[0] * s3_2D[1]
-        )
+    # C32 corresponds to the signed area of 2-simplex: (_po_2D, s1_2D, s3_2D)
+    C32 = (
+        p_o_2D[0] * s3_2D[1]
+        + p_o_2D[1] * s1_2D[0]
+        + s3_2D[0] * s1_2D[1]
+        - p_o_2D[0] * s1_2D[1]
+        - p_o_2D[1] * s3_2D[0]
+        - s1_2D[0] * s3_2D[1]
+    )
 
-        # C33 corresponds to the signed area of 2-simplex: (p_o_2D, s1_2D, s2_2D)
-        C33 = (
-            p_o_2D[0] * s1_2D[1]
-            + p_o_2D[1] * s2_2D[0]
-            + s1_2D[0] * s2_2D[1]
-            - p_o_2D[0] * s2_2D[1]
-            - p_o_2D[1] * s1_2D[0]
-            - s2_2D[0] * s1_2D[1]
-        )
+    # C33 corresponds to the signed area of 2-simplex: (p_o_2D, s1_2D, s2_2D)
+    C33 = (
+        p_o_2D[0] * s1_2D[1]
+        + p_o_2D[1] * s2_2D[0]
+        + s1_2D[0] * s2_2D[1]
+        - p_o_2D[0] * s2_2D[1]
+        - p_o_2D[1] * s1_2D[0]
+        - s2_2D[0] * s1_2D[1]
+    )
 
-        comp1 = _same_sign(M_max, C31)
-        comp2 = _same_sign(M_max, C32)
-        comp3 = _same_sign(M_max, C33)
+    comp1 = _same_sign(M_max, C31)
+    comp2 = _same_sign(M_max, C32)
+    comp3 = _same_sign(M_max, C33)
 
-        # all the same sign, p_o is inside the 2-simplex
-        if comp1 and comp2 and comp3:
-            return wp.vec3(C31 / M_max, C32 / M_max, C33 / M_max)
+    # all the same sign, p_o is inside the 2-simplex
+    if comp1 and comp2 and comp3:
+        return wp.vec3(C31 / M_max, C32 / M_max, C33 / M_max)
 
-        # find the smallest distance, and use the corresponding barycentric coordinates
-        dmin = FLOAT_MAX
-        coordinates = wp.vec3(0.0, 0.0, 0.0)
+    # find the smallest distance, and use the corresponding barycentric coordinates
+    dmin = FLOAT_MAX
+    coordinates = wp.vec3(0.0, 0.0, 0.0)
 
-        if not comp1:
-            subcoord = _S1D(s2, s3)
-            x = subcoord[0] * s2 + subcoord[1] * s3
-            d = wp.dot(x, x)
-            coordinates[0] = 0.0
-            coordinates[1] = subcoord[0]
+    if not comp1:
+        subcoord = _S1D(s2, s3)
+        x = subcoord[0] * s2 + subcoord[1] * s3
+        d = wp.dot(x, x)
+        coordinates[0] = 0.0
+        coordinates[1] = subcoord[0]
+        coordinates[2] = subcoord[1]
+        dmin = d
+
+    if not comp2:
+        subcoord = _S1D(s1, s3)
+        x = subcoord[0] * s1 + subcoord[1] * s3
+        d = wp.dot(x, x)
+        if d < dmin:
+            coordinates[0] = subcoord[0]
+            coordinates[1] = 0.0
             coordinates[2] = subcoord[1]
             dmin = d
 
-        if not comp2:
-            subcoord = _S1D(s1, s3)
-            x = subcoord[0] * s1 + subcoord[1] * s3
-            d = wp.dot(x, x)
-            if d < dmin:
-                coordinates[0] = subcoord[0]
-                coordinates[1] = 0.0
-                coordinates[2] = subcoord[1]
-                dmin = d
+    if not comp3:
+        subcoord = _S1D(s1, s2)
+        x = subcoord[0] * s1 + subcoord[1] * s2
+        d = wp.dot(x, x)
+        if d < dmin:
+            coordinates[0] = subcoord[0]
+            coordinates[1] = subcoord[1]
+            coordinates[2] = 0.0
+    return coordinates
 
-        if not comp3:
-            subcoord = _S1D(s1, s2)
-            x = subcoord[0] * s1 + subcoord[1] * s2
-            d = wp.dot(x, x)
-            if d < dmin:
-                coordinates[0] = subcoord[0]
-                coordinates[1] = subcoord[1]
-                coordinates[2] = 0.0
-        return coordinates
 
-    @wp.func
-    def _S1D(s1: wp.vec3, s2: wp.vec3):
-        # find projection of origin onto the 1-simplex:
-        p_o = _project_origin_line(s1, s2)
+@wp.func
+def _S1D(s1: wp.vec3, s2: wp.vec3):
+    # find projection of origin onto the 1-simplex:
+    p_o = _project_origin_line(s1, s2)
 
-        # find the axis with the largest projection "shadow" of the simplex
-        mu_max = 0.0
-        index = 0
-        for i in range(3):
-            mu = s1[i] - s2[i]
-            if wp.abs(mu) >= wp.abs(mu_max):
-                mu_max = mu
-                index = i
+    # find the axis with the largest projection "shadow" of the simplex
+    mu_max = 0.0
+    index = 0
+    for i in range(3):
+        mu = s1[i] - s2[i]
+        if wp.abs(mu) >= wp.abs(mu_max):
+            mu_max = mu
+            index = i
 
-        C1 = p_o[index] - s2[index]
-        C2 = s1[index] - p_o[index]
+    C1 = p_o[index] - s2[index]
+    C2 = s1[index] - p_o[index]
 
-        # inside the simplex
-        if _same_sign(mu_max, C1) and _same_sign(mu_max, C2):
-            return wp.vec2(C1 / mu_max, C2 / mu_max)
-        return wp.vec2(0.0, 1.0)
+    # inside the simplex
+    if _same_sign(mu_max, C1) and _same_sign(mu_max, C2):
+        return wp.vec2(C1 / mu_max, C2 / mu_max)
+    return wp.vec2(0.0, 1.0)
 
+
+def build_gjk_generic(support_func: Any):
     @wp.func
     def _gjk(
         tolerance: float,
@@ -541,6 +488,73 @@ def build_ccd_generic(support_func: Any):
         result.simplex2 = simplex2
         result.simplex = simplex
         return result
+
+    return _gjk
+
+
+def build_ccd_generic(support_func: Any):
+    """Build a continuous collision detection (CCD) system using a generic support function.
+
+    This function takes a support function as input and returns a collection of helper functions
+    for performing collision detection between geometric primitives. The support function is used
+    to find the furthest point on a geometry in a given direction.
+
+    The support function must have the following signature:
+        def support_func(geom: Any, geom_type: int, dir: wp.vec3) -> tuple[int, wp.vec3]:
+    The type of geom must be a struct that can look as follows:
+        @wp.struct
+        class Geom:
+            pos: wp.vec3
+            rot: wp.mat33
+            normal: wp.vec3
+            size: wp.vec3
+            index: int
+    Note that only the index member is mandatory. All other members can be chosen as needed for
+    the support function.
+
+    The returned functions implement the GJK (Gilbert-Johnson-Keerthi) and EPA (Expanding Polytope Algorithm)
+    algorithms for computing distances between convex shapes and handling penetration cases.
+
+    Args:
+        support_func: A function that takes a geometry object, geometry type, and direction vector
+            and returns (index, point) where:
+            - index is the index of the support point in the geometry
+            - point is the furthest point on the geometry in the given direction
+
+    Returns:
+        A collection of helper functions including:
+        - _attach_face: Attaches a triangular face to the polytope
+        - _epa_support: Computes support points for EPA algorithm
+        - _linear_combine: Performs linear combination of vertices
+        - _almost_equal: Checks if two vectors are approximately equal
+        - _subdistance: Computes closest point on simplex to origin
+        And other internal functions used by GJK/EPA algorithms.
+    """
+
+    @wp.func
+    def _attach_face(pt: Polytope, idx: int, v1: int, v2: int, v3: int):
+        # compute witness point v
+        r, ret = _project_origin_plane(pt.verts[v3], pt.verts[v2], pt.verts[v1])
+        if ret:
+            return 0.0
+
+        face_verts = wp.vec3i(v1, v2, v3)
+        pt.face_verts[idx] = face_verts
+        pt.face_v[idx] = r
+
+        pt.face_dist2[idx] = wp.dot(r, r)
+        pt.face_index[idx] = -1
+        return pt.face_dist2[idx]
+
+    @wp.func
+    def _epa_support(pt: Polytope, idx: int, geom1: Any, geom2: Any, geom1_type: int, geom2_type: int, dir: wp.vec3):
+        index1, s1 = wp.static(support_func)(geom1, geom1_type, dir)
+        index2, s2 = wp.static(support_func)(geom2, geom2_type, -dir)
+
+        pt.verts[idx] = s1 - s2
+        pt.verts1[idx] = s1
+        pt.verts2[idx] = s2
+        return index1, index2
 
     @wp.func
     def _same_side(p0: wp.vec3, p1: wp.vec3, p2: wp.vec3, p3: wp.vec3):
@@ -1065,6 +1079,8 @@ def build_ccd_generic(support_func: Any):
             x1, x2 = _epa_witness(pt, idx)
             return -wp.sqrt(pt.face_dist2[idx]), x1, x2
         return 0.0, wp.vec3(), wp.vec3()
+
+    _gjk = build_gjk_generic(support_func)
 
     @wp.func
     def ccd(

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -17,3 +17,284 @@
 from typing import Any
 
 import warp as wp
+
+from newton.geometry import (
+    GEO_BOX,
+    GEO_CAPSULE,
+    GEO_CYLINDER,
+    GEO_SPHERE,
+)
+
+
+# A small constant to avoid division by zero and other numerical issues
+MJ_MINVAL = 1e-15
+
+
+@wp.struct
+class Geom:
+    pos: wp.vec3
+    rot: wp.mat33
+    size: wp.vec3
+
+
+@wp.func
+def spinlock_acquire(lock: wp.array(dtype=wp.int32)):
+    # Try to acquire the lock by setting it to 1 if it's 0
+    while wp.atomic_cas(lock, 0, 0, 1) == 1:
+        pass
+
+
+@wp.func
+def spinlock_release(lock: wp.array(dtype=wp.int32)):
+    # Release the lock by setting it back to 0
+    wp.atomic_exch(lock, 0, 0)
+
+
+@wp.func
+def geom_ray_intersect(geom: Geom, geomtype: int, p: wp.vec3, d: wp.vec3):
+    """
+    Computes the intersection of a ray with a geometry.
+
+    Args:
+        geom: The geometry to intersect with.
+        geomtype: The type of the geometry.
+        p: The origin of the ray.
+        d: The direction of the ray.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
+
+    # transform ray to local frame
+    p_local = wp.transpose(geom.rot) @ (p - geom.pos)
+    d_local = wp.transpose(geom.rot) @ d
+    d_len_sq = wp.dot(d_local, d_local)
+
+    if d_len_sq < MJ_MINVAL:
+        return -1.0
+
+    # normalize d_local
+    inv_d_len = 1.0 / wp.sqrt(d_len_sq)
+    d_local_norm = d_local * inv_d_len
+
+    if geomtype == GEO_SPHERE:
+        r = geom.size[0]
+        oc = p_local
+        b = wp.dot(oc, d_local_norm)
+        c = wp.dot(oc, oc) - r * r
+
+        delta = b * b - c
+        if delta >= 0.0:
+            sqrt_delta = wp.sqrt(delta)
+            t1 = -b - sqrt_delta
+            if t1 >= 0.0:
+                t_hit = t1 * inv_d_len
+            else:
+                t2 = -b + sqrt_delta
+                if t2 >= 0.0:
+                    t_hit = t2 * inv_d_len
+
+    elif geomtype == GEO_BOX:
+        t_near = -1.0e10
+        t_far = 1.0e10
+        hit = 1
+
+        for i in range(3):
+            if wp.abs(d_local[i]) < MJ_MINVAL:
+                if p_local[i] < -geom.size[i] or p_local[i] > geom.size[i]:
+                    hit = 0
+            else:
+                inv_d_i = 1.0 / d_local[i]
+                t1 = (-geom.size[i] - p_local[i]) * inv_d_i
+                t2 = (geom.size[i] - p_local[i]) * inv_d_i
+
+                if t1 > t2:
+                    temp = t1
+                    t1 = t2
+                    t2 = temp
+
+                t_near = wp.max(t_near, t1)
+                t_far = wp.min(t_far, t2)
+
+        if hit == 1 and t_near <= t_far and t_far >= 0.0:
+            if t_near >= 0.0:
+                t_hit = t_near
+            else:
+                t_hit = t_far
+
+    elif geomtype == GEO_CAPSULE:
+        r = geom.size[0]
+        h = geom.size[1]
+        min_t = 1.0e10
+
+        # Intersection with cylinder body
+        a_cyl = d_local_norm[0] * d_local_norm[0] + d_local_norm[1] * d_local_norm[1]
+        if a_cyl > MJ_MINVAL:
+            b_cyl = 2.0 * (p_local[0] * d_local_norm[0] + p_local[1] * d_local_norm[1])
+            c_cyl = p_local[0] * p_local[0] + p_local[1] * p_local[1] - r * r
+            delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+            if delta_cyl >= 0.0:
+                sqrt_delta_cyl = wp.sqrt(delta_cyl)
+                t1 = (-b_cyl - sqrt_delta_cyl) / (2.0 * a_cyl)
+                if t1 >= 0.0:
+                    z = p_local[2] + t1 * d_local_norm[2]
+                    if wp.abs(z) <= h:
+                        min_t = wp.min(min_t, t1)
+
+                t2 = (-b_cyl + sqrt_delta_cyl) / (2.0 * a_cyl)
+                if t2 >= 0.0:
+                    z = p_local[2] + t2 * d_local_norm[2]
+                    if wp.abs(z) <= h:
+                        min_t = wp.min(min_t, t2)
+
+        # Intersection with sphere caps
+        # Top cap
+        oc_top = p_local - wp.vec3(0.0, 0.0, h)
+        b_top = wp.dot(oc_top, d_local_norm)
+        c_top = wp.dot(oc_top, oc_top) - r * r
+        delta_top = b_top * b_top - c_top
+        if delta_top >= 0.0:
+            sqrt_delta_top = wp.sqrt(delta_top)
+            t1_top = -b_top - sqrt_delta_top
+            if t1_top >= 0.0:
+                if (p_local[2] + t1_top * d_local_norm[2]) >= h:
+                    min_t = wp.min(min_t, t1_top)
+
+            t2_top = -b_top + sqrt_delta_top
+            if t2_top >= 0.0:
+                if (p_local[2] + t2_top * d_local_norm[2]) >= h:
+                    min_t = wp.min(min_t, t2_top)
+
+        # Bottom cap
+        oc_bot = p_local - wp.vec3(0.0, 0.0, -h)
+        b_bot = wp.dot(oc_bot, d_local_norm)
+        c_bot = wp.dot(oc_bot, oc_bot) - r * r
+        delta_bot = b_bot * b_bot - c_bot
+        if delta_bot >= 0.0:
+            sqrt_delta_bot = wp.sqrt(delta_bot)
+            t1_bot = -b_bot - sqrt_delta_bot
+            if t1_bot >= 0.0:
+                if (p_local[2] + t1_bot * d_local_norm[2]) <= -h:
+                    min_t = wp.min(min_t, t1_bot)
+
+            t2_bot = -b_bot + sqrt_delta_bot
+            if t2_bot >= 0.0:
+                if (p_local[2] + t2_bot * d_local_norm[2]) <= -h:
+                    min_t = wp.min(min_t, t2_bot)
+
+        if min_t < 1.0e9:
+            t_hit = min_t * inv_d_len
+
+    elif geomtype == GEO_CYLINDER:
+        r = geom.size[0]
+        h = geom.size[1]
+        min_t = 1.0e10
+
+        # Intersection with cylinder body
+        a_cyl = d_local[0] * d_local[0] + d_local[1] * d_local[1]
+        if a_cyl > MJ_MINVAL:
+            b_cyl = 2.0 * (p_local[0] * d_local[0] + p_local[1] * d_local[1])
+            c_cyl = p_local[0] * p_local[0] + p_local[1] * p_local[1] - r * r
+            delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+            if delta_cyl >= 0.0:
+                sqrt_delta_cyl = wp.sqrt(delta_cyl)
+                inv_2a = 1.0 / (2.0 * a_cyl)
+                t1 = (-b_cyl - sqrt_delta_cyl) * inv_2a
+                if t1 >= 0.0:
+                    z = p_local[2] + t1 * d_local[2]
+                    if wp.abs(z) <= h:
+                        min_t = wp.min(min_t, t1)
+
+                t2 = (-b_cyl + sqrt_delta_cyl) * inv_2a
+                if t2 >= 0.0:
+                    z = p_local[2] + t2 * d_local[2]
+                    if wp.abs(z) <= h:
+                        min_t = wp.min(min_t, t2)
+
+        # Intersection with caps
+        if wp.abs(d_local[2]) > MJ_MINVAL:
+            inv_d_z = 1.0 / d_local[2]
+            # Top cap
+            t_top = (h - p_local[2]) * inv_d_z
+            if t_top >= 0.0:
+                x = p_local[0] + t_top * d_local[0]
+                y = p_local[1] + t_top * d_local[1]
+                if x * x + y * y <= r * r:
+                    min_t = wp.min(min_t, t_top)
+
+            # Bottom cap
+            t_bot = (-h - p_local[2]) * inv_d_z
+            if t_bot >= 0.0:
+                x = p_local[0] + t_bot * d_local[0]
+                y = p_local[1] + t_bot * d_local[1]
+                if x * x + y * y <= r * r:
+                    min_t = wp.min(min_t, t_bot)
+
+        if min_t < 1.0e9:
+            t_hit = min_t
+
+    return t_hit
+
+
+@wp.kernel
+def raycast_kernel(
+    # Model
+    body_q: wp.array(dtype=wp.transform),
+    shape_body: wp.array(dtype=int),
+    shape_transform: wp.array(dtype=wp.transform),
+    geom_type: wp.array(dtype=int),
+    geom_size: wp.array(dtype=wp.vec3),
+    # Ray
+    p: wp.vec3,
+    d: wp.vec3,
+    # Lock helper
+    lock: wp.array(dtype=wp.int32),
+    # Output
+    min_dist: wp.array(dtype=float),
+    min_index: wp.array(dtype=int),
+):
+    """
+    Computes the intersection of a ray with all geometries in the scene.
+
+    Args:
+        body_q: Array of body transforms.
+        shape_body: Maps shape index to body index.
+        shape_transform: Array of local shape transforms.
+        geom_type: Array of geometry types for each geometry.
+        geom_size: Array of sizes for each geometry.
+        p: The origin of the ray.
+        d: The direction of the ray.
+        lock: Lock array used for synchronization. Expected to be initialized to 0.
+        min_dist: A single-element array to store the minimum intersection distance. Expected to be initialized to a large value like 1e10.
+        min_index: A single-element array to store the index of the closest geometry. Expected to be initialized to -1.
+    """
+    tid = wp.tid()
+
+    # compute shape transform
+    b = shape_body[tid]
+
+    X_wb = wp.transform_identity()
+    if b >= 0:
+        X_wb = body_q[b]
+
+    X_bs = shape_transform[tid]
+
+    X_ws = wp.mul(X_wb, X_bs)
+
+    geom = Geom()
+    geom.pos = wp.transform_get_translation(X_ws)
+    geom.rot = wp.quat_to_matrix(wp.transform_get_rotation(X_ws))
+    geom.size = geom_size[tid]
+
+    geomtype = geom_type[tid]
+
+    t = geom_ray_intersect(geom, geomtype, p, d)
+
+    if t >= 0.0 and t < min_dist[0]:
+        spinlock_acquire(lock)
+        # Still use an atomic inside the spinlock to get a volatile read
+        old_min = wp.atomic_min(min_dist, 0, t)
+        if t < old_min:
+            min_index[0] = tid
+        spinlock_release(lock)

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -186,7 +186,7 @@ def geom_ray_intersect(X_ws: wp.transform, size: wp.vec3, geomtype: int, p: wp.v
 
         if min_t < 1.0e9:
             t_hit = min_t * inv_d_len
-            wp.printf("t_hit: %f\n", t_hit)
+            # wp.printf("t_hit: %f\n", t_hit)
 
     elif geomtype == GEO_CYLINDER:
         r = size[0]

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -255,6 +255,7 @@ def raycast_kernel(
     # Output
     min_dist: wp.array(dtype=float),
     min_index: wp.array(dtype=int),
+    min_body_index: wp.array(dtype=int),
 ):
     """
     Computes the intersection of a ray with all geometries in the scene.
@@ -270,6 +271,7 @@ def raycast_kernel(
         lock: Lock array used for synchronization. Expected to be initialized to 0.
         min_dist: A single-element array to store the minimum intersection distance. Expected to be initialized to a large value like 1e10.
         min_index: A single-element array to store the index of the closest geometry. Expected to be initialized to -1.
+        min_body_index: A single-element array to store the body index of the closest geometry. Expected to be initialized to -1.
     """
     tid = wp.tid()
 
@@ -297,6 +299,7 @@ def raycast_kernel(
         spinlock_acquire(lock)
         # Still use an atomic inside the spinlock to get a volatile read
         old_min = wp.atomic_min(min_dist, 0, t)
-        if t < old_min:
+        if t <= old_min:
             min_index[0] = tid
+            min_body_index[0] = b
         spinlock_release(lock)

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Any
+
+import warp as wp

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 
-from typing import Any
-
 import warp as wp
 
 from newton.geometry import (
@@ -27,214 +25,310 @@ from newton.geometry import (
 
 
 # A small constant to avoid division by zero and other numerical issues
-MJ_MINVAL = 1e-15
+MINVAL = 1e-15
 
 
 @wp.func
-def spinlock_acquire(lock: wp.array(dtype=wp.int32)):
+def _spinlock_acquire(lock: wp.array(dtype=wp.int32)):
     # Try to acquire the lock by setting it to 1 if it's 0
     while wp.atomic_cas(lock, 0, 0, 1) == 1:
         pass
 
 
 @wp.func
-def spinlock_release(lock: wp.array(dtype=wp.int32)):
+def _spinlock_release(lock: wp.array(dtype=wp.int32)):
     # Release the lock by setting it back to 0
     wp.atomic_exch(lock, 0, 0)
 
 
 @wp.func
-def geom_ray_intersect(X_ws: wp.transform, size: wp.vec3, geomtype: int, p: wp.vec3, d: wp.vec3):
-    """
-    Computes the intersection of a ray with a geometry.
+def ray_intersect_sphere(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float):
+    """Computes ray-sphere intersection.
 
     Args:
-        X_ws: The world-to-shape transform.
-        size: The size of the geometry.
-        geomtype: The type of the geometry.
-        p: The origin of the ray.
-        d: The direction of the ray.
+        geom_to_world: The world transform of the sphere.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the sphere.
 
     Returns:
         The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
     """
     t_hit = -1.0
 
-    #pos = wp.transform_get_translation(X_ws)
-    #rot = wp.quat_to_matrix(wp.transform_get_rotation(X_ws))
-    X_sw = wp.transform_inverse(X_ws)
-
     # transform ray to local frame
-    p_local = wp.transform_point(X_sw, p)
-    d_local = wp.transform_vector(X_sw, d)
-    d_len_sq = wp.dot(d_local, d_local)
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
 
-    if d_len_sq < MJ_MINVAL:
+    d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
+    if d_len_sq < MINVAL:
         return -1.0
 
-    # normalize d_local
     inv_d_len = 1.0 / wp.sqrt(d_len_sq)
-    d_local_norm = d_local * inv_d_len
+    d_local_norm = ray_direction_local * inv_d_len
+
+    oc = ray_origin_local
+    b = wp.dot(oc, d_local_norm)
+    c = wp.dot(oc, oc) - r * r
+
+    delta = b * b - c
+    if delta >= 0.0:
+        sqrt_delta = wp.sqrt(delta)
+        t1 = -b - sqrt_delta
+        if t1 >= 0.0:
+            t_hit = t1 * inv_d_len
+        else:
+            t2 = -b + sqrt_delta
+            if t2 >= 0.0:
+                t_hit = t2 * inv_d_len
+    return t_hit
+
+
+@wp.func
+def ray_intersect_box(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3):
+    """Computes ray-box intersection.
+
+    Args:
+        geom_to_world: The world transform of the box.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        size: The half-extents of the box.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    t_hit = -1.0
+    t_near = -1.0e10
+    t_far = 1.0e10
+    hit = 1
+
+    for i in range(3):
+        if wp.abs(ray_direction_local[i]) < MINVAL:
+            if ray_origin_local[i] < -size[i] or ray_origin_local[i] > size[i]:
+                hit = 0
+        else:
+            inv_d_i = 1.0 / ray_direction_local[i]
+            t1 = (-size[i] - ray_origin_local[i]) * inv_d_i
+            t2 = (size[i] - ray_origin_local[i]) * inv_d_i
+
+            if t1 > t2:
+                temp = t1
+                t1 = t2
+                t2 = temp
+
+            t_near = wp.max(t_near, t1)
+            t_far = wp.min(t_far, t2)
+
+    if hit == 1 and t_near <= t_far and t_far >= 0.0:
+        if t_near >= 0.0:
+            t_hit = t_near
+        else:
+            t_hit = t_far
+    return t_hit
+
+
+@wp.func
+def ray_intersect_capsule(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float):
+    """Computes ray-capsule intersection.
+
+    Args:
+        geom_to_world: The world transform of the capsule.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the capsule.
+        h: The half-height of the capsule's cylindrical part.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
+
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
+    if d_len_sq < MINVAL:
+        return -1.0
+
+    inv_d_len = 1.0 / wp.sqrt(d_len_sq)
+    d_local_norm = ray_direction_local * inv_d_len
+
+    min_t = 1.0e10
+
+    # Intersection with cylinder body
+    a_cyl = d_local_norm[0] * d_local_norm[0] + d_local_norm[1] * d_local_norm[1]
+    if a_cyl > MINVAL:
+        b_cyl = 2.0 * (ray_origin_local[0] * d_local_norm[0] + ray_origin_local[1] * d_local_norm[1])
+        c_cyl = ray_origin_local[0] * ray_origin_local[0] + ray_origin_local[1] * ray_origin_local[1] - r * r
+        delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+        if delta_cyl >= 0.0:
+            sqrt_delta_cyl = wp.sqrt(delta_cyl)
+            t1 = (-b_cyl - sqrt_delta_cyl) / (2.0 * a_cyl)
+            if t1 >= 0.0:
+                z = ray_origin_local[2] + t1 * d_local_norm[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t1)
+
+            t2 = (-b_cyl + sqrt_delta_cyl) / (2.0 * a_cyl)
+            if t2 >= 0.0:
+                z = ray_origin_local[2] + t2 * d_local_norm[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t2)
+
+    # Intersection with sphere caps
+    # Top cap
+    oc_top = ray_origin_local - wp.vec3(0.0, 0.0, h)
+    b_top = wp.dot(oc_top, d_local_norm)
+    c_top = wp.dot(oc_top, oc_top) - r * r
+    delta_top = b_top * b_top - c_top
+    if delta_top >= 0.0:
+        sqrt_delta_top = wp.sqrt(delta_top)
+        t1_top = -b_top - sqrt_delta_top
+        if t1_top >= 0.0:
+            if (ray_origin_local[2] + t1_top * d_local_norm[2]) >= h:
+                min_t = wp.min(min_t, t1_top)
+
+        t2_top = -b_top + sqrt_delta_top
+        if t2_top >= 0.0:
+            if (ray_origin_local[2] + t2_top * d_local_norm[2]) >= h:
+                min_t = wp.min(min_t, t2_top)
+
+    # Bottom cap
+    oc_bot = ray_origin_local - wp.vec3(0.0, 0.0, -h)
+    b_bot = wp.dot(oc_bot, d_local_norm)
+    c_bot = wp.dot(oc_bot, oc_bot) - r * r
+    delta_bot = b_bot * b_bot - c_bot
+    if delta_bot >= 0.0:
+        sqrt_delta_bot = wp.sqrt(delta_bot)
+        t1_bot = -b_bot - sqrt_delta_bot
+        if t1_bot >= 0.0:
+            if (ray_origin_local[2] + t1_bot * d_local_norm[2]) <= -h:
+                min_t = wp.min(min_t, t1_bot)
+
+        t2_bot = -b_bot + sqrt_delta_bot
+        if t2_bot >= 0.0:
+            if (ray_origin_local[2] + t2_bot * d_local_norm[2]) <= -h:
+                min_t = wp.min(min_t, t2_bot)
+
+    if min_t < 1.0e9:
+        t_hit = min_t * inv_d_len
+
+    return t_hit
+
+
+@wp.func
+def ray_intersect_cylinder(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float
+):
+    """Computes ray-cylinder intersection.
+
+    Args:
+        geom_to_world: The world transform of the cylinder.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the cylinder.
+        h: The half-height of the cylinder.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    t_hit = -1.0
+    min_t = 1.0e10
+
+    # Intersection with cylinder body
+    a_cyl = ray_direction_local[0] * ray_direction_local[0] + ray_direction_local[1] * ray_direction_local[1]
+    if a_cyl > MINVAL:
+        b_cyl = 2.0 * (ray_origin_local[0] * ray_direction_local[0] + ray_origin_local[1] * ray_direction_local[1])
+        c_cyl = ray_origin_local[0] * ray_origin_local[0] + ray_origin_local[1] * ray_origin_local[1] - r * r
+        delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+        if delta_cyl >= 0.0:
+            sqrt_delta_cyl = wp.sqrt(delta_cyl)
+            inv_2a = 1.0 / (2.0 * a_cyl)
+            t1 = (-b_cyl - sqrt_delta_cyl) * inv_2a
+            if t1 >= 0.0:
+                z = ray_origin_local[2] + t1 * ray_direction_local[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t1)
+
+            t2 = (-b_cyl + sqrt_delta_cyl) * inv_2a
+            if t2 >= 0.0:
+                z = ray_origin_local[2] + t2 * ray_direction_local[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t2)
+
+    # Intersection with caps
+    if wp.abs(ray_direction_local[2]) > MINVAL:
+        inv_d_z = 1.0 / ray_direction_local[2]
+        # Top cap
+        t_top = (h - ray_origin_local[2]) * inv_d_z
+        if t_top >= 0.0:
+            x = ray_origin_local[0] + t_top * ray_direction_local[0]
+            y = ray_origin_local[1] + t_top * ray_direction_local[1]
+            if x * x + y * y <= r * r:
+                min_t = wp.min(min_t, t_top)
+
+        # Bottom cap
+        t_bot = (-h - ray_origin_local[2]) * inv_d_z
+        if t_bot >= 0.0:
+            x = ray_origin_local[0] + t_bot * ray_direction_local[0]
+            y = ray_origin_local[1] + t_bot * ray_direction_local[1]
+            if x * x + y * y <= r * r:
+                min_t = wp.min(min_t, t_bot)
+
+    if min_t < 1.0e9:
+        t_hit = min_t
+
+    return t_hit
+
+
+@wp.func
+def geom_ray_intersect(
+    geom_to_world: wp.transform, size: wp.vec3, geomtype: int, ray_origin: wp.vec3, ray_direction: wp.vec3
+):
+    """
+    Computes the intersection of a ray with a geometry.
+
+    Args:
+        geom_to_world: The world-to-shape transform.
+        size: The size of the geometry.
+        geomtype: The type of the geometry.
+        ray_origin: The origin of the ray.
+        ray_direction: The direction of the ray.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
 
     if geomtype == GEO_SPHERE:
         r = size[0]
-        oc = p_local
-        b = wp.dot(oc, d_local_norm)
-        c = wp.dot(oc, oc) - r * r
-
-        delta = b * b - c
-        if delta >= 0.0:
-            sqrt_delta = wp.sqrt(delta)
-            t1 = -b - sqrt_delta
-            if t1 >= 0.0:
-                t_hit = t1 * inv_d_len
-            else:
-                t2 = -b + sqrt_delta
-                if t2 >= 0.0:
-                    t_hit = t2 * inv_d_len
+        t_hit = ray_intersect_sphere(geom_to_world, ray_origin, ray_direction, r)
 
     elif geomtype == GEO_BOX:
-        t_near = -1.0e10
-        t_far = 1.0e10
-        hit = 1
-
-        for i in range(3):
-            if wp.abs(d_local[i]) < MJ_MINVAL:
-                if p_local[i] < -size[i] or p_local[i] > size[i]:
-                    hit = 0
-            else:
-                inv_d_i = 1.0 / d_local[i]
-                t1 = (-size[i] - p_local[i]) * inv_d_i
-                t2 = (size[i] - p_local[i]) * inv_d_i
-
-                if t1 > t2:
-                    temp = t1
-                    t1 = t2
-                    t2 = temp
-
-                t_near = wp.max(t_near, t1)
-                t_far = wp.min(t_far, t2)
-
-        if hit == 1 and t_near <= t_far and t_far >= 0.0:
-            if t_near >= 0.0:
-                t_hit = t_near
-            else:
-                t_hit = t_far
+        t_hit = ray_intersect_box(geom_to_world, ray_origin, ray_direction, size)
 
     elif geomtype == GEO_CAPSULE:
-
-        # wp.printf("capsule\n")
-
         r = size[0]
         h = size[1]
-        min_t = 1.0e10
-
-        # Intersection with cylinder body
-        a_cyl = d_local_norm[0] * d_local_norm[0] + d_local_norm[1] * d_local_norm[1]
-        if a_cyl > MJ_MINVAL:
-            b_cyl = 2.0 * (p_local[0] * d_local_norm[0] + p_local[1] * d_local_norm[1])
-            c_cyl = p_local[0] * p_local[0] + p_local[1] * p_local[1] - r * r
-            delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
-            if delta_cyl >= 0.0:
-                sqrt_delta_cyl = wp.sqrt(delta_cyl)
-                t1 = (-b_cyl - sqrt_delta_cyl) / (2.0 * a_cyl)
-                if t1 >= 0.0:
-                    z = p_local[2] + t1 * d_local_norm[2]
-                    if wp.abs(z) <= h:
-                        min_t = wp.min(min_t, t1)
-
-                t2 = (-b_cyl + sqrt_delta_cyl) / (2.0 * a_cyl)
-                if t2 >= 0.0:
-                    z = p_local[2] + t2 * d_local_norm[2]
-                    if wp.abs(z) <= h:
-                        min_t = wp.min(min_t, t2)
-
-        # Intersection with sphere caps
-        # Top cap
-        oc_top = p_local - wp.vec3(0.0, 0.0, h)
-        b_top = wp.dot(oc_top, d_local_norm)
-        c_top = wp.dot(oc_top, oc_top) - r * r
-        delta_top = b_top * b_top - c_top
-        if delta_top >= 0.0:
-            sqrt_delta_top = wp.sqrt(delta_top)
-            t1_top = -b_top - sqrt_delta_top
-            if t1_top >= 0.0:
-                if (p_local[2] + t1_top * d_local_norm[2]) >= h:
-                    min_t = wp.min(min_t, t1_top)
-
-            t2_top = -b_top + sqrt_delta_top
-            if t2_top >= 0.0:
-                if (p_local[2] + t2_top * d_local_norm[2]) >= h:
-                    min_t = wp.min(min_t, t2_top)
-
-        # Bottom cap
-        oc_bot = p_local - wp.vec3(0.0, 0.0, -h)
-        b_bot = wp.dot(oc_bot, d_local_norm)
-        c_bot = wp.dot(oc_bot, oc_bot) - r * r
-        delta_bot = b_bot * b_bot - c_bot
-        if delta_bot >= 0.0:
-            sqrt_delta_bot = wp.sqrt(delta_bot)
-            t1_bot = -b_bot - sqrt_delta_bot
-            if t1_bot >= 0.0:
-                if (p_local[2] + t1_bot * d_local_norm[2]) <= -h:
-                    min_t = wp.min(min_t, t1_bot)
-
-            t2_bot = -b_bot + sqrt_delta_bot
-            if t2_bot >= 0.0:
-                if (p_local[2] + t2_bot * d_local_norm[2]) <= -h:
-                    min_t = wp.min(min_t, t2_bot)
-
-        if min_t < 1.0e9:
-            t_hit = min_t * inv_d_len
-            # wp.printf("t_hit: %f\n", t_hit)
+        t_hit = ray_intersect_capsule(geom_to_world, ray_origin, ray_direction, r, h)
 
     elif geomtype == GEO_CYLINDER:
         r = size[0]
         h = size[1]
-        min_t = 1.0e10
-
-        # Intersection with cylinder body
-        a_cyl = d_local[0] * d_local[0] + d_local[1] * d_local[1]
-        if a_cyl > MJ_MINVAL:
-            b_cyl = 2.0 * (p_local[0] * d_local[0] + p_local[1] * d_local[1])
-            c_cyl = p_local[0] * p_local[0] + p_local[1] * p_local[1] - r * r
-            delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
-            if delta_cyl >= 0.0:
-                sqrt_delta_cyl = wp.sqrt(delta_cyl)
-                inv_2a = 1.0 / (2.0 * a_cyl)
-                t1 = (-b_cyl - sqrt_delta_cyl) * inv_2a
-                if t1 >= 0.0:
-                    z = p_local[2] + t1 * d_local[2]
-                    if wp.abs(z) <= h:
-                        min_t = wp.min(min_t, t1)
-
-                t2 = (-b_cyl + sqrt_delta_cyl) * inv_2a
-                if t2 >= 0.0:
-                    z = p_local[2] + t2 * d_local[2]
-                    if wp.abs(z) <= h:
-                        min_t = wp.min(min_t, t2)
-
-        # Intersection with caps
-        if wp.abs(d_local[2]) > MJ_MINVAL:
-            inv_d_z = 1.0 / d_local[2]
-            # Top cap
-            t_top = (h - p_local[2]) * inv_d_z
-            if t_top >= 0.0:
-                x = p_local[0] + t_top * d_local[0]
-                y = p_local[1] + t_top * d_local[1]
-                if x * x + y * y <= r * r:
-                    min_t = wp.min(min_t, t_top)
-
-            # Bottom cap
-            t_bot = (-h - p_local[2]) * inv_d_z
-            if t_bot >= 0.0:
-                x = p_local[0] + t_bot * d_local[0]
-                y = p_local[1] + t_bot * d_local[1]
-                if x * x + y * y <= r * r:
-                    min_t = wp.min(min_t, t_bot)
-
-        if min_t < 1.0e9:
-            t_hit = min_t
+        t_hit = ray_intersect_cylinder(geom_to_world, ray_origin, ray_direction, r, h)
 
     return t_hit
 
@@ -248,8 +342,8 @@ def raycast_kernel(
     geom_type: wp.array(dtype=int),
     geom_size: wp.array(dtype=wp.vec3),
     # Ray
-    p: wp.vec3,
-    d: wp.vec3,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
     # Lock helper
     lock: wp.array(dtype=wp.int32),
     # Output
@@ -266,8 +360,8 @@ def raycast_kernel(
         shape_transform: Array of local shape transforms.
         geom_type: Array of geometry types for each geometry.
         geom_size: Array of sizes for each geometry.
-        p: The origin of the ray.
-        d: The direction of the ray.
+        ray_origin: The origin of the ray.
+        ray_direction: The direction of the ray.
         lock: Lock array used for synchronization. Expected to be initialized to 0.
         min_dist: A single-element array to store the minimum intersection distance. Expected to be initialized to a large value like 1e10.
         min_index: A single-element array to store the index of the closest geometry. Expected to be initialized to -1.
@@ -284,22 +378,17 @@ def raycast_kernel(
 
     X_bs = shape_transform[tid]
 
-    X_ws = wp.mul(X_wb, X_bs)
-
-    # geom = Geom()
-    # geom.pos = wp.transform_get_translation(X_ws)
-    # geom.rot = wp.quat_to_matrix(wp.transform_get_rotation(X_ws))
-    # geom.size = geom_size[tid]
+    geom_to_world = wp.mul(X_wb, X_bs)
 
     geomtype = geom_type[tid]
 
-    t = geom_ray_intersect(X_ws, geom_size[tid], geomtype, p, d)
+    t = geom_ray_intersect(geom_to_world, geom_size[tid], geomtype, ray_origin, ray_direction)
 
     if t >= 0.0 and t < min_dist[0]:
-        spinlock_acquire(lock)
+        _spinlock_acquire(lock)
         # Still use an atomic inside the spinlock to get a volatile read
         old_min = wp.atomic_min(min_dist, 0, t)
         if t <= old_min:
             min_index[0] = tid
             min_body_index[0] = b
-        spinlock_release(lock)
+        _spinlock_release(lock)

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import warp as wp
+
+import newton
+from newton.geometry import GEO_BOX, GEO_CAPSULE, GEO_CYLINDER, GEO_SPHERE
+from newton.geometry.raycast import (
+    geom_ray_intersect,
+    ray_intersect_box,
+    ray_intersect_capsule,
+    ray_intersect_cylinder,
+    ray_intersect_sphere,
+)
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+wp.config.quiet = True
+
+
+class TestRaycast(unittest.TestCase):
+    pass
+
+
+# Kernels to test ray intersection functions
+@wp.kernel
+def kernel_test_sphere(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_sphere(geom_to_world, ray_origin, ray_direction, r)
+
+
+@wp.kernel
+def kernel_test_box(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    size: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_box(geom_to_world, ray_origin, ray_direction, size)
+
+
+@wp.kernel
+def kernel_test_capsule(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+    h: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_capsule(geom_to_world, ray_origin, ray_direction, r, h)
+
+
+@wp.kernel
+def kernel_test_cylinder(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+    h: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_cylinder(geom_to_world, ray_origin, ray_direction, r, h)
+
+
+@wp.kernel
+def kernel_test_geom(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    size: wp.vec3,
+    geomtype: int,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = geom_ray_intersect(geom_to_world, size, geomtype, ray_origin, ray_direction)
+
+
+# Test functions
+def test_ray_intersect_sphere(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 1.0
+
+    # Case 1: Ray hits sphere
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 2: Ray misses sphere
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    # Case 3: Ray starts inside
+    ray_origin = wp.vec3(0.0, 0.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+
+def test_ray_intersect_box(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    size = wp.vec3(1.0, 1.0, 1.0)
+
+    # Case 1: Ray hits box
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 2: Ray misses box
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    # Case 3: Ray starts inside
+    ray_origin = wp.vec3(0.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 4: Rotated box
+    # Rotate 45 degrees around Z axis
+    rot = wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.785398)  # pi/4
+    geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 0.0), rot)
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.41421, delta=1e-5)
+
+
+def test_ray_intersect_capsule(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 0.5
+    h = 1.0
+
+    # Case 1: Hit cylinder part
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Case 2: Hit top cap
+    ray_origin = wp.vec3(0.0, 0.0, -2.0)
+    ray_direction = wp.vec3(0.0, 0.0, 1.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.0 - 0.5, delta=1e-5)
+
+    # Case 3: Miss
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+
+def test_ray_intersect_cylinder(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 0.5
+    h = 1.0
+
+    # Case 1: Hit cylinder body
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Case 2: Hit top cap
+    ray_origin = wp.vec3(0.0, 0.0, -2.0)
+    ray_direction = wp.vec3(0.0, 0.0, 1.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 3: Miss
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+
+def test_geom_ray_intersect(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+
+    # Sphere
+    size = wp.vec3(1.0, 0.0, 0.0)  # r
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_SPHERE, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Box
+    size = wp.vec3(1.0, 1.0, 1.0)  # half-extents
+    wp.launch(
+        kernel_test_geom, dim=1, inputs=[out_t, geom_to_world, size, GEO_BOX, ray_origin, ray_direction], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Capsule
+    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_CAPSULE, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Cylinder
+    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_CYLINDER, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+
+devices = get_test_devices()
+for device in devices:
+    add_function_test(TestRaycast, f"test_ray_intersect_sphere_{device}", test_ray_intersect_sphere, devices=[device])
+    add_function_test(TestRaycast, f"test_ray_intersect_box_{device}", test_ray_intersect_box, devices=[device])
+    add_function_test(TestRaycast, f"test_ray_intersect_capsule_{device}", test_ray_intersect_capsule, devices=[device])
+    add_function_test(
+        TestRaycast, f"test_ray_intersect_cylinder_{device}", test_ray_intersect_cylinder, devices=[device]
+    )
+    add_function_test(TestRaycast, f"test_geom_ray_intersect_{device}", test_geom_ray_intersect, devices=[device])
+
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2)

--- a/newton/utils/render.py
+++ b/newton/utils/render.py
@@ -542,13 +542,6 @@ def CreateSimRenderer(renderer):
                 if self.state is None:
                     return
 
-                # # normalize direction
-                # direction = direction / np.linalg.norm(direction)
-
-                # # set ray origin and direction
-                # p = wp.vec3(camera_pos[0], camera_pos[1], camera_pos[2])
-                # d = wp.vec3(direction[0], direction[1], direction[2])
-
                 # aspect ratio
                 aspect_ratio = self.screen_width / self.screen_height
 
@@ -577,9 +570,6 @@ def CreateSimRenderer(renderer):
 
                 # transform ray from render-space (Y-up) to simulation-space (Z-up)
                 inv_model_matrix = self._inv_model_matrix.reshape(4, 4)
-
-                print("inv_model_matrix:")
-                print(inv_model_matrix)
 
                 p_h = np.append(camera_pos, 1.0)
                 p_transformed_h = inv_model_matrix @ p_h
@@ -634,32 +624,11 @@ def CreateSimRenderer(renderer):
 
                 dist = self.min_dist.numpy()[0]
                 index = self.min_index.numpy()[0]
-                print("#" * 80)
-                if dist < 1.0e10:
-                    print(f"Hit geom {index} at distance {dist} (out of {num_geoms} total geometries)")
-                    print(f"Mouse coordinates: x={x}, y={y}")
-                    print("""
-    #     #  ###  ##### 
-    #     #   #     #   
-    #     #   #     #   
-    #######   #     #   
-    #     #   #     #   
-    #     #   #     #   
-    #     #  ###    #   
-    """)
-                else:
-                    print(f"No geometry was hit by the ray (out of {num_geoms} total geometries)")
-                    print(f"Mouse coordinates: x={x}, y={y}")
-                print(f"Ray origin: ({p[0]:.3f}, {p[1]:.3f}, {p[2]:.3f})")
-                print(f"Ray direction: ({d[0]:.3f}, {d[1]:.3f}, {d[2]:.3f})")
-                print(f"Camera direction: ({camera_front[0]:.3f}, {camera_front[1]:.3f}, {camera_front[2]:.3f})")
-                # print(f"Camera position: ({self._camera_pos[0]:.3f}, {self._camera_pos[1]:.3f}, {self._camera_pos[2]:.3f})")
-                # # print(f"Camera target: ({self._camera_target[0]:.3f}, {self._camera_target[1]:.3f}, {self._camera_target[2]:.3f})")
-                # print(f"Camera up vector: ({self._camera_up[0]:.3f}, {self._camera_up[1]:.3f}, {self._camera_up[2]:.3f})")
-                # print(f"Camera field of view: {self.camera_fov:.1f} degrees")
-                # print(f"Camera near plane: {self.camera_near_plane:.3f}")
-                # print(f"Camera far plane: {self.camera_far_plane:.3f}")
-                print("#" * 80)
+                if debug:
+                    if dist < 1.0e10:
+                        print("#" * 80)
+                        print(f"Hit geom {index} at distance {dist}")
+                        print("#" * 80)
 
         def render_muscles(
             self,


### PR DESCRIPTION
## Description
Users should be able to use the mouse cursor to interact with a running simulation as requested in https://github.com/newton-physics/newton/issues/59. This MR adds the required functionality.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [~] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
