### PR TITLE
Improve user exeprience of ASV benchmarks

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -180,7 +180,7 @@ jobs:
           source .venv/bin/activate
           uv pip install asv virtualenv
           asv machine --yes
-          asv continuous --launch-method spawn --interleave-rounds --append-samples --no-only-changed -b Fast ${{ github.event.pull_request.base.sha }} \$HEAD_SHA 2>&1
+          asv continuous --launch-method spawn --interleave-rounds --append-samples --no-only-changed -e -b Fast ${{ github.event.pull_request.base.sha }} \$HEAD_SHA 2>&1
           EOF
 
           # Prepare script to be passed as SSM parameters

--- a/asv/benchmarks/compilation/bench_example_load.py
+++ b/asv/benchmarks/compilation/bench_example_load.py
@@ -17,6 +17,9 @@ import subprocess
 import sys
 
 import warp as wp
+
+wp.config.quiet = True
+
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 
@@ -38,8 +41,6 @@ class SlowExampleRobotAnymal:
             sys.executable,
             "-m",
             "newton.examples.robot.example_robot_anymal_c_walk",
-            "--num-frames",
-            "1",
             "--viewer",
             "null",
         ]
@@ -200,10 +201,28 @@ class SlowExampleBasicUrdf:
 
 if __name__ == "__main__":
     from newton.utils import run_benchmark
+    import argparse
 
