### PR TITLE
Avoid using private imports in cloth examples

### DIFF
--- a/newton/_src/solvers/style3d/solver_style3d.py
+++ b/newton/_src/solvers/style3d/solver_style3d.py
@@ -20,6 +20,7 @@ import warp as wp
 from ...sim import Contacts, Control, State, Style3DModel, Style3DModelBuilder
 from ..solver import SolverBase
 from .builder import PDMatrixBuilder
+from .collision import Collision
 from .kernels import (
     accumulate_dragging_pd_diag_kernel,
     eval_bend_kernel,
@@ -65,7 +66,6 @@ class SolverStyle3D(SolverBase):
     def __init__(
         self,
         model: Style3DModel,
-        collision_handler=None,
         iterations=10,
         linear_iterations=10,
         drag_spring_stiff: float = 1e2,
@@ -74,8 +74,6 @@ class SolverStyle3D(SolverBase):
         """
         Args:
             model: The `Style3DModel` to integrate.
-            collision_handler (CollisionHandler or None, optional):
-                Handles collision detection and response. If `None`, collision handling will be disabled.
             iterations: Number of non-linear iterations per step.
             linear_iterations: Number of linear iterations (currently PCG iter) per non-linear iteration.
             drag_spring_stiff: The stiffness of spring connecting barycentric-weighted drag-point and target-point.
@@ -84,7 +82,7 @@ class SolverStyle3D(SolverBase):
 
         super().__init__(model)
         self.style3d_model = model
-        self.collision = collision_handler
+        self.collision = Collision(model)  # set None to disable
         self.linear_iterations = linear_iterations
         self.nonlinear_iterations = iterations
         self.drag_spring_stiff = drag_spring_stiff

--- a/newton/examples/cloth/example_cloth_h1.py
+++ b/newton/examples/cloth/example_cloth_h1.py
@@ -34,7 +34,6 @@ import newton
 import newton.examples
 import newton.ik as ik
 import newton.utils
-from newton._src.solvers.style3d import Collision
 
 
 class Example:
@@ -185,15 +184,12 @@ class Example:
         # ------------------------------------------------------------------
         # Cloth solver
         # ------------------------------------------------------------------
-        collision_handler = Collision(self.model)
-        collision_handler.radius = 3.5e-3
-
         self.cloth_solver = newton.solvers.SolverStyle3D(
             model=self.model,
             iterations=self.iterations,
-            collision_handler=collision_handler,
         )
         self.cloth_solver.precompute(h1)
+        self.cloth_solver.collision.radius = 3.5e-3
         self.control = self.model.control()
         self.contacts = self.model.collide(self.state)
         self.shape_flags = self.model.shape_flags.numpy()

--- a/newton/examples/cloth/example_cloth_hanging.py
+++ b/newton/examples/cloth/example_cloth_hanging.py
@@ -186,7 +186,6 @@ class Example:
 
     def test(self):
         if self.solver_type != "style3d":
-            # TODO(Style3D): handle ground collisions
             newton.examples.test_particle_state(
                 self.state_0,
                 "particles are above the ground",

--- a/newton/examples/cloth/example_cloth_style3d.py
+++ b/newton/examples/cloth/example_cloth_style3d.py
@@ -21,7 +21,6 @@ import newton
 import newton.examples
 import newton.utils
 from newton import Mesh, ParticleFlags
-from newton._src.solvers.style3d import Collision
 
 
 class Example:
@@ -129,8 +128,6 @@ class Example:
         self.solver = newton.solvers.SolverStyle3D(
             model=self.model,
             iterations=self.iterations,
-            collision_handler=Collision(self.model),
-            # collision_handler = CollisionHandler(self.model),
         )
         self.solver.precompute(
             builder,


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Avoid using private imports in the cloth examples that are relative to the Style3D solver.​

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified collision handling in the Style3D solver: collisions are now always enabled and managed internally.
  * Constructor no longer accepts an external collision handler; configure collision via solver.collision (e.g., radius) after initialization.

* **Chores**
  * Updated cloth examples to align with the new API: removed explicit collision handler creation/imports and set collision radius post-construction.
  * Cleaned up an outdated comment in a hanging cloth example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->