### PR TITLE
Fix for body_iquat randomization #147

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -881,6 +881,7 @@ def update_body_inertia_kernel(
 
     # Calculate eigenvalues and eigenvectors
     eigenvectors, eigenvalues = wp.eig3(I)
+    vecs_transposed = wp.transpose(eigenvectors)
 
     # Bubble sort for 3 elements in descending order
     for i in range(2):
@@ -891,12 +892,12 @@ def update_body_inertia_kernel(
                 eigenvalues[j] = eigenvalues[j + 1]
                 eigenvalues[j + 1] = temp_val
                 # Swap eigenvectors
-                temp_vec = eigenvectors[j]
-                eigenvectors[j] = eigenvectors[j + 1]
-                eigenvectors[j + 1] = temp_vec
+                temp_vec = vecs_transposed[j]
+                vecs_transposed[j] = vecs_transposed[j + 1]
+                vecs_transposed[j + 1] = temp_vec
 
     # Convert eigenvectors to quaternion (xyzw format)
-    q = wp.quat_from_matrix(wp.matrix_from_cols(eigenvectors[0], eigenvectors[1], eigenvectors[2]))
+    q = wp.quat_from_matrix(wp.transpose(vecs_transposed))
     q = wp.normalize(q)
 
     # Convert from xyzw to wxyz format

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -881,6 +881,8 @@ def update_body_inertia_kernel(
 
     # Calculate eigenvalues and eigenvectors
     eigenvectors, eigenvalues = wp.eig3(I)
+
+    # transpose eigenvectors to allow reshuffling by indexing rows.
     vecs_transposed = wp.transpose(eigenvectors)
 
     # Bubble sort for 3 elements in descending order

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -863,10 +863,8 @@ def update_body_mass_ipos_kernel(
 @wp.kernel
 def update_body_inertia_kernel(
     body_inertia: wp.array(dtype=wp.mat33f),
-    body_quat: wp.array2d(dtype=wp.quatf),
     bodies_per_env: int,
     body_mapping: wp.array(dtype=int),
-    up_axis: int,
     # outputs
     body_inertia_out: wp.array2d(dtype=wp.vec3f),
     body_iquat_out: wp.array2d(dtype=wp.quatf),
@@ -878,9 +876,8 @@ def update_body_inertia_kernel(
     if mjc_idx == -1:
         return
 
-    # Get inertia tensor and body orientation
+    # Get inertia tensor
     I = body_inertia[tid]
-    # body_q = body_quat[worldid, mjc_idx]
 
     # Calculate eigenvalues and eigenvectors
     eigenvectors, eigenvalues = wp.eig3(I)
@@ -898,17 +895,16 @@ def update_body_inertia_kernel(
                 eigenvectors[j] = eigenvectors[j + 1]
                 eigenvectors[j + 1] = temp_vec
 
-    # this does not work yet, I think we are reporting in the wrong reference frame
-    # Convert eigenvectors to quaternion (xyzw format for mujoco)
-    # q = wp.quat_from_matrix(wp.mat33f(eigenvectors[0], eigenvectors[1], eigenvectors[2]))
-    # q = wp.normalize(q)
+    # Convert eigenvectors to quaternion (xyzw format)
+    q = wp.quat_from_matrix(wp.matrix_from_cols(eigenvectors[0], eigenvectors[1], eigenvectors[2]))
+    q = wp.normalize(q)
 
-    # Convert from wxyz to xyzw format and compose with body orientation
-    # q = wp.quat(q[1], q[2], q[3], q[0])
+    # Convert from xyzw to wxyz format
+    q = wp.quat(q[1], q[2], q[3], q[0])
 
     # Store results
     body_inertia_out[worldid, mjc_idx] = eigenvalues
-    # body_iquat_out[worldid, mjc_idx] = q
+    body_iquat_out[worldid, mjc_idx] = q
 
 
 @wp.kernel(module="unique", enable_backward=False)
@@ -2368,7 +2364,7 @@ class SolverMuJoCo(SolverBase):
             # "body_pos",
             # "body_quat",
             "body_ipos",
-            # "body_iquat",
+            "body_iquat",
             "body_mass",
             # "body_subtreemass",
             # "subtree_mass",
@@ -2486,10 +2482,8 @@ class SolverMuJoCo(SolverBase):
             dim=self.model.body_count,
             inputs=[
                 self.model.body_inertia,
-                self.mjw_model.body_quat,
                 bodies_per_env,
                 self.to_mjc_body_index,
-                self.model.up_axis,
             ],
             outputs=[self.mjw_model.body_inertia, self.mjw_model.body_iquat],
             device=self.model.device,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -387,36 +387,24 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
         bodies_per_env = self.model.body_count // self.model.num_envs
         for i in range(self.model.body_count):
             env_idx = i // bodies_per_env
+            # Unified inertia generation for all environments, parameterized by env_idx
             if env_idx == 0:
-                # First environment: random SPD inertia with off-diagonal (rotational) elements
-                a = np.float32(2.5 + self.rng.uniform(0.0, 0.5))
-                b = np.float32(3.5 + self.rng.uniform(0.0, 0.5))
-                c = np.float32(min(a + b - 0.1, 4.5))
-                ab = np.float32(self.rng.uniform(-0.2, 0.2))
-                ac = np.float32(self.rng.uniform(-0.2, 0.2))
-                bc = np.float32(self.rng.uniform(-0.2, 0.2))
-                inertia = np.array([[a, ab, ac],
-                                    [ab, b, bc],
-                                    [ac, bc, c]], dtype=np.float32)
-                eigvals = np.linalg.eigvalsh(inertia)
-                if np.any(eigvals <= 0):
-                    inertia += np.eye(3, dtype=np.float32) * (np.abs(np.min(eigvals)) + 0.1)
-                new_inertias[i] = inertia
+                a_base, b_base, c_max = 2.5, 3.5, 4.5
             else:
-                # Second environment: random SPD inertia with off-diagonal (rotational) elements
-                a = np.float32(3.5 + self.rng.uniform(0.0, 0.5))
-                b = np.float32(4.5 + self.rng.uniform(0.0, 0.5))
-                c = np.float32(min(a + b - 0.1, 5.5))
-                ab = np.float32(self.rng.uniform(-0.2, 0.2))
-                ac = np.float32(self.rng.uniform(-0.2, 0.2))
-                bc = np.float32(self.rng.uniform(-0.2, 0.2))
-                inertia = np.array([[a, ab, ac],
-                                    [ab, b, bc],
-                                    [ac, bc, c]], dtype=np.float32)
-                eigvals = np.linalg.eigvalsh(inertia)
-                if np.any(eigvals <= 0):
-                    inertia += np.eye(3, dtype=np.float32) * (np.abs(np.min(eigvals)) + 0.1)
-                new_inertias[i] = inertia
+                a_base, b_base, c_max = 3.5, 4.5, 5.5
+            a = np.float32(a_base + self.rng.uniform(0.0, 0.5))
+            b = np.float32(b_base + self.rng.uniform(0.0, 0.5))
+            c = np.float32(min(a + b - 0.1, c_max))
+            ab = np.float32(self.rng.uniform(-0.2, 0.2))
+            ac = np.float32(self.rng.uniform(-0.2, 0.2))
+            bc = np.float32(self.rng.uniform(-0.2, 0.2))
+            inertia = np.array([[a, ab, ac],
+                                [ab, b, bc],
+                                [ac, bc, c]], dtype=np.float32)
+            eigvals = np.linalg.eigvalsh(inertia)
+            if np.any(eigvals <= 0):
+                inertia += np.eye(3, dtype=np.float32) * (np.abs(np.min(eigvals)) + 0.1)
+            new_inertias[i] = inertia
         self.model.body_inertia.assign(new_inertias)
 
         # Initialize solver

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -398,9 +398,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
             ab = np.float32(self.rng.uniform(-0.2, 0.2))
             ac = np.float32(self.rng.uniform(-0.2, 0.2))
             bc = np.float32(self.rng.uniform(-0.2, 0.2))
-            inertia = np.array([[a, ab, ac],
-                                [ab, b, bc],
-                                [ac, bc, c]], dtype=np.float32)
+            inertia = np.array([[a, ab, ac], [ab, b, bc], [ac, bc, c]], dtype=np.float32)
             eigvals = np.linalg.eigvalsh(inertia)
             if np.any(eigvals <= 0):
                 inertia += np.eye(3, dtype=np.float32) * (np.abs(np.min(eigvals)) + 0.1)
@@ -428,7 +426,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                         newton_eigvecs = newton_eigvecs.reshape((3, 3))
 
                         newton_eigvals = np.array(newton_eigvals)
-                        
+
                         mjc_eigvals = mjc_inertia  # Already in diagonal form
                         mjc_iquat = np.roll(solver.mjw_model.body_iquat.numpy()[env_idx, mjc_idx].astype(np.float32), 1)
 
@@ -436,12 +434,16 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                         sort_indices = np.argsort(newton_eigvals)
                         newton_eigvals = newton_eigvals[sort_indices]
                         newton_eigvecs = newton_eigvecs[:, sort_indices]
-                        
+
                         # reverse because we want descending order of eigenvalues
                         newton_eigvals = newton_eigvals[::-1]
                         newton_eigvecs = newton_eigvecs[::-1]
 
-                        newton_quat = wp.quat_from_matrix(wp.matrix_from_cols(wp.vec3(newton_eigvecs[0]), wp.vec3(newton_eigvecs[1]), wp.vec3(newton_eigvecs[2])))                        
+                        newton_quat = wp.quat_from_matrix(
+                            wp.matrix_from_cols(
+                                wp.vec3(newton_eigvecs[0]), wp.vec3(newton_eigvecs[1]), wp.vec3(newton_eigvecs[2])
+                            )
+                        )
                         newton_quat = wp.normalize(newton_quat)
 
                         for dim in range(3):

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -426,7 +426,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                         newton_eigvecs = newton_eigvecs.reshape((3, 3))
 
                         newton_eigvals = np.array(newton_eigvals)
-                        
+
                         mjc_eigvals = mjc_inertia  # Already in diagonal form
                         mjc_iquat = np.roll(solver.mjw_model.body_iquat.numpy()[env_idx, mjc_idx].astype(np.float32), 1)
 
@@ -437,7 +437,9 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
 
                         newton_quat = wp.quat_from_matrix(
                             wp.matrix_from_cols(
-                                wp.vec3(newton_eigvecs[:, 0]), wp.vec3(newton_eigvecs[:, 1]), wp.vec3(newton_eigvecs[:, 2])
+                                wp.vec3(newton_eigvecs[:, 0]),
+                                wp.vec3(newton_eigvecs[:, 1]),
+                                wp.vec3(newton_eigvecs[:, 2]),
                             )
                         )
                         newton_quat = wp.normalize(newton_quat)
@@ -454,7 +456,7 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                         mjc_iquat_np = np.array(mjc_iquat)
                         if np.dot(newton_quat_np, mjc_iquat_np) < 0:
                             newton_quat_np = -newton_quat_np
-                        
+
                         for dim in range(4):
                             self.assertAlmostEqual(
                                 float(mjc_iquat_np[dim]),


### PR DESCRIPTION
Now that the body frame is correct, setting this up is pretty simple.

Inspired by mjuu_fullinertia which is the function that MuJoCo uses in the compiler to go from matrix to diagonal + principal axes.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Orientation quaternions are now derived from inertia tensors via eigen-decomposition, improving accuracy for non-diagonal inertias.
  - Per-world body orientation quaternions are included in expanded model data.

- Bug Fixes
  - More robust handling and normalization of inertia-derived orientations with consistent component ordering.

- Refactor
  - Simplified inertia update flow by removing reliance on externally provided body orientations.

- Tests
  - Enhanced tests generate full SPD inertias with off-diagonals, verify eigenvalues and orientation quaternions against MuJoCo (including post-step checks) and ensure float32 consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->