### PR TITLE
Fixup H1 asset paths after asset refactor in asset repo

### DIFF
--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -53,7 +53,7 @@ class Example:
         h1.default_shape_cfg.mu = 0.75
 
         asset_path = newton.utils.download_asset("unitree_h1")
-        asset_file = str(asset_path / "usd" / "h1_minimal.usd")
+        asset_file = str(asset_path / "usd" / "h1_minimal.usda")
         h1.add_usd(
             asset_file,
             ignore_paths=["/GroundPlane"],

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -1061,7 +1061,7 @@ class TestImportSampleAssets(unittest.TestCase):
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_h1(self):
         builder = newton.ModelBuilder()
-        asset_path = str(newton.utils.download_asset("unitree_h1/usd") / "h1_minimal.usd")
+        asset_path = str(newton.utils.download_asset("unitree_h1/usd") / "h1_minimal.usda")
 
         builder.add_usd(
             asset_path,


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
With the USD asset refactor for H1, we need to change the example and import UT to use the new USDA file.

Asset-PR: https://github.com/newton-physics/newton-assets/pull/17

UTs pass if I run locally with the asset pull happening from my fork.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
