### PR TITLE
Add style3d solver support to the cloth hanging example.

### DIFF
--- a/newton/examples/example_cloth_hanging.py
+++ b/newton/examples/example_cloth_hanging.py
@@ -33,6 +33,7 @@ import newton.utils
 
 class SolverType(Enum):
     EULER = "euler"
+    STYLE3D = "style3d"
     XPBD = "xpbd"
     VBD = "vbd"
 
@@ -59,6 +60,8 @@ class Example:
 
         if self.solver_type == SolverType.EULER:
             self.num_substeps = 32
+        elif self.solver_type == SolverType.STYLE3D:
+            self.num_substeps = 2
         else:
             self.num_substeps = 10
 
@@ -72,7 +75,10 @@ class Example:
 
         self.renderer_scale_factor = 1.0
 
-        builder = newton.ModelBuilder()
+        if self.solver_type == SolverType.STYLE3D:
+            builder = newton.sim.Style3DModelBuilder()
+        else:
+            builder = newton.ModelBuilder()
 
         if self.solver_type == SolverType.EULER:
             ground_cfg = builder.default_shape_cfg.copy()
@@ -106,6 +112,13 @@ class Example:
                 "tri_kd": 1.0e1,
             }
 
+        elif self.solver_type == SolverType.STYLE3D:
+            common_params.pop("edge_ke")
+            solver_params = {
+                "tri_aniso_ke": wp.vec3(1.0e4, 1.0e4, 1.0e3),
+                "edge_aniso_ke": wp.vec3(2.0e-6, 1.0e-6, 5.0e-6),
+            }
+
         elif self.solver_type == SolverType.XPBD:
             solver_params = {
                 "add_springs": True,
@@ -120,7 +133,10 @@ class Example:
                 "tri_kd": 1.0e-1,
             }
 
-        builder.add_cloth_grid(**common_params, **solver_params)
+        if self.solver_type == SolverType.STYLE3D:
+            builder.add_aniso_cloth_grid(**common_params, **solver_params)
+        else:
+            builder.add_cloth_grid(**common_params, **solver_params)
 
         if self.solver_type == SolverType.VBD:
             builder.color(include_bending=True)
@@ -132,6 +148,12 @@ class Example:
 
         if self.solver_type == SolverType.EULER:
             self.solver = newton.solvers.SemiImplicitSolver(model=self.model)
+        elif self.solver_type == SolverType.STYLE3D:
+            self.solver = newton.solvers.Style3DSolver(
+                model=self.model,
+                iterations=self.iterations,
+            )
+            self.solver.precompute(builder)
         elif self.solver_type == SolverType.XPBD:
             self.solver = newton.solvers.XPBDSolver(
                 model=self.model,
@@ -150,6 +172,7 @@ class Example:
                 scaling=self.renderer_scale_factor,
                 enable_backface_culling=False,
             )
+            self.renderer.paused = True
         else:
             self.renderer = None
 

--- a/newton/examples/example_cloth_hanging.py
+++ b/newton/examples/example_cloth_hanging.py
@@ -172,7 +172,6 @@ class Example:
                 scaling=self.renderer_scale_factor,
                 enable_backface_culling=False,
             )
-            self.renderer.paused = True
         else:
             self.renderer = None
 


### PR DESCRIPTION
## Description
Add style3d solver support to the cloth hanging example.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a “Style3D” simulation option for the cloth hanging demo.
  * Added support for anisotropic cloth materials for more realistic behavior.
  * Automatic ground setup selection based on the chosen solver.
* **Performance**
  * Style3D uses fewer substeps for faster simulations while preserving visual quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->