### PR TITLE
Fix quaternion inversion in USD importer

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -177,10 +177,7 @@ def parse_usd(
         if not attr or not attr.HasAuthoredValue():
             return default
         val = attr.Get()
-        if invert_rotations:
-            quat = wp.quat(*val.imaginary, -val.real)
-        else:
-            quat = wp.quat(*val.imaginary, val.real)
+        quat = wp.quat(*val.imaginary, val.real)
         l = wp.length(quat)
         if np.isfinite(l) and l > 0.0:
             return quat

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -177,7 +177,7 @@ def parse_usd(
         if not attr or not attr.HasAuthoredValue():
             return default
         val = attr.Get()
-        quat = wp.quat(*val.imaginary, val.real)
+        quat = from_gfquat(val)
         l = wp.length(quat)
         if np.isfinite(l) and l > 0.0:
             return quat

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -321,6 +321,57 @@ class TestImportUsd(unittest.TestCase):
             self.assertFalse(builder.shape_flags[vi] & newton.ShapeFlags.COLLIDE_SHAPES)
             self.assertTrue(builder.shape_flags[ci] & newton.ShapeFlags.COLLIDE_SHAPES)
 
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_non_symmetric_inertia(self):
+        """Test importing USD with inertia specified in principal axes that don't align with body frame."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics  # noqa: PLC0415
+
+        # Create USD stage
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+
+        # Create box and apply physics APIs
+        box = UsdGeom.Cube.Define(stage, "/World/Box")
+        UsdPhysics.CollisionAPI.Apply(box.GetPrim())
+        UsdPhysics.RigidBodyAPI.Apply(box.GetPrim())
+        mass_api = UsdPhysics.MassAPI.Apply(box.GetPrim())
+
+        # Set mass
+        mass_api.CreateMassAttr().Set(1.0)
+
+        # Set diagonal inertia in principal axes frame
+        # Principal moments: [2, 4, 6] kg⋅m²
+        mass_api.CreateDiagonalInertiaAttr().Set(Gf.Vec3f(2.0, 4.0, 6.0))
+
+        # Set principal axes rotated from body frame
+        # Rotate 45° around Z, then 30° around Y
+        # Hardcoded quaternion values for this rotation
+        q = wp.quat(0.1830127, 0.1830127, 0.6830127, 0.6830127)
+        R = np.array(wp.quat_to_matrix(q)).reshape(3, 3)
+
+        # Set principal axes using quaternion
+        mass_api.CreatePrincipalAxesAttr().Set(Gf.Quatf(q.w, q.x, q.y, q.z))
+
+        # Parse USD
+        builder = newton.ModelBuilder()
+        parse_usd(stage, builder)
+
+        # Verify parsing
+        self.assertEqual(builder.body_count, 1)
+        self.assertEqual(builder.shape_count, 1)
+        self.assertAlmostEqual(builder.body_mass[0], 1.0, places=6)
+
+        # Get parsed inertia tensor
+        inertia_parsed = np.array(builder.body_inertia[0])
+
+        # Calculate expected inertia tensor in body frame
+        # I_body = R * I_principal * R^T
+        I_principal = np.diag([2.0, 4.0, 6.0])
+        I_body_expected = R @ I_principal @ R.T
+
+        # Verify the parsed inertia matches our calculated body frame inertia
+        np.testing.assert_allclose(inertia_parsed.reshape(3, 3), I_body_expected, rtol=1e-5, atol=1e-8)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2, failfast=True)


### PR DESCRIPTION
Partially replacing #552 

I think this is safe to submit given that we only use that function in one place. We do however need to figure out why this was there in the first place.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized quaternion parsing for USD imports to produce normalized quaternions, improving determinism and consistency in orientation handling.

* **Tests**
  * Added coverage for non-symmetric inertia specified in principal axes misaligned with the body frame, verifying correct transformation into the body-frame inertia tensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->