### PR TITLE
Update lockfile to use Warp 1.10.0.dev20250915

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.9.0.dev20250825 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.10.0.dev20250915 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.6.dev802089588 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129",
     "python -m pip install git+https://github.com/google-deepmind/mujoco_warp@8f870c87272888f36dcec4e337285de55e0eaa30",

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -13,8 +13,8 @@ To install Newton, see the :doc:`installation` guide.
 Python Dependency Management
 ----------------------------
 
-UV Lock File
-^^^^^^^^^^^^
+uv lockfile management
+^^^^^^^^^^^^^^^^^^^^^^
 
 When using uv, the `lockfile <https://docs.astral.sh/uv/concepts/projects/layout/#the-lockfile>`__
 (``uv.lock``) is used to resolve project dependencies into exact versions for reproducibility among different machines.
@@ -160,6 +160,21 @@ To automatically run pre-commit hooks with ``git commit``:
             pre-commit install
 
 The hooks can be uninstalled with ``pre-commit uninstall``.
+
+Using a local Warp installation with uv
+---------------------------------------
+
+Use the following steps to run Newton with a local build of Warp:
+
+.. code-block:: console
+
+    uv venv
+    source .venv/bin/activate
+    uv sync --extra dev
+    uv pip install -e "warp-lang @ ../warp"
+
+The Warp initialization message should then properly reflect the local Warp installation instead of the locked version,
+e.g. when running ``python -m newton.examples basic_pendulum``.
 
 Building the documentation
 --------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ explicit = true
 
 [tool.uv.sources]
 mujoco-warp = { git = "https://github.com/google-deepmind/mujoco_warp" }
-warp-lang = { index = "nvidia", marker = "sys_platform != 'darwin'" }
+warp-lang = { index = "nvidia" }
 mujoco = { index = "mujoco" }
 torch = [{ index = "pytorch-cu129", extra = "torch-cu12" }]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform != 'darwin'",
@@ -1000,8 +1000,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "platform_machine == 'aarch64' and extra == 'examples'", specifier = ">=2.1.0a3" },
     { name = "usd-exchange", marker = "platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.1.0a3" },
     { name = "usd-exchange", marker = "platform_machine == 'aarch64' and extra == 'torch-cu12'", specifier = ">=2.1.0a3" },
-    { name = "warp-lang", marker = "sys_platform != 'darwin'", specifier = ">=1.7.0.dev20250823", index = "https://pypi.nvidia.com/" },
-    { name = "warp-lang", marker = "sys_platform == 'darwin'", specifier = ">=1.7.0.dev20250823" },
+    { name = "warp-lang", specifier = ">=1.7.0.dev20250823", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["dev", "docs", "examples", "importers", "sim", "torch-cu12"]
 
@@ -2334,17 +2333,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.9.0.dev20250825"
+version = "1.10.0.dev20250915"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250825-py3-none-macosx_10_13_universal2.whl", hash = "sha256:b53b0640534f5659fb5b9e68e6c5d518565e5aed07f729151b7dec4e888e566e" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250825-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:28f7ef23bcd128bb6da2d2115b7eb34ebb0c8d28b522d71b287ae636516e28e3" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250825-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:204b8cfde848b3f2eb80f34646b5f11c91bec896ba7168e42ffe69ad4ca445e2" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.9.0.dev20250825-py3-none-win_amd64.whl", hash = "sha256:b7068b75ff622ffa295a83526d4e18e85b0327c21664949df89ede821dc4bd20" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.10.0.dev20250915-py3-none-macosx_10_13_universal2.whl", hash = "sha256:460280a62c3824e834568f52e65248a906f3ab7e3f7d46315475ef4065c0310e" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.10.0.dev20250915-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a4642695733356e3d28410792d348f3c9239c3cdbc02b47ded7d1d5a15a5ff96" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.10.0.dev20250915-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:66f3d42faa99b2368db592d887fd888485e39eb3fca4af2679e98ab48a6784f9" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.10.0.dev20250915-py3-none-win_amd64.whl", hash = "sha256:d7baa544175f196af32a9becc8ddcff69fb4f3f4b38a64e6f007ac298413b446" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Since there are now MacOS nightlies for Warp published at https://pypi.nvidia.com/warp-lang/, we can simplify the `pyproject.toml` file and we might as well update the Warp dependency at the same time.

**Update**: Warp 1.10.0.dev20250916 and newer currently segfaults on Windows for `test_anymal_reset.py`.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled warp-lang installation from the NVIDIA index across all platforms (macOS included).

- **Documentation**
  - Renamed “UV Lock File” to “uv lockfile management.”
  - Added step-by-step guidance for running the project with a local Warp build using uv; placed before the "Building the documentation" section.

- **Chores**
  - Updated benchmarking/install config to use a newer warp-lang pre-release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->