### PR TITLE
Usd example g1

### DIFF
--- a/newton/examples/example_g1.py
+++ b/newton/examples/example_g1.py
@@ -38,16 +38,16 @@ class Example:
         self.use_mujoco = True
         articulation_builder = newton.ModelBuilder()
 
-        asset_path = newton.utils.download_asset("g1_description")
+        asset_path = newton.utils.download_asset("g1_usd")
 
-        newton.utils.parse_mjcf(
-            str(asset_path / "g1_29dof_with_hand_rev_1_0.xml"),
+        newton.utils.parse_usd(
+            str(asset_path / "g1_isaac.usd"),
             articulation_builder,
+            xform=wp.transform(wp.vec3f(0, 0, 0.8), wp.quat_identity()),
             collapse_fixed_joints=True,
-            up_axis="Z",
             enable_self_collisions=False,
         )
-        articulation_builder.approximate_meshes("bounding_box")
+        articulation_builder.approximate_meshes()
 
         spacing = 3.0
         sqn = int(wp.ceil(wp.sqrt(float(self.num_envs))))


### PR DESCRIPTION
## Description
This PR changes the G1 example to use the USD asset instead of the MJCF asset.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this MR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
