### PR TITLE
Improve docs

### DIFF
--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -23,7 +23,7 @@ To convert between these two representations we use forward and inverse kinemati
 forward kinematics (:func:`newton.eval_fk`) converts generalized coordinates to maximal coordinates, and inverse kinematics (:func:`newton.eval_ik`) converts maximal coordinates to generalized coordinates.
 
 In Newton, we support both parameterizations and it is up to the solver which one to use to read and write the configuration.
-For example, :class:`newton.solvers.SolverMuJoCo` and :class:`newton.solvers.SolverFeatherstone` use generalized coordinates, while :class:`newton.solvers.SolverXPBD` and :class:`newton.solvers.SolverSemiImplicit` use maximal coordinates.
+For example, :class:`~newton.solvers.SolverMuJoCo` and :class:`~newton.solvers.SolverFeatherstone` use generalized coordinates, while :class:`~newton.solvers.SolverXPBD` and :class:`~newton.solvers.SolverSemiImplicit` use maximal coordinates.
 
 When declaring an articulation using the :class:`~newton.ModelBuilder`, the rigid body poses (maximal coordinates :attr:`newton.State.body_q`) are initialized by the ``xform`` argument:
 

--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -20,7 +20,7 @@ Key Features
 ------------
 
 * **GPU-accelerated**: Leverages NVIDIA Warp for fast, scalable simulation.
-* **Multiple solver implementations** - XPBD, VBD, Mujoco, Featherstone, Euler
+* **Multiple solver implementations** - XPBD, VBD, MuJoCo, Featherstone, Euler
 * **Modular design** - Easily extendable with new solvers and components
 * **Differentiable**: Supports differentiable simulation for machine learning and optimization.
 * **Rich Import/Export**: Load models from URDF, MJCF, USD, and more.
@@ -36,13 +36,14 @@ High-Level Architecture
 -----------------------
 
 .. mermaid::
+   :config: {"theme": "forest"}
 
    graph TD
    A[ModelBuilder] -->|builds| B[Model]
    B --> C[State]
    C --> D[Solver]
    D --> C
-   B --> F[Renderer]
+   B --> F[Viewer]
    C --> F
    G[Importer] --> A
    I[Application] --> A
@@ -52,7 +53,7 @@ High-Level Architecture
 - **Model**: Encapsulates the physical structure, parameters, and configuration.
 - **State**: Represents the dynamic state (positions, velocities, etc.).
 - **Solver**: Advances the simulation by integrating physics.
-- **Renderer**: Visualizes the simulation in real-time or offline.
+- **Viewer**: Visualizes the simulation in real-time or offline.
 - **Importer**: Loads models from external formats (URDF, MJCF, USD).
 
 Quick Links


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
* Document maximal vs. generalized coordinates
* Use "forest" theme for mermaid diagram to improve legibility under dark theme:

<img width="1135" height="1015" alt="image" src="https://github.com/user-attachments/assets/a04879fd-3b5a-4b2a-b631-1b6fdf4413f6" />


## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
