### PR TITLE
MJCF importer: correctly rotate inertia tensor

### DIFF
--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -117,6 +117,92 @@ class TestImportMjcf(unittest.TestCase):
                 self.assertEqual(meshes[1].maxhullvert, 128)
                 self.assertEqual(meshes[2].maxhullvert, 64)  # Default value
 
+    def test_inertia_rotation(self):
+        """Test that inertia tensors are properly rotated using sandwich product R @ I @ R.T"""
+        
+        # Test case 1: Diagonal inertia with rotation
+        mjcf_diagonal = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test_diagonal">
+    <worldbody>
+        <body>
+            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068" 
+                      mass="1.0" diaginertia="1.0 2.0 3.0"/>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+        # Test case 2: Full inertia with rotation
+        mjcf_full = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test_full">
+    <worldbody>
+        <body>
+            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068" 
+                      mass="1.0" fullinertia="1.0 2.0 3.0 0.1 0.2 0.3"/>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+        # Test diagonal inertia rotation
+        builder = newton.ModelBuilder()
+        newton.utils.parse_mjcf(mjcf_diagonal, builder, ignore_inertial_definitions=False)
+        model = builder.finalize()
+
+        # The quaternion (0.7071068, 0, 0, 0.7071068) in MuJoCo WXYZ format represents a 90-degree rotation around Z-axis
+        # This transforms the diagonal inertia [1, 2, 3] to [2, 1, 3] via sandwich product R @ I @ R.T
+        expected_diagonal = np.array([[2.0, 0.0, 0.0],
+                                     [0.0, 1.0, 0.0],
+                                     [0.0, 0.0, 3.0]])
+        
+        actual_inertia = model.body_inertia.numpy()[0]
+        np.testing.assert_array_almost_equal(actual_inertia, expected_diagonal, decimal=6)
+
+        # Test full inertia rotation
+        builder = newton.ModelBuilder()
+        newton.utils.parse_mjcf(mjcf_full, builder, ignore_inertial_definitions=False)
+        model = builder.finalize()
+
+        # For full inertia, we need to compute the expected result manually
+        # Original inertia matrix:
+        # [1.0  0.1  0.2]
+        # [0.1  2.0  0.3]
+        # [0.2  0.3  3.0]
+        
+        # The quaternion (0.7071068, 0, 0, 0.7071068) transforms the inertia
+        # We need to use the same quaternion-to-matrix conversion as the MJCF importer
+        
+        original_inertia = np.array([[1.0, 0.1, 0.2],
+                                    [0.1, 2.0, 0.3],
+                                    [0.2, 0.3, 3.0]])
+        
+        # For full inertia, calculate the expected result analytically using the same quaternion
+        # Original inertia matrix:
+        # [1.0  0.1  0.2]
+        # [0.1  2.0  0.3]
+        # [0.2  0.3  3.0]
+        
+        # The quaternion (0.7071068, 0, 0, 0.7071068) in MuJoCo WXYZ format represents a 90-degree rotation around Z-axis
+        # Calculate the expected result analytically using the correct rotation matrix
+        # For a 90-degree Z-axis rotation: R = [0 -1 0; 1 0 0; 0 0 1]
+        
+        original_inertia = np.array([[1.0, 0.1, 0.2],
+                                    [0.1, 2.0, 0.3],
+                                    [0.2, 0.3, 3.0]])
+        
+        # Rotation matrix for 90-degree rotation around Z-axis
+        rotation_matrix = np.array([[0.0, -1.0, 0.0],
+                                   [1.0, 0.0, 0.0],
+                                   [0.0, 0.0, 1.0]])
+        
+        expected_full = rotation_matrix @ original_inertia @ rotation_matrix.T
+        
+        actual_inertia = model.body_inertia.numpy()[0]
+        np.testing.assert_array_almost_equal(actual_inertia, expected_full, decimal=6)
+
+        # Verify that the rotation was actually applied (not just identity)
+        assert not np.allclose(actual_inertia, original_inertia, atol=1e-6)
+
 
 if __name__ == "__main__":
     wp.clear_kernel_cache()

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -119,7 +119,7 @@ class TestImportMjcf(unittest.TestCase):
 
     def test_inertia_rotation(self):
         """Test that inertia tensors are properly rotated using sandwich product R @ I @ R.T"""
