### PR TITLE
[Warp Raytrace] Minor Refactoring

### DIFF
--- a/newton/_src/sensors/warp_raytrace/ray.py
+++ b/newton/_src/sensors/warp_raytrace/ray.py
@@ -16,14 +16,17 @@
 
 import warp as wp
 
-from newton._src.math import safe_div
-
 EPSILON = 1e-6
 MAXVAL = 1e10
 
 
 class vec6f(wp.types.vector(length=6, dtype=wp.float32)):
     pass
+
+
+@wp.func
+def safe_div(x: wp.float32, y: wp.float32) -> wp.float32:
+    return x / wp.where(y != 0.0, y, EPSILON)
 
 
 @wp.func
@@ -65,7 +68,7 @@ def ray_compute_quadratic(a: wp.float32, b: wp.float32, c: wp.float32) -> tuple[
     det = wp.sqrt(det)
 
     # compute the two solutions
-    den = safe_div(1.0, a, EPSILON)
+    den = safe_div(1.0, a)
     x0 = (-b - det) * den
     x1 = (-b + det) * den
     x = wp.vec2f(x0, x1)


### PR DESCRIPTION
Minor Refactoring for the Warp Raytracer.
Undoing the recent change of using the `save_div` from `newton.math` since the Warp Raytracer is used in places without otherwise importing Newton :)

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized ray tracing rendering pipeline for improved kernel execution efficiency
  * Streamlined internal rendering architecture with enhanced parameter handling and reduced memory overhead
  * Improved output image processing to better support multi-format rendering operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->