### PR TITLE
Switch to velocity-space ik to support all joint types

### DIFF
--- a/newton/examples/example_ik_benchmark.py
+++ b/newton/examples/example_ik_benchmark.py
@@ -178,6 +178,7 @@ class Example:
                     max_problems,
                     n_residuals,
                     len(self.cfg.ee_links) * 3 + ee * 3,
+                    canonicalize_quat_err=False,
                 )
             )
 

--- a/newton/tests/test_ik.py
+++ b/newton/tests/test_ik.py
@@ -26,7 +26,7 @@ import newton.sim.ik as ik
 from newton.tests.unittest_utils import add_function_test, assert_np_equal, get_test_devices
 
 # ----------------------------------------------------------------------------
-# helpers
+# helpers: planar 2-revolute baseline
 # ----------------------------------------------------------------------------
 
 
@@ -62,6 +62,70 @@ def _build_two_link_planar(device) -> newton.Model:
     return model
 
 
+# ----------------------------------------------------------------------------
+# helpers - FREE-REV
+# ----------------------------------------------------------------------------
+
+
+def _build_free_plus_revolute(device) -> newton.Model:
+    """
+    Returns a model whose root link is attached with a FREE joint
+    followed by one REV link.
+    """
+    builder = newton.ModelBuilder()
+
+    link1 = builder.add_body(
+        xform=wp.transform([0.0, 0.0, 0.0], wp.quat_identity()),
+        mass=1.0,
+    )
+    builder.add_joint_free(
+        parent=-1,
+        child=link1,
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+
+    link2 = builder.add_body(
+        xform=wp.transform([1.0, 0.0, 0.0], wp.quat_identity()),
+        mass=1.0,
+    )
+    builder.add_joint_revolute(
+        parent=link1,
+        child=link2,
+        parent_xform=wp.transform([0.5, 0.0, 0.0], wp.quat_identity()),
+        child_xform=wp.transform([-0.5, 0.0, 0.0], wp.quat_identity()),
+        axis=[0.0, 0.0, 1.0],
+    )
+
+    model = builder.finalize(device=device, requires_grad=True)
+    return model
+
+
+# ----------------------------------------------------------------------------
+# helpers - D6
+# ----------------------------------------------------------------------------
+
+
+def _build_single_d6(device) -> newton.Model:
+    builder = newton.ModelBuilder()
+    cfg = newton.ModelBuilder.JointDofConfig
+    link = builder.add_body(xform=wp.transform_identity(), mass=1.0)
+    builder.add_joint_d6(
+        parent=-1,
+        child=link,
+        linear_axes=[cfg(axis=newton.Axis.X), cfg(axis=newton.Axis.Y), cfg(axis=newton.Axis.Z)],
+        angular_axes=[cfg(axis=[1, 0, 0]), cfg(axis=[0, 1, 0]), cfg(axis=[0, 0, 1])],
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    return builder.finalize(device=device, requires_grad=True)
+
+
+# ----------------------------------------------------------------------------
+# common FK utility
+# ----------------------------------------------------------------------------
+
+
 def _fk_end_effector_positions(
     model: newton.Model, body_q_2d: wp.array, n_problems: int, ee_link_index: int, ee_offset: wp.vec3
 ) -> np.ndarray:
@@ -79,11 +143,11 @@ def _fk_end_effector_positions(
 
 
 # ----------------------------------------------------------------------------
-# 1.  Convergence tests (one per Jacobian mode)
+# 1.  Convergence tests
 # ----------------------------------------------------------------------------
 
 
-def _convergence_test(test, device, mode: ik.JacobianMode):
+def _convergence_test_planar(test, device, mode: ik.JacobianMode):
     with wp.ScopedDevice(device):
         n_problems = 3
         model = _build_two_link_planar(device)
@@ -133,15 +197,114 @@ def _convergence_test(test, device, mode: ik.JacobianMode):
 
 
 def test_convergence_autodiff(test, device):
-    _convergence_test(test, device, ik.JacobianMode.AUTODIFF)
+    _convergence_test_planar(test, device, ik.JacobianMode.AUTODIFF)
 
 
 def test_convergence_analytic(test, device):
-    _convergence_test(test, device, ik.JacobianMode.ANALYTIC)
+    _convergence_test_planar(test, device, ik.JacobianMode.ANALYTIC)
 
 
 def test_convergence_mixed(test, device):
-    _convergence_test(test, device, ik.JacobianMode.MIXED)
+    _convergence_test_planar(test, device, ik.JacobianMode.MIXED)
+
+
+def _convergence_test_free(test, device, mode: ik.JacobianMode):
+    with wp.ScopedDevice(device):
+        n_problems = 3
+        model = _build_free_plus_revolute(device)
+
+        requires_grad = mode in [ik.JacobianMode.AUTODIFF, ik.JacobianMode.MIXED]
+        joint_q_2d = wp.zeros((n_problems, model.joint_coord_count), dtype=wp.float32, requires_grad=requires_grad)
+        joint_qd_2d = wp.zeros((n_problems, model.joint_dof_count), dtype=wp.float32)
+        body_q_2d = wp.zeros((n_problems, model.body_count), dtype=wp.transform)
+        body_qd_2d = wp.zeros((n_problems, model.body_count), dtype=wp.spatial_vector)
+
+        targets = wp.array([[1.0, 1.0, 0.0]] * n_problems, dtype=wp.vec3)
+        ee_link = 1  # second body
+        ee_off = wp.vec3(0.5, 0.0, 0.0)
+
+        pos_obj = ik.PositionObjective(
+            link_index=ee_link,
+            link_offset=ee_off,
+            target_positions=targets,
+            n_problems=n_problems,
+            total_residuals=3,
+            residual_offset=0,
+        )
+
+        solver = ik.IKSolver(model, joint_q_2d, [pos_obj], lambda_initial=1e-3, jacobian_mode=mode)
+
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        initial = _fk_end_effector_positions(model, body_q_2d, n_problems, ee_link, ee_off)
+
+        solver.solve(iterations=60)
+
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        final = _fk_end_effector_positions(model, body_q_2d, n_problems, ee_link, ee_off)
+
+        for prob in range(n_problems):
+            err0 = np.linalg.norm(initial[prob] - targets.numpy()[prob])
+            err1 = np.linalg.norm(final[prob] - targets.numpy()[prob])
+            test.assertLess(err1, err0, f"[FREE] mode {mode} problem {prob} did not improve")
+            test.assertLess(err1, 1e-3, f"[FREE] mode {mode} problem {prob} final error too high ({err1:.3f})")
+
+
+def test_convergence_autodiff_free(test, device):
+    _convergence_test_free(test, device, ik.JacobianMode.AUTODIFF)
+
+
+def test_convergence_analytic_free(test, device):
+    _convergence_test_free(test, device, ik.JacobianMode.ANALYTIC)
+
+
+def test_convergence_mixed_free(test, device):
+    _convergence_test_free(test, device, ik.JacobianMode.MIXED)
+
+
+def _convergence_test_d6(test, device, mode: ik.JacobianMode):
+    with wp.ScopedDevice(device):
+        n_problems = 3
+        model = _build_single_d6(device)
+        requires_grad = mode in [ik.JacobianMode.AUTODIFF, ik.JacobianMode.MIXED]
+        joint_q_2d = wp.zeros((n_problems, model.joint_coord_count), dtype=wp.float32, requires_grad=requires_grad)
+        joint_qd_2d = wp.zeros((n_problems, model.joint_dof_count), dtype=wp.float32)
+        body_q_2d = wp.zeros((n_problems, model.body_count), dtype=wp.transform)
+        body_qd_2d = wp.zeros((n_problems, model.body_count), dtype=wp.spatial_vector)
+
+        pos_targets = wp.array([[0.2, 0.3, 0.1]] * n_problems, dtype=wp.vec3)
+        angles = [math.pi / 6 + prob * math.pi / 8 for prob in range(n_problems)]
+        rot_targets = wp.array([[0.0, 0.0, math.sin(a / 2), math.cos(a / 2)] for a in angles], dtype=wp.vec4)
+
+        pos_obj = ik.PositionObjective(0, wp.vec3(0.0, 0.0, 0.0), pos_targets, n_problems, 6, 0)
+        rot_obj = ik.RotationObjective(0, wp.quat_identity(), rot_targets, n_problems, 6, 3)
+
+        solver = ik.IKSolver(model, joint_q_2d, [pos_obj, rot_obj], lambda_initial=1e-3, jacobian_mode=mode)
+
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        initial = _fk_end_effector_positions(model, body_q_2d, n_problems, 0, wp.vec3(0.0, 0.0, 0.0))
+
+        solver.solve(iterations=80)
+
+        ik._eval_fk_batched(model, joint_q_2d, joint_qd_2d, body_q_2d, body_qd_2d)
+        final = _fk_end_effector_positions(model, body_q_2d, n_problems, 0, wp.vec3(0.0, 0.0, 0.0))
+
+        for prob in range(n_problems):
+            err0 = np.linalg.norm(initial[prob] - pos_targets.numpy()[prob])
+            err1 = np.linalg.norm(final[prob] - pos_targets.numpy()[prob])
+            test.assertLess(err1, err0)
+            test.assertLess(err1, 1e-3)
+
+
+def test_convergence_autodiff_d6(test, device):
+    _convergence_test_d6(test, device, ik.JacobianMode.AUTODIFF)
+
+
+def test_convergence_analytic_d6(test, device):
+    _convergence_test_d6(test, device, ik.JacobianMode.ANALYTIC)
+
+
+def test_convergence_mixed_d6(test, device):
+    _convergence_test_d6(test, device, ik.JacobianMode.MIXED)
 
 
 # ----------------------------------------------------------------------------
@@ -244,6 +407,25 @@ def test_joint_limit_jacobian_compare(test, device):
 
 
 # ----------------------------------------------------------------------------
+# 2d.  D6 jacobian
+# ----------------------------------------------------------------------------
+
+
+def _d6_objective_builder(model, n_problems):
+    pos_targets = wp.array([[0.2, 0.3, 0.1]] * n_problems, dtype=wp.vec3)
+    angles = [math.pi / 6 + prob * math.pi / 8 for prob in range(n_problems)]
+    rot_targets = wp.array([[0.0, 0.0, math.sin(a / 2), math.cos(a / 2)] for a in angles], dtype=wp.vec4)
+
+    pos_obj = ik.PositionObjective(0, wp.vec3(0.0, 0.0, 0.0), pos_targets, n_problems, 6, 0)
+    rot_obj = ik.RotationObjective(0, wp.quat_identity(), rot_targets, n_problems, 6, 3)
+    return [pos_obj, rot_obj]
+
+
+def test_d6_jacobian_compare(test, device):
+    _jacobian_compare(test, device, _d6_objective_builder)
+
+
+# ----------------------------------------------------------------------------
 # 3.  Test-class registration per device
 # ----------------------------------------------------------------------------
 
@@ -254,12 +436,26 @@ class TestIKModes(unittest.TestCase):
     pass
 
 
+# Planar REV-REV convergence
 add_function_test(TestIKModes, "test_convergence_autodiff", test_convergence_autodiff, devices)
 add_function_test(TestIKModes, "test_convergence_analytic", test_convergence_analytic, devices)
 add_function_test(TestIKModes, "test_convergence_mixed", test_convergence_mixed, devices)
+
+# FREE-joint convergence
+add_function_test(TestIKModes, "test_convergence_autodiff_free", test_convergence_autodiff_free, devices)
+add_function_test(TestIKModes, "test_convergence_analytic_free", test_convergence_analytic_free, devices)
+add_function_test(TestIKModes, "test_convergence_mixed_free", test_convergence_mixed_free, devices)
+
+# D6-joint convergence
+add_function_test(TestIKModes, "test_convergence_autodiff_d6", test_convergence_autodiff_d6, devices)
+add_function_test(TestIKModes, "test_convergence_analytic_d6", test_convergence_analytic_d6, devices)
+add_function_test(TestIKModes, "test_convergence_mixed_d6", test_convergence_mixed_d6, devices)
+
+# Jacobian equality
 add_function_test(TestIKModes, "test_position_jacobian_compare", test_position_jacobian_compare, devices)
 add_function_test(TestIKModes, "test_rotation_jacobian_compare", test_rotation_jacobian_compare, devices)
 add_function_test(TestIKModes, "test_joint_limit_jacobian_compare", test_joint_limit_jacobian_compare, devices)
+add_function_test(TestIKModes, "test_d6_jacobian_compare", test_d6_jacobian_compare, devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Upgrades Newton’s  IK to a velocity-space optimization. Δq is now produced in joint‑velocity space (like `joint_qd`) and integrated through Featherstone's `jcalc_integrate()`, letting us:
- support every joint type (FREE, BALL, D6 …) under the analytic / autodiff back‑ends
- pull Jacobian columns directly from the motion sub‑space with no joint type branching
- keep the same API and benchmarks

**Testing**: `test_ik.py` now tests convergence for a free joint.

**Interactive example**: `example_ik_interactive.py` can be run with `--floating` to include a free joint connecting the base of the h1 robot to the world so the torso can move (as seen below).

![output](https://github.com/user-attachments/assets/d5c17448-cbda-4a5b-8791-1d48681386d2)



## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added new inverse kinematics tests for models with both free and revolute joints, covering multiple Jacobian computation modes.
  * Introduced a floating base mode option in the interactive IK example, allowing the robot model to use a floating 6-DOF base.

* **Refactor**
  * Unified inverse kinematics solver and objectives to consistently use joint degrees of freedom (DoFs) instead of joint coordinates, improving compatibility with complex joint types.
  * Streamlined coordinate handling in the interactive IK example to operate in world space when using the floating base mode.
  * Updated rotation objective to optionally disable quaternion error canonicalization for IK solving.

* **Bug Fixes**
  * Corrected joint indexing and initialization in IK examples to ensure accurate joint state setup.

* **Tests**
  * Expanded the test suite with additional convergence tests for free-plus-revolute and 6-DOF joint models.
  * Added Jacobian comparison tests for 6-DOF joint objectives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->