### PR TITLE
Improve performance of `ModelBuilder.add_builder` method

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -638,10 +638,7 @@ class ModelBuilder:
         offsets = self._compute_replicate_offsets(num_copies, spacing)
         xform = wp.transform_identity()
         for i in range(num_copies):
-            offset = offsets[i]
-            # assign translation
-            for j in range(3):
-                xform[j] = offset[j]
+            xform[:3] = offsets[i]
             self.add_builder(builder, xform=xform)
 
     def add_articulation(self, key: str | None = None):
@@ -1033,8 +1030,7 @@ class ModelBuilder:
                         xform_prev = wp.transform(*builder.joint_q[qi : qi + 7])
                         tf = transform_mul(xform, xform_prev)
                         qi += start_q
-                        for j in range(7):
-                            self.joint_q[qi + j] = tf[j]
+                        self.joint_q[qi : qi + 7] = tf
                     elif builder.joint_parent[i] == -1:
                         self.joint_X_p[start_X_p + i] = transform_mul(xform, builder.joint_X_p[i])
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1030,11 +1030,11 @@ class ModelBuilder:
                 for i in range(len(builder.joint_X_p)):
                     if builder.joint_type[i] == JointType.FREE:
                         qi = builder.joint_q_start[i]
-                        xform_prev = wp.transform(builder.joint_q[qi : qi + 3], builder.joint_q[qi + 3 : qi + 7])
+                        xform_prev = wp.transform(*builder.joint_q[qi : qi + 7])
                         tf = transform_mul(xform, xform_prev)
                         qi += start_q
-                        self.joint_q[qi : qi + 3] = tf.p
-                        self.joint_q[qi + 3 : qi + 7] = tf.q
+                        for j in range(7):
+                            self.joint_q[qi + j] = tf[j]
                     elif builder.joint_parent[i] == -1:
                         self.joint_X_p[start_X_p + i] = transform_mul(xform, builder.joint_X_p[i])
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4452,11 +4452,11 @@ class ModelBuilder:
                     continue
 
                 # Ensure canonical order (smaller_element, larger_element)
-                shape_a, shape_b = min(s1, s2), max(s1, s2)
+                if s1 > s2:
+                    s1, s2 = s2, s1
 
-                if (shape_a, shape_b) not in filters:
-                    contact_pairs.append((shape_a, shape_b))
-                    filters.add((shape_a, shape_b))
+                if (s1, s2) not in filters:
+                    contact_pairs.append((s1, s2))
 
         model.shape_contact_pairs = wp.array(np.array(contact_pairs), dtype=wp.vec2i, device=model.device)
         model.shape_contact_pair_count = len(contact_pairs)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1056,9 +1056,8 @@ class ModelBuilder:
         self.shape_collision_group.extend(builder.shape_collision_group)
 
         # Copy collision filter pairs with offset
-        shape_count_offset = self.shape_count
         self.shape_collision_filter_pairs.extend(
-            [(i + shape_count_offset, j + shape_count_offset) for i, j in builder.shape_collision_filter_pairs]
+            [(i + start_shape_idx, j + start_shape_idx) for i, j in builder.shape_collision_filter_pairs]
         )
 
         # Handle environment group assignments

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -968,7 +968,6 @@ class ModelBuilder:
 
         # dispatches two transform multiplies to the native implementation
         def transform_mul(a, b):
-            # out = wp.transformf()
             out = wp.transform.from_buffer(np.empty(7, dtype=np.float32))
             transform_mul_cfunc(a, b, ctypes.byref(out))
             return out

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4159,7 +4159,7 @@ class ModelBuilder:
                 self.shape_material_restitution, dtype=wp.float32, requires_grad=requires_grad
             )
 
-            m.shape_collision_filter_pairs = self.shape_collision_filter_pairs
+            m.shape_collision_filter_pairs = set(self.shape_collision_filter_pairs)
             m.shape_collision_group = self.shape_collision_group
 
             # ---------------------
