### PR TITLE
Remove incoming xform handling from MuJoCo solver

### DIFF
--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -672,7 +672,6 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         shape_sizes = self.model.shape_scale.numpy()
         shape_transforms = self.model.shape_transform.numpy()
         shape_bodies = self.model.shape_body.numpy()
-        shape_incoming_xform = self.model.shape_incoming_xform.numpy()
 
         # Get all property arrays from MuJoCo
         geom_friction = solver.mjw_model.geom_friction.numpy()
@@ -770,10 +769,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 actual_pos = geom_pos[world_idx, geom_idx]
                 actual_quat = geom_quat[world_idx, geom_idx]
 
-                # Get expected transform from Newton
-                incoming_xform = wp.transform(*shape_incoming_xform[shape_idx])
-                # account for incoming transform due to joint child transform
-                shape_transform = incoming_xform * wp.transform(*shape_transforms[shape_idx])
+                shape_transform = wp.transform(*shape_transforms[shape_idx])
                 expected_pos = wp.vec3(*shape_transform.p)
                 expected_quat = wp.quat(*shape_transform.q)
 
@@ -822,7 +818,6 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
 
         # Get mappings
         to_newton_shape_index = self.model.to_newton_shape_index.numpy()
-        shape_incoming_xform = self.model.shape_incoming_xform.numpy()
         num_geoms = solver.mj_model.ngeom
 
         # Run an initial simulation step
@@ -980,9 +975,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 self.assertTrue(size_changed, f"Size should have changed for shape {shape_idx}")
 
                 # Verify 5: Position and orientation updated
-                # Compute expected values based on new transforms
-                incoming_xform = wp.transform(*shape_incoming_xform[shape_idx])
-                new_transform = incoming_xform * wp.transform(*new_transforms[shape_idx])
+                new_transform = wp.transform(*new_transforms[shape_idx])
                 expected_pos = new_transform.p
                 expected_quat = new_transform.q
 


### PR DESCRIPTION
Because we are properly handling the parent-to-child rotation, the geoms are now both in local body space and there is no need to offset them anymore.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified geometry transform handling to rely solely on per-shape transforms, removing the prior corrective incoming-transform layer. This may change geometry alignment versus earlier versions.
- Tests
  - Updated tests to match the new transform behavior, removing expectations tied to the incoming-transform composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->