### PR TITLE
Fix URDF resolution of filenames

### DIFF
--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -247,7 +247,9 @@ def parse_urdf(
                             if filename.startswith("package://"):
                                 fn = filename.replace("package://", "")
                                 package_name = fn.split("/")[0]
-                                parent_urdf_folder = os.path.abspath(os.path.join(os.path.abspath(source), os.pardir, os.pardir, os.pardir))
+                                parent_urdf_folder = os.path.abspath(
+                                    os.path.join(os.path.abspath(source), os.pardir, os.pardir, os.pardir)
+                                )
                                 package_dirs = [parent_urdf_folder]
                             else:
                                 package_dirs = []


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of mesh file paths in URDF files with package-relative references, enabling robust path resolution relative to URDF package directories.
  * Enhanced error handling and diagnostics for unresolved file references with better warning origin tracing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->