### PR TITLE
Fix gravity display in ViewerGL

### DIFF
--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -852,7 +852,7 @@ class ViewerGL(ViewerBase):
                     imgui.text(f"Environments: {self.model.num_envs}")
                     axis_names = ["X", "Y", "Z"]
                     imgui.text(f"Up Axis: {axis_names[self.model.up_axis]}")
-                    gravity = self.model.gravity
+                    gravity = self.model.gravity.numpy()[0]
                     gravity_text = f"Gravity: ({gravity[0]:.2f}, {gravity[1]:.2f}, {gravity[2]:.2f})"
                     imgui.text(gravity_text)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

#804 introduced a bug in ViewerGL where the gravity display does not work anymore:
```
  File "newton/newton/_src/viewer/viewer_gl.py", line 455, in _update
    self._render_ui()
  File "newton/newton/_src/viewer/viewer_gl.py", line 815, in _render_ui
    self._render_left_panel()
  File "newton/newton/_src/viewer/viewer_gl.py", line 856, in _render_left_panel
    gravity_text = f"Gravity: ({gravity[0]:.2f}, {gravity[1]:.2f}, {gravity[2]:.2f})"
  File "warp/warp/types.py", line 2929, in __getitem__
    raise RuntimeError("Item indexing is not supported on wp.array objects")
RuntimeError: Item indexing is not supported on wp.array objects
```

This PR fixes it.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gravity value display in the viewer to show a proper numeric vector.
  * Resolved formatting/type issues that could cause incorrect or unreadable gravity output.
  * Improved consistency of gravity rendering across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->