### PR TITLE
Rename custom warp sim USD attributes

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -159,3 +159,34 @@ Renderers
 +-----------------------------------------------+----------------------------------------------+
 |:class:`warp.sim.render.OpenGLRenderer`        |:class:`newton.viewer.RendererOpenGL`         |
 +-----------------------------------------------+----------------------------------------------+
+
+USD Assets
+----------
+
+The custom USD attribute prefix has been changed from "warp" to "newton" and the attribute names are now consistently in snake case.
+
++---------------------------------------------+----------------------------------------------+
+| **warp.sim**                                | **Newton**                                   |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:armature`                     | `physics:newton:armature`                    |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:articulationIndex`            | `physics:newton:articulation_index`          |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:collapse_fixed_joints`        | `physics:newton:collapse_fixed_joints`       |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:contact_ka`                   | `physics:newton:contact_ka`                  |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:contact_kd`                   | `physics:newton:contact_kd`                  |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:contact_ke`                   | `physics:newton:contact_ke`                  |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:contact_kf`                   | `physics:newton:contact_kf`                  |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:contact_thickness`            | `physics:newton:contact_thickness`           |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:joint_drive_gains_scaling`    | `physics:newton:joint_drive_gains_scaling`   |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:joint_limit_kd`               | `physics:newton:joint_limit_kd`              |
++---------------------------------------------+----------------------------------------------+
+| `physics:warp:joint_limit_ke`               | `physics:newton:joint_limit_ke`              |
++---------------------------------------------+----------------------------------------------+

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -850,9 +850,9 @@ def parse_usd(
                 else:
                     usd_prim = stage.GetPrimAtPath(Sdf.Path(key))
                     if "TensorPhysicsArticulationRootAPI" in usd_prim.GetPrimTypeInfo().GetAppliedAPISchemas():
-                        usd_prim.CreateAttribute("physics:newton:articulation_index", Sdf.ValueTypeNames.UInt, True).Set(
-                            articulation_id
-                        )
+                        usd_prim.CreateAttribute(
+                            "physics:newton:articulation_index", Sdf.ValueTypeNames.UInt, True
+                        ).Set(articulation_id)
                         articulation_roots.append(key)
 
                 if key in body_specs:

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -64,12 +64,12 @@ def parse_usd(
         default_density (float): The default density to use for bodies without a density attribute.
         only_load_enabled_rigid_bodies (bool): If True, only rigid bodies which do not have `physics:rigidBodyEnabled` set to False are loaded.
         only_load_enabled_joints (bool): If True, only joints which do not have `physics:jointEnabled` set to False are loaded.
-        joint_drive_gains_scaling (float): The default scaling of the PD control gains (stiffness and damping), if not set in the PhysicsScene with as "warp:joint_drive_gains_scaling".
+        joint_drive_gains_scaling (float): The default scaling of the PD control gains (stiffness and damping), if not set in the PhysicsScene with as "newton:joint_drive_gains_scaling".
         invert_rotations (bool): If True, inverts any rotations defined in the shape transforms.
         verbose (bool): If True, print additional information about the parsed USD file.
         ignore_paths (List[str]): A list of regular expressions matching prim paths to ignore.
         cloned_env (str): The prim path of an environment which is cloned within this USD file. Siblings of this environment prim will not be parsed but instead be replicated via `ModelBuilder.add_builder(builder, xform)` to speed up the loading of many instantiated environments.
-        collapse_fixed_joints (bool): If True, fixed joints are removed and the respective bodies are merged. Only considered if not set on the PhysicsScene with as "warp:collapse_fixed_joints".
+        collapse_fixed_joints (bool): If True, fixed joints are removed and the respective bodies are merged. Only considered if not set on the PhysicsScene with as "newton:collapse_fixed_joints".
         enable_self_collisions (bool): Determines the default behavior of whether self-collisions are enabled for all shapes. If a shape has the attribute ``physxArticulation:enabledSelfCollisions`` defined, this attribute takes precedence.
         apply_up_axis_from_stage (bool): If True, the up axis of the stage will be used to set :attr:`newton.ModelBuilder.up_axis`. Otherwise, the stage will be rotated such that its up axis aligns with the builder's up axis. Default is False.
         root_path (str): The USD path to import, defaults to "/".
@@ -488,7 +488,7 @@ def parse_usd(
         path = str(prim.GetPath())
 
         body_armature = parse_float_with_fallback(
-            (prim, physics_scene_prim), "warp:armature", builder.default_body_armature
+            (prim, physics_scene_prim), "newton:armature", builder.default_body_armature
         )
 
         if add_body_to_builder:
@@ -543,10 +543,10 @@ def parse_usd(
             "enabled": joint_desc.jointEnabled,
         }
         current_joint_limit_ke = parse_float_with_fallback(
-            (joint_prim, physics_scene_prim), "warp:joint_limit_ke", default_joint_limit_ke
+            (joint_prim, physics_scene_prim), "newton:joint_limit_ke", default_joint_limit_ke
         )
         current_joint_limit_kd = parse_float_with_fallback(
-            (joint_prim, physics_scene_prim), "warp:joint_limit_kd", default_joint_limit_kd
+            (joint_prim, physics_scene_prim), "newton:joint_limit_kd", default_joint_limit_kd
         )
 
         if key == UsdPhysics.ObjectType.FixedJoint:
@@ -734,7 +734,7 @@ def parse_usd(
 
         # Updating joint_drive_gains_scaling if set of the PhysicsScene
         joint_drive_gains_scaling = parse_float(
-            physics_scene_prim, "warp:joint_drive_gains_scaling", joint_drive_gains_scaling
+            physics_scene_prim, "newton:joint_drive_gains_scaling", joint_drive_gains_scaling
         )
     else:
         # builder.up_vector, builder.up_axis = get_up_vector_and_axis(stage)
@@ -850,7 +850,7 @@ def parse_usd(
                 else:
                     usd_prim = stage.GetPrimAtPath(Sdf.Path(key))
                     if "TensorPhysicsArticulationRootAPI" in usd_prim.GetPrimTypeInfo().GetAppliedAPISchemas():
-                        usd_prim.CreateAttribute("physics:warp:articulationIndex", Sdf.ValueTypeNames.UInt, True).Set(
+                        usd_prim.CreateAttribute("physics:newton:articulation_index", Sdf.ValueTypeNames.UInt, True).Set(
                             articulation_id
                         )
                         articulation_roots.append(key)
@@ -1011,12 +1011,12 @@ def parse_usd(
                     "body": body_id,
                     "xform": shape_xform,
                     "cfg": ModelBuilder.ShapeConfig(
-                        ke=parse_float_with_fallback(prim_and_scene, "warp:contact_ke", builder.default_shape_cfg.ke),
-                        kd=parse_float_with_fallback(prim_and_scene, "warp:contact_kd", builder.default_shape_cfg.kd),
-                        kf=parse_float_with_fallback(prim_and_scene, "warp:contact_kf", builder.default_shape_cfg.kf),
-                        ka=parse_float_with_fallback(prim_and_scene, "warp:contact_ka", builder.default_shape_cfg.ka),
+                        ke=parse_float_with_fallback(prim_and_scene, "newton:contact_ke", builder.default_shape_cfg.ke),
+                        kd=parse_float_with_fallback(prim_and_scene, "newton:contact_kd", builder.default_shape_cfg.kd),
+                        kf=parse_float_with_fallback(prim_and_scene, "newton:contact_kf", builder.default_shape_cfg.kf),
+                        ka=parse_float_with_fallback(prim_and_scene, "newton:contact_ka", builder.default_shape_cfg.ka),
                         thickness=parse_float_with_fallback(
-                            prim_and_scene, "warp:contact_thickness", builder.default_shape_cfg.thickness
+                            prim_and_scene, "newton:contact_thickness", builder.default_shape_cfg.thickness
                         ),
                         mu=material.dynamicFriction,
                         restitution=material.restitution,
@@ -1200,7 +1200,7 @@ def parse_usd(
     collapse_results = None
     merged_body_data = {}
     path_body_relative_transform = {}
-    if scene_attributes.get("warp:collapse_fixed_joints", collapse_fixed_joints):
+    if scene_attributes.get("newton:collapse_fixed_joints", collapse_fixed_joints):
         collapse_results = builder.collapse_fixed_joints()
         body_merged_parent = collapse_results["body_merged_parent"]
         body_merged_transform = collapse_results["body_merged_transform"]

--- a/newton/examples/assets/ant.usda
+++ b/newton/examples/assets/ant.usda
@@ -128,7 +128,7 @@ def Xform "ant" (
         float physics:density = 1
         custom string physics:engine = "warp"
         vector3f physics:velocity = (0, 0, 0)
-        custom uint physics:warp:articulationIndex = 0
+        custom uint physics:newton:articulation_index = 0
         float warpSim:armature = 0.01
         def "collisions"
         {

--- a/newton/tests/assets/ant.usda
+++ b/newton/tests/assets/ant.usda
@@ -128,7 +128,7 @@ def Xform "ant" (
         float physics:density = 1
         custom string physics:engine = "warp"
         vector3f physics:velocity = (0, 0, 0)
-        custom uint physics:warp:articulationIndex = 0
+        custom uint physics:newton:articulation_index = 0
         float warpSim:armature = 0.01
         def "collisions"
         {

--- a/newton/tests/assets/ant_multi.usda
+++ b/newton/tests/assets/ant_multi.usda
@@ -102,7 +102,7 @@ def "World"
                 )
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 0
+                    custom uint physics:newton:articulation_index = 0
                     bool physxRigidBody:disableGravity = 0
                     bool physxRigidBody:enableGyroscopicForces = 1
                     float physxRigidBody:maxDepenetrationVelocity = 10
@@ -310,7 +310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 1
+                    custom uint physics:newton:articulation_index = 1
                 }
 
                 over "joints"
@@ -435,7 +435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 2
+                    custom uint physics:newton:articulation_index = 2
                 }
 
                 over "joints"
@@ -560,7 +560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 3
+                    custom uint physics:newton:articulation_index = 3
                 }
 
                 over "joints"
@@ -685,7 +685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 4
+                    custom uint physics:newton:articulation_index = 4
                 }
 
                 over "joints"
@@ -810,7 +810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 5
+                    custom uint physics:newton:articulation_index = 5
                 }
 
                 over "joints"
@@ -935,7 +935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 6
+                    custom uint physics:newton:articulation_index = 6
                 }
 
                 over "joints"
@@ -1060,7 +1060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 7
+                    custom uint physics:newton:articulation_index = 7
                 }
 
                 over "joints"
@@ -1185,7 +1185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 8
+                    custom uint physics:newton:articulation_index = 8
                 }
 
                 over "joints"
@@ -1310,7 +1310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 9
+                    custom uint physics:newton:articulation_index = 9
                 }
 
                 over "joints"
@@ -1435,7 +1435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 10
+                    custom uint physics:newton:articulation_index = 10
                 }
 
                 over "joints"
@@ -1560,7 +1560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 11
+                    custom uint physics:newton:articulation_index = 11
                 }
 
                 over "joints"
@@ -1685,7 +1685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 12
+                    custom uint physics:newton:articulation_index = 12
                 }
 
                 over "joints"
