### PR TITLE
Migrated the Fix for Inactive Vertices from Warp to Newton

### DIFF
--- a/newton/solvers/solver.py
+++ b/newton/solvers/solver.py
@@ -33,10 +33,13 @@ def integrate_particles(
     v_new: wp.array(dtype=wp.vec3),
 ):
     tid = wp.tid()
+    x0 = x[tid]
+
     if (particle_flags[tid] & PARTICLE_FLAG_ACTIVE) == 0:
+        x_new[tid] = x0
+        v_new[tid] = wp.vec3(0.0)
         return
 
-    x0 = x[tid]
     v0 = v[tid]
     f0 = f[tid]
 

--- a/newton/tests/test_cloth.py
+++ b/newton/tests/test_cloth.py
@@ -828,7 +828,8 @@ def test_cloth_sagging(test, device, solver):
     fixed_points = np.where(np.logical_not(example.model.particle_flags.numpy()))
     # examine that the simulation does not explode
     final_pos = example.state0.particle_q.numpy()
-    test.assertTrue((initial_pos[fixed_points, :] == final_pos[fixed_points, :]).all())
+    test.assertTrue((initial_pos[fixed_points, :] == example.state0.particle_q.numpy()[fixed_points, :]).all())
+    test.assertTrue((initial_pos[fixed_points, :] == example.state1.particle_q.numpy()[fixed_points, :]).all())
     test.assertTrue((final_pos < 1e5).all())
     # examine that the simulation has moved
     test.assertTrue((example.init_pos != final_pos).any())


### PR DESCRIPTION
Fixing #42 

Migrated a fix from Warp:  https://github.com/NVIDIA/warp/commit/e95adb60a2aa1cde0efe91d59fdd2821c16b8a85

Fixes for VBD is brought in by another PR. This PR handles the fixes for Euler and XPBD solver.

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured inactive particles retain their position and have zero velocity after simulation steps.

* **Tests**
  * Improved test coverage to verify that fixed particles maintain their initial positions throughout the simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->