### PR TITLE
MjWarp dependency upgrade

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -721,7 +721,7 @@ wheels = [
 [[package]]
 name = "mujoco-warp"
 version = "0.0.1"
-source = { git = "https://github.com/google-deepmind/mujoco_warp#ca6e29285b856cc06bd39127aafadbf4dd56f944" }
+source = { git = "https://github.com/google-deepmind/mujoco_warp#64bb938f87b6aaf840753ef9ddc198db655020c0" }
 dependencies = [
     { name = "absl-py" },
     { name = "etils", extra = ["epath"] },


### PR DESCRIPTION
fixes bug in convex-plane collision that was crashing the benchmarks.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
