### PR TITLE
Fix invalid read in `SensorContact`

### DIFF
--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -90,13 +90,14 @@ def select_aggregate_net_force(
     sp_ord = bisect_shape_pairs(sp_sorted, num_sp, normalized_pair)
 
     force = contact_force[con_idx] * contact_normal[con_idx]
-    if sp_ord < num_sp and sp_sorted[sp_ord] == normalized_pair:
-        # add the force to the pair's force accumulators
-        offset = sp_ep_offset[sp_ord]
-        for i in range(sp_ep_count[sp_ord]):
-            ep = sp_ep[offset + i]
-            force_acc, flip = ep[0], ep[1]
-            wp.atomic_add(net_force, force_acc, wp.where(sp_flip != flip, -force, force))
+    if sp_ord < num_sp:
+        if sp_sorted[sp_ord] == normalized_pair:
+            # add the force to the pair's force accumulators
+            offset = sp_ep_offset[sp_ord]
+            for i in range(sp_ep_count[sp_ord]):
+                ep = sp_ep[offset + i]
+                force_acc, flip = ep[0], ep[1]
+                wp.atomic_add(net_force, force_acc, wp.where(sp_flip != flip, -force, force))
 
     # add contribution for shape a and b
     for i in range(2):
@@ -104,9 +105,10 @@ def select_aggregate_net_force(
         mono_ord = bisect_shape_pairs(sp_sorted, num_sp, mono_sp)
 
         # for shape vs all, only one accumulator is supported and flip is trivially true
-        if mono_ord < num_sp and sp_sorted[mono_ord] == mono_sp:
-            force_acc = sp_ep[sp_ep_offset[mono_ord]][0]
-            wp.atomic_add(net_force, force_acc, wp.where(bool(i), -force, force))
+        if mono_ord < num_sp:
+            if sp_sorted[mono_ord] == mono_sp:
+                force_acc = sp_ep[sp_ep_offset[mono_ord]][0]
+                wp.atomic_add(net_force, force_acc, wp.where(bool(i), -force, force))
 
 
 class MatchAny:


### PR DESCRIPTION
## Description
This change fixes an invalid read that often occurs during contact sensor evaluation. (Unsupported) short-circuit evaluation is assumed in the kernel line below, leading to invalid reads when all shape pairs are smaller than the thread's shape pair.

resolves #1385

```
if sp_ord < num_sp and sp_sorted[sp_ord] == normalized_pair:
```

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code maintenance and structural improvements with no user-facing changes.

---

**Note:** This release contains refactoring improvements to internal components. End-users should experience no changes in functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->