### PR TITLE
fix: pbo resize bug

### DIFF
--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -140,6 +140,16 @@ class ViewerGL(ViewerBase):
 
         self.set_model(None)
 
+    def _invalidate_pbo(self):
+        """Invalidate PBO resources, forcing reallocation on next get_frame() call."""
+        if self._wp_pbo is not None:
+            self._wp_pbo = None  # Let Python garbage collect the RegisteredGLBuffer
+        if self._pbo is not None:
+            gl = RendererGL.gl
+            pbo_id = (gl.GLuint * 1)(self._pbo)
+            gl.glDeleteBuffers(1, pbo_id)
+            self._pbo = None
+
     def register_ui_callback(self, callback, position="side"):
         """
         Register a UI callback to be rendered during the UI phase.
@@ -966,6 +976,7 @@ class ViewerGL(ViewerBase):
         """
         fb_w, fb_h = self.renderer.window.get_framebuffer_size()
         self.camera.update_screen_size(fb_w, fb_h)
+        self._invalidate_pbo()
 
         if self.ui:
             self.ui.resize(width, height)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->
Fixed the PBO resize bug in viewer_gl.py (issue #1413 ). The changes:

1. Added _invalidate_pbo() method that properly cleans up the OpenGL buffer and CUDA registration;
2. Call _invalidate_pbo() in on_resize() so the PBO is reallocated with correct dimensions on the next get_frame() call.

Note on tests: This bug fix handles window resize events which require GUI interaction and cannot be easily automated in headless CI. The fix was manually verified using a reproduction script in the issue #1413 .

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the viewer display would not properly refresh when resizing the window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->