### PR TITLE
[WIP] Add swizzling overhead benchmark

### DIFF
--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -243,7 +243,7 @@ class _SwizzleBenchmark:
             for _ in range(self.num_frames):
                 self.step()
 
-            swizzle_overhead = 100.0 * self.overhead_time / (self.overhead_time + self.step_time)
+        swizzle_overhead = 100.0 * self.overhead_time / (self.overhead_time + self.step_time)
 
         return swizzle_overhead
 


### PR DESCRIPTION
## Description
- Adding a new benchmark to measure the swizzling overhead of Newton

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swizzle benchmarking that reports swizzling overhead alongside step timing.
  * Introduced a graph-capture timing path measuring control, pre-step, step, and post-step phases.
  * New swizzle benchmark variants are registered and runnable via existing benchmark interfaces with per-environment graph-based execution.

* **Chores**
  * Updated KPI benchmark parameter formats to nested lists for compatibility with new variants.
  * Retains graceful fallback when graph capture is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->