-        
+
         # Test case 1: Diagonal inertia with rotation
         mjcf_diagonal = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="test_diagonal">
@@ -151,10 +151,8 @@ class TestImportMjcf(unittest.TestCase):
 
         # The quaternion (0.7071068, 0, 0, 0.7071068) in MuJoCo WXYZ format represents a 90-degree rotation around Z-axis
         # This transforms the diagonal inertia [1, 2, 3] to [2, 1, 3] via sandwich product R @ I @ R.T
-        expected_diagonal = np.array([[2.0, 0.0, 0.0],
-                                     [0.0, 1.0, 0.0],
-                                     [0.0, 0.0, 3.0]])
-        
+        expected_diagonal = np.array([[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 3.0]])
+
         actual_inertia = model.body_inertia.numpy()[0]
         np.testing.assert_array_almost_equal(actual_inertia, expected_diagonal, decimal=6)
 
@@ -168,35 +166,29 @@ class TestImportMjcf(unittest.TestCase):
         # [1.0  0.1  0.2]
         # [0.1  2.0  0.3]
         # [0.2  0.3  3.0]
-        
+
         # The quaternion (0.7071068, 0, 0, 0.7071068) transforms the inertia
         # We need to use the same quaternion-to-matrix conversion as the MJCF importer
-        
-        original_inertia = np.array([[1.0, 0.1, 0.2],
-                                    [0.1, 2.0, 0.3],
-                                    [0.2, 0.3, 3.0]])
-        
+
+        original_inertia = np.array([[1.0, 0.1, 0.2], [0.1, 2.0, 0.3], [0.2, 0.3, 3.0]])
+
         # For full inertia, calculate the expected result analytically using the same quaternion
         # Original inertia matrix:
         # [1.0  0.1  0.2]
         # [0.1  2.0  0.3]
         # [0.2  0.3  3.0]
-        
+
         # The quaternion (0.7071068, 0, 0, 0.7071068) in MuJoCo WXYZ format represents a 90-degree rotation around Z-axis
         # Calculate the expected result analytically using the correct rotation matrix
         # For a 90-degree Z-axis rotation: R = [0 -1 0; 1 0 0; 0 0 1]
-        
-        original_inertia = np.array([[1.0, 0.1, 0.2],
-                                    [0.1, 2.0, 0.3],
-                                    [0.2, 0.3, 3.0]])
-        
+
+        original_inertia = np.array([[1.0, 0.1, 0.2], [0.1, 2.0, 0.3], [0.2, 0.3, 3.0]])
+
         # Rotation matrix for 90-degree rotation around Z-axis
-        rotation_matrix = np.array([[0.0, -1.0, 0.0],
-                                   [1.0, 0.0, 0.0],
-                                   [0.0, 0.0, 1.0]])
-        
+        rotation_matrix = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+
         expected_full = rotation_matrix @ original_inertia @ rotation_matrix.T
-        
+
         actual_inertia = model.body_inertia.numpy()[0]
         np.testing.assert_array_almost_equal(actual_inertia, expected_full, decimal=6)
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -125,7 +125,7 @@ class TestImportMjcf(unittest.TestCase):
 <mujoco model="test_diagonal">
     <worldbody>
         <body>
-            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068" 
+            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068"
                       mass="1.0" diaginertia="1.0 2.0 3.0"/>
         </body>
     </worldbody>
@@ -137,7 +137,7 @@ class TestImportMjcf(unittest.TestCase):
 <mujoco model="test_full">
     <worldbody>
         <body>
-            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068" 
+            <inertial pos="0 0 0" quat="0.7071068 0 0 0.7071068"
                       mass="1.0" fullinertia="1.0 2.0 3.0 0.1 0.2 0.3"/>
         </body>
     </worldbody>

