### PR TITLE
Pre-download manipulation_objects assets for panda hydro test

### DIFF
--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -190,6 +190,8 @@ def main(argv=None):
         "anybotics_anymal_d",
         "anybotics_anymal_d/usd",
         "franka_emika_panda",
+        "manipulation_objects/cup",  # Used in robot.example_robot_panda_hydro
+        "manipulation_objects/pad",  # Used in robot.example_robot_panda_hydro
         "unitree_go2",
         "unitree_g1",
         "unitree_g1/usd",


### PR DESCRIPTION
## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

At the start of `newton/tests/thirdparty/unittest_parallel.py` we download a list of assets we know we are going to need when running unit tests. This helps prevent race conditions during the parallel test execution.

This pull request updates this list of assets to include manipulation_objects/cup and manipulation_objects/pad, which are used by the `robot.example_robot_panda_hydro` test `test_examples.py.`

Note: This [job](https://github.com/newton-physics/newton/actions/runs/20969771063/job/60269905513) has a strange "No space left on device" issue, which is suspicious.

Mentioning it here for record-keeping:

```
======================================================================
test_robot.example_robot_panda_hydro_cuda_0 (test_examples.TestRobotExamples.test_robot.example_robot_panda_hydro_cuda_0)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/actions-runner/_work/newton/newton/newton/tests/unittest_utils.py", line 296, in test_func
    func(self, device, **kwargs)
  File "/actions-runner/_work/newton/newton/newton/tests/test_examples.py", line 189, in run
    test.assertEqual(
AssertionError: 1 != 0 : Failed with return code 1, command: coverage run --data-file=/tmp/tmpef8dk29j/tmpoe0k8pa2 -m newton.examples.robot.example_robot_panda_hydro --device cuda:0 --test --viewer usd --output-path /actions-runner/_work/newton/newton/newton/tests/outputs/robot.example_robot_panda_hydro_cuda_0.usd --num-frames 600

Output:
Warp 1.11.0.dev20251205 initialized:
   Git commit: 6dc700bf80f89f8a8445bc2378cea313cb39ecea
   CUDA Toolkit 12.9, Driver 13.0
   Devices:
     "cpu"      : "x86_64"
     "cuda:0"   : "NVIDIA L40S" (44 GiB, sm_89, mempool enabled)
   Kernel cache:
     /actions-runner/.cache/warp/1.11.0.dev20251205
Module newton._src.geometry.inertia 6989b15 load on device 'cuda:0' took 1.11 ms  (cached)
Cloning https://github.com/newton-physics/newton-assets.git (branch: main)...
Successfully downloaded folder to: /actions-runner/.cache/newton/newton-assets_manipulation_objects_pad_26140fa5/manipulation_objects/pad
Cloning https://github.com/newton-physics/newton-assets.git (branch: main)...

Traceback (most recent call last):
  File "/actions-runner/_work/newton/newton/newton/_src/utils/download_assets.py", line 181, in download_git_folder
    repo = git.Repo.clone_from(
           ^^^^^^^^^^^^^^^^^^^^
  File "/actions-runner/_work/newton/newton/.venv/lib/python3.11/site-packages/git/repo/base.py", line 1543, in clone_from
    return cls._clone(
           ^^^^^^^^^^^
  File "/actions-runner/_work/newton/newton/.venv/lib/python3.11/site-packages/git/repo/base.py", line 1414, in _clone
    finalize_process(proc, stderr=stderr)
  File "/actions-runner/_work/newton/newton/.venv/lib/python3.11/site-packages/git/util.py", line 512, in finalize_process
    proc.wait(**kwargs)
  File "/actions-runner/_work/newton/newton/.venv/lib/python3.11/site-packages/git/cmd.py", line 419, in wait
    raise GitCommandError(remove_password_if_present(self.args), status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --branch=main --depth=1 -- https://github.com/newton-physics/newton-assets.git /actions-runner/.cache/newton/newton-assets_manipulation_objects_cup_4d310a8a
  stderr: 'Cloning into '/actions-runner/.cache/newton/newton-assets_manipulation_objects_cup_4d310a8a'...
POST git-upload-pack (352 bytes)
POST git-upload-pack (194 bytes)
Updating files:  74% (437/590)
Updating files:  74% (438/590)
Updating files:  74% (440/590)
Updating files:  75% (443/590)
Updating files:  76% (449/590)
Updating files:  77% (455/590)
Updating files:  78% (461/590)
Updating files:  79% (467/590)
Updating files:  80% (472/590)
Updating files:  81% (478/590)
Updating files:  82% (484/590)
Updating files:  83% (490/590)
Updating files:  84% (496/590)
Updating files:  85% (502/590)
Updating files:  86% (508/590)
Updating files:  87% (514/590)
error: unable to write file unitree_h1/meshes/left_knee_link.STL
error: unable to write file unitree_h1/meshes/left_knee_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_pitch_link.STL
Updating files:  88% (520/590)
error: unable to write file unitree_h1/meshes/left_shoulder_pitch_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_roll_link.STL
error: unable to write file unitree_h1/meshes/left_shoulder_roll_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_yaw_link.STL
error: unable to write file unitree_h1/meshes/left_shoulder_yaw_link.dae
error: unable to write file unitree_h1/meshes/logo_link.STL
Updating files:  89% (526/590)
error: unable to write file unitree_h1/meshes/logo_link.dae
error: unable to write file unitree_h1/meshes/pelvis.STL
error: unable to write file unitree_h1/meshes/pelvis.dae
error: unable to write file unitree_h1/meshes/right_ankle_link.STL
error: unable to write file unitree_h1/meshes/right_ankle_link.dae
Updating files:  90% (531/590)
error: unable to write file unitree_h1/meshes/right_elbow_link.STL
error: unable to write file unitree_h1/meshes/right_elbow_link.dae
error: unable to write file unitree_h1/meshes/right_hand_link.STL
error: unable to write file unitree_h1/meshes/right_hand_link.dae
error: unable to write file unitree_h1/meshes/right_hip_pitch_link.STL
error: unable to write file unitree_h1/meshes/right_hip_pitch_link.dae
Updating files:  91% (537/590)
error: unable to write file unitree_h1/meshes/right_hip_roll_link.STL
error: unable to write file unitree_h1/meshes/right_hip_roll_link.dae
error: unable to write file unitree_h1/meshes/right_hip_yaw_link.STL
error: unable to write file unitree_h1/meshes/right_hip_yaw_link.dae
error: unable to write file unitree_h1/meshes/right_knee_link.STL
error: unable to write file unitree_h1/meshes/right_knee_link.dae
Updating files:  92% (543/590)
error: unable to write file unitree_h1/meshes/right_shoulder_pitch_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_pitch_link.dae
error: unable to write file unitree_h1/meshes/right_shoulder_roll_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_roll_link.dae
error: unable to write file unitree_h1/meshes/right_shoulder_yaw_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_yaw_link.dae
Updating files:  93% (549/590)
error: unable to write file unitree_h1/meshes/torso_link.STL
error: unable to write file unitree_h1/meshes/torso_link.dae
fatal: cannot create directory at 'unitree_h1/mjcf': No space left on device
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'

'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/actions-runner/_work/newton/newton/newton/examples/robot/example_robot_panda_hydro.py", line 475, in <module>
    example = Example(viewer, scene=args.scene, num_worlds=args.num_worlds, test_mode=args.test)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/actions-runner/_work/newton/newton/newton/examples/robot/example_robot_panda_hydro.py", line 198, in __init__
    cup_asset_path = newton.utils.download_asset("manipulation_objects/cup")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/actions-runner/_work/newton/newton/newton/_src/utils/download_assets.py", line 261, in download_asset
    return download_git_folder(
           ^^^^^^^^^^^^^^^^^^^^
  File "/actions-runner/_work/newton/newton/newton/_src/utils/download_assets.py", line 217, in download_git_folder
    raise RuntimeError(f"Git operation failed: {e}") from e
RuntimeError: Git operation failed: Cmd('git') failed due to: exit code(128)
  cmdline: git clone -v --branch=main --depth=1 -- https://github.com/newton-physics/newton-assets.git /actions-runner/.cache/newton/newton-assets_manipulation_objects_cup_4d310a8a
  stderr: 'Cloning into '/actions-runner/.cache/newton/newton-assets_manipulation_objects_cup_4d310a8a'...
POST git-upload-pack (352 bytes)
POST git-upload-pack (194 bytes)
Updating files:  74% (437/590)
Updating files:  74% (438/590)
Updating files:  74% (440/590)
Updating files:  75% (443/590)
Updating files:  76% (449/590)
Updating files:  77% (455/590)
Updating files:  78% (461/590)
Updating files:  79% (467/590)
Updating files:  80% (472/590)
Updating files:  81% (478/590)
Updating files:  82% (484/590)
Updating files:  83% (490/590)
Updating files:  84% (496/590)
Updating files:  85% (502/590)
Updating files:  86% (508/590)
Updating files:  87% (514/590)
error: unable to write file unitree_h1/meshes/left_knee_link.STL
error: unable to write file unitree_h1/meshes/left_knee_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_pitch_link.STL
Updating files:  88% (520/590)
error: unable to write file unitree_h1/meshes/left_shoulder_pitch_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_roll_link.STL
error: unable to write file unitree_h1/meshes/left_shoulder_roll_link.dae
error: unable to write file unitree_h1/meshes/left_shoulder_yaw_link.STL
error: unable to write file unitree_h1/meshes/left_shoulder_yaw_link.dae
error: unable to write file unitree_h1/meshes/logo_link.STL
Updating files:  89% (526/590)
error: unable to write file unitree_h1/meshes/logo_link.dae
error: unable to write file unitree_h1/meshes/pelvis.STL
error: unable to write file unitree_h1/meshes/pelvis.dae
error: unable to write file unitree_h1/meshes/right_ankle_link.STL
error: unable to write file unitree_h1/meshes/right_ankle_link.dae
Updating files:  90% (531/590)
error: unable to write file unitree_h1/meshes/right_elbow_link.STL
error: unable to write file unitree_h1/meshes/right_elbow_link.dae
error: unable to write file unitree_h1/meshes/right_hand_link.STL
error: unable to write file unitree_h1/meshes/right_hand_link.dae
error: unable to write file unitree_h1/meshes/right_hip_pitch_link.STL
error: unable to write file unitree_h1/meshes/right_hip_pitch_link.dae
Updating files:  91% (537/590)
error: unable to write file unitree_h1/meshes/right_hip_roll_link.STL
error: unable to write file unitree_h1/meshes/right_hip_roll_link.dae
error: unable to write file unitree_h1/meshes/right_hip_yaw_link.STL
error: unable to write file unitree_h1/meshes/right_hip_yaw_link.dae
error: unable to write file unitree_h1/meshes/right_knee_link.STL
error: unable to write file unitree_h1/meshes/right_knee_link.dae
Updating files:  92% (543/590)
error: unable to write file unitree_h1/meshes/right_shoulder_pitch_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_pitch_link.dae
error: unable to write file unitree_h1/meshes/right_shoulder_roll_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_roll_link.dae
error: unable to write file unitree_h1/meshes/right_shoulder_yaw_link.STL
error: unable to write file unitree_h1/meshes/right_shoulder_yaw_link.dae
Updating files:  93% (549/590)
error: unable to write file unitree_h1/meshes/torso_link.STL
error: unable to write file unitree_h1/meshes/torso_link.dae
fatal: cannot create directory at 'unitree_h1/mjcf': No space left on device
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'

'


----------------------------------------------------------------------
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new assets to test downloads, expanding available manipulation objects for testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->