### PR TITLE
Add banners to membership verification workflow steps

### DIFF
--- a/.github/workflows/pr_target_aws_gpu_benchmarks.yml
+++ b/.github/workflows/pr_target_aws_gpu_benchmarks.yml
@@ -46,6 +46,25 @@ jobs:
             echo "" >&2
             echo "After updating your visibility, push a new commit to this PR to re-run the check." >&2
             echo "--------------------------------------------------------------------------------" >&2
+
+            # Surface warnings as visible annotations (yellow banners in job view)
+            echo "::warning::This PR requires manual approval before GPU benchmarks can run (author is not a recognized org member)."
+            echo "::warning::If you are a newton-physics org member with private membership, make it public at https://github.com/orgs/newton-physics/people"
+
+            # Write to job summary (appears in Summary tab)
+            cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
+          ## ⚠️ Manual Approval Required
+
+          This PR was authored by an external contributor. GPU benchmarks require manual approval from a maintainer before they can run.
+
+          ### Are you a newton-physics org member?
+
+          If your membership is set to **Private**, the workflow cannot detect it. To fix:
+
+          1. Go to [newton-physics People](https://github.com/orgs/newton-physics/people)
+          2. Find your username and change visibility from **Private** to **Public**
+          3. Push a new commit to re-trigger the check
+          EOF
           fi
 
   require-approval:

--- a/.github/workflows/pr_target_aws_gpu_tests.yml
+++ b/.github/workflows/pr_target_aws_gpu_tests.yml
@@ -46,6 +46,25 @@ jobs:
             echo "" >&2
             echo "After updating your visibility, push a new commit to this PR to re-run the check." >&2
             echo "--------------------------------------------------------------------------------" >&2
+
+            # Surface warnings as visible annotations (yellow banners in job view)
+            echo "::warning::This PR requires manual approval before GPU tests can run (author is not a recognized org member)."
+            echo "::warning::If you are a newton-physics org member with private membership, make it public at https://github.com/orgs/newton-physics/people"
+
+            # Write to job summary (appears in Summary tab)
+            cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
+          ## ⚠️ Manual Approval Required
+
+          This PR was authored by an external contributor. GPU tests require manual approval from a maintainer before they can run.
+
+          ### Are you a newton-physics org member?
+
+          If your membership is set to **Private**, the workflow cannot detect it. To fix:
+
+          1. Go to [newton-physics People](https://github.com/orgs/newton-physics/people)
+          2. Find your username and change visibility from **Private** to **Public**
+          3. Push a new commit to re-trigger the check
+          EOF
           fi
 
   require-approval:


### PR DESCRIPTION
## Summary

- Add `::warning::` annotations (yellow banners at top of job view) and `$GITHUB_STEP_SUMMARY` markdown to the membership check step in both PR GPU test and benchmark workflows
- When the author is not a recognized org member, the banners explain the manual approval requirement and link org members with private membership to the fix

## Test plan

- [x] Verified on fork ([shi-eric/newton#17](https://github.com/shi-eric/newton/pull/17)) with hacked workflows that force the NOT_MEMBER path — annotations appeared and job summary rendered correctly

Closes #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request workflow notifications for external contributors, displaying manual approval requirements and step-by-step guidance for membership visibility resolution directly in job summaries and workflow warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->