--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -89,7 +89,7 @@ def parse_mjcf(
         xform = wp.transform(*xform)
 
     # Check if input is XML string content or a file path
-    if mjcf_filename_or_string.strip().startswith('<?xml') or mjcf_filename_or_string.strip().startswith('<mujoco'):
+    if mjcf_filename_or_string.strip().startswith("<?xml") or mjcf_filename_or_string.strip().startswith("<mujoco"):
         # It's XML string content
         root = ET.fromstring(mjcf_filename_or_string)
         mjcf_dirname = "."
@@ -710,7 +710,6 @@ def parse_mjcf(
                 I_m[1, 0] = I_m[0, 1]
                 I_m[2, 0] = I_m[0, 2]
                 I_m[2, 1] = I_m[1, 2]
-                
 
             rot = wp.quat_to_matrix(inertial_frame.q)
             rot_np = np.array(rot).reshape(3, 3)

--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -31,7 +31,7 @@ from newton.sim import ModelBuilder
 
 
 def parse_mjcf(
-    mjcf_filename: str,
+    mjcf_filename_or_string: str,
     builder: ModelBuilder,
     xform: Transform | None = None,
     floating: bool | None = None,
@@ -59,7 +59,7 @@ def parse_mjcf(
     Parses MuJoCo XML (MJCF) file and adds the bodies and joints to the given ModelBuilder.
 
     Args:
-        mjcf_filename (str): The filename of the MuJoCo file to parse.
+        mjcf_filename_or_string (str): The filename of the MuJoCo file to parse, or the MJCF XML string content.
         builder (ModelBuilder): The :class:`ModelBuilder` to add the bodies and joints to.
         xform (Transform): The transform to apply to the imported mechanism.
         floating (bool): If True, the articulation is treated as a floating base. If False, the articulation is treated as a fixed base. If None, the articulation is treated as a floating base if a free joint is found in the MJCF, otherwise it is treated as a fixed base.
@@ -88,9 +88,16 @@ def parse_mjcf(
     else:
         xform = wp.transform(*xform)
 
-    mjcf_dirname = os.path.dirname(mjcf_filename)
-    file = ET.parse(mjcf_filename)
-    root = file.getroot()
+    # Check if input is XML string content or a file path
+    if mjcf_filename_or_string.strip().startswith('<?xml') or mjcf_filename_or_string.strip().startswith('<mujoco'):
+        # It's XML string content
+        root = ET.fromstring(mjcf_filename_or_string)
+        mjcf_dirname = "."
+    else:
+        # It's a file path
+        mjcf_dirname = os.path.dirname(mjcf_filename_or_string)
+        file = ET.parse(mjcf_filename_or_string)
+        root = file.getroot()
 
     use_degrees = True  # angles are in degrees by default
     euler_seq = [0, 1, 2]  # XYZ by default

--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -703,8 +703,12 @@ def parse_mjcf(
                 I_m[1, 0] = I_m[0, 1]
                 I_m[2, 0] = I_m[0, 2]
                 I_m[2, 1] = I_m[1, 2]
+                
+
             rot = wp.quat_to_matrix(inertial_frame.q)
-            I_m = rot @ wp.mat33(I_m)
+            rot_np = np.array(rot).reshape(3, 3)
+            I_m = rot_np @ I_m @ rot_np.T
+            I_m = wp.mat33(I_m)
             m = float(inertial_attrib.get("mass", "0"))
             builder.body_mass[link] = m
             builder.body_inv_mass[link] = 1.0 / m if m > 0.0 else 0.0


### PR DESCRIPTION
based on #442 

Adds:
* correct rotation of inertia tensor
* an entry point to mjcf importer that allows us to pass a string (mostly useful for testing)
* tests for inertia rotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a test to verify correct rotation of inertia tensors when importing MJCF files.

* **Bug Fixes**
  * Corrected the rotation of inertia tensors during MJCF import to ensure accurate physical behavior.

* **Chores**
  * Improved MJCF import functionality to support both file paths and raw XML strings as input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->