### PR TITLE
[DRAFT]: New feature: sim_usd.py: a utility that reads a USD file, runs a Newton sim ba…

### DIFF
--- a/newton/_src/core/spatial.py
+++ b/newton/_src/core/spatial.py
@@ -329,7 +329,53 @@ def quat_between_axes(*axes: AxisType) -> wp.quat:
     return q
 
 
+@wp.func
+def angvel_between_quats(q1: wp.quat, q2: wp.quat, dt: float):
+    """
+    Compute angular velocity vector omega (rad/s) taking orientation q1 to q2 over time dt.
+
+    Args:
+        q1, q2 : wp.quat
+            Unit quaternions representing orientations.
+        dt : float
+            Time step in seconds (> 0).
+
+    Returns:
+        omega : ndarray shape (3,)
+            Angular velocity vector in rad/s.
+
+    Notes:
+        - Uses omega = (2/dt) * log( q_rel ), where q_rel = q2 * conj(q1) with shortest-arc fix.
+        - The returned omega corresponds to the rotation that maps q1 to q2.
+        - q1 and q2 are normalized internally; dt must be positive.
+    """
+
+    if wp.dot(q1, q2) < 0.0:
+        q2 = -q2
+
+    q_rel = q2 * wp.quat_inverse(q1)
+    q_rel = wp.normalize(q_rel)
+
+    v = wp.vec3(q_rel.x, q_rel.y, q_rel.z)
+    w = wp.clamp(q_rel.w, -1.0, 1.0)
+
+    v_norm = wp.length(v)
+
+    # Stable handling for small angles
+    eps = 1e-12
+    if v_norm < eps:
+        omega = (2.0 / dt) * v
+    else:
+        phi = wp.atan2(v_norm, w)
+        n = v / v_norm
+        theta = 2.0 * phi
+        omega = (theta / dt) * n
+
+    return omega
+
+
 __all__ = [
+    "angvel_between_quats",
     "quat_between_axes",
     "quat_decompose",
     "quat_from_euler",

--- a/newton/_src/sim/collide_unified.py
+++ b/newton/_src/sim/collide_unified.py
@@ -329,6 +329,8 @@ class CollisionPipelineUnified:
         self.enable_contact_matching = enable_contact_matching
         self.reduce_contacts = reduce_contacts
         self.shape_pairs_max = (shape_count * (shape_count - 1)) // 2
+        if broad_phase_mode == BroadPhaseMode.EXPLICIT:
+            self.shape_pairs_max = min(self.shape_pairs_max, len(shape_pairs_filtered))
 
         # Initialize broad phase
         if self.broad_phase_mode == BroadPhaseMode.NXN:

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -96,6 +96,7 @@ def integrate_rigid_body(
 
     # angular damping
     w1 *= 1.0 - angular_damping * dt
+    v1 *= 1.0 - angular_damping * dt
 
     q_new = wp.transform(x1 - wp.quat_rotate(r1, com), r1)
     qd_new = wp.spatial_vector(v1, w1)

--- a/newton/_src/utils/add_bdx_physics_schema.py
+++ b/newton/_src/utils/add_bdx_physics_schema.py
@@ -1,0 +1,390 @@
+import argparse
+
+import numpy as np
+import warp as wp
+from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+
+def apply_collision_api(prim):
+    type_name = str(prim.GetTypeName()).lower()
+
+    if "proxy" in str(prim.GetPath()):
+        return
+
+    if type_name in ("mesh", "capsule", "sphere", "box", "cylinder", "cone"):
+        print(f"Applying CollisionAPI to {prim}")
+        collisionAPI = UsdPhysics.CollisionAPI.Apply(prim)
+        collisionAPI.CreateCollisionEnabledAttr(True)
+
+    for child in prim.GetChildren():
+        apply_collision_api(child)
+
+
+def parse_xform(prim, local=True):
+    xform = UsdGeom.Xform(prim)
+    if local:
+        mat = np.array(xform.GetLocalTransformation(), dtype=np.float32)
+    else:
+        mat = np.array(xform.ComputeLocalToWorldTransform(Usd.TimeCode.Default()), dtype=np.float32)
+    rot = wp.quat_from_matrix(wp.mat33(mat[:3, :3].T.flatten()))
+    pos = mat[3, :3]
+    return wp.transform(pos, rot)
+
+
+def add_chainlink_joints(stage):
+    chains = {
+        "HangingLanternA_01": "HangingLanternChainA_05",
+        "HangingLanternA_02": "HangingLanternChainA_06",
+        "HangingLanternA_03": "HangingLanternChainA_04",
+        "HangingLanternC_01": "HangingLanternChainA_01",
+        "HangingLanternC_02": "HangingLanternChainA_07",
+        "HangingLanternD_01": "HangingLanternChainA_03",
+        "HangingLanternE_01": "HangingLanternChainA_02",
+    }
+
+    bad_links = ["16", "40"]
+
+    world = stage.GetPrimAtPath("/World")
+
+    for lantern, chain in chains.items():
+        lantern_prim = world.GetPrimAtPath(f"/World/{lantern}")
+        UsdPhysics.RigidBodyAPI.Apply(lantern_prim)
+
+        apply_collision_api(lantern_prim)
+
+        chain_geo_prim = world.GetPrimAtPath(f"/World/{chain}/geo")
+        chain_joints_prim = world.GetPrimAtPath(f"/World/{chain}/geo/joints")
+
+        chainlinks = [
+            child
+            for child in chain_geo_prim.GetChildren()
+            if "chainlink" in str(child.GetPath()) and not any(xx in str(child.GetPath()) for xx in bad_links)
+        ]
+
+        for chainlink in chainlinks:
+            UsdPhysics.RigidBodyAPI.Apply(chainlink)
+            mass_api = UsdPhysics.MassAPI.Apply(chainlink)
+            mass_api.CreateMassAttr().Set(0.1)
+            print(f"Applied RigidBodyAPI to {chainlink}")
+            # apply_collision_api(lantern_prim)
+
+        # chainlink joints
+        joints = [UsdPhysics.SphericalJoint(joint_prim) for joint_prim in chain_joints_prim.GetChildren()]
+
+        for k, joint in enumerate(joints):
+            if k >= len(chainlinks):
+                continue
+
+            if k > 0:
+                joint.GetBody0Rel().AddTarget(chainlinks[k - 1].GetPrimPath())
+                joint.GetBody1Rel().AddTarget(chainlinks[k].GetPrimPath())
+
+                b0_xform = parse_xform(chainlinks[k - 1])
+                b1_xform = parse_xform(chainlinks[k])
+                local_pos_1 = 0.5 * wp.transform_point(
+                    wp.transform_inverse(b1_xform), wp.transform_get_translation(b0_xform)
+                )
+                local_pos_0 = 0.5 * wp.transform_point(
+                    wp.transform_inverse(b0_xform), wp.transform_get_translation(b1_xform)
+                )
+
+                joint.GetLocalPos1Attr().Set(Gf.Vec3f(local_pos_1[0], local_pos_1[1], local_pos_1[2]))
+                joint.GetLocalPos0Attr().Set(Gf.Vec3f(local_pos_0[0], local_pos_0[1], local_pos_0[2]))
+            else:
+                joint.GetBody0Rel().AddTarget(chainlinks[k].GetPrimPath())
+                b0_xform = parse_xform(chainlinks[k])
+                joint.GetLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                joint.GetLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                joint.GetBody1Rel().AddTarget("/World")
+
+            # print(
+            #     f"Joint from {joint.GetBody0Rel().GetTargets()[0]} to {joint.GetBody1Rel().GetTargets()[0]} local pos: {joint.GetLocalPos1Attr().Get()}"
+            # )
+
+        UsdPhysics.ArticulationRootAPI.Apply(chainlinks[0])
+
+        # chain/lantern
+        lantern_joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/{lantern}_joint")
+        lantern_joint.GetBody0Rel().AddTarget(chainlinks[-1].GetPrimPath())
+        lantern_joint.GetBody1Rel().AddTarget(lantern_prim.GetPrimPath())
+
+        b0_xform = parse_xform(chainlinks[-1], local=False)
+        b1_xform = parse_xform(lantern_prim, local=False)
+        local_pos = wp.transform_point(wp.transform_inverse(b1_xform), wp.transform_get_translation(b0_xform))
+        lantern_joint.GetLocalPos1Attr().Set(Gf.Vec3f(local_pos[0], local_pos[1], local_pos[2]))
+
+        print(f"Added lanterns for chain {chain} [{lantern}]")
+
+
+def add_lantern_joints(stage):
+    chains = [
+        [
+            "HangingLanternChainA_08",
+            "HangingLanternChainA_05",
+            "HangingLanternA_01",
+        ],
+        [
+            "HangingLanternChainA_13",
+            "HangingLanternChainA_06",
+            "HangingLanternA_02",
+        ],
+        [
+            "HangingLanternChainA_04",
+            "HangingLanternA_03",
+        ],
+        [
+            "HangingLanternChainA_12",
+            "HangingLanternChainA_01",
+            "HangingLanternC_01",
+        ],
+        [
+            "HangingLanternChainA_11",
+            "HangingLanternChainA_07",
+            "HangingLanternC_02",
+        ],
+        [
+            "HangingLanternChainA_09",
+            "HangingLanternChainA_02",
+            "HangingLanternE_01",
+        ],
+        [
+            "HangingLanternChainA_10",
+            "HangingLanternChainA_03",
+            "HangingLanternD_01",
+        ],
+    ]
+
+    chain_link_length = 0.6
+
+    world = stage.GetPrimAtPath("/World")
+
+    for chain_idx, chain in enumerate(chains):
+        # register links as rigid bodies
+        bodies = []
+        for i, link in enumerate(chain):
+            chain_prim = world.GetPrimAtPath(f"/World/{link}")
+            UsdPhysics.RigidBodyAPI.Apply(chain_prim)
+            apply_collision_api(world.GetPrimAtPath(f"/World/{link}/geo"))
+            bodies.append(chain_prim)
+
+            if i > 0 and i < len(chain) - 1:
+                # connect links with fixed joints
+                fixed_joint = UsdPhysics.FixedJoint.Define(stage, f"/World/fixed_joint_{chain_idx}_{i}")
+                fixed_joint.GetBody0Rel().AddTarget(bodies[i - 1].GetPrimPath())
+                fixed_joint.GetBody1Rel().AddTarget(bodies[i].GetPrimPath())
+                fixed_joint.GetLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, chain_link_length))
+
+        UsdPhysics.ArticulationRootAPI.Apply(bodies[0])
+
+        anchor_joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/anchor_joint_{chain_idx}")
+        anchor_joint.GetBody0Rel().AddTarget(bodies[0].GetPrimPath())
+        anchor_joint.GetBody1Rel().AddTarget("/World")
+        anchor_joint.GetLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, chain_link_length))
+        anchor_joint.GetLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, chain_link_length))
+
+        lantern_joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/lantern_joint_{chain_idx}")
+        lantern_joint.GetBody0Rel().AddTarget(bodies[-2].GetPrimPath())
+        lantern_joint.GetBody1Rel().AddTarget(bodies[-1].GetPrimPath())
+
+        # figure out world pose of the lantern to compute the right offset from the last chain link
+        lantern_xform = parse_xform(bodies[-1])
+        chain_xform = parse_xform(bodies[-2])
+        lantern_offset = lantern_xform.p - chain_xform.p
+        lantern_joint.GetLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, -lantern_offset[2]))
+
+        print(f"Added lanterns for chain {chain_idx} [{', '.join(chain)}]")
+
+
+def add_rod_joints(stage, use_fixed_joints=False):
+    # name of rod parent prim, name of lantern prim, number of rod links
+    rods = [
+        ("HangingLanternChainA_01", "HangingLanternC_01"),  # 3
+        ("HangingLanternChainA_02", "HangingLanternE_01"),  # 2
+        ("HangingLanternChainA_03", "HangingLanternD_01"),  # 1
+        ("HangingLanternChainA_04", "HangingLanternA_03"),  # 1
+        ("HangingLanternChainA_05", "HangingLanternA_01"),  # 1
+        ("HangingLanternChainA_06", "HangingLanternA_02"),  # 2
+        ("HangingLanternChainA_07", "HangingLanternC_02"),  # 2
+    ]
+
+    joints = []
+    world = stage.GetPrimAtPath("/World")
+    for rod_idx, (chain_name, lantern_name) in enumerate(rods):
+        jp_prim = stage.GetPrimAtPath(f"/World/{chain_name}/geo/jointpositions")
+        joint_positions: list[wp.vec3] = [parse_xform(child, local=False).p for child in jp_prim.GetChildren()]
+        # register links as rigid bodies
+        geo_prim = stage.GetPrimAtPath(f"/World/{chain_name}/geo")
+        rod_link_prims = geo_prim.GetChildren()[1:]  # skip "jointpositions" prim
+        assert len(joint_positions) == len(rod_link_prims) + 1
+        assert len(rod_link_prims) > 0
+        UsdPhysics.ArticulationRootAPI.Apply(rod_link_prims[0])
+        for i, rod_prim in enumerate(rod_link_prims):
+            UsdPhysics.RigidBodyAPI.Apply(rod_prim)
+            apply_collision_api(rod_prim)
+
+            if i > 0:
+                # connect rod links
+                if use_fixed_joints:
+                    joint = UsdPhysics.FixedJoint.Define(stage, f"/World/rod_joint_{rod_idx}_{i}")
+                else:
+                    joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/rod_joint_{rod_idx}_{i}")
+                joint.GetBody0Rel().AddTarget(rod_link_prims[i - 1].GetPrimPath())
+                joint.GetBody1Rel().AddTarget(rod_link_prims[i].GetPrimPath())
+                diff = joint_positions[i - 1] - joint_positions[i]
+                joint.GetLocalPos1Attr().Set(Gf.Vec3f(*diff))
+                joints.append(joint)
+
+        anchor_joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/anchor_joint_{rod_idx}")
+        anchor_joint.GetBody0Rel().AddTarget(rod_link_prims[0].GetPrimPath())
+        anchor_joint.GetBody1Rel().AddTarget("/World")
+        p0 = joint_positions[0] - joint_positions[1]
+        anchor_joint.GetLocalPos0Attr().Set(Gf.Vec3f(*p0))
+        p1 = joint_positions[0] - parse_xform(rod_link_prims[0], local=False).p
+        anchor_joint.GetLocalPos1Attr().Set(Gf.Vec3f(*p1))
+        joints.append(anchor_joint)
+
+        lantern_prim = stage.GetPrimAtPath(f"/World/{lantern_name}")
+        UsdPhysics.RigidBodyAPI.Apply(lantern_prim)
+        apply_collision_api(lantern_prim)
+
+        lantern_joint = UsdPhysics.SphericalJoint.Define(stage, f"/World/lantern_joint_{rod_idx}")
+        lantern_joint.GetBody0Rel().AddTarget(rod_link_prims[-1].GetPrimPath())
+        lantern_joint.GetBody1Rel().AddTarget(lantern_prim.GetPrimPath())
+
+        # figure out world pose of the lantern to compute the right offset from the last rod link
+        lantern_xform = parse_xform(lantern_prim)
+        lantern_offset = lantern_xform.p - joint_positions[-1]
+        lantern_joint.GetLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, -lantern_offset[2]))
+        joints.append(lantern_joint)
+
+        print(f"Added joints for chain {chain_name} [{', '.join(str(p.GetPrimPath()) for p in rod_link_prims)}]")
+
+
+def add_lantern_rod_joints(stage):
+    chains = {
+        "HangingLanternA_01": "HangingLanternChainA_05",
+        "HangingLanternA_02": "HangingLanternChainA_06",
+        "HangingLanternA_03": "HangingLanternChainA_04",
+        "HangingLanternC_01": "HangingLanternChainA_01",
+        "HangingLanternC_02": "HangingLanternChainA_07",
+        "HangingLanternD_01": "HangingLanternChainA_03",
+        "HangingLanternE_01": "HangingLanternChainA_02",
+    }
+
+    world = stage.GetPrimAtPath("/World")
+
+    for lantern, chain in chains.items():
+        lantern_prim = world.GetPrimAtPath(f"/World/{lantern}")
+        UsdPhysics.RigidBodyAPI.Apply(lantern_prim)
+
+        apply_collision_api(lantern_prim)
+
+        chain_geo_prim = world.GetPrimAtPath(f"/World/{chain}/geo")
+        chain_joints_prim = world.GetPrimAtPath(f"/World/{chain}/geo/jointpositions")
+
+        chainlinks = [child for child in chain_geo_prim.GetChildren() if "hangingLanternChain" in str(child.GetPath())]
+
+        for chainlink in chainlinks:
+            UsdPhysics.RigidBodyAPI.Apply(chainlink)
+            # mass_api = UsdPhysics.MassAPI.Apply(chainlink)
+            # mass_api.CreateMassAttr().Set(2.0)
+            print(f"Applied RigidBodyAPI to {chainlink}")
+            apply_collision_api(chainlink)
+
+        # chainlink joints
+        joints = list(chain_joints_prim.GetChildren())
+
+        chainlinks = list(reversed(chainlinks))
+
+        for k, joint_xf_prim in enumerate(joints):
+            joint_xform = parse_xform(joint_xf_prim, local=False)
+
+            joint = UsdPhysics.SphericalJoint.Define(stage, f"{joint_xf_prim.GetPath()}/joint")
+
+            if k == 0:
+                b0 = chainlinks[k]
+                b1 = stage.GetPrimAtPath("/World")
+            elif k == len(joints) - 1:
+                b0 = chainlinks[k - 1]
+                b1 = lantern_prim
+            else:
+                b0 = chainlinks[k - 1]
+                b1 = chainlinks[k]
+
+            joint.GetBody0Rel().AddTarget(b0.GetPrimPath())
+            joint.GetBody1Rel().AddTarget(b1.GetPrimPath())
+
+            b0_xform = parse_xform(b0, local=False)
+            local_pos_0 = wp.transform_point(wp.transform_inverse(b0_xform), wp.transform_get_translation(joint_xform))
+            joint.GetLocalPos0Attr().Set(Gf.Vec3f(local_pos_0[0], local_pos_0[1], local_pos_0[2]))
+
+            if k > 0:
+                b1_xform = parse_xform(b1, local=False)
+            else:
+                b1_xform = b0_xform
+
+            local_pos_1 = wp.transform_point(wp.transform_inverse(b1_xform), wp.transform_get_translation(joint_xform))
+            joint.GetLocalPos1Attr().Set(Gf.Vec3f(local_pos_1[0], local_pos_1[1], local_pos_1[2]))
+
+            print(
+                f"Joint from {joint.GetBody0Rel().GetTargets()[0]} to {joint.GetBody1Rel().GetTargets()[0]} local pos: {joint.GetLocalPos1Attr().Get()}"
+            )
+            # break
+
+        UsdPhysics.ArticulationRootAPI.Apply(chainlinks[0])
+
+        print(f"Added lanterns for chain {chain} [{lantern}]")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_path", type=str)
+    args = parser.parse_args()
+
+    output_path = args.input_path.replace(".usd", "_physics.usd")
+
+    stage = Usd.Stage.Open(args.input_path)
+
+    for prim in stage.Traverse():
+        if "proxy" in str(prim.GetPath()):
+            continue
+        path = str(prim.GetPath()).split("/")
+
+        # ROBOT
+        if any(name in path[-1] for name in ("HEAD", "HIP", "KNEE", "PELVIS", "NECK", "FOOT", "ANTENNA")):
+            print(f"Applying RigidBodyAPI to {prim}")
+            rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(prim)
+            rigidBodyAPI.CreateKinematicEnabledAttr(True)
+
+            for child in prim.GetChildren():
+                apply_collision_api(child)
+
+        # TERRAIN (adjust)
+        elif any(name in path[-1] for name in ("terrainMaincol",)):
+            print(f"Applying CollisionAPI to {prim}")
+            collisionAPI = UsdPhysics.CollisionAPI.Apply(prim)
+            collisionAPI.CreateCollisionEnabledAttr(True)
+
+        # RIGID BODIES (adjust)
+        elif len(path) == 5 and any(name in path[-1] for name in ("gear", "piece", "piston")):
+            print(f"Applying RigidBodyAPI and MassAPI to {prim}")
+            rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(prim)
+            massAPI = UsdPhysics.MassAPI.Apply(prim)
+
+            for child in prim.GetChildren():
+                apply_collision_api(child)
+
+    # check if lanterns are present
+    if stage.GetPrimAtPath("/World/HangingLanternChainA_01/geo/joints").IsValid():
+        print("Adding chain links")
+        add_chainlink_joints(stage)
+    elif stage.GetPrimAtPath("/World/HangingLanternChainA_01/geo/jointpositions").IsValid():
+        print("Adding rod links")
+        add_lantern_rod_joints(stage)  # V1 (Gilles)
+        # add_rod_joints(stage) # V2 (Eric)
+    elif stage.GetPrimAtPath("/World/HangingLanternChainA_08").IsValid():
+        print("Adding lanterns")
+        add_lantern_joints(stage)
+
+    stage.Export(output_path)
+    print(f"Saved to {output_path}")

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1004,6 +1004,11 @@ def parse_usd(
             return True
         return False
 
+    # parse static visual-only shapes on the World prim
+    if load_visual_shapes:
+        root_prim = stage.GetPrimAtPath(root_path)
+        _load_visual_shapes_impl(-1, root_prim, incoming_world_xform, wp.vec3(1.0, 1.0, 1.0))
+
     # Parsing physics materials from the stage
     for sdf_path, desc in data_for_key(ret_dict, UsdPhysics.ObjectType.RigidBodyMaterial):
         if warn_invalid_desc(sdf_path, desc):

--- a/newton/_src/utils/sim_usd.py
+++ b/newton/_src/utils/sim_usd.py
@@ -1,12 +1,20 @@
-# Copyright (c) 2022 NVIDIA CORPORATION.  All rights reserved.
-# NVIDIA CORPORATION and its licensors retain all intellectual property
-# and proprietary rights in and to this software, related documentation
-# and any modifications thereto.  Any use, reproduction, disclosure or
-# distribution of this software and related documentation without an express
-# license agreement from NVIDIA CORPORATION is strictly prohibited.
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ###########################################################################
-# Warp script to run simulations on USD files
+# Newton script to run simulations on USD files
 #
 # Simulates the stage of the input USD file as described by the USD Physics
 # definitions.

--- a/newton/_src/utils/sim_usd.py
+++ b/newton/_src/utils/sim_usd.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2022 NVIDIA CORPORATION.  All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+
+###########################################################################
+# Warp script to run simulations on USD files
+#
+# Simulates the stage of the input USD file as described by the USD Physics
+# definitions.
+#
+###########################################################################
+
+from enum import Enum
+from typing import Optional
+from pathlib import Path
+
+from pxr import Usd
+
+import warp as wp
+import newton
+from newton.utils import parse_usd
+import numpy as np
+
+
+class IntegratorType(Enum):
+    EULER = "euler"
+    XPBD = "xpbd"
+    VBD = "vbd"
+    MJWARP = "mjwarp"
+
+    def __str__(self):
+        return self.value
+
+
+class Simulator:
+    # TODO: make logic for the case when attributes can be specified in multiple places
+    #       eg: fps specified on the stage or physxScene:timeStepsPerSecond for substeps
+
+    MODEL_ATTRIBUTES = {
+        "newton:joint_attach_kd": "joint_attach_kd",
+        "newton:joint_attach_ke": "joint_attach_ke",
+        "newton:soft_contact_kd": "soft_contact_kd",
+        "newton:soft_contact_ke": "soft_contact_ke",
+    }
+    SOLVER_ATTRIBUTES = {
+        "newton:collide_on_substeps": "collide_on_substeps",
+        "newton:fps": "fps",
+        "newton:integrator": "integrator_type",
+        "newton:integrator_iterations": "integrator_iterations",
+        "newton:substeps": "substeps",
+    }
+    INTEGRATOR_ATTRIBUTES = {
+        IntegratorType.EULER: {
+            "newton:euler:angular_damping": "angular_damping",
+            "newton:euler:friction_smoothing": "friction_smoothing",
+        },
+        IntegratorType.VBD: {"newton:vbd:friction_epsilon": "friction_epsilon"},
+        IntegratorType.XPBD: {
+            "newton:xpbd:soft_body_relaxation": "soft_body_relaxation",
+            "newton:xpbd:soft_contact_relaxation": "soft_contact_relaxation",
+            "newton:xpbd:joint_linear_relaxation": "joint_linear_relaxation",
+            "newton:xpbd:joint_angular_relaxation": "joint_angular_relaxation",
+            "newton:xpbd:rigid_contact_relaxation": "rigid_contact_relaxation",
+            "newton:xpbd:rigid_contact_con_weighting": "rigid_contact_con_weighting",
+            "newton:xpbd:angular_damping": "angular_damping",
+            "newton:xpbd:enable_restitution": "enable_restitution",
+        },
+        IntegratorType.MJWARP: {
+            "newton:mjwarp:use_mujoco_cpu": "use_mujoco_cpu",
+            "newton:mjwarp:solver": "solver",
+            "newton:mjwarp:integrator": "integrator",
+            "newton:mjwarp:iterations": "iterations",
+            "newton:mjwarp:ls_iterations": "ls_iterations",
+            "newton:mjwarp:save_to_mjcf": "save_to_mjcf",
+            "newton:mjwarp:contact_stiffness_time_const": "contact_stiffness_time_const",
+        },
+    }
+    MODEL_ATTRIBUTES_KEYS = MODEL_ATTRIBUTES.keys()
+    SOLVER_ATTRIBUTES_KEYS = SOLVER_ATTRIBUTES.keys()
+
+    def __init__(self, input_path, output_path, integrator: Optional[IntegratorType] = None):
+        def create_stage_from_path(input_path) -> Usd.Stage:
+            stage = Usd.Stage.Open(input_path, Usd.Stage.LoadAll)
+            flattened = stage.Flatten()
+            out_stage = Usd.Stage.Open(flattened.identifier)
+            return out_stage
+
+        self.sim_time = 0.0
+        self.profiler = {}
+
+        self.in_stage = create_stage_from_path(input_path)
+
+        builder = newton.ModelBuilder()
+        builder.up_axis = newton.Axis.Z
+        results = parse_usd(
+            self.in_stage,
+            builder,
+            invert_rotations=True,
+            collapse_fixed_joints=True,
+        )
+
+        scene_attributes = results["scene_attributes"]
+        self._apply_solver_attributes(scene_attributes)
+
+        if integrator:
+            self.integrator_type = integrator
+
+        if self.integrator_type == IntegratorType.VBD:
+            builder.color()
+        self.model = builder.finalize()
+        self.builder_results = results
+        orig_orientation_1 = self.model.body_q.numpy().flatten()[3:]
+        print(f"__init__ orig_orientation_1 = {orig_orientation_1}")
+
+        self.path_body_map = self.builder_results["path_body_map"]
+        collapse_results = self.builder_results["collapse_results"]
+        self.path_body_relative_transform = self.builder_results["path_body_relative_transform"]
+        if collapse_results:
+            self.body_remap = collapse_results["body_remap"]
+            self.body_merged_parent = collapse_results["body_merged_parent"]
+            self.body_merged_transform = collapse_results["body_merged_transform"]
+        else:
+            self.body_remap = None
+            self.body_merged_parent = None
+            self.body_merged_transform = None
+
+        self._apply_model_attributes(scene_attributes)
+        self._setup_integrator(scene_attributes)
+
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+
+        # NB: body_q will be modified, so initial state will be slightly altered
+        if self.model.joint_count:
+            newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0, mask=None)
+
+        self.use_cuda_graph = wp.get_device().is_cuda
+        if self.use_cuda_graph:
+            with wp.ScopedCapture() as capture:
+                self.simulate()
+            self.graph = capture.graph
+
+        self.renderer = newton.viewer.RendererUsd(
+            self.model,
+            stage=output_path,
+            source_stage=input_path,
+            path_body_relative_transform=self.path_body_relative_transform,
+            path_body_map=self.path_body_map,
+            builder_results=self.builder_results,
+        )
+
+    def _apply_solver_attributes(self, scene_attributes: dict):
+        """Apply scene attributes parsed from the stage to self."""
+
+        # Defaults
+        self.fps = 60
+        self.sim_substeps = 32
+        self.integrator_type = IntegratorType.XPBD
+        self.integrator_iterations = 100
+        self.collide_on_substeps = True
+
+        # Loading attributes
+        set_attrs = set(scene_attributes.keys())
+        solver_attrs = set_attrs.intersection(self.SOLVER_ATTRIBUTES_KEYS)
+
+        for attr in solver_attrs:
+            self.__dict__[self.SOLVER_ATTRIBUTES[attr]] = scene_attributes[attr]
+
+        # Derived/computed attributes that depend on the above
+        self.frame_dt = 1.0 / self.fps
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.integrator_type = IntegratorType(self.integrator_type)
+
+    def _apply_model_attributes(self, scene_attributes: dict):
+        """Apply scene attributes parsed from the stage to the model."""
+
+        # Defaults
+        self.model.ground = False
+        self.model.soft_contact_ke = 1.0e4
+        self.model.soft_contact_kd = 1.0e2
+
+        # Loading attributes
+        set_attrs = set(scene_attributes.keys())
+        model_attrs = set_attrs.intersection(self.MODEL_ATTRIBUTES_KEYS)
+
+        for attr in model_attrs:
+            self.model.__dict__[self.MODEL_ATTRIBUTES[attr]] = scene_attributes[attr]
+
+    def _setup_integrator(self, scene_attributes: dict):
+        """Set up the integrator, and apply attributes parsed from the stage."""
+
+        # TODO: add Euler integrator
+        # if self.integrator_type == IntegratorType.EULER:
+        #     self.integrator = newton.SemiImplicitIntegrator()
+        if self.integrator_type == IntegratorType.XPBD:
+            solver_args = {"iterations": scene_attributes.get("newton:xpbd:iterations", self.integrator_iterations)}
+            self.integrator = newton.solvers.XPBDSolver(self.model, **solver_args)
+        elif self.integrator_type == IntegratorType.MJWARP:
+            solver_args = {
+                "use_mujoco_cpu": scene_attributes.get("newton:mjwarp:use_mujoco_cpu", False),
+                "solver": scene_attributes.get("newton:mjwarp:solver", "newton"),
+                "integrator": scene_attributes.get("newton:mjwarp:integrator", "euler"),
+                "iterations": scene_attributes.get("newton:mjwarp:iterations", self.integrator_iterations),
+                "ls_iterations": scene_attributes.get("newton:mjwarp:ls_iterations", 5),
+                "save_to_mjcf": scene_attributes.get("newton:mjwarp:save_to_mjcf", "sim_usd_mjcf.xml"),
+                "contact_stiffness_time_const": scene_attributes.get(
+                    "newton:mjwarp:contact_stiffness_time_const", 0.02
+                ),
+            }
+            self.integrator = newton.solvers.SolverMuJoCo(
+                self.model,
+                **solver_args,
+            )
+        else:
+            self.integrator = newton.solvers.VBDIntegrator(self.model, iterations=self.integrator_iterations)
+
+        # Loading attributes
+        set_attrs = set(scene_attributes.keys())
+        cur_integrator = self.INTEGRATOR_ATTRIBUTES[self.integrator_type]
+        integrator_attrs = set_attrs.intersection(cur_integrator.keys())
+        for attr in integrator_attrs:
+            self.integrator.__dict__[cur_integrator[attr]] = scene_attributes[attr]
+
+    def simulate(self):
+        rigid_contact_margin = 0.1
+        if not self.collide_on_substeps:
+            self.contacts = self.model.collide(self.state_0, rigid_contact_margin=rigid_contact_margin)
+
+        for _ in range(self.sim_substeps):
+            if self.collide_on_substeps:
+                self.contacts = self.model.collide(self.state_0, rigid_contact_margin=rigid_contact_margin)
+
+            self.state_0.clear_forces()
+            self.integrator.step(self.state_0, self.state_1, None, self.contacts, self.sim_dt)
+
+            # swap states
+            (self.state_0, self.state_1) = (self.state_1, self.state_0)
+
+    def step(self):
+        with wp.ScopedTimer("step", dict=self.profiler):
+            if self.use_cuda_graph:
+                wp.capture_launch(self.graph)
+            else:
+                self.simulate()
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        with wp.ScopedTimer("render", dict=self.profiler):
+            self.renderer.begin_frame(self.sim_time)
+            self.renderer.render_update_stage(self.state_0)
+            self.renderer.end_frame()
+
+    def save(self):
+        self.renderer.save()
+
+
+def print_time_profiler(simulator):
+    frame_times = simulator.profiler["step"]
+    render_times = simulator.profiler["render"]
+    print("\nAverage frame sim time: {:.2f} ms".format(sum(frame_times) / len(frame_times)))
+    print("\nAverage frame render time: {:.2f} ms".format(sum(render_times) / len(render_times)))
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "stage_path",
+        help="Path to the input USD file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Path to the output USD file.",
+    )
+    parser.add_argument("-d", "--device", type=str, default=None, help="Override the default Warp device.")
+    parser.add_argument("-n", "--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument(
+        "-i",
+        "--integrator",
+        help="Type of integrator",
+        type=IntegratorType,
+        choices=list(IntegratorType),
+        default=None,
+    )
+
+    args = parser.parse_known_args()[0]
+
+    if not args.output:
+        path = Path(args.stage_path)
+        base_path = path.parent / "output"
+        base_path.mkdir(parents=True, exist_ok=True)
+        args.output = str(base_path / path.name)
+        print(f'Output path not specified (-o flag). Writing to "{args.output}".')
+
+    with wp.ScopedDevice(args.device):
+        simulator = Simulator(input_path=args.stage_path, output_path=args.output, integrator=args.integrator)
+
+        for i in range(args.num_frames):
+            print(f"frame {i}")
+            simulator.step()
+            simulator.render()
+
+        print_time_profiler(simulator)
+
+        simulator.save()

