### PR TITLE
Add basic raycast sensor

### DIFF
--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -321,12 +321,11 @@ def ray_intersect_mesh(
     scaled_direction = wp.cw_div(ray_direction_local, size)
 
     # Normalize direction for the mesh query
-    dir_length_sq = wp.dot(scaled_direction, scaled_direction)
-    if dir_length_sq < MINVAL:
+    scaled_dir_length = wp.length(scaled_direction)
+    if scaled_dir_length < MINVAL:
         return t_hit
 
-    dir_length = wp.sqrt(dir_length_sq)
-    normalized_direction = scaled_direction / dir_length
+    normalized_direction = scaled_direction / scaled_dir_length
 
     # Warp mesh query variables
     t = float(0.0)      # hit distance along ray
@@ -341,11 +340,14 @@ def ray_intersect_mesh(
     if wp.mesh_query_ray(mesh_id, scaled_origin, normalized_direction, max_t, t, u, v, sign, normal, face_index):
         if t >= 0.0:
             # Transform hit distance back to world space
-            # Account for scaling and original direction length
-            scale_factor = wp.length(size) / 3.0  # Average scale factor
-            world_dir_length = wp.length(ray_direction_local)
-            if world_dir_length > MINVAL:
-                t_hit = t * scale_factor * dir_length / world_dir_length
+            # t is distance along normalized_direction in scaled space
+            # Convert to distance along original ray_direction_local
+            original_dir_length = wp.length(ray_direction_local)
+            if original_dir_length > MINVAL:
+                # Convert from distance along normalized scaled direction to distance along original ray
+                # t is distance along normalized_direction
+                # We want distance along ray_direction_local
+                t_hit = t / scaled_dir_length * original_dir_length
 
     return t_hit
 

--- a/newton/_src/utils/raycast_sensor.py
+++ b/newton/_src/utils/raycast_sensor.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import numpy as np
+import warp as wp
+
+from ..geometry.raycast import raycast_sensor_kernel
+from ..sim import Model, State
+
+
+@wp.kernel
+def clamp_no_hits_kernel(depth_image: wp.array(dtype=float), max_dist: float, width: int):
+    """Kernel to replace max_distance values with -1.0 to indicate no intersection."""
+    tid = wp.tid()
+    if depth_image[tid] >= max_dist:
+        depth_image[tid] = -1.0
+
+
+class RaycastSensor:
+    """Raycast-based depth sensor for generating depth images.
+
+    The RaycastSensor simulates a depth camera by casting rays from a virtual camera through each pixel
+    in an image. For each pixel, it finds the closest intersection with the scene geometry and records
+    the distance as a depth value.
+
+    The sensor supports perspective cameras with configurable field of view, aspect ratio, and resolution.
+    The resulting depth image has the same resolution as specified, with depth values representing the
+    distance from the camera to the closest surface along each ray.
+
+    .. rubric:: Camera Coordinate System
+
+    The camera uses a right-handed coordinate system where:
+    - The forward direction (camera_direction) is the direction the camera is looking
+    - The up direction (camera_up) defines the camera's vertical orientation
+    - The right direction (camera_right) is computed as the cross product of forward and up
+
+    .. rubric:: Depth Values
+
+    - Positive depth values: Distance to the closest surface
+    - Negative depth values (-1.0): No intersection found (ray missed all geometry)
+
+    Attributes:
+        device: The device (CPU/GPU) where computations are performed
+        camera_position: 3D position of the camera in world space
+        camera_direction: Forward direction vector (normalized)
+        camera_up: Up direction vector (normalized)
+        camera_right: Right direction vector (normalized)
+        fov_radians: Vertical field of view in radians
+        aspect_ratio: Width/height aspect ratio
+        width: Image width in pixels
+        height: Image height in pixels
+        depth_image: 2D depth image array (height, width)
+    """
+
+    def __init__(
+        self,
+        model: Model,
+        camera_position: tuple[float, float, float] | np.ndarray,
+        camera_direction: tuple[float, float, float] | np.ndarray,
+        camera_up: tuple[float, float, float] | np.ndarray,
+        fov_radians: float,
+        width: int,
+        height: int,
+        max_distance: float = 1000.0,
+    ):
+        """Initialize a RaycastSensor.
+
+        Args:
+            model: The Newton model containing the geometry to raycast against
+            camera_position: 3D position of the camera in world space
+            camera_direction: Forward direction of the camera (will be normalized)
+            camera_up: Up direction of the camera (will be normalized)
+            fov_radians: Vertical field of view in radians
+            width: Image width in pixels
+            height: Image height in pixels
+            max_distance: Maximum ray distance; rays beyond this return no hit
+        """
+        self.model = model
+        self.device = model.device
+        self.width = width
+        self.height = height
+        self.fov_radians = fov_radians
+        self.aspect_ratio = float(width) / float(height)
+        self.max_distance = max_distance
+
+        # Set initial camera parameters
+        self.camera_position = np.array(camera_position, dtype=np.float32)
+        camera_dir = np.array(camera_direction, dtype=np.float32)
+        camera_up = np.array(camera_up, dtype=np.float32)
+
+        # Pre-compute field of view scale
+        self.fov_scale = math.tan(fov_radians * 0.5)
+
+        # Create depth image buffer
+        self._depth_buffer = wp.zeros((height, width), dtype=float, device=self.device)
+        self.depth_image = self._depth_buffer
+        self._resolution = wp.vec2(float(width), float(height))
+
+        # Compute camera basis vectors and warp vectors
+        self._compute_camera_basis(camera_dir, camera_up)
+
+    def _compute_camera_basis(self, direction: np.ndarray, up: np.ndarray):
+        """Compute orthonormal camera basis vectors and update warp vectors.
+
+        Args:
+            direction: Camera direction vector (will be normalized)
+            up: Camera up vector (will be normalized)
+        """
+        # Normalize direction vectors
+        self.camera_direction = direction / np.linalg.norm(direction)
+        self.camera_up = up / np.linalg.norm(up)
+
+        # Compute right vector as cross product of forward and up
+        self.camera_right = np.cross(self.camera_direction, self.camera_up)
+        right_norm = np.linalg.norm(self.camera_right)
+        if right_norm < 1e-8:
+            # Camera direction and up are parallel, use a different up vector
+            if abs(self.camera_direction[2]) < 0.9:
+                temp_up = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+            else:
+                temp_up = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+            self.camera_right = np.cross(self.camera_direction, temp_up)
+            right_norm = np.linalg.norm(self.camera_right)
+        self.camera_right = self.camera_right / right_norm
+
+        # Recompute up vector to ensure orthogonality
+        self.camera_up = np.cross(self.camera_right, self.camera_direction)
+        self.camera_up = self.camera_up / np.linalg.norm(self.camera_up)
+
+        # Update warp vectors
+        self._camera_position = wp.vec3(*self.camera_position)
+        self._camera_direction = wp.vec3(*self.camera_direction)
+        self._camera_up = wp.vec3(*self.camera_up)
+        self._camera_right = wp.vec3(*self.camera_right)
+
+    def eval(self, state: State):
+        """Evaluate the raycast sensor to generate a depth image.
+
+        Casts rays from the camera through each pixel and records the distance to the closest
+        intersection with the scene geometry.
+
+        Args:
+            state: The current state of the simulation containing body poses
+        """
+        # Reset depth buffer to maximum distance
+        self._depth_buffer.fill_(self.max_distance)
+
+        # Launch raycast kernel for each pixel-shape combination
+        # We use 3D launch with dimensions (width, height, num_shapes)
+        num_shapes = len(self.model.shape_body)
+        if num_shapes > 0:
+            wp.launch(
+                kernel=raycast_sensor_kernel,
+                dim=(self.width, self.height, num_shapes),
+                inputs=[
+                    # Model data
+                    state.body_q,
+                    self.model.shape_body,
+                    self.model.shape_transform,
+                    self.model.shape_type,
+                    self.model.shape_scale,
+                    self.model.shape_source_ptr,
+                    # Camera parameters
+                    self._camera_position,
+                    self._camera_direction,
+                    self._camera_up,
+                    self._camera_right,
+                    self.fov_scale,
+                    self.aspect_ratio,
+                    self._resolution,
+                ],
+                outputs=[self._depth_buffer],
+                device=self.device,
+            )
+
+        # Set pixels that still have max_distance to -1.0 to indicate no hit
+        self._clamp_no_hits()
+
+    def _clamp_no_hits(self):
+        """Replace max_distance values with -1.0 to indicate no intersection."""
+        # Flatten the depth buffer for linear indexing
+        flattened_buffer = self._depth_buffer.flatten()
+
+        wp.launch(
+            kernel=clamp_no_hits_kernel,
+            dim=self.height * self.width,
+            inputs=[flattened_buffer, self.max_distance, self.width],
+            device=self.device,
+        )
+
+    def get_depth_image(self) -> wp.array2d:
+        """Get the depth image as a 2D array.
+
+        Returns:
+            2D depth image array with shape (height, width). Values are:
+            - Positive: Distance to closest surface
+            - -1.0: No intersection found
+        """
+        return self.depth_image
+
+    def get_depth_image_numpy(self) -> np.ndarray:
+        """Get the depth image as a numpy array.
+
+        Returns:
+            Numpy array with shape (height, width) containing depth values.
+            Values are the same as get_depth_image() but as a numpy array.
+        """
+        return self.depth_image.numpy()
+
+    def update_camera_pose(
+        self,
+        position: tuple[float, float, float] | np.ndarray | None = None,
+        direction: tuple[float, float, float] | np.ndarray | None = None,
+        up: tuple[float, float, float] | np.ndarray | None = None,
+    ):
+        """Update the camera pose parameters.
+
+        Args:
+            position: New camera position (if provided)
+            direction: New camera direction (if provided, will be normalized)
+            up: New camera up vector (if provided, will be normalized)
+        """
+        if position is not None:
+            self.camera_position = np.array(position, dtype=np.float32)
+
+        if direction is not None or up is not None:
+            # Use current values if not provided
+            camera_dir = np.array(direction, dtype=np.float32) if direction is not None else self.camera_direction
+            camera_up = np.array(up, dtype=np.float32) if up is not None else self.camera_up
+
+            # Recompute camera basis using shared method
+            self._compute_camera_basis(camera_dir, camera_up)
+
+    def update_camera_parameters(
+        self,
+        fov_radians: float | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        max_distance: float | None = None,
+    ):
+        """Update camera intrinsic parameters.
+
+        Args:
+            fov_radians: New vertical field of view in radians
+            width: New image width in pixels
+            height: New image height in pixels
+            max_distance: New maximum ray distance
+        """
+        recreate_buffer = False
+
+        if width is not None and width != self.width:
+            self.width = width
+            recreate_buffer = True
+
+        if height is not None and height != self.height:
+            self.height = height
+            recreate_buffer = True
+
+        if fov_radians is not None:
+            self.fov_radians = fov_radians
+            self.fov_scale = math.tan(fov_radians * 0.5)
+
+        if max_distance is not None:
+            self.max_distance = max_distance
+
+        if recreate_buffer:
+            self.aspect_ratio = float(self.width) / float(self.height)
+            self._resolution = wp.vec2(float(self.width), float(self.height))
+            self._depth_buffer = wp.zeros((self.height, self.width), dtype=float, device=self.device)
+            self.depth_image = self._depth_buffer
+
+    def point_camera_at(
+        self,
+        target: tuple[float, float, float] | np.ndarray,
+        position: tuple[float, float, float] | np.ndarray | None = None,
+        up: tuple[float, float, float] | np.ndarray | None = None,
+    ):
+        """Point the camera at a specific target location.
+
+        Args:
+            target: 3D point to look at
+            position: New camera position (if provided)
+            up: Up vector for camera orientation (default: [0, 0, 1])
+        """
+        if position is not None:
+            self.camera_position = np.array(position, dtype=np.float32)
+        if up is None:
+            up = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+
+        target = np.array(target, dtype=np.float32)
+        direction = target - self.camera_position
+
+        self.update_camera_pose(
+            position=self.camera_position,
+            direction=direction,
+            up=up,
+        )

--- a/newton/_src/utils/render.py
+++ b/newton/_src/utils/render.py
@@ -789,6 +789,7 @@ def CreateSimRenderer(renderer):
                         self.model.shape_transform,
                         self.model.shape_type,
                         self.model.shape_scale,
+                        self.model.shape_source_ptr,
                         p,
                         d,
                         self.lock,

--- a/newton/_src/viewer/picking.py
+++ b/newton/_src/viewer/picking.py
@@ -131,6 +131,7 @@ class Picking:
                 self.model.shape_transform,
                 self.model.shape_type,
                 self.model.shape_scale,
+                self.model.shape_source_ptr,
                 p,
                 d,
                 self.lock,

--- a/newton/sensors.py
+++ b/newton/sensors.py
@@ -19,7 +19,13 @@ from ._src.utils.contact_sensor import (
     populate_contacts,
 )
 
+# Raycast sensors
+from ._src.utils.raycast_sensor import (
+    RaycastSensor,
+)
+
 __all__ = [
     "ContactSensor",
     "populate_contacts",
+    "RaycastSensor",
 ]

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -15,14 +15,17 @@
 
 import unittest
 
+import numpy as np
 import warp as wp
 
+import newton
 from newton import GeoType
 from newton._src.geometry.raycast import (
     ray_intersect_box,
     ray_intersect_capsule,
     ray_intersect_cylinder,
     ray_intersect_geom,
+    ray_intersect_mesh,
     ray_intersect_sphere,
 )
 from newton.tests.unittest_utils import add_function_test, get_test_devices
@@ -93,9 +96,23 @@ def kernel_test_geom(
     geomtype: int,
     ray_origin: wp.vec3,
     ray_direction: wp.vec3,
+    mesh_id: wp.uint64,
 ):
     tid = wp.tid()
-    out_t[tid] = ray_intersect_geom(geom_to_world, size, geomtype, ray_origin, ray_direction)
+    out_t[tid] = ray_intersect_geom(geom_to_world, size, geomtype, ray_origin, ray_direction, mesh_id)
+
+
+@wp.kernel
+def kernel_test_mesh(
+    out_t: wp.array(dtype=float),
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    size: wp.vec3,
+    mesh_id: wp.uint64,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_mesh(geom_to_world, ray_origin, ray_direction, size, mesh_id)
 
 
 # Test functions
@@ -213,13 +230,14 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     geom_to_world = wp.transform_identity()
     ray_origin = wp.vec3(-2.0, 0.0, 0.0)
     ray_direction = wp.vec3(1.0, 0.0, 0.0)
+    mesh_id = wp.uint64(0)  # No mesh for primitive shapes
 
     # Sphere
     size = wp.vec3(1.0, 0.0, 0.0)  # r
     wp.launch(
         kernel_test_geom,
         dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.SPHERE, ray_origin, ray_direction],
+        inputs=[out_t, geom_to_world, size, GeoType.SPHERE, ray_origin, ray_direction, mesh_id],
         device=device,
     )
     test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
@@ -229,7 +247,7 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     wp.launch(
         kernel_test_geom,
         dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.BOX, ray_origin, ray_direction],
+        inputs=[out_t, geom_to_world, size, GeoType.BOX, ray_origin, ray_direction, mesh_id],
         device=device,
     )
     test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
@@ -239,7 +257,7 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     wp.launch(
         kernel_test_geom,
         dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.CAPSULE, ray_origin, ray_direction],
+        inputs=[out_t, geom_to_world, size, GeoType.CAPSULE, ray_origin, ray_direction, mesh_id],
         device=device,
     )
     test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
