### PR TITLE
Skip adjoint code generations in examples that don't use autodiff

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.9.0.dev20250713 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.9.0.dev20250721 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.4.dev778924297 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128",
     "python -m pip install git+https://github.com/google-deepmind/mujoco_warp.git@ab687b8b8cd91ffbde200615e96572c7fd0b81d5",

--- a/newton/examples/example_anymal_c_walk.py
+++ b/newton/examples/example_anymal_c_walk.py
@@ -34,6 +34,8 @@ import newton.examples
 import newton.utils
 from newton.sim import Control, State
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def compute_observations_anymal(

--- a/newton/examples/example_anymal_c_walk_on_sand.py
+++ b/newton/examples/example_anymal_c_walk_on_sand.py
@@ -32,6 +32,8 @@ import newton.utils
 from newton.examples.example_anymal_c_walk import AnymalController
 from newton.solvers.implicit_mpm import ImplicitMPMSolver
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def update_collider_mesh(

--- a/newton/examples/example_anymal_c_walk_physx_policy.py
+++ b/newton/examples/example_anymal_c_walk_physx_policy.py
@@ -23,13 +23,14 @@
 #
 ###########################################################################
 
-
 import torch
 import warp as wp
 
 import newton
 import newton.utils
 from newton.sim import State
+
+wp.config.enable_backward = False
 
 lab_to_mujoco = [9, 3, 6, 0, 10, 4, 7, 1, 11, 5, 8, 2]
 mujoco_to_lab = [3, 7, 11, 1, 5, 9, 2, 6, 10, 0, 4, 8]

--- a/newton/examples/example_cartpole.py
+++ b/newton/examples/example_cartpole.py
@@ -28,6 +28,8 @@ import newton
 import newton.examples
 import newton.utils
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, stage_path="example_cartpole.usd", num_envs=8, use_cuda_graph=True):

--- a/newton/examples/example_cloth_bending.py
+++ b/newton/examples/example_cloth_bending.py
@@ -31,6 +31,8 @@ import newton
 import newton.examples
 import newton.utils
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, stage_path="example_cloth_bending.usd", num_frames=300):

--- a/newton/examples/example_cloth_hanging.py
+++ b/newton/examples/example_cloth_hanging.py
@@ -28,6 +28,8 @@ import warp as wp
 import newton
 import newton.utils
 
+wp.config.enable_backward = False
+
 
 class SolverType(Enum):
     EULER = "euler"

--- a/newton/examples/example_cloth_self_contact.py
+++ b/newton/examples/example_cloth_self_contact.py
@@ -34,6 +34,8 @@ import newton
 import newton.utils
 from newton.geometry import PARTICLE_FLAG_ACTIVE
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def initialize_rotation(

--- a/newton/examples/example_cloth_style3d.py
+++ b/newton/examples/example_cloth_style3d.py
@@ -23,6 +23,8 @@ import newton.examples
 import newton.utils
 from newton.geometry import PARTICLE_FLAG_ACTIVE, Mesh
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, stage_path="example_cloth_style3d.usd", num_frames=3000):

--- a/newton/examples/example_ik_benchmark.py
+++ b/newton/examples/example_ik_benchmark.py
@@ -29,6 +29,8 @@ import newton
 import newton.sim.ik as ik
 import newton.utils
 
+wp.config.enable_backward = False
+
 
 @dataclass(frozen=True)
 class RobotCfg:

--- a/newton/examples/example_ik_interactive.py
+++ b/newton/examples/example_ik_interactive.py
@@ -28,6 +28,8 @@ import newton.utils
 from newton.sim import eval_fk
 from newton.utils.gizmo import GizmoSystem
 
+wp.config.enable_backward = False
+
 # -------------------------------------------------------------------------
 # Utility classes
 # -------------------------------------------------------------------------

--- a/newton/examples/example_mpm_granular.py
+++ b/newton/examples/example_mpm_granular.py
@@ -23,6 +23,8 @@ import warp as wp
 import newton
 from newton.solvers.implicit_mpm import ImplicitMPMSolver
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, options: argparse.Namespace):

--- a/newton/examples/example_quadruped.py
+++ b/newton/examples/example_quadruped.py
@@ -33,6 +33,8 @@ import newton.examples
 import newton.sim
 import newton.utils
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, stage_path="example_quadruped.usd", num_envs=8):

--- a/newton/examples/example_rigid_force.py
+++ b/newton/examples/example_rigid_force.py
@@ -27,6 +27,8 @@ import warp as wp
 
 import newton
 
+wp.config.enable_backward = False
+
 
 class Example:
     def __init__(self, stage_path: str | None = "example_rigid_force.usd", headless: bool = False):

--- a/newton/examples/example_selection_articulations.py
+++ b/newton/examples/example_selection_articulations.py
@@ -27,6 +27,8 @@ USE_TORCH = False
 COLLAPSE_FIXED_JOINTS = False
 VERBOSE = True
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def compute_middle_kernel(

--- a/newton/examples/example_selection_cartpole.py
+++ b/newton/examples/example_selection_cartpole.py
@@ -27,6 +27,8 @@ USE_TORCH = False
 COLLAPSE_FIXED_JOINTS = False
 VERBOSE = True
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def randomize_states_kernel(joint_q: wp.array2d(dtype=float), seed: int):

--- a/newton/examples/example_selection_materials.py
+++ b/newton/examples/example_selection_materials.py
@@ -32,6 +32,8 @@ VERBOSE = True
 # - If False, each shape in each environment gets its own random value.
 RANDOMIZE_PER_ENV = True
 
+wp.config.enable_backward = False
+
 
 @wp.kernel
 def compute_middle_kernel(

--- a/uv.lock
+++ b/uv.lock
@@ -1358,7 +1358,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "warp-lang", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.9.0.dev20250713", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.9.0.dev20250721", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [[package]]
@@ -1462,7 +1462,7 @@ name = "newton-physics"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "warp-lang", version = "1.9.0.dev20250713", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
+    { name = "warp-lang", version = "1.9.0.dev20250721", source = { registry = "https://pypi.nvidia.com/" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
@@ -2955,7 +2955,7 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.9.0.dev20250713"
+version = "1.9.0.dev20250721"
 source = { registry = "https://pypi.nvidia.com/" }
 resolution-markers = [
     "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')",
@@ -2973,9 +2973,9 @@ dependencies = [
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250713-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ec1c67cb64774d819097a88b7c5f4926c858dee7665bc398035cb3cb73cd8e41" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250713-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:7ee2376073e7a0092c67f47096efc81088e25ad986b412762f500d7eaf6d4f91" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250713-py3-none-win_amd64.whl", hash = "sha256:b6dd1d6e872b16259315c40b63ccdf39678790633569f1c99fc0c2bb5812b844" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250721-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:41ddf805575ceb40341f7d32ef9a46b9afcc90c560df9886b9860f70d7abdb6e" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250721-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:6eb509aee31072ce37615e53d406dbd5e7b282fabc36d5eeea448ea90efcac0e" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250721-py3-none-win_amd64.whl", hash = "sha256:20e1f79596b9204f82ad5329b523cc0d7b666f83546d9746840f16786d3e58bc" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This is an additional optimization that should speed up compile times in the examples.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the version of the `warp-lang` package used in the configuration.
* **Style**
  * Disabled backward differentiation in multiple example scripts to standardize Warp configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->