### PR TITLE
Added multidevice support

### DIFF
--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -607,13 +607,33 @@ class ArticulationView:
         # launch appropriate kernel based on attribute dimensionality
         # TODO: cache concrete overload per attribute?
         if attrib.ndim == 1:
-            wp.launch(set_articulation_attribute_1d_kernel, dim=attrib.shape, inputs=[mask, values, attrib], device=self.device)
+            wp.launch(
+                set_articulation_attribute_1d_kernel,
+                dim=attrib.shape,
+                inputs=[mask, values, attrib],
+                device=self.device,
+            )
         elif attrib.ndim == 2:
-            wp.launch(set_articulation_attribute_2d_kernel, dim=attrib.shape, inputs=[mask, values, attrib], device=self.device)
+            wp.launch(
+                set_articulation_attribute_2d_kernel,
+                dim=attrib.shape,
+                inputs=[mask, values, attrib],
+                device=self.device,
+            )
         elif attrib.ndim == 3:
-            wp.launch(set_articulation_attribute_3d_kernel, dim=attrib.shape, inputs=[mask, values, attrib], device=self.device)
+            wp.launch(
+                set_articulation_attribute_3d_kernel,
+                dim=attrib.shape,
+                inputs=[mask, values, attrib],
+                device=self.device,
+            )
         elif attrib.ndim == 4:
-            wp.launch(set_articulation_attribute_4d_kernel, dim=attrib.shape, inputs=[mask, values, attrib], device=self.device)
+            wp.launch(
+                set_articulation_attribute_4d_kernel,
+                dim=attrib.shape,
+                inputs=[mask, values, attrib],
+                device=self.device,
+            )
         else:
             raise NotImplementedError(f"Unsupported attribute with ndim={attrib.ndim}")
 


### PR DESCRIPTION
## Description

Fixes #1340 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device execution for articulation attribute operations to ensure kernel computations run on the correct device, improving reliability and preventing potential device mismatch errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->