### PR TITLE
asv: Update `FastInitializeModel` to remove 'cartpole' parameter

### DIFF
--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -17,6 +17,8 @@ import gc
 import os
 import sys
 
+from asv_runner.benchmarks.mark import skip_for_params
+
 # Force headless mode for CI environments before any pyglet imports
 os.environ["PYGLET_HEADLESS"] = "1"
 
@@ -124,9 +126,11 @@ class FastInitializeModel:
 
     def setup_cache(self):
         # Load a small model to cache the kernels
-        builder = Example.create_model_builder("cartpole", 1, randomize=False, seed=123)
-        model = builder.finalize(device="cpu")
-        del model
+        for robot in self.params[0]:
+            builder = Example.create_model_builder(robot, 1, randomize=False, seed=123)
+            model = builder.finalize(device="cpu")
+            del model
+            del builder
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_initialize_model(self, robot, num_worlds):


### PR DESCRIPTION
Failures in pull request workflows

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

We're seeing a lot of false positives for the `peakmem` benchmark for changes that don't even touch the Newton code base.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated benchmark setup to initialize and finalize models for each parameterized robot, improving resource cleanup and preventing leftover builders.
  * Continued to skip the GPU-dependent benchmark when no CUDA device is available, keeping prior guarded behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->