### PR TITLE
feat: parse mesh colors during URDF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
 - Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
 - Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
+- Parse URDF `<material>` colors (inline `<color rgba>` and named material references) during import and apply them to `ModelBuilder.shape_color` for all shape types
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
 - Add USD parsing for `NewtonSiteAPI` to mark shapes as sites.

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -420,6 +420,16 @@ def parse_urdf(
             custom_attributes = parse_custom_attributes(geo.attrib, builder_custom_attr_shape, parsing_mode="urdf")
             shape_kwargs["custom_attributes"] = custom_attributes
 
+            # parse material color (if any)
+            geo_color = None
+            mat_el = geom_group.find("material")
+            if mat_el is not None:
+                color_el = mat_el.find("color")
+                if color_el is not None:
+                    rgba = color_el.get("rgba")
+                    if rgba:
+                        geo_color = [float(c) for c in rgba.split()[:3]]
+
             tf = parse_transform(geom_group)
             if incoming_xform is not None:
                 tf = incoming_xform * tf

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -420,23 +420,11 @@ def parse_urdf(
             custom_attributes = parse_custom_attributes(geo.attrib, builder_custom_attr_shape, parsing_mode="urdf")
             shape_kwargs["custom_attributes"] = custom_attributes
 
-            # parse material color (if any)
-            geo_color = None
-            mat_el = geom_group.find("material")
-            if mat_el is not None:
-                color_el = mat_el.find("color")
-                if color_el is not None:
-                    rgba = color_el.get("rgba")
-                    if rgba:
-                        geo_color = [float(c) for c in rgba.split()[:3]]
-
             tf = parse_transform(geom_group)
             if incoming_xform is not None:
                 tf = incoming_xform * tf
 
-            material_info = {"color": None, "texture": None}
-            if just_visual:
-                material_info = resolve_material(geom_group.find("material"))
+            material_info = resolve_material(geom_group.find("material"))
 
             for box in geo.findall("box"):
                 size = box.get("size") or "1 1 1"
@@ -446,6 +434,7 @@ def parse_urdf(
                     hx=size[0] * 0.5 * scale,
                     hy=size[1] * 0.5 * scale,
                     hz=size[2] * 0.5 * scale,
+                    color=material_info["color"],
                     **shape_kwargs,
                 )
                 shapes.append(s)
@@ -454,6 +443,7 @@ def parse_urdf(
                 s = builder.add_shape_sphere(
                     xform=tf,
                     radius=float(sphere.get("radius") or "1") * scale,
+                    color=material_info["color"],
                     **shape_kwargs,
                 )
                 shapes.append(s)
@@ -465,6 +455,7 @@ def parse_urdf(
                     xform=xform,
                     radius=float(cylinder.get("radius") or "1") * scale,
                     half_height=float(cylinder.get("length") or "1") * 0.5 * scale,
+                    color=material_info["color"],
                     **shape_kwargs,
                 )
                 shapes.append(s)
@@ -476,6 +467,7 @@ def parse_urdf(
                     xform=xform,
                     radius=float(capsule.get("radius") or "1") * scale,
                     half_height=float(capsule.get("height") or "1") * 0.5 * scale,
+                    color=material_info["color"],
                     **shape_kwargs,
                 )
                 shapes.append(s)

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -2000,6 +2000,104 @@ class TestUrdfJointFriction(unittest.TestCase):
         for val in friction_values:
             self.assertAlmostEqual(float(val), 0.0, places=5)
 
+    def test_named_material_color_on_primitive(self):
+        """Robot-level named materials should resolve to colors on primitive shapes."""
+        urdf = """
+<robot name="named_mat_test">
+    <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    <link name="base_link">
+        <visual>
+            <geometry><sphere radius="0.5"/></geometry>
+            <material name="red"/>
+        </visual>
+    </link>
+</robot>
+"""
+        builder = newton.ModelBuilder()
+        parse_urdf(urdf, builder)
+        self.assertEqual(builder.shape_count, 1)
+        self.assertEqual(tuple(builder.shape_color[0]), (1.0, 0.0, 0.0))
+
+    def test_inline_material_color_on_primitive(self):
+        """Inline material color should apply to primitive shapes."""
+        urdf = """
+<robot name="inline_mat_test">
+    <link name="base_link">
+        <visual>
+            <geometry><box size="1 1 1"/></geometry>
+            <material name="green"><color rgba="0.0 1.0 0.0 1.0"/></material>
+        </visual>
+    </link>
+</robot>
+"""
+        builder = newton.ModelBuilder()
+        parse_urdf(urdf, builder)
+        self.assertEqual(builder.shape_count, 1)
+        self.assertEqual(tuple(builder.shape_color[0]), (0.0, 1.0, 0.0))
+
+    def test_named_material_color_multiple_primitives(self):
+        """Named materials should resolve for all primitive shape types."""
+        urdf = """
+<robot name="multi_prim_test">
+    <material name="blue"><color rgba="0.0 0.0 1.0 1.0"/></material>
+    <link name="base_link">
+        <visual>
+            <geometry><box size="1 1 1"/></geometry>
+            <material name="blue"/>
+        </visual>
+        <visual>
+            <geometry><cylinder radius="0.5" length="1.0"/></geometry>
+            <material name="blue"/>
+        </visual>
+        <visual>
+            <geometry><sphere radius="0.5"/></geometry>
+            <material name="blue"/>
+        </visual>
+    </link>
+</robot>
+"""
+        builder = newton.ModelBuilder()
+        parse_urdf(urdf, builder)
+        self.assertEqual(builder.shape_count, 3)
+        for i in range(3):
+            self.assertEqual(tuple(builder.shape_color[i]), (0.0, 0.0, 1.0), f"shape {i}")
+
+    def test_inline_overrides_named_material(self):
+        """Inline color on a named material should override the robot-level definition."""
+        urdf = """
+<robot name="override_test">
+    <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    <link name="base_link">
+        <visual>
+            <geometry><sphere radius="0.5"/></geometry>
+            <material name="red"><color rgba="0.0 1.0 0.0 1.0"/></material>
+        </visual>
+    </link>
+</robot>
+"""
+        builder = newton.ModelBuilder()
+        parse_urdf(urdf, builder)
+        self.assertEqual(builder.shape_count, 1)
+        self.assertEqual(tuple(builder.shape_color[0]), (0.0, 1.0, 0.0))
+
+    def test_named_material_color_on_mesh(self):
+        """Robot-level named materials should resolve to colors on mesh shapes."""
+        urdf = """
+<robot name="mesh_named_mat_test">
+    <material name="red"><color rgba="1.0 0.0 0.0 1.0"/></material>
+    <link name="base_link">
+        <visual>
+            <geometry><mesh filename="cube.obj"/></geometry>
+            <material name="red"/>
+        </visual>
+    </link>
+</robot>
+"""
+        builder = newton.ModelBuilder()
+        parse_urdf(urdf, builder, {"cube.obj": MESH_OBJ})
+        self.assertEqual(builder.shape_count, 1)
+        self.assertEqual(tuple(builder.shape_color[0]), (1.0, 0.0, 0.0))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Colors specified in URDF files are now parsed so that the Viewers show them.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
    - Note: I do not think this feature requires changes to documentation, as it is simply expected behavior
- [x] `CHANGELOG.md` has been updated

## Test plan

Added 5 tests to `import_urdf` and ran all with `uv run --extra dev -m newton.tests -k test_import_urdf`
- `test_named_material_color_on_primitive` — robot-level <material name="red"> resolves to the correct color on a sphere.
- `test_inline_material_color_on_primitive` — inline <color> inside a <material> element applies to a box.
 - `test_named_material_color_multiple_primitives` — a single named material resolves correctly across box, cylinder, and sphere shapes.
 - `test_inline_overrides_named_material` — inline <color> on a reference to a named material takes precedence over the robot-level definition.
 - `test_named_material_color_on_mesh` — robot-level named material resolves to the correct color on a mesh shape (different code path via load_meshes_from_file).

## New feature / API change

### Before
<img width="1114" height="778" alt="image" src="https://github.com/user-attachments/assets/c518f32b-08d4-4b5d-a6c3-1b4eb3262167" />

### After
<img width="1114" height="778" alt="image" src="https://github.com/user-attachments/assets/ae7676d0-bd3c-4df4-8aa9-90f6902b9266" />