### PR TITLE
Fix parallel linesearch option in MuJoCo solver

### DIFF
--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -2147,7 +2147,6 @@ class MuJoCoSolver(SolverBase):
             # set mjwarp-only settings
             self.mjw_model.opt.ls_parallel = ls_parallel
 
-
             if separate_envs_to_worlds:
                 nworld = model.num_envs
             else:

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -2102,6 +2102,7 @@ class MuJoCoSolver(SolverBase):
         # m.opt.disableflags = disableflags
         self.mj_model.opt.impratio = impratio
         self.mj_model.opt.jacobian = mujoco.mjtJacobian.mjJAC_AUTO
+        self.mj_model.opt.ls_parallel = ls_parallel
 
         MuJoCoSolver.update_mjc_data(self.mj_data, model, state)
 

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -2102,7 +2102,6 @@ class MuJoCoSolver(SolverBase):
         # m.opt.disableflags = disableflags
         self.mj_model.opt.impratio = impratio
         self.mj_model.opt.jacobian = mujoco.mjtJacobian.mjJAC_AUTO
-        self.mj_model.opt.ls_parallel = ls_parallel
 
         MuJoCoSolver.update_mjc_data(self.mj_data, model, state)
 
@@ -2144,6 +2143,10 @@ class MuJoCoSolver(SolverBase):
             model.to_mjc_geom_index = wp.array(to_mjc_geom_array, dtype=wp.int32)  # pyright: ignore[reportAttributeAccessIssue]
 
             self.mjw_model = mujoco_warp.put_model(self.mj_model)
+
+            # set mjwarp-only settings
+            self.mjw_model.opt.ls_parallel = ls_parallel
+
 
             if separate_envs_to_worlds:
                 nworld = model.num_envs

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -48,9 +48,13 @@ class TestMuJoCoSolver(unittest.TestCase):
 
     def test_ls_parallel_option(self):
         """Test that ls_parallel option is properly set on the MuJoCo Warp model."""
-        # Create minimal model
+        # Create minimal model with proper inertia
         builder = newton.ModelBuilder()
-        body = builder.add_body(mass=1.0)
+        body = builder.add_body(
+            mass=1.0, 
+            com=(0.0, 0.0, 0.0), 
+            I_m=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+        )
         builder.add_joint_revolute(-1, body)
         model = builder.finalize()
         

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -46,6 +46,22 @@ class TestMuJoCoSolver(unittest.TestCase):
         """
         self.assertTrue(True, "setUp method completed.")
 
+    def test_ls_parallel_option(self):
+        """Test that ls_parallel option is properly set on the MuJoCo Warp model."""
+        # Create minimal model
+        builder = newton.ModelBuilder()
+        body = builder.add_body(mass=1.0)
+        builder.add_joint_revolute(-1, body)
+        model = builder.finalize()
+        
+        # Test with ls_parallel=True
+        solver = MuJoCoSolver(model, ls_parallel=True)
+        self.assertTrue(solver.mjw_model.opt.ls_parallel, "ls_parallel should be True when set to True")
+        
+        # Test with ls_parallel=False (default)
+        solver_default = MuJoCoSolver(model, ls_parallel=False)
+        self.assertFalse(solver_default.mjw_model.opt.ls_parallel, "ls_parallel should be False when set to False")
+
     @unittest.skip("Trajectory rendering for debugging")
     def test_render_trajectory(self):
         """Simulates and renders a trajectory if solver and renderer are available."""

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -50,18 +50,14 @@ class TestMuJoCoSolver(unittest.TestCase):
         """Test that ls_parallel option is properly set on the MuJoCo Warp model."""
         # Create minimal model with proper inertia
         builder = newton.ModelBuilder()
-        body = builder.add_body(
-            mass=1.0, 
-            com=(0.0, 0.0, 0.0), 
-            I_m=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
-        )
+        body = builder.add_body(mass=1.0, com=(0.0, 0.0, 0.0), I_m=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
         builder.add_joint_revolute(-1, body)
         model = builder.finalize()
-        
+
         # Test with ls_parallel=True
         solver = MuJoCoSolver(model, ls_parallel=True)
         self.assertTrue(solver.mjw_model.opt.ls_parallel, "ls_parallel should be True when set to True")
-        
+
         # Test with ls_parallel=False (default)
         solver_default = MuJoCoSolver(model, ls_parallel=False)
         self.assertFalse(solver_default.mjw_model.opt.ls_parallel, "ls_parallel should be False when set to False")


### PR DESCRIPTION
I did a bad merge at that point and the setting was never propagated to the solver.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the `ls_parallel` option in the MuJoCo solver, allowing users to control parallelization settings.

* **Tests**
  * Introduced a new unit test to verify correct handling of the `ls_parallel` option in the MuJoCo solver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->