### PR TITLE
Fix crashing issue in IsaacLab when trying to pick an object

### DIFF
--- a/newton/_src/viewer/picking.py
+++ b/newton/_src/viewer/picking.py
@@ -27,7 +27,7 @@ class Picking:
     Picking system.
 
     Allows to pick a body in the viewer by right clicking on it and dragging the mouse.
-    This can be used to move objects around in the viewer, a typical use case is to check solver resilience or
+    This can be used to move objects around in the viewer, a typical use case is to check for solver resilience or
     see how well a RL policy is coping with disturbances.
     """
 
@@ -195,9 +195,10 @@ class Picking:
         if dist < 1.0e10 and body_index >= 0:
             self.pick_dist = dist
 
-            # world space hit point
+            # Ensures that the ray direction and start point are vec3f objects
             d = wp.vec3f(d[0], d[1], d[2])
             p = wp.vec3f(p[0], p[1], p[2])
+            # world space hit point
             hit_point_world = p + d * float(dist)
 
             wp.launch(


### PR DESCRIPTION
## Description

In Isaaclab, right clicking on a robot will lead to a crash. This seems to come from that some of the data is in the pxr.Gf.Vec3 and not wp.vec3f which are not interoperable.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable and consistent object picking: fixes sporadic selection errors and incorrect hit-point calculations in complex scenes, reducing failed or inaccurate picks.

* **Documentation**
  * Clarified public API docs for picking controls, improving discoverability and predictability of selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->