### PR TITLE
[Test] Disable peakmem_initialize_model_cpu benchmark

### DIFF
--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -138,6 +138,8 @@ class FastInitializeModel:
         _model = builder.finalize()
         wp.synchronize_device()
 
+    # TODO: Investigate reason for test failure and enable it again
+    @skip_benchmark_if(True)
     def peakmem_initialize_model_cpu(self, robot, num_worlds):
         gc.collect()
 


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