@@ -1810,7 +1810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 13
+                    custom uint physics:newton:articulation_index = 13
                 }
 
                 over "joints"
@@ -1935,7 +1935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 14
+                    custom uint physics:newton:articulation_index = 14
                 }
 
                 over "joints"
@@ -2060,7 +2060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 15
+                    custom uint physics:newton:articulation_index = 15
                 }
 
                 over "joints"
@@ -2185,7 +2185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 16
+                    custom uint physics:newton:articulation_index = 16
                 }
 
                 over "joints"
@@ -2310,7 +2310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 17
+                    custom uint physics:newton:articulation_index = 17
                 }
 
                 over "joints"
@@ -2435,7 +2435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 18
+                    custom uint physics:newton:articulation_index = 18
                 }
 
                 over "joints"
@@ -2560,7 +2560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 19
+                    custom uint physics:newton:articulation_index = 19
                 }
 
                 over "joints"
@@ -2685,7 +2685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 20
+                    custom uint physics:newton:articulation_index = 20
                 }
 
                 over "joints"
@@ -2810,7 +2810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 21
+                    custom uint physics:newton:articulation_index = 21
                 }
 
                 over "joints"
@@ -2935,7 +2935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 22
+                    custom uint physics:newton:articulation_index = 22
                 }
 
                 over "joints"
