### PR TITLE
Defer resolution of MESH_MAXHULLVERT default in importers

### DIFF
--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -171,7 +171,7 @@ class Mesh:
         uvs: Sequence[Vec2] | nparray | None = None,
         compute_inertia: bool = True,
         is_solid: bool = True,
-        maxhullvert: int = MESH_MAXHULLVERT,
+        maxhullvert: int | None = None,
         color: Vec3 | None = None,
         roughness: float | None = None,
         metallic: float | None = None,
@@ -191,7 +191,7 @@ class Mesh:
             uvs: Optional per-vertex UVs, shape (N, 2).
             compute_inertia: If True, compute mass, inertia tensor, and center of mass (default: True).
             is_solid: If True, mesh is assumed solid for inertia computation (default: True).
-            maxhullvert: Max vertices for convex hull approximation (default: 64).
+            maxhullvert: Max vertices for convex hull approximation (default: MESH_MAXHULLVERT).
             color: Optional per-mesh base color (values in [0, 1]).
             roughness: Optional mesh roughness in [0, 1].
             metallic: Optional mesh metallic in [0, 1].
@@ -211,6 +211,8 @@ class Mesh:
         self.is_solid = is_solid
         self.has_inertia = compute_inertia
         self.mesh = None
+        if maxhullvert is None:
+            maxhullvert = MESH_MAXHULLVERT
         self.maxhullvert = maxhullvert
         self._cached_hash = None
         self._texture_hash = None

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -46,7 +46,6 @@ from ..core.types import (
     nparray,
 )
 from ..geometry import (
-    MESH_MAXHULLVERT,
     SDF,
     GeoType,
     Mesh,
@@ -1444,7 +1443,7 @@ class ModelBuilder:
         joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
         bodies_follow_joint_ordering: bool = True,
         collapse_fixed_joints: bool = False,
-        mesh_maxhullvert: int = MESH_MAXHULLVERT,
+        mesh_maxhullvert: int | None = None,
         force_position_velocity_actuation: bool = False,
     ):
         """
@@ -1520,7 +1519,7 @@ class ModelBuilder:
         load_visual_shapes: bool = True,
         hide_collision_shapes: bool = False,
         parse_mujoco_options: bool = True,
-        mesh_maxhullvert: int = MESH_MAXHULLVERT,
+        mesh_maxhullvert: int | None = None,
         schema_resolvers: list[SchemaResolver] | None = None,
         force_position_velocity_actuation: bool = False,
     ) -> dict[str, Any]:
@@ -1663,7 +1662,7 @@ class ModelBuilder:
         verbose: bool = False,
         skip_equality_constraints: bool = False,
         convert_3d_hinge_to_ball_joints: bool = False,
-        mesh_maxhullvert: int = MESH_MAXHULLVERT,
+        mesh_maxhullvert: int | None = None,
         ctrl_direct: bool = False,
         path_resolver: Callable[[str | None, str], str] | None = None,
     ):

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2591,7 +2591,7 @@ class SolverMuJoCo(SolverBase):
         actuated_axes: list[int] | None = None,
         skip_visual_only_geoms: bool = True,
         include_sites: bool = True,
-        mesh_maxhullvert: int = MESH_MAXHULLVERT,
+        mesh_maxhullvert: int | None = None,
         ls_parallel: bool = False,
     ) -> tuple[MjWarpModel, MjWarpData, MjModel, MjData]:
         """
