### PR TITLE
fix(viewer): add missing JointType.BALL support to contact line kernel

### DIFF
--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -384,6 +384,7 @@ def compute_joint_basis_lines(
         joint_t != int(newton.JointType.REVOLUTE)
         and joint_t != int(newton.JointType.D6)
         and joint_t != int(newton.JointType.CABLE)
+        and joint_t != int(newton.JointType.BALL)
     ):
         # Set NaN for unsupported joints to hide them
         line_starts[tid] = wp.vec3(wp.nan, wp.nan, wp.nan)


### PR DESCRIPTION
## Description
This PR fixes an issue where Ball joints were not being visualized in the viewer. The `compute_joint_basis_lines` kernel was explicitly excluding `JointType.BALL`, causing joint axes to not be rendered.

## Changes
- Updated `newton/_src/viewer/kernels.py` to include `JointType.BALL` in the supported joint types check.

## Verification
- Verified locally. Happy to provide more information if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BALL joints are no longer displayed in the viewer, as visualization support for this joint type is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->