### PR TITLE
Fix root shapes in ArticulationView with fixed base

### DIFF
--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -990,8 +990,8 @@ class ArticulationView:
         # handle custom slice
         if isinstance(_slice, Slice):
             _slice = _slice.get()
-        elif not isinstance(_slice, (NoneType, int)):
-            raise ValueError(f"Invalid slice type: expected Slice or int, got {type(_slice)}")
+        elif not isinstance(_slice, (NoneType, int, slice)):
+            raise ValueError(f"Invalid slice type: expected slice or int, got {type(_slice)}")
 
         if _slice is None:
             value_slice = layout.indices if is_indexed else layout.slice

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -57,15 +57,14 @@ class TestSelection(unittest.TestCase):
 
         L = 9  # num links
         J = 9  # num joints
+        S = 13  # num shapes
 
         if floating:
             D = 14  # num joint dofs
             C = 15  # num joint coords
-            S = 13  # num shapes
         else:
             D = 8  # num joint dofs
             C = 8  # num joint coords
-            S = 13  # num shapes
 
         # scene with just one ant
         single_ant_model = ant.finalize()


### PR DESCRIPTION
Previously, `ArticulationView.get_root_transforms()` returned inconsistent shapes:
* `(num_worlds, num_artis)` for floating base articulatuions.
* `(num_worlds, num_artis, 1)` for fixed base articulatuions.

Now, it consistently returns `(num_worlds, num_artis)` regardless of the root joint type.


## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of attribute selection inputs and corrected multi-dimensional layout handling to ensure consistent indexing, shapes, and trailing-dimension alignment.

* **Tests**
  * Parameterized tests covering both floating and fixed base configurations, validating selection shapes and root-velocity behavior across single, per-world, and multi-world views; note: duplicate public test entries were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->