### PR TITLE
Remove axis parameter from ModelBuilder.add_shape_*() functions #493

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -28,7 +28,6 @@ from typing import Any, Literal
 import numpy as np
 import warp as wp
 
-from ..core.spatial import quat_between_axes
 from ..core.types import (
     Axis,
     AxisType,
@@ -2251,20 +2250,18 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:
         """Adds a capsule collision shape to a body.
 
-        The capsule is centered at its local origin as defined by `xform`. Its length extends along the specified `axis`.
+        The capsule is centered at its local origin as defined by `xform`. Its length extends along the Z-axis.
 
         Args:
             body (int): The index of the parent body this shape belongs to. Use -1 for shapes not attached to any specific body.
             xform (Transform | None): The transform of the capsule in the parent body's local frame. If `None`, the identity transform `wp.transform()` is used. Defaults to `None`.
             radius (float): The radius of the capsule's hemispherical ends and its cylindrical segment. Defaults to `1.0`.
             half_height (float): The half-length of the capsule's central cylindrical segment (excluding the hemispherical ends). Defaults to `0.5`.
-            axis (AxisType): The local axis of the capsule along which its length is aligned (typically `Axis.X`, `Axis.Y`, or `Axis.Z`). Defaults to `Axis.Z`.
             cfg (ShapeConfig | None): The configuration for the shape's physical and collision properties. If `None`, :attr:`default_shape_cfg` is used. Defaults to `None`.
             key (str | None): An optional unique key for identifying the shape. If `None`, a default key is automatically generated. Defaults to `None`.
 
@@ -2276,9 +2273,6 @@ class ModelBuilder:
             xform = wp.transform()
         else:
             xform = wp.transform(*xform)
-        # internally capsule axis is always +Z
-        q = quat_between_axes(Axis.Z, axis)
-        xform = wp.transform(xform.p, xform.q * q)
 
         if cfg is None:
             cfg = self.default_shape_cfg
@@ -2298,20 +2292,18 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:
         """Adds a cylinder collision shape to a body.
 
-        The cylinder is centered at its local origin as defined by `xform`. Its length extends along the specified `axis`.
+        The cylinder is centered at its local origin as defined by `xform`. Its length extends along the Z-axis.
 
         Args:
             body (int): The index of the parent body this shape belongs to. Use -1 for shapes not attached to any specific body.
             xform (Transform | None): The transform of the cylinder in the parent body's local frame. If `None`, the identity transform `wp.transform()` is used. Defaults to `None`.
             radius (float): The radius of the cylinder. Defaults to `1.0`.
-            half_height (float): The half-length of the cylinder along the `axis`. Defaults to `0.5`.
-            axis (AxisType): The local axis of the cylinder along which its length is aligned (e.g., `Axis.X`, `Axis.Y`, `Axis.Z`). Defaults to `Axis.Z`.
+            half_height (float): The half-length of the cylinder along the Z-axis. Defaults to `0.5`.
             cfg (ShapeConfig | None): The configuration for the shape's physical and collision properties. If `None`, :attr:`default_shape_cfg` is used. Defaults to `None`.
             key (str | None): An optional unique key for identifying the shape. If `None`, a default key is automatically generated. Defaults to `None`.
 
@@ -2323,9 +2315,6 @@ class ModelBuilder:
             xform = wp.transform()
         else:
             xform = wp.transform(*xform)
-        # internally cylinder axis is always +Z
-        q = quat_between_axes(Axis.Z, axis)
-        xform = wp.transform(xform.p, xform.q * q)
 
         if cfg is None:
             cfg = self.default_shape_cfg
@@ -2345,13 +2334,12 @@ class ModelBuilder:
         xform: Transform | None = None,
         radius: float = 1.0,
         half_height: float = 0.5,
-        axis: AxisType = Axis.Z,
         cfg: ShapeConfig | None = None,
         key: str | None = None,
     ) -> int:
         """Adds a cone collision shape to a body.
 
-        The cone's origin is at its geometric center, with the base at -half_height and apex at +half_height along the specified `axis`.
+        The cone's origin is at its geometric center, with the base at -half_height and apex at +half_height along the Z-axis.
         The center of mass is located at -half_height/2 from the origin (1/4 of the total height from the base toward the apex).
 
         Args:
@@ -2359,7 +2347,6 @@ class ModelBuilder:
             xform (Transform | None): The transform of the cone in the parent body's local frame. If `None`, the identity transform `wp.transform()` is used. Defaults to `None`.
             radius (float): The radius of the cone's base. Defaults to `1.0`.
             half_height (float): The half-height of the cone (distance from the geometric center to either the base or apex). The total height is 2*half_height. Defaults to `0.5`.
-            axis (AxisType): The local axis of the cone along which its height is aligned. The apex points toward the positive direction of this axis. Defaults to `Axis.Z`.
             cfg (ShapeConfig | None): The configuration for the shape's physical and collision properties. If `None`, :attr:`default_shape_cfg` is used. Defaults to `None`.
             key (str | None): An optional unique key for identifying the shape. If `None`, a default key is automatically generated. Defaults to `None`.
 
@@ -2371,9 +2358,6 @@ class ModelBuilder:
             xform = wp.transform()
         else:
             xform = wp.transform(*xform)
-        # internally cone axis is always +Z
-        q = quat_between_axes(Axis.Z, axis)
-        xform = wp.transform(xform.p, xform.q * q)
 
         if cfg is None:
             cfg = self.default_shape_cfg

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -407,12 +407,14 @@ def parse_mjcf(
                     geom_height = geom_size[1]
                     geom_up_axis = up_axis
 
+                # Apply axis rotation to transform
+                tf = wp.transform(tf.p, tf.q * quat_between_axes(Axis.Z, geom_up_axis))
+
                 if geom_type == "cylinder":
                     s = builder.add_shape_capsule(
                         xform=tf,
                         radius=geom_radius,
                         half_height=geom_height,
-                        axis=geom_up_axis,
                         **shape_kwargs,
                     )
                     shapes.append(s)
@@ -421,7 +423,6 @@ def parse_mjcf(
                         xform=tf,
                         radius=geom_radius,
                         half_height=geom_height,
-                        axis=geom_up_axis,
                         **shape_kwargs,
                     )
                     shapes.append(s)

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -156,23 +156,25 @@ def parse_urdf(
                 shapes.append(s)
 
             for cylinder in geo.findall("cylinder"):
+                # Apply axis rotation to transform
+                xform = wp.transform(tf.p, tf.q * quat_between_axes(Axis.Z, up_axis))
                 s = builder.add_shape_capsule(
                     body=link,
-                    xform=tf,
+                    xform=xform,
                     radius=float(cylinder.get("radius") or "1") * scale,
                     half_height=float(cylinder.get("length") or "1") * 0.5 * scale,
-                    axis=up_axis,
                     cfg=shape_cfg,
                 )
                 shapes.append(s)
 
             for capsule in geo.findall("capsule"):
+                # Apply axis rotation to transform
+                xform = wp.transform(tf.p, tf.q * quat_between_axes(Axis.Z, up_axis))
                 s = builder.add_shape_capsule(
                     body=link,
-                    xform=tf,
+                    xform=xform,
                     radius=float(capsule.get("radius") or "1") * scale,
                     half_height=float(capsule.get("height") or "1") * 0.5 * scale,
-                    axis=up_axis,
                     cfg=shape_cfg,
                 )
                 shapes.append(s)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -376,12 +376,14 @@ def parse_usd(
                 radius = parse_float(prim, "radius", 0.5) * scale[0]
                 half_height = parse_float(prim, "height", 2.0) / 2 * scale[1]
                 assert not has_attribute(prim, "extents"), "Capsule extents are not supported."
+                # Apply axis rotation to transform
+                axis_idx = "XYZ".index(axis_str)
+                xform = wp.transform(xform.p, xform.q * quat_between_axes(Axis.Z, axis_idx))
                 shape_id = builder.add_shape_capsule(
                     parent_body_id,
                     xform,
                     radius,
                     half_height,
-                    axis="XYZ".index(axis_str),
                     cfg=visual_shape_cfg,
                     key=path_name,
                 )
@@ -390,12 +392,14 @@ def parse_usd(
                 radius = parse_float(prim, "radius", 0.5) * scale[0]
                 half_height = parse_float(prim, "height", 2.0) / 2 * scale[1]
                 assert not has_attribute(prim, "extents"), "Cylinder extents are not supported."
+                # Apply axis rotation to transform
+                axis_idx = "XYZ".index(axis_str)
+                xform = wp.transform(xform.p, xform.q * quat_between_axes(Axis.Z, axis_idx))
                 shape_id = builder.add_shape_cylinder(
                     parent_body_id,
                     xform,
                     radius,
                     half_height,
-                    axis="XYZ".index(axis_str),
                     cfg=visual_shape_cfg,
                     key=path_name,
                 )
@@ -404,12 +408,14 @@ def parse_usd(
                 radius = parse_float(prim, "radius", 0.5) * scale[0]
                 half_height = parse_float(prim, "height", 2.0) / 2 * scale[1]
                 assert not has_attribute(prim, "extents"), "Cone extents are not supported."
+                # Apply axis rotation to transform
+                axis_idx = "XYZ".index(axis_str)
+                xform = wp.transform(xform.p, xform.q * quat_between_axes(Axis.Z, axis_idx))
                 shape_id = builder.add_shape_cone(
                     parent_body_id,
                     xform,
                     radius,
                     half_height,
-                    axis="XYZ".index(axis_str),
                     cfg=visual_shape_cfg,
                     key=path_name,
                 )
@@ -1034,25 +1040,37 @@ def parse_usd(
                         radius=shape_spec.radius * scale[0],
                     )
                 elif key == UsdPhysics.ObjectType.CapsuleShape:
+                    # Apply axis rotation to transform
+                    axis = int(shape_spec.axis)
+                    shape_params["xform"] = wp.transform(
+                        shape_params["xform"].p, shape_params["xform"].q * quat_between_axes(Axis.Z, axis)
+                    )
                     shape_id = builder.add_shape_capsule(
                         **shape_params,
                         radius=shape_spec.radius * scale[(int(shape_spec.axis) + 1) % 3],
                         half_height=shape_spec.halfHeight * scale[int(shape_spec.axis)],
-                        axis=int(shape_spec.axis),
                     )
                 elif key == UsdPhysics.ObjectType.CylinderShape:
+                    # Apply axis rotation to transform
+                    axis = int(shape_spec.axis)
+                    shape_params["xform"] = wp.transform(
+                        shape_params["xform"].p, shape_params["xform"].q * quat_between_axes(Axis.Z, axis)
+                    )
                     shape_id = builder.add_shape_cylinder(
                         **shape_params,
                         radius=shape_spec.radius * scale[(int(shape_spec.axis) + 1) % 3],
                         half_height=shape_spec.halfHeight * scale[int(shape_spec.axis)],
-                        axis=int(shape_spec.axis),
                     )
                 elif key == UsdPhysics.ObjectType.ConeShape:
+                    # Apply axis rotation to transform
+                    axis = int(shape_spec.axis)
+                    shape_params["xform"] = wp.transform(
+                        shape_params["xform"].p, shape_params["xform"].q * quat_between_axes(Axis.Z, axis)
+                    )
                     shape_id = builder.add_shape_cone(
                         **shape_params,
                         radius=shape_spec.radius * scale[(int(shape_spec.axis) + 1) % 3],
                         half_height=shape_spec.halfHeight * scale[int(shape_spec.axis)],
-                        axis=int(shape_spec.axis),
                     )
                 elif key == UsdPhysics.ObjectType.MeshShape:
                     mesh = UsdGeom.Mesh(prim)

--- a/newton/tests/test_cone_orientation.py
+++ b/newton/tests/test_cone_orientation.py
@@ -6,6 +6,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.core import quat_between_axes
 from newton._src.geometry import kernels
 
 
@@ -26,7 +27,6 @@ class TestConeOrientation(unittest.TestCase):
             body=body_id,
             radius=self.radius,
             half_height=self.half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=self.density),
         )
 
@@ -88,11 +88,13 @@ class TestConeOrientation(unittest.TestCase):
             with self.subTest(axis=axis_name):
                 builder = newton.ModelBuilder()
                 body_id = builder.add_body()
+                # Apply axis rotation to transform
+                xform = wp.transform(wp.vec3(), quat_between_axes(newton.Axis.Z, axis_enum))
                 builder.add_shape_cone(
                     body=body_id,
+                    xform=xform,
                     radius=self.radius,
                     half_height=self.half_height,
-                    axis=axis_enum,
                     cfg=newton.ModelBuilder.ShapeConfig(density=self.density),
                 )
 
@@ -112,7 +114,6 @@ class TestConeOrientation(unittest.TestCase):
             body=body_id,
             radius=self.radius,
             half_height=self.half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=self.density),
         )
 
@@ -133,7 +134,6 @@ class TestConeOrientation(unittest.TestCase):
             body=body_id,
             radius=self.radius,
             half_height=self.half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=self.density),
         )
 

--- a/newton/tests/test_inertia.py
+++ b/newton/tests/test_inertia.py
@@ -20,6 +20,7 @@ import warp as wp
 from warp.render import OpenGLRenderer
 
 import newton
+from newton._src.core import quat_between_axes
 from newton._src.geometry.inertia import (
     compute_box_inertia,
     compute_cone_inertia,
@@ -170,7 +171,6 @@ class TestInertia(unittest.TestCase):
             body=body_z,
             radius=radius,
             half_height=half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=density),
         )
         model_z = builder_z.finalize()
@@ -183,11 +183,13 @@ class TestInertia(unittest.TestCase):
         # Y-axis capsule
         builder_y = newton.ModelBuilder()
         body_y = builder_y.add_body()
+        # Apply Y-axis rotation
+        xform = wp.transform(wp.vec3(), quat_between_axes(newton.Axis.Z, newton.Axis.Y))
         builder_y.add_shape_capsule(
             body=body_y,
+            xform=xform,
             radius=radius,
             half_height=half_height,
-            axis=newton.Axis.Y,
             cfg=newton.ModelBuilder.ShapeConfig(density=density),
         )
         model_y = builder_y.finalize()
@@ -200,11 +202,13 @@ class TestInertia(unittest.TestCase):
         # X-axis capsule
         builder_x = newton.ModelBuilder()
         body_x = builder_x.add_body()
+        # Apply X-axis rotation
+        xform = wp.transform(wp.vec3(), quat_between_axes(newton.Axis.Z, newton.Axis.X))
         builder_x.add_shape_capsule(
             body=body_x,
+            xform=xform,
             radius=radius,
             half_height=half_height,
-            axis=newton.Axis.X,
             cfg=newton.ModelBuilder.ShapeConfig(density=density),
         )
         model_x = builder_x.finalize()
@@ -221,7 +225,6 @@ class TestInertia(unittest.TestCase):
             body=body_cyl,
             radius=radius,
             half_height=half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=density),
         )
         model_cyl = builder_cyl.finalize()
@@ -239,7 +242,6 @@ class TestInertia(unittest.TestCase):
             body=body_cone,
             radius=radius,
             half_height=half_height,
-            axis=newton.Axis.Z,
             cfg=newton.ModelBuilder.ShapeConfig(density=density),
         )
         model_cone = builder_cone.finalize()

--- a/newton/tests/test_rigid_contact.py
+++ b/newton/tests/test_rigid_contact.py
@@ -19,6 +19,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.core import quat_between_axes
 from newton.tests.unittest_utils import add_function_test, assert_np_equal, get_test_devices
 
 wp.config.quiet = True
@@ -116,11 +117,13 @@ def test_shapes_on_plane(test: TestRigidContact, device, solver_fn):
 
         b = builder.add_body(xform=wp.transform(wp.vec3(2.0, y_pos, 1.0), wp.quat_identity()))
         builder.add_joint_free(b)
+        # Apply Y-axis rotation to capsule
+        xform = wp.transform(wp.vec3(), quat_between_axes(newton.Axis.Z, newton.Axis.Y))
         builder.add_shape_capsule(
             body=b,
+            xform=xform,
             radius=0.1 * scale,
             half_height=0.3 * scale,
-            axis=newton.Axis.Y,
         )
         expected_end_positions.append(wp.vec3(2.0, y_pos, 0.1 * scale))
 

--- a/newton/tests/test_up_axis.py
+++ b/newton/tests/test_up_axis.py
@@ -18,6 +18,7 @@ import unittest
 import warp as wp
 
 import newton
+from newton._src.core import quat_between_axes
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 wp.config.quiet = True
@@ -31,7 +32,9 @@ def test_gravity(test: TestControlForce, device, solver_fn, up_axis: newton.Axis
     builder = newton.ModelBuilder(up_axis=up_axis, gravity=-9.81)
 
     b = builder.add_body()
-    builder.add_shape_capsule(b, axis=up_axis)
+    # Apply axis rotation to transform
+    xform = wp.transform(wp.vec3(), quat_between_axes(newton.Axis.Z, up_axis))
+    builder.add_shape_capsule(b, xform=xform)
     builder.add_joint_free(b)
 
     model = builder.finalize(device=device)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Closes #493

This PR removes the `axis` parameter from `ModelBuilder.add_shape_capsule()`, `ModelBuilder.add_shape_cylinder()`, and `ModelBuilder.add_shape_cone()` functions. These shapes now always align with the Z-axis by default, and any desired orientation should be achieved by applying rotation transforms.

### Changes Made:
- **API Change**: Removed `axis` parameter from the three shape creation methods
- **Updated Importers**: Modified USD, MJCF, and URDF importers to apply axis rotations via transforms before creating shapes
- **Simplified Implementation**: Shapes internally no longer handle axis rotation - this is now the responsibility of the caller
- **Updated Tests**: Fixed all tests that were using the `axis` parameter to use rotation transforms instead

### Breaking Change:
Users who were creating capsules, cylinders, or cones with non-Z axis alignment will need to update their code:

**Before:**
```python
builder.add_shape_capsule(body, axis=newton.Axis.Y, radius=0.5, half_height=1.0)
```

**After:**
```python
xform = wp.transform(wp.vec3(), newton.quat_between_axes(newton.Axis.Z, newton.Axis.Y))
builder.add_shape_capsule(body, xform=xform, radius=0.5, half_height=1.0)
```

### Implementation Notes:
- The `quat_between_axes` function correctly handles the identity case (Z-to-Z), so no special handling is needed
- All importers now consistently apply rotations when shapes have non-Z axis alignment
- This change simplifies the ModelBuilder API and makes axis handling more explicit

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to-date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified shape orientation: removed the axis parameter from adding capsules, cylinders, and cones.
  * Shapes now default to Z-axis alignment; use xform to set orientation.
  * Importers (MJCF, URDF, USD) now embed axis alignment in the transform for consistent behavior.
  * This change alters the public API for these shape-adding methods.

* **Tests**
  * Updated tests to use xform-based orientation and validate COM/inertia with the new approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->