### PR TITLE
Change asv CI call to add table comparison

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -180,7 +180,9 @@ jobs:
           source .venv/bin/activate
           uv pip install asv virtualenv
           asv machine --yes
-          asv continuous --launch-method spawn --interleave-rounds --append-samples --no-only-changed -e -b Fast ${{ github.event.pull_request.base.sha }} \$HEAD_SHA 2>&1
+          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast \$HEAD_SHA 2>&1
+          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast ${{ github.event.pull_request.base.sha }} 2>&1
+          asv compare --split \$HEAD_SHA ${{ github.event.pull_request.base.sha }} 2>&1
           EOF
 
           # Prepare script to be passed as SSM parameters


### PR DESCRIPTION
## Description
- Separated asv call in GPU benchmark job into 2, and add a table comparison.
This was suggested in #722 .

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
