### PR TITLE
Change gitlab CI to run UTs in parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -101,7 +101,7 @@ linting:
     - when: manual # If not auto-triggered, allow any pipeline to run this job manually
       allow_failure: true
   script:
-    - uv run --extra dev --extra torch-cu12 -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml --serial-fallback
+    - uv run --extra dev --extra torch-cu12 -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
 linux-x86_64 test:
   image: ghcr.io/astral-sh/uv:bookworm


### PR DESCRIPTION
## Description
Change the gitlab CI job to run UT in parallel.
This will be used as a test to judge its stability before to switch the github CI runs.
I opened a PR on gitlab to confirm that it is currently working.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration linting configuration by streamlining command options, with no changes to lint/test behavior.
  * No impact on application features, performance, or user experience.
  * Developer CI runs may be slightly more consistent; build and test steps remain the same.
  * Deployment artifacts and versioning are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->