### PR TITLE
Fix shape of constraint weight array in XPBD

### DIFF
--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -227,7 +227,7 @@ class SolverXPBD(SolverBase):
 
         if contacts:
             if self.rigid_contact_con_weighting:
-                rigid_contact_inv_weight = wp.zeros_like(contacts.rigid_contact_thickness0)
+                rigid_contact_inv_weight = wp.zeros(model.body_count, dtype=float, device=model.device)
             rigid_contact_inv_weight_init = None
 
         if control is None:


### PR DESCRIPTION
## Description
This change addresses an invalid memory access (#1397) that could occur as a result of initializing the constraint weight array to the contact count instead of `model.body_count`. It was most likely to occur in very small set-ups involving spheres as this can lead to a maximum contact count below the body count.

resolves #1397 

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rigid contact weight allocation to properly align with body count rather than contact thickness, ensuring correct tensor dimensioning in physics simulations.
  * Enhanced device and data type handling for physics computations, improving multi-device compatibility and numerical precision.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->