### PR TITLE
Fix for contact rendering in example_quadruped.py

### DIFF
--- a/newton/_src/utils/render.py
+++ b/newton/_src/utils/render.py
@@ -20,7 +20,7 @@ from collections import defaultdict
 import numpy as np
 import warp as wp
 from warp.render import OpenGLRenderer, UsdRenderer
-from warp.render.utils import solidify_mesh, tab10_color_map
+from warp.render.utils import compute_contact_points, solidify_mesh, tab10_color_map
 
 from ..core import Axis, AxisType
 from ..geometry import GeoType, ShapeFlags, raycast


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added internal support to compute world-space contact points used by contact rendering.
  * No visible UI, workflow, public API, or data format changes.
  * No configuration or migration required; existing projects continue to run as before.
  * Performance and stability unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->