### PR TITLE
Adds picking support to the OpenGL sim viewer

### DIFF
--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -104,6 +104,7 @@ class Example:
     def simulate(self):
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
+            self.renderer.apply_picking_force(self.state_0)
             self.contacts = self.model.collide(self.state_0)
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
             self.state_0, self.state_1 = self.state_1, self.state_0
@@ -123,7 +124,7 @@ class Example:
         with wp.ScopedTimer("render"):
             self.renderer.begin_frame(self.sim_time)
             self.renderer.render(self.state_0)
-            self.renderer.render_contacts(self.state_0, self.contacts, contact_point_radius=1e-2)
+            self.renderer.render_contacts(self.state_0.body_q, self.contacts, contact_point_radius=1e-2)
             self.renderer.end_frame()
 
 

--- a/newton/geometry/raycast.py
+++ b/newton/geometry/raycast.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import warp as wp
+
+from newton.geometry import (
+    GEO_BOX,
+    GEO_CAPSULE,
+    GEO_CYLINDER,
+    GEO_SPHERE,
+)
+
+# A small constant to avoid division by zero and other numerical issues
+MINVAL = 1e-15
+
+
+@wp.func
+def _spinlock_acquire(lock: wp.array(dtype=wp.int32)):
+    # Try to acquire the lock by setting it to 1 if it's 0
+    while wp.atomic_cas(lock, 0, 0, 1) == 1:
+        pass
+
+
+@wp.func
+def _spinlock_release(lock: wp.array(dtype=wp.int32)):
+    # Release the lock by setting it back to 0
+    wp.atomic_exch(lock, 0, 0)
+
+
+@wp.func
+def ray_intersect_sphere(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float):
+    """Computes ray-sphere intersection.
+
+    Args:
+        geom_to_world: The world transform of the sphere.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the sphere.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
+
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
+    if d_len_sq < MINVAL:
+        return -1.0
+
+    inv_d_len = 1.0 / wp.sqrt(d_len_sq)
+    d_local_norm = ray_direction_local * inv_d_len
+
+    oc = ray_origin_local
+    b = wp.dot(oc, d_local_norm)
+    c = wp.dot(oc, oc) - r * r
+
+    delta = b * b - c
+    if delta >= 0.0:
+        sqrt_delta = wp.sqrt(delta)
+        t1 = -b - sqrt_delta
+        if t1 >= 0.0:
+            t_hit = t1 * inv_d_len
+        else:
+            t2 = -b + sqrt_delta
+            if t2 >= 0.0:
+                t_hit = t2 * inv_d_len
+    return t_hit
+
+
+@wp.func
+def ray_intersect_box(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3):
+    """Computes ray-box intersection.
+
+    Args:
+        geom_to_world: The world transform of the box.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        size: The half-extents of the box.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    t_hit = -1.0
+    t_near = -1.0e10
+    t_far = 1.0e10
+    hit = 1
+
+    for i in range(3):
+        if wp.abs(ray_direction_local[i]) < MINVAL:
+            if ray_origin_local[i] < -size[i] or ray_origin_local[i] > size[i]:
+                hit = 0
+        else:
+            inv_d_i = 1.0 / ray_direction_local[i]
+            t1 = (-size[i] - ray_origin_local[i]) * inv_d_i
+            t2 = (size[i] - ray_origin_local[i]) * inv_d_i
+
+            if t1 > t2:
+                temp = t1
+                t1 = t2
+                t2 = temp
+
+            t_near = wp.max(t_near, t1)
+            t_far = wp.min(t_far, t2)
+
+    if hit == 1 and t_near <= t_far and t_far >= 0.0:
+        if t_near >= 0.0:
+            t_hit = t_near
+        else:
+            t_hit = t_far
+    return t_hit
+
+
+@wp.func
+def ray_intersect_capsule(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float):
+    """Computes ray-capsule intersection.
+
+    Args:
+        geom_to_world: The world transform of the capsule.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the capsule.
+        h: The half-height of the capsule's cylindrical part.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
+
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
+    if d_len_sq < MINVAL:
+        return -1.0
+
+    inv_d_len = 1.0 / wp.sqrt(d_len_sq)
+    d_local_norm = ray_direction_local * inv_d_len
+
+    min_t = 1.0e10
+
+    # Intersection with cylinder body
+    a_cyl = d_local_norm[0] * d_local_norm[0] + d_local_norm[1] * d_local_norm[1]
+    if a_cyl > MINVAL:
+        b_cyl = 2.0 * (ray_origin_local[0] * d_local_norm[0] + ray_origin_local[1] * d_local_norm[1])
+        c_cyl = ray_origin_local[0] * ray_origin_local[0] + ray_origin_local[1] * ray_origin_local[1] - r * r
+        delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+        if delta_cyl >= 0.0:
+            sqrt_delta_cyl = wp.sqrt(delta_cyl)
+            t1 = (-b_cyl - sqrt_delta_cyl) / (2.0 * a_cyl)
+            if t1 >= 0.0:
+                z = ray_origin_local[2] + t1 * d_local_norm[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t1)
+
+            t2 = (-b_cyl + sqrt_delta_cyl) / (2.0 * a_cyl)
+            if t2 >= 0.0:
+                z = ray_origin_local[2] + t2 * d_local_norm[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t2)
+
+    # Intersection with sphere caps
+    # Top cap
+    oc_top = ray_origin_local - wp.vec3(0.0, 0.0, h)
+    b_top = wp.dot(oc_top, d_local_norm)
+    c_top = wp.dot(oc_top, oc_top) - r * r
+    delta_top = b_top * b_top - c_top
+    if delta_top >= 0.0:
+        sqrt_delta_top = wp.sqrt(delta_top)
+        t1_top = -b_top - sqrt_delta_top
+        if t1_top >= 0.0:
+            if (ray_origin_local[2] + t1_top * d_local_norm[2]) >= h:
+                min_t = wp.min(min_t, t1_top)
+
+        t2_top = -b_top + sqrt_delta_top
+        if t2_top >= 0.0:
+            if (ray_origin_local[2] + t2_top * d_local_norm[2]) >= h:
+                min_t = wp.min(min_t, t2_top)
+
+    # Bottom cap
+    oc_bot = ray_origin_local - wp.vec3(0.0, 0.0, -h)
+    b_bot = wp.dot(oc_bot, d_local_norm)
+    c_bot = wp.dot(oc_bot, oc_bot) - r * r
+    delta_bot = b_bot * b_bot - c_bot
+    if delta_bot >= 0.0:
+        sqrt_delta_bot = wp.sqrt(delta_bot)
+        t1_bot = -b_bot - sqrt_delta_bot
+        if t1_bot >= 0.0:
+            if (ray_origin_local[2] + t1_bot * d_local_norm[2]) <= -h:
+                min_t = wp.min(min_t, t1_bot)
+
+        t2_bot = -b_bot + sqrt_delta_bot
+        if t2_bot >= 0.0:
+            if (ray_origin_local[2] + t2_bot * d_local_norm[2]) <= -h:
+                min_t = wp.min(min_t, t2_bot)
+
+    if min_t < 1.0e9:
+        t_hit = min_t * inv_d_len
+
+    return t_hit
+
+
+@wp.func
+def ray_intersect_cylinder(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float
+):
+    """Computes ray-cylinder intersection.
+
+    Args:
+        geom_to_world: The world transform of the cylinder.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the cylinder.
+        h: The half-height of the cylinder.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ray_origin_local = wp.transform_point(world_to_geom, ray_origin)
+    ray_direction_local = wp.transform_vector(world_to_geom, ray_direction)
+
+    t_hit = -1.0
+    min_t = 1.0e10
+
+    # Intersection with cylinder body
+    a_cyl = ray_direction_local[0] * ray_direction_local[0] + ray_direction_local[1] * ray_direction_local[1]
+    if a_cyl > MINVAL:
+        b_cyl = 2.0 * (ray_origin_local[0] * ray_direction_local[0] + ray_origin_local[1] * ray_direction_local[1])
+        c_cyl = ray_origin_local[0] * ray_origin_local[0] + ray_origin_local[1] * ray_origin_local[1] - r * r
+        delta_cyl = b_cyl * b_cyl - 4.0 * a_cyl * c_cyl
+        if delta_cyl >= 0.0:
+            sqrt_delta_cyl = wp.sqrt(delta_cyl)
+            inv_2a = 1.0 / (2.0 * a_cyl)
+            t1 = (-b_cyl - sqrt_delta_cyl) * inv_2a
+            if t1 >= 0.0:
+                z = ray_origin_local[2] + t1 * ray_direction_local[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t1)
+
+            t2 = (-b_cyl + sqrt_delta_cyl) * inv_2a
+            if t2 >= 0.0:
+                z = ray_origin_local[2] + t2 * ray_direction_local[2]
+                if wp.abs(z) <= h:
+                    min_t = wp.min(min_t, t2)
+
+    # Intersection with caps
+    if wp.abs(ray_direction_local[2]) > MINVAL:
+        inv_d_z = 1.0 / ray_direction_local[2]
+        # Top cap
+        t_top = (h - ray_origin_local[2]) * inv_d_z
+        if t_top >= 0.0:
+            x = ray_origin_local[0] + t_top * ray_direction_local[0]
+            y = ray_origin_local[1] + t_top * ray_direction_local[1]
+            if x * x + y * y <= r * r:
+                min_t = wp.min(min_t, t_top)
+
+        # Bottom cap
+        t_bot = (-h - ray_origin_local[2]) * inv_d_z
+        if t_bot >= 0.0:
+            x = ray_origin_local[0] + t_bot * ray_direction_local[0]
+            y = ray_origin_local[1] + t_bot * ray_direction_local[1]
+            if x * x + y * y <= r * r:
+                min_t = wp.min(min_t, t_bot)
+
+    if min_t < 1.0e9:
+        t_hit = min_t
+
+    return t_hit
+
+
+@wp.func
+def ray_intersect_geom(
+    geom_to_world: wp.transform, size: wp.vec3, geomtype: int, ray_origin: wp.vec3, ray_direction: wp.vec3
+):
+    """
+    Computes the intersection of a ray with a geometry.
+
+    Args:
+        geom_to_world: The world-to-shape transform.
+        size: The size of the geometry.
+        geomtype: The type of the geometry.
+        ray_origin: The origin of the ray.
+        ray_direction: The direction of the ray.
+
+    Returns:
+        The distance along the ray to the closest intersection point, or -1.0 if there is no intersection.
+    """
+    t_hit = -1.0
+
+    if geomtype == GEO_SPHERE:
+        r = size[0]
+        t_hit = ray_intersect_sphere(geom_to_world, ray_origin, ray_direction, r)
+
+    elif geomtype == GEO_BOX:
+        t_hit = ray_intersect_box(geom_to_world, ray_origin, ray_direction, size)
+
+    elif geomtype == GEO_CAPSULE:
+        r = size[0]
+        h = size[1]
+        t_hit = ray_intersect_capsule(geom_to_world, ray_origin, ray_direction, r, h)
+
+    elif geomtype == GEO_CYLINDER:
+        r = size[0]
+        h = size[1]
+        t_hit = ray_intersect_cylinder(geom_to_world, ray_origin, ray_direction, r, h)
+
+    return t_hit
+
+
+@wp.kernel
+def raycast_kernel(
+    # Model
+    body_q: wp.array(dtype=wp.transform),
+    shape_body: wp.array(dtype=int),
+    shape_transform: wp.array(dtype=wp.transform),
+    geom_type: wp.array(dtype=int),
+    geom_size: wp.array(dtype=wp.vec3),
+    # Ray
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    # Lock helper
+    lock: wp.array(dtype=wp.int32),
+    # Output
+    min_dist: wp.array(dtype=float),
+    min_index: wp.array(dtype=int),
+    min_body_index: wp.array(dtype=int),
+):
+    """
+    Computes the intersection of a ray with all geometries in the scene.
+
+    Args:
+        body_q: Array of body transforms.
+        shape_body: Maps shape index to body index.
+        shape_transform: Array of local shape transforms.
+        geom_type: Array of geometry types for each geometry.
+        geom_size: Array of sizes for each geometry.
+        ray_origin: The origin of the ray.
+        ray_direction: The direction of the ray.
+        lock: Lock array used for synchronization. Expected to be initialized to 0.
+        min_dist: A single-element array to store the minimum intersection distance. Expected to be initialized to a large value like 1e10.
+        min_index: A single-element array to store the index of the closest geometry. Expected to be initialized to -1.
+        min_body_index: A single-element array to store the body index of the closest geometry. Expected to be initialized to -1.
+    """
+    tid = wp.tid()
+
+    # compute shape transform
+    b = shape_body[tid]
+
+    X_wb = wp.transform_identity()
+    if b >= 0:
+        X_wb = body_q[b]
+
+    X_bs = shape_transform[tid]
+
+    geom_to_world = wp.mul(X_wb, X_bs)
+
+    geomtype = geom_type[tid]
+
+    t = ray_intersect_geom(geom_to_world, geom_size[tid], geomtype, ray_origin, ray_direction)
+
+    if t >= 0.0 and t < min_dist[0]:
+        _spinlock_acquire(lock)
+        # Still use an atomic inside the spinlock to get a volatile read
+        old_min = wp.atomic_min(min_dist, 0, t)
+        if t <= old_min:
+            min_index[0] = tid
+            min_body_index[0] = b
+        _spinlock_release(lock)

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import warp as wp
+
+from newton.geometry import GEO_BOX, GEO_CAPSULE, GEO_CYLINDER, GEO_SPHERE
+from newton.geometry.raycast import (
+    ray_intersect_geom,
+    ray_intersect_box,
+    ray_intersect_capsule,
+    ray_intersect_cylinder,
+    ray_intersect_sphere,
+)
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+wp.config.quiet = True
+
+
+class TestRaycast(unittest.TestCase):
+    pass
+
+
+# Kernels to test ray intersection functions
+@wp.kernel
+def kernel_test_sphere(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_sphere(geom_to_world, ray_origin, ray_direction, r)
+
+
+@wp.kernel
+def kernel_test_box(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    size: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_box(geom_to_world, ray_origin, ray_direction, size)
+
+
+@wp.kernel
+def kernel_test_capsule(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+    h: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_capsule(geom_to_world, ray_origin, ray_direction, r, h)
+
+
+@wp.kernel
+def kernel_test_cylinder(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    r: float,
+    h: float,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_cylinder(geom_to_world, ray_origin, ray_direction, r, h)
+
+
+@wp.kernel
+def kernel_test_geom(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    size: wp.vec3,
+    geomtype: int,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_geom(geom_to_world, size, geomtype, ray_origin, ray_direction)
+
+
+# Test functions
+def test_ray_intersect_sphere(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 1.0
+
+    # Case 1: Ray hits sphere
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 2: Ray misses sphere
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    # Case 3: Ray starts inside
+    ray_origin = wp.vec3(0.0, 0.0, 0.0)
+    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+
+def test_ray_intersect_box(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    size = wp.vec3(1.0, 1.0, 1.0)
+
+    # Case 1: Ray hits box
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 2: Ray misses box
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    # Case 3: Ray starts inside
+    ray_origin = wp.vec3(0.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 4: Rotated box
+    # Rotate 45 degrees around Z axis
+    rot = wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.785398)  # pi/4
+    geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 0.0), rot)
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.41421, delta=1e-5)
+
+
+def test_ray_intersect_capsule(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 0.5
+    h = 1.0
+
+    # Case 1: Hit cylinder part
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Case 2: Hit top cap
+    ray_origin = wp.vec3(0.0, 0.0, -2.0)
+    ray_direction = wp.vec3(0.0, 0.0, 1.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.0 - 0.5, delta=1e-5)
+
+    # Case 3: Miss
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+
+def test_ray_intersect_cylinder(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    r = 0.5
+    h = 1.0
+
+    # Case 1: Hit cylinder body
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Case 2: Hit top cap
+    ray_origin = wp.vec3(0.0, 0.0, -2.0)
+    ray_direction = wp.vec3(0.0, 0.0, 1.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Case 3: Miss
+    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    wp.launch(
+        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+
+def test_geom_ray_intersect(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+    ray_direction = wp.vec3(1.0, 0.0, 0.0)
+
+    # Sphere
+    size = wp.vec3(1.0, 0.0, 0.0)  # r
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_SPHERE, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Box
+    size = wp.vec3(1.0, 1.0, 1.0)  # half-extents
+    wp.launch(
+        kernel_test_geom, dim=1, inputs=[out_t, geom_to_world, size, GEO_BOX, ray_origin, ray_direction], device=device
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+    # Capsule
+    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_CAPSULE, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+    # Cylinder
+    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GEO_CYLINDER, ray_origin, ray_direction],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+
+devices = get_test_devices()
+for device in devices:
+    add_function_test(TestRaycast, f"test_ray_intersect_sphere_{device}", test_ray_intersect_sphere, devices=[device])
+    add_function_test(TestRaycast, f"test_ray_intersect_box_{device}", test_ray_intersect_box, devices=[device])
+    add_function_test(TestRaycast, f"test_ray_intersect_capsule_{device}", test_ray_intersect_capsule, devices=[device])
+    add_function_test(
+        TestRaycast, f"test_ray_intersect_cylinder_{device}", test_ray_intersect_cylinder, devices=[device]
+    )
+    add_function_test(TestRaycast, f"test_geom_ray_intersect_{device}", test_geom_ray_intersect, devices=[device])
+
+
+if __name__ == "__main__":
+    wp.clear_kernel_cache()
+    unittest.main(verbosity=2)

--- a/newton/utils/render.py
+++ b/newton/utils/render.py
@@ -19,10 +19,104 @@ from collections import defaultdict
 
 import numpy as np
 import warp as wp
+from pyglet.window import mouse
 from warp.render import OpenGLRenderer, UsdRenderer
 from warp.render.utils import solidify_mesh, tab10_color_map
 
 import newton
+from newton.geometry import raycast
+
+
+@wp.kernel
+def compute_pick_state_kernel(
+    body_q: wp.array(dtype=wp.transform),
+    body_index: int,
+    hit_point_world: wp.vec3,
+    # output
+    pick_body: wp.array(dtype=int),
+    pick_state: wp.array(dtype=float),
+):
+    if body_index < 0:
+        return
+
+    # store body index
+    pick_body[0] = body_index
+
+    # store target world
+    pick_state[3] = hit_point_world[0]
+    pick_state[4] = hit_point_world[1]
+    pick_state[5] = hit_point_world[2]
+
+    # compute and store local space attachment point
+    X_wb = body_q[body_index]
+    X_bw = wp.transform_inverse(X_wb)
+    pick_pos_local = wp.transform_point(X_bw, hit_point_world)
+
+    pick_state[0] = pick_pos_local[0]
+    pick_state[1] = pick_pos_local[1]
+    pick_state[2] = pick_pos_local[2]
+
+
+@wp.kernel
+def apply_picking_force_kernel(
+    body_q: wp.array(dtype=wp.transform),
+    body_qd: wp.array(dtype=wp.spatial_vector),
+    body_f: wp.array(dtype=wp.spatial_vector),
+    pick_body_arr: wp.array(dtype=int),
+    pick_state: wp.array(dtype=float),
+):
+    pick_body = pick_body_arr[0]
+    if pick_body < 0:
+        return
+
+    pick_pos_local = wp.vec3(pick_state[0], pick_state[1], pick_state[2])
+    pick_target_world = wp.vec3(pick_state[3], pick_state[4], pick_state[5])
+    pick_stiffness = pick_state[6]
+    pick_damping = pick_state[7]
+    angular_damping = 1.0  # Damping coefficient for angular velocity
+
+    # world space attachment point
+    X_wb = body_q[pick_body]
+    pick_pos_world = wp.transform_point(X_wb, pick_pos_local)
+
+    # center of mass
+    com = wp.transform_get_translation(X_wb)
+
+    # get velocity of attachment point
+    omega = wp.spatial_top(body_qd[pick_body])
+    vel_com = wp.spatial_bottom(body_qd[pick_body])
+    vel_world = vel_com + wp.cross(omega, pick_pos_world - com)
+
+    # compute spring force
+    f = pick_stiffness * (pick_target_world - pick_pos_world) - pick_damping * vel_world
+
+    # compute torque with angular damping
+    t = wp.cross(pick_pos_world - com, f) - angular_damping * omega
+
+    # apply force and torque
+    wp.atomic_add(body_f, pick_body, wp.spatial_vector(t, f))
+
+
+@wp.kernel
+def update_pick_target_kernel(
+    p: wp.vec3,
+    d: wp.vec3,
+    pick_camera_front: wp.vec3,
+    # read-write
+    pick_state: wp.array(dtype=float),
+):
+    # get current target position
+    current_target = wp.vec3(pick_state[3], pick_state[4], pick_state[5])
+
+    # compute distance from ray origin to current target
+    dist = wp.length(current_target - p)
+
+    # project new target onto sphere with same radius
+    new_target = p + d * dist
+
+    pick_state[3] = new_target[0]
+    pick_state[4] = new_target[1]
+    pick_state[5] = new_target[2]
 
 
 @wp.kernel
@@ -79,6 +173,8 @@ def CreateSimRenderer(renderer):
             up_axis: newton.AxisType | None = None,
             show_joints: bool = False,
             show_particles: bool = True,
+            pick_stiffness: float = 20000.0,
+            pick_damping: float = 2000.0,
             **render_kwargs,
         ):
             """
@@ -91,6 +187,8 @@ def CreateSimRenderer(renderer):
                 up_axis (newton.AxisType, optional): The up-axis for the scene. If not provided, it's inferred from the model, or defaults to "Z" if no model is given. Defaults to None.
                 show_joints (bool, optional): Whether to visualize joints. Defaults to False.
                 show_particles (bool, optional): Whether to visualize particles. Defaults to True.
+                pick_stiffness (float, optional): Stiffness of the picking force. Defaults to 20000.0.
+                pick_damping (float, optional): Damping of the picking force. Defaults to 2000.0.
                 **render_kwargs: Additional keyword arguments for the underlying renderer.
             """
             if up_axis is None:
@@ -108,8 +206,37 @@ def CreateSimRenderer(renderer):
             if model:
                 self.populate(model)
 
+            self.state = None
+            self.min_dist = None
+            self.min_index = None
+            self.min_body_index = None
+            self.lock = None
             self._contact_points0 = None
             self._contact_points1 = None
+
+            # picking state
+            self.pick_body = wp.array([-1], dtype=int, device=model.device if model else "cpu", pinned=True)
+            # pick_state array format (stored in a warp array for graph capture support):
+            # [0:3] - pick point in world space (vec3)
+            # [3:6] - pick target point in world space (vec3)
+            # [6] - pick spring stiffness
+            # [7] - pick spring damping
+            pick_state_np = np.zeros(8, dtype=np.float32)
+            if model:
+                pick_state_np[6] = pick_stiffness
+                pick_state_np[7] = pick_damping
+            self.pick_state = wp.array(pick_state_np, dtype=float, device=model.device if model else "cpu")
+
+            self.pick_dist = 0.0
+            self.pick_camera_front = wp.vec3()
+            self._default_on_mouse_drag = None
+
+            if isinstance(self, OpenGLRenderer):
+                if not self.headless:
+                    self.window.on_mouse_press = self.on_mouse_press
+                    self.window.on_mouse_release = self.on_mouse_release
+                    self._default_on_mouse_drag = self.window.on_mouse_drag
+                    self.window.on_mouse_drag = self.on_mouse_drag
 
         def populate(self, model: newton.Model):
             """
@@ -450,12 +577,33 @@ def CreateSimRenderer(renderer):
             """
             return tab10_color_map(instance_count)
 
+        def apply_picking_force(self, state: newton.State):
+            """Applies a force to the body at the picking position.
+            Args:
+                state (newton.State): The simulation state.
+            """
+            # Launch kernel always because of graph capture
+            wp.launch(
+                kernel=apply_picking_force_kernel,
+                dim=1,
+                inputs=[
+                    state.body_q,
+                    state.body_qd,
+                    state.body_f,
+                    self.pick_body,
+                    self.pick_state,
+                ],
+                device=self.model.device,
+            )
+
         def render(self, state: newton.State):
             """
             Updates the renderer with the given simulation state.
             Args:
                 state (newton.State): The simulation state to render.
             """
+            self.state = state
+
             if self.skip_rendering:
                 return
 
@@ -480,6 +628,8 @@ def CreateSimRenderer(renderer):
             # update bodies
             if self.model.body_count:
                 self.update_body_transforms(state.body_q)
+
+            self.state = state
 
         def render_particles_and_springs(
             self,
@@ -511,6 +661,159 @@ def CreateSimRenderer(renderer):
             # render springs
             if spring_indices is not None:
                 self.render_line_list("springs", particle_q, spring_indices.flatten(), (0.25, 0.5, 0.25), 0.02)
+
+        def on_mouse_press(self, x, y, button, modifiers):
+            # action 1 for press
+            self.on_mouse_click(x, y, button, 1)
+
+        def on_mouse_release(self, x, y, button, modifiers):
+            # action 0 for release
+            self.pick_body.fill_(-1)
+            self.on_mouse_click(x, y, button, 0)
+
+        def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+            if self.pick_body.numpy()[0] < 0:
+                # default camera controls
+                if self._default_on_mouse_drag:
+                    self._default_on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+                return
+
+            p, d, _ = self.get_world_ray(x, y)
+            d = wp.normalize(d)
+
+            wp.launch(
+                kernel=update_pick_target_kernel,
+                dim=1,
+                inputs=[
+                    p,
+                    d,
+                    self.pick_camera_front,
+                    self.pick_state,
+                ],
+                device=self.model.device,
+            )
+
+        def get_world_ray(self, x: float, y: float) -> tuple[wp.vec3, wp.vec3, np.ndarray]:
+            # aspect ratio
+            aspect_ratio = self.screen_width / self.screen_height
+
+            # pre-compute factor from vertical FOV
+            fov_rad = np.radians(self.camera_fov)
+            alpha = np.tan(fov_rad * 0.5)  # = tan(fov/2)
+
+            # camera vectors → NumPy
+            camera_front = np.array(self._camera_front, dtype=np.float32)
+            camera_up = np.array(self._camera_up, dtype=np.float32)
+            camera_pos = np.array(self._camera_pos, dtype=np.float32)
+
+            # build an orthonormal basis (front, right, up)
+            front = camera_front / np.linalg.norm(camera_front)
+            right = np.cross(front, camera_up)
+            right = right / np.linalg.norm(right)
+            up = np.cross(right, front)  # already unit length
+
+            # normalised pixel coordinates
+            u = 2.0 * (x / self.screen_width) - 1.0  # [-1, 1] left → right
+            v = 2.0 * (y / self.screen_height) - 1.0  # [-1, 1] bottom → top
+
+            # ray direction in world space (before normalisation)
+            direction = front + u * alpha * aspect_ratio * right + v * alpha * up
+            direction = direction / np.linalg.norm(direction)
+
+            # transform ray from render-space to simulation-space
+            inv_model_matrix = self._inv_model_matrix.reshape(4, 4)
+
+            p_h = np.append(camera_pos, 1.0)
+            p_transformed_h = inv_model_matrix @ p_h
+            p_sim = p_transformed_h[:3]
+
+            d_h = np.append(direction, 0.0)
+            d_transformed_h = inv_model_matrix @ d_h
+            d_sim = d_transformed_h[:3]
+
+            # output
+            p = wp.vec3(p_sim[0], p_sim[1], p_sim[2])  # ray origin
+            d = wp.vec3(d_sim[0], d_sim[1], d_sim[2])  # ray direction
+
+            return p, d, camera_front
+
+        def on_mouse_click(self, x, y, button, action):
+            # want to pick on mouse-down events
+            if action != 1:  # Press
+                return
+
+            if button == mouse.RIGHT:  # right-click
+                if self.state is None:
+                    return
+
+                p, d, camera_front = self.get_world_ray(x, y)
+
+                debug = False
+                if debug and isinstance(self, SimRendererOpenGL):
+                    p_np = np.array([p[0], p[1], p[2]])
+                    d_np = np.array([d[0], d[1], d[2]])
+                    # use a large length for visualization
+                    end_point = p_np + d_np * 1000.0
+                    self.render_line_strip("__picking_ray__", [p_np, end_point], color=(1.0, 1.0, 0.0), radius=0.005)
+
+                num_geoms = self.model.shape_count
+                if num_geoms == 0:
+                    return
+
+                if self.min_dist is None:
+                    self.min_dist = wp.array([1.0e10], dtype=float, device=self.model.device)
+                    self.min_index = wp.array([-1], dtype=int, device=self.model.device)
+                    self.min_body_index = wp.array([-1], dtype=int, device=self.model.device)
+                    self.lock = wp.array([0], dtype=wp.int32, device=self.model.device)
+                else:
+                    self.min_dist.fill_(1.0e10)
+                    self.min_index.fill_(-1)
+                    self.min_body_index.fill_(-1)
+                    self.lock.zero_()
+
+                wp.launch(
+                    kernel=raycast.raycast_kernel,
+                    dim=num_geoms,
+                    inputs=[
+                        self.state.body_q,
+                        self.model.shape_body,
+                        self.model.shape_transform,
+                        self.model.shape_geo.type,
+                        self.model.shape_geo.scale,
+                        p,
+                        d,
+                        self.lock,
+                    ],
+                    outputs=[self.min_dist, self.min_index, self.min_body_index],
+                    device=self.model.device,
+                )
+                wp.synchronize()
+
+                dist = self.min_dist.numpy()[0]
+                index = self.min_index.numpy()[0]
+                body_index = self.min_body_index.numpy()[0]
+
+                if dist < 1.0e10 and body_index >= 0:
+                    self.pick_dist = dist
+                    self.pick_camera_front = wp.vec3(camera_front[0], camera_front[1], camera_front[2])
+
+                    # world space hit point
+                    hit_point_world = p + d * dist
+
+                    wp.launch(
+                        kernel=compute_pick_state_kernel,
+                        dim=1,
+                        inputs=[self.state.body_q, body_index, hit_point_world],
+                        outputs=[self.pick_body, self.pick_state],
+                        device=self.model.device,
+                    )
+                    wp.synchronize()
+
+                if debug:
+                    if dist < 1.0e10:
+                        print("#" * 80)
+                        print(f"Hit geom {index} of body {body_index} at distance {dist}")
+                        print("#" * 80)
 
         def render_muscles(
             self,


### PR DESCRIPTION
## Description
Users should be able to use the mouse cursor to interact with a running simulation as requested in https://github.com/newton-physics/newton/issues/59. This MR adds the required functionality.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [~] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