@@ -3060,7 +3060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 23
+                    custom uint physics:newton:articulation_index = 23
                 }
 
                 over "joints"
@@ -3185,7 +3185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 24
+                    custom uint physics:newton:articulation_index = 24
                 }
 
                 over "joints"
@@ -3310,7 +3310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 25
+                    custom uint physics:newton:articulation_index = 25
                 }
 
                 over "joints"
@@ -3435,7 +3435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 26
+                    custom uint physics:newton:articulation_index = 26
                 }
 
                 over "joints"
@@ -3560,7 +3560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 27
+                    custom uint physics:newton:articulation_index = 27
                 }
 
                 over "joints"
@@ -3685,7 +3685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 28
+                    custom uint physics:newton:articulation_index = 28
                 }
 
                 over "joints"
@@ -3810,7 +3810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 29
+                    custom uint physics:newton:articulation_index = 29
                 }
 
                 over "joints"
@@ -3935,7 +3935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 30
+                    custom uint physics:newton:articulation_index = 30
                 }
 
                 over "joints"
@@ -4060,7 +4060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 31
+                    custom uint physics:newton:articulation_index = 31
                 }
 
                 over "joints"
@@ -4185,7 +4185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 32
+                    custom uint physics:newton:articulation_index = 32
                 }
 
                 over "joints"
