### PR TITLE
Incorrect Inertia Computation for Capsules, Cylinders, and Cones Due to Default Axis Mismatch #486

### DIFF
--- a/newton/geometry/inertia.py
+++ b/newton/geometry/inertia.py
@@ -60,7 +60,7 @@ def compute_sphere_inertia(density: float, r: float) -> tuple[float, wp.vec3, wp
 
 
 def compute_capsule_inertia(density: float, r: float, h: float) -> tuple[float, wp.vec3, wp.mat33]:
-    """Helper to compute mass and inertia of a solid capsule extending along the y-axis
+    """Helper to compute mass and inertia of a solid capsule extending along the z-axis
 
     Args:
         density: The capsule density
@@ -82,18 +82,19 @@ def compute_capsule_inertia(density: float, r: float, h: float) -> tuple[float, 
     Ia = mc * (0.25 * r * r + (1.0 / 12.0) * h * h) + ms * (0.4 * r * r + 0.375 * r * h + 0.25 * h * h)
     Ib = (mc * 0.5 + ms * 0.4) * r * r
 
-    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ia]])
+    # For Z-axis orientation: I_xx = I_yy = Ia, I_zz = Ib
+    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
 
     return (m, wp.vec3(), I)
 
 
 def compute_cylinder_inertia(density: float, r: float, h: float) -> tuple[float, wp.vec3, wp.mat33]:
-    """Helper to compute mass and inertia of a solid cylinder extending along the y-axis
+    """Helper to compute mass and inertia of a solid cylinder extending along the z-axis
 
     Args:
         density: The cylinder density
         r: The cylinder radius
-        h: The cylinder height (extent along the y-axis)
+        h: The cylinder height (extent along the z-axis)
 
     Returns:
 
@@ -105,18 +106,19 @@ def compute_cylinder_inertia(density: float, r: float, h: float) -> tuple[float,
     Ia = 1 / 12 * m * (3 * r * r + h * h)
     Ib = 1 / 2 * m * r * r
 
-    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ia]])
+    # For Z-axis orientation: I_xx = I_yy = Ia, I_zz = Ib
+    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
 
     return (m, wp.vec3(), I)
 
 
 def compute_cone_inertia(density: float, r: float, h: float) -> tuple[float, wp.vec3, wp.mat33]:
-    """Helper to compute mass and inertia of a solid cone extending along the y-axis
+    """Helper to compute mass and inertia of a solid cone extending along the z-axis
 
     Args:
         density: The cone density
         r: The cone radius
-        h: The cone height (extent along the y-axis)
+        h: The cone height (extent along the z-axis)
 
     Returns:
 
