### PR TITLE
Update newton-usd-schemas for py3.13 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ importers = [
     "usd-exchange>=2.1.0a3 ; platform_machine == 'aarch64'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.1.0a1",
+    "newton-usd-schemas>=0.1.0a2",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2809,12 +2809,12 @@ requires-dist = [
     { name = "mujoco-warp", marker = "extra == 'torch-cu12'", git = "https://github.com/google-deepmind/mujoco_warp" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.1" },
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9.0" },
-    { name = "newton-usd-schemas", marker = "extra == 'dev'", specifier = ">=0.1.0a1" },
-    { name = "newton-usd-schemas", marker = "extra == 'docs'", specifier = ">=0.1.0a1" },
-    { name = "newton-usd-schemas", marker = "extra == 'examples'", specifier = ">=0.1.0a1" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.1.0a1" },
-    { name = "newton-usd-schemas", marker = "extra == 'notebook'", specifier = ">=0.1.0a1" },
-    { name = "newton-usd-schemas", marker = "extra == 'torch-cu12'", specifier = ">=0.1.0a1" },
+    { name = "newton-usd-schemas", marker = "extra == 'dev'", specifier = ">=0.1.0a2" },
+    { name = "newton-usd-schemas", marker = "extra == 'docs'", specifier = ">=0.1.0a2" },
+    { name = "newton-usd-schemas", marker = "extra == 'examples'", specifier = ">=0.1.0a2" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.1.0a2" },
+    { name = "newton-usd-schemas", marker = "extra == 'notebook'", specifier = ">=0.1.0a2" },
+    { name = "newton-usd-schemas", marker = "extra == 'torch-cu12'", specifier = ">=0.1.0a2" },
     { name = "open3d", marker = "extra == 'remesh'", specifier = ">=0.18.0" },
     { name = "pycollada", marker = "extra == 'dev'", specifier = ">=0.9" },
     { name = "pycollada", marker = "extra == 'docs'", specifier = ">=0.9" },
@@ -2887,11 +2887,11 @@ dev = [{ name = "asv", specifier = ">=0.6.4" }]
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3d/a3/f708afd807325b28aacce60d318cc6eaffcbc5e205c6c1cbbdc57f1c7d0d/newton_usd_schemas-0.1.0a1.tar.gz", hash = "sha256:84e8d49280ece789a44cabab6e4f9abf567e6d7e32080a7c6a9fefd03ae83986", size = 49655, upload-time = "2025-12-17T21:27:43.676Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/da/60f5392ac3241658a733b484dcbbf5366c006ef6efa485e1c94b948d8c20/newton_usd_schemas-0.1.0a2.tar.gz", hash = "sha256:bd2861efcdc401e9dd32e0cc3428096f707e7752602ab3050cd4a4c81022854d", size = 57443, upload-time = "2026-01-27T15:29:47.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/11/8a12f800377f102925347160cacb468607efe486a9b3bab4aa325348487a/newton_usd_schemas-0.1.0a1-py3-none-any.whl", hash = "sha256:101cfcc67668de460bf5bc16e31668a2e5660e3aaea6823a0d373496803d26d8", size = 10340, upload-time = "2025-12-17T21:27:42.456Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2e/c6c221493084b3850d131d3e5ca6475c647810d4835eb15b02bbf7f2ca52/newton_usd_schemas-0.1.0a2-py3-none-any.whl", hash = "sha256:bec9d980618f9cfb551151dafeabb44c502db77e11bd87188f2863502f5ab6ad", size = 10366, upload-time = "2026-01-27T15:29:45.837Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Update newton-usd-schemas for py3.13 support as per https://github.com/newton-physics/newton-usd-schemas/issues/28

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped an optional dependency to a newer alpha release to align with recent improvements and maintain compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->