### PR TITLE
Fix example_robot_anymal_c_walk.py

### DIFF
--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -159,7 +159,7 @@ class Example:
         use_mujoco_contacts = args.use_mujoco_contacts if args else False
         if not use_mujoco_contacts:
             # Temporarily fix: override to use mujoco contact
-            print("WARNING: use_mujoco_contact is ignored, switch to use MjWarp collision pipeline")
+            print("WARNING: use_mujoco_contacts is ignored, switch to use MjWarp collision pipeline")
             use_mujoco_contacts = True
 
         # Create collision pipeline from command-line args (default: CollisionPipelineUnified with EXPLICIT)


### PR DESCRIPTION
## Description
Change temporarily default to mujoco collision pipeline
Explicitly set newton solver to avoid issue in the future

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact handling to avoid redundant recomputation when external contact data is used, reducing simulation inconsistencies.
  * Added a runtime warning when contact mode is forced to clarify behavior.

* **Chores**
  * Explicitly selected the solver mode and tuned solver iteration settings for more stable, deterministic simulations.
  * Increased supported contact capacity (nconmax=100) to better handle scenarios with many collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->