### PR TITLE
Add an option to pass Solimp / Solref joint values to MujocoWarp through the builder / model. #536

### DIFF
--- a/newton/sim/model.py
+++ b/newton/sim/model.py
@@ -241,6 +241,10 @@ class Model:
         """Joint velocity limits, shape [joint_dof_count], float."""
         self.joint_friction = None
         """Joint friction coefficient, shape [joint_dof_count], float."""
+        self.joint_solref = None
+        """MuJoCo solver reference parameters for joint constraints, shape [joint_dof_count, 2], float. Each row contains (stiffness_time_const, damping_time_const)."""
+        self.joint_solimp = None
+        """MuJoCo solver impedance parameters for joint constraints, shape [joint_dof_count, 5], float. Each row contains (dmin, dmax, width, midpoint, power)."""
         self.joint_dof_dim = None
         """Number of linear and angular dofs per joint, shape [joint_count, 2], int."""
         self.joint_dof_mode = None

--- a/newton/sim/model.py
+++ b/newton/sim/model.py
@@ -403,6 +403,8 @@ class Model:
         self.attribute_frequency["joint_effort_limit"] = "joint_dof"
         self.attribute_frequency["joint_friction"] = "joint_dof"
         self.attribute_frequency["joint_velocity_limit"] = "joint_dof"
+        self.attribute_frequency["joint_solref"] = "joint_dof"
+        self.attribute_frequency["joint_solimp"] = "joint_dof"
 
         # attributes per shape
         self.attribute_frequency["shape_transform"] = "shape"

--- a/newton/solvers/mujoco/solver_mujoco.py
+++ b/newton/solvers/mujoco/solver_mujoco.py
@@ -1769,8 +1769,10 @@ class MuJoCoSolver(SolverBase):
         model_joint_solimp = None
         if model.joint_solref is not None:
             model_joint_solref = model.joint_solref.numpy()
+            assert model_joint_solref.shape[0] == model.joint_dof_count
         if model.joint_solimp is not None:
             model_joint_solimp = model.joint_solimp.numpy()
+            assert model_joint_solimp.shape[0] == model.joint_dof_count
         body_mass = model.body_mass.numpy()
         body_inertia = model.body_inertia.numpy()
         body_com = model.body_com.numpy()
@@ -2062,11 +2064,11 @@ class MuJoCoSolver(SolverBase):
                     joint_params["frictionloss"] = joint_friction[ai]
                     # Set solref and solimp if available (using solref_limit and solimp_limit for joint limits)
                     if model_joint_solref is not None:
-                        joint_params["solref_limit"] = model_joint_solref[ai]
+                        joint_params["solref_limit"] = tuple(model_joint_solref[ai])
                     elif joint_solref is not None:
                         joint_params["solref_limit"] = joint_solref
                     if model_joint_solimp is not None:
-                        joint_params["solimp_limit"] = model_joint_solimp[ai]
+                        joint_params["solimp_limit"] = tuple(model_joint_solimp[ai])
                     elif joint_solimp is not None:
                         joint_params["solimp_limit"] = joint_solimp
                     lower, upper = joint_limit_lower[ai], joint_limit_upper[ai]
@@ -2134,11 +2136,11 @@ class MuJoCoSolver(SolverBase):
                     joint_params["frictionloss"] = joint_friction[ai]
                     # Set solref and solimp if available (using solref_limit and solimp_limit for joint limits)
                     if model_joint_solref is not None:
-                        joint_params["solref_limit"] = model_joint_solref[ai]
+                        joint_params["solref_limit"] = tuple(model_joint_solref[ai])
                     elif joint_solref is not None:
                         joint_params["solref_limit"] = joint_solref
                     if model_joint_solimp is not None:
-                        joint_params["solimp_limit"] = model_joint_solimp[ai]
+                        joint_params["solimp_limit"] = tuple(model_joint_solimp[ai])
                     elif joint_solimp is not None:
                         joint_params["solimp_limit"] = joint_solimp
                     lower, upper = joint_limit_lower[ai], joint_limit_upper[ai]

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -212,6 +212,84 @@ class TestImportMjcf(unittest.TestCase):
         # Verify that the rotation was actually applied (not just identity)
         assert not np.allclose(actual_inertia, original_inertia, atol=1e-6)
 
