### PR TITLE
Use a unique module for the `count_contact_points` kernel

### DIFF
--- a/newton/geometry/kernels.py
+++ b/newton/geometry/kernels.py
@@ -766,7 +766,8 @@ def create_soft_contacts(
 # region Rigid body collision detection
 
 
-@wp.kernel(enable_backward=False)
+# NOTE: Kernel is in a unique module to speed up cold-start ModelBuilder.finalize() time
+@wp.kernel(enable_backward=False, module="unique")
 def count_contact_points(
     contact_pairs: wp.array(dtype=wp.vec2i),
     shape_type: wp.array(dtype=int),


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

`finalize()` includes a kernel launch via `m.rigid_contact_max = count_rigid_contact_points(m)` which forces all the kernels in the `newton.geometry.kernel` module to be compiled. By moving the `count_contact_points` kernel to a unique module, we can often significantly reduce the time it takes `finalize()` to run when the Warp kernel cache is empty. The relative impact is dependent on the environment count.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance for initializing certain geometry operations, resulting in faster startup times for related features. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->