### PR TITLE
Point typos hook at pyproject.toml config and add menagerie words

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,5 +30,5 @@ repos:
     rev: v1.42.0
     hooks:
       - id: typos
-        args: []
+        args: [--config, pyproject.toml]
         exclude: \.(js|css)$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,15 @@ files.extend-exclude = ["/examples/assets", "*.urdf", "*.usd", "*.usda", "*.mjcf
 arange = "arange"
 ba = "ba"
 HAA = "HAA"
+# MuJoCo Menagerie brand/product names
+Pincher = "Pincher"
+Robotis = "Robotis"
+robotis = "robotis"
+Iit = "Iit"
+IIT = "IIT"
+iit = "iit"
+PN = "PN"
+pnd = "pnd"
 
 [tool.typos.default.extend-identifiers]
 PNGs = "PNGs"


### PR DESCRIPTION
The typos pre-commit hook was not reading the [tool.typos] config in pyproject.toml. Add --config flag so it picks up the word allowlist. Add MuJoCo Menagerie brand/product names to the allowlist.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configurations for spell-checking, including configuration file reference and extended word list additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->