### PR TITLE
Zero compliance diag buffer before bsr_get_diag

### DIFF
--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -1123,6 +1123,7 @@ def solve_rheology(
         compliance_mat_diagonal = None
     else:
         compliance_mat_diagonal = _register_temp(fem.borrow_temporary(temporary_store, shape=stress.shape, dtype=mat66))
+        # TODO: Remove .zero_() workaround once Newton uses warp_lang-1.12.0.dev20260113 or newer.
         compliance_mat_diagonal.zero_()
         sp.bsr_get_diag(compliance_mat, out=compliance_mat_diagonal)
 


### PR DESCRIPTION
## Description
- Problem: `sp.bsr_get_diag` leaves missing diagonal blocks untouched, which can propagate stale values; in my case this led to NaNs in some environments.
- Fix: explicitly zero `compliance_mat_diagonal` before calling `bsr_get_diag` in the implicit MPM rheology solve.

I opened https://github.com/NVIDIA/warp/pull/1170 to fix this at the source. In the meantime, I’m opening this local change in Newton to avoid the NaNs or other undesired behavior.

I’m not sure whether it’s better to wait for the Warp PR to be merged or to keep this safeguard here as well.
@gdaviet let me know what you prefer

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [X] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability by explicitly zero-initializing intermediate matrix data before use, preventing uninitialized values from affecting diagonal extraction.
  * No public APIs or exported interfaces were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->