### PR TITLE
Skip the stdout check in `test_model_and_state_recorder_binary`

### DIFF
--- a/newton/tests/test_recorder.py
+++ b/newton/tests/test_recorder.py
@@ -404,6 +404,7 @@ add_function_test(
     "test_model_and_state_recorder_binary",
     test_model_and_state_recorder_binary,
     devices=devices,
+    check_output=False,  # Ignore "Please install 'psutil'" UserWarning
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is to avoid future issues with updating Warp

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Newer versions of Warp will throw a `UserWarning` when `Device.free_memory` is accessed for a CPU device. This causes issues in the `test_model_and_state_recorder_binary` test when `transfer_to_model()` is called and we hit the line `target_value = getattr(target_obj, attr_name)`.

This pull request disables the check for that test that fails if anything is detected in the `sys.stdout` stream.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted a test to suppress a known system library warning, resulting in cleaner test output and more reliable CI runs. No user-facing or functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->