### PR TITLE
Add CI check for stale API docs and fix local build warnings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,9 +35,11 @@ jobs:
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e  # v1.1.1
       - name: Build Sphinx documentation
         run: uv run --extra docs --extra sim sphinx-build -W -b html docs docs/_build/html
-
-      - name: Clear Sphinx build folder
-        run: rm -rf docs/_build
-
+      - name: Verify API docs are up-to-date
+        run: |
+          git diff --exit-code docs/api/ || {
+            echo "::error::API docs are stale. Run 'python docs/generate_api.py' and commit the changes."
+            exit 1
+          }
       - name: Run Sphinx doctests
         run: uv run --extra docs --extra sim sphinx-build -W -b doctest docs docs/_build/doctest

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -59,6 +59,8 @@ newton
    AxisType
    eval_fk
    eval_ik
+   eval_jacobian
+   eval_mass_matrix
 
 .. rubric:: Constants
 

--- a/docs/api/newton_utils.rst
+++ b/docs/api/newton_utils.rst
@@ -23,12 +23,16 @@ newton.utils
    color_graph
    compute_world_offsets
    create_box_mesh
+   create_cable_stiffness_from_elastic_moduli
    create_capsule_mesh
    create_cone_mesh
    create_cylinder_mesh
    create_ellipsoid_mesh
+   create_parallel_transport_cable_quaternions
    create_plane_mesh
    create_sphere_mesh
+   create_straight_cable_points
+   create_straight_cable_points_and_quaternions
    download_asset
    event_scope
    leaky_max
@@ -37,6 +41,7 @@ newton.utils
    normalize_texture
    plot_graph
    quat_between_axes
+   quat_between_vectors_robust
    quat_decompose
    quat_from_euler
    quat_to_euler

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,11 @@ release = project_version
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-# Add docs/_ext to Python import path so custom extensions can be imported
+# Add docs/ and docs/_ext to Python import path so custom extensions and
+# sibling scripts (e.g. generate_api) can be imported.
+_docs_path = str(Path(__file__).parent)
+if _docs_path not in sys.path:
+    sys.path.append(_docs_path)
 _ext_path = Path(__file__).parent / "_ext"
 if str(_ext_path) not in sys.path:
     sys.path.append(str(_ext_path))
@@ -386,5 +390,9 @@ def _on_builder_inited(_app: Any) -> None:
 
 
 def setup(app: Any) -> None:
-    # Copy on build init so `_static/viser/index.html` is always present in the built site.
+    # Regenerate API .rst files so builds always reflect the current public API.
+    from generate_api import generate_all  # noqa: PLC0415
+
+    generate_all()
+
     app.connect("builder-inited", _on_builder_inited)

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -283,10 +283,13 @@ def write_module_page(mod_name: str) -> None:
 
 
 # -----------------------------------------------------------------------------
-# Script entry
+# Public entry point
 # -----------------------------------------------------------------------------
 
-if __name__ == "__main__":
+
+def generate_all() -> None:
+    """Regenerate all API ``.rst`` files under :data:`OUTPUT_DIR`."""
+
     # delete previously generated files
     shutil.rmtree(OUTPUT_DIR, ignore_errors=True)
 
@@ -295,4 +298,12 @@ if __name__ == "__main__":
 
     for mod in all_modules:
         write_module_page(mod)
+
+
+# -----------------------------------------------------------------------------
+# Script entry
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    generate_all()
     print("\nDone. Add docs/api/index.rst to your TOC or glob it in.")

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -60,7 +60,7 @@ def compute_vertex_normals(
     indices: wp.array | np.ndarray,
     normals: wp.array | None = None,
     *,
-    device: wp.context.Device | str | None = None,
+    device: wp.DeviceLike = None,
     normalize: bool = True,
 ) -> wp.array: ...
 
@@ -71,7 +71,7 @@ def compute_vertex_normals(
     indices: np.ndarray,
     normals: np.ndarray | None = None,
     *,
-    device: wp.context.Device | str | None = None,
+    device: wp.DeviceLike = None,
     normalize: bool = True,
 ) -> np.ndarray: ...
 
@@ -81,7 +81,7 @@ def compute_vertex_normals(
     indices: wp.array | np.ndarray,
     normals: wp.array | np.ndarray | None = None,
     *,
-    device: wp.context.Device | str | None = None,
+    device: wp.DeviceLike = None,
     normalize: bool = True,
 ) -> wp.array | np.ndarray:
     """Compute per-vertex normals from triangle indices.


### PR DESCRIPTION
## Summary
- Integrate `generate_api.py` into the Sphinx build via `conf.py`'s `setup()` so API `.rst` files are always regenerated before each build
- Add a post-build CI step that runs `git diff --exit-code docs/api/` to catch uncommitted API doc changes in PRs
- Extract `generate_all()` from `generate_api.py` so it can be called programmatically (standalone `python docs/generate_api.py` still works)
- Replace deprecated `wp.context.Device` type annotations with `wp.DeviceLike` in `compute_vertex_normals`
- Remove unnecessary Sphinx build folder clearing between the HTML and doctest builds, since they write to separate output subdirectories

Closes #405

## Test plan
- [ ] Verify `sphinx-build -W -b html docs docs/_build/html` succeeds with zero warnings (generate_all runs automatically)
- [ ] Verify `python docs/generate_api.py && git diff --exit-code docs/api/` shows no changes on a clean checkout
- [ ] Simulate staleness by editing a `docs/api/*.rst` file and confirm the CI step catches it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added several new utility functions for cables/quaternions and two new math helpers to the public API.

* **Documentation**
  * Added a public entry point to regenerate API pages and enforce that generated API docs are up-to-date during doc builds.
  * Enhanced doc build to allow importing custom extensions and sibling scripts.

* **Chores**
  * CI now verifies API documentation is current on pull requests.

* **Refactor**
  * Standardized type annotations in a mesh utility for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->