### PR TITLE
Update AWS instance type in GPU unit tests workflow from g6.xlarge to g5.xlarge

### DIFF
--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -3,7 +3,7 @@ name: GPU Unit Tests on AWS EC2
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6.xlarge
+  AWS_INSTANCE_TYPE: g5.xlarge
   AWS_VOLUME_SIZE: 64
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a

--- a/.github/workflows/push_aws_gpu_tests.yml
+++ b/.github/workflows/push_aws_gpu_tests.yml
@@ -3,7 +3,7 @@ name: Push Events - AWS GPU Tests
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6.xlarge
+  AWS_INSTANCE_TYPE: g5.xlarge
   AWS_VOLUME_SIZE: 64
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a


### PR DESCRIPTION
## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

It seems like we're having instance availability issues today with g6.xlarge

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AWS EC2 instance type used for GPU tests in GitHub Actions workflows. This change does not affect test logic or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->