### PR TITLE
Increase `KpiInitializeModel` timeout to 1 hr

### DIFF
--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -32,7 +32,7 @@ class KpiInitializeModel:
     number = 1
     repeat = 3
     min_run_count = 1
-    timeout = 1800
+    timeout = 3600
 
     def setup(self, robot, num_envs):
         wp.init()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

The 30-minute timeout has been resulting in some timeouts for the 8192-count G1 and H1 envs.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the timeout duration for certain initialization processes from 30 minutes to 1 hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->