@@ -4424,7 +4424,7 @@ class ModelBuilder:
             - Sets `model.shape_contact_pair_count` to the number of contact pairs found.
         """
         # Copy the set of filtered-out shape pairs to avoid modifying the original
-        filters = set(self.shape_collision_filter_pairs)
+        filters = model.shape_collision_filter_pairs
         contact_pairs = []
 
         # Sort shapes by env group in case they are not sorted, keep only colliding shapes

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4452,10 +4452,12 @@ class ModelBuilder:
 
                 # Ensure canonical order (smaller_element, larger_element)
                 if s1 > s2:
-                    s1, s2 = s2, s1
+                    shape_a, shape_b = s2, s1
+                else:
+                    shape_a, shape_b = s1, s2
 
-                if (s1, s2) not in filters:
-                    contact_pairs.append((s1, s2))
+                if (shape_a, shape_b) not in filters:
+                    contact_pairs.append((shape_a, shape_b))
 
         model.shape_contact_pairs = wp.array(np.array(contact_pairs), dtype=wp.vec2i, device=model.device)
         model.shape_contact_pair_count = len(contact_pairs)

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -920,12 +920,12 @@ def parse_mjcf(
 
     for i in range(start_shape_count, end_shape_count):
         for j in visual_shapes:
-            builder.shape_collision_filter_pairs.add((i, j))
+            builder.shape_collision_filter_pairs.append((i, j))
 
     if not enable_self_collisions:
         for i in range(start_shape_count, end_shape_count):
             for j in range(i + 1, end_shape_count):
-                builder.shape_collision_filter_pairs.add((i, j))
+                builder.shape_collision_filter_pairs.append((i, j))
 
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -532,12 +532,12 @@ def parse_urdf(
 
     for i in range(start_shape_count, end_shape_count):
         for j in visual_shapes:
-            builder.shape_collision_filter_pairs.add((i, j))
+            builder.shape_collision_filter_pairs.append((i, j))
 
     if not enable_self_collisions:
         for i in range(start_shape_count, end_shape_count):
             for j in range(i + 1, end_shape_count):
-                builder.shape_collision_filter_pairs.add((i, j))
+                builder.shape_collision_filter_pairs.append((i, j))
 
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1253,13 +1253,13 @@ def parse_usd(
     for path1, path2 in path_collision_filters:
         shape1 = path_shape_map[path1]
         shape2 = path_shape_map[path2]
-        builder.shape_collision_filter_pairs.add((shape1, shape2))
+        builder.shape_collision_filter_pairs.append((shape1, shape2))
 
     # apply collision filters to all shapes that have no collision
     for shape_id in no_collision_shapes:
         for other_shape_id in range(builder.shape_count):
             if other_shape_id != shape_id:
-                builder.shape_collision_filter_pairs.add((shape_id, other_shape_id))
+                builder.shape_collision_filter_pairs.append((shape_id, other_shape_id))
 
     # apply collision filters from articulations that have self collisions disabled
     for art_id, bodies in articulation_bodies.items():
@@ -1267,7 +1267,7 @@ def parse_usd(
             for body1, body2 in itertools.combinations(bodies, 2):
                 for shape1 in builder.body_shapes[body1]:
                     for shape2 in builder.body_shapes[body2]:
-                        builder.shape_collision_filter_pairs.add((shape1, shape2))
+                        builder.shape_collision_filter_pairs.append((shape1, shape2))
 
     # overwrite inertial properties of bodies that have PhysicsMassAPI schema applied
     if UsdPhysics.ObjectType.RigidBody in ret_dict:

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -108,7 +108,7 @@ class Example:
         for body1, body2 in itertools.combinations(bodies, 2):
             for shape1 in allegro_hand.body_shapes[body1]:
                 for shape2 in allegro_hand.body_shapes[body2]:
-                    allegro_hand.shape_collision_filter_pairs.add((shape1, shape2))
+                    allegro_hand.shape_collision_filter_pairs.append((shape1, shape2))
 
         # hide collision shapes for the hand links
         for i, key in enumerate(allegro_hand.shape_key):

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -532,24 +532,31 @@ class TestModel(unittest.TestCase):
         self.assertEqual(joint_groups[3], 1)  # b1_0->b1_1 from env 1
 
     def test_add_builder(self):
-        body_xform = wp.transform(wp.vec3(1.0, 2.0, 3.0), wp.quat_rpy(0.5, 0.6, 0.7))
+        orig_xform = wp.transform(wp.vec3(1.0, 2.0, 3.0), wp.quat_rpy(0.5, 0.6, 0.7))
         offset_xform = wp.transform(wp.vec3(4.0, 5.0, 6.0), wp.quat_rpy(-0.7, 0.8, -0.9))
 
         fixed_base = ModelBuilder()
-        fixed_base.add_body(xform=body_xform)
-        fixed_base.add_joint_revolute(parent=-1, child=0, parent_xform=body_xform)
+        fixed_base.add_body(xform=orig_xform)
+        fixed_base.add_joint_revolute(parent=-1, child=0, parent_xform=orig_xform)
+        fixed_base.add_shape_sphere(body=0, xform=orig_xform)
 
         floating_base = ModelBuilder()
-        floating_base.add_body(xform=body_xform)
+        floating_base.add_body(xform=orig_xform)
         floating_base.add_joint_free(parent=-1, child=0)
+        floating_base.add_shape_sphere(body=0, xform=orig_xform)
+
+        static_shape = ModelBuilder()
+        static_shape.add_shape_sphere(body=-1, xform=orig_xform)
 
         builder = ModelBuilder()
         builder.add_builder(fixed_base, xform=offset_xform)
         builder.add_builder(floating_base, xform=offset_xform)
+        builder.add_builder(static_shape, xform=offset_xform)
 
         self.assertEqual(builder.body_count, 2)
         self.assertEqual(builder.joint_count, 2)
         self.assertEqual(builder.articulation_count, 2)
+        self.assertEqual(builder.shape_count, 3)
         self.assertEqual(builder.body_group, [0, 1])
         self.assertEqual(builder.joint_group, [0, 1])
         self.assertEqual(builder.joint_type, [newton.JointType.REVOLUTE, newton.JointType.FREE])
@@ -557,10 +564,20 @@ class TestModel(unittest.TestCase):
         self.assertEqual(builder.joint_child, [0, 1])
         self.assertEqual(builder.joint_q_start, [0, 1])
         self.assertEqual(builder.joint_qd_start, [0, 1])
-        self.assertEqual(builder.body_q[0], offset_xform * body_xform)
-        self.assertEqual(builder.body_q[1], offset_xform * body_xform)
-        assert_np_equal(np.array(builder.joint_X_p[0]), np.array(offset_xform * body_xform), tol=1.0e-6)
-        assert_np_equal(np.array(builder.joint_q[1:]), np.array(offset_xform * body_xform), tol=1.0e-6)
+        self.assertEqual(builder.shape_group, [0, 1, 2])
+        self.assertEqual(builder.shape_body, [0, 1, -1])
+        self.assertEqual(builder.body_shapes, {0: [0], 1: [1], -1: [2]})
+        self.assertEqual(builder.body_q[0], offset_xform * orig_xform)
+        self.assertEqual(builder.body_q[1], offset_xform * orig_xform)
+        # fixed base has updated parent transform
+        assert_np_equal(np.array(builder.joint_X_p[0]), np.array(offset_xform * orig_xform), tol=1.0e-6)
+        # floating base has updated joint coordinates
+        assert_np_equal(np.array(builder.joint_q[1:]), np.array(offset_xform * orig_xform), tol=1.0e-6)
+        # shapes with a parent body keep the original transform
+        assert_np_equal(np.array(builder.shape_transform[0]), np.array(orig_xform), tol=1.0e-6)
+        assert_np_equal(np.array(builder.shape_transform[1]), np.array(orig_xform), tol=1.0e-6)
+        # static shape receives the offset transform
+        assert_np_equal(np.array(builder.shape_transform[2]), np.array(offset_xform * orig_xform), tol=1.0e-6)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -531,6 +531,37 @@ class TestModel(unittest.TestCase):
         self.assertEqual(joint_groups[2], 1)  # world->b1_0 from env 1
         self.assertEqual(joint_groups[3], 1)  # b1_0->b1_1 from env 1
 
+    def test_add_builder(self):
+        body_xform = wp.transform(wp.vec3(1.0, 2.0, 3.0), wp.quat_rpy(0.5, 0.6, 0.7))
+        offset_xform = wp.transform(wp.vec3(4.0, 5.0, 6.0), wp.quat_rpy(-0.7, 0.8, -0.9))
+
+        fixed_base = ModelBuilder()
+        fixed_base.add_body(xform=body_xform)
+        fixed_base.add_joint_revolute(parent=-1, child=0, parent_xform=body_xform)
+
+        floating_base = ModelBuilder()
+        floating_base.add_body(xform=body_xform)
+        floating_base.add_joint_free(parent=-1, child=0)
+
+        builder = ModelBuilder()
+        builder.add_builder(fixed_base, xform=offset_xform)
+        builder.add_builder(floating_base, xform=offset_xform)
+
+        self.assertEqual(builder.body_count, 2)
+        self.assertEqual(builder.joint_count, 2)
+        self.assertEqual(builder.articulation_count, 2)
+        self.assertEqual(builder.body_group, [0, 1])
+        self.assertEqual(builder.joint_group, [0, 1])
+        self.assertEqual(builder.joint_type, [newton.JointType.REVOLUTE, newton.JointType.FREE])
+        self.assertEqual(builder.joint_parent, [-1, -1])
+        self.assertEqual(builder.joint_child, [0, 1])
+        self.assertEqual(builder.joint_q_start, [0, 1])
+        self.assertEqual(builder.joint_qd_start, [0, 1])
+        self.assertEqual(builder.body_q[0], offset_xform * body_xform)
+        self.assertEqual(builder.body_q[1], offset_xform * body_xform)
+        assert_np_equal(np.array(builder.joint_X_p[0]), np.array(offset_xform * body_xform), tol=1.0e-6)
+        assert_np_equal(np.array(builder.joint_q[1:]), np.array(offset_xform * body_xform), tol=1.0e-6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Improve performance of `add_builder`, `replicate`, and `find_shape_contact_pairs` methods in `ModelBuilder`.
Add unit tests for `add_builder` method.
Addresses https://github.com/newton-physics/newton/issues/55.

### Time Measurements

| Environment (8192 envs) | Function                 | Before  | After |
|--------------------------|--------------------------|---------|-------|
| Allegro hand             | ModelBuilder.replicate   | 28.3 s  | 2.8 s |
|                          | ModelBuilder.finalize    | 3.7 s   | 2.9 s |
| G1 humanoid              | ModelBuilder.replicate   | 47.6 s  | 5.1 s |
|                          | ModelBuilder.finalize    | 4.2 s   | 5.1 s |
| Cartpole                 | ModelBuilder.replicate   | 5.8 s   | 0.8 s |
|                          | ModelBuilder.finalize    | 0.4 s   | 0.3 s |


## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Collision-filter pairs now preserve insertion order and may include duplicates, changing collision-filtering behavior across imports and model composition.
  * Model composition and replication are more efficient—transform reuse and reduced allocations improve merge/replication performance and memory use.

* **Tests**
  * Added test coverage validating composition of multiple builders and transform propagation.

* **Documentation**
  * Example updated to reflect new collision-filter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->