+    def test_joint_solref_solimp_import(self):
+        """Test that joint solref and solimp parameters are correctly imported from MJCF."""
+        # Create a temporary MJCF file with custom joint solref and solimp values
+        mjcf_content = """
+        <mujoco>
+            <worldbody>
+                <body name="body1" pos="0 0 1">
+                    <inertial pos="0 0 0" mass="1.0" diaginertia="0.1 0.1 0.1"/>
+                    <joint name="joint1" type="hinge" axis="0 0 1"
+                           solref="0.05 2.0"
+                           solimp="0.8 0.9 0.002 0.6 3.0"/>
+                </body>
+                <body name="body2" pos="1 0 1">
+                    <inertial pos="0 0 0" mass="1.0" diaginertia="0.1 0.1 0.1"/>
+                    <joint name="joint2" type="slide" axis="1 0 0"
+                           solref="0.1 1.5"/>
+                    <!-- joint2 has solref but no solimp, should use defaults -->
+                </body>
+                <body name="body3" pos="2 0 1">
+                    <inertial pos="0 0 0" mass="1.0" diaginertia="0.1 0.1 0.1"/>
+                    <joint name="joint3" type="hinge" axis="0 1 0"/>
+                    <!-- joint3 has neither solref nor solimp, should use defaults -->
+                </body>
+            </worldbody>
+        </mujoco>
+        """
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(mjcf_content)
+            mjcf_filename = f.name
+
+        try:
+            # Import the MJCF file
+            builder = newton.ModelBuilder()
+            newton.utils.parse_mjcf(mjcf_filename, builder)
+            model = builder.finalize()
+
+            # Check that we have 3 joints
+            self.assertEqual(model.joint_count, 3)
+            self.assertEqual(model.joint_dof_count, 3)
+
+            # Check joint_solref and joint_solimp arrays exist
+            self.assertIsNotNone(model.joint_solref, "joint_solref should not be None")
+            self.assertIsNotNone(model.joint_solimp, "joint_solimp should not be None")
+
+            solref_values = model.joint_solref.numpy()
+            solimp_values = model.joint_solimp.numpy()
+
+            # Joint 1: Should have custom solref and solimp
+            np.testing.assert_array_almost_equal(
+                solref_values[0], [0.05, 2.0], err_msg="Joint 1 should have custom solref values from MJCF"
+            )
+            np.testing.assert_array_almost_equal(
+                solimp_values[0],
+                [0.8, 0.9, 0.002, 0.6, 3.0],
+                err_msg="Joint 1 should have custom solimp values from MJCF",
+            )
+
+            # Joint 2: Should have custom solref but default solimp
+            np.testing.assert_array_almost_equal(
+                solref_values[1], [0.1, 1.5], err_msg="Joint 2 should have custom solref values from MJCF"
+            )
+            np.testing.assert_array_almost_equal(
+                solimp_values[1], [0.9, 0.95, 0.001, 0.5, 2.0], err_msg="Joint 2 should have default solimp values"
+            )
+
+            # Joint 3: Should have default solref and solimp
+            np.testing.assert_array_almost_equal(
+                solref_values[2], [0.02, 1.0], err_msg="Joint 3 should have default solref values"
+            )
+            np.testing.assert_array_almost_equal(
+                solimp_values[2], [0.9, 0.95, 0.001, 0.5, 2.0], err_msg="Joint 3 should have default solimp values"
+            )
+
+        finally:
+            # Clean up the temporary file
+            os.unlink(mjcf_filename)
+
 
 if __name__ == "__main__":
     wp.clear_kernel_cache()

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -328,6 +329,195 @@ class TestImportUsd(unittest.TestCase):
             assert_np_equal(np.array(builder.shape_scale[vi]), np.array(builder.shape_scale[ci]), tol=1e-5)
             self.assertFalse(builder.shape_flags[vi] & int(newton.geometry.SHAPE_FLAG_COLLIDE_SHAPES))
             self.assertTrue(builder.shape_flags[ci] & int(newton.geometry.SHAPE_FLAG_COLLIDE_SHAPES))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_joint_solref_solimp_import(self):
