### PR TITLE
Fix contact shape mapping

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1938,7 +1938,6 @@ class SolverMuJoCo(SolverBase):
         self.selected_joints = wp.array(selected_joints, dtype=wp.int32, device=model.device)
         self.selected_bodies = wp.array(selected_bodies, dtype=wp.int32, device=model.device)
         selected_shapes_set = set(selected_shapes)
-        selected_bodies_set = set(selected_bodies)
 
         def add_geoms(newton_body_id: int, incoming_xform: wp.transform | None = None):
             body = mj_bodies[body_mapping[newton_body_id]]


### PR DESCRIPTION
## Description
This PR removes the no-longer correct contact shape introduced for the contact sensors in favor of the mapping used elsewhere.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified MuJoCo contact/geometry mapping with direct geometry creation and a unified internal mapping, reducing intermediate structures and streamlining contact updates.
- Chores
  - Removed deprecated API for explicit contact-geometry mapping and related configuration state. If your integration depended on creating or passing a custom mapping, update it to rely on the built-in unified mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->