### PR TITLE
Fix potential joint indexing issue in SolverMuJoCo #562

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2153,8 +2153,9 @@ class SolverMuJoCo(SolverBase):
             tf = wp.transform(*joint_parent_xform[j])
             tf = tf * wp.transform_inverse(wp.transform(*joint_child_xform[j]))
 
-            joint_pos = wp.vec3(*joint_child_xform[j, :3])
-            joint_rot = wp.quat(*joint_child_xform[j, 3:])
+            jc_xform = wp.transform(*joint_child_xform[j])
+            joint_pos = jc_xform.p
+            joint_rot = jc_xform.q
 
             # ensure unique body name
             name = model.body_key[child]
@@ -2188,7 +2189,7 @@ class SolverMuJoCo(SolverBase):
                     joint_names[name] += 1
                     name = f"{name}_{joint_names[name]}"
 
-            joint_mjc_dof_start[j] = len(spec.joints)
+            joint_mjc_dof_start[ji] = len(spec.joints)
 
             if j_type == JointType.FREE:
                 body.add_joint(

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2146,12 +2146,15 @@ class SolverMuJoCo(SolverBase):
             # add body
             body_mapping[child] = len(mj_bodies)
 
-            # this assumes that the joint position is 0
-            tf = wp.transform(*joint_parent_xform[ji])
-            tf = tf * wp.transform_inverse(wp.transform(*joint_child_xform[ji]))
+            # use the correct global joint index
+            j = selected_joints[ji]
 
-            joint_pos = wp.vec3(*joint_child_xform[ji, :3])
-            joint_rot = wp.quat(*joint_child_xform[ji, 3:])
+            # this assumes that the joint position is 0
+            tf = wp.transform(*joint_parent_xform[j])
+            tf = tf * wp.transform_inverse(wp.transform(*joint_child_xform[j]))
+
+            joint_pos = wp.vec3(*joint_child_xform[j, :3])
+            joint_rot = wp.quat(*joint_child_xform[j, 3:])
 
             # ensure unique body name
             name = model.body_key[child]
@@ -2175,9 +2178,9 @@ class SolverMuJoCo(SolverBase):
             mj_bodies.append(body)
 
             # add joint
-            j_type = joint_type[ji]
-            qd_start = joint_qd_start[ji]
-            name = model.joint_key[ji]
+            j_type = joint_type[j]
+            qd_start = joint_qd_start[j]
+            name = model.joint_key[j]
             if name not in joint_names:
                 joint_names[name] = 1
             else:
@@ -2185,7 +2188,7 @@ class SolverMuJoCo(SolverBase):
                     joint_names[name] += 1
                     name = f"{name}_{joint_names[name]}"
 
-            joint_mjc_dof_start[ji] = len(spec.joints)
+            joint_mjc_dof_start[j] = len(spec.joints)
 
             if j_type == JointType.FREE:
                 body.add_joint(
@@ -2195,7 +2198,7 @@ class SolverMuJoCo(SolverBase):
                     limited=False,
                 )
             elif j_type in supported_joint_types:
-                lin_axis_count, ang_axis_count = joint_dof_dim[ji]
+                lin_axis_count, ang_axis_count = joint_dof_dim[j]
                 # linear dofs
                 for i in range(lin_axis_count):
                     ai = qd_start + i

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -1554,6 +1554,11 @@ class TestMuJoCoConversion(unittest.TestCase):
         expected_selected = [0, 2]
         np.testing.assert_array_equal(selected_joints, expected_selected, "Should select only env 0 joints [0, 2]")
 
+        # Also verify per-env DOF mapping is set for both local joints (indices 0 and 1)
+        dof_start_map = solver.joint_mjc_dof_start.numpy()
+        self.assertNotEqual(dof_start_map[0], -1, "Local joint 0 must have a valid MuJoCo DOF start")
+        self.assertNotEqual(dof_start_map[1], -1, "Local joint 1 must have a valid MuJoCo DOF start")
+
         # THE BUG: When processing selected joints, the code uses ji directly
         # So when ji=1:
         # - It SHOULD use joint[selected_joints[1]] = joint[2] (free joint from env 0)
@@ -1564,10 +1569,6 @@ class TestMuJoCoConversion(unittest.TestCase):
 
         # Get joint types from MuJoCo
         mjc_joint_types = mjw_model.jnt_type.numpy()  # First world
-
-        print(f"Selected joints: {selected_joints}")
-        print(f"Newton joint types: {joint_types} (1=revolute, 4=free)")
-        print(f"\nMuJoCo joint types: {mjc_joint_types} (0=free, 3=hinge)")
 
         # Expected MuJoCo joint types for env 0 after topological sorting:
         # Joint 2 (free) will be first because it's on body 0 (the base)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -1538,7 +1538,6 @@ class TestMuJoCoConversion(unittest.TestCase):
         expected_groups = [0, 1, 0, 1]
         self.assertEqual(list(joint_groups), expected_groups)
 
-        # Joint types: REVOLUTE=0, FREE=2
         # Expected types: [revolute, revolute, free, free]
         self.assertEqual(joint_types[0], JointType.REVOLUTE, "Joint 0 should be revolute")
         self.assertEqual(joint_types[1], JointType.REVOLUTE, "Joint 1 should be revolute")

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -20,7 +20,7 @@ import numpy as np  # For numerical operations and random values
 import warp as wp
 
 import newton
-from newton import Mesh
+from newton import JointType, Mesh
 from newton.solvers import SolverMuJoCo, SolverNotifyFlags
 
 
@@ -1500,6 +1500,98 @@ class TestMuJoCoConversion(unittest.TestCase):
             [tf.q.w, tf.q.x, tf.q.y, tf.q.z],
             atol=1e-6,
         )
