### PR TITLE
Update Python package name from `newton-physics` from `newton`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/newton-physics
+      url: https://pypi.org/p/newton
     permissions:
       id-token: write
     steps:

--- a/README.md
+++ b/README.md
@@ -202,21 +202,22 @@ uv sync --extra examples
 </table>
 
 ## Inverse Kinematics Examples
+
 <table>
   <tr>
     <td align="center" width="33%">
-      <a href="newton/examples/ik/example_ik_franka.py">
-        <img src="docs/images/examples/example_ik_franka.jpg" alt="IK Franka">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_franka.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_ik_franka.jpg" alt="IK Franka">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/ik/example_ik_h1.py">
-        <img src="docs/images/examples/example_ik_h1.jpg" alt="IK H1">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_h1.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_ik_h1.jpg" alt="IK H1">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/ik/example_ik_benchmark.py">
-        <img src="docs/images/examples/example_ik_benchmark.jpg" alt="IK Benchmark">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_benchmark.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_ik_benchmark.jpg" alt="IK Benchmark">
       </a>
     </td>
   </tr>
@@ -230,26 +231,26 @@ uv sync --extra examples
     <td align="center">
       <code>uv run -m newton.examples ik_benchmark</code>
     </td>
-    
+
   </tr>
   <tr>
     <td align="center" width="33%">
-      <a href="newton/examples/cloth/example_cloth_franka.py">
-        <img src="docs/images/examples/example_cloth_franka.jpg" alt="Cloth Franka">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_franka.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_cloth_franka.jpg" alt="Cloth Franka">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/cloth/example_cloth_twist.py">
-        <img src="docs/images/examples/example_cloth_twist.jpg" alt="Cloth Twist">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_twist.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_cloth_twist.jpg" alt="Cloth Twist">
       </a>
     </td>
   </tr>
   <tr>
     <td align="center">
-      <code>python -m newton.examples cloth_franka</code>
+      <code>uv run -m newton.examples cloth_franka</code>
     </td>
     <td align="center">
-      <code>python -m newton.examples cloth_twist</code>
+      <code>uv run -m newton.examples cloth_twist</code>
     </td>
   </tr>
 
@@ -324,18 +325,18 @@ uv sync --extra examples
 <table>
   <tr>
     <td align="center" width="33%">
-      <a href="newton/examples/diffsim/example_diffsim_ball.py">
-        <img src="docs/images/examples/example_diffsim_ball.jpg" alt="DiffSim Ball">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_ball.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_diffsim_ball.jpg" alt="DiffSim Ball">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/diffsim/example_diffsim_cloth.py">
-        <img src="docs/images/examples/example_diffsim_cloth.jpg" alt="DiffSim Cloth">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_cloth.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_diffsim_cloth.jpg" alt="DiffSim Cloth">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/diffsim/example_diffsim_drone.py">
-        <img src="docs/images/examples/example_diffsim_drone.jpg" alt="DiffSim Drone">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_drone.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_diffsim_drone.jpg" alt="DiffSim Drone">
       </a>
     </td>
   </tr>
@@ -352,13 +353,13 @@ uv sync --extra examples
   </tr>
   <tr>
     <td align="center" width="33%">
-      <a href="newton/examples/diffsim/example_diffsim_spring_cage.py">
-        <img src="docs/images/examples/example_diffsim_spring_cage.jpg" alt="DiffSim Spring Cage">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_spring_cage.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_diffsim_spring_cage.jpg" alt="DiffSim Spring Cage">
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="newton/examples/diffsim/example_diffsim_soft_body.py">
-        <img src="docs/images/examples/example_diffsim_soft_body.jpg" alt="DiffSim Soft Body">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_soft_body.py">
+        <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_diffsim_soft_body.jpg" alt="DiffSim Soft Body">
       </a>
     </td>
     <td align="center" width="33%">

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.9.0.dev20250806 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.9.0.dev20250825 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.6.dev797870883 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.7.1+cu128 --index-url https://download.pytorch.org/whl/cu128",
     "python -m pip install git+https://github.com/google-deepmind/mujoco_warp@baeb10e73237df13802217d310788e1f02dcf92d",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "project": "newton-physics",
