### PR TITLE
Update `warp-lang` to `1.11.0.dev20251115`

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.11.0.dev20251111 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.11.0.dev20251115 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.3.8.dev832233427 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129",
     "python -m pip install git+https://github.com/google-deepmind/mujoco_warp@bf1c0ca5ab3276cf0a8fce012edcdbdf0d8848a2",

--- a/uv.lock
+++ b/uv.lock
@@ -3850,17 +3850,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.11.0.dev20251111"
+version = "1.11.0.dev20251115"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251111-py3-none-macosx_11_0_arm64.whl", hash = "sha256:033cb7d65e9fa8d8dad86c2ea6c4ac77827c7fcce4a7d2a6e6dc8e2853333da0" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251111-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f098bd77e44aa81282c635d352fb02aa1ca42be7bab0a926fb5fe97a22457e64" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251111-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a3e297bb7d49c4e39990e95b7614d9a9b7c7f5d2e5a8d6424d4047979d932d0a" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251111-py3-none-win_amd64.whl", hash = "sha256:e585a3c17e991f872704a13d3b149f3fc781494f9ed83c20df55ea916a1f8e08" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6c7bb4161870be27cd5a4a2f85392b9f06265bf15256c5d849a05e9a7e5f0c2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a3ddda2336e228e080f96cf1e2a9c1a35b30297e66518589cd9a04f1c496e988" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3ce6c2490447c3e4a5632aee2cb51506011929404dcb6d9885fb0e394e8578e2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.11.0.dev20251115-py3-none-win_amd64.whl", hash = "sha256:b14e7f24693efdc59d4fba2104edb3c1de24cfcdf5d5cd8d0e4454e00fa406ea" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Contains a fix for `.pch` files ending up in the current working directory (temporarily before they're automatically deleted).

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated warp-lang prerelease version in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->