### PR TITLE
Add `arange` to `extend-words`, don't autofix `typos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,4 @@ repos:
     rev: v1.38.1
     hooks:
       - id: typos
+        args: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ reportUnusedCallResult = false
 files.extend-exclude = ["/examples/assets", "*.urdf", "*.usd", "*.usda", "*.mjcf"]
 
 [tool.typos.default.extend-words]
+arange = "arange"
 ba = "ba"
 HAA = "HAA"
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

- Update the `pre-commit` hook so that typos are not automatically fixed by `typos`
- Add `arange` to the `[tool.typos.default.extend-words]` section in `pyproject.toml`

Closes #1249

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell-checking tool configuration to refine dictionary settings and ensure consistent hook configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->