### PR TITLE
Populate incoming shape xforms for all environments

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2270,6 +2270,13 @@ class SolverMuJoCo(SolverBase):
                         shape_incoming_xform[global_shape_idx] = mjc_tf * wp.transform_inverse(original_tf)
         else:
             full_shape_mapping = {k: (0, v) for k, v in shape_mapping.items()}
+            for shape_idx, geom_idx in shape_mapping.items():
+                if geom_idx >= 0:
+                    original_tf = wp.transform(*shape_transform[shape_idx])
+                    mjc_p = self.mj_model.geom_pos[geom_idx]
+                    mjc_q = self.mj_model.geom_quat[geom_idx]
+                    mjc_tf = wp.transform(mjc_p, quat_from_mjc(mjc_q))
+                    shape_incoming_xform[shape_idx] = mjc_tf * wp.transform_inverse(original_tf)
 
         self.mj_data = mujoco.MjData(self.mj_model)
 


### PR DESCRIPTION
We need to populate incoming xforms for all shapes not only the template (env0) shapes. This was causing issues on the lab side.

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed geometry transform handling in multi-environment simulations so mesh shapes are consistently positioned and oriented across environments.
  * Unified transform behavior between single- and multi-environment runs by expanding shape-to-geom mappings across environments.
  * Non-mesh geometries remain unaffected; overall accuracy and reliability when running multiple environments improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->