### PR TITLE
Tentative fix for flaky mpm_anymal test (GH-918)

### DIFF
--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -312,10 +312,11 @@ class Example:
             lambda q, qd: newton.utils.vec_inside_limits(qd, forward_vel_min, forward_vel_max),
             indices=[0],
         )
+        voxel_size = self.mpm_solver.mpm_model.voxel_size
         newton.examples.test_particle_state(
             self.state_0,
             "all particles are above the ground",
-            lambda q, qd: q[2] > -0.02,
+            lambda q, qd: q[2] >= -voxel_size,
         )
 
     def render(self):


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ground contact detection in the MPM Anymal example by switching from a fixed threshold to a voxel-size-based threshold, making collisions more accurate across simulation resolutions and reducing false positives/negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->