+        """Test that joint solref and solimp parameters are correctly imported from USD."""
+        try:
+            from pxr import Sdf, Usd, UsdGeom, UsdPhysics  # noqa: PLC0415
+        except ImportError:
+            self.skipTest("USD not available")
+
+        # Create a temporary USD file with custom joint newton:joint_solref and newton:joint_solimp attributes
+        with tempfile.NamedTemporaryFile(suffix=".usda", delete=False) as f:
+            usd_filename = f.name
+
+        try:
+            # Create USD stage
+            stage = Usd.Stage.CreateNew(usd_filename)
+
+            # Add physics scene
+            physics_scene = UsdPhysics.Scene.Define(stage, "/physicsScene")
+            physics_scene.CreateGravityDirectionAttr().Set((0.0, 0.0, -1.0))
+            physics_scene.CreateGravityMagnitudeAttr().Set(9.81)
+
+            # Create an articulation to contain our bodies and joints
+            UsdPhysics.ArticulationRootAPI.Apply(stage.DefinePrim("/articulation", "Xform"))
+
+            # Create ground body with collision shape as part of articulation
+            ground_prim = stage.DefinePrim("/articulation/ground", "Xform")
+            rigid_body = UsdPhysics.RigidBodyAPI.Apply(ground_prim)
+            rigid_body.CreateRigidBodyEnabledAttr().Set(True)
+            UsdPhysics.MassAPI.Apply(ground_prim)
+
+            # Add collision shape to ground
+            ground_shape = UsdGeom.Cube.Define(stage, "/articulation/ground/shape")
+            ground_shape.CreateSizeAttr().Set(10.0)
+            UsdPhysics.CollisionAPI.Apply(ground_shape.GetPrim())
+
+            # Create first body with joint that has custom solref/solimp
+            body1_prim = stage.DefinePrim("/articulation/body1", "Xform")
+            UsdGeom.Xform(body1_prim).AddTranslateOp().Set((0.0, 0.0, 1.0))
+            rigid_body1 = UsdPhysics.RigidBodyAPI.Apply(body1_prim)
+            rigid_body1.CreateRigidBodyEnabledAttr().Set(True)
+            mass_api1 = UsdPhysics.MassAPI.Apply(body1_prim)
+            mass_api1.CreateMassAttr().Set(1.0)
+
+            # Add collision shape to body1
+            body1_shape = UsdGeom.Cube.Define(stage, "/articulation/body1/shape")
+            body1_shape.CreateSizeAttr().Set(0.5)
+            UsdPhysics.CollisionAPI.Apply(body1_shape.GetPrim())
+
+            # Create revolute joint with custom solref/solimp
+            joint1 = UsdPhysics.RevoluteJoint.Define(stage, "/articulation/joint1")
+            joint1.CreateAxisAttr().Set("Z")
+            joint1.CreateBody0Rel().SetTargets(["/articulation/ground"])
+            joint1.CreateBody1Rel().SetTargets(["/articulation/body1"])
+            joint1.CreateLowerLimitAttr().Set(-90.0)
+            joint1.CreateUpperLimitAttr().Set(90.0)
+
+            # Add custom warp attributes
+            joint1_prim = joint1.GetPrim()
+            joint1_prim.CreateAttribute("warp:joint_solref", Sdf.ValueTypeNames.FloatArray).Set([0.05, 2.0])
+            joint1_prim.CreateAttribute("warp:joint_solimp", Sdf.ValueTypeNames.FloatArray).Set(
+                [0.8, 0.9, 0.002, 0.6, 3.0]
+            )
+
+            # Create second body with joint that has only solref
+            body2_prim = stage.DefinePrim("/articulation/body2", "Xform")
+            UsdGeom.Xform(body2_prim).AddTranslateOp().Set((1.0, 0.0, 1.0))
+            rigid_body2 = UsdPhysics.RigidBodyAPI.Apply(body2_prim)
+            rigid_body2.CreateRigidBodyEnabledAttr().Set(True)
+            mass_api2 = UsdPhysics.MassAPI.Apply(body2_prim)
+            mass_api2.CreateMassAttr().Set(1.0)
+
+            # Add collision shape to body2
+            body2_shape = UsdGeom.Cube.Define(stage, "/articulation/body2/shape")
+            body2_shape.CreateSizeAttr().Set(0.5)
+            UsdPhysics.CollisionAPI.Apply(body2_shape.GetPrim())
+
+            # Create prismatic joint with only custom solref
+            joint2 = UsdPhysics.PrismaticJoint.Define(stage, "/articulation/joint2")
+            joint2.CreateAxisAttr().Set("X")
+            joint2.CreateBody0Rel().SetTargets(["/articulation/ground"])
+            joint2.CreateBody1Rel().SetTargets(["/articulation/body2"])
+            joint2.CreateLowerLimitAttr().Set(-1.0)
+            joint2.CreateUpperLimitAttr().Set(1.0)
+
+            # Add only solref attribute
+            joint2_prim = joint2.GetPrim()
+            joint2_prim.CreateAttribute("warp:joint_solref", Sdf.ValueTypeNames.FloatArray).Set([0.1, 1.5])
+
+            # Create third body with joint that has no custom attributes
+            body3_prim = stage.DefinePrim("/articulation/body3", "Xform")
+            UsdGeom.Xform(body3_prim).AddTranslateOp().Set((2.0, 0.0, 1.0))
+            rigid_body3 = UsdPhysics.RigidBodyAPI.Apply(body3_prim)
+            rigid_body3.CreateRigidBodyEnabledAttr().Set(True)
+            mass_api3 = UsdPhysics.MassAPI.Apply(body3_prim)
+            mass_api3.CreateMassAttr().Set(1.0)
+
+            # Add collision shape to body3
+            body3_shape = UsdGeom.Cube.Define(stage, "/articulation/body3/shape")
+            body3_shape.CreateSizeAttr().Set(0.5)
+            UsdPhysics.CollisionAPI.Apply(body3_shape.GetPrim())
+
+            # Create revolute joint with no custom attributes
+            joint3 = UsdPhysics.RevoluteJoint.Define(stage, "/articulation/joint3")
+            joint3.CreateAxisAttr().Set("Y")
+            joint3.CreateBody0Rel().SetTargets(["/articulation/ground"])
+            joint3.CreateBody1Rel().SetTargets(["/articulation/body3"])
+            joint3.CreateLowerLimitAttr().Set(-45.0)
+            joint3.CreateUpperLimitAttr().Set(45.0)
+
+            # Save the stage
+            stage.Save()
+
+            # Import the USD file
+            builder = newton.ModelBuilder()
+            parse_usd(usd_filename, builder)
+            model = builder.finalize()
+
+            # Check joints - there will be free joints for each body plus our defined joints
+            # Filter to only the joints we explicitly defined
+            joint_types = model.joint_type.numpy()
+
+            # Debug: print all joint types (commented out)
+            # print(f"Total joints: {model.joint_count}")
+            # print(f"Joint types: {joint_types}")
+            # print(f"Joint type values: FREE={newton.JOINT_FREE}, REVOLUTE={newton.JOINT_REVOLUTE}, PRISMATIC={newton.JOINT_PRISMATIC}, D6={newton.JOINT_D6}")
+            # print(f"Body count: {model.body_count}")
+
+            revolute_joints = [i for i in range(model.joint_count) if joint_types[i] == newton.JOINT_REVOLUTE]
+            prismatic_joints = [i for i in range(model.joint_count) if joint_types[i] == newton.JOINT_PRISMATIC]
+
+            # The joints might be imported as D6 joints
+            d6_joints = [i for i in range(model.joint_count) if joint_types[i] == newton.JOINT_D6]
+
+            # We should have at least 3 non-free joints
+            non_free_joints = len(revolute_joints) + len(prismatic_joints) + len(d6_joints)
+            self.assertGreaterEqual(
+                non_free_joints,
+                3,
+                f"Should have at least 3 non-free joints, but got {non_free_joints} (revolute: {len(revolute_joints)}, prismatic: {len(prismatic_joints)}, d6: {len(d6_joints)})",
+            )
+
+            # Check joint_solref and joint_solimp arrays exist
+            self.assertIsNotNone(model.joint_solref, "joint_solref should not be None")
+            self.assertIsNotNone(model.joint_solimp, "joint_solimp should not be None")
+
+            solref_values = model.joint_solref.numpy()
+            solimp_values = model.joint_solimp.numpy()
+
+            # Check that we have the expected solref/solimp values somewhere in the arrays
+            # Since free joints are added, we need to search for our specific values
+
+            # Find DOFs with custom solref values
+            custom_solref1_found = False
+            custom_solref2_found = False
+
+            for i in range(model.joint_dof_count):
+                if np.allclose(solref_values[i], [0.05, 2.0]):
+                    # This should be joint1 with custom solref and solimp
+                    custom_solref1_found = True
+                    np.testing.assert_array_almost_equal(
+                        solimp_values[i],
+                        [0.8, 0.9, 0.002, 0.6, 3.0],
+                        err_msg="Joint with solref [0.05, 2.0] should have custom solimp values",
+                    )
+                elif np.allclose(solref_values[i], [0.1, 1.5]):
+                    # This should be joint2 with custom solref but default solimp
+                    custom_solref2_found = True
+                    np.testing.assert_array_almost_equal(
+                        solimp_values[i],
+                        [0.9, 0.95, 0.001, 0.5, 2.0],
+                        err_msg="Joint with solref [0.1, 1.5] should have default solimp values",
+                    )
+
+            self.assertTrue(custom_solref1_found, "Should find joint with custom solref [0.05, 2.0]")
+            self.assertTrue(custom_solref2_found, "Should find joint with custom solref [0.1, 1.5]")
+
+            # Also check that some joints have default values
+            default_joints = [
+                i
+                for i in range(model.joint_dof_count)
+                if np.allclose(solref_values[i], [0.02, 1.0])
+                and np.allclose(solimp_values[i], [0.9, 0.95, 0.001, 0.5, 2.0])
+            ]
+            self.assertGreater(len(default_joints), 0, "Should have at least one joint with default solref/solimp")
+
+        finally:
+            # Clean up the temporary file
+            os.unlink(usd_filename)
 
 
 if __name__ == "__main__":

