### PR TITLE
Add --quiet flag to examples to suppress Warp messages

### DIFF
--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -336,6 +336,12 @@ def create_parser():
         default=None,
         help="Maximum number of worlds to render (for performance with many environments).",
     )
+    parser.add_argument(
+        "--quiet",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Suppress Warp compilation messages.",
+    )
 
     return parser
 
@@ -364,6 +370,10 @@ def init(parser=None):
     else:
         # When parser is provided, use parse_args() to properly handle --help
         args = parser.parse_args()
+
+    # Suppress Warp compilation messages if requested
+    if args.quiet:
+        wp.config.quiet = True
 
     # Set device if specified
     if args.device:

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -140,7 +140,7 @@ def add_example_test(
             command = [sys.executable]
 
         # Append Warp commands
-        command.extend(["-m", f"newton.examples.{name}", "--device", str(device), "--test"])
+        command.extend(["-m", f"newton.examples.{name}", "--device", str(device), "--test", "--quiet"])
 
         if not use_viewer:
             stage_path = (


### PR DESCRIPTION
Add a --quiet / --no-quiet CLI argument to the shared example argument parser. When set, it applies wp.config.quiet = True before any kernels are compiled, suppressing the "Module ... load on device" messages.

Example tests pass --quiet by default for cleaner test output.

Fixes #1408



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --quiet command-line option that allows users to suppress compilation messages when executing Newton examples, resulting in cleaner terminal output.
  * Updated test execution to automatically use the --quiet flag, reducing output verbosity and improving readability of test results during automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->