### PR TITLE
Disable GUI picking for cube stacking example.

### DIFF
--- a/newton/examples/ik/example_ik_cube_stacking.py
+++ b/newton/examples/ik/example_ik_cube_stacking.py
@@ -270,6 +270,7 @@ class Example:
             self.viewer = newton.viewer.ViewerNull()
 
         self.viewer.set_model(self.model)
+        self.viewer.picking_enabled = False  # Disable interactive GUI picking for this example
 
         # Set cube colors
         self.shape_map = {key: s for s, key in enumerate(self.model.shape_key)}
@@ -310,9 +311,6 @@ class Example:
                 self.contacts = self.model.collide(self.state_0, collision_pipeline=self.collision_pipeline)
 
             self.state_0.clear_forces()
-
-            # apply forces to the model for picking, wind, etc
-            self.viewer.apply_forces(self.state_0)
 
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled interactive GUI picking in the cube stacking physics example.
  * Removed force application operations from the simulation loop to prevent unintended behavior during substeps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->