### PR TITLE
Update readme to execute all examples with uv run

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ uv sync --extra examples
       <code>uv run -m newton.examples basic_joints</code>
     </td>
     <td align="center">
-      <!-- <code>python -m newton.examples basic_viewer</code> -->
+      <!-- <code>uv run -m newton.examples basic_viewer</code> -->
     </td>
   </tr>
 </table>
@@ -222,13 +222,13 @@ uv sync --extra examples
   </tr>
   <tr>
     <td align="center">
-      <code>python -m newton.examples ik_franka</code>
+      <code>uv run -m newton.examples ik_franka</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples ik_h1</code>
+      <code>uv run -m newton.examples ik_h1</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples ik_benchmark</code>
+      <code>uv run -m newton.examples ik_benchmark</code>
     </td>
   </tr>
 </table>
@@ -319,13 +319,13 @@ uv sync --extra examples
   </tr>
   <tr>
     <td align="center">
-      <code>python -m newton.examples diffsim_ball</code>
+      <code>uv run -m newton.examples diffsim_ball</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples diffsim_cloth</code>
+      <code>uv run -m newton.examples diffsim_cloth</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples diffsim_drone</code>
+      <code>uv run -m newton.examples diffsim_drone</code>
     </td>
   </tr>
   <tr>
@@ -345,13 +345,13 @@ uv sync --extra examples
   </tr>
   <tr>
     <td align="center">
-      <code>python -m newton.examples diffsim_spring_cage</code>
+      <code>uv run -m newton.examples diffsim_spring_cage</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples diffsim_soft_body</code>
+      <code>uv run -m newton.examples diffsim_soft_body</code>
     </td>
     <td align="center">
-      <!-- Future MPM example -->
+      <!-- Future diffsim example -->
     </td>
   </tr>
 </table>


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR closes #640 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [-] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [-] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to use uv run -m for all example invocations, replacing python -m across sections.
  * Covered examples include: basic_viewer; IK (ik_franka, ik_h1, ik_benchmark); DiffSim (diffsim_ball, diffsim_cloth, diffsim_drone, diffsim_spring_cage, diffsim_soft_body).
  * Revised a placeholder note from “Future MPM example” to “Future diffsim example”.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->