### PR TITLE
Change AWS instance for PR CI job from g6e.xlarge to g6e.2xlarge

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -3,7 +3,7 @@ name: GPU Benchmarks
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.xlarge
+  AWS_INSTANCE_TYPE: g6e.2xlarge
   AWS_VOLUME_SIZE: 64
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a

--- a/.github/workflows/pr_aws_gpu_tests.yml
+++ b/.github/workflows/pr_aws_gpu_tests.yml
@@ -3,7 +3,7 @@ name: GPU Unit Tests on AWS EC2
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.xlarge
+  AWS_INSTANCE_TYPE: g6e.2xlarge
   AWS_VOLUME_SIZE: 64
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a


### PR DESCRIPTION
## Description
Change AWS instance for PR CI job from g6e.xlarge to g6e.2xlarge

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI GPU benchmark workflow to use a larger AWS GPU instance type (g6e.2xlarge).
  - Updated CI GPU test workflow to use a larger AWS GPU instance type (g6e.2xlarge).
- Tests
  - Test execution environment adjusted in CI; no changes to test definitions.
  - No user-facing functionality changes; only infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->