### PR TITLE
Fix replay type inference

### DIFF
--- a/newton/_src/utils/recorder.py
+++ b/newton/_src/utils/recorder.py
@@ -22,6 +22,7 @@ from typing import Generic, TypeVar
 
 import numpy as np
 import warp as wp
+from warp._src import types as warp_types
 
 from ..geometry import Mesh
 from ..sim import Model, State
@@ -508,8 +509,6 @@ def _serialize_warp_dtype(dtype) -> dict:
     Returns:
         A dict containing dtype info that can be used to reconstruct the type.
     """
-    from warp._src import types as warp_types
-
     dtype_str = str(dtype)
     dtype_name = dtype.__name__
 

--- a/newton/examples/example_replay_viewer.py
+++ b/newton/examples/example_replay_viewer.py
@@ -30,6 +30,7 @@
 ###########################################################################
 
 import os
+import traceback
 
 import newton
 import newton.examples
@@ -205,8 +206,6 @@ class ReplayUI:
             self.status_color = (1.0, 0.3, 0.3, 1.0)  # Red
             print(f"[ReplayUI] File not found: {file_path}")
         except Exception as e:
-            import traceback
-
             self.status_message = f"Error loading recording: {str(e)[:50]}..."
             self.status_color = (1.0, 0.3, 0.3, 1.0)  # Red
             print(f"[ReplayUI] Error loading recording: {file_path}")


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Types like vec5 that use the underlying c++ type called vec_t were not properly deserialized. That should be fixed now. The test coverage has been extended.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and diagnostics when loading recordings, providing clearer messages for file-related issues.

* **Improvements**
  * Better support for complex data types in recording serialization and playback.
  * Improved backward compatibility when replaying existing recordings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->