-    run_benchmark(SlowExampleBasicUrdf)
-    run_benchmark(SlowExampleRobotAnymal)
-    run_benchmark(SlowExampleRobotCartpole)
-    run_benchmark(SlowExampleRobotHumanoid)
-    run_benchmark(SlowExampleClothFranka)
-    run_benchmark(SlowExampleClothTwist)
+    benchmark_list = {
+        "SlowExampleBasicUrdf" : SlowExampleBasicUrdf,
+        "SlowExampleRobotAnymal" : SlowExampleRobotAnymal,
+        "SlowExampleRobotCartpole" : SlowExampleRobotCartpole,
+        "SlowExampleRobotHumanoid" : SlowExampleRobotHumanoid,
+        "SlowExampleClothFranka" : SlowExampleClothFranka,
+        "SlowExampleClothTwist" : SlowExampleClothTwist,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/compilation/bench_example_load.py
+++ b/asv/benchmarks/compilation/bench_example_load.py
@@ -200,21 +200,22 @@ class SlowExampleBasicUrdf:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "SlowExampleBasicUrdf" : SlowExampleBasicUrdf,
-        "SlowExampleRobotAnymal" : SlowExampleRobotAnymal,
-        "SlowExampleRobotCartpole" : SlowExampleRobotCartpole,
-        "SlowExampleRobotHumanoid" : SlowExampleRobotHumanoid,
-        "SlowExampleClothFranka" : SlowExampleClothFranka,
-        "SlowExampleClothTwist" : SlowExampleClothTwist,
+        "SlowExampleBasicUrdf": SlowExampleBasicUrdf,
+        "SlowExampleRobotAnymal": SlowExampleRobotAnymal,
+        "SlowExampleRobotCartpole": SlowExampleRobotCartpole,
+        "SlowExampleRobotHumanoid": SlowExampleRobotHumanoid,
+        "SlowExampleClothFranka": SlowExampleClothFranka,
+        "SlowExampleClothTwist": SlowExampleClothTwist,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -83,17 +83,18 @@ class FastInitializeModel:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "KpiInitializeModel" : KpiInitializeModel,
-        "FastInitializeModel" : FastInitializeModel,
+        "KpiInitializeModel": KpiInitializeModel,
+        "FastInitializeModel": FastInitializeModel,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -18,6 +18,7 @@ import gc
 import warp as wp
 
 wp.config.enable_backward = False
+wp.config.quiet = True
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
@@ -79,3 +80,28 @@ class FastInitializeModel:
             model = builder.finalize()
 
         del model
+
+
+if __name__ == "__main__":
+    from newton.utils import run_benchmark
+    import argparse
+
+    benchmark_list = {
+        "KpiInitializeModel" : KpiInitializeModel,
+        "FastInitializeModel" : FastInitializeModel,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -38,16 +38,17 @@ class FastExampleAnymalPretrained:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "FastExampleAnymalPretrained" : FastExampleAnymalPretrained,
+        "FastExampleAnymalPretrained": FastExampleAnymalPretrained,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -16,6 +16,8 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.quiet = True
+
 import newton
 from newton.examples.robot.example_robot_anymal_c_walk import Example
 
@@ -33,3 +35,27 @@ class FastExampleAnymalPretrained:
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+if __name__ == "__main__":
+    from newton.utils import run_benchmark
+    import argparse
+
+    benchmark_list = {
+        "FastExampleAnymalPretrained" : FastExampleAnymalPretrained,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_cloth.py
+++ b/asv/benchmarks/simulation/bench_cloth.py
@@ -56,17 +56,18 @@ class FastExampleClothTwist:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "FastExampleClothManipulation" : FastExampleClothManipulation,
-        "FastExampleClothTwist" : FastExampleClothTwist,
+        "FastExampleClothManipulation": FastExampleClothManipulation,
+        "FastExampleClothTwist": FastExampleClothTwist,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/simulation/bench_cloth.py
+++ b/asv/benchmarks/simulation/bench_cloth.py
@@ -16,6 +16,8 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.quiet = True
+
 import newton.examples
 from newton.examples.cloth.example_cloth_franka import Example as ExampleClothManipulation
 from newton.examples.cloth.example_cloth_twist import Example as ExampleClothTwist
@@ -55,6 +57,24 @@ class FastExampleClothTwist:
 
 if __name__ == "__main__":
     from newton.utils import run_benchmark
+    import argparse
 
-    run_benchmark(FastExampleClothManipulation)
-    run_benchmark(FastExampleClothTwist)
+    benchmark_list = {
+        "FastExampleClothManipulation" : FastExampleClothManipulation,
+        "FastExampleClothTwist" : FastExampleClothTwist,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -18,6 +18,7 @@ import time
 import warp as wp
 
 wp.config.enable_backward = False
+wp.config.quiet = True
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
@@ -384,3 +385,36 @@ class KpiHumanoid:
         return total_time * 1000 / (self.num_frames * example.sim_substeps * num_envs * self.samples)
 
     track_simulate.unit = "ms/env-step"
+
+
+if __name__ == "__main__":
+    from newton.utils import run_benchmark
+    import argparse
+
+    benchmark_list = {
+        "FastAnt" : FastAnt,
+        "FastCartpole" : FastCartpole,
+        "FastG1" : FastG1,
+        "FastH1" : FastH1,
+        "FastHumanoid" : FastHumanoid,
+        "KpiAnt" : KpiAnt,
+        "KpiCartpole" : KpiCartpole,
+        "KpiG1" : KpiG1,
+        "KpiH1" : KpiH1,
+        "KpiHumanoid" : KpiHumanoid,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -388,25 +388,26 @@ class KpiHumanoid:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "FastAnt" : FastAnt,
-        "FastCartpole" : FastCartpole,
-        "FastG1" : FastG1,
-        "FastH1" : FastH1,
-        "FastHumanoid" : FastHumanoid,
-        "KpiAnt" : KpiAnt,
-        "KpiCartpole" : KpiCartpole,
-        "KpiG1" : KpiG1,
-        "KpiH1" : KpiH1,
-        "KpiHumanoid" : KpiHumanoid,
+        "FastAnt": FastAnt,
+        "FastCartpole": FastCartpole,
+        "FastG1": FastG1,
+        "FastH1": FastH1,
+        "FastHumanoid": FastHumanoid,
+        "KpiAnt": KpiAnt,
+        "KpiCartpole": KpiCartpole,
+        "KpiG1": KpiG1,
+        "KpiH1": KpiH1,
+        "KpiHumanoid": KpiHumanoid,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -16,6 +16,8 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.quiet = True
+
 import newton
 from newton.examples.basic.example_basic_urdf import Example
 
@@ -33,3 +35,27 @@ class FastExampleQuadrupedXPBD:
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+if __name__ == "__main__":
+    from newton.utils import run_benchmark
+    import argparse
+
+    benchmark_list = {
+        "FastExampleQuadrupedXPBD" : FastExampleQuadrupedXPBD,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -38,16 +38,17 @@ class FastExampleQuadrupedXPBD:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "FastExampleQuadrupedXPBD" : FastExampleQuadrupedXPBD,
+        "FastExampleQuadrupedXPBD": FastExampleQuadrupedXPBD,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/asv/benchmarks/simulation/bench_selection.py
+++ b/asv/benchmarks/simulation/bench_selection.py
@@ -16,6 +16,9 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.quiet = True
+
+
 import newton
 from newton.examples.selection.example_selection_cartpole import Example
 
@@ -33,3 +36,27 @@ class FastExampleSelectionCartpoleMuJoCo:
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+if __name__ == "__main__":
+    from newton.utils import run_benchmark
+    import argparse
+
+    benchmark_list = {
+        "FastExampleSelectionCartpoleMuJoCo" : FastExampleSelectionCartpoleMuJoCo,
+    }
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+    )
+    args = parser.parse_known_args()[0]
+
+    if args.bench is None:
+        benchmarks = benchmark_list.keys()
+    else:
+        benchmarks = args.bench
+
+    for key in benchmarks:
+        benchmark = benchmark_list[key]
+        run_benchmark(benchmark)

--- a/asv/benchmarks/simulation/bench_selection.py
+++ b/asv/benchmarks/simulation/bench_selection.py
@@ -29,7 +29,7 @@ class FastExampleSelectionCartpoleMuJoCo:
 
     def setup(self):
         self.num_frames = 200
-        self.example = Example(viewer=newton.viewer.ViewerNull(num_frames=self.num_frames), num_envs=16)
+        self.example = Example(viewer=newton.viewer.ViewerNull(num_frames=self.num_frames), num_envs=16, verbose=False)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_simulate(self):

--- a/asv/benchmarks/simulation/bench_selection.py
+++ b/asv/benchmarks/simulation/bench_selection.py
@@ -39,16 +39,17 @@ class FastExampleSelectionCartpoleMuJoCo:
 
 
 if __name__ == "__main__":
-    from newton.utils import run_benchmark
     import argparse
 
+    from newton.utils import run_benchmark
+
     benchmark_list = {
-        "FastExampleSelectionCartpoleMuJoCo" : FastExampleSelectionCartpoleMuJoCo,
+        "FastExampleSelectionCartpoleMuJoCo": FastExampleSelectionCartpoleMuJoCo,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        "-b", "--bench", default=None, action='append', choices=benchmark_list.keys(), help="Run a single benchmark."
+        "-b", "--bench", default=None, action="append", choices=benchmark_list.keys(), help="Run a single benchmark."
     )
     args = parser.parse_known_args()[0]
 

--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -99,12 +99,7 @@ def _setup_g1(articulation_builder):
         enable_self_collisions=False,
     )
     simplified_meshes = {}
-    try:
-        import tqdm  # noqa: PLC0415
-
-        meshes = tqdm.tqdm(articulation_builder.shape_source, desc="Simplifying meshes")
-    except ImportError:
-        meshes = articulation_builder.shape_source
+    meshes = articulation_builder.shape_source
     for i, m in enumerate(meshes):
         if m is None:
             continue

--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -312,15 +312,21 @@ class Example:
         else:
             raise ValueError(f"Name of the provided robot not recognized: {robot}")
 
-        builder = newton.ModelBuilder()
-        offsets = newton.examples.compute_env_offsets(num_envs)
-        for i in range(num_envs):
-            if randomize:
+        if randomize:
+            for i in range(num_envs):
                 articulation_builder.joint_q[root_dofs:] = rng.uniform(
                     -1.0, 1.0, size=(len(articulation_builder.joint_q) - root_dofs,)
                 ).tolist()
-            builder.add_builder(articulation_builder, xform=wp.transform(offsets[i], wp.quat_identity()))
 
+        builder = newton.ModelBuilder()
+        builder.replicate(articulation_builder, num_envs, spacing=(4.0, 4.0, 0.0))
+        if randomize:
+            njoint = len(articulation_builder.joint_q)
+            for i in range(num_envs):
+                istart = i * njoint
+                builder.joint_q[istart + root_dofs:istart + njoint] = rng.uniform(
+                    -1.0, 1.0, size=(njoint - root_dofs)
+                ).tolist()
         builder.add_ground_plane()
         return builder
 

--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -307,19 +307,13 @@ class Example:
         else:
             raise ValueError(f"Name of the provided robot not recognized: {robot}")
 
-        if randomize:
-            for i in range(num_envs):
-                articulation_builder.joint_q[root_dofs:] = rng.uniform(
-                    -1.0, 1.0, size=(len(articulation_builder.joint_q) - root_dofs,)
-                ).tolist()
-
         builder = newton.ModelBuilder()
         builder.replicate(articulation_builder, num_envs, spacing=(4.0, 4.0, 0.0))
         if randomize:
             njoint = len(articulation_builder.joint_q)
             for i in range(num_envs):
                 istart = i * njoint
-                builder.joint_q[istart + root_dofs:istart + njoint] = rng.uniform(
+                builder.joint_q[istart + root_dofs : istart + njoint] = rng.uniform(
                     -1.0, 1.0, size=(njoint - root_dofs)
                 ).tolist()
         builder.add_ground_plane()

--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -34,7 +34,6 @@ from newton.selection import ArticulationView
 
 USE_TORCH = False
 COLLAPSE_FIXED_JOINTS = False
-VERBOSE = True
 
 
 @wp.kernel
@@ -56,7 +55,7 @@ def apply_forces_kernel(joint_q: wp.array2d(dtype=float), joint_f: wp.array2d(dt
 
 
 class Example:
-    def __init__(self, viewer, num_envs=16):
+    def __init__(self, viewer, num_envs=16, verbose=True):
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
 
@@ -91,7 +90,7 @@ class Example:
         # =======================
         # get cartpole view
         # =======================
-        self.cartpoles = ArticulationView(self.model, "/cartPole", verbose=VERBOSE)
+        self.cartpoles = ArticulationView(self.model, "/cartPole", verbose=verbose)
 
         # =========================
         # randomize initial state


### PR DESCRIPTION
## Description
This is part of #722.
In order to improve error message coming from asv:
- Added the `-e` option in the CI job.
- Added the `wp.config.quiet` in all benchmark files to keep information printing as low as possible.
- Removed information printing in `example_mujoco` about mesh simplification.
- Updated `example_mujoco`  to use `replicate` function to remove deprecated warning.
- Removed the `ScopeTimer` in the anymal walking example.
- Added an option to turn off the verbose option in the selection example.
- Added a `__main__` to all benchmark files to be able to run them individually

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
