### PR TITLE
Fix various typos in comments and docstrings

### DIFF
--- a/newton/_src/solvers/implicit_mpm/render_grains.py
+++ b/newton/_src/solvers/implicit_mpm/render_grains.py
@@ -170,7 +170,7 @@ def update_render_grains(
      1) a particle-local affine update using the particle velocity gradient and
         particle positions (APIC-like), and 2) a grid-based PIC advection using
         the current velocity field. After advection, positions are projected
-        back using an ellipsoidal appoximation of the particle defined by its
+        back using an ellipsoidal approximation of the particle defined by its
         deformation frame and ``particle_radius``.
 
     If no velocity field is available in the ``state`` the function

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -540,7 +540,7 @@ class ImplicitMPMOptions:
     yield_stress: float = 0.0
     """Yield stress for the plasticity model. (Pa)"""
     hardening: float = 0.0
-    """Hardening factor for the plasticity model (Mulltiplier for det(Fp))."""
+    """Hardening factor for the plasticity model (Multiplier for det(Fp))."""
     critical_fraction: float = 0.0
     """Fraction for particles under which the yield surface collapses."""
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2001,7 +2001,7 @@ class SolverMuJoCo(SolverBase):
         body_name_counts = {}
         joint_names = {}
 
-        # number of shapes which are replicated per env (exludes singular static shapes from a negative group)
+        # number of shapes which are replicated per env (excludes singular static shapes from a negative group)
         shape_range_len = 0
 
         if separate_envs_to_worlds:

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -44,7 +44,7 @@ class ViewerBase:
         # maps from geometry hash -> mesh path
         self._geometry_cache: dict[str, str] = {}
 
-        # line vertices for contact vizualization
+        # line vertices for contact visualization
         self._contact_points0 = None
         self._contact_points1 = None
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected minor typos and wording in internal docstrings and comments across simulation and viewer modules to improve clarity (e.g., “approximation,” “Multiplier,” “excludes,” “visualization”).
  * Clarified descriptive text related to rendering and hardening factor without altering intent.
  * No changes to behavior, public APIs, or configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->