@@ -2639,6 +2639,8 @@ class SolverMuJoCo(SolverBase):
             tuple[MjWarpModel, MjWarpData, MjModel, MjData]: Model and data objects for
                 ``mujoco_warp`` and MuJoCo.
         """
+        if mesh_maxhullvert is None:
+            mesh_maxhullvert = MESH_MAXHULLVERT
 
         if not model.joint_count:
             raise ValueError("The model must have at least one joint to be able to convert it to MuJoCo.")

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -747,7 +747,7 @@ def get_mesh(
     prim: Usd.Prim,
     load_normals: bool = False,
     load_uvs: bool = False,
-    maxhullvert: int = MESH_MAXHULLVERT,
+    maxhullvert: int | None = None,
     face_varying_normal_conversion: Literal[
         "vertex_averaging", "angle_weighted", "vertex_splitting"
     ] = "vertex_splitting",
@@ -762,7 +762,7 @@ def get_mesh(
     prim: Usd.Prim,
     load_normals: bool = False,
     load_uvs: bool = False,
-    maxhullvert: int = MESH_MAXHULLVERT,
+    maxhullvert: int | None = None,
     face_varying_normal_conversion: Literal[
         "vertex_averaging", "angle_weighted", "vertex_splitting"
     ] = "vertex_splitting",
@@ -776,7 +776,7 @@ def get_mesh(
     prim: Usd.Prim,
     load_normals: bool = False,
     load_uvs: bool = False,
-    maxhullvert: int = MESH_MAXHULLVERT,
+    maxhullvert: int | None = None,
     face_varying_normal_conversion: Literal[
         "vertex_averaging", "angle_weighted", "vertex_splitting"
     ] = "vertex_splitting",
@@ -846,6 +846,8 @@ def get_mesh(
         newton.Mesh: The loaded mesh, or ``(mesh, uv_indices)`` if
         ``return_uv_indices`` is True.
     """
+    if maxhullvert is None:
+        maxhullvert = MESH_MAXHULLVERT
 
     mesh = UsdGeom.Mesh(prim)
 

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -158,7 +158,7 @@ def parse_mjcf(
     verbose: bool = False,
     skip_equality_constraints: bool = False,
     convert_3d_hinge_to_ball_joints: bool = False,
-    mesh_maxhullvert: int = MESH_MAXHULLVERT,
+    mesh_maxhullvert: int | None = None,
     ctrl_direct: bool = False,
     path_resolver: Callable[[str | None, str], str] | None = None,
 ):
@@ -203,6 +203,8 @@ def parse_mjcf(
             from :attr:`newton.Control.joint_target_pos` and :attr:`newton.Control.joint_target_vel`.
         path_resolver (Callable): Callback to resolve file paths. Takes (base_dir, file_path) and returns a resolved path. For <include> elements, can return either a file path or XML content directly. For asset elements (mesh, texture, etc.), must return an absolute file path. The default resolver joins paths and returns absolute file paths.
     """
+    if mesh_maxhullvert is None:
+        mesh_maxhullvert = MESH_MAXHULLVERT
     if xform is None:
         xform = wp.transform_identity()
     else:

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -84,7 +84,7 @@ def parse_urdf(
     joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
     bodies_follow_joint_ordering: bool = True,
     collapse_fixed_joints: bool = False,
-    mesh_maxhullvert: int = MESH_MAXHULLVERT,
+    mesh_maxhullvert: int | None = None,
     force_position_velocity_actuation: bool = False,
 ):
     """
@@ -116,6 +116,8 @@ def parse_urdf(
             damping > 0, :attr:`~newton.ActuatorMode.EFFORT` if a drive is present but both gains are zero
             (direct torque control), or :attr:`~newton.ActuatorMode.NONE` if no drive/actuation is applied.
     """
+    if mesh_maxhullvert is None:
+        mesh_maxhullvert = MESH_MAXHULLVERT
     axis_xform = wp.transform(wp.vec3(0.0), quat_between_axes(up_axis, builder.up_axis))
     if xform is None:
         xform = axis_xform

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -60,7 +60,7 @@ def parse_usd(
     load_visual_shapes: bool = True,
     hide_collision_shapes: bool = False,
     parse_mujoco_options: bool = True,
-    mesh_maxhullvert: int = MESH_MAXHULLVERT,
+    mesh_maxhullvert: int | None = None,
     schema_resolvers: list[SchemaResolver] | None = None,
     force_position_velocity_actuation: bool = False,
 ) -> dict[str, Any]:
@@ -147,6 +147,8 @@ def parse_usd(
             * - ``"path_original_body_map"``
               - Mapping from prim path to original body index before ``collapse_fixed_joints``
     """
+    if mesh_maxhullvert is None:
+        mesh_maxhullvert = MESH_MAXHULLVERT
     if schema_resolvers is None:
         schema_resolvers = [SchemaResolverNewton()]
     collect_schema_attrs = len(schema_resolvers) > 0


### PR DESCRIPTION
Change all function signatures that use MESH_MAXHULLVERT as a default parameter value to default to None instead, resolving to MESH_MAXHULLVERT inside the function body. This allows users to modify MESH_MAXHULLVERT at runtime and have the change reflected when loading assets.

Fixes #1450

