### PR TITLE
Fix XPBD velocity target control

### DIFF
--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -1887,7 +1887,8 @@ def solve_body_joints(
             damping = 0.0
 
             target_vel = axis_target_vel[dim]
-            derr_rel = derr - target_vel
+            angular_c_len = wp.length(angular_c)
+            derr_rel = derr - target_vel * angular_c_len
 
             # consider joint limits irrespective of mode
             lower = axis_limits_lower[dim]

--- a/newton/tests/test_joint_controllers.py
+++ b/newton/tests/test_joint_controllers.py
@@ -310,21 +310,19 @@ for device in devices:
             target_ke=2000.0,
             target_kd=500.0,
         )
-        # TODO: XPBD velocity control is not working correctly
-        if solver_name != "xpbd":
-            add_function_test(
-                TestJointController,
-                f"test_revolute_joint_controller_velocity_target_{solver_name}",
-                test_revolute_controller,
-                devices=[device],
-                solver_fn=solver_fn,
-                pos_target_val=0.0,
-                vel_target_val=wp.pi / 2.0,
-                expected_pos=None,
-                expected_vel=wp.pi / 2.0,
-                target_ke=0.0,
-                target_kd=500.0,
-            )
+        add_function_test(
+            TestJointController,
+            f"test_revolute_joint_controller_velocity_target_{solver_name}",
+            test_revolute_controller,
+            devices=[device],
+            solver_fn=solver_fn,
+            pos_target_val=0.0,
+            vel_target_val=wp.pi / 2.0,
+            expected_pos=None,
+            expected_vel=wp.pi / 2.0,
+            target_ke=0.0,
+            target_kd=500.0,
+        )
 
         if solver_name == "mujoco_cpu" or solver_name == "mujoco_warp":
             # Ball joint tests


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined joint velocity target calculations in the physics solver to scale with angular corrections, improving simulation stability and accuracy.

* **Tests**
  * Extended test coverage for joint velocity targets across all solver implementations for comprehensive validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->