### PR TITLE
Exclude body contacts

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1350,7 +1350,11 @@ class ModelBuilder:
 
         if collision_filter_parent and parent > -1:
             for child_shape in self.body_shapes[child]:
+                if not self.shape_flags[child_shape] & ShapeFlags.COLLIDE_SHAPES:
+                    continue
                 for parent_shape in self.body_shapes[parent]:
+                    if not self.shape_flags[parent_shape] & ShapeFlags.COLLIDE_SHAPES:
+                        continue
                     # Ensure canonical order (smaller, larger) for consistent lookup
                     a, b = parent_shape, child_shape
                     if a > b:
@@ -1913,6 +1917,7 @@ class ModelBuilder:
         show_joint_keys=True,
         show_joint_types=True,
         plot_shapes=True,
+        show_shape_keys=True,
         show_shape_types=True,
         show_legend=True,
     ):
@@ -1926,6 +1931,7 @@ class ModelBuilder:
             show_joint_keys (bool): Whether to show the joint keys or indices
             show_joint_types (bool): Whether to show the joint types
             plot_shapes (bool): Whether to render the shapes connected to the rigid bodies
+            show_shape_keys (bool): Whether to show the shape keys or indices
             show_shape_types (bool): Whether to show the shape geometry types
             show_legend (bool): Whether to show a legend
         """
@@ -1976,10 +1982,12 @@ class ModelBuilder:
             vertices = ["-1"] + [str(i) for i in range(self.body_count)]
         if plot_shapes:
             for i in range(self.shape_count):
-                shape_label = f"shape_{i}"
+                shape_label = []
+                if show_shape_keys:
+                    shape_label.append(self.shape_key[i])
                 if show_shape_types:
-                    shape_label += f"\n({shape_type_str(self.shape_type[i])})"
-                vertices.append(shape_label)
+                    shape_label.append(f"\n({shape_type_str(self.shape_type[i])})")
+                vertices.append("\n".join(shape_label))
         edges = []
         edge_labels = []
         for i in range(self.joint_count):
@@ -2402,13 +2410,11 @@ class ModelBuilder:
             scale = (1.0, 1.0, 1.0)
         self.shape_body.append(body)
         shape = self.shape_count
-        if body in self.body_shapes:
+        if cfg.has_shape_collision:
             # no contacts between shapes of the same body
             for same_body_shape in self.body_shapes[body]:
                 self.shape_collision_filter_pairs.append((same_body_shape, shape))
-            self.body_shapes[body].append(shape)
-        else:
-            self.body_shapes[body] = [shape]
+        self.body_shapes[body].append(shape)
         self.shape_key.append(key or f"shape_{shape}")
         self.shape_transform.append(xform)
         self.shape_flags.append(cfg.flags)
@@ -2426,7 +2432,7 @@ class ModelBuilder:
         self.shape_collision_group.append(cfg.collision_group)
         self.shape_collision_radius.append(compute_shape_radius(type, scale, src))
         self.shape_group.append(self.current_env_group)
-        if cfg.collision_filter_parent and body > -1 and body in self.joint_parents:
+        if cfg.has_shape_collision and cfg.collision_filter_parent and body > -1 and body in self.joint_parents:
             for parent_body in self.joint_parents[body]:
                 if parent_body > -1:
                     for parent_shape in self.body_shapes[parent_body]:

--- a/newton/_src/sim/graph_coloring.py
+++ b/newton/_src/sim/graph_coloring.py
@@ -259,14 +259,16 @@ def color_graph(
     return color_groups
 
 
-def plot_graph(vertices, edges, edge_labels=None):
+def plot_graph(vertices, edges, edge_labels=None, node_labels=None, node_colors=None):
     """
     Plots a graph using matplotlib and networkx.
 
     Args:
-        vertices: A numpy array of shape (N, 3) containing the vertex positions.
+        vertices: A numpy array of shape (N,) containing the vertex indices.
         edges: A numpy array of shape (M, 2) containing the vertex indices of the edges.
         edge_labels: A list of edge labels.
