### PR TITLE
Fix selection slice shapes

### DIFF
--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -516,7 +516,7 @@ class ArticulationView:
         elif isinstance(_slice, Slice):
             _slice = _slice.get()
         elif isinstance(_slice, int):
-            _slice = slice(_slice, _slice + 1)
+            return attrib[:, _slice]
         else:
             raise TypeError(f"Invalid slice type: expected Slice or int, got {type(_slice)}")
 
@@ -524,14 +524,14 @@ class ArticulationView:
             # create strided array
             if _slice.start == _slice.stop:
                 #! workaround for empty slice until this is fixed: https://github.com/NVIDIA/warp/issues/958
-                ptr_offset = _slice.start * attrib.strides[1]
                 attrib = wp.array(
-                    ptr=attrib.ptr + ptr_offset if attrib.ptr is not None else None,
+                    ptr=attrib.ptr,
                     dtype=attrib.dtype,
-                    shape=(attrib.shape[0], 0),
+                    shape=(attrib.shape[0], 0, *attrib.shape[2:]),
                     strides=attrib.strides,
                     device=attrib.device,
                     pinned=attrib.pinned,
+                    copy=False,
                 )
             else:
                 attrib = attrib[:, _slice]

--- a/newton/tests/test_anymal_reset.py
+++ b/newton/tests/test_anymal_reset.py
@@ -115,7 +115,7 @@ class TestAnymalReset(unittest.TestCase):
         self.control = self.model.control()
         newton.eval_fk(self.model, self.state_0.joint_q, self.state_0.joint_qd, self.state_0)
         self.anymal = ArticulationView(
-            self.model, "*/Robot/base", verbose=False, exclude_joint_types=[newton.JointType.FREE]
+            self.model, "*/anymal/base", verbose=False, exclude_joint_types=[newton.JointType.FREE]
         )
         self.default_root_transforms = wp.clone(self.anymal.get_root_transforms(self.model))
         self.default_root_velocities = wp.clone(self.anymal.get_root_velocities(self.model))


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

* Fix selection shape with fixed and floating base articulations.
* Fix selection shape with empty slices.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Direct integer-based slicing now supported, returning a collapsed axis.

- Bug Fixes
  - Empty-slice selections preserve trailing dimensions and yield consistent zero-length shapes.

- Performance
  - Reduced unnecessary memory copies for empty slices, improving slicing efficiency.

- Tests
  - Updated test targeting to match model naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->