### PR TITLE
Fix test test_robot.example_robot_anymal_d_cuda_0

### DIFF
--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -86,7 +86,7 @@ class Example:
             impratio=100,
             iterations=100,
             ls_iterations=50,
-            nconmax=35,
+            nconmax=45,
             njmax=100,
             use_mujoco_contacts=args.use_mujoco_contacts if args else False,
         )


### PR DESCRIPTION
## Description
Following the merge of #1295, the test test_robot.example_robot_anymal_d_cuda_0 seems to fail due to overflow.
This increase of nconmax should solve the issue.
Example of failure:
https://github.com/newton-physics/newton/actions/runs/20937863230/job/60164800649

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated robot simulation example configuration parameters for improved contact handling accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->