### PR TITLE
Add missing Slice.__eq__() method to fix lru_cache behaviour

### DIFF
--- a/newton/utils/selection.py
+++ b/newton/utils/selection.py
@@ -114,6 +114,9 @@ class Slice:
     def __hash__(self):
         return hash((self.start, self.stop))
 
+    def __eq__(self, other):
+        return self.start == other.start and self.stop == other.stop
+
     def __str__(self):
         return f"({self.start}, {self.stop})"
 

--- a/newton/utils/selection.py
+++ b/newton/utils/selection.py
@@ -115,7 +115,7 @@ class Slice:
         return hash((self.start, self.stop))
 
     def __eq__(self, other):
-        return self.start == other.start and self.stop == other.stop
+        return isinstance(other, Slice) and self.start == other.start and self.stop == other.stop
 
     def __str__(self):
         return f"({self.start}, {self.stop})"


### PR DESCRIPTION
This fixes frequent cache misses with `lru_cache` in the `ArticulationView._get_attribute_array()` method, which can lead to performance degradation over time.

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved comparison capabilities for certain objects, allowing them to be checked for equality based on their attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->