### PR TITLE
Fix robot policy example after lin/ang vel swap

### DIFF
--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -18,14 +18,16 @@
 #
 # Shows how to control robot pretrained in IsaacLab with RL.
 # The policy is loaded from a file and the robot is controlled via keyboard.
-# Press space to start the simulation.
+#
 # Press "p" to reset the robot.
 # Press "i", "j", "k", "l", "u", "o" to move the robot.
 # Run this example with:
-# python example_robot_policy.py --robot g1_29dof
-# python example_robot_policy.py --robot go2
-# python example_robot_policy.py --robot anymal
-# to run the example with physX trained policies run with --physx
+# python -m newton.examples robot_policy --robot g1_29dof
+# python -m newton.examples robot_policy --robot g1_23dof
+# python -m newton.examples robot_policy --robot go2
+# python -m newton.examples robot_policy --robot anymal
+# python -m newton.examples robot_policy --robot anymal --physx
+# to run the example with a PhysX-trained policy run with --physx
 ###########################################################################
 
 from dataclasses import dataclass
@@ -136,8 +138,8 @@ def compute_obs(
     joint_qd = state.joint_qd if state.joint_qd is not None else []
 
     root_quat_w = torch.tensor(joint_q[3:7], device=device, dtype=torch.float32).unsqueeze(0)
-    root_lin_vel_w = torch.tensor(joint_qd[3:6], device=device, dtype=torch.float32).unsqueeze(0)
-    root_ang_vel_w = torch.tensor(joint_qd[:3], device=device, dtype=torch.float32).unsqueeze(0)
+    root_lin_vel_w = torch.tensor(joint_qd[:3], device=device, dtype=torch.float32).unsqueeze(0)
+    root_ang_vel_w = torch.tensor(joint_qd[3:6], device=device, dtype=torch.float32).unsqueeze(0)
     joint_pos_current = torch.tensor(joint_q[7:], device=device, dtype=torch.float32).unsqueeze(0)
     joint_vel_current = torch.tensor(joint_qd[6:], device=device, dtype=torch.float32).unsqueeze(0)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
The robot policy examples broke with the lin/ang vel swap that recently landed in main. This fixes the examples, and also improves the instructions to match other examples.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mapping of root linear and angular velocities in robot policy observations, improving simulation accuracy and model behavior.

* **Documentation**
  * Updated run instructions to use module-style invocation (python -m …) with clearer examples and options (e.g., PhysX).
  * Simplified simulation-start guidance by removing the explicit “Press space to start the simulation” line and adding a general usage note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->