### PR TITLE
Fix nightly Warp CI to resolve pre-release builds

### DIFF
--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -42,7 +42,7 @@ jobs:
           version: "0.9.0"
 
       - name: Update warp-lang in lock file
-        run: uv lock -P warp-lang
+        run: uv lock -P warp-lang --prerelease allow
 
       - name: Check if warp-lang version changed
         id: check-update
@@ -129,7 +129,7 @@ jobs:
         run: uv python install
 
       - name: Update lock file with latest warp-lang nightly build
-        run: uv lock -P warp-lang
+        run: uv lock -P warp-lang --prerelease allow
 
       - name: Run Tests
         run: uv run --extra dev --extra torch-cu12 -m newton.tests --junit-report-xml rspec.xml


### PR DESCRIPTION
## Summary
- Add `--prerelease allow` to `uv lock -P warp-lang` so uv considers pre-release versions
- Without this flag, the `>=1.11.0` specifier causes uv to resolve to the latest stable release (v1.11.1) instead of nightly dev builds

## Test plan
- [x] Verified fix on fork via `workflow_dispatch`: the workflow correctly resolved `warp-lang v1.12.0.dev20260210` ([run](https://github.com/shi-eric/newton/actions/runs/21884011460))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to allow prerelease versions when updating dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->