### PR TITLE
Quick fix for static shape mapping error

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2239,7 +2239,7 @@ class SolverMuJoCo(SolverBase):
                 # The local index is consistent for a given part of the model across all environments.
                 if template_shape_idx >= shapes_per_env * model.num_envs:
                     # not an actual template, but a static shape
-                    global_shape_indices = dict.fromkeys(range(model.num_envs), template_shape_idx)
+                    global_shape_indices = {0: template_shape_idx}
                     global_shapes.append(template_shape_idx)
                 else:
                     local_shape_idx = template_shape_idx % shapes_per_env


### PR DESCRIPTION
## Description
This change introduces a quick fix for the bug in static shape mapping in `SolverMuJoCo` that could result in missed collisions when a static geom is involved. For a more robust fix, introducing an explicit mapping from shapes to "template shapes" would make sense.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects handling of static shapes across multiple environments in MuJoCo.
  - Fixes shape-to-geom mapping inconsistencies and ensures reliable reverse mappings per environment.
  - Aligns incoming transforms with live MuJoCo geom transforms to prevent pose mismatches.

- Refactor
  - Streamlines mapping logic to uniformly support both per-environment and global shapes without altering public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->