### PR TITLE
Fixes for pre-trained anymal-c example/benchmark

### DIFF
--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -142,7 +142,7 @@ class Example:
             builder.joint_target_kd[i] = 5
 
         self.model = builder.finalize()
-        self.solver = newton.solvers.SolverMuJoCo(self.model)
+        self.solver = newton.solvers.SolverMuJoCo(self.model, ls_parallel=True)
 
         self.viewer.set_model(self.model)
 


### PR DESCRIPTION
Don't call collide because we do the collisions in MuJoCo
Enable parallel linesearch.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
