### PR TITLE
Update warp-lang dependency

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.12.0.dev20251219 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.12.0.dev20260120 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U --pre mujoco==3.4.1.dev856273160 -f https://py.mujoco.org/",
     "python -m pip install -U torch==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129",
     "python -m pip install git+https://github.com/google-deepmind/mujoco_warp@b72cc0ff7679c86846aebaec3be639a33aec01a7",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -4395,17 +4395,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.0.dev20251219"
+version = "1.12.0.dev20260120"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20251219-py3-none-macosx_11_0_arm64.whl", hash = "sha256:05308ee70a657d43db52a041c25137d2ad162d5a254dc54d218e223e949569a0" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20251219-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:86f389e555720d4eb65eab086c6776cde45179c559e26986c4e8a9121969b06f" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20251219-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:ac8b3c6e54a77bc681c020717da5613cc8227682c50d79e2f881570a4142bcad" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20251219-py3-none-win_amd64.whl", hash = "sha256:4640cfa6ebe9f06eee440d7c17b7124ceca24a62681d089d9291e03beef9be63" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260120-py3-none-macosx_11_0_arm64.whl", hash = "sha256:794c473a22bbd0bc679b6a3cebcabb22d97453dbc474fe4c8596e181429efdf0" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260120-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:7603df8124ef1abe66eab3fbc2fb4efd15297dc7f8c93809def60c22a5b75c2d" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260120-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:41be8f76847078d73d47ea89fc9fa2de6db3cfafb6a8e067eb46571305d7a652" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260120-py3-none-win_amd64.whl", hash = "sha256:3ad21d57dfa792b0c19d7a9d17b038908ea01f203912f5d60336e38d42ce734c" },
 ]
 
 [[package]]


### PR DESCRIPTION
This should hopefully fix the flakyness of the CPU tests. Closes #1405 

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-release build dependency to the latest version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->