### PR TITLE
Fix non-determinism in examples with ls_parallel=True

### DIFF
--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -157,7 +157,12 @@ class Example:
         )
 
         # setup solvers
-        self.solver = newton.solvers.SolverMuJoCo(self.model, ls_parallel=True, njmax=50)
+        self.solver = newton.solvers.SolverMuJoCo(
+            self.model,
+            ls_parallel=True,
+            ls_iterations=50,
+            njmax=50,  # ls_iterations=50 for determinism
+        )
         self.mpm_solver = SolverImplicitMPM(mpm_model, mpm_options)
 
         # simulation state

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -163,6 +163,7 @@ class Example:
             self.model,
             use_mujoco_contacts=args.use_mujoco_contacts if args else False,
             ls_parallel=True,
+            ls_iterations=50,  # Increased from default 10 for determinism
             njmax=50,
             nconmax=75,
         )


### PR DESCRIPTION
Increase ls_iterations from default 10 to 50 for examples using ls_parallel=True to ensure deterministic solver behavior.

Affected examples:
- example_robot_anymal_c_walk
- example_mpm_anymal

Root cause: With ls_iterations=10, the parallel line search doesn't converge sufficiently, causing non-deterministic results where different parallel threads produce slightly different outputs depending on execution order. With ls_iterations=50, the line search converges more thoroughly and produces deterministic results.

Other examples already use ls_iterations=100 or higher:
- example_robot_panda_hydro (100)
- example_sdf (100)
- example_ik_cube_stacking (100)
- test_hydroelastic (100)

Testing: Ran anymal_c_walk test 15 times, all passed (previously had ~30-40% failure rate due to robot falling/drifting sideways).

closes #1487 


## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
