### PR TITLE
Switch MuJoCo examples and Benchmarks to Parallel Linesearch

### DIFF
--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -381,7 +381,9 @@ if __name__ == "__main__":
     parser.add_argument("--ls-iteration", type=int, default=None, help="Number of linesearch iterations.")
     parser.add_argument("--njmax", type=int, default=None, help="Maximum number of constraints per environment.")
     parser.add_argument("--nconmax", type=int, default=None, help="Maximum number of collision per environment.")
-    parser.add_argument("--ls-parallel", default=True, action=argparse.BooleanOptionalAction, help="Use parallel line search.")
+    parser.add_argument(
+        "--ls-parallel", default=True, action=argparse.BooleanOptionalAction, help="Use parallel line search."
+    )
 
     args = parser.parse_known_args()[0]
 


### PR DESCRIPTION
First step towards aligning the benchmarks with IsaacLab configs. There, parallel linesearch is enabled everywhere.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-robot control for parallel line-search in the MuJoCo example with sensible defaults per robot.
  - New CLI flag --ls-parallel to override parallel line-search at runtime.

- **Documentation**
  - Example configuration and docs updated to show the parallel line-search setting and per-robot defaults.
  - Configuration summary now prints the active Parallel Line Search setting.

- **Notes**
  - No breaking changes; behavior is configurable via defaults or CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->