### PR TITLE
[Warp Raytrace] Support for custom clear color/depth

### DIFF
--- a/asv/benchmarks/simulation/bench_tiled_camera_sensor.py
+++ b/asv/benchmarks/simulation/bench_tiled_camera_sensor.py
@@ -108,7 +108,8 @@ class TiledCameraSensorBenchmark:
                     self.color_image,
                     self.depth_image,
                     refit_bvh=False,
-                    clear_images=False,
+                    clear_color=None,
+                    clear_depth=None,
                 )
         self.timings["render_pixel"] = timer.elapsed
 
@@ -126,7 +127,8 @@ class TiledCameraSensorBenchmark:
                     self.color_image,
                     self.depth_image,
                     refit_bvh=False,
-                    clear_images=False,
+                    clear_color=None,
+                    clear_depth=None,
                 )
         self.timings["render_tiled"] = timer.elapsed
 

--- a/newton/_src/sensors/tiled_camera_sensor.py
+++ b/newton/_src/sensors/tiled_camera_sensor.py
@@ -319,7 +319,8 @@ class TiledCameraSensor:
         color_image: wp.array(dtype=wp.uint32, ndim=3) | None = None,
         depth_image: wp.array(dtype=wp.float32, ndim=3) | None = None,
         refit_bvh: bool = True,
-        clear_images: bool = True,
+        clear_color: int | None = 0xFF666666,
+        clear_depth: float | None = 0.0,
     ):
         """
         Render color and depth images for all worlds and cameras.
@@ -334,7 +335,8 @@ class TiledCameraSensor:
             depth_image: Optional output array for depth data (num_worlds, num_cameras, width*height).
                         If None, no depth rendering is performed.
             refit_bvh: Whether to refit the BVH or not.
-            clear_images: Whether to clear the images before rendering or not.
+            clear_color: The color to clear the color image with (or skip if None).
+            clear_depth: The value to clear the depth image with (or skip if None).
         """
         if state is not None:
             self.update_from_state(state)
@@ -346,7 +348,8 @@ class TiledCameraSensor:
             color_image,
             depth_image,
             refit_bvh=refit_bvh,
-            clear_images=clear_images,
+            clear_color=clear_color,
+            clear_depth=clear_depth,
         )
 
     def compute_pinhole_camera_rays(

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -25,9 +25,6 @@ if TYPE_CHECKING:
     from .render_context import RenderContext
 
 
-BACKGROUND_COLOR = 255 << 24 | int(0.4 * 255.0) << 16 | int(0.4 * 255.0) << 8 | int(0.4 * 255.0)
-
-
 @wp.func
 def tid_to_tile_coord(tid: wp.int32, num_worlds: wp.int32, num_cameras: wp.int32, tile_size: wp.int32, width: wp.int32):
     num_views_per_pixel = num_worlds * num_cameras
@@ -311,18 +308,18 @@ def render_megakernel(
     camera_rays: wp.array(dtype=wp.vec3f, ndim=4),
     color_image: wp.array(dtype=wp.uint32, ndim=3) | None = None,
     depth_image: wp.array(dtype=wp.float32, ndim=3) | None = None,
-    clear_images: bool = True,
+    clear_color: int | None = 0,
+    clear_depth: float | None = 0.0,
 ):
     if rc.tile_rendering:
         assert rc.width % rc.tile_size == 0, "render width must be a multiple of tile_size"
         assert rc.height % rc.tile_size == 0, "render height must be a multiple of tile_size"
 
-    if clear_images:
-        if color_image is not None:
-            color_image.fill_(wp.uint32(BACKGROUND_COLOR))
+    if clear_color is not None and color_image is not None:
+        color_image.fill_(wp.uint32(clear_color))
 
-        if depth_image is not None:
-            depth_image.fill_(wp.float32(0.0))
+    if clear_depth is not None and depth_image is not None:
+        depth_image.fill_(wp.float32(clear_depth))
 
     wp.launch(
         kernel=_render_megakernel,

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -174,13 +174,21 @@ class RenderContext:
         color_image: wp.array(dtype=wp.uint32, ndim=3) | None = None,
         depth_image: wp.array(dtype=wp.float32, ndim=3) | None = None,
         refit_bvh: bool = True,
-        clear_images: bool = True,
+        clear_color: int | None = 0,
+        clear_depth: float | None = 0.0,
     ):
         if self.has_geometries or self.has_particles or self.has_triangle_mesh:
             if refit_bvh:
                 self.refit_bvh()
             render_megakernel(
-                self, camera_positions, camera_orientations, camera_rays, color_image, depth_image, clear_images
+                self,
+                camera_positions,
+                camera_orientations,
+                camera_rays,
+                color_image,
+                depth_image,
+                clear_color,
+                clear_depth,
             )
 
     def __compute_bvh_geom_bounds(self):


### PR DESCRIPTION
Support for custom clear color/depth in the Warp Raytrace renderer

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated rendering pipeline to use separate color and depth buffer clearing parameters instead of a unified control flag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->