### PR TITLE
Add a GitLab job to test Newton against the latest Warp nightly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,9 +106,8 @@ linting:
 linux-x86_64 test:
   image: ghcr.io/astral-sh/uv:bookworm
   extends:
+    - .ipp_lnx_x86_64_gpu
     - .test_common
-  tags:
-    - lnx-x86_64-gpu-1x-570.158.01
 
 # TODO: mujoco load dll often fails on Windows, disabling
 .windows-x86_64 test:
@@ -123,13 +122,34 @@ linux-x86_64 test:
   tags:
     - win-x86_64-gpu-1x-573.42
 
+linux-x86_64 test warp nightly:
+  image: ghcr.io/astral-sh/uv:bookworm
+  extends:
+    - .ipp_lnx_x86_64_gpu
+  stage: test
+  needs: []
+  artifacts:
+    when: always
+    paths:
+      - rspec.xml
+    reports:
+      junit: rspec.xml
+  before_script:
+    - uv venv
+    - source .venv/bin/activate
+    - uv sync --extra dev --extra torch-cu12
+    - uv pip install -U --pre warp-lang
+  script:
+    - python -m newton.tests --junit-report-xml rspec.xml
+  allow_failure: true # TODO: Remove this after outstanding issues are resolved
+
 # --- Stage: Build ---
 build_package:
   stage: build
   image: ghcr.io/astral-sh/uv:bookworm
   needs: []
   extends:
-    - .omni_nvks_micro_runner
+    - .ipp_lnx_x86_64_cpu_micro
   script:
     - uv build --wheel
     - uvx twine check dist/*
@@ -143,7 +163,7 @@ build_package:
   image: ghcr.io/astral-sh/uv:bookworm
   needs: []
   extends:
-    - .omni_nvks_micro_runner
+    - .ipp_lnx_x86_64_cpu_micro
   artifacts:
     paths:
       - public
@@ -172,10 +192,10 @@ doctest:
   stage: docs
   image: ghcr.io/astral-sh/uv:bookworm
   needs: []
+  extends:
+    - .ipp_lnx_x86_64_gpu
   script:
     - uv run --extra docs sphinx-build -W -b doctest docs docs/_build/doctest
-  tags:
-    - lnx-x86_64-gpu-1x-570.158.01
 
 # Build documentation and publish on gitlab-master
 # This only runs in the default branch pipeline. The "pages" name is special for GitLab.


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This is just to help detect problems early on before someone tries to update Warp in the `uv.lock` file.

Yes, **GitLab**. I also updated the GitLab workflow file to use the new runner IPP runner tags.

~~`psutil` has been added to deal with some issues with the `recorder.py` in newer Warp versions. A self-checkout bug has been filed (5559463), and we can remove this dependency in the future if needed.~~

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing feature changes in this release.

- Tests
  - Expanded automated test coverage to include GPU-backed runs and nightly suites, improving reliability of performance-sensitive features.
  - Enhanced test reporting for clearer visibility into failures.

- Documentation
  - Improved documentation build pipeline for more consistent publication.

- Chores
  - CI pipeline optimized and standardized across environments to increase stability and reduce flakiness.
  - Refined job configurations to streamline builds and accelerate feedback without affecting application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->