### PR TITLE
SolverMuJoCo cleanup: don't count max contacts again

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -34,7 +34,6 @@ from ...sim import (
     Model,
     State,
     color_graph,
-    count_rigid_contact_points,
     plot_graph,
 )
 from ...utils import topological_sort
@@ -2351,7 +2350,7 @@ class SolverMuJoCo(SolverBase):
                 if ncon_per_env is not None:
                     rigid_contact_max = nworld * ncon_per_env
                 else:
-                    rigid_contact_max = count_rigid_contact_points(model)
+                    rigid_contact_max = model.rigid_contact_max
                 nconmax = max(rigid_contact_max, self.mj_data.ncon * nworld)  # this avoids error in mujoco.
             njmax = max(njmax, self.mj_data.nefc)
             self.mjw_data = mujoco_warp.put_data(


### PR DESCRIPTION
we already do this in builder.finalize()

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Simulations now consistently use the model’s configured maximum rigid contacts, improving stability and preventing under- or over-allocation of contact slots when no per-environment limit is specified.

- Refactor
  - Internal logic for determining contact limits was simplified to rely on model settings, reducing discrepancy between configured limits and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->