### PR TITLE
Draft: XPBD improvments

### DIFF
--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -1927,39 +1927,6 @@ def solve_body_joints(
 
 
 @wp.func
-def ke_kd_to_solref(ke: float, kd: float) -> wp.vec2:
-    """Convert stiffness (ke) and damping (kd) to time constant and damping ratio.
-
-    This conversion matches MuJoCo's solref parameter format, enabling consistent
-    contact behavior between XPBD and MuJoCo solvers.
-
-    Args:
-        ke: Contact elastic stiffness (N/m or equivalent)
-        kd: Contact damping coefficient (N*s/m or equivalent)
-
-    Returns:
-        vec2 containing (time_constant, damping_ratio):
-        - time_constant: Characteristic time for contact dynamics (seconds)
-        - damping_ratio: 1.0 = critically damped, <1 = underdamped, >1 = overdamped
-    """
-    time_constant = 0.0
-    damping_ratio = 1.0
-
-    if ke > 0.0 and kd > 0.0:
-        # Convert from stiffness/damping to MuJoCo's solref timeconst and dampratio
-        # Based on: kd = 2 / timeconst, ke = 1 / (timeconst^2 * dampratio^2)
-        time_constant = 2.0 / kd
-        damping_ratio = wp.sqrt(1.0 / (time_constant * time_constant * ke))
-    elif ke > 0.0:
-        # If no damping was set, use default damping ratio
-        time_constant = wp.sqrt(1.0 / ke)
-        damping_ratio = 1.0
-    # else: hard contact (time_constant = 0)
-
-    return wp.vec2(time_constant, damping_ratio)
-
-
-@wp.func
 def compute_contact_constraint_delta(
     err: float,
     tf_a: wp.transform,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -47,6 +47,37 @@ class SolverXPBD(SolverBase):
     After constructing :class:`Model`, :class:`State`, and :class:`Control` (optional) objects, this time-integrator
     may be used to advance the simulation state forward in time.
 
+    Args:
+        model: The simulation model
+        iterations: Number of solver iterations per substep
+        soft_body_relaxation: Relaxation factor for soft body constraints
+        soft_contact_relaxation: Relaxation factor for soft body contacts
+        joint_linear_relaxation: Relaxation factor for joint linear constraints
+        joint_angular_relaxation: Relaxation factor for joint angular constraints
+        joint_linear_compliance: Compliance for joint linear constraints
+        joint_angular_compliance: Compliance for joint angular constraints
+        rigid_contact_relaxation: Relaxation factor for rigid contact constraints (0.0-1.0)
+        rigid_contact_time_constant: Time constant for mass-independent contact compliance (seconds).
+            When > 0, adds compliance that scales with effective mass, making contact behavior
+            consistent regardless of object mass. Set to 0 for hard contacts. This is equivalent
+            to MuJoCo's solref[0] parameter.
+        rigid_contact_damping_ratio: Damping ratio for contact dynamics (MuJoCo-style). Only active
+            when time_constant > 0. Values: 0 = undamped (oscillatory), 1 = critically damped
+            (smooth, no overshoot), >1 = overdamped (slow but stable). Default is 1.0 (critically
+            damped). This is equivalent to MuJoCo's solref[1] parameter.
+        rigid_contact_con_weighting: Whether to weight contact corrections by contact count
+        rigid_contact_max_depenetration_velocity: Hard limit on the resulting relative normal
+            velocity (m/s) at contact points after contact resolution. This clamps how fast
+            the contact points can be separating after the impulse is applied, preventing
+            violent "explosion" artifacts when objects are deeply interpenetrating. Set to 0
+            to disable (default). Typical values: 1-5 m/s. This is mass-independent
+            and acts as a physical velocity cap on the contact resolution outcome.
+        angular_damping: Angular velocity damping factor applied during integration.
+            Reduces angular velocity by a factor of (1 - angular_damping * dt) each step.
+            Set to 0.0 (default) for no damping. Note: this is an approximate linear
+            damping model, not exact exponential decay.
+        enable_restitution: Whether to enable contact restitution (bounciness)
+
     Example
     -------
 
@@ -72,7 +103,10 @@ class SolverXPBD(SolverBase):
         joint_linear_compliance: float = 0.0,
         joint_angular_compliance: float = 0.0,
         rigid_contact_relaxation: float = 0.8,
+        rigid_contact_time_constant: float = 0.0,
+        rigid_contact_damping_ratio: float = 1.0,
         rigid_contact_con_weighting: bool = True,
+        rigid_contact_max_depenetration_velocity: float = 0.0,
         angular_damping: float = 0.0,
         enable_restitution: bool = False,
     ):
@@ -88,7 +122,10 @@ class SolverXPBD(SolverBase):
         self.joint_angular_compliance = joint_angular_compliance
 
         self.rigid_contact_relaxation = rigid_contact_relaxation
+        self.rigid_contact_time_constant = rigid_contact_time_constant
+        self.rigid_contact_damping_ratio = rigid_contact_damping_ratio
         self.rigid_contact_con_weighting = rigid_contact_con_weighting
+        self.rigid_contact_max_depenetration_velocity = rigid_contact_max_depenetration_velocity
 
         self.angular_damping = angular_damping
 
@@ -532,6 +569,9 @@ class SolverXPBD(SolverBase):
                                 model.shape_material_torsional_friction,
                                 model.shape_material_rolling_friction,
                                 self.rigid_contact_relaxation,
+                                self.rigid_contact_time_constant,
+                                self.rigid_contact_damping_ratio,
+                                self.rigid_contact_max_depenetration_velocity,
                                 dt,
                             ],
                             outputs=[


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->
This MR is mainly intended for discussions. In case we agree to bring the XPBD improvements to main, then I'll of course add some unit tests.

Add more options to prevent/control XPBD's explosive and energy injecting contact resolution

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional shape-material-based contact solving for per-shape compliance and damping.
  * New runtime options to enable shape-material contact mode and to cap depenetration velocity.
  * XPBD-style compliant contact path with accumulated impulses for tunable, iterative contact response.

* **Bug Fixes / Stability**
  * Clamping of accumulated impulses and post-impulse velocities to reduce excessive penetration/separation and improve solver stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->