+
+    def test_noncontiguous_joint_indexing(self):
+        """
+        Test for joint indexing bug when selected_joints is noncontiguous.
+
+        This reproduces issue #562 where ji is used directly to index joint arrays
+        instead of using selected_joints[ji] when processing filtered joints.
+        """
+        # Create a simple robot with 2 bodies and 1 revolute joint
+        robot = newton.ModelBuilder()
+        robot.add_body()  # body 0
+        robot.add_body()  # body 1
+        robot.add_joint_revolute(parent=0, child=1, axis=(0, 0, 1))
+        robot.add_shape_box(0, hx=0.1, hy=0.1, hz=0.1)
+        robot.add_shape_box(1, hx=0.1, hy=0.1, hz=0.1)
+
+        # Main builder adds the robot to env 0 and env 1
+        builder = newton.ModelBuilder()
+        builder.add_builder(robot, environment=0)  # Creates bodies 0,1 and joint 0 (revolute)
+        builder.add_builder(robot, environment=1)  # Creates bodies 2,3 and joint 1 (revolute)
+
+        # Now add free joints to the parent bodies of each robot
+        builder.current_env_group = 0
+        builder.add_joint_free(child=0)  # Free joint for body 0 (env 0) - joint 2
+
+        builder.current_env_group = 1
+        builder.add_joint_free(child=2)  # Free joint for body 2 (env 1) - joint 3
+
+        model = builder.finalize()
+
+        # Verify setup - we should have 4 joints total
+        joint_groups = model.joint_group.numpy()
+        joint_types = model.joint_type.numpy()
+
+        # Expected groups: [0, 1, 0, 1] - revolute from env0, revolute from env1, free from env0, free from env1
+        expected_groups = [0, 1, 0, 1]
+        self.assertEqual(list(joint_groups), expected_groups)
+
+        # Joint types: REVOLUTE=0, FREE=2
+        # Expected types: [revolute, revolute, free, free]
+        self.assertEqual(joint_types[0], JointType.REVOLUTE, "Joint 0 should be revolute")
+        self.assertEqual(joint_types[1], JointType.REVOLUTE, "Joint 1 should be revolute")
+        self.assertEqual(joint_types[2], JointType.FREE, "Joint 2 should be free")
+        self.assertEqual(joint_types[3], JointType.FREE, "Joint 3 should be free")
+
+        # Create solver with env separation
+        # This should select only env 0 joints: [0, 2] (noncontiguous!)
+        solver = SolverMuJoCo(model, separate_envs_to_worlds=True)
+
+        # Check selected joints
+        selected_joints = solver.selected_joints.numpy()
+        expected_selected = [0, 2]
+        np.testing.assert_array_equal(selected_joints, expected_selected, "Should select only env 0 joints [0, 2]")
+
+        # THE BUG: When processing selected joints, the code uses ji directly
+        # So when ji=1:
+        # - It SHOULD use joint[selected_joints[1]] = joint[2] (free joint from env 0)
+        # - But it INCORRECTLY uses joint[1] (revolute joint from env 1)
+
+        # Check the MuJoCo model has the correct joint types
+        mjw_model = solver.mjw_model
+
+        # Get joint types from MuJoCo
+        mjc_joint_types = mjw_model.jnt_type.numpy()  # First world
+
+        print(f"Selected joints: {selected_joints}")
+        print(f"Newton joint types: {joint_types} (1=revolute, 4=free)")
+        print(f"\nMuJoCo joint types: {mjc_joint_types} (0=free, 3=hinge)")
+
+        # Expected MuJoCo joint types for env 0 after topological sorting:
+        # Joint 2 (free) will be first because it's on body 0 (the base)
+        # Joint 0 (revolute) will be second because it connects to child body 1
+        # MuJoCo type mapping: FREE=0, BALL=1, SLIDE=2, HINGE=3
+        expected_mjc_types_fixed = [0, 3]  # free, hinge (after topological sort)
+        expected_mjc_types_buggy = [3, 3]  # hinge, hinge (with the bug)
+
+        # Check if we have the correct joint types
+        # With the bug fixed, we should get [0, 3] (free, hinge)
+        # With the bug present, we'd get [3, 3] (both hinges)
+
+        if np.array_equal(mjc_joint_types, expected_mjc_types_buggy):
+            self.fail(
+                f"BUG DETECTED: MuJoCo has joint types {mjc_joint_types} (both hinges). "
+                f"This indicates the bug is using joint[1] instead of joint[{selected_joints[1]}]"
+            )
+        else:
+            # The fix worked! We have the correct joint types
+            np.testing.assert_array_equal(
+                mjc_joint_types,
+                expected_mjc_types_fixed,
+                err_msg=f"MuJoCo should have joint types {expected_mjc_types_fixed} (free=0, hinge=3) after topological sort",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Fixes #562

This PR fixes a joint indexing bug in SolverMuJoCo that occurs when `selected_joints` is noncontiguous (e.g., when using `separate_envs_to_worlds=True` to filter joints by environment).

### The Bug
When processing selected joints, the code was incorrectly using the loop index `ji` directly to access joint data arrays:
```python
# Bug: using ji directly
joint_parent_xform[ji]
joint_type[ji]
joint_qd_start[ji]
# etc.
```

This caused the solver to use data from wrong joints. For example, if `selected_joints = [0, 2]`, when `ji=1`, the code would incorrectly access data from joint 1 instead of joint 2.

### The Fix
Added proper mapping from loop index to global joint index:
```python
# Fix: map to correct global joint index
j = selected_joints[ji]
joint_parent_xform[j]
joint_type[j]
joint_qd_start[j]
# etc.
```

### Testing
Added a comprehensive unit test `test_noncontiguous_joint_indexing` that:
- Creates a model with joints from alternating environments
- Uses `separate_envs_to_worlds=True` to create noncontiguous selected joints
- Verifies that MuJoCo receives the correct joint types (free vs revolute)
- Fails when the bug is present (all joints appear as revolute)
- Passes when the bug is fixed (correct mix of free and revolute joints)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed joint indexing in the MuJoCo solver to correctly handle noncontiguous joint selections across replicated environments, ensuring accurate joint types, DOF counts, and transforms for mixed free/revolute setups—improves multi-environment simulation correctness and stability.

- Tests
  - Added tests that validate noncontiguous joint indexing and joint type ordering across environments to prevent regressions and ensure solver correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->