### PR TITLE
Fix apply_mjc_control in the case of CPU mujoco

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1369,8 +1369,8 @@ class SolverMuJoCo(SolverBase):
             xfrc = mj_data.xfrc_applied
             nworld = mj_data.nworld
         else:
-            ctrl = wp.empty((1, len(mj_data.ctrl)), dtype=wp.float32, device=model.device)
-            qfrc = wp.empty((1, len(mj_data.qfrc_applied)), dtype=wp.float32, device=model.device)
+            ctrl = wp.zeros((1, len(mj_data.ctrl)), dtype=wp.float32, device=model.device)
+            qfrc = wp.zeros((1, len(mj_data.qfrc_applied)), dtype=wp.float32, device=model.device)
             xfrc = wp.zeros((1, len(mj_data.xfrc_applied)), dtype=wp.spatial_vector, device=model.device)
             nworld = 1
         axes_per_env = model.joint_dof_count // nworld


### PR DESCRIPTION
## Description
This solves #637.
The issue is that when no control was applied with CPU mujoco, we were sending undefined control.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of control and force values to start at zero in a specific simulation path, preventing unpredictable behavior.
  * Improves simulation stability and determinism in edge cases.

* **Chores**
  * No changes to public APIs or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->