### PR TITLE
Change ASV CI job AWS instance from g6e.2xlarge to g6e.xlarge

### DIFF
--- a/.github/workflows/pr_aws_gpu_asv.yml
+++ b/.github/workflows/pr_aws_gpu_asv.yml
@@ -3,7 +3,7 @@ name: GPU Benchmarks
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.2xlarge
+  AWS_INSTANCE_TYPE: g6e.xlarge
   AWS_VOLUME_SIZE: 64
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a


### PR DESCRIPTION
## Description
Change ASV CI job AWS instance from g6e.2xlarge to g6e.xlarge

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GPU benchmark CI environment to use a new instance type, improving stability and maintaining coverage for automated performance checks on pull requests.
  * No changes to product functionality; end-user experience remains unchanged.
  * Benchmark results and release quality validations continue as before.
  * No action required from users; this update only affects internal build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->