### PR TITLE
Reduce iterations for diffsim tests

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -393,7 +393,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_ball",
     devices=test_devices,
-    test_options={"num_frames": 250 * 36},  # train_iters * sim_steps
+    test_options={"num_frames": 4 * 36},  # train_iters * sim_steps
     test_options_cpu={"num_frames": 2 * 36},
     use_viewer=True,
 )
@@ -402,7 +402,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_cloth",
     devices=test_devices,
-    test_options={"num_frames": 64 * 120},  # train_iters * sim_steps
+    test_options={"num_frames": 4 * 120},  # train_iters * sim_steps
     test_options_cpu={"num_frames": 2 * 120},
     use_viewer=True,
 )
@@ -411,8 +411,8 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_drone",
     devices=test_devices,
-    test_options={"num_frames": 360},  # sim_steps
-    test_options_cpu={"num_frames": 360},
+    test_options={"num_frames": 180},  # sim_steps
+    test_options_cpu={"num_frames": 10},
     use_viewer=True,
 )
 
@@ -420,7 +420,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_spring_cage",
     devices=test_devices,
-    test_options={"num_frames": 30 * 30},  # train_iters * sim_steps
+    test_options={"num_frames": 4 * 30},  # train_iters * sim_steps
     test_options_cpu={"num_frames": 2 * 30},
     use_viewer=True,
 )
@@ -429,7 +429,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_soft_body",
     devices=test_devices,
-    test_options={"num_frames": 300 * 60},  # train_iters * sim_steps
+    test_options={"num_frames": 4 * 60},  # train_iters * sim_steps
     test_options_cpu={"num_frames": 2 * 60},
     use_viewer=True,
 )


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR reduces the number of training iterations for diffsim exmaples and closes #650 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced frame counts in multiple simulation example tests to significantly shorten runtime and reduce resource usage, while preserving viewer behavior.
  * Delivers faster local and CI test runs, improving developer feedback cycles and pipeline efficiency.
  * No functional changes to simulations; user-facing behavior remains the same.
  * No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->