### PR TITLE
Add pre-commit hook for `uv.lock`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
         args: [--fix] # Apply fixes to resolve lint violations.
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.8.22
+    hooks:
+      # Update the uv lockfile
+      - id: uv-lock


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This pull request adds the `uv-lock` hook mentioned in https://docs.astral.sh/uv/guides/integration/pre-commit/ to help with catching issues if someone modifies `pyproject.toml` dependencies without updating the uv lockfile.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated step to update dependency lockfiles during pre-commit checks, improving consistency and reliability across environments.
  * Enhances developer workflow by integrating lockfile maintenance into the existing pre-commit sequence.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->