### PR TITLE
Use `num_frames=2` for `example_cloth_franka_cpu` test

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -258,7 +258,7 @@ add_example_test(
     name="cloth.example_cloth_franka",
     devices=test_devices,
     test_options={"num_frames": 50},
-    test_options_cpu={"num_frames": 10},
+    test_options_cpu={"num_frames": 2},
     use_viewer=True,
 )
 add_example_test(


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

On my system, each frame was taking almost 20 seconds, so we should significantly reduce the number of frames used for the CPU version of this example test.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized an example test by reducing CPU workload, significantly speeding up test execution and lowering resource usage.
  * Maintains existing behavior for non-CPU runs (including viewer-enabled scenarios), ensuring consistent results.
  * No changes to user-facing features, settings, or outputs.
  * Improves CI reliability and shortens local development feedback loops without impacting runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->