### PR TITLE
Fix selection slice from integer

### DIFF
--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -515,7 +515,9 @@ class ArticulationView:
             _slice = self._frequency_slices.get(frequency)
         elif isinstance(_slice, Slice):
             _slice = _slice.get()
-        elif not isinstance(_slice, int):
+        elif isinstance(_slice, int):
+            _slice = slice(_slice, _slice + 1)
+        else:
             raise TypeError(f"Invalid slice type: expected Slice or int, got {type(_slice)}")
 
         if _slice is not None:


### PR DESCRIPTION
Fix `ArticulationView.get_root_transforms()` raising this error with fixed-base articulations:
```
  File "/home/antoiner/Documents/newton/newton/_src/utils/selection.py", line 523, in _get_attribute_array
    if _slice.start == _slice.stop:
       ^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'start'
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
