### PR TITLE
[DRAFT] Add `Model.joint_act` that reads from `MjData.qfrc_actuator`

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -417,6 +417,7 @@ class ModelBuilder:
         self.joint_X_c = []  # frame of child com (in child coordinates)     (constant)
         self.joint_q = []
         self.joint_qd = []
+        self.joint_act = []
         self.joint_f = []
 
         self.joint_type = []
@@ -1101,6 +1102,7 @@ class ModelBuilder:
             "joint_dof_mode",
             "joint_key",
             "joint_qd",
+            "joint_act",
             "joint_f",
             "joint_target",
             "joint_limit_lower",
@@ -1336,6 +1338,7 @@ class ModelBuilder:
             self.joint_q.append(0.0)
         for _ in range(dof_count):
             self.joint_qd.append(0.0)
+            self.joint_act.append(0.0)
             self.joint_f.append(0.0)
 
         if joint_type == JointType.FREE or joint_type == JointType.DISTANCE or joint_type == JointType.BALL:
@@ -2084,6 +2087,7 @@ class ModelBuilder:
                 "type": self.joint_type[i],
                 "q": self.joint_q[q_start : q_start + q_dim],
                 "qd": self.joint_qd[qd_start : qd_start + qd_dim],
+                "act": self.joint_act[qd_start : qd_start + qd_dim],
                 "armature": self.joint_armature[qd_start : qd_start + qd_dim],
                 "q_start": q_start,
                 "qd_start": qd_start,
@@ -2277,6 +2281,7 @@ class ModelBuilder:
         self.joint_child.clear()
         self.joint_q.clear()
         self.joint_qd.clear()
+        self.joint_act.clear()
         self.joint_q_start.clear()
         self.joint_qd_start.clear()
         self.joint_enabled.clear()
@@ -4331,6 +4336,7 @@ class ModelBuilder:
             m.joint_target_kd = wp.array(self.joint_target_kd, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_dof_mode = wp.array(self.joint_dof_mode, dtype=wp.int32)
             m.joint_target = wp.array(self.joint_target, dtype=wp.float32, requires_grad=requires_grad)
+            m.joint_act = wp.array(self.joint_act, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_f = wp.array(self.joint_f, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_effort_limit = wp.array(self.joint_effort_limit, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_velocity_limit = wp.array(self.joint_velocity_limit, dtype=wp.float32, requires_grad=requires_grad)

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -226,6 +226,8 @@ class Model:
         """Generalized joint positions for state initialization, shape [joint_coord_count], float."""
         self.joint_qd = None
         """Generalized joint velocities for state initialization, shape [joint_dof_count], float."""
+        self.joint_act = None
+        """Generalized joint actuation for state initialization, shape [joint_dof_count], float."""
         self.joint_f = None
         """Generalized joint forces for state initialization, shape [joint_dof_count], float."""
         self.joint_target = None
@@ -405,6 +407,7 @@ class Model:
 
         # attributes per joint dof
         self.attribute_frequency["joint_qd"] = "joint_dof"
+        self.attribute_frequency["joint_act"] = "joint_dof"
         self.attribute_frequency["joint_f"] = "joint_dof"
         self.attribute_frequency["joint_armature"] = "joint_dof"
         self.attribute_frequency["joint_target"] = "joint_dof"
@@ -470,6 +473,7 @@ class Model:
         if self.joint_count:
             s.joint_q = wp.clone(self.joint_q, requires_grad=requires_grad)
             s.joint_qd = wp.clone(self.joint_qd, requires_grad=requires_grad)
+            s.joint_act = wp.clone(self.joint_act, requires_grad=requires_grad)
 
         return s
 

--- a/newton/_src/sim/state.py
+++ b/newton/_src/sim/state.py
@@ -61,6 +61,9 @@ class State:
         self.joint_qd: wp.array | None = None
         """Generalized joint velocity coordinates, shape (joint_dof_count,), dtype float."""
 
+        self.joint_act: wp.array | None = None
+        """Generalized joint actuation, shape (joint_dof_count,), dtype float."""
+
     def clear_forces(self) -> None:
         """
         Clear all force arrays (for particles and bodies) in the state object.


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Adds attribute `State.joint_act` to read actuation from `MjData.qfrc_actuator`. This PR is a draft to illustrate the current challenge of modifying (`ModelBuilder`, `Model`, `State`, `SolverMujoco`) in order to read attributes from `MjData` that are not currently supported in Newton.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-DOF joint activation (joint_act) across the builder, model, and state, enabling storage and retrieval of actuation values.
  - Included joint_act in model export and state cloning, keeping it aligned with joint positions and velocities.
  - Preserved joint_act through joint collapse/restore workflows.
  - Integrated actuator state with MuJoCo and MuJoCo Warp backends, synchronizing joint_act during coordinate conversions and state updates for consistent data exchange.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->