### PR TITLE
Add `merge_group` event to GitHub workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  merge_group:
   pull_request:
     branches:
       - main

--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -12,6 +12,7 @@ env:
   AWS_S3_BUCKET: newton-github-workflow-artifacts
 
 on:
+  merge_group:
   pull_request_target:
 
 # Cancels in-progress runs of this workflow for the same pull request,

--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -12,6 +12,7 @@ env:
   AWS_S3_BUCKET: newton-github-workflow-artifacts
 
 on:
+  merge_group:
   pull_request_target:
 
 # Cancels in-progress runs of this workflow for the same pull request,


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

To position Newton to adopt [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), we first need to update the workflow files to have the `merge_group` event trigger, which is explained in the documentation.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Continuous integration workflows now also run on merge group events in addition to pull request events.
  - Expanded triggers ensure pipelines execute for merge grouping without changing workflow steps or behavior.
  - No user-facing features or behavior changes included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->