### PR TITLE
Change go2 asset in robot policy to use new USDA file

### DIFF
--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -69,7 +69,7 @@ ROBOT_CONFIGS = {
     "go2": RobotConfig(
         asset_dir="unitree_go2",
         policy_path={"mjw": "rl_policies/mjw_go2.pt", "physx": "rl_policies/physx_go2.pt"},
-        asset_path="usd/go2.usd",
+        asset_path="usd/go2.usda",
         yaml_path="rl_policies/go2.yaml",
     ),
     "g1_29dof": RobotConfig(


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
With the USD asset refactor for GO2, we need to change the robot policy example to use the new USDA instead of the USD.

Asset-PR: https://github.com/newton-physics/newton-assets/pull/15

UTs pass if I run locally with the asset pull happening from my fork.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the GO2 robot asset reference to ensure the example loads reliably across environments, preventing asset-not-found errors. No changes to behavior or user-facing APIs.

* **Chores**
  * Aligned asset paths with current repository format for consistency and smoother setup in examples. No impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->