### PR TITLE
[test] Test benchmark CI

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -180,7 +180,9 @@ jobs:
           source .venv/bin/activate
           uv pip install asv virtualenv
           asv machine --yes
-          asv continuous --launch-method spawn --interleave-rounds --append-samples --no-only-changed -e -b Fast ${{ github.event.pull_request.base.sha }} \$HEAD_SHA 2>&1
+          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast \$HEAD_SHA 2>&1
+          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast ${{ github.event.pull_request.base.sha }} 2>&1
+          asv compare --split \$HEAD_SHA ${{ github.event.pull_request.base.sha }} 2>&1
           EOF
 
           # Prepare script to be passed as SSM parameters

--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -180,9 +180,9 @@ jobs:
           source .venv/bin/activate
           uv pip install asv virtualenv
           asv machine --yes
-          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast \$HEAD_SHA 2>&1
-          asv run --launch-method spawn --interleave-rounds --append-samples -e -b Fast ${{ github.event.pull_request.base.sha }} 2>&1
-          asv compare --split \$HEAD_SHA ${{ github.event.pull_request.base.sha }} 2>&1
+          ASV_CONTINUOUS="asv continuous --launch-method spawn --interleave-rounds --append-samples --no-only-changed -e -b Fast ${{ github.event.pull_request.base.sha }} \$HEAD_SHA 2>&1"
+          ASV_COMPARE="asv compare --split \$HEAD_SHA ${{ github.event.pull_request.base.sha }} 2>&1"
+          ${ASV_CONTINUOUS} || (${ASV_COMPARE} && exit 2)
           EOF
 
           # Prepare script to be passed as SSM parameters

--- a/newton/examples/example_mujoco.py
+++ b/newton/examples/example_mujoco.py
@@ -120,6 +120,8 @@ def _setup_h1(articulation_builder):
     articulation_builder.default_joint_cfg.armature = 0.1
     articulation_builder.default_body_armature = 0.1
 
+    assert False
+
     asset_path = newton.utils.download_asset("unitree_h1")
     articulation_builder.add_mjcf(
         str(asset_path / "mjcf" / "h1_with_hand.xml"),


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - The H1 setup path in the MuJoCo example is now disabled and will fail immediately when invoked, preventing asset downloads and model loading. Other example paths are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->