@@ -249,10 +267,128 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     wp.launch(
         kernel_test_geom,
         dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.CYLINDER, ray_origin, ray_direction],
+        inputs=[out_t, geom_to_world, size, GeoType.CYLINDER, ray_origin, ray_direction, mesh_id],
         device=device,
     )
     test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+
+
+def test_ray_intersect_mesh(test: TestRaycast, device: str):
+    """Test mesh raycasting using a simple quad made of two triangles."""
+    out_t = wp.zeros(1, dtype=float, device=device)
+
+    # Create a simple quad mesh (2x2 quad at z=0)
+    vertices = np.array(
+        [
+            [-1.0, -1.0, 0.0],  # bottom left
+            [1.0, -1.0, 0.0],  # bottom right
+            [1.0, 1.0, 0.0],  # top right
+            [-1.0, 1.0, 0.0],  # top left
+        ],
+        dtype=np.float32,
+    )
+
+    indices = np.array(
+        [
+            [0, 1, 2],  # first triangle
+            [0, 2, 3],  # second triangle
+        ],
+        dtype=np.int32,
+    ).flatten()
+
+    # Create Newton mesh and finalize to get Warp mesh
+    with wp.ScopedDevice(device):
+        mesh = newton.Mesh(vertices, indices, compute_inertia=False)
+        mesh_id = mesh.finalize(device=device)
+
+    # Test cases
+    geom_to_world = wp.transform_identity()
+    size = wp.vec3(1.0, 1.0, 1.0)  # no scaling
+
+    # Case 1: Ray hits the quad from above
+    ray_origin = wp.vec3(0.0, 0.0, 2.0)
+    ray_direction = wp.vec3(0.0, 0.0, -1.0)
+    wp.launch(
+        kernel_test_mesh,
+        dim=1,
+        inputs=[out_t, geom_to_world, ray_origin, ray_direction, size, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0, delta=1e-3)  # Should hit at z=0, distance=2
+
+    # Case 2: Ray hits the quad from below
+    ray_origin = wp.vec3(0.0, 0.0, -2.0)
+    ray_direction = wp.vec3(0.0, 0.0, 1.0)
+    wp.launch(
+        kernel_test_mesh,
+        dim=1,
+        inputs=[out_t, geom_to_world, ray_origin, ray_direction, size, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0, delta=1e-3)  # Should hit at z=0, distance=2
+
+    # Case 3: Ray misses the quad
+    ray_origin = wp.vec3(2.0, 2.0, 2.0)  # Outside quad bounds
+    ray_direction = wp.vec3(0.0, 0.0, -1.0)
+    wp.launch(
+        kernel_test_mesh,
+        dim=1,
+        inputs=[out_t, geom_to_world, ray_origin, ray_direction, size, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)  # Should miss
+
+    # Case 4: Ray hits quad at angle
+    ray_origin = wp.vec3(-2.0, 0.0, 1.0)
+    ray_direction = wp.vec3(1.0, 0.0, -0.5)  # Angled ray
+    wp.launch(
+        kernel_test_mesh,
+        dim=1,
+        inputs=[out_t, geom_to_world, ray_origin, ray_direction, size, mesh_id],
+        device=device,
+    )
+    # Calculate expected distance: ray hits quad at x=0, z=0
+    # Ray equation: (-2, 0, 1) + t*(1, 0, -0.5) = (0, 0, 0)
+    # -2 + t = 0 -> t = 2
+    # 1 - 0.5*t = 0 -> t = 2
+    expected_dist = 2.0 * np.sqrt(1.0**2 + 0.5**2)  # |t| * |direction|
+    test.assertAlmostEqual(out_t.numpy()[0], expected_dist, delta=1e-3)
+
+
+def test_mesh_ray_intersect_via_geom(test: TestRaycast, device: str):
+    """Test mesh raycasting through the ray_intersect_geom interface."""
+    out_t = wp.zeros(1, dtype=float, device=device)
+
+    # Create a simple triangle mesh
+    vertices = np.array(
+        [
+            [-1.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [0.0, 1.0, 0.0],  # Triangle pointing up
+        ],
+        dtype=np.float32,
+    )
+
+    indices = np.array([0, 1, 2], dtype=np.int32)
+
+    # Create and finalize mesh
+    with wp.ScopedDevice(device):
+        mesh = newton.Mesh(vertices, indices, compute_inertia=False)
+        mesh_id = mesh.finalize(device=device)
+
+    # Test ray hitting the triangle
+    geom_to_world = wp.transform_identity()
+    size = wp.vec3(1.0, 1.0, 1.0)
+    ray_origin = wp.vec3(0.0, 0.0, 2.0)
+    ray_direction = wp.vec3(0.0, 0.0, -1.0)
+
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GeoType.MESH, ray_origin, ray_direction, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 2.0, delta=1e-3)  # Should hit triangle at z=0
 
 
 devices = get_test_devices()
@@ -264,6 +400,10 @@ for device in devices:
         TestRaycast, f"test_ray_intersect_cylinder_{device}", test_ray_intersect_cylinder, devices=[device]
     )
     add_function_test(TestRaycast, f"test_geom_ray_intersect_{device}", test_geom_ray_intersect, devices=[device])
+    add_function_test(TestRaycast, f"test_ray_intersect_mesh_{device}", test_ray_intersect_mesh, devices=[device])
+    add_function_test(
+        TestRaycast, f"test_mesh_ray_intersect_via_geom_{device}", test_mesh_ray_intersect_via_geom, devices=[device]
+    )
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_raycast_sensor.py
+++ b/newton/tests/test_raycast_sensor.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import os
+import unittest
+
+import numpy as np
+import warp as wp
+from PIL import Image
+
+import newton
+from newton.sensors import RaycastSensor
+from newton.tests.unittest_utils import add_function_test
+
+EXPORT_IMAGES = False
+
+def save_depth_image_as_grayscale(depth_image: np.ndarray, filename: str):
+    """Save a depth image as a grayscale image to C:\\tmp.
+
+    Args:
+        depth_image: 2D numpy array with depth values (-1.0 for no hit, positive for distances)
+        filename: Name of the file (without extension)
+    """  
+
+    # Handle the depth image: -1.0 means no hit, positive values are distances
+    img_data = depth_image.copy().astype(np.float32)
+
+    # Replace -1.0 (no hit) with 0 (black)
+    img_data[img_data < 0] = 0
+
+    # Normalize positive values to 0-255 range
+    if np.any(img_data > 0):
+        max_depth = np.max(img_data)
+        min_depth = np.min(img_data[img_data > 0])  # Minimum positive depth
+
+        # Invert: closer objects = brighter, farther = darker
+        # Scale to 50-255 range (so background/no-hit stays at 0)
+        img_data[img_data > 0] = 255 - ((img_data[img_data > 0] - min_depth) / (max_depth - min_depth)) * 205
+
+    # Convert to uint8 and save
+    img_data = np.clip(img_data, 0, 255).astype(np.uint8)
+    image = Image.fromarray(img_data)
+
+    filepath = f"{filename}.png"
+    image.save(filepath)
+    print(f"Saved depth image to: {filepath}")
+
+
+def create_cubemap_scene(device="cpu"):
+    """Create a scene with 6 different objects positioned around origin for cube map views."""
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+
+    # Position objects at distance ~6 units from origin in different directions
+    # This ensures each cube map face sees a different object
+
+    # Capsule: positioned in +X direction
+    capsule_body = builder.add_body(xform=wp.transform(wp.vec3(6.0, 0.0, 0.0), wp.quat_identity()))
+    builder.add_shape_capsule(body=capsule_body, radius=0.8, half_height=1.5)
+
+    # Sphere: positioned in -X direction
+    sphere_body = builder.add_body(xform=wp.transform(wp.vec3(-6.0, 0.0, 0.0), wp.quat_identity()))
+    builder.add_shape_sphere(body=sphere_body, radius=1.2)
+
+    # Cone: positioned in +Y direction
+    cone_body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 6.0, 0.0), wp.quat_identity()))
+    builder.add_shape_cone(body=cone_body, radius=1.1, half_height=1.3)
+
+    # Cylinder: positioned in -Y direction
+    cylinder_body = builder.add_body(xform=wp.transform(wp.vec3(0.0, -6.0, 0.0), wp.quat_identity()))
+    builder.add_shape_cylinder(body=cylinder_body, radius=0.9, half_height=1.2)
+
+    # Cube: positioned in +Z direction
+    cube_body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 6.0), wp.quat_identity()))
+    builder.add_shape_box(body=cube_body, hx=1.0, hy=1.0, hz=1.0)
+
+    # Tetrahedron mesh: positioned in -Z direction
+    tetrahedron_body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, -6.0), wp.quat_identity()))
+
+    # Create tetrahedron mesh vertices and faces
+    # Regular tetrahedron with vertices at distance ~1.5 from center
+    s = 1.5  # Scale factor
+    vertices = np.array(
+        [
+            [s, s, s],  # vertex 0
+            [s, -s, -s],  # vertex 1
+            [-s, s, -s],  # vertex 2
+            [-s, -s, s],  # vertex 3
+        ],
+        dtype=np.float32,
+    )
+
+    faces = np.array(
+        [
+            [0, 1, 2],  # face 0
+            [0, 3, 1],  # face 1
+            [0, 2, 3],  # face 2
+            [1, 3, 2],  # face 3
+        ],
+        dtype=np.int32,
+    )
+
+    # Create newton Mesh object and add to builder
+    tetrahedron_mesh = newton.Mesh(vertices, faces.flatten())
+    builder.add_shape_mesh(body=tetrahedron_body, mesh=tetrahedron_mesh, scale=(1.0, 1.0, 1.0))
+
+    # Build the model
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+    return model
+
+
+def test_raycast_sensor_cubemap(test: unittest.TestCase, device):
+    """Test raycast sensor by creating cube map views from origin."""
+
+    # Create scene with 6 different objects (one for each cube map face)
+    model = create_cubemap_scene(device)
+    state = model.state()
+
+    # Update body transforms (important for raycast operations)
+    newton.eval_fk(model, state.joint_q, state.joint_qd, state)
+
+    print(f"Created scene with {model.body_count} bodies and {len(model.shape_body)} shapes")
+    print("Objects positioned for cube map views:")
+    print("  +X: Capsule, -X: Sphere, +Y: Cone, -Y: Cylinder, +Z: Cube, -Z: Tetrahedron")
+
+    # Define 6 cube map camera directions
+    cubemap_views = [
+        ("positive_x", (0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),  # Looking +X (capsule)
+        ("negative_x", (0.0, 0.0, 0.0), (-1.0, 0.0, 0.0), (0.0, 0.0, 1.0)),  # Looking -X (sphere)
+        ("positive_y", (0.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),  # Looking +Y (cone)
+        ("negative_y", (0.0, 0.0, 0.0), (0.0, -1.0, 0.0), (0.0, 0.0, 1.0)),  # Looking -Y (cylinder)
+        ("positive_z", (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, 1.0, 0.0)),  # Looking +Z (cube)
+        ("negative_z", (0.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)),  # Looking -Z (tetrahedron)
+    ]
+
+    # Create raycast sensor (we'll update camera parameters for each view)
+    sensor = RaycastSensor(
+        model=model,
+        camera_position=(0.0, 0.0, 0.0),  # At origin
+        camera_direction=(1.0, 0.0, 0.0),  # Initial direction (will be updated)
+        camera_up=(0.0, 0.0, 1.0),  # Initial up (will be updated)
+        fov_radians=math.pi / 2,  # 90 degrees - typical for cube map faces
+        width=256,
+        height=256,
+        max_distance=50.0,
+    )
+
+    total_hits = 0
+
+    # Render each cube map face
+    for view_name, position, direction, up in cubemap_views:
+        print(f"Rendering {view_name} view...")
+
+        # Update camera pose for this view
+        sensor.update_camera_pose(position=position, direction=direction, up=up)
+
+        # Evaluate the sensor
+        sensor.eval(state)
+
+        # Get depth image
+        depth_image = sensor.get_depth_image_numpy()
+
+        # Count hits for this view
+        hits_in_view = np.sum(depth_image > 0)
+        total_hits += hits_in_view
+
+        print(f"  {view_name}: {hits_in_view} pixels hit objects")
+        if hits_in_view > 0:
+            min_depth = np.min(depth_image[depth_image > 0])
+            max_depth = np.max(depth_image[depth_image > 0])
+            print(f"  Depth range: {min_depth:.2f} to {max_depth:.2f}")
+
+        # Save depth image
+        save_depth_image_as_grayscale(depth_image, f"cubemap_{view_name}")
+
+    # Verify we detected objects
+    test.assertGreater(total_hits, 0, "Should detect objects in cube map views")
+    print(f"Total hits across all views: {total_hits}")
+    print("Cube map rendering complete!")
+
+
+class TestRaycastSensor(unittest.TestCase):
+    pass
+
+
+# Register test for both CPU and GPU
+devices = ["cuda:0"]  # Focus on CUDA for now
+add_function_test(TestRaycastSensor, "test_raycast_sensor_cubemap", test_raycast_sensor_cubemap, devices=devices)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

- RaycastSensor: Depth camera sensor using ray casting
- Added ray-cone and ray-mesh intersection support
- Public API via newton.sensors.RaycastSensor


## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
