### PR TITLE
solverMuJoCo: change nefc_per_env to njmax

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1159,7 +1159,7 @@ class SolverMuJoCo(SolverBase):
         mjw_model: MjWarpModel | None = None,
         mjw_data: MjWarpData | None = None,
         separate_envs_to_worlds: bool | None = None,
-        nefc_per_env: int = 100,
+        njmax: int = 100,
         ncon_per_env: int | None = None,
         iterations: int = 20,
         ls_iterations: int = 10,
@@ -1185,7 +1185,7 @@ class SolverMuJoCo(SolverBase):
             mjw_model (MjWarpModel | None): Optional pre-existing MuJoCo Warp model. If provided with `mjw_data`, conversion from Newton model is skipped.
             mjw_data (MjWarpData | None): Optional pre-existing MuJoCo Warp data. If provided with `mjw_model`, conversion from Newton model is skipped.
             separate_envs_to_worlds (bool | None): If True, each Newton environment is mapped to a separate MuJoCo world. Defaults to `not use_mujoco_cpu`.
-            nefc_per_env (int): Number of constraints per environment (world).
+            njmax (int): Maximum number of constraints per environment (world).
             ncon_per_env (int | None): Number of contact points per environment (world). If None, the number of contact points is estimated from the model.
             iterations (int): Number of solver iterations.
             ls_iterations (int): Number of line search iterations for the solver.
@@ -1250,7 +1250,7 @@ class SolverMuJoCo(SolverBase):
                     disableflags=disableflags,
                     disable_contacts=disable_contacts,
                     separate_envs_to_worlds=separate_envs_to_worlds,
-                    nefc_per_env=nefc_per_env,
+                    njmax=njmax,
                     ncon_per_env=ncon_per_env,
                     iterations=iterations,
                     ls_iterations=ls_iterations,
@@ -1644,7 +1644,7 @@ class SolverMuJoCo(SolverBase):
         separate_envs_to_worlds: bool = True,
         iterations: int = 20,
         ls_iterations: int = 10,
-        nefc_per_env: int = 100,  # number of constraints per world
+        njmax: int = 100,  # number of constraints per world
         ncon_per_env: int | None = None,
         solver: int | str = "cg",
         integrator: int | str = "euler",
@@ -2353,7 +2353,7 @@ class SolverMuJoCo(SolverBase):
                 else:
                     rigid_contact_max = count_rigid_contact_points(model)
                 nconmax = max(rigid_contact_max, self.mj_data.ncon * nworld)  # this avoids error in mujoco.
-            njmax = max(nefc_per_env, self.mj_data.nefc)
+            njmax = max(njmax, self.mj_data.nefc)
             self.mjw_data = mujoco_warp.put_data(
                 self.mj_model, self.mj_data, nworld=nworld, nconmax=nconmax, njmax=njmax
             )

--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -243,7 +243,7 @@ class Example:
             integrator=integrator,
             iterations=solver_iteration,
             ls_iterations=ls_iteration,
-            nefc_per_env=njmax,
+            njmax=njmax,
             ncon_per_env=nconmax,
         )
 

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -77,7 +77,7 @@ class Example:
             use_mujoco_cpu=False,
             solver="newton",
             integrator="euler",
-            nefc_per_env=300,
+            njmax=300,
             ncon_per_env=150,
             cone="elliptic",
             impratio=100,

--- a/newton/tests/test_anymal_reset.py
+++ b/newton/tests/test_anymal_reset.py
@@ -100,7 +100,7 @@ class TestAnymalReset(unittest.TestCase):
             impratio = 100.0
 
         self.solver = newton.solvers.SolverMuJoCo(
-            self.model, solver=2, cone=cone_type, impratio=impratio, iterations=100, ls_iterations=50, nefc_per_env=200
+            self.model, solver=2, cone=cone_type, impratio=impratio, iterations=100, ls_iterations=50, njmax=200
         )
 
         self.renderer = None if self.headless else newton.viewer.RendererOpenGL(self.model, stage_path)

--- a/newton/tests/test_equality_constraints.py
+++ b/newton/tests/test_equality_constraints.py
@@ -45,7 +45,7 @@ class TestEqualityConstraints(unittest.TestCase):
             integrator="euler",
             iterations=100,
             ls_iterations=50,
-            nefc_per_env=100,
+            njmax=100,
             ncon_per_env=50,
         )
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -315,7 +315,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         self.model.body_com.assign(new_coms)
 
         # Initialize solver
-        solver = SolverMuJoCo(self.model, ls_iterations=1, iterations=1, disable_contacts=True, nefc_per_env=1)
+        solver = SolverMuJoCo(self.model, ls_iterations=1, iterations=1, disable_contacts=True, njmax=1)
 
         # Check that COM positions were transferred correctly
         bodies_per_env = self.model.body_count // self.model.num_envs


### PR DESCRIPTION
This makes it more aligned with the MuJoCo language and makes the error messages useful

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
