### PR TITLE
Add option to show inertia boxes in viewer (#563)

### DIFF
--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -43,6 +43,9 @@ class ViewerBase:
         # map from shape hash -> Instances
         self._shape_instances = {}
 
+        # inertia box instances -- created on-demand
+        self._inertia_box_instances: ViewerBase.ShapeInstances | None = None
+
         # cache for geometry created via log_shapes()
         # maps from geometry hash -> mesh path
         self._geometry_cache: dict[str, str] = {}
@@ -69,6 +72,7 @@ class ViewerBase:
         self.show_collision = False  # force show collision shapes
         self.show_visual = True  # show visual shapes (non collider)
         self.show_static = False  # force static shapes to be visible
+        self.show_inertia_boxes = False
 
     def is_running(self) -> bool:
         return True
@@ -215,6 +219,24 @@ class ViewerBase:
                 shapes.colors if self.model_changed else None,
                 shapes.materials if self.model_changed else None,
                 hidden=not visible,
+            )
+
+        # update inertia box transforms if visible
+        if self.show_inertia_boxes:
+            if self._inertia_box_instances is None:
+                # create instance batch on-demand
+                self._populate_inertia_boxes()
+            self._inertia_box_instances.update(state, world_offsets=self.world_offsets)
+
+        if self._inertia_box_instances is not None:
+            self.log_instances(
+                self._inertia_box_instances.name,
+                self._inertia_box_instances.mesh,
+                self._inertia_box_instances.world_xforms,
+                self._inertia_box_instances.scales,
+                self._inertia_box_instances.colors,
+                self._inertia_box_instances.materials,
+                hidden=not self.show_inertia_boxes,
             )
 
         self._log_triangles(state)
@@ -745,6 +767,64 @@ class ViewerBase:
         # upload all batches to the GPU
         for batch in self._shape_instances.values():
             batch.finalize()
+
+    # creates meshes and instances for each shape in the Model
+    def _populate_inertia_boxes(self):
+        # convert to NumPy
+        body_count = self.model.body_count
+        body_inertia = self.model.body_inertia.numpy()
+        body_inv_mass = self.model.body_inv_mass.numpy()
+        body_com = self.model.body_com.numpy()
+        body_world = self.model.body_world.numpy()
+
+        scale = (1.0, 1.0, 1.0)
+        thickness = 0.0
+        is_solid = True
+        geo_src = None
+        geo_args = (newton.GeoType.BOX, scale, thickness, is_solid, geo_src)
+        geo_hash = self._hash_geometry(*geo_args)
+        if geo_hash not in self._geometry_cache:
+            mesh_name = self._populate_geometry(*geo_args)
+        else:
+            mesh_name = self._geometry_cache[geo_hash]
+
+        static = False
+        flags = newton.ShapeFlags.VISIBLE
+
+        shape_name = "/model/inertia_boxes"
+        batch = ViewerBase.ShapeInstances(shape_name, static, flags, mesh_name, self.device)
+
+        # loop over bodys
+        for body in range(body_count):
+            rot, principal_inertia = wp.eig3(wp.mat33(body_inertia[body]))
+            xform = wp.transform(body_com[body], wp.quat_from_matrix(rot))
+
+            # computes extents of the solid box that would have similar inertia
+            # Note: GeoType.BOX exemplar has sides of length 2.0
+            box_inertia = principal_inertia * body_inv_mass[body] * (12 / 8.0)
+            scale = (
+                np.sqrt(box_inertia[2] + box_inertia[1] - box_inertia[0]),
+                np.sqrt(box_inertia[0] + box_inertia[2] - box_inertia[1]),
+                np.sqrt(box_inertia[1] + box_inertia[0] - box_inertia[2]),
+            )
+
+            # shape options
+            parent = body
+
+            color = self._shape_color_map(body)
+            if color is None:
+                color = wp.vec3(0.5, 0.5, 0.5)
+            else:
+                color = wp.vec3(color)
+
+            material = wp.vec4(0.5, 0.0, 0.0, 0.0)  # roughness, metallic, checker, unused
+
+            # add render instance
+            batch.add(parent, xform, scale, color, material, body_world[body])
+
+        # batch to the GPU
+        batch.finalize()
+        self._inertia_box_instances = batch
 
     def _log_joints(self, state):
         """

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -1085,6 +1085,10 @@ class ViewerGL(ViewerBase):
                     show_visual = self.show_visual
                     changed, self.show_visual = imgui.checkbox("Show Visual", show_visual)
 
+                    # Inertia boxes toggle
+                    show_inertia_boxes = self.show_inertia_boxes
+                    changed, self.show_inertia_boxes = imgui.checkbox("Show Inertia Boxes", show_inertia_boxes)
+
             imgui.set_next_item_open(True, imgui.Cond_.appearing)
             if imgui.collapsing_header("Example Options"):
                 # Render UI callbacks for side panel


### PR DESCRIPTION
## Description

Implement #563 : show equivalent solid boxes that would give same inertia as simulated bodies
<img width="480" height="633" alt="Screenshot from 2025-11-12 16-02-36" src="https://github.com/user-attachments/assets/1c5856cd-8681-42da-88a4-26d5bd4a0af2" />

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to toggle inertia box visualization in the viewer
  * "Show Inertia Boxes" checkbox now available in the Visualization panel for rendering inertia boxes alongside shapes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->