@@ -4310,7 +4310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 33
+                    custom uint physics:newton:articulation_index = 33
                 }
 
                 over "joints"
@@ -4435,7 +4435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 34
+                    custom uint physics:newton:articulation_index = 34
                 }
 
                 over "joints"
@@ -4560,7 +4560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 35
+                    custom uint physics:newton:articulation_index = 35
                 }
 
                 over "joints"
@@ -4685,7 +4685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 36
+                    custom uint physics:newton:articulation_index = 36
                 }
 
                 over "joints"
@@ -4810,7 +4810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 37
+                    custom uint physics:newton:articulation_index = 37
                 }
 
                 over "joints"
@@ -4935,7 +4935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 38
+                    custom uint physics:newton:articulation_index = 38
                 }
 
                 over "joints"
@@ -5060,7 +5060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 39
+                    custom uint physics:newton:articulation_index = 39
                 }
 
                 over "joints"
@@ -5185,7 +5185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 40
+                    custom uint physics:newton:articulation_index = 40
                 }
 
                 over "joints"
@@ -5310,7 +5310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 41
+                    custom uint physics:newton:articulation_index = 41
                 }
 
                 over "joints"
@@ -5435,7 +5435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 42
+                    custom uint physics:newton:articulation_index = 42
                 }
 
                 over "joints"
@@ -5560,7 +5560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 43
+                    custom uint physics:newton:articulation_index = 43
                 }
 
                 over "joints"
