### PR TITLE
Tentative fix for mpm flakiness using voxel_size-based tols

### DIFF
--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -299,10 +299,11 @@ class Example:
             lambda q, qd: newton.utils.vec_inside_limits(qd, forward_vel_min, forward_vel_max),
             indices=[0],
         )
+        voxel_size = self.mpm_solver.mpm_model.voxel_size
         newton.examples.test_particle_state(
             self.state_0,
             "all particles are above the ground",
-            lambda q, qd: q[2] > -0.03,
+            lambda q, qd: q[2] > -voxel_size,
         )
 
     def render(self):

--- a/newton/examples/mpm/example_mpm_granular.py
+++ b/newton/examples/mpm/example_mpm_granular.py
@@ -113,10 +113,11 @@ class Example:
         self.sim_time += self.frame_dt
 
     def test(self):
+        voxel_size = self.solver.mpm_model.voxel_size
         newton.examples.test_particle_state(
             self.state_0,
             "all particles are above the ground",
-            lambda q, qd: q[2] > -0.05,
+            lambda q, qd: q[2] > -voxel_size,
         )
         cube_extents = wp.vec3(0.5, 2.0, 0.6) * 0.9
         cube_center = wp.vec3(0.75, 0, 0.9)

--- a/newton/examples/mpm/example_mpm_twoway_coupling.py
+++ b/newton/examples/mpm/example_mpm_twoway_coupling.py
@@ -278,10 +278,11 @@ class Example:
             "all bodies are above the sand",
             lambda q, qd: q[2] > 0.45,
         )
+        voxel_size = self.mpm_solver.mpm_model.voxel_size
         newton.examples.test_particle_state(
             self.sand_state_0,
             "all particles are above the ground",
-            lambda q, qd: q[2] > -0.05,
+            lambda q, qd: q[2] > -voxel_size,
         )
 
     def render(self):


### PR DESCRIPTION

## Description
Tentative for #1015 by using test tolerances based on the sim voxel size

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ground-boundary detection in MPM example simulations now uses the solver's voxel size instead of fixed vertical thresholds, improving particle ground classification and consistency across simulation resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->