### PR TITLE
Add overflow warnings for narrow-phase collision buffers

### DIFF
--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -2013,7 +2013,7 @@ class NarrowPhase:
             kernel=verify_narrow_phase_buffers,
             dim=[1],
             inputs=[
-                num_candidate_pair,
+                candidate_pair_count,
                 candidate_pair.shape[0],
                 self.gjk_candidate_pairs_count,
                 self.gjk_candidate_pairs.shape[0],

--- a/newton/tests/test_narrow_phase.py
+++ b/newton/tests/test_narrow_phase.py
@@ -1797,7 +1797,7 @@ class TestBufferOverflowWarnings(unittest.TestCase):
         capture.begin()
         narrow_phase.launch(
             candidate_pair=candidate_pair,
-            num_candidate_pair=num_candidate_pair,
+            candidate_pair_count=num_candidate_pair,
             shape_types=arrays[0],
             shape_data=arrays[1],
             shape_transform=arrays[2],
@@ -1863,7 +1863,7 @@ class TestBufferOverflowWarnings(unittest.TestCase):
         capture.begin()
         narrow_phase.launch(
             candidate_pair=candidate_pair,
-            num_candidate_pair=num_candidate_pair,
+            candidate_pair_count=num_candidate_pair,
             shape_types=arrays[0],
             shape_data=arrays[1],
             shape_transform=arrays[2],


### PR DESCRIPTION
## Description

Add a verification kernel that checks all intermediate narrow-phase buffers for overflow after collision kernels complete. Previously, when buffers filled up, pairs were silently dropped with no warning — leading to incorrect simulation results with no indication of the problem.

The `verify_narrow_phase_buffers` kernel is launched with `dim=[1]` at the end of `launch_custom_write()` and checks 8 buffers:
- GJK candidate pairs
- Mesh-convex shape pairs
- Triangle pairs
- Mesh-plane shape pairs
- Mesh-mesh shape pairs
- Heightfield shape pairs
- Heightfield cell pairs
- SDF-SDF shape pairs

Each check prints a `wp.printf` warning with the overflowed count and the buffer capacity. Follows the same pattern as the existing `verify_collision_step` kernel in `sdf_hydroelastic.py`.

Closes #1187

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

No migration changes needed — this is a new diagnostic warning with no API changes.

## Before your PR is \"Ready for review\"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime verification that checks collision-buffer capacities and emits warnings when counts exceed limits after narrow-phase processing and at the end of full collision runs (warnings reported on CUDA devices).

* **Tests**
  * Added tests validating buffer-overflow detection and warning emission during collision processing, ensuring over-capacity conditions are reported while still producing contact results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->