### PR TITLE
Trigger release workflow only on tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,13 @@
-name: Release Publishing to PyPI
+name: Release
 
-on: push
+# This workflow runs when a tag is pushed.
+# The publish-to-pypi job requires manual approval via the 'pypi' environment protection rules
+# configured in Settings > Environments > pypi.
+
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build:
@@ -18,10 +25,8 @@ jobs:
         with:
           version: "0.9.0"
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-      - name: Build a binary wheel and a source tarball
+        run: uv python install
+      - name: Build a binary wheel
         run: uv build --wheel
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
@@ -31,7 +36,7 @@ jobs:
 
   publish-to-pypi:
     name: Publish Python distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'newton-physics/newton'
+    if: github.repository == 'newton-physics/newton'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -51,7 +56,7 @@ jobs:
 
   create-github-release:
     name: Create GitHub Release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'newton-physics/newton'
     needs:
       - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update release.yml to run only when tags are pushed instead of all pushes, eliminating skipped job noise. Also rename workflow and add repository check for consistency.

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

I didn't like seeing these "job skipped" messages in our workflows due to the way the checks were done. This should eliminate the noise.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow configuration to refine the build and publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->