### PR TITLE
fix: support multiple worldbody elements in MJCF parser

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1423,48 +1423,49 @@ def parse_mjcf(
     start_shape_count = len(builder.shape_type)
     joint_indices = []  # Collect joint indices as we create them
 
-    world = root.find("worldbody")
-    world_class = get_class(world)
-    world_defaults = merge_attrib(class_defaults["__all__"], class_defaults.get(world_class, {}))
+    # Process all worldbody elements (MuJoCo allows multiple, e.g. from includes)
+    for world in root.findall("worldbody"):
+        world_class = get_class(world)
+        world_defaults = merge_attrib(class_defaults["__all__"], class_defaults.get(world_class, {}))
 
-    # -----------------
-    # add bodies
+        # -----------------
+        # add bodies
 
-    for body in world.findall("body"):
-        parse_body(body, -1, world_defaults, incoming_xform=xform)
+        for body in world.findall("body"):
+            parse_body(body, -1, world_defaults, incoming_xform=xform)
 
-    # -----------------
-    # add static geoms
+        # -----------------
+        # add static geoms
 
-    parse_shapes(
-        defaults=world_defaults,
-        body_name="world",
-        link=-1,
-        geoms=world.findall("geom"),
-        density=default_shape_density,
-        incoming_xform=xform,
-    )
-
-    if parse_sites:
-        _parse_sites_impl(
+        parse_shapes(
             defaults=world_defaults,
             body_name="world",
             link=-1,
-            sites=world.findall("site"),
+            geoms=world.findall("geom"),
+            density=default_shape_density,
             incoming_xform=xform,
         )
 
-    # -----------------
-    # process frame elements at worldbody level
+        if parse_sites:
+            _parse_sites_impl(
+                defaults=world_defaults,
+                body_name="world",
+                link=-1,
+                sites=world.findall("site"),
+                incoming_xform=xform,
+            )
 
-    process_frames(
-        world.findall("frame"),
-        parent_body=-1,
-        defaults=world_defaults,
-        childclass=None,
-        world_xform=xform,
-        body_relative_xform=None,  # Static geoms use world coords
-    )
+        # -----------------
+        # process frame elements at worldbody level
+
+        process_frames(
+            world.findall("frame"),
+            parent_body=-1,
+            defaults=world_defaults,
+            childclass=None,
+            world_xform=xform,
+            body_relative_xform=None,  # Static geoms use world coords
+        )
 
     # -----------------
     # add equality constraints


### PR DESCRIPTION
MuJoCo allows multiple <worldbody> elements in a single model (e.g., when using <include> to bring in separate MJCF files). Previously, Newton's parser only processed the first worldbody element.

Changed root.find('worldbody') to iterate over root.findall('worldbody') so all worldbody elements are processed into the world body, matching MuJoCo's behavior.

Added tests for:
- Multiple inline worldbody elements with geoms and bodies
- Multiple worldbody elements with sites
- Includes that create multiple worldbody elements

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced MJCF file parsing to correctly handle multiple worldbody elements with per-world configuration and defaults.
  * Improved processing of bodies, geoms, sites, and frames across multiple worldbodies.

* **Tests**
  * Added comprehensive test coverage for multiple worldbody scenarios, including cross-worldbody site parsing and external content inclusion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->