### PR TITLE
Canonical collision filter pairs

### DIFF
--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -299,9 +299,9 @@ UsdPhysics ``physics:filteredPairs`` relationships).
     body = builder.add_body()
     shape_a = builder.add_shape_sphere(body, radius=0.5)
     shape_b = builder.add_shape_box(body, hx=0.5, hy=0.5, hz=0.5)
-    
+
     # Exclude this specific pair from collision detection
-    builder.shape_collision_filter_pairs.append((shape_a, shape_b))
+    builder.add_shape_collision_filter_pair(shape_a, shape_b)
 
 Filter pairs are automatically populated in several cases:
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -764,6 +764,15 @@ class ModelBuilder:
         # Incrementally maintained counts for custom string frequencies
         self._custom_frequency_counts: dict[str, int] = {}
 
+    def _add_collision_filter_pair(self, shape_a: int, shape_b: int) -> None:
+        """Add a collision filter pair in canonical order.
+
+        Args:
+            shape_a: First shape index
+            shape_b: Second shape index
+        """
+        self.shape_collision_filter_pairs.append((min(shape_a, shape_b), max(shape_a, shape_b)))
+
     def add_custom_attribute(self, attribute: CustomAttribute) -> None:
         """
         Define a custom per-entity attribute to be added to the Model.
@@ -6433,7 +6442,9 @@ class ModelBuilder:
             )
             m.shape_contact_margin = wp.array(self.shape_contact_margin, dtype=wp.float32, requires_grad=requires_grad)
 
-            m.shape_collision_filter_pairs = set(self.shape_collision_filter_pairs)
+            m.shape_collision_filter_pairs = {
+                (min(s1, s2), max(s1, s2)) for s1, s2 in self.shape_collision_filter_pairs
+            }
             m.shape_collision_group = wp.array(self.shape_collision_group, dtype=wp.int32)
 
             # ---------------------

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -219,7 +219,7 @@ class Model:
         self.shape_collision_group = None
         """Collision group of each shape, shape [shape_count], int. Array populated during finalization."""
         self.shape_collision_filter_pairs: set[tuple[int, int]] = set()
-        """Pairs of shape indices that should not collide."""
+        """Pairs of shape indices (s1, s2) that should not collide. Pairs are in canonical order: s1 < s2."""
         self.shape_collision_radius = None
         """Collision radius for bounding sphere broadphase, shape [shape_count], float. Not supported by :class:`~newton.solvers.SolverMuJoCo`."""
         self.shape_contact_pairs = None

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1662,7 +1662,8 @@ class SolverMuJoCo(SolverBase):
             (i, j)
             for i, j in zip(shape_a, shape_b, strict=True)
             if (
-                (selected_shapes[i], selected_shapes[j]) not in model.shape_collision_filter_pairs
+                (min(selected_shapes[i], selected_shapes[j]), max(selected_shapes[i], selected_shapes[j]))
+                not in model.shape_collision_filter_pairs
                 and (cgroup[i] == cgroup[j] or cgroup[i] == -1 or cgroup[j] == -1)
             )
         ]

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1570,7 +1570,7 @@ def parse_mjcf(
             # Add all shape pairs from these bodies to collision filter
             for shape1_idx in body1_shapes:
                 for shape2_idx in body2_shapes:
-                    builder.shape_collision_filter_pairs.append((shape1_idx, shape2_idx))
+                    builder.add_shape_collision_filter_pair(shape1_idx, shape2_idx)
 
             if verbose:
                 print(

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1715,12 +1715,12 @@ def parse_mjcf(
 
     for i in range(start_shape_count, end_shape_count):
         for j in visual_shapes:
-            builder.shape_collision_filter_pairs.append((i, j))
+            builder.add_shape_collision_filter_pair(i, j)
 
     if not enable_self_collisions:
         for i in range(start_shape_count, end_shape_count):
             for j in range(i + 1, end_shape_count):
-                builder.shape_collision_filter_pairs.append((i, j))
+                builder.add_shape_collision_filter_pair(i, j)
 
     # Create articulation from all collected joints
     if joint_indices:

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -652,12 +652,12 @@ def parse_urdf(
 
     for i in range(start_shape_count, end_shape_count):
         for j in visual_shapes:
-            builder.shape_collision_filter_pairs.append((i, j))
+            builder.add_shape_collision_filter_pair(i, j)
 
     if not enable_self_collisions:
         for i in range(start_shape_count, end_shape_count):
             for j in range(i + 1, end_shape_count):
-                builder.shape_collision_filter_pairs.append((i, j))
+                builder.add_shape_collision_filter_pair(i, j)
 
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1576,13 +1576,13 @@ def parse_usd(
     for path1, path2 in path_collision_filters:
         shape1 = path_shape_map[path1]
         shape2 = path_shape_map[path2]
-        builder.shape_collision_filter_pairs.append((shape1, shape2))
+        builder.add_shape_collision_filter_pair(shape1, shape2)
 
     # apply collision filters to all shapes that have no collision
     for shape_id in no_collision_shapes:
         for other_shape_id in range(builder.shape_count):
             if other_shape_id != shape_id:
-                builder.shape_collision_filter_pairs.append((shape_id, other_shape_id))
+                builder.add_shape_collision_filter_pair(shape_id, other_shape_id)
 
     # apply collision filters from articulations that have self collisions disabled
     for art_id, bodies in articulation_bodies.items():
@@ -1590,7 +1590,7 @@ def parse_usd(
             for body1, body2 in itertools.combinations(bodies, 2):
                 for shape1 in builder.body_shapes[body1]:
                     for shape2 in builder.body_shapes[body2]:
-                        builder.shape_collision_filter_pairs.append((shape1, shape2))
+                        builder.add_shape_collision_filter_pair(shape1, shape2)
 
     # overwrite inertial properties of bodies that have PhysicsMassAPI schema applied
     if UsdPhysics.ObjectType.RigidBody in ret_dict:


### PR DESCRIPTION
## Description
`Model.shape_collision_filter_pairs` is expected to have shape pairs `(s1, s2)` in canonical order, i.e. s1 < s2. When created from `ModelBuilder.shape_collision_filter_pairs`, this is is not being enforced.

This change enforces the pair ordering when creating `Model.shape_collision_filter_pairs`. It also adds a helper `ModelBuilder.add_shape_collision_filter_pair` to introduce this invariant on `ModelBuilder.shape_collision_filter_pairs`.

Resolves #1395.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to register shape collision filter pairs instead of mutating internal lists.

* **Documentation**
  * Clarified that stored collision filter pairs use canonical ordering (s1 < s2).

* **Bug Fixes / Consistency**
  * Normalized collision-pair ordering across code paths to ensure consistent matching and storage.

* **Tests**
  * Added a test ensuring collision filter pairs are normalized to canonical order on finalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->