--- a/newton/_src/utils/sim_usd_gtc.py
+++ b/newton/_src/utils/sim_usd_gtc.py
@@ -1,0 +1,1243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###########################################################################
+# Newton script to run simulations on USD files
+#
+# Simulates the stage of the input USD file as described by the USD Physics
+# definitions.
+#
+###########################################################################
+
+import inspect
+import itertools
+import os
+from enum import Enum
+from typing import ClassVar, Optional
+
+import numpy as np
+import warp as wp
+
+# wp.config.verify_cuda = True
+# wp.config.verify_fp = True
+from pxr import Usd, UsdGeom, UsdPhysics
+
+import newton
+from newton._src.core.spatial import angvel_between_quats
+from newton._src.utils.import_usd import parse_usd
+from newton._src.usd.schema_resolver import (
+    SchemaAttribute as Attribute,
+    PrimType,
+    SchemaResolver,
+    SchemaResolverManager,
+)
+from newton._src.utils.update_usd import UpdateUsd
+
+
+def parse_xform(prim, time=Usd.TimeCode.Default(), return_mat=False):
+    from pxr import UsdGeom
+
+    xform = UsdGeom.Xform(prim)
+    mat = np.array(xform.ComputeLocalToWorldTransform(time), dtype=np.float32)
+    if return_mat:
+        return mat
+    rot = wp.quat_from_matrix(wp.mat33(mat[:3, :3].T.flatten()))
+    pos = mat[3, :3]
+    return wp.transform(pos, rot)
+
+
+def _build_solver_args_from_resolver(
+    resolver_mgr, prim, prim_type, solver_cls, defaults: dict[str, object] | None = None
+):
+    defaults = defaults or {}
+    sig = inspect.signature(solver_cls.__init__)
+    solver_args = {}
+    for name, param in sig.parameters.items():
+        # skip self, model, and var positional/keyword args: *args/**kwargs
+        if name in ("self", "model") or param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
+        value = resolver_mgr.get_value(prim, prim_type, name, defaults.get(name))
+        if value is not None:
+            solver_args[name] = value
+    return solver_args
+
+
+class IntegratorType(Enum):
+    EULER = "euler"
+    XPBD = "xpbd"
+    VBD = "vbd"
+    MJWARP = "mjwarp"
+    COUPLED_MPM = "cmpm"
+
+    def __str__(self):
+        return self.value
+
+
+class SchemaResolverSimUsd(SchemaResolver):
+    name: ClassVar[str] = "sim_usd"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            # model attributes
+            "joint_attach_kd": Attribute("newton:joint_attach_kd", 2718.0),
+            "joint_attach_ke": Attribute("newton:joint_attach_ke", 2718.0),
+            "soft_contact_ke": Attribute("newton:soft_contact_ke", 1.0e4),
+            "soft_contact_kd": Attribute("newton:soft_contact_kd", 1.0e2),
+            # solver attributes
+            "fps": Attribute("newton:fps", 60),
+            "sim_substeps": Attribute("newton:substeps", 12),
+            "integrator_type": Attribute("newton:integrator", "xpbd"),
+            "integrator_iterations": Attribute("newton:integrator_iterations", 32),
+            "collide_on_substeps": Attribute("newton:collide_on_substeps", True),
+        },
+        PrimType.BODY: {
+            "kinematic_collider": Attribute("physics:kinematicEnabled", False),
+        },
+        PrimType.SHAPE: {
+            "kinematic_collider": Attribute("physics:kinematicEnabled", False),
+        },
+    }
+
+
+class SchemaResolverEuler(SchemaResolver):
+    name: ClassVar[str] = "euler"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            "angular_damping": Attribute("newton:euler:angular_damping", 2718.0),
+            "friction_smoothing": Attribute("newton:euler:friction_smoothing", 2718.0),
+        },
+    }
+
+
+class SchemaResolverVBD(SchemaResolver):
+    name: ClassVar[str] = "vbd"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            "friction_epsilon": Attribute("newton:vbd:friction_epsilon", 2718.0),
+        },
+    }
+
+
+class SchemaResolverXPBD(SchemaResolver):
+    name: ClassVar[str] = "xpbd"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            "soft_body_relaxation": Attribute("newton:xpbd:soft_body_relaxation", 0.9),
+            "soft_contact_relaxation": Attribute("newton:xpbd:soft_contact_relaxation", 0.9),
+            "joint_linear_relaxation": Attribute("newton:xpbd:joint_linear_relaxation", 1.0),
+            "joint_angular_relaxation": Attribute("newton:xpbd:joint_angular_relaxation", 1.0),
+            "rigid_contact_relaxation": Attribute("newton:xpbd:rigid_contact_relaxation", 1.0),
+            "rigid_contact_con_weighting": Attribute("newton:xpbd:rigid_contact_con_weighting", True),
+            "angular_damping": Attribute("newton:xpbd:angular_damping", 0.2),
+            "enable_restitution": Attribute("newton:xpbd:enable_restitution", False),
+        },
+    }
+
+
+class SchemaResolverMJWarp(SchemaResolver):
+    name: ClassVar[str] = "mjwarp"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            "use_mujoco_cpu": Attribute("newton:mjwarp:use_mujoco_cpu", False),
+            "solver": Attribute("newton:mjwarp:solver", "newton"),
+            "integrator": Attribute("newton:mjwarp:integrator", "implicitfast"),
+            "iterations": Attribute("newton:mjwarp:iterations", 30),
+            "ls_iterations": Attribute("newton:mjwarp:ls_iterations", 15),
+            "save_to_mjcf": Attribute("newton:mjwarp:save_to_mjcf", "sim_usd_mjcf.xml"),
+            "contact_stiffness_time_const": Attribute("newton:mjwarp:contact_stiffness_time_const", 0.02),
+            "ncon_per_world": Attribute("newton:mjwarp:ncon_per_world", 150),
+            "njmax": Attribute("newton:mjwarp:njmax", 300),
+        },
+    }
+
+
+class SchemaResolverCoupledMPM(SchemaResolver):
+    name: ClassVar[str] = "cmpm"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {},
+    }
+
+
+class SchemaResolverMPM(SchemaResolver):
+    name: ClassVar[str] = "mpm"
+    mapping: ClassVar[dict[PrimType, dict[str, Attribute]]] = {
+        PrimType.SCENE: {
+            "voxel_size": Attribute("newton:mpm:voxel_size", 0.05),
+            "grid_type": Attribute("newton:mpm:grid_type", "sparse"),
+            "max_iterations": Attribute("newton:mpm:max_iterations", 250),
+        },
+    }
+
+
+class CoupledMPMIntegrator(newton.solvers.SolverBase):
+    """Integrator for coupled MPM and rigid body solvers."""
+
+    def __init__(self, model: newton.Model, particles_dict: dict[str, np.ndarray], **kwargs):
+        super().__init__(model)
+
+        self.particles_dict = particles_dict
+
+        rigid_solver_kwargs = {}
+
+        mpm_options = newton.solvers.SolverImplicitMPM.Options()
+        for key, value in kwargs.items():
+            if hasattr(mpm_options, key):
+                setattr(mpm_options, key, value)
+            else:
+                rigid_solver_kwargs[key] = value
+
+        mpm_model = self._build_mpm_model(model, mpm_options)
+
+        self.mpm_solver = newton.solvers.SolverImplicitMPM(mpm_model, mpm_options)
+
+        self.mpm_state_0 = mpm_model.model.state()
+        self.mpm_state_1 = mpm_model.model.state()
+
+        self.mpm_solver.enrich_state(self.mpm_state_0)
+        self.mpm_solver.enrich_state(self.mpm_state_1)
+
+        self.rigid_solver = newton.solvers.SolverXPBD(model, **rigid_solver_kwargs)
+
+        self._initialized = False
+
+        self.particle_render_colors = wp.full(
+            mpm_model.model.particle_count, value=wp.vec3(0.7, 0.6, 0.4), dtype=wp.vec3, device=mpm_model.model.device
+        )
+
+    def step(
+        self,
+        state_0: newton.State,
+        state_1: newton.State,
+        control: newton.Control,
+        contacts: newton.Contacts,
+        dt: float,
+    ):
+        if not self._initialized:
+            self.sand_body_forces = wp.zeros_like(state_0.body_f)
+            self.collider_impulses = None
+            self.collider_impulse_pos = None
+            self.collider_impulse_ids = None
+            self.collect_collider_impulses(self.mpm_state_0)
+            self._initialized = True
+
+        has_compliance_bodies = self.mpm_state_0.body_q is not None
+
+        if has_compliance_bodies:
+            wp.launch(
+                compute_body_forces,
+                dim=self.collider_impulse_ids.shape[0],
+                inputs=[
+                    dt,
+                    self.collider_impulse_ids,
+                    self.collider_impulses,
+                    self.collider_impulse_pos,
+                    self.collider_body_id,
+                    state_0.body_q,
+                    self.model.body_com,
+                    self.model.body_mass,
+                    state_0.body_f,
+                ],
+            )
+
+        self.sand_body_forces.assign(state_0.body_f)
+        self.rigid_solver.step(state_0, state_1, control, contacts, dt)
+
+        # Subtract previously applied impulses from body velocities
+        if has_compliance_bodies:
+            wp.launch(
+                substract_body_force,
+                dim=self.mpm_state_0.body_q.shape,
+                inputs=[
+                    dt,
+                    state_1.body_q,
+                    state_1.body_qd,
+                    self.sand_body_forces,
+                    self.model.body_inv_inertia,
+                    self.model.body_inv_mass,
+                    self.mpm_state_0.body_q,
+                    self.mpm_state_0.body_qd,
+                ],
+            )
+
+        self.mpm_solver.step(self.mpm_state_0, self.mpm_state_1, None, None, dt)
+
+        self.collect_collider_impulses(self.mpm_state_1)
+
+        self.mpm_state_0, self.mpm_state_1 = self.mpm_state_1, self.mpm_state_0
+
+    def _build_mpm_model(self, model, mpm_options):
+        sand_builder = newton.ModelBuilder()
+        self._add_particles(sand_builder, mpm_options.voxel_size)
+        sand_model = sand_builder.finalize()
+
+        # basic particle material params
+        sand_model.particle_mu = 0.48
+        sand_model.particle_ke = 1.0e15
+        sand_model.particle_kd = 0.0
+        sand_model.particle_adhesion = 0.0
+        sand_model.particle_cohesion = 0.0
+
+        mpm_model = newton.solvers.SolverImplicitMPM.Model(sand_model, mpm_options)
+
+        self._setup_mpm_collider(model, mpm_model)
+
+        return mpm_model
+
+    def _setup_mpm_collider(self, model: newton.Model, mpm_model: newton.solvers.SolverImplicitMPM.Model):
+        collider_body_id = np.arange(-1, model.body_count)
+
+        mpm_model.setup_collider(
+            model=self.model,
+            collider_body_ids=collider_body_id,
+            collider_friction=[0.5 for _ in collider_body_id],
+            collider_adhesion=[0.0 for _ in collider_body_id],
+            # body_mass=wp.zeros_like(self.model.body_mass),  # so that the bodies are considered as kinematic,
+            ground_height=-10.0,
+        )
+
+        self.collider_body_id = wp.array(collider_body_id, dtype=int)
+
+    def _add_particles(self, sand_builder: newton.ModelBuilder, voxel_size: float):
+        density = 2500
+
+        if self.particles_dict:
+            psize = voxel_size / 2.0
+            radius = float(psize * 0.5)
+            mass = float(psize**3 * density)
+
+            points = np.vstack([pts for pts in self.particles_dict.values()])
+        else:
+            # ------------------------------------------
+            # Add sand bed (1m x 2m x 0.5m) above ground
+            # ------------------------------------------
+            particles_per_cell = 3.0
+
+            bed_lo = np.array([3.0, -1.0, 0.0])
+            bed_hi = np.array([4.0, 1.0, 0.5])
+            bed_res = np.array(np.ceil(particles_per_cell * (bed_hi - bed_lo) / voxel_size), dtype=int)
+
+            # spawn particles on a jittered grid
+            Nx, Ny, Nz = bed_res
+            px = np.linspace(bed_lo[0], bed_hi[0], Nx + 1)
+            py = np.linspace(bed_lo[1], bed_hi[1], Ny + 1)
+            pz = np.linspace(bed_lo[2], bed_hi[2], Nz + 1)
+            points = np.stack(np.meshgrid(px, py, pz)).reshape(3, -1).T
+
+            cell_size = (bed_hi - bed_lo) / bed_res
+            cell_volume = np.prod(cell_size)
+            radius = float(np.max(cell_size) * 0.5)
+            mass = float(np.prod(cell_volume) * density)
+
+            rng = np.random.default_rng()
+            points += 2.0 * radius * (rng.random(points.shape) - 0.5)
+
+        sand_builder.particle_q = points
+        sand_builder.particle_qd = np.zeros_like(points)
+        sand_builder.particle_mass = np.full(points.shape[0], mass)
+        sand_builder.particle_radius = np.full(points.shape[0], radius)
+        sand_builder.particle_flags = np.ones(points.shape[0], dtype=int)
+
+    def collect_collider_impulses(self, mpm_state):
+        self.collider_impulses, self.collider_impulse_pos, self.collider_impulse_ids = (
+            self.mpm_solver.collect_collider_impulses(mpm_state)
+        )
+
+
+@wp.kernel
+def compute_body_forces(
+    dt: float,
+    collider_ids: wp.array(dtype=int),
+    collider_impulses: wp.array(dtype=wp.vec3),
+    collider_impulse_pos: wp.array(dtype=wp.vec3),
+    body_ids: wp.array(dtype=int),
+    body_q: wp.array(dtype=wp.transform),
+    body_com: wp.array(dtype=wp.vec3),
+    body_mass: wp.array(dtype=float),
+    body_f: wp.array(dtype=wp.spatial_vector),
+):
+    i = wp.tid()
+
+    cid = collider_ids[i]
+    if cid >= 0 and cid < body_ids.shape[0]:
+        body_index = body_ids[cid]
+        if body_index >= 0:
+            m = body_mass[body_index]
+
+            f_world = collider_impulses[i] / dt
+            max_f = 0.0 * m
+            if wp.length(f_world) > max_f:
+                f_world = f_world * max_f / wp.length(f_world)
+
+            X_wb = body_q[body_index]
+            X_com = body_com[body_index]
+            r = collider_impulse_pos[i] - wp.transform_point(X_wb, X_com)
+            wp.atomic_add(body_f, body_index, wp.spatial_vector(f_world, wp.cross(r, f_world)))
+
+
+@wp.kernel
+def substract_body_force(
+    dt: float,
+    body_q: wp.array(dtype=wp.transform),
+    body_qd: wp.array(dtype=wp.spatial_vector),
+    body_f: wp.array(dtype=wp.spatial_vector),
+    body_inv_inertia: wp.array(dtype=wp.mat33),
+    body_inv_mass: wp.array(dtype=float),
+    body_q_res: wp.array(dtype=wp.transform),
+    body_qd_res: wp.array(dtype=wp.spatial_vector),
+):
+    body_id = wp.tid()
+
+    # Remove previously applied force
+    f = body_f[body_id]
+    delta_v = dt * body_inv_mass[body_id] * wp.spatial_top(f)
+    r = wp.transform_get_rotation(body_q[body_id])
+
+    delta_w = dt * wp.quat_rotate(r, body_inv_inertia[body_id] * wp.quat_rotate_inv(r, wp.spatial_bottom(f)))
+
+    body_q_res[body_id] = body_q[body_id]
+    body_qd_res[body_id] = body_qd[body_id] - wp.spatial_vector(delta_v, delta_w)
+
+
+@wp.kernel
+def extract_rotation_and_scales(
+    transform: wp.array(dtype=wp.mat33),
+    rotation: wp.array(dtype=wp.vec4h),
+    scales: wp.array(dtype=wp.vec3),
+):
+    i = wp.tid()
+
+    A = transform[i]
+
+    Q = wp.mat33()
+    R = wp.mat33()
+    wp.qr3(A, Q, R)
+
+    q = wp.quat_from_matrix(Q)
+
+    rotation[i] = wp.vec4h(wp.vec4(q[0], q[1], q[2], q[3]))
+    scales[i] = wp.vec3(wp.length(R[0]), wp.length(R[1]), wp.length(R[2]))
+
+
+def extract_particle_rotation_and_scales(state: newton.State):
+    particle_transform_rotation = wp.empty(state.particle_count, dtype=wp.vec4h)
+    particle_transform_scales = wp.empty(state.particle_count, dtype=wp.vec3)
+
+    wp.launch(
+        extract_rotation_and_scales,
+        dim=state.particle_count,
+        inputs=[
+            state.particle_transform,
+            particle_transform_rotation,
+            particle_transform_scales,
+        ],
+    )
+
+    return particle_transform_rotation, particle_transform_scales
+
+
+class Simulator:
+    def __init__(
+        self,
+        input_path,
+        output_path,
+        num_frames: int,
+        integrator: Optional[IntegratorType] = None,
+        sim_time: float = 0.0,
+        sim_frame: int = 0,
+        record_path: str = "",
+        usd_offset: wp.vec3 = wp.vec3(0.0, 0.0, 0.0),
+        use_unified_collision_pipeline: bool = True,
+        use_coacd: bool = False,
+        enable_timers: bool = False,
+    ):
+        def create_stage_from_path(input_path) -> Usd.Stage:
+            stage = Usd.Stage.Open(input_path, Usd.Stage.LoadAll)
+            flattened = stage.Flatten()
+            out_stage = Usd.Stage.Open(flattened.identifier)
+            return out_stage
+
+        self.profiler = {}
+        self.usd_offset = usd_offset
+        self.enable_timers = enable_timers
+        self.record_path = record_path
+
+        self.in_stage = create_stage_from_path(input_path)
+
+        builder = newton.ModelBuilder()
+        builder.default_joint_cfg = newton.ModelBuilder.JointDofConfig(limit_ke=1.0e3, limit_kd=1.0e1, friction=1e-5)
+        builder.default_joint_cfg.armature = 0.001
+        builder.default_joint_cfg.friction = 0.0
+        builder.up_axis = newton.Axis.Z
+        builder.default_shape_cfg.density = 1000.0
+        builder.default_shape_cfg.ke = 1.0e4
+        builder.default_shape_cfg.kd = 5.0e1
+        builder.default_shape_cfg.thickness = 0.001
+        results = parse_usd(
+            builder,
+            self.in_stage,
+            collapse_fixed_joints=False,  # ! keep it disabled for the lanterns to not disrupt the USD body mapping
+            # ignore_paths=[".*BDXDroid"],
+            xform=wp.transform(self.usd_offset, wp.quat_identity()),
+            # hide_collision_shapes=False,
+            skip_mesh_approximation=True,
+            ignore_paths=[
+                ".*proxy",
+                # ".*proxy/Ground_Collider/mesh_0",
+            ],
+        )
+        self.R = SchemaResolverManager([SchemaResolverSimUsd(), SchemaResolverMJWarp()])
+        self.physics_prim = next(iter([prim for prim in self.in_stage.Traverse() if prim.IsA(UsdPhysics.Scene)]), None)
+
+        # set up pair-wise filters for the BDX Droid shapes to disable self collisions
+        droid_shapes: list[int] = []
+        for i, key in enumerate(builder.shape_key):
+            if "BDXDroid" in key:
+                droid_shapes.append(i)
+        for shape1, shape2 in itertools.combinations(droid_shapes, 2):
+            builder.shape_collision_filter_pairs.append((shape1, shape2))
+
+        self._setup_solver_attributes()
+        self.sim_time = max(sim_time, sim_frame * self.frame_dt)
+
+        # create custom attributes for the recorder
+        if self.record_path:
+            self._bdxlanterndemo_add_custom_attributes_for_recorder(builder)
+
+        if integrator:
+            self.integrator_type = integrator
+        # TODO: this is where we want people to be able to write their own code. Need to go to self.prebuilder_finalize(). Other option is to use lambda/callback function.
+        # disable collisions for the lantern chains
+        chain_shapes = [i for i, key in enumerate(builder.shape_key) if "chain" in key.lower()]
+        for shape1, shape2 in itertools.product(chain_shapes, range(builder.shape_count)):
+            builder.shape_collision_filter_pairs.append((shape1, shape2))
+            builder.shape_collision_filter_pairs.append((shape2, shape1))
+        if use_unified_collision_pipeline:
+            # convert all collision meshes to convex hulls but keep terrain high-res meshes (just for visualization)
+            shape_indices = [
+                i
+                for i, (flags, key) in enumerate(zip(builder.shape_flags, builder.shape_key))
+                if flags & newton.ShapeFlags.COLLIDE_SHAPES
+                and "terrainMaincol" not in key
+                and "ground_plane" not in key
+            ]
+
+            lantern_shapes = [i for i in shape_indices if "HangingLantern" in builder.shape_key[i]]
+            other_shapes = [i for i in shape_indices if i not in lantern_shapes]
+
+            if use_coacd:
+                builder.approximate_meshes(
+                    "coacd",
+                    lantern_shapes,
+                    keep_visual_shapes=True,
+                    threshold=0.15,
+                )
+                builder.approximate_meshes(
+                    "convex_hull",
+                    other_shapes,
+                    keep_visual_shapes=True,
+                )
+            else:
+                builder.approximate_meshes(
+                    "convex_hull",
+                    lantern_shapes + other_shapes,
+                    keep_visual_shapes=False,
+                )
+
+        self._collect_animated_colliders(builder, results["path_body_map"])
+        if self.integrator_type == IntegratorType.VBD:
+            builder.color()
+        self.model = builder.finalize()
+        self.builder_results = results
+
+        self.path_body_map = self.builder_results["path_body_map"]
+        self.path_shape_map = results["path_shape_map"]
+        self.body_path_map = {idx: path for path, idx in self.path_body_map.items()}
+        self.shape_path_map = {idx: path for path, idx in self.path_shape_map.items()}
+        collapse_results = self.builder_results["collapse_results"]
+        self.path_body_relative_transform = self.builder_results["path_body_relative_transform"]
+        if collapse_results:
+            self.body_remap = collapse_results["body_remap"]
+            self.body_merged_parent = collapse_results["body_merged_parent"]
+            self.body_merged_transform = collapse_results["body_merged_transform"]
+        else:
+            self.body_remap = None
+            self.body_merged_parent = None
+            self.body_merged_transform = None
+
+        self._setup_model_attributes()
+        self._setup_integrator()
+
+        self.droid_is_walking = True
+        self.droid_is_walking_wp = wp.array([self.droid_is_walking], dtype=wp.bool)
+        self.current_frame = 0
+        self.num_frames = num_frames
+
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+
+        # animation data
+        self.collider_body_q = None
+        self.collider_body_qd = None
+        self.time_step_wp = wp.zeros(1, dtype=wp.int32)
+        self._process_collider_animations(num_frames=num_frames)
+        self._update_animated_colliders()
+        # TODO: double check whether this is specific to MJWarp or XPBD
+        if use_unified_collision_pipeline:
+            self.collision_pipeline = newton.CollisionPipelineUnified.from_model(
+                self.model,
+                rigid_contact_max_per_pair=20,
+                broad_phase_mode=newton.BroadPhaseMode.EXPLICIT,
+            )
+        else:
+            self.collision_pipeline = newton.CollisionPipeline.from_model(
+                self.model,
+                rigid_contact_max_per_pair=20,
+            )
+
+        if self.integrator_type != IntegratorType.MJWARP:
+            self.contacts = self.model.collide(
+                self.state_0,
+                collision_pipeline=self.collision_pipeline,
+            )
+        else:
+            # use MuJoCo's own collision handling
+            self.contacts = None
+
+        # NB: body_q will be modified, so initial state will be slightly altered
+        if self.model.joint_count:
+            newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0, mask=None)
+
+        # Setup USD updater to write into
+        self.usd_updater = UpdateUsd(
+            stage=output_path,
+            source_stage=input_path,
+            path_body_relative_transform=self.path_body_relative_transform,
+            path_body_map=self.path_body_map,
+            builder_results=self.builder_results,
+            up_axis="Z",
+            global_offset=self.usd_offset,
+        )
+        self.usd_updater.configure_body_mapping(
+            path_body_map=self.path_body_map,
+            path_body_relative_transform=self.path_body_relative_transform,
+            builder_results=self.builder_results,
+        )
+
+        # TODO: has an option to configure Newton viewer?? Have a flag to turn on/off the viewer and to support USD Camera.
+        self.show_viewer = True
+        if self.show_viewer:
+            self.viewer = newton.viewer.ViewerGL()
+
+            self.viewer.set_model(self.model)
+
+            # add a UI callback to toggle the droid is walking
+            def toggle_droid_is_walking(imgui):
+                changed, droid_is_walking = imgui.checkbox("Droid is walking", self.droid_is_walking)
+                if changed:
+                    self.droid_is_walking = droid_is_walking
+                    self.droid_is_walking_wp.fill_(self.droid_is_walking)
+
+                imgui.text(f"Current frame: {self.current_frame} / {self.num_frames}")
+                imgui.progress_bar(self.current_frame / self.num_frames)
+
+            self.viewer.register_ui_callback(toggle_droid_is_walking, position="side")
+
+            if self.record_path:
+                self.viewer.start_recording(self.record_path)
+
+        self.use_cuda_graph = wp.get_device().is_cuda
+        self.is_mujoco_cpu_mode = self.integrator_type == IntegratorType.MJWARP and self.integrator.use_mujoco_cpu
+        self.graph = None
+        if self.use_cuda_graph and not self.is_mujoco_cpu_mode:
+            with wp.ScopedCapture() as capture:
+                self.simulate()
+            self.graph = capture.graph
+
+    def _setup_solver_attributes(self):
+        """Apply scene attributes parsed from the stage to self."""
+
+        self.fps = self.R.get_value(self.physics_prim, PrimType.SCENE, "fps")
+        self.sim_substeps = self.R.get_value(self.physics_prim, PrimType.SCENE, "sim_substeps")
+        self.integrator_type = self.R.get_value(self.physics_prim, PrimType.SCENE, "integrator_type")
+        self.integrator_iterations = self.R.get_value(self.physics_prim, PrimType.SCENE, "integrator_iterations")
+        self.collide_on_substeps = self.R.get_value(self.physics_prim, PrimType.SCENE, "collide_on_substeps")
+
+        # Derived/computed attributes that depend on the above
+        self.frame_dt = 1.0 / self.fps
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.integrator_type = IntegratorType(self.integrator_type)
+        self.rigid_contact_margin = self.R.get_value(self.physics_prim, PrimType.SCENE, "contact_margin", 0.001)
+
+    def _setup_model_attributes(self):
+        """Apply scene attributes parsed from the stage to the model."""
+
+        # Defaults
+        # TODO: set self.model.ground from the resolver manager
+        self.model.soft_contact_kd = self.R.get_value(self.physics_prim, PrimType.SCENE, "soft_contact_kd")
+        self.model.soft_contact_ke = self.R.get_value(self.physics_prim, PrimType.SCENE, "soft_contact_ke")
+
+    def _setup_integrator(self):
+        """Set up the integrator, and apply attributes parsed from the stage."""
+
+        if self.integrator_type == IntegratorType.XPBD:
+            res = SchemaResolverXPBD()
+            R = SchemaResolverManager([res])
+            solver_args = _build_solver_args_from_resolver(
+                resolver_mgr=R,
+                prim=self.physics_prim,
+                prim_type=PrimType.SCENE,
+                solver_cls=newton.solvers.SolverXPBD,
+                defaults={"iterations": self.integrator_iterations},
+            )
+            self.integrator = newton.solvers.SolverXPBD(self.model, **solver_args)
+
+        elif self.integrator_type == IntegratorType.MJWARP:
+            res = SchemaResolverMJWarp()
+            R = SchemaResolverManager([res])
+            solver_args = _build_solver_args_from_resolver(
+                resolver_mgr=R,
+                prim=self.physics_prim,
+                prim_type=PrimType.SCENE,
+                solver_cls=newton.solvers.SolverMuJoCo,
+                defaults={"iterations": self.integrator_iterations},
+            )
+            self.integrator = newton.solvers.SolverMuJoCo(
+                self.model, **solver_args, ls_parallel=True, cone="elliptic", impratio=3.0
+            )
+
+        elif self.integrator_type == IntegratorType.COUPLED_MPM:
+            res = SchemaResolverCoupledMPM()
+            R = SchemaResolverManager([SchemaResolverMPM(), SchemaResolverXPBD()])
+            solver_args = _build_solver_args_from_resolver(
+                resolver_mgr=R,
+                prim=self.physics_prim,
+                prim_type=PrimType.SCENE,
+                solver_cls=newton.solvers.SolverXPBD,
+                defaults={"iterations": self.integrator_iterations},
+            )
+            mpm_solver_args = _build_solver_args_from_resolver(
+                resolver_mgr=R,
+                prim=self.physics_prim,
+                prim_type=PrimType.SCENE,
+                solver_cls=newton.solvers.SolverImplicitMPM.Options,
+                defaults={},
+            )
+
+            particles_dict = {}
+            for prim in self.in_stage.Traverse():
+                if prim.GetTypeName() == "PointInstancer":
+                    pi = UsdGeom.PointInstancer(prim)
+                    particles_dict[prim.GetPath()] = np.array(pi.GetPositionsAttr().Get())
+
+            self.integrator = CoupledMPMIntegrator(self.model, particles_dict, **solver_args, **mpm_solver_args)
+        else:  # VBD
+            res = SchemaResolverVBD()
+            R = SchemaResolverManager([res])
+            solver_args = _build_solver_args_from_resolver(
+                resolver_mgr=R,
+                prim=self.physics_prim,
+                prim_type=PrimType.SCENE,
+                solver_cls=newton.solvers.VBDIntegrator,
+                defaults={"iterations": self.integrator_iterations},
+            )
+            self.integrator = newton.solvers.VBDIntegrator(self.model, **solver_args)
+
+        # Iterate resolver-defined keys (these are your internal integrator attribute names)
+        var_map = res.mapping.get(PrimType.SCENE, {})
+        for key in var_map.keys():
+            value = R.get_value(self.physics_prim, PrimType.SCENE, key)
+            if value is not None and hasattr(self.integrator, key):
+                setattr(self.integrator, key, value)
+
+    def _collect_animated_colliders(self, builder, path_body_map):
+        """
+        Go through the builder mass array and set the inverse mass and inertia to 0 for kinematic bodies.
+        """
+        self.animated_colliders_body_ids = []
+        self.animated_colliders_paths = []
+        self.animated_colliders_joint_q_start = []  # start indices of joint_q of the free joints corresponding to the animated colliders
+        self.animated_colliders_joint_qd_start = []  # start indices of joint_qd of the free joints corresponding to the animated colliders
+        R = SchemaResolverManager([SchemaResolverSimUsd()])
+        for path, body_id in path_body_map.items():
+            kinematic_collider = R.get_value(self.in_stage.GetPrimAtPath(path), PrimType.BODY, "kinematic_collider")
+            if kinematic_collider:
+                builder.body_mass[body_id] = 0.0
+                builder.body_inv_mass[body_id] = 0.0
+                builder.body_inv_inertia[body_id] = wp.mat33(0.0)
+
+                self.animated_colliders_body_ids.append(body_id)
+                self.animated_colliders_paths.append(path)
+                joint_id = builder.joint_child.index(body_id)
+                self.animated_colliders_joint_q_start.append(builder.joint_q_start[joint_id])
+                self.animated_colliders_joint_qd_start.append(builder.joint_qd_start[joint_id])
+                # Mujoco requires nonzero inertia
+                if self.integrator_type == IntegratorType.MJWARP:
+                    m = 0.1
+                    builder.body_mass[body_id] = m
+                    builder.body_inv_mass[body_id] = 1 / m
+                    builder.body_inertia[body_id] = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+                    builder.body_inv_inertia[body_id] = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+        self.animated_colliders_joint_q_start_wp = wp.array(self.animated_colliders_joint_q_start, dtype=wp.int32)
+        self.animated_colliders_joint_qd_start_wp = wp.array(self.animated_colliders_joint_qd_start, dtype=wp.int32)
+        self.animated_colliders_body_ids_wp = wp.array(self.animated_colliders_body_ids, dtype=wp.int32)
+
+    def _process_collider_animations(self, num_frames: int):
+        xform_mats = []
+        starting_frame = int(self.sim_time / self.frame_dt)
+
+        for frame in range(starting_frame, starting_frame + num_frames + 1):
+            sim_time = frame * self.frame_dt
+            for substep in range(self.sim_substeps):
+                time = self.fps * (sim_time + self.sim_dt / self.sim_substeps * float(substep))
+                mats = []
+                for path in self.animated_colliders_paths:
+                    prim = self.in_stage.GetPrimAtPath(path)
+                    mat = parse_xform(prim, time, return_mat=True)
+                    mats.append(mat.T)
+                xform_mats.append(mats)
+
+        mats = wp.array2d(xform_mats, dtype=wp.mat44)
+
+        num_bodies = len(self.animated_colliders_paths)
+        self.collider_body_q = wp.empty((num_frames * self.sim_substeps, num_bodies), dtype=wp.transform)
+        self.collider_body_qd = wp.empty((num_frames * self.sim_substeps, num_bodies), dtype=wp.spatial_vector)
+
+        @wp.kernel(module="unique")
+        def compute_collider_coordinates_kernel(
+            xform_mats: wp.array2d(dtype=wp.mat44),
+            usd_offset: wp.vec3,
+            # outputs
+            collider_body_q: wp.array2d(dtype=wp.transform),
+            collider_body_qd: wp.array2d(dtype=wp.spatial_vector),
+        ):
+            frame, body_id = wp.tid()
+            mat = xform_mats[frame, body_id]
+            mat_next = xform_mats[frame + wp.static(self.sim_substeps), body_id]
+            tf = wp.transform_from_matrix(mat)
+            tf_next = wp.transform_from_matrix(mat_next)
+            vel = (tf_next.p - tf.p) / wp.static(self.frame_dt)
+            ang = angvel_between_quats(tf.q, tf_next.q, wp.static(self.frame_dt))
+            tf.p += usd_offset
+            collider_body_q[frame, body_id] = tf
+            collider_body_qd[frame, body_id] = wp.spatial_vector(vel, ang)
+
+        wp.launch(
+            compute_collider_coordinates_kernel,
+            dim=self.collider_body_q.shape,
+            inputs=[mats, self.usd_offset],
+            outputs=[self.collider_body_q, self.collider_body_qd],
+        )
+
+    @wp.kernel
+    def _update_animated_colliders_kernel(
+        time_step: wp.array(dtype=wp.int32),
+        collider_body_q: wp.array2d(dtype=wp.transform),
+        collider_body_qd: wp.array2d(dtype=wp.spatial_vector),
+        colliders_joint_q_start: wp.array(dtype=wp.int32),
+        colliders_joint_qd_start: wp.array(dtype=wp.int32),
+        collider_body_ids: wp.array(dtype=int),
+        # outputs
+        body_q: wp.array(dtype=wp.transform),
+        body_qd: wp.array(dtype=wp.spatial_vector),
+        joint_q: wp.array(dtype=wp.float32),
+        joint_qd: wp.array(dtype=wp.float32),
+    ):
+        i = wp.tid()
+        step = min(time_step[0], len(collider_body_q) - 1)
+        body_id = collider_body_ids[i]
+        q = collider_body_q[step, i]
+        qd = collider_body_qd[step, i]
+
+        # update maximal coordinates
+        body_q[body_id] = q
+        body_qd[body_id] = qd
+
+        # update generalized coordinates (necessary for MuJoCo)
+        q_start = colliders_joint_q_start[i]
+        qd_start = colliders_joint_qd_start[i]
+        for j in range(7):
+            joint_q[q_start + j] = q[j]
+        for j in range(6):
+            joint_qd[qd_start + j] = qd[j]
+
+    @wp.kernel
+    def _advance_substep_time_kernel(
+        time_step: wp.array(dtype=wp.int32),
+        droid_is_walking: wp.array(dtype=bool),
+    ):
+        if droid_is_walking[0]:
+            time_step[0] += 1
+
+    def _advance_substep_time(self):
+        wp.launch(
+            self._advance_substep_time_kernel,
+            dim=1,
+            inputs=[self.time_step_wp, self.droid_is_walking_wp],
+        )
+
+    def _update_animated_colliders(self):
+        wp.launch(
+            self._update_animated_colliders_kernel,
+            dim=len(self.animated_colliders_body_ids),
+            inputs=[
+                self.time_step_wp,
+                self.collider_body_q,
+                self.collider_body_qd,
+                self.animated_colliders_joint_q_start_wp,
+                self.animated_colliders_joint_qd_start_wp,
+                self.animated_colliders_body_ids_wp,
+            ],
+            outputs=[self.state_0.body_q, self.state_0.body_qd, self.state_0.joint_q, self.state_0.joint_qd],
+        )
+
+    def _bdxlanterndemo_add_custom_attributes_for_recorder(self, builder):
+        builder.add_custom_attribute(
+            "mouse_position",
+            newton.ModelAttributeFrequency.ONCE,
+            default=wp.vec2(0.0, 0.0),
+            dtype=wp.vec2,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "droid_is_walking",
+            newton.ModelAttributeFrequency.ONCE,
+            default=False,
+            dtype=bool,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "camera_position",
+            newton.ModelAttributeFrequency.ONCE,
+            default=wp.vec3(0.0, 0.0, 0.0),
+            dtype=wp.vec3,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "camera_fov",
+            newton.ModelAttributeFrequency.ONCE,
+            default=45.0,
+            dtype=float,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "camera_pitch",
+            newton.ModelAttributeFrequency.ONCE,
+            default=0.0,
+            dtype=float,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "camera_yaw",
+            newton.ModelAttributeFrequency.ONCE,
+            default=-180.0,
+            dtype=float,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+        builder.add_custom_attribute(
+            "picking_line",
+            newton.ModelAttributeFrequency.ONCE,
+            default=wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            dtype=wp.spatial_vector,
+            assignment=newton.ModelAttributeAssignment.STATE,
+        )
+
+    def _bdxlanterndemo_setup_viewer_for_recording(self):
+        if self.viewer.file_playback is None:
+            # write camera, mouse coordinates to the state so we can record it to a file
+            self.state_0.mouse_position.fill_(self.viewer.mouse_position)
+            self.state_0.mouse_button.fill_(self.viewer.mouse_button)
+            self.state_0.camera_position.fill_(wp.vec3(*self.viewer.camera.pos))
+            self.state_0.camera_fov.fill_(self.viewer.camera.fov)
+            self.state_0.camera_pitch.fill_(self.viewer.camera.pitch)
+            self.state_0.camera_yaw.fill_(self.viewer.camera.yaw)
+            self.state_0.droid_is_walking.fill_(self.droid_is_walking)
+            if not self.viewer.picking.is_picking() or self.viewer.picking.pick_body.numpy()[0] < 0:
+                self.state_0.picking_line.fill_(wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            else:
+                pick_state = self.viewer.picking.pick_state.numpy()
+                self.state_0.picking_line.fill_(wp.spatial_vector(*pick_state[8:14]))
+        else:
+            # Render picking line from playback
+            pick_state = self.state_0.picking_line.numpy()[0]
+            picked_point = wp.vec3(*pick_state[:3])
+            pick_target = wp.vec3(*pick_state[3:])
+            starts = wp.array([picked_point], dtype=wp.vec3, device=self.viewer.device)
+            ends = wp.array([pick_target], dtype=wp.vec3, device=self.viewer.device)
+            colors = wp.array([wp.vec3(0.0, 1.0, 1.0)], dtype=wp.vec3, device=self.viewer.device)
+            self.viewer.log_lines("picking_line_playback", starts, ends, colors, hidden=False)
+
+    def simulate(self):
+        if not self.collide_on_substeps and self.integrator_type != IntegratorType.MJWARP:
+            self.contacts = self.model.collide(
+                self.state_0,
+                collision_pipeline=self.collision_pipeline,
+            )
+
+        for _ in range(self.sim_substeps):
+            self._update_animated_colliders()
+            self._advance_substep_time()
+
+            if self.collide_on_substeps and self.integrator_type != IntegratorType.MJWARP:
+                self.contacts = self.model.collide(
+                    self.state_0,
+                    collision_pipeline=self.collision_pipeline,
+                )
+
+            self.state_0.clear_forces()
+            self.viewer.apply_forces(self.state_0)
+            self.integrator.step(self.state_0, self.state_1, None, self.contacts, self.sim_dt)
+
+            # swap states
+            (self.state_0, self.state_1) = (self.state_1, self.state_0)
+
+    def step(self):
+        with wp.ScopedTimer("step", dict=self.profiler, active=self.enable_timers, synchronize=True):
+            if self.graph is not None:
+                try:
+                    wp.capture_launch(self.graph)
+                except Exception as e:
+                    print(f"Error launching graph: {e}. Falling back to regular execution, which may be slower.")
+                    self.graph = None
+                    self.simulate()
+            else:
+                self.simulate()
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        # if self.integrator_type == IntegratorType.MJWARP:
+        #     newton.eval_fk(self.model, self.state_0.joint_q, self.state_0.joint_qd, self.state_0, mask=None)
+
+        with wp.ScopedTimer("render", dict=self.profiler, active=self.enable_timers, synchronize=True):
+            if self.usd_updater is not None:
+                self.usd_updater.begin_frame(self.sim_time)
+                with wp.ScopedTimer("update_usd", dict=self.profiler, active=self.enable_timers, synchronize=True):
+                    self.usd_updater.update_usd(self.state_0)
+                if self.integrator_type == IntegratorType.COUPLED_MPM:
+                    rot, scale = extract_particle_rotation_and_scales(self.integrator.mpm_state_0)
+                    self.usd_updater.render_points(
+                        path="/particles",
+                        points=self.integrator.mpm_state_0.particle_q,
+                        rotations=rot,
+                        scales=scale,
+                        radius=float(self.integrator.mpm_solver.mpm_model.model.particle_radius.numpy()[0]),
+                    )
+                self.usd_updater.end_frame()
+
+            if self.show_viewer:
+                if self.record_path:
+                    self._bdxlanterndemo_setup_viewer_for_recording()
+
+                # print(f"Mouse position: {self.state_0.mouse_position.numpy()[0]}, button: {self.state_0.mouse_button.numpy()[0]}")
+
+                # if self.integrator_type == IntegratorType.MJWARP:
+                #     self.integrator.render_mujoco_viewer()
+                self.viewer.begin_frame(self.sim_time)
+                with wp.ScopedTimer("log_state", dict=self.profiler, active=self.enable_timers, synchronize=True):
+                    self.viewer.log_state(self.state_0)
+                with wp.ScopedTimer("log_contacts", dict=self.profiler, active=self.enable_timers, synchronize=True):
+                    self.viewer.log_contacts(self.contacts, self.state_0)
+                if self.integrator_type == IntegratorType.COUPLED_MPM:
+                    self.viewer.log_points(
+                        "sand",
+                        points=self.integrator.mpm_state_0.particle_q,
+                        radii=self.integrator.mpm_solver.mpm_model.model.particle_radius,
+                        colors=self.integrator.particle_render_colors,
+                        hidden=False,
+                    )
+                    impulses, pos, cid = self.integrator.mpm_solver.collect_collider_impulses(
+                        self.integrator.mpm_state_0
+                    )
+                    self.viewer.log_lines(
+                        "impulses",
+                        starts=pos,
+                        ends=pos + impulses,
+                        colors=wp.full(pos.shape[0], value=wp.vec3(1.0, 0.0, 0.0), dtype=wp.vec3),
+                    )
+                self.viewer.end_frame()
+
+    def save(self):
+        if self.usd_updater is not None:
+            self.usd_updater.close()
+        self.viewer.close()
+
+
+def print_time_profiler(simulator):
+    frame_times = simulator.profiler.get("step", None)
+    render_times = simulator.profiler.get("render", None)
+    if frame_times:
+        print(f"\nAverage frame sim time: {sum(frame_times) / len(frame_times):.2f} ms")
+    if render_times:
+        print(f"\nAverage frame render time: {sum(render_times) / len(render_times):.2f} ms")
+
+
+def render_mouse_state(x, y, button, width, height):
+    rgb = np.zeros((height, width, 3), dtype=np.uint8)
+    colors = [
+        (255, 255, 255),
+        (255, 0, 0),
+        (0, 255, 255),
+        (0, 255, 0),
+        (0, 0, 255),
+    ]
+    px, py = int(x * width), int(y * height)
+    y_start = max(py - 1, 0)
+    y_end = min(py + 1, height - 1) + 1  # +1 because slice end is exclusive
+    x_start = max(px - 1, 0)
+    x_end = min(px + 1, width - 1) + 1
+    if button.any():
+        color = colors[button.argmax()]
+    else:
+        color = (255, 255, 255)
+    rgb[y_start:y_end, x_start:x_end] = color
+    return rgb
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "stage_path",
+        help="Path to the input USD file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Path to the output USD file.",
+        default="",
+    )
+    parser.add_argument("-d", "--device", type=str, default=None, help="Override the default Warp device.")
+    parser.add_argument("-n", "--num_frames", type=int, default=300, help="Total number of frames.")
+    parser.add_argument(
+        "-i",
+        "--integrator",
+        help="Type of integrator",
+        type=IntegratorType,
+        choices=list(IntegratorType),
+        default=None,
+    )
+    parser.add_argument(
+        "-t",
+        "--sim_time",
+        help="Simulation time",
+        type=float,
+        default=0.0,
+    )
+    parser.add_argument(
+        "-s",
+        "--sim_frame",
+        help="Simulation frame",
+        type=int,
+        default=0,
+    )
+    parser.add_argument(
+        "-p",
+        "--pause",
+        help="Pause droid walking sequence at the given frame number",
+        type=int,
+        default=0,
+    )
+    parser.add_argument(
+        "-r",
+        "--record",
+        help="File path to where to record the interaction (needs to be a .bin file)",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "-l",
+        "--load",
+        help="File path of a recording (.bin) file to load for playback",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "-f",
+        "--render_folder",
+        help="Folder path to where to store rendered PNG frames",
+        type=str,
+        default="",
+    )
+    parser.add_argument(
+        "--usd_offset",
+        help="USD offset as three floats: x y z (e.g., '0.0 0.0 0.0')",
+        type=str,
+        default="0.0 0.0 0.0",
+    )
+    parser.add_argument(
+        "--use_unified_collision_pipeline",
+        help="Use the unified collision pipeline",
+        type=bool,
+        default=True,
+    )
+    parser.add_argument(
+        "--use_coacd",
+        help="Use COACD for collision mesh approximation",
+        type=bool,
+        default=False,
+    )
+    parser.add_argument(
+        "--enable_timers",
+        help="Enable timers",
+        type=bool,
+        default=True,
+    )
+
+    args = parser.parse_known_args()[0]
+
+    # Parse usd_offset argument
+    try:
+        offset_values = [float(x) for x in args.usd_offset.split()]
+        if len(offset_values) != 3:
+            raise ValueError("usd_offset must have exactly 3 values")
+        usd_offset = wp.vec3(*offset_values)
+    except (ValueError, AttributeError) as e:
+        print(f"Error parsing usd_offset: {e}. Using default (0.0, 0.0, 0.0)")
+        usd_offset = wp.vec3(0.0, 0.0, 0.0)
+
+    if not args.output:
+        from pathlib import Path
+
+        path = Path(args.stage_path)
+        base_path = path.parent / "output"
+        base_path.mkdir(parents=True, exist_ok=True)
+        args.output = str(base_path / path.name)
+        print(f'Output path not specified (-o flag). Writing to "{args.output}".')
+
+    with wp.ScopedDevice(args.device):
+        simulator = Simulator(
+            input_path=args.stage_path,
+            output_path=args.output,
+            integrator=args.integrator,
+            num_frames=args.num_frames,
+            sim_time=args.sim_time,
+            sim_frame=args.sim_frame,
+            record_path=args.record,
+            usd_offset=usd_offset,
+            use_unified_collision_pipeline=args.use_unified_collision_pipeline,
+            use_coacd=args.use_coacd,
+        )
+
+        i = 0
+        while i < args.num_frames:
+            print(f"frame {i}")
+            simulator.step()
+            simulator.render()
+            i += 1
+
+        print_time_profiler(simulator)
+
+        simulator.save()
+

--- a/newton/_src/utils/sim_usd_gtc.py
+++ b/newton/_src/utils/sim_usd_gtc.py
@@ -460,6 +460,7 @@ class Simulator:
         use_unified_collision_pipeline: bool = True,
         use_coacd: bool = False,
         enable_timers: bool = False,
+        load_visual_shapes: bool = False,
     ):
         def create_stage_from_path(input_path) -> Usd.Stage:
             stage = Usd.Stage.Open(input_path, Usd.Stage.LoadAll)
