### PR TITLE
Increase AWS SSM command timeouts

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -185,7 +185,8 @@ jobs:
 
           # Prepare script to be passed as SSM parameters
           jq -n --arg script_body "$(cat remote_script.sh)" \
-          '{ "commands": [$script_body] }' > ssm_params.json
+          --arg timeout "$AWS_ROLE_DURATION" \
+          '{ "commands": [$script_body], "executionTimeout": [$timeout] }' > ssm_params.json
 
           # Echo script for debugging
           cat remote_script.sh

--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -192,7 +192,8 @@ jobs:
 
           # Prepare script to be passed as SSM parameters
           jq -n --arg script_body "$(cat remote_script.sh)" \
-          '{ "commands": [$script_body] }' > ssm_params.json
+          --arg timeout "$AWS_ROLE_DURATION" \
+          '{ "commands": [$script_body], "executionTimeout": [$timeout] }' > ssm_params.json
 
           # Echo script for debugging
           cat remote_script.sh

--- a/.github/workflows/push_aws_gpu_tests.yml
+++ b/.github/workflows/push_aws_gpu_tests.yml
@@ -138,7 +138,8 @@ jobs:
 
           # Prepare script to be passed as SSM parameters
           jq -n --arg script_body "$(cat remote_script.sh)" \
-          '{ "commands": [$script_body] }' > ssm_params.json
+          --arg timeout "$AWS_ROLE_DURATION" \
+          '{ "commands": [$script_body], "executionTimeout": [$timeout] }' > ssm_params.json
 
           # Echo script for debugging
           cat remote_script.sh


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

`AWS-RunShellScript` has a `"executionTimeout"` setting that we should increase along with the rest of the timeouts.

Without this setting, an increased test time was not taking effect:

```
    "executionTimeout": {
      "type": "String",
      "default": "3600",
      "description": "(Optional) The time in seconds for a command to complete before it is considered to have failed. Default is 3600 (1 hour). Maximum is 172800 (48 hours).",
      "allowedPattern": "([1-9][0-9]{0,4})|(1[0-6][0-9]{4})|(17[0-1][0-9]{3})|(172[0-7][0-9]{2})|(172800)"
    }
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit execution timeouts to remote GPU test and benchmark runs in AWS, aligned with session duration, preventing indefinite hangs and improving CI reliability.
* **Tests**
  * Enforced per-command timeout for GPU workflows to ensure stalled runs fail fast with clear status, without altering existing polling or result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->