+  "project": "newton",
   "project_url": "https://github.com/newton-physics/newton",
   "repo": ".",
   "branches": ["main"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "newton-physics"
+name = "newton"
 dynamic = ["version"]
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
@@ -31,19 +31,19 @@ dependencies = ["warp-lang>=1.7.0.dev20250625"]
 # Core simulation dependencies
 sim = [
     # MuJoCo simulation
-    "mujoco-warp>=0.0.1",            # MuJoCo, warp-accelerated
-    "mujoco>=3.3.3.dev769049331",    # MuJoCo physics engine
+    "mujoco-warp>=0.0.1",         # MuJoCo, warp-accelerated
+    "mujoco>=3.3.3.dev769049331", # MuJoCo physics engine
 ]
 
 # Asset import and mesh processing dependencies
 importers = [
     # Mesh processing dependencies used by ModelBuilder.approximate_meshes
-    "scipy",                         # for convex hull approximation
-    "fast-simplification>=0.1.11",   # for mesh simplification
-    "alphashape>=1.3.1",             # for alphashape remeshing
-    "coacd>=1.0.7",                  # for convex decomposition
-    "trimesh>=4.6.8",                # for mesh operations and V-HACD
-    "pycollada>=0.9",                # for loading mesh data with trimesh
+    "scipy",                       # for convex hull approximation
+    "fast-simplification>=0.1.11", # for mesh simplification
+    "alphashape>=1.3.1",           # for alphashape remeshing
+    "coacd>=1.0.7",                # for convex decomposition
+    "trimesh>=4.6.8",              # for mesh operations and V-HACD
+    "pycollada>=0.9",              # for loading mesh data with trimesh
 
     # USD core libraries
     "usd-core>=25.5 ; platform_machine != 'aarch64'",
@@ -51,25 +51,25 @@ importers = [
 
 # Examples dependencies including visualization
 examples = [
-    "newton-physics[sim]",           # include simulation dependencies
-    "newton-physics[importers]",     # include import dependencies
-    "pyglet>=2.1.6",                 # for OpenGL viewer
-    "GitPython>=3.1.44",             # for downloading assets via newton.utils.download_asset()
-    "imgui_bundle>=1.92.0",          # for viewer GUI
+    "newton[sim]",          # include simulation dependencies
+    "newton[importers]",    # include import dependencies
+    "pyglet>=2.1.6",        # for OpenGL viewer
+    "GitPython>=3.1.44",    # for downloading assets via newton.utils.download_asset()
+    "imgui_bundle>=1.92.0", # for viewer GUI
 ]
 
 # Extra dependency needed to run examples that inference an RL policy
 torch-cu12 = [
-    "newton-physics[examples]",      # include example dependencies
-    "torch>=2.7.0",                  # Cuda 12 PyTorch
+    "newton[examples]", # include example dependencies
+    "torch>=2.7.0",     # Cuda 12 PyTorch
 ]
 
 # Development and Testing
 # Contains all w/o torch, plus development debugging dependencies
 dev = [
-    "newton-physics[examples]",      # includes examples, which pulls in sim and visualization
-    "tqdm>=4.67.1",                  # for progress bars
-    "coverage[toml]>=7.8.0",         # for code coverage testing
+    "newton[examples]",      # includes examples, which pulls in sim and visualization
+    "tqdm>=4.67.1",          # for progress bars
+    "coverage[toml]>=7.8.0", # for code coverage testing
 ]
 
 # Documentation dependencies
@@ -181,7 +181,11 @@ exclude_lines = [
     "if 0:",
     "if __name__ == .__main__.:",
 ]
-omit = ["*/newton/examples/*", "*/newton/tests/*", "*/newton/tests/thirdparty/*"]
+omit = [
+    "*/newton/examples/*",
+    "*/newton/tests/*",
+    "*/newton/tests/thirdparty/*",
+]
 
 [tool.basedpyright]
 reportUnknownVariableType = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["warp-lang>=1.7.0.dev20250625"]
+dependencies = ["warp-lang>=1.7.0.dev20250823"]
 
 [project.optional-dependencies]
 # Core simulation dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -788,7 +788,7 @@ wheels = [
 ]
 
 [[package]]
-name = "newton-physics"
+name = "newton"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang", version = "1.8.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
@@ -857,6 +857,7 @@ torch-cu12 = [
     { name = "coacd" },
     { name = "fast-simplification" },
     { name = "gitpython" },
+    { name = "imgui-bundle" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
     { name = "pycollada" },
@@ -890,8 +891,10 @@ requires-dist = [
     { name = "fast-simplification", marker = "extra == 'torch-cu12'", specifier = ">=0.1.11" },
     { name = "gitpython", marker = "extra == 'dev'", specifier = ">=3.1.44" },
     { name = "gitpython", marker = "extra == 'examples'", specifier = ">=3.1.44" },
+    { name = "gitpython", marker = "extra == 'torch-cu12'", specifier = ">=3.1.44" },
     { name = "imgui-bundle", marker = "extra == 'dev'", specifier = ">=1.92.0" },
     { name = "imgui-bundle", marker = "extra == 'examples'", specifier = ">=1.92.0" },
+    { name = "imgui-bundle", marker = "extra == 'torch-cu12'", specifier = ">=1.92.0" },
     { name = "mujoco", marker = "extra == 'dev'", specifier = ">=3.3.3.dev769049331", index = "https://py.mujoco.org/" },
     { name = "mujoco", marker = "extra == 'examples'", specifier = ">=3.3.3.dev769049331", index = "https://py.mujoco.org/" },
     { name = "mujoco", marker = "extra == 'sim'", specifier = ">=3.3.3.dev769049331", index = "https://py.mujoco.org/" },
@@ -918,7 +921,7 @@ requires-dist = [
     { name = "sphinx-design", marker = "extra == 'docs'", specifier = "<=0.6.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.3.0" },
     { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1.0.0" },
-    { name = "torch", marker = "extra == 'torch-cu12'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "newton-physics", extra = "torch-cu12" } },
+    { name = "torch", marker = "extra == 'torch-cu12'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "newton", extra = "torch-cu12" } },
     { name = "tqdm", marker = "extra == 'dev'", specifier = ">=4.67.1" },
     { name = "trimesh", marker = "extra == 'dev'", specifier = ">=4.6.8" },
     { name = "trimesh", marker = "extra == 'examples'", specifier = ">=4.6.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -931,8 +931,8 @@ requires-dist = [
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'examples'", specifier = ">=25.5" },
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5" },
     { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'torch-cu12'", specifier = ">=25.5" },
-    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250625", index = "https://pypi.nvidia.com/" },
-    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250625" },
+    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250823", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250823" },
 ]
 provides-extras = ["dev", "docs", "examples", "importers", "sim", "torch-cu12"]
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

I have secured the `newton` PyPI package name in https://github.com/pypi/support/issues/6216#issuecomment-3229463069 (note: testpypi is still squatted) so this pull request updates the name in the `pyproject.toml` file accordingly.

- The publishing workflow job is updated.
- Some issues with the `README.md` is also fixed.
- Minimum Warp version is set to 20250823 due to new BVH rebuild usage
- ASV workflow job is synchronized with uv.lock version

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Renamed package/distribution from “newton-physics” to “newton,” including extras and publishing target.
  - Updated benchmark/config metadata and bumped warp-lang prerelease versions and dependency ranges.
  - No runtime behavior changes.

- Documentation
  - Replaced relative example links and images with stable absolute GitHub URLs.
  - Updated example run commands to use “uv run” where applicable and applied minor formatting improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->