### PR TITLE
Remove unused code that causes a crash on Linux

### DIFF
--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -537,7 +537,6 @@ class MeshInstancerGL:
         self.device = mesh.device
         self.hidden = False
         self.instance_transform_buffer = None
-        self.instance_scale_buffer = None
         self.instance_color_buffer = None
         self.instance_material_buffer = None
 
@@ -555,13 +554,12 @@ class MeshInstancerGL:
                 # Ignore any errors (e.g., context already destroyed)
                 pass
 
-        if self.vao is not None:
+        if hasattr(self, "vao") and self.vao is not None:
             try:
                 gl.glDeleteVertexArrays(1, self.vao)
                 gl.glDeleteBuffers(1, self.instance_transform_buffer)
                 gl.glDeleteBuffers(1, self.instance_color_buffer)
                 gl.glDeleteBuffers(1, self.instance_material_buffer)
-                gl.glDeleteBuffers(1, self.instance_scale_buffer)
             except Exception:
                 # Ignore any errors during interpreter shutdown
                 pass


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Toggling the collision geometry visualization in the example viewer causes a crash on Linux (but works on Windows). This MR removes some unused code and first tests show that this also removes the crash on Linux.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [~] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved cleanup logic to prevent errors during app shutdown or partial initialization when graphics resources aren’t fully created.
  - More resilient handling of graphics resources, reducing potential crashes or warnings in edge cases.
- Refactor
  - Removed an unused graphics buffer to streamline resource management and reduce overhead.
- Chores
  - Minor internal cleanup to simplify destruction paths without affecting public APIs or rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->