### PR TITLE
Fix: Support X-up to Z-up rotation

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -149,6 +149,18 @@ The :meth:`newton.ModelBuilder.add_joint_free()` method now initializes the posi
 The universal and compound joints have been removed in favor of the more general D6 joint.
 
 
+Up-Axis Support
+---------------
+
+Newton now supports multiple up-axis conventions including X-up, Y-up, and Z-up. When using different up-axis conventions:
+
+- For X-up to Z-up conversion: position coordinates are transformed as ``(x, y, z) -> (-z, y, x)`` with a 90-degree rotation around the Y-axis
+- For Y-up to Z-up conversion: position coordinates are transformed as ``(x, y, z) -> (x, -z, y)`` with a 90-degree rotation around the X-axis  
+- For Z-up: no conversion is needed as it's the default convention
+
+This up-axis conversion is automatically applied when loading assets via importers and during simulation with the MuJoCo solver.
+
+
 Renderers
 ---------
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -320,9 +320,11 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                     mjc_pos = solver.mjw_model.body_ipos.numpy()[env_idx, mjc_idx]
 
                     # Convert positions based on up_axis
-                    if self.model.up_axis == 1:  # Y-axis up
+                    if self.model.up_axis == 0:  # X-axis up to Z-up: (x, y, z) -> (-z, y, x)
+                        expected_pos = np.array([-newton_pos[2], newton_pos[1], newton_pos[0]])
+                    elif self.model.up_axis == 1:  # Y-axis up to Z-up: (x, y, z) -> (x, -z, y)
                         expected_pos = np.array([newton_pos[0], -newton_pos[2], newton_pos[1]])
-                    else:  # Z-axis up
+                    else:  # Z-axis up: no conversion
                         expected_pos = newton_pos
 
                     for dim in range(3):
@@ -354,9 +356,11 @@ class TestMuJoCoSolverMassProperties(TestMuJoCoSolverPropertiesBase):
                     mjc_pos = solver.mjw_model.body_ipos.numpy()[env_idx, mjc_idx]
 
                     # Convert positions based on up_axis
-                    if self.model.up_axis == 1:  # Y-axis up
+                    if self.model.up_axis == 0:  # X-axis up to Z-up: (x, y, z) -> (-z, y, x)
+                        expected_pos = np.array([-newton_pos[2], newton_pos[1], newton_pos[0]])
+                    elif self.model.up_axis == 1:  # Y-axis up to Z-up: (x, y, z) -> (x, -z, y)
                         expected_pos = np.array([newton_pos[0], -newton_pos[2], newton_pos[1]])
-                    else:  # Z-axis up
+                    else:  # Z-axis up: no conversion
                         expected_pos = newton_pos
 
                     for dim in range(3):
@@ -806,7 +810,13 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 shape_body = shape_bodies[shape_idx]
 
                 # Handle up-axis conversion if needed
-                if self.model.up_axis == 1:  # Y-up to Z-up conversion
+                if self.model.up_axis == 0:  # X-up to Z-up: (x, y, z) -> (-z, y, x) with rotation around Y-axis
+                    # For static geoms, position conversion
+                    if shape_body == -1:
+                        expected_pos = wp.vec3(-expected_pos[2], expected_pos[1], expected_pos[0])
+                    rot_x2z = wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), -wp.pi * 0.5)
+                    expected_quat = rot_x2z * expected_quat
+                elif self.model.up_axis == 1:  # Y-up to Z-up: (x, y, z) -> (x, -z, y) with rotation around X-axis
                     # For static geoms, position conversion
                     if shape_body == -1:
                         expected_pos = wp.vec3(expected_pos[0], -expected_pos[2], expected_pos[1])
@@ -1015,7 +1025,12 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 shape_body = self.model.shape_body.numpy()[shape_idx]
 
                 # Handle up-axis conversion if needed
-                if self.model.up_axis == 1:  # Y-up to Z-up conversion
+                if self.model.up_axis == 0:  # X-up to Z-up: (x, y, z) -> (-z, y, x) with rotation around Y-axis
+                    if shape_body == -1:
+                        expected_pos = wp.vec3(-expected_pos[2], expected_pos[1], expected_pos[0])
+                    rot_x2z = wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), -wp.pi * 0.5)
+                    expected_quat = rot_x2z * expected_quat
+                elif self.model.up_axis == 1:  # Y-up to Z-up: (x, y, z) -> (x, -z, y) with rotation around X-axis
                     if shape_body == -1:
                         expected_pos = wp.vec3(expected_pos[0], -expected_pos[2], expected_pos[1])
                     rot_y2z = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), -wp.pi * 0.5)

--- a/newton/tests/test_up_axis.py
+++ b/newton/tests/test_up_axis.py
@@ -83,6 +83,14 @@ for device in devices:
             solver_fn=solver_fn,
             up_axis=newton.Axis.Z,
         )
+        add_function_test(
+            TestControlForce,
+            f"test_gravity_x_up_{solver_name}",
+            test_gravity,
+            devices=[device],
+            solver_fn=solver_fn,
+            up_axis=newton.Axis.X,
+        )
 
 if __name__ == "__main__":
     wp.clear_kernel_cache()


### PR DESCRIPTION

## Description
Adds support for `X-up → Z-up` conversion alongside existing `Y-up → Z-up`.
Introduces a shared `convert_up_axis()` helper for quaternion and position transforms.
- Handles all up_axis values (0, 1, 2) uniformly.
- Refactors redundant conversion logic.
- Closes #229.

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date


- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
