### PR TITLE
Fix inertia matrix format in usd parser

### DIFF
--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -984,7 +984,7 @@ def parse_usd(
             if np.linalg.norm(i_diag) > 0.0:
                 rot = np.array(wp.quat_to_matrix(i_rot), dtype=np.float32).reshape(3, 3)
                 inertia = rot @ np.diag(i_diag) @ rot.T
-                builder.body_inertia[body_id] = inertia
+                builder.body_inertia[body_id] = wp.mat33(inertia)
                 if inertia.any():
                     builder.body_inv_inertia[body_id] = wp.inverse(wp.mat33(*inertia))
                 else:


### PR DESCRIPTION
## Description
In `ModelBuilder`, `self.body_inertia` is expected to be a list of `wp.mat33`. The USD parser could add a `np.ndarray` instead.

## Newton Migration Guide
- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