@@ -5685,7 +5685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 44
+                    custom uint physics:newton:articulation_index = 44
                 }
 
                 over "joints"
@@ -5810,7 +5810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 45
+                    custom uint physics:newton:articulation_index = 45
                 }
 
                 over "joints"
@@ -5935,7 +5935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 46
+                    custom uint physics:newton:articulation_index = 46
                 }
 
                 over "joints"
@@ -6060,7 +6060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 47
+                    custom uint physics:newton:articulation_index = 47
                 }
 
                 over "joints"
@@ -6185,7 +6185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 48
+                    custom uint physics:newton:articulation_index = 48
                 }
 
                 over "joints"
@@ -6310,7 +6310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 49
+                    custom uint physics:newton:articulation_index = 49
                 }
 
                 over "joints"
@@ -6435,7 +6435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 50
+                    custom uint physics:newton:articulation_index = 50
                 }
 
                 over "joints"
@@ -6560,7 +6560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 51
+                    custom uint physics:newton:articulation_index = 51
                 }
 
                 over "joints"
@@ -6685,7 +6685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 52
+                    custom uint physics:newton:articulation_index = 52
                 }
 
                 over "joints"
@@ -6810,7 +6810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 53
+                    custom uint physics:newton:articulation_index = 53
                 }
 
                 over "joints"
@@ -6935,7 +6935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 54
+                    custom uint physics:newton:articulation_index = 54
                 }
 
                 over "joints"
@@ -7060,7 +7060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 55
+                    custom uint physics:newton:articulation_index = 55
                 }
 
                 over "joints"
@@ -7185,7 +7185,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 56
+                    custom uint physics:newton:articulation_index = 56
                 }
 
                 over "joints"
@@ -7310,7 +7310,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 57
+                    custom uint physics:newton:articulation_index = 57
                 }
 
                 over "joints"
@@ -7435,7 +7435,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 58
+                    custom uint physics:newton:articulation_index = 58
                 }
 
                 over "joints"
@@ -7560,7 +7560,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 59
+                    custom uint physics:newton:articulation_index = 59
                 }
 
                 over "joints"
@@ -7685,7 +7685,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 60
+                    custom uint physics:newton:articulation_index = 60
                 }
 
                 over "joints"
@@ -7810,7 +7810,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 61
+                    custom uint physics:newton:articulation_index = 61
                 }
 
                 over "joints"
@@ -7935,7 +7935,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 62
+                    custom uint physics:newton:articulation_index = 62
                 }
 
                 over "joints"
@@ -8060,7 +8060,7 @@ def "World"
                 over "torso"
                 {
                     custom string physics:engine = "warp"
-                    custom uint physics:warp:articulationIndex = 63
+                    custom uint physics:newton:articulation_index = 63
                 }
 
                 over "joints"

--- a/newton/tests/assets/cube_cylinder.usda
+++ b/newton/tests/assets/cube_cylinder.usda
@@ -47,7 +47,7 @@ over "Render" (
 
 def PhysicsScene "physicsScene"
 {
-    bool warp:collapse_fixed_joints = 0
+    bool newton:collapse_fixed_joints = 0
 }
 
 def Xform "World"

--- a/newton/tests/assets/pendulum_revolute_vs_d6.usda
+++ b/newton/tests/assets/pendulum_revolute_vs_d6.usda
@@ -20,7 +20,7 @@ def Xform "Robot" (
     {
         float3 physics:diagonalInertia = (1, 1, 1)
         float physics:mass = 1000000
-        custom uint physics:warp:articulationIndex = 0
+        custom uint physics:newton:articulation_index = 0
     }
 
     def Xform "BodyL" (


### PR DESCRIPTION
## Description
Renames the custom USD attributes' prefix from `warp` to `newton`, and uses snake case everywhere, e.g. `physics:warp:articulationIndex` → `physics:newton:articulation_index`.

## Newton Migration Guide
- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
