### PR TITLE
Fix njmax setting on example_mpm_anymal

### DIFF
--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -216,7 +216,7 @@ class Example:
         mpm_model.setup_collider([self.collider_mesh], collider_friction=[0.5], collider_adhesion=[0.0])
 
         # setup solvers
-        self.solver = newton.solvers.SolverMuJoCo(self.model)
+        self.solver = newton.solvers.SolverMuJoCo(self.model, ls_parallel=True, njmax=50)
         self.mpm_solver = SolverImplicitMPM(mpm_model, mpm_options)
 
         # simulation state


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The MPM Anymal example now initializes the solver with parallel line-search and a maximum Newton step limit. This can reduce solve times and improve convergence robustness on supported hardware, leading to smoother and more reliable simulation runs without user configuration changes. Existing workflows continue to work as before. No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->