### PR TITLE
Remove hardcoded subnet ID from AWS workflow

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -74,7 +74,6 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          subnet-id: subnet-051b9d2e71acf8047
           security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
           aws-resource-tags: >
             [

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -74,7 +74,6 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          subnet-id: subnet-051b9d2e71acf8047
           security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
           aws-resource-tags: >
             [

--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -99,7 +99,6 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          subnet-id: subnet-051b9d2e71acf8047
           security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
           aws-resource-tags: >
             [


### PR DESCRIPTION
## Summary

- Fixes flaky AWS GPU CI runner startup caused by hardcoding a single subnet/AZ.
- Removes `subnet-id: subnet-051b9d2e71acf8047` from EC2 runner startup in:
  - `.github/workflows/aws_gpu_tests.yml`
  - `.github/workflows/aws_gpu_benchmarks.yml`
  - `.github/workflows/scheduled_nightly_warp_tests.yml`
- Allows EC2 placement to use any available AZ in `us-east-2`, improving resilience when `g6e.2xlarge` capacity is unavailable in one zone.

## Why

- CI was failing with: insufficient `g6e.2xlarge` capacity in `us-east-2a`.
- The fixed subnet effectively pinned launches to a single AZ, preventing AWS from selecting other zones with capacity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration for test and benchmark workflows to simplify EC2 instance provisioning settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->