@@ -1193,6 +1194,12 @@ if __name__ == "__main__":
         help="Enable timers",
         type=bool,
         default=True,
+    )
+    parser.add_argument(
+        "--load_visual_shapes",
+        help="Load visual shapes",
+        type=bool,
+        default=False,
     )
 
     args = parser.parse_known_args()[0]

--- a/newton/_src/utils/update_usd.py
+++ b/newton/_src/utils/update_usd.py
@@ -1,0 +1,510 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import warp as wp
+
+
+class UpdateUsd:
+    def __init__(
+        self,
+        stage: str | Usd.Stage,
+        source_stage: str | Usd.Stage | None = None,
+        scaling: float = 1.0,
+        fps: int = 60,
+        up_axis: AxisType | None = None,
+        path_body_map: dict | None = None,
+        path_body_relative_transform: dict | None = None,
+        builder_results: dict | None = None,
+        global_offset: wp.vec3 | None = None,
+    ):
+        """
+        Construct a UpdateUsd object.
+
+        Args:
+            model (newton.Model): The Newton physics model to render.
+            stage (str | Usd.Stage): The USD stage to render to. This is the output stage.
+            source_stage (str | Usd.Stage, optional): The USD stage to use as a source for the output stage.
+            scaling (float, optional): Scaling factor for the rendered objects. Defaults to 1.0.
+            fps (int, optional): Frames per second for the animation. Defaults to 60.
+            up_axis (newton.AxisType, optional): Up axis for the scene. If None, uses model's up axis. Defaults to None.
+            show_joints (bool, optional): Whether to show joint visualizations.  Defaults to False.
+            path_body_map (dict, optional): A dictionary mapping prim paths to body IDs.
+            path_body_relative_transform (dict, optional): A dictionary mapping prim paths to relative transformations.
+            builder_results (dict, optional): A dictionary containing builder results.
+            global_offset (wp.vec3, optional): A global offset to apply to the stage.
+        """
+        if source_stage:
+            if path_body_map is None:
+                raise ValueError("path_body_map must be set if you are providing a source_stage")
+            if path_body_relative_transform is None:
+                raise ValueError("path_body_relative_transform must be set if you are providing a source_stage")
+            if builder_results is None:
+                raise ValueError("builder_results must be set if you are providing a source_stage")
+
+        self.source_stage = source_stage
+        self.global_offset: wp.vec3 = global_offset if global_offset is not None else wp.vec3(0.0, 0.0, 0.0)
+        if not self.source_stage:
+            raise ValueError("source_stage must be set")
+        else:
+            self.stage = self._create_output_stage(self.source_stage, stage)
+            self.fps = fps
+            self.scaling = scaling
+            self.up_axis = up_axis
+            self.path_body_map = path_body_map
+            self.path_body_relative_transform = path_body_relative_transform
+            self.builder_results = builder_results
+            self._prepare_output_stage()
+            self._precompute_parents_xform_inverses()
+
+    def _prepare_output_stage(self):
+        """
+        Set USD parameters on the output stage to match the simulation settings.
+
+        Must be called after _apply_solver_attributes!"""
+        from pxr import Sdf  # noqa: PLC0415
+
+        if self.path_body_map is None:
+            raise ValueError("self.path_body_map must be set before calling _prepare_output_stage")
+
+        self.stage.SetStartTimeCode(0.0)
+        self.stage.SetEndTimeCode(0.0)
+        # NB: this is now coming from warp:fps, but timeCodesPerSecond is a good source too
+        self.stage.SetTimeCodesPerSecond(self.fps)
+
+        for prim_path in self.path_body_map.keys():
+            prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+            self._xform_to_tqs(prim)
+
+    def _precompute_parents_xform_inverses(self):
+        """
+        Convention: prefix c is for **current** prim.
+        Prefix p is for **parent** prim.
+        """
+        from pxr import Sdf, Usd  # noqa: PLC0415
+
+        if self.path_body_map is None:
+            raise ValueError("self.path_body_map must be set before calling _precompute_parents_xform_inverses")
+
+        self.parent_translates = {}
+        self.parent_inv_Rs = {}
+        self.parent_inv_Rns = {}
+
+        with wp.ScopedTimer("prep_parents_xform"):
+            time = Usd.TimeCode.Default()
+            for prim_path in self.path_body_map.keys():
+                current_prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+                parent_path = str(current_prim.GetParent().GetPath())
+
+                if parent_path not in self.parent_translates:
+                    (
+                        self.parent_translates[parent_path],
+                        self.parent_inv_Rs[parent_path],
+                        self.parent_inv_Rns[parent_path],
+                    ) = self._compute_parents_inverses(prim_path, time)
+
+    def begin_frame(self, time):
+        """
+        Begin a new frame at the given simulation time.
+
+        Parameters:
+            time (float): The simulation time for the new frame.
+        """
+        # super().begin_frame(time)
+        self.time = round(time * self.fps)
+        self.stage.SetEndTimeCode(self.time)
+
+    def end_frame(self):
+        """
+        End the current frame.
+
+        This method is a placeholder for any end-of-frame logic required by the backend.
+        """
+        pass
+
+    def attach_source_stage(self, source_stage: str | Usd.Stage, output_stage: str | Usd.Stage):
+        """
+        Attach a USD stage created from a source stage (flattened copy) as the viewer's stage.
+
+        """
+        if isinstance(output_stage, str):
+            stage = Usd.Stage.Open(source_stage, Usd.Stage.LoadAll)
+            flattened = stage.Flatten()
+            temp_stage = Usd.Stage.Open(flattened.identifier)
+            exported = temp_stage.ExportToString()
+
+            new_stage = Usd.Stage.CreateNew(output_stage)
+            new_stage.GetRootLayer().ImportFromString(exported)
+            self.stage = new_stage
+        elif isinstance(output_stage, Usd.Stage):
+            self.stage = output_stage
+        else:
+            raise ValueError("output_stage must be a string or a Usd.Stage")
+
+        # carry over fps and basic settings
+        self.stage.SetFramesPerSecond(self.fps)
+        self.stage.SetStartTimeCode(0)
+        return self.stage
+
+    #    def create_output_stage_from_source(self, source_stage: str | Usd.Stage, output_stage: str | Usd.Stage) -> Usd.Stage:
+    #        """
+    #        Create and return a new stage from a source, without attaching it. Provided for convenience.
+    #        """
+    #        if isinstance(output_stage, str):
+    #            stage = Usd.Stage.Open(source_stage, Usd.Stage.LoadAll)
+    #            flattened = stage.Flatten()
+    #            temp_stage = Usd.Stage.Open(flattened.identifier)
+    #            exported = temp_stage.ExportToString()
+    #
+    #            new_stage = Usd.Stage.CreateNew(output_stage)
+    #            new_stage.GetRootLayer().ImportFromString(exported)
+    #            return new_stage
+    #        elif isinstance(output_stage, Usd.Stage):
+    #            return output_stage
+    #        else:
+    #            raise ValueError("output_stage must be a string or a Usd.Stage")
+    #
+    def configure_body_mapping(
+        self,
+        path_body_map: dict,
+        path_body_relative_transform: dict,
+        builder_results: dict,
+    ):
+        """
+        Configure mapping from USD prim paths to body indices and precompute parent inverses.
+        """
+        if path_body_map is None:
+            raise ValueError("path_body_map must be set for configure_body_mapping")
+        if path_body_relative_transform is None:
+            raise ValueError("path_body_relative_transform must be set for configure_body_mapping")
+        if builder_results is None:
+            raise ValueError("builder_results must be set for configure_body_mapping")
+
+        self.path_body_map = path_body_map
+        self.path_body_relative_transform = path_body_relative_transform
+        self.builder_results = builder_results
+
+        # Stage-wide prep to align xform stacks and cache parent inverses
+        self._prepare_output_stage_for_mapping()
+        self._precompute_parents_xform_inverses()
+
+    def update_usd(self, state):
+        """
+        Write transforms of USD prims as time-sampled animation in USD using the current simulation state.
+
+        Args:
+            state (newton.State): The simulation state to render.
+        """
+        from pxr import Sdf  # noqa: PLC0415
+
+        if self.path_body_map is None:
+            raise ValueError("configure_body_mapping must be called before update_stage_from_state")
+
+        # body_q is either a warp array (preferred) or numpy; ensure numpy here
+        body_q = state.body_q.numpy()
+        if self.global_offset is not None:
+            body_q[:, :3] -= self.global_offset
+
+        # Use a change block for efficient time-sampled updates
+        with Sdf.ChangeBlock():
+            for prim_path, body_id in self.path_body_map.items():
+                full_xform = wp.transform(*body_q[body_id])
+
+                # apply relative xform if any
+                rel_xform = self.path_body_relative_transform.get(prim_path)
+                if rel_xform:
+                    full_xform = wp.mul(full_xform, rel_xform)
+
+                # convert to local space relative to parent (if required)
+                full_xform = self._apply_parents_inverse_xform(wp.transform(*full_xform), prim_path, body_q)
+
+                # set xform ops at current frame index
+                self._update_usd_prim_xform(prim_path, full_xform)
+
+    def render_points(
+        self,
+        path: str,
+        points: wp.array,
+        rotations: wp.array | None = None,
+        scales: wp.array | None = None,
+        radius: float | None = None,
+    ):
+        from pxr import UsdGeom
+
+        stage = self.stage
+        time = self.time
+
+        instancer_path = path
+        instancer = UsdGeom.PointInstancer.Get(stage, instancer_path)
+        if not instancer:
+            # UsdGeom.Xform.Define(stage, root_path)
+            instancer = UsdGeom.PointInstancer.Define(stage, instancer_path)
+            instancer_sphere = UsdGeom.Sphere.Define(stage, instancer.GetPath().AppendChild("sphere"))
+            instancer_sphere.GetRadiusAttr().Set(radius)
+            # instancer_sphere = UsdGeom.Cube.Define(self.stage, instancer.GetPath().AppendChild("sphere"))
+            # instancer_sphere.GetSizeAttr().Set(radius*2.0)
+
+            instancer.CreatePrototypesRel().SetTargets([instancer_sphere.GetPath()])
+            instancer.CreateProtoIndicesAttr().Set([0] * len(points))
+
+        instancer.GetPositionsAttr().Set(points.numpy() - self.global_offset, time)
+
+        if rotations is not None:
+            instancer.GetOrientationsAttr().Set(rotations.numpy(), time)
+
+        if scales is not None:
+            instancer.GetScalesAttr().Set(scales.numpy(), time)
+
+    def _apply_parents_inverse_xform(self, full_xform: wp.transform, prim_path: str, body_q: wp.array) -> wp.transform:
+        """
+        Transformation in Warp sim consists of translation and pure rotation: trnslt and quat.
+        Transformations of bodies are stored in body_q in simulation state.
+        For sim_usd, trnslt is computed directly from PhysicsUtils by the function GetRigidBodyTransformation
+        in parseUtils.cpp:
+            const GfMatrix4d mat = UsdGeomXformable(bodyPrim).ComputeLocalToWorldTransform(UsdTimeCode::Default());
+            const GfTransform tr(mat);
+            const GfVec3d pos = tr.GetTranslation();
+            const GfQuatd rot = tr.GetRotation().GetQuat();
+        In import_nvusd, we set trnslt = pos and quat = fromgfquat(rot), where fromgfquat has the following logic:
+        wp.normalize(wp.quat(*gfquat.imaginary, gfquat.real)).
+
+        For trnslt, we have:
+            warp_trnslt = xform.ComputeLocalToWorldTransform().GetTranslation().
+        But in USD space:
+            xform.ComputeLocalToworldTransform() = xform.GetLocalTransform() * xform.ComputeParentToWorldTransform()
+            Prim_LTW_USD = Prim_Local_USD * Parent_LTW_USD,
+        or in Warp space, we work with transpose and arrive at:
+            Prim_LTW = Parent_LTW * Prim_Local
+            warp_trnslt = p_Rot * prim_trnslt + p_trnslt,
+            i.e.
+            prim_trnslt = p_inv_Rot * (warp_trnslt - p_trnslt).
+
+        For rotation, we have:
+            rot = tr.GetRotation().GetQuat();
+            warp_quat = wp.normalize(wp.quat(rot)).
+        However, rot is already normalized, so we don't actually need to renormalize it.
+        So in Warp space,
+            warp_Rot = p_Rot * diag(1/s_x, 1/s_y, 1/s_z) * prim_Rot, so
+            prim_Rot = wp.inv(p_Rot * diag(1/s_x, 1/s_y, 1/s_z)) * warp_Rot
+
+        Both p_inv_Rot and wp.inv(p_Rot * diag(1/s_x, 1/s_y, 1/s_z)) do not change during sim, so they are computed in __init__.
+        """
+        from pxr import Sdf  # noqa: PLC0415
+
+        current_prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+        parent_path = str(current_prim.GetParent().GetPath())
+
+        if parent_path in self.path_body_map:
+            parent_xform = wp.transform(*body_q[self.path_body_map[parent_path]])
+            return wp.transform_inverse(parent_xform) * full_xform
+
+        parent_translate = self.parent_translates[parent_path]
+        parent_inv_Rot = self.parent_inv_Rs[parent_path]
+        parent_inv_Rot_n = self.parent_inv_Rns[parent_path]
+
+        warp_translate = wp.transform_get_translation(full_xform)
+        warp_quat = wp.transform_get_rotation(full_xform)
+
+        prim_translate = parent_inv_Rot * (warp_translate - wp.vec3(parent_translate))
+        prim_quat = parent_inv_Rot_n * warp_quat
+
+        return wp.transform(prim_translate, prim_quat)
+
+    def _update_usd_prim_xform(self, prim_path: str, warp_xform: wp.transform):
+        from pxr import Gf, Sdf, UsdGeom  # noqa: PLC0415
+
+        prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+
+        pos = tuple(map(float, warp_xform[0:3]))
+        rot = tuple(map(float, warp_xform[3:7]))
+
+        xform = UsdGeom.Xform(prim)
+        xform_ops = xform.GetOrderedXformOps()
+
+        # Detect precision from the first xform op (translation)
+        if xform_ops and xform_ops[0].GetPrecision() == UsdGeom.XformOp.PrecisionDouble:
+            # Use double precision types
+            if pos is not None:
+                xform_ops[0].Set(Gf.Vec3d(pos[0], pos[1], pos[2]), self.time)
+            if rot is not None:
+                xform_ops[1].Set(Gf.Quatd(rot[3], rot[0], rot[1], rot[2]), self.time)
+        else:
+            # Use float precision types
+            if pos is not None:
+                xform_ops[0].Set(Gf.Vec3f(pos[0], pos[1], pos[2]), self.time)
+            if rot is not None:
+                xform_ops[1].Set(Gf.Quatf(rot[3], rot[0], rot[1], rot[2]), self.time)
+
+    # Note: if _compute_parents_inverses turns to be too slow, then we should consider using a UsdGeomXformCache as described here:
+    # https://openusd.org/release/api/class_usd_geom_imageable.html#a4313664fa692f724da56cc254bce70fc
+    def _compute_parents_inverses(self, prim_path: str, time: Usd.TimeCode):
+        from pxr import Gf, Sdf, UsdGeom  # noqa: PLC0415
+
+        prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+        xform = UsdGeom.Xform(prim)
+
+        parent_world = Gf.Matrix4f(xform.ComputeParentToWorldTransform(time))
+        Rpw = wp.mat33(parent_world.ExtractRotationMatrix().GetTranspose())
+        (_, _, s, _, translate_parent_world, _) = parent_world.Factor()
+
+        transpose_Rpwn = wp.mat33(
+            Rpw[0, 0] / s[0],
+            Rpw[1, 0] / s[0],
+            Rpw[2, 0] / s[0],
+            Rpw[0, 1] / s[1],
+            Rpw[1, 1] / s[1],
+            Rpw[2, 1] / s[1],
+            Rpw[0, 2] / s[2],
+            Rpw[1, 2] / s[2],
+            Rpw[2, 2] / s[2],
+        )
+        inv_Rpwn = wp.quat_from_matrix(transpose_Rpwn)
+        inv_Rpw = wp.inverse(Rpw)
+
+        return translate_parent_world, inv_Rpw, inv_Rpwn
+
+    def _precompute_parents_xform_inverses(self):
+        """
+        Convention: prefix c is for **current** prim.
+        Prefix p is for **parent** prim.
+        """
+        from pxr import Sdf, Usd  # noqa: PLC0415
+
+        if self.path_body_map is None:
+            raise ValueError("path_body_map must be set before calling _precompute_parents_xform_inverses")
+
+        self.parent_translates = {}
+        self.parent_inv_Rs = {}
+        self.parent_inv_Rns = {}
+
+        time = Usd.TimeCode.Default()
+        for prim_path in self.path_body_map.keys():
+            current_prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+            parent_path = str(current_prim.GetParent().GetPath())
+
+            if parent_path not in self.parent_translates:
+                (
+                    self.parent_translates[parent_path],
+                    self.parent_inv_Rs[parent_path],
+                    self.parent_inv_Rns[parent_path],
+                ) = self._compute_parents_inverses(prim_path, time)
+
+    def _prepare_output_stage_for_mapping(self):
+        from pxr import Sdf  # noqa: PLC0415
+
+        if self.path_body_map is None:
+            raise ValueError("path_body_map must be set before calling _prepare_output_stage_for_mapping")
+
+        # Reset time codes to align with viewer timeline
+        self.stage.SetStartTimeCode(0.0)
+        # keep existing end-time; it will be extended in begin_frame
+        self.stage.SetTimeCodesPerSecond(self.fps)
+
+        for prim_path in self.path_body_map.keys():
+            prim = self.stage.GetPrimAtPath(Sdf.Path(prim_path))
+            self._xform_to_tqs(prim)
+
+    def _create_output_stage(self, source_stage: str | Usd.Stage, output_stage: str | Usd.Stage) -> Usd.Stage:
+        from pxr import Usd  # noqa: PLC0415
+
+        if isinstance(output_stage, str):
+            source_stage = Usd.Stage.Open(source_stage, Usd.Stage.LoadAll)
+            flattened = source_stage.Flatten()
+            stage = Usd.Stage.Open(flattened.identifier)
+            exported = stage.ExportToString()
+
+            output_stage = Usd.Stage.CreateNew(output_stage)
+            output_stage.GetRootLayer().ImportFromString(exported)
+            return output_stage
+        elif isinstance(output_stage, Usd.Stage):
+            return output_stage
+        else:
+            raise ValueError("output_stage must be a string or a Usd.Stage")
+
+    def close(self):
+        """
+        Finalize and save the USD stage.
+
+        This should be called when all logging is complete to ensure the USD file is written.
+        """
+        try:
+            self.stage.Save()
+            self.stage = None
+            print("USD stage saved successfully")
+        except Exception as e:
+            print("Failed to save USD stage:", e)
+            return False
+
+    @staticmethod
+    def _xform_to_tqs(prim: Usd.Prim, time: Usd.TimeCode | None = None):
+        """
+        Update the transformation stack of a primitive to translate/orient/scale format.
+
+        The original transformation stack is assumed to be a rigid transformation.
+        The precision (float/double) is detected from existing transform ops.
+        """
+        from pxr import Gf, Usd, UsdGeom  # noqa: PLC0415
+
+        if time is None:
+            time = Usd.TimeCode.Default()
+
+        _tqs_op_order = [UsdGeom.XformOp.TypeTranslate, UsdGeom.XformOp.TypeOrient, UsdGeom.XformOp.TypeScale]
+
+        xform = UsdGeom.Xform(prim)
+        xform_ops = xform.GetOrderedXformOps()
+
+        # Detect precision from existing transform ops
+        # Prefer double if any op uses double, otherwise use float
+        detected_precision = UsdGeom.XformOp.PrecisionFloat
+        if xform_ops:
+            for op in xform_ops:
+                if op.GetPrecision() == UsdGeom.XformOp.PrecisionDouble:
+                    detected_precision = UsdGeom.XformOp.PrecisionDouble
+                    break
+
+        _tqs_op_precision = [detected_precision, detected_precision, detected_precision]
+
+        # if the order, type, and precision of the transformation is already in our canonical form, then there's no need to change anything.
+        if _tqs_op_order == [op.GetOpType() for op in xform_ops] and _tqs_op_precision == [
+            op.GetPrecision() for op in xform_ops
+        ]:
+            return
+
+        # this assumes no skewing
+        # NB: the rotation coming from Factor is the result of solving an eigenvalue problem. We found wrong answer with non-identity scaling.
+        m_lcl = xform.GetLocalTransformation(time)
+        (_, _, scale, _, translation, _) = m_lcl.Factor()
+
+        # Use appropriate type based on detected precision
+        if detected_precision == UsdGeom.XformOp.PrecisionDouble:
+            t = Gf.Vec3d(translation)
+            q = Gf.Quatd(m_lcl.ExtractRotationQuat())
+            s = Gf.Vec3d(scale)
+        else:
+            t = Gf.Vec3f(translation)
+            q = Gf.Quatf(m_lcl.ExtractRotationQuat())
+            s = Gf.Vec3f(scale)
+
+        # need to reset the transform
+        for op in xform_ops:
+            attr = op.GetAttr()
+            prim.RemoveProperty(attr.GetName())
+
+        xform.ClearXformOpOrder()
+        xform.AddTranslateOp(precision=detected_precision).Set(t)
+        xform.AddOrientOp(precision=detected_precision).Set(q)
+        xform.AddScaleOp(precision=detected_precision).Set(s)


