### PR TITLE
Fix randomize option in bench_mujoco.py

### DIFF
--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -45,7 +45,9 @@ class _FastBenchmark:
 
     def setup(self):
         if not hasattr(self, "builder") or self.builder is None:
-            self.builder = Example.create_model_builder(self.robot, self.num_worlds, randomize=self.random_init, seed=123)
+            self.builder = Example.create_model_builder(
+                self.robot, self.num_worlds, randomize=self.random_init, seed=123
+            )
 
         self.example = Example(
             stage_path=None,
@@ -100,7 +102,9 @@ class _KpiBenchmark:
         if not hasattr(self, "builder") or self.builder is None:
             self.builder = {}
         if num_worlds not in self.builder:
-            self.builder[num_worlds] = Example.create_model_builder(self.robot, num_worlds, randomize=self.random_init, seed=123)
+            self.builder[num_worlds] = Example.create_model_builder(
+                self.robot, num_worlds, randomize=self.random_init, seed=123
+            )
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def track_simulate(self, num_worlds):


### PR DESCRIPTION
## Description
- Fixed the randomize option in bench_mujoco.py

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
