### PR TITLE
MJCF Importer Incorrectly Converts Cylinder Colliders to Capsules #333

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -411,7 +411,7 @@ def parse_mjcf(
                 tf = wp.transform(tf.p, tf.q * quat_between_axes(Axis.Z, geom_up_axis))
 
                 if geom_type == "cylinder":
-                    s = builder.add_shape_capsule(
+                    s = builder.add_shape_cylinder(
                         xform=tf,
                         radius=geom_radius,
                         half_height=geom_height,

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -158,7 +158,7 @@ def parse_urdf(
             for cylinder in geo.findall("cylinder"):
                 # Apply axis rotation to transform
                 xform = wp.transform(tf.p, tf.q * quat_between_axes(Axis.Z, up_axis))
-                s = builder.add_shape_capsule(
+                s = builder.add_shape_cylinder(
                     body=link,
                     xform=xform,
                     radius=float(cylinder.get("radius") or "1") * scale,


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR fixes the MJCF and URDF importers to properly preserve cylinder collision shapes instead of incorrectly converting them to capsules. Closes #333

### Changes Made:
- **MJCF Importer**: Changed `add_shape_capsule` to `add_shape_cylinder` for cylinder geometries in `newton/_src/utils/import_mjcf.py`
- **URDF Importer**: Changed `add_shape_capsule` to `add_shape_cylinder` for cylinder geometries in `newton/_src/utils/import_urdf.py`
- **USD Importer**: No changes needed - already correctly handles cylinders
- **Tests**: Added unit tests to verify cylinder shapes are properly imported and their properties (radius, height) are preserved

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date
  - *Note: No migration guide updates needed for this bug fix*

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
  - Added `test_cylinder_shapes_preserved` and `test_cylinder_properties_preserved` tests for MJCF importer
  - Added `test_cylinder_shapes_preserved` test for URDF importer
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cylinder geometries are now correctly imported as cylinders (not capsules) from both MJCF and URDF files, preserving dimensions and orientation for visual and collision elements. This improves geometric fidelity during import.

* **Tests**
  * Added tests for MJCF and URDF imports to verify cylinder shape preservation and correct mapping of radius and half-height properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->