### PR TITLE
Simple articulation USD import fails #517

### DIFF
--- a/newton/tests/assets/revolute_articulation.usda
+++ b/newton/tests/assets/revolute_articulation.usda
@@ -1,0 +1,270 @@
+#usda 1.0
+(
+    customLayerData = {
+        dictionary cameraSettings = {
+            dictionary Front = {
+                double3 position = (50200.000000000015, -1.1146639167236572e-11, 0)
+                double radius = 500
+            }
+            dictionary Perspective = {
+                double3 position = (4.999999999999999, 5, 5.0000000000000036)
+                double3 target = (-3.978038876084611e-8, -3.978038431995401e-8, 7.956077041626486e-8)
+            }
+            dictionary Right = {
+                double3 position = (0, -50010, -1.1104450692300816e-11)
+                double radius = 500
+            }
+            dictionary Top = {
+                double3 position = (0, 0, 50010)
+                double radius = 500
+            }
+            string boundCamera = "/OmniverseKit_Persp"
+        }
+        dictionary omni_layer = {
+            string authoring_layer = "./revolute_articulation.usd"
+            dictionary muteness = {
+            }
+        }
+        int refinementOverrideImplVersion = 0
+        dictionary renderSettings = {
+        }
+    }
+    defaultPrim = "Articulation"
+    doc = """Generated from Composed Stage of root layer https://omniverse-content-staging.s3-us-west-2.amazonaws.com/Assets/Isaac/5.0/Isaac/Robots/IsaacSim/SimpleArticulation/revolute_articulation.usd
+"""
+    endTimeCode = 100
+    metersPerUnit = 1
+    startTimeCode = 0
+    timeCodesPerSecond = 60
+    upAxis = "Z"
+)
+
+def Xform "Articulation" (
+    apiSchemas = ["PhysicsArticulationRootAPI", "PhysxArticulationAPI", "IsaacRobotAPI"]
+)
+{
+    string isaac:description
+    string isaac:namespace
+    rel isaac:physics:robotJoints = </Articulation/Arm/RevoluteJoint>
+    rel isaac:physics:robotLinks = [
+        </Articulation/CenterPivot>,
+        </Articulation/Arm>,
+    ]
+    bool physxArticulation:enabledSelfCollisions = 0
+    int physxArticulation:solverPositionIterationCount = 64
+    int physxArticulation:solverVelocityIterationCount = 64
+    double3 xformOp:rotateXYZ = (0, 0, 0)
+    double3 xformOp:scale = (1, 1, 1)
+    double3 xformOp:translate = (0, 0, 0)
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+
+    def Sphere "CenterPivot" (
+        apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI", "PhysicsMassAPI", "IsaacLinkAPI"]
+    )
+    {
+        float3[] extent = [(-50, -50, -50), (50, 50, 50)]
+        string isaac:nameOverride
+        vector3f physics:angularVelocity = (0, 0, 0)
+        point3f physics:centerOfMass = (0, 0, 0)
+        float3 physics:diagonalInertia = (0.0001, 0.0001, 0.0001)
+        bool physics:kinematicEnabled = 0
+        float physics:mass = 2
+        bool physics:rigidBodyEnabled = 1
+        vector3f physics:velocity = (0, 0, 0)
+        float physxRigidBody:maxDepenetrationVelocity = 0.049999997
+        float physxRigidBody:maxLinearVelocity = inf
+        float physxRigidBody:sleepThreshold = 5e-7
+        float physxRigidBody:stabilizationThreshold = 1e-9
+        double radius = 0.4999999888241291
+        custom bool refinementEnableOverride = 1
+        custom int refinementLevel = 2
+        quatf xformOp:orient = (1, 0, 0, 0)
+        double3 xformOp:scale = (0.2, 0.2, 0.2)
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def PhysicsFixedJoint "FixedJoint" (
+            apiSchemas = ["IsaacJointAPI"]
+        )
+        {
+            custom string isaac:nameOverride
+            float[] isaac:physics:AccelerationLimit
+            float[] isaac:physics:JerkLimit
+            custom int isaac:physics:Rot_X:DofOffset
+            custom int isaac:physics:Rot_Y:DofOffset
+            custom int isaac:physics:Rot_Z:DofOffset
+            custom int isaac:physics:Tr_X:DofOffset
+            custom int isaac:physics:Tr_Y:DofOffset
+            custom int isaac:physics:Tr_Z:DofOffset
+            rel physics:body0 = </Articulation/CenterPivot>
+            float physics:breakForce = inf
+            float physics:breakTorque = inf
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (0.6324555, 0, 0, 0)
+        }
+    }
+
+    def Cube "Arm" (
+        apiSchemas = ["PhysicsRigidBodyAPI", "PhysxRigidBodyAPI", "PhysicsCollisionAPI", "PhysxCollisionAPI", "PhysicsMassAPI", "IsaacLinkAPI"]
+    )
+    {
+        float3[] extent = [(-50, -50, -50), (50, 50, 50)]
+        string isaac:nameOverride
+        vector3f physics:angularVelocity = (0, 0, 0)
+        point3f physics:centerOfMass = (0, 0, 0)
+        bool physics:collisionEnabled = 1
+        float3 physics:diagonalInertia = (0.0001, 0.0001, 0.0001)
+        bool physics:kinematicEnabled = 0
+        float physics:mass = 2
+        bool physics:rigidBodyEnabled = 1
+        vector3f physics:velocity = (0, 0, 0)
+        float physxCollision:contactOffset = -inf
+        float physxCollision:restOffset = -inf
+        float physxRigidBody:angularDamping = 0
+        float physxRigidBody:maxDepenetrationVelocity = 0.049999997
+        float physxRigidBody:maxLinearVelocity = inf
+        float physxRigidBody:sleepThreshold = 5e-7
+        float physxRigidBody:stabilizationThreshold = 1e-9
+        double size = 0.9999999776482582
+        quatf xformOp:orient = (1, 0, 0, 0)
+        double3 xformOp:scale = (2, 0.1, 0.1)
+        double3 xformOp:translate = (0.9999999776482582, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def PhysicsRevoluteJoint "RevoluteJoint" (
+            apiSchemas = ["PhysicsDriveAPI:angular", "IsaacJointAPI"]
+        )
+        {
+            float drive:angular:physics:damping = 100000
+            float drive:angular:physics:maxForce = inf
+            float drive:angular:physics:stiffness = 100000
+            float drive:angular:physics:targetPosition = 0
+            custom string isaac:nameOverride
+            float[] isaac:physics:AccelerationLimit
+            float[] isaac:physics:JerkLimit
+            custom int isaac:physics:Rot_X:DofOffset
+            custom int isaac:physics:Rot_Y:DofOffset
+            custom int isaac:physics:Rot_Z:DofOffset
+            custom int isaac:physics:Tr_X:DofOffset
+            custom int isaac:physics:Tr_Y:DofOffset
+            custom int isaac:physics:Tr_Z:DofOffset
+            uniform token physics:axis = "Y"
+            rel physics:body0 = </Articulation/Arm>
+            rel physics:body1 = </Articulation/CenterPivot>
+            float physics:breakForce = inf
+            float physics:breakTorque = inf
+            point3f physics:localPos0 = (-0.5, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+    }
+}
+
+def Xform "World"
+{
+    def DistantLight "defaultLight" (
+        apiSchemas = ["ShapingAPI"]
+    )
+    {
+        float angle = 1
+        float inputs:angle = 1
+        float inputs:intensity = 3000
+        float inputs:shaping:cone:angle = 180
+        float inputs:shaping:cone:softness = 0
+        float inputs:shaping:focus = 0
+        color3f inputs:shaping:focusTint = (0, 0, 0)
+        float intensity = 3000
+        float shaping:cone:angle = 180
+        float shaping:cone:softness
+        float shaping:focus
+        color3f shaping:focusTint
+        asset shaping:ies:file
+        double3 xformOp:rotateXYZ = (45, 0, 90)
+        double3 xformOp:scale = (0.009999999776482582, 0.009999999776482582, 0.009999999776482582)
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+}
+
+def PhysicsScene "physicsScene" (
+    apiSchemas = ["PhysxSceneAPI"]
+)
+{
+    vector3f physics:gravityDirection = (0, 0, -1)
+    float physics:gravityMagnitude = 10
+    uniform token physxScene:broadphaseType = "MBP"
+    bool physxScene:enableCCD = 1
+    bool physxScene:enableGPUDynamics = 0 (
+        allowedTokens = []
+    )
+    bool physxScene:enableStabilization = 1
+    float physxScene:frictionCorrelationDistance = 0.00025
+    float physxScene:frictionOffsetThreshold = 0.0004
+    uniform token physxScene:solverType = "TGS"
+}
+
+def "Render" (
+    hide_in_stage_window = true
+    no_delete = true
+)
+{
+    def "OmniverseKit"
+    {
+        def "HydraTextures" (
+            hide_in_stage_window = true
+            no_delete = true
+        )
+        {
+            def RenderProduct "omni_kit_widget_viewport_ViewportTexture_0" (
+                apiSchemas = ["OmniRtxSettingsCommonAdvancedAPI_1", "OmniRtxSettingsRtAdvancedAPI_1", "OmniRtxSettingsPtAdvancedAPI_1", "OmniRtxPostColorGradingAPI_1", "OmniRtxPostChromaticAberrationAPI_1", "OmniRtxPostBloomPhysicalAPI_1", "OmniRtxPostMatteObjectAPI_1", "OmniRtxPostCompositingAPI_1", "OmniRtxPostDofAPI_1", "OmniRtxPostMotionBlurAPI_1", "OmniRtxPostTvNoiseAPI_1", "OmniRtxPostTonemapIrayReinhardAPI_1", "OmniRtxPostDebugSettingsAPI_1", "OmniRtxDebugSettingsAPI_1"]
+                hide_in_stage_window = true
+                no_delete = true
+            )
+            {
+                rel camera = </OmniverseKit_Persp>
+                token omni:rtx:background:source:texture:textureMode = "repeatMirrored"
+                token omni:rtx:background:source:type = "domeLight"
+                bool omni:rtx:dlss:frameGeneration = 0
+                string omni:rtx:material:db:rtSensorNameToIdMap = "DefaultMaterial:0;AsphaltStandardMaterial:1;AsphaltWeatheredMaterial:2;VegetationGrassMaterial:3;WaterStandardMaterial:4;GlassStandardMaterial:5;FiberGlassMaterial:6;MetalAlloyMaterial:7;MetalAluminumMaterial:8;MetalAluminumOxidizedMaterial:9;PlasticStandardMaterial:10;RetroMarkingsMaterial:11;RetroSignMaterial:12;RubberStandardMaterial:13;SoilClayMaterial:14;ConcreteRoughMaterial:15;ConcreteSmoothMaterial:16;OakTreeBarkMaterial:17;FabricStandardMaterial:18;PlexiGlassStandardMaterial:19;MetalSilverMaterial:20"
+                bool omni:rtx:material:db:syncLoads = 1
+                bool omni:rtx:post:registeredCompositing:invertColorCorrection = 1
+                bool omni:rtx:post:registeredCompositing:invertToneMap = 1
+                bool omni:rtx:pt:lightcache:cached:dontResolveConflicts = 1
+                int omni:rtx:pt:maxSamplesPerLaunch = 2073600
+                int omni:rtx:pt:mgpu:maxPixelsPerRegionExponent = 12
+                color3f omni:rtx:rt:ambientLight:color = (0.1, 0.1, 0.1)
+                bool omni:rtx:rt:demoire = 0
+                bool omni:rtx:rt:lightcache:spatialCache:dontResolveConflicts = 1
+                bool omni:rtx:scene:hydra:materialSyncLoads = 1
+                bool omni:rtx:scene:hydra:mdlMaterialWarmup = 1
+                uint omni:rtx:viewTile:limit = 4294967295
+                rel orderedVars = </Render/Vars/LdrColor>
+                custom bool overrideClipRange = 0
+                uniform int2 resolution = (1280, 720)
+            }
+        }
+    }
+
+    def RenderSettings "OmniverseGlobalRenderSettings" (
+        apiSchemas = ["OmniRtxSettingsGlobalRtAdvancedAPI_1", "OmniRtxSettingsGlobalPtAdvancedAPI_1"]
+        no_delete = true
+    )
+    {
+        rel products = </Render/OmniverseKit/HydraTextures/omni_kit_widget_viewport_ViewportTexture_0>
+    }
+
+    def "Vars"
+    {
+        def RenderVar "LdrColor" (
+            hide_in_stage_window = true
+            no_delete = true
+        )
+        {
+            uniform string sourceName = "LdrColor"
+        }
+    }
+}
+

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -99,6 +99,53 @@ class TestImportUsd(unittest.TestCase):
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_revolute_articulation(self):
+        """Test importing USD with a joint that has missing body1.
+
+        This tests the behavior where:
+        - Normally: body0 is parent, body1 is child
+        - When body1 is missing: body0 becomes child, world (-1) becomes parent
+
+        The test USD file contains a FixedJoint inside CenterPivot that only
+        specifies body0 (itself) but no body1, which should result in the joint
+        connecting CenterPivot to the world.
+        """
+        builder = newton.ModelBuilder()
+
+        results = parse_usd(
+            os.path.join(os.path.dirname(__file__), "assets", "revolute_articulation.usda"),
+            builder,
+            collapse_fixed_joints=False,  # Don't collapse to see all joints
+        )
+
+        # The articulation has 2 bodies
+        self.assertEqual(builder.body_count, 2)
+        self.assertEqual(set(builder.body_key), {"/Articulation/Arm", "/Articulation/CenterPivot"})
+
+        # Should have 3 joints:
+        # 1. Free joint for articulation root (automatically added)
+        # 2. Revolute joint between CenterPivot and Arm (normal joint with both bodies)
+        # 3. Fixed joint with only body0 specified (CenterPivot to world)
+        self.assertEqual(builder.joint_count, 3)
+
+        # Verify joint types
+        self.assertEqual(builder.joint_type[0], newton.JOINT_FREE)
+        self.assertEqual(builder.joint_type[1], newton.JOINT_REVOLUTE)
+        self.assertEqual(builder.joint_type[2], newton.JOINT_FIXED)
+
+        # The key test: verify the FixedJoint connects CenterPivot to world
+        # because body1 was missing in the USD file
+        fixed_joint_idx = 2
+        self.assertEqual(builder.joint_parent[fixed_joint_idx], -1)  # Parent is world (-1)
+        # Child should be CenterPivot (which was body0 in the USD)
+        center_pivot_idx = builder.body_key.index("/Articulation/CenterPivot")
+        self.assertEqual(builder.joint_child[fixed_joint_idx], center_pivot_idx)
+
+        # Verify the import results mapping
+        self.assertEqual(len(results["path_body_map"]), 2)
+        self.assertEqual(len(results["path_shape_map"]), 1)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_ordering(self):
         builder_dfs = newton.ModelBuilder()
         parse_usd(

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -515,6 +515,11 @@ def parse_usd(
         # if parent_id == -1:
         #     print("joint connected to world")
         child_id = path_body_map.get(child_path, -1)
+        # If child_id is -1, swap parent and child
+        if child_id == -1:
+            parent_id, child_id = child_id, parent_id
+            if verbose:
+                print(f"Joint {joint_path} connects {parent_path} to world")
         parent_tf = wp.transform(joint_desc.localPose0Position, from_gfquat(joint_desc.localPose0Orientation))
         if incoming_xform is not None:
             parent_tf = wp.mul(incoming_xform, parent_tf)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR fixes a bug in USD import where joints with missing `body1` references would cause a `KeyError: -1`.

### Problem
When importing USD files, if a joint only specifies `body0` but not `body1`, the import would fail with a KeyError when trying to access `body_shapes[-1]`.

### Solution
The fix properly handles this case by following the standard physics engine convention:
- **Normal behavior**: `body0` is parent, `body1` is child
- **When `body1` is missing**: `body0` becomes child, world (-1) becomes parent

This is implemented with a simple check that swaps parent and child IDs when `child_id == -1`.

### Testing
Added `test_import_revolute_articulation` which tests importing a USD file (`revolute_articulation.usda`) containing a FixedJoint with only `body0` specified. The test verifies that the joint correctly connects to the world frame.

Closes #517

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date
  - No migration guide changes needed as this is a bug fix that doesn't change the API

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
  - Added clear comments in the code explaining the behavior
- [x] Code passes formatting and linting checks with `pre-commit run -a`
