### PR TITLE
Test `example_ik_benchmark`, remove CUDA graph workaround

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -44,11 +44,6 @@ from newton.tests.unittest_utils import (
 
 wp.init()
 
-supports_load_during_graph_capture = False
-
-if wp.context.runtime.driver_version >= (12, 3):
-    supports_load_during_graph_capture = True
-
 
 def _build_command_line_options(test_options: dict[str, Any]) -> list:
     """Helper function to build command-line options from the test options dictionary."""
@@ -233,33 +228,21 @@ add_example_test(
     TestBasicRobotExamples,
     name="example_cartpole",
     devices=test_devices,
-    test_options={
-        "stage_path": "None",
-        "num_frames": 100 if supports_load_during_graph_capture else 10,
-        "use_cuda_graph": supports_load_during_graph_capture,
-    },
+    test_options={"stage_path": "None", "num_frames": 100},
     test_options_cpu={"num_frames": 10},
 )
 add_example_test(
     TestBasicRobotExamples,
     name="example_g1",
     devices=test_devices,
-    test_options={
-        "stage_path": "None",
-        "num_frames": 500 if supports_load_during_graph_capture else 20,
-        "use_cuda_graph": supports_load_during_graph_capture,
-    },
+    test_options={"stage_path": "None", "num_frames": 500},
     test_options_cpu={"num_frames": 10},
 )
 add_example_test(
     TestBasicRobotExamples,
     name="example_humanoid",
     devices=test_devices,
-    test_options={
-        "stage_path": "None",
-        "num_frames": 500 if supports_load_during_graph_capture else 20,
-        "use_cuda_graph": supports_load_during_graph_capture,
-    },
+    test_options={"stage_path": "None", "num_frames": 500},
     test_options_cpu={"num_frames": 10},
 )
 add_example_test(
@@ -304,21 +287,21 @@ add_example_test(
     TestSelectionAPIExamples,
     name="example_selection_articulations",
     devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options={"stage_path": "None", "num_frames": 100},
     test_options_cpu={"num_frames": 10},
 )
 add_example_test(
     TestSelectionAPIExamples,
     name="example_selection_cartpole",
     devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options={"stage_path": "None", "num_frames": 100},
     test_options_cpu={"num_frames": 10},
 )
 add_example_test(
     TestSelectionAPIExamples,
     name="example_selection_materials",
     devices=test_devices,
-    test_options={"stage_path": "None", "num_frames": 100, "use_cuda_graph": supports_load_during_graph_capture},
+    test_options={"stage_path": "None", "num_frames": 100},
     test_options_cpu={"num_frames": 10},
 )
 
@@ -338,6 +321,11 @@ add_example_test(
     name="example_rigid_force",
     devices=test_devices,
     test_options={"headless": True},
+)
+add_example_test(
+    TestOtherExamples,
+    name="example_ik_benchmark",
+    devices=test_devices,
 )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Add `example_ik_benchmark` to the examples tested by `test_examples.py`

Remove a workaround to test examples on systems with older drivers that can't support module loading during graph capture.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