--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -487,6 +487,18 @@ def parse_mjcf(
                 joint_range = parse_vec(joint_attrib, "range", (default_joint_limit_lower, default_joint_limit_upper))
                 joint_armature.append(parse_float(joint_attrib, "armature", default_joint_armature) * armature_scale)
 
+                # Parse solref and solimp if present
+                joint_solref = None
+                joint_solimp = None
+                if "solref" in joint_attrib:
+                    solref_vals = parse_vec(joint_attrib, "solref", None)
+                    if solref_vals is not None and len(solref_vals) >= 2:
+                        joint_solref = (float(solref_vals[0]), float(solref_vals[1]))
+                if "solimp" in joint_attrib:
+                    solimp_vals = parse_vec(joint_attrib, "solimp", None)
+                    if solimp_vals is not None and len(solimp_vals) >= 5:
+                        joint_solimp = tuple(float(v) for v in solimp_vals[:5])
+
                 if joint_type_str == "free":
                     joint_type = newton.JOINT_FREE
                     break
@@ -504,6 +516,8 @@ def parse_mjcf(
                     target_ke=parse_float(joint_attrib, "stiffness", default_joint_stiffness),
                     target_kd=parse_float(joint_attrib, "damping", default_joint_damping),
                     armature=joint_armature[-1],
+                    solref=joint_solref,
+                    solimp=joint_solimp,
                 )
                 if is_angular:
                     angular_axes.append(ax)

--- a/newton/utils/import_mjcf.py
+++ b/newton/utils/import_mjcf.py
@@ -491,13 +491,19 @@ def parse_mjcf(
                 joint_solref = None
                 joint_solimp = None
                 if "solref" in joint_attrib:
-                    solref_vals = parse_vec(joint_attrib, "solref", None)
-                    if solref_vals is not None and len(solref_vals) >= 2:
-                        joint_solref = (float(solref_vals[0]), float(solref_vals[1]))
+                    try:
+                        solref_vals = np.fromstring(joint_attrib["solref"], sep=" ", dtype=np.float32)
+                        if len(solref_vals) >= 2 and np.isfinite(solref_vals[:2]).all():
+                            joint_solref = (float(solref_vals[0]), float(solref_vals[1]))
+                    except (ValueError, TypeError):
+                        pass  # Skip malformed values
                 if "solimp" in joint_attrib:
-                    solimp_vals = parse_vec(joint_attrib, "solimp", None)
-                    if solimp_vals is not None and len(solimp_vals) >= 5:
-                        joint_solimp = tuple(float(v) for v in solimp_vals[:5])
+                    try:
+                        solimp_vals = np.fromstring(joint_attrib["solimp"], sep=" ", dtype=np.float32)
+                        if len(solimp_vals) >= 5 and np.isfinite(solimp_vals[:5]).all():
+                            joint_solimp = tuple(float(v) for v in solimp_vals[:5])
+                    except (ValueError, TypeError):
+                        pass  # Skip malformed values
 
                 if joint_type_str == "free":
                     joint_type = newton.JOINT_FREE

--- a/newton/utils/import_usd.py
+++ b/newton/utils/import_usd.py
@@ -524,14 +524,12 @@ def parse_usd(
 
         # Parse custom solref and solimp attributes
         joint_solref, joint_solimp = None, None
-        if joint_prim.HasAttribute("warp:joint_solref"):
-            solref_attr = joint_prim.GetAttribute("warp:joint_solref").Get()
-            if solref_attr and len(solref_attr) >= 2:
-                joint_solref = (float(solref_attr[0]), float(solref_attr[1]))
-        if joint_prim.HasAttribute("warp:joint_solimp"):
-            solimp_attr = joint_prim.GetAttribute("warp:joint_solimp").Get()
-            if solimp_attr and len(solimp_attr) >= 5:
-                joint_solimp = tuple(float(v) for v in solimp_attr[:5])
+        solref_vec = parse_vec(joint_prim, "warp:joint_solref")
+        if solref_vec is not None and len(solref_vec) >= 2:
+            joint_solref = (float(solref_vec[0]), float(solref_vec[1]))
+        solimp_vec = parse_vec(joint_prim, "warp:joint_solimp")
+        if solimp_vec is not None and len(solimp_vec) >= 5:
+            joint_solimp = tuple(float(v) for v in solimp_vec[:5])
 
         joint_params = {
             "parent": parent_id,


### PR DESCRIPTION
## Description

This PR adds support for passing MuJoCo's `solref` and `solimp` joint parameters through Newton's model pipeline. These solver parameters control joint constraint behavior and are essential for matching the performance characteristics of native MuJoCo/MJX assets when importing from MJCF or USD formats.

### Changes:
- Added `solref` (tuple[float, float]) and `solimp` (tuple[float, float, float, float, float]) fields to `ModelBuilder.JointDofConfig`
- Added `joint_solref` and `joint_solimp` arrays to the `Model` class to store per-DOF solver parameters
- Updated `ModelBuilder` to track and finalize these parameters into warp arrays
- Modified `MuJoCoSolver` to pass these parameters as `solref_limit` and `solimp_limit` to MuJoCo joints
- Added support for importing these parameters from:
  - MJCF files: reads `solref` and `solimp` attributes from `<joint>` tags
  - USD files: reads `warp:joint_solref` and `warp:joint_solimp` custom attributes
- Updated `add_joint_revolute` and `add_joint_prismatic` methods to accept optional `solref` and `solimp` parameters
- Added comprehensive tests for parameter passing and import functionality

### Purpose:
To reduce the performance gap between MJX assets and USD converted assets, we need to be able to feed extra joint parameters to MuJoCo. Solimp and Solref are critical solver parameters that affect convergence and stability.

Closes #536

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-axis joint solver parameters (solref, solimp) added with sensible defaults; configurable when creating joints and propagated into finalized models and the MuJoCo converter/solver.
  * MJCF and USD importers now read and apply joint solver attributes when present.

* **Documentation**
  * Updated docs and docstrings describing new solver parameters and default behavior.

* **Tests**
  * Added MJCF, USD, and solver integration tests validating import and end-to-end propagation (some duplicated test entries present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->