### PR TITLE
Round the computed world offsets/spacing to closest bigger integer #983

### DIFF
--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -185,7 +185,7 @@ class ViewerBase:
         margin = 1.5  # 50% margin between worlds
 
         # Default to 2D square grid arrangement perpendicular to up axis
-        spacing = [max(max_extents) * margin] * 3
+        spacing = [np.ceil(max(max_extents) * margin)] * 3
         spacing[self.model.up_axis] = 0.0
 
         # Set world offsets with computed spacing

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -144,7 +144,6 @@ class Example:
         self.contacts = self.model.collide(self.state_0)
 
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((1.0, 1.0, 0.0))
 
         self.capture()
 

--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -95,7 +95,6 @@ class Example:
 
         # ensure this is called at the end of the Example constructor
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((3.0, 3.0, 0.0))
 
         # put graph capture into it's own function
         self.capture()

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -92,7 +92,6 @@ class Example:
         self.contacts = self.model.collide(self.state_0)
 
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((3.0, 3.0, 0.0))
 
         self.capture()
 

--- a/newton/examples/robot/example_robot_humanoid.py
+++ b/newton/examples/robot/example_robot_humanoid.py
@@ -75,7 +75,6 @@ class Example:
         self.contacts = self.model.collide(self.state_0)
 
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((3.0, 3.0, 0.0))
 
         self.capture()
 

--- a/newton/examples/selection/example_selection_articulations.py
+++ b/newton/examples/selection/example_selection_articulations.py
@@ -188,7 +188,6 @@ class Example:
             wp.launch(init_masks, dim=num_worlds, inputs=[self.mask_0, self.mask_1])
 
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((4.0, 4.0, 0.0))
 
         # reset all
         self.reset()

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -139,7 +139,6 @@ class Example:
         self.solver = newton.solvers.SolverMuJoCo(self.model, njmax=100, ncon_per_world=100)
 
         self.viewer.set_model(self.model)
-        self.viewer.set_world_offsets((4.0, 4.0, 0.0))
 
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

- Added np.ceil() in auto-computing world spacing in viewer.
- Removed viewer.set_world_offsets() from examples where manually set spacing was the same as auto-computed.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the viewer's world offset computation to use refined spacing calculations based on maximum extents, improving default world frame positioning
  * Streamlined initialization across all robot and sensor examples by removing manual world offset configuration; examples now rely on automatic default positioning for proper camera alignment and world frame placement during rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->