@@ -128,7 +130,8 @@ def compute_cone_inertia(density: float, r: float, h: float) -> tuple[float, wp.
     Ia = 1 / 20 * m * (3 * r * r + 2 * h * h)
     Ib = 3 / 10 * m * r * r
 
-    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ia]])
+    # For Z-axis orientation: I_xx = I_yy = Ia, I_zz = Ib
+    I = wp.mat33([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
 
     return (m, wp.vec3(), I)
 

--- a/newton/tests/test_inertia.py
+++ b/newton/tests/test_inertia.py
@@ -154,6 +154,101 @@ class TestInertia(unittest.TestCase):
         assert_np_equal(np.array(builder.body_inertia[0]), np.array(I_sphere), tol=4e2)
         self.assertAlmostEqual(builder.body_mass[0], mass_sphere, delta=1e2)
 
+    def test_capsule_cylinder_cone_axis_inertia(self):
+        """Test that capsules, cylinders, and cones have correct inertia for different axis orientations."""
+        # Test parameters
+        radius = 0.5
+        half_height = 1.0
+        density = 1000.0
+
+        # Test capsule inertia for different axes
+        # Z-axis capsule (default)
+        builder_z = newton.ModelBuilder()
+        body_z = builder_z.add_body()
+        builder_z.add_shape_capsule(
+            body=body_z,
+            radius=radius,
+            half_height=half_height,
+            axis=newton.Axis.Z,
+            cfg=newton.ModelBuilder.ShapeConfig(density=density),
+        )
+        model_z = builder_z.finalize()
+        I_z = model_z.body_inertia.numpy()[0]
+
+        # For Z-axis aligned capsule, I_xx should equal I_yy, and I_zz should be different
+        self.assertAlmostEqual(I_z[0, 0], I_z[1, 1], delta=1e-6, msg="I_xx should equal I_yy for Z-axis capsule")
+        self.assertNotAlmostEqual(I_z[0, 0], I_z[2, 2], delta=1e-3, msg="I_xx should not equal I_zz for Z-axis capsule")
+
+        # Y-axis capsule
+        builder_y = newton.ModelBuilder()
+        body_y = builder_y.add_body()
+        builder_y.add_shape_capsule(
+            body=body_y,
+            radius=radius,
+            half_height=half_height,
+            axis=newton.Axis.Y,
+            cfg=newton.ModelBuilder.ShapeConfig(density=density),
+        )
+        model_y = builder_y.finalize()
+        I_y = model_y.body_inertia.numpy()[0]
+
+        # For Y-axis aligned capsule, I_xx should equal I_zz, and I_yy should be different
+        self.assertAlmostEqual(I_y[0, 0], I_y[2, 2], delta=1e-6, msg="I_xx should equal I_zz for Y-axis capsule")
+        self.assertNotAlmostEqual(I_y[0, 0], I_y[1, 1], delta=1e-3, msg="I_xx should not equal I_yy for Y-axis capsule")
+
+        # X-axis capsule
+        builder_x = newton.ModelBuilder()
+        body_x = builder_x.add_body()
+        builder_x.add_shape_capsule(
+            body=body_x,
+            radius=radius,
+            half_height=half_height,
+            axis=newton.Axis.X,
+            cfg=newton.ModelBuilder.ShapeConfig(density=density),
+        )
+        model_x = builder_x.finalize()
+        I_x = model_x.body_inertia.numpy()[0]
+
+        # For X-axis aligned capsule, I_yy should equal I_zz, and I_xx should be different
+        self.assertAlmostEqual(I_x[1, 1], I_x[2, 2], delta=1e-6, msg="I_yy should equal I_zz for X-axis capsule")
+        self.assertNotAlmostEqual(I_x[0, 0], I_x[1, 1], delta=1e-3, msg="I_xx should not equal I_yy for X-axis capsule")
+
+        # Test cylinder inertia for Z-axis
+        builder_cyl = newton.ModelBuilder()
+        body_cyl = builder_cyl.add_body()
+        builder_cyl.add_shape_cylinder(
+            body=body_cyl,
+            radius=radius,
+            half_height=half_height,
+            axis=newton.Axis.Z,
+            cfg=newton.ModelBuilder.ShapeConfig(density=density),
+        )
+        model_cyl = builder_cyl.finalize()
+        I_cyl = model_cyl.body_inertia.numpy()[0]
+
+        self.assertAlmostEqual(I_cyl[0, 0], I_cyl[1, 1], delta=1e-6, msg="I_xx should equal I_yy for Z-axis cylinder")
+        self.assertNotAlmostEqual(
+            I_cyl[0, 0], I_cyl[2, 2], delta=1e-3, msg="I_xx should not equal I_zz for Z-axis cylinder"
+        )
+
+        # Test cone inertia for Z-axis
+        builder_cone = newton.ModelBuilder()
+        body_cone = builder_cone.add_body()
+        builder_cone.add_shape_cone(
+            body=body_cone,
+            radius=radius,
+            half_height=half_height,
+            axis=newton.Axis.Z,
+            cfg=newton.ModelBuilder.ShapeConfig(density=density),
+        )
+        model_cone = builder_cone.finalize()
+        I_cone = model_cone.body_inertia.numpy()[0]
+
+        self.assertAlmostEqual(I_cone[0, 0], I_cone[1, 1], delta=1e-6, msg="I_xx should equal I_yy for Z-axis cone")
+        self.assertNotAlmostEqual(
+            I_cone[0, 0], I_cone[2, 2], delta=1e-3, msg="I_xx should not equal I_zz for Z-axis cone"
+        )
+
 
 if __name__ == "__main__":
     wp.clear_kernel_cache()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Fixes incorrect inertia computation for capsules, cylinders, and cones due to axis mismatch. Closes #486

### Problem
When adding capsule, cylinder, or cone shapes, they are internally stored with Z-axis orientation:
```python
# internally capsule axis is always +Z
q = quat_between_axes(Axis.Z, axis)
xform = wp.transform(xform.p, xform.q * q)
```

However, the inertia computation functions (`compute_capsule_inertia`, `compute_cylinder_inertia`, `compute_cone_inertia`) were calculating inertia assuming Y-axis orientation. This mismatch caused incorrect inertia tensors, leading to inaccurate rotational dynamics in physics simulations.

### Solution
Updated the inertia computation functions in `newton/geometry/inertia.py` to compute inertia for Z-axis orientation:
- Changed docstrings to reflect Z-axis orientation
- Modified inertia tensor assignment: changed from `I = [[Ia, 0, 0], [0, Ib, 0], [0, 0, Ia]]` (Y-axis) to `I = [[Ia, 0, 0], [0, Ia, 0], [0, 0, Ib]]` (Z-axis)
- Added comprehensive unit tests in `test_inertia.py` to verify correct inertia computation for all three axes (X, Y, Z)

### Testing
Added `test_capsule_cylinder_cone_axis_inertia()` which verifies:
- Z-axis aligned shapes have I_xx = I_yy ≠ I_zz
- Y-axis aligned shapes have I_xx = I_zz ≠ I_yy  
- X-axis aligned shapes have I_yy = I_zz ≠ I_xx

All existing tests continue to pass.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to-date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that capsules, cylinders, and cones extend along the z-axis, with corresponding changes to comments and inertia tensor descriptions.

* **Tests**
  * Added new tests to verify that inertia tensors for capsules, cylinders, and cones reflect correct axis orientation and symmetry properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->