### PR TITLE
Fixed MJC shape mapping

### DIFF
--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -687,7 +687,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         tested_count = 0
         for world_idx in range(self.model.num_envs):
             for geom_idx in range(num_geoms):
-                shape_idx = to_newton_shape_index[geom_idx]
+                shape_idx = to_newton_shape_index[world_idx, geom_idx]
                 if shape_idx < 0:  # No mapping for this geom
                     continue
 
@@ -892,7 +892,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         tested_count = 0
         for world_idx in range(self.model.num_envs):
             for geom_idx in range(num_geoms):
-                shape_idx = to_newton_shape_index[geom_idx]
+                shape_idx = to_newton_shape_index[world_idx, geom_idx]
                 if shape_idx < 0:  # No mapping
                     continue
 


### PR DESCRIPTION
Currently all geoms in all environments of MJC map to the geoms in the first environment in Newton. This is a wrong behavior and prevents material shape randomization.


<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for multiple environments in MuJoCoWarp by making shape-to-geom index mappings environment-aware.

* **Bug Fixes**
  * Updated array indexing in tests and core logic to correctly handle environment-specific mappings for shape and geometry indices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->