### PR TITLE
Fix damping and stiffness parsing on non-compound joints?

### DIFF
--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -567,13 +567,13 @@ def parse_usd(
             else:
                 if joint_desc.drive.enabled:
                     joint_params["target"] *= DegreesToRadian
-                    # joint_params["target_kd"] /= DegreesToRadian / joint_drive_gains_scaling
-                    # joint_params["target_ke"] /= DegreesToRadian / joint_drive_gains_scaling
+                    joint_params["target_kd"] /= DegreesToRadian / joint_drive_gains_scaling
+                    joint_params["target_ke"] /= DegreesToRadian / joint_drive_gains_scaling
 
                 joint_params["limit_lower"] *= DegreesToRadian
                 joint_params["limit_upper"] *= DegreesToRadian
-                # joint_params["limit_ke"] /= DegreesToRadian / joint_drive_gains_scaling
-                # joint_params["limit_kd"] /= DegreesToRadian / joint_drive_gains_scaling
+                joint_params["limit_ke"] /= DegreesToRadian / joint_drive_gains_scaling
+                joint_params["limit_kd"] /= DegreesToRadian / joint_drive_gains_scaling
 
                 builder.add_joint_revolute(**joint_params)
         elif key == UsdPhysics.ObjectType.SphericalJoint:


### PR DESCRIPTION
## Description

Resolve issues with damping and stiffness not being parsed correctly in IsaacLab: #515 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