### PR DESCRIPTION
`sim_usd` is a utility that reads a USD file, runs a Newton simulation, and renders USD file as a result. For this version, we support rigid body. Here are a few examples of simulations that are run using Newton:
![incline_v0-mid--receive-even-nose_2x2_grid_annotated](https://github.com/user-attachments/assets/7b006af0-2c29-4f62-9d2e-201d668dbbe4)
![incline_v0-mid--charm-crime-February_2x2_grid_annotated](https://github.com/user-attachments/assets/dd8a5770-3b93-4cf7-a0c5-9c263ed488da)
![domino_v0_2x2_grid_annotated](https://github.com/user-attachments/assets/6148cbd6-89bb-4108-9e00-ff25794165d4)
![collapse_v2_2x2_grid_annotated](https://github.com/user-attachments/assets/2d898814-3764-4b3e-8d8d-940c1adcf74a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * USD-based simulation runners with multiple integrators (including coupled MPM), CLI, and optional GPU acceleration.
  * Utilities to create/update USD output stages and emit per-frame transforms and point data.
  * New tooling to augment USD stages with physics schemas and joint/rigid-body setups.

* **Enhancements**
  * Added angular-velocity between orientations computation.
  * Applied angular damping to linear velocity for more stable integration.
  * Optional parsing of visual-only shapes during import.

* **Bug Fixes**
  * Prevented over-allocation in unified collision pipeline when explicit shape lists are used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->