### PR TITLE
Add a GitHub workflow to Newton against the latest nightly Warp version

### DIFF
--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -1,0 +1,162 @@
+name: Newton + Warp Nightly Builds
+
+# This workflow runs daily to test Newton with the latest nightly warp-lang builds.
+# It uses machulav/ec2-github-runner to spin up GPU instances on AWS EC2.
+# Scheduled workflows automatically run on the default branch (main).
+#
+# The workflow first checks if there's a new warp-lang nightly build by running
+# 'uv lock -P warp-lang' on a standard GitHub runner. Only if a new version is detected
+# will it spin up an expensive EC2 GPU instance to run the full test suite.
+
+# Workflow configuration variables
+env:
+  AWS_REGION: us-east-2
+  AWS_INSTANCE_TYPE: g6e.2xlarge
+  AWS_VOLUME_SIZE: 92
+  AWS_VOLUME_TYPE: gp3
+  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
+  AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
+  AWS_ROLE_DURATION: 1800
+
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 8 AM UTC (midnight PST)
+  workflow_dispatch:  # Allow manual triggers
+
+jobs:
+  check-warp-update:
+    name: Check for new warp-lang nightly build
+    if: github.repository == 'newton-physics/newton'
+    runs-on: ubuntu-latest
+    outputs:
+      warp-updated: ${{ steps.check-update.outputs.warp-updated }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca
+        with:
+          version: "0.9.0"
+
+      - name: Update warp-lang in lock file
+        run: uv lock -P warp-lang
+
+      - name: Check if warp-lang version changed
+        id: check-update
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "No new warp-lang nightly build detected"
+            echo "warp-updated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "New warp-lang nightly build detected!"
+            echo "warp-updated=true" >> "$GITHUB_OUTPUT"
+            echo "Current warp-lang dependency tree:"
+            uv tree --package warp-lang
+          fi
+
+  start-runner:
+    name: Start self-hosted EC2 runner
+    needs: check-warp-update
+    if: needs.check-warp-update.outputs.warp-updated == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
+      - name: Get the latest AWS Deep Learning Base GPU AMI
+        run: |
+          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
+          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
+            --owners amazon \
+            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
+            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
+            --output text)
+          if [[ -z "$LATEST_AMI_ID" ]]; then
+            echo "❌ No AMI ID found. Exiting."
+            exit 1
+          fi
+          echo "Latest AMI ID found: $LATEST_AMI_ID"
+          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ env.LATEST_AMI_ID }}
+          ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
+          subnet-id: subnet-051b9d2e71acf8047
+          security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "ec2-github-runner"},
+              {"Key": "created-by", "Value": "github-actions-newton-role"},
+              {"Key": "GitHub-Repository", "Value": "${{ github.repository }}"}
+            ]
+
+  nightly-warp-tests:
+    name: Run Tests with Warp Nightly Build
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+    env:
+      HOME: /actions-runner
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca
+        with:
+          version: "0.9.0"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Update lock file with latest warp-lang nightly build
+        run: uv lock -P warp-lang
+
+      - name: Run Tests
+        run: uv run --extra dev --extra torch-cu12 -m newton.tests --junit-report-xml rspec.xml
+
+      - name: Test Summary
+        if: ${{ !cancelled() }}
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+
+  stop-runner:
+    name: Stop self-hosted EC2 runner
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs:
+      - start-runner
+      - nightly-warp-tests
+    if: always() && needs.start-runner.result != 'skipped' && github.repository == 'newton-physics/newton'
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
+
+      - name: Stop EC2 runner
+        uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512
+        with:
+          mode: stop
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

As part of the efforts to move all our CI/CD over to GitHub, we need to add a job that does the same thing as the job we ran on the internal GitLab instance to test Newton against the most recent nightly Warp build.

There are also some cost-saving optimizations to skip the scheduled job if Newton is already testing with the latest nightly build of Warp.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated nightly testing pipeline to improve continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->