### PR TITLE
fix(examples): propagate IK solution to model state in Franka example

### DIFF
--- a/newton/examples/ik/example_ik_franka.py
+++ b/newton/examples/ik/example_ik_franka.py
@@ -120,6 +120,7 @@ class Example:
 
     def simulate(self):
         self.solver.step(self.joint_q, self.joint_q, iterations=self.ik_iters)
+        wp.copy(self.model.joint_q, self.joint_q)
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transform and push into IK objectives."""


### PR DESCRIPTION
## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR fixes a bug in [newton/examples/ik/example_ik_franka.py](cci:7://file:///Users/alecive/code/experiments/newton/newton/examples/ik/example_ik_franka.py:0:0-0:0) where the solved joint positions (`joint_q`) were not being copied back to the model state (`self.model.joint_q`). As a result, the viewer was not rendering the updated robot pose, and the robot appeared static despite the solver working correctly.

This change adds `wp.copy(self.model.joint_q, self.joint_q)` to the simulate() method to ensure the visualization updates with the IK solution.

Original behavior:

https://github.com/user-attachments/assets/0fbe1942-d252-4da3-8a83-24532c0628d2

Behavior after fix:

https://github.com/user-attachments/assets/1ca4dc8a-6fb3-49df-9443-71a1d5e1034d


## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in `[docs/migration.rst](cci:7://file:///Users/alecive/code/experiments/newton/docs/migration.rst:0:0-0:0)` is up-to date (No migration changes required; bug fix only)

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see [newton/tests/test_examples.py](cci:7://file:///Users/alecive/code/experiments/newton/newton/tests/test_examples.py:0:0-0:0)) - Verified manually with `uv run -m newton.examples ik_franka`. No need for additional tests.
- [x] Documentation is up-to-date (No docs changes needed)
- [x] Code passes formatting and linting checks with `pre-commit run -a` (Single line change follows existing style)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the inverse kinematics example to properly update the model state with solver results after each simulation step. The model's joint positions now accurately reflect the calculations performed by the inverse kinematics solver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->