### PR TITLE
Update nightly test schedule to run at 3 AM instead of midnight (PST)

### DIFF
--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -20,7 +20,7 @@ env:
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Daily at 8 AM UTC (midnight PST)
+    - cron: '0 11 * * *'  # Daily at 11 AM UTC (3 AM PST)
   workflow_dispatch:  # Allow manual triggers
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This should better align with the creation and publishing of new Warp nightly builds. Currently the midnight execution of the workflow means it happens before a new Warp nightly build is published.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scheduled timing for automated test runs from 8:00 UTC to 11:00 UTC daily.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->