### PR TITLE
Use warnings.warn instead of wp.utils.warn

### DIFF
--- a/newton/geometry/utils.py
+++ b/newton/geometry/utils.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import os
+import warnings
 from collections import defaultdict
 from typing import Literal
 
@@ -339,7 +340,9 @@ def remesh_ftetwild(vertices, faces, optimize=False, edge_length_fac=0.05, verbo
     new_faces = np.array(surface_faces, dtype=np.int32)
 
     if len(new_vertices) == 0 or len(new_faces) == 0:
-        wp.utils.warn("Remeshing failed, the optimized mesh has no vertices or faces; return previous mesh.")
+        warnings.warn(
+            "Remeshing failed, the optimized mesh has no vertices or faces; return previous mesh.", stacklevel=2
+        )
         return vertices, faces
 
     return new_vertices, new_faces

--- a/newton/sim/builder.py
+++ b/newton/sim/builder.py
@@ -2295,7 +2295,9 @@ class ModelBuilder:
                 if raise_on_failure:
                     raise RuntimeError(f"Remeshing with method '{method}' failed.") from e
                 else:
-                    wp.warn(f"Remeshing with method '{method}' failed: {e}. Falling back to convex_hull.")
+                    warnings.warn(
+                        f"Remeshing with method '{method}' failed: {e}. Falling back to convex_hull.", stacklevel=2
+                    )
                     method = "convex_hull"
 
         if method in RemeshingMethod.__args__:
@@ -2316,8 +2318,9 @@ class ModelBuilder:
                         if raise_on_failure:
                             raise RuntimeError(f"Remeshing with method '{method}' failed for shape {shape}.") from e
                         else:
-                            wp.warn(
-                                f"Remeshing with method '{method}' failed for shape {shape}: {e}. Falling back to bounding_box."
+                            warnings.warn(
+                                f"Remeshing with method '{method}' failed for shape {shape}: {e}. Falling back to bounding_box.",
+                                stacklevel=2,
                             )
                             continue
                 # note we need to copy the mesh to avoid modifying the original mesh

--- a/newton/sim/graph_coloring.py
+++ b/newton/sim/graph_coloring.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from enum import Enum
 
 import numpy as np
 import warp as wp
-import warp.utils
 
 
 class ColoringAlgorithm(Enum):
@@ -247,10 +247,11 @@ def color_graph(
         )
 
         if max_min_ratio > target_max_min_color_ratio:
-            wp.utils.warn(
+            warnings.warn(
                 f"Color balancing terminated early: max/min ratio {max_min_ratio:.3f} "
                 f"exceeds target {target_max_min_color_ratio:.3f}. "
-                "The graph may not be further optimizable."
+                "The graph may not be further optimizable.",
+                stacklevel=2,
             )
 
     color_groups = convert_to_color_groups(num_colors, particle_colors, return_wp_array=False)

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from itertools import product
 from typing import TYPE_CHECKING, Any
 
@@ -1753,8 +1754,9 @@ class MuJoCoSolver(SolverBase):
         joints_simple = list(zip(joint_parent[selected_joints], joint_child[selected_joints]))
         joint_order = newton.utils.topological_sort(joints_simple, use_dfs=True)
         if any(joint_order != np.arange(len(joints_simple))):
-            wp.utils.warn(
-                "Joint order is not in depth-first topological order while converting Newton model to MuJoCo, this may lead to diverging kinematics between MuJoCo and Newton."
+            warnings.warn(
+                "Joint order is not in depth-first topological order while converting Newton model to MuJoCo, this may lead to diverging kinematics between MuJoCo and Newton.",
+                stacklevel=2,
             )
 
         # maps from Newton body index to the transform to be applied to its children
@@ -2072,9 +2074,10 @@ class MuJoCoSolver(SolverBase):
         if separate_envs_to_worlds and model.num_envs > 1:
             shapes_per_env = model.shape_count // model.num_envs
             if model.shape_count % model.num_envs != 0:
-                wp.utils.warn(
+                warnings.warn(
                     f"Total shape count {model.shape_count} is not divisible by number of environments {model.num_envs}. "
-                    "Shape mapping to MuJoCo geoms may be incorrect."
+                    "Shape mapping to MuJoCo geoms may be incorrect.",
+                    stacklevel=2,
                 )
 
             full_shape_mapping = {}

--- a/newton/solvers/vbd/solver_vbd.py
+++ b/newton/solvers/vbd/solver_vbd.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import warp as wp
 from warp.types import float32, matrix
@@ -2330,7 +2332,7 @@ class VBDSolver(SolverBase):
         self.self_contact_margin = self_contact_margin
 
         if model.device.is_cpu and use_tile_solve:
-            wp.utils.warn("Tiled solve requires model.device='cuda'. Tiled solve is disabled.")
+            warnings.warn("Tiled solve requires model.device='cuda'. Tiled solve is disabled.", stacklevel=2)
 
         self.use_tile_solve = use_tile_solve and model.device.is_cuda
 

--- a/newton/utils/import_urdf.py
+++ b/newton/utils/import_urdf.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+import warnings
 import xml.etree.ElementTree as ET
 from urllib.parse import unquote, urlsplit
 
@@ -189,8 +190,9 @@ def parse_urdf(
                     if package_name in urdf_folder:
                         filename = os.path.join(urdf_folder[: urdf_folder.rindex(package_name)], fn)
                     else:
-                        wp.utils.warn(
-                            f'Warning: package "{package_name}" not found in URDF folder while loading mesh at "{filename}"'
+                        warnings.warn(
+                            f'Warning: package "{package_name}" not found in URDF folder while loading mesh at "{filename}"',
+                            stacklevel=2,
                         )
                 elif filename.startswith(("http://", "https://")):
                     # download mesh
@@ -200,7 +202,7 @@ def parse_urdf(
                 else:
                     filename = os.path.join(os.path.dirname(urdf_filename), filename)
                 if not os.path.exists(filename):
-                    wp.utils.warn(f"Warning: mesh file {filename} does not exist")
+                    warnings.warn(f"Warning: mesh file {filename} does not exist", stacklevel=2)
                     continue
 
                 import trimesh  # noqa: PLC0415


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized all warning messages to use Python's built-in warning system, improving consistency and traceability of warnings across the application. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->