### PR TITLE
Fix parallel UT execution on CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version-file: ".python-version"
       - name: Run Tests
-        run: uv run --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
+        run: uv run --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:

--- a/newton/tests/unittest_utils.py
+++ b/newton/tests/unittest_utils.py
@@ -370,24 +370,25 @@ def write_junit_results(
     )
 
     for test_data in test_records:
-        test = test_data[0]
-        test_duration = test_data[1]
-        test_status = test_data[2]
+        test_classname = test_data[0]
+        test_methodname = test_data[1]
+        test_duration = test_data[2]
+        test_status = test_data[3]
 
         test_case = ET.SubElement(
-            root, "testcase", classname=test.__class__.__name__, name=test._testMethodName, time=f"{test_duration:.3f}"
+            root, "testcase", classname=test_classname, name=test_methodname, time=f"{test_duration:.3f}"
         )
 
         if test_status == "FAIL":
-            failure = ET.SubElement(test_case, "failure", message=str(test_data[3]))
-            failure.text = str(test_data[4])  # Stacktrace
+            failure = ET.SubElement(test_case, "failure", message=str(test_data[4]))
+            failure.text = str(test_data[5])  # Stacktrace
         elif test_status == "ERROR":
             error = ET.SubElement(test_case, "error")
-            error.text = str(test_data[4])  # Stacktrace
+            error.text = str(test_data[5])  # Stacktrace
         elif test_status == "SKIP":
             skip = ET.SubElement(test_case, "skipped")
             # Set the skip reason
-            skip.set("message", str(test_data[3]))
+            skip.set("message", str(test_data[5]))
 
     tree = ET.ElementTree(root)
 
@@ -419,7 +420,7 @@ class ParallelJunitTestResult(unittest.TextTestResult):
 
     def _record_test(self, test, code, message=None, details=None):
         duration = round((time.perf_counter_ns() - self.start_time) * 1e-9, 3)  # [s]
-        self.test_record.append((test, duration, code, message, details))
+        self.test_record.append((test.__class__.__name__, test._testMethodName, duration, code, message, details))
 
     def addSuccess(self, test):
         super(unittest.TextTestResult, self).addSuccess(test)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
- Fix the parallel execution of UT on CPU and turn on the option, CI job went from 30min to 15min.
- Issue was that we were storing the whole test object instead of just what was required.
This solves #336.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Simplified CI test execution by removing an obsolete fallback option, streamlining the pipeline and reducing potential flakiness. No impact on application features or user experience.

* Tests
  * Improved test result reporting and recording format to produce more accurate and detailed test reports across parallel runs, enhancing CI build verification consistency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->