### PR TITLE
SolverMuJoCo: Expand geom_margin to avoid OOB read with heterogeneous worlds

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3953,7 +3953,7 @@ class SolverMuJoCo(SolverBase):
             "geom_pos",
             "geom_quat",
             "geom_friction",
-            # "geom_margin",
+            "geom_margin",
             "geom_gap",
             # "geom_rgba",
             # "site_pos",


### PR DESCRIPTION
## Description
`geom_margin` is currently not being expanded, resulting in an OOB read in the `contact_params` func.
This change expands the field, avoiding the corrupt read, without exposing the attribute until this is mapped onto a Newton concept.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced physics simulation world management by ensuring the geom_margin attribute is now properly synchronized across multiple world instances. This update improves consistency in collision margin behavior when replicating physics environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->