### PR TITLE
Update MjWarp dependency and associated changes

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -19,7 +19,7 @@
     "python -m pip install -U --pre warp-lang==1.9.0.dev20250721 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.4.dev778924297 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128",
-    "python -m pip install git+https://github.com/google-deepmind/mujoco_warp.git@ab687b8b8cd91ffbde200615e96572c7fd0b81d5",
+    "python -m pip install git+https://github.com/google-deepmind/mujoco_warp#aa87210336c5925c9fbec75ae4092888af997ac3",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -19,7 +19,7 @@
     "python -m pip install -U --pre warp-lang==1.9.0.dev20250721 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.4.dev778924297 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128",
-    "python -m pip install git+https://github.com/google-deepmind/mujoco_warp#aa87210336c5925c9fbec75ae4092888af997ac3",
+    "python -m pip install git+https://github.com/google-deepmind/mujoco_warp@aa87210336c5925c9fbec75ae4092888af997ac3",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]
 }

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -2091,7 +2091,6 @@ class MuJoCoSolver(SolverBase):
             full_shape_mapping = shape_mapping
 
         self.mj_data = mujoco.MjData(self.mj_model)
-        self.mj_data.nefc = nefc_per_env
 
         self.mj_model.opt.tolerance = tolerance
         self.mj_model.opt.ls_tolerance = ls_tolerance
@@ -2174,7 +2173,7 @@ class MuJoCoSolver(SolverBase):
                 else:
                     rigid_contact_max = newton.sim.count_rigid_contact_points(model)
                 nconmax = max(rigid_contact_max, self.mj_data.ncon * nworld)  # this avoids error in mujoco.
-            njmax = max(nworld * nefc_per_env, nworld * self.mj_data.nefc)
+            njmax = max(nefc_per_env, self.mj_data.nefc)
             self.mjw_data = mujoco_warp.put_data(
                 self.mj_model, self.mj_data, nworld=nworld, nconmax=nconmax, njmax=njmax
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1348,7 +1348,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp#ab687b8b8cd91ffbde200615e96572c7fd0b81d5" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp#aa87210336c5925c9fbec75ae4092888af997ac3" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
njmax is now per world, so we need to change the numbers we pass there in MuJoCo solver.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of constraints in the MuJoCo solver for better model conversion consistency.  
* **Chores**
  * Updated the MuJoCo Warp package version used during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->