+        node_labels: A list of node labels.
+        node_colors: A list of node colors.
     """
     import matplotlib.pyplot as plt  # noqa: PLC0415
     import networkx as nx  # noqa: PLC0415
@@ -291,11 +293,11 @@ def plot_graph(vertices, edges, edge_labels=None):
     pos = nx.spring_layout(G, k=3.5, iterations=200)
 
     default_draw_args = {"alpha": 0.9, "edgecolors": "black", "linewidths": 0.5}
-    nx.draw_networkx_nodes(G, pos, **default_draw_args)
+    nx.draw_networkx_nodes(G, pos, node_color=node_colors, **default_draw_args)
     nx.draw_networkx_labels(
         G,
         pos,
-        labels=dict(enumerate(vertices)),
+        labels=dict(enumerate(node_labels if node_labels is not None else vertices)),
         font_size=8,
         bbox={"facecolor": "white", "alpha": 0.8, "edgecolor": "none", "pad": 0.5},
     )

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -516,7 +516,7 @@ class ArticulationView:
         elif isinstance(_slice, Slice):
             _slice = _slice.get()
         elif isinstance(_slice, int):
-            _slice = slice(_slice, _slice + 1)
+            return attrib[:, _slice]
         else:
             raise TypeError(f"Invalid slice type: expected Slice or int, got {type(_slice)}")
 
@@ -524,14 +524,14 @@ class ArticulationView:
             # create strided array
             if _slice.start == _slice.stop:
                 #! workaround for empty slice until this is fixed: https://github.com/NVIDIA/warp/issues/958
-                ptr_offset = _slice.start * attrib.strides[1]
                 attrib = wp.array(
-                    ptr=attrib.ptr + ptr_offset if attrib.ptr is not None else None,
+                    ptr=attrib.ptr,
                     dtype=attrib.dtype,
-                    shape=(attrib.shape[0], 0),
+                    shape=(attrib.shape[0], 0, *attrib.shape[2:]),
                     strides=attrib.strides,
                     device=attrib.device,
                     pinned=attrib.pinned,
+                    copy=False,
                 )
             else:
                 attrib = attrib[:, _slice]

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -28,7 +28,6 @@
 #
 ###########################################################################
 
-import itertools
 import re
 
 import warp as wp
@@ -96,19 +95,11 @@ class Example:
         allegro_hand.add_usd(
             asset_file,
             xform=wp.transform(wp.vec3(0, 0, 0.5)),
-            enable_self_collisions=False,
+            enable_self_collisions=True,
             ignore_paths=[".*Dummy", ".*CollisionPlane", ".*goal", ".*palm_link/visuals", ".*DexCube/visuals"],
             load_non_physics_prims=True,
             hide_collision_shapes=False,
         )
-
-        # manually disable self collisions for the hand links
-        joint_start, joint_end = tuple(allegro_hand.articulation_start)  # there are only 2 entries currently
-        bodies = [allegro_hand.joint_child[j] for j in range(joint_start, joint_end)]
-        for body1, body2 in itertools.combinations(bodies, 2):
-            for shape1 in allegro_hand.body_shapes[body1]:
-                for shape2 in allegro_hand.body_shapes[body2]:
-                    allegro_hand.shape_collision_filter_pairs.append((shape1, shape2))
 
         # hide collision shapes for the hand links
         for i, key in enumerate(allegro_hand.shape_key):
@@ -128,8 +119,6 @@ class Example:
         builder.add_ground_plane()
 
         self.model = builder.finalize()
-        # print("Colliders:")
-        # print("\n".join(map(str, ((np.array(self.model.shape_key)[self.model.shape_contact_pairs.numpy()])).tolist())))
 
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.model)
 
@@ -206,8 +195,6 @@ class Example:
         self.viewer.log_state(self.state_0)
         self.viewer.log_contacts(self.contacts, self.state_0)
         self.viewer.end_frame()
-
-        # self.solver.render_mujoco_viewer()
 
     def test(self):
         pass


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Continuation of @camevor's work on https://github.com/newton-physics/newton/pull/793:
* Faster implementation of the body pairs to exclude in contact generation from SolverMuJoCo
* Only generate shape contact filters for colliding shapes
* Improvements to some graph plotting utility functions (only used for debugging)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
