### PR TITLE
Update AWS workflows to g7e.2xlarge with multi-AZ failover

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -7,10 +7,9 @@ name: GPU Benchmarks on AWS EC2 (Reusable)
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.2xlarge
+  AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_PRIMARY_SUBNET_ID: subnet-051b9d2e71acf8047
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
@@ -65,59 +64,20 @@ jobs:
           fi
           echo "Latest AMI ID found: $LATEST_AMI_ID"
           echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
-      - name: Build EC2 availability zones config
-        run: |
-          SECURITY_GROUP_ID=$(echo "${{ env.AWS_SECURITY_GROUP_IDS }}" | cut -d',' -f1 | xargs)
-          VPC_ID=$(aws ec2 describe-security-groups --region ${{ env.AWS_REGION }} \
-            --group-ids "$SECURITY_GROUP_ID" \
-            --query 'SecurityGroups[0].VpcId' \
-            --output text)
-          ALL_SUBNETS_JSON=$(aws ec2 describe-subnets --region ${{ env.AWS_REGION }} \
-            --filters "Name=vpc-id,Values=$VPC_ID" "Name=state,Values=available" \
-            --query 'Subnets[].SubnetId' \
-            --output json)
-          AWS_AVAILABILITY_ZONES_CONFIG=$(python3 - <<'PY'
-          import json
-          import os
-
-          primary_subnet = os.environ["AWS_PRIMARY_SUBNET_ID"]
-          security_group_id = os.environ["SECURITY_GROUP_ID"]
-          image_id = os.environ["LATEST_AMI_ID"]
-          region = os.environ["AWS_REGION"]
-          subnets = json.loads(os.environ["ALL_SUBNETS_JSON"])
-
-          ordered_subnets = [primary_subnet] + [s for s in subnets if s != primary_subnet]
-          unique_subnets = []
-          seen = set()
-          for subnet in ordered_subnets:
-              if subnet and subnet not in seen:
-                  seen.add(subnet)
-                  unique_subnets.append(subnet)
-
-          config = [
-              {
-                  "imageId": image_id,
-                  "subnetId": subnet,
-                  "securityGroupId": security_group_id,
-                  "region": region,
-              }
-              for subnet in unique_subnets
-          ]
-          print(json.dumps(config, separators=(",", ":")))
-          PY
-          )
-          echo "AWS_AVAILABILITY_ZONES_CONFIG=$AWS_AVAILABILITY_ZONES_CONFIG" >> "$GITHUB_ENV"
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512  # v2.4.3
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          availability-zones-config: ${{ env.AWS_AVAILABILITY_ZONES_CONFIG }}
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
+          availability-zones-config: >
+            [
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
+            ]
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -9,10 +9,9 @@ name: GPU Unit Tests on AWS EC2 (Reusable)
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.2xlarge
+  AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_PRIMARY_SUBNET_ID: subnet-051b9d2e71acf8047
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
@@ -65,59 +64,20 @@ jobs:
           fi
           echo "Latest AMI ID found: $LATEST_AMI_ID"
           echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
-      - name: Build EC2 availability zones config
-        run: |
-          SECURITY_GROUP_ID=$(echo "${{ env.AWS_SECURITY_GROUP_IDS }}" | cut -d',' -f1 | xargs)
-          VPC_ID=$(aws ec2 describe-security-groups --region ${{ env.AWS_REGION }} \
-            --group-ids "$SECURITY_GROUP_ID" \
-            --query 'SecurityGroups[0].VpcId' \
-            --output text)
-          ALL_SUBNETS_JSON=$(aws ec2 describe-subnets --region ${{ env.AWS_REGION }} \
-            --filters "Name=vpc-id,Values=$VPC_ID" "Name=state,Values=available" \
-            --query 'Subnets[].SubnetId' \
-            --output json)
-          AWS_AVAILABILITY_ZONES_CONFIG=$(python3 - <<'PY'
-          import json
-          import os
-
-          primary_subnet = os.environ["AWS_PRIMARY_SUBNET_ID"]
-          security_group_id = os.environ["SECURITY_GROUP_ID"]
-          image_id = os.environ["LATEST_AMI_ID"]
-          region = os.environ["AWS_REGION"]
-          subnets = json.loads(os.environ["ALL_SUBNETS_JSON"])
-
-          ordered_subnets = [primary_subnet] + [s for s in subnets if s != primary_subnet]
-          unique_subnets = []
-          seen = set()
-          for subnet in ordered_subnets:
-              if subnet and subnet not in seen:
-                  seen.add(subnet)
-                  unique_subnets.append(subnet)
-
-          config = [
-              {
-                  "imageId": image_id,
-                  "subnetId": subnet,
-                  "securityGroupId": security_group_id,
-                  "region": region,
-              }
-              for subnet in unique_subnets
-          ]
-          print(json.dumps(config, separators=(",", ":")))
-          PY
-          )
-          echo "AWS_AVAILABILITY_ZONES_CONFIG=$AWS_AVAILABILITY_ZONES_CONFIG" >> "$GITHUB_ENV"
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512  # v2.4.3
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          availability-zones-config: ${{ env.AWS_AVAILABILITY_ZONES_CONFIG }}
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
+          availability-zones-config: >
+            [
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
+            ]
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},

--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -11,10 +11,9 @@ name: Newton + Warp Nightly Builds
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g6e.2xlarge
+  AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_PRIMARY_SUBNET_ID: subnet-051b9d2e71acf8047
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 1800
@@ -90,59 +89,20 @@ jobs:
           fi
           echo "Latest AMI ID found: $LATEST_AMI_ID"
           echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
-      - name: Build EC2 availability zones config
-        run: |
-          SECURITY_GROUP_ID=$(echo "${{ env.AWS_SECURITY_GROUP_IDS }}" | cut -d',' -f1 | xargs)
-          VPC_ID=$(aws ec2 describe-security-groups --region ${{ env.AWS_REGION }} \
-            --group-ids "$SECURITY_GROUP_ID" \
-            --query 'SecurityGroups[0].VpcId' \
-            --output text)
-          ALL_SUBNETS_JSON=$(aws ec2 describe-subnets --region ${{ env.AWS_REGION }} \
-            --filters "Name=vpc-id,Values=$VPC_ID" "Name=state,Values=available" \
-            --query 'Subnets[].SubnetId' \
-            --output json)
-          AWS_AVAILABILITY_ZONES_CONFIG=$(python3 - <<'PY'
-          import json
-          import os
-
-          primary_subnet = os.environ["AWS_PRIMARY_SUBNET_ID"]
-          security_group_id = os.environ["SECURITY_GROUP_ID"]
-          image_id = os.environ["LATEST_AMI_ID"]
-          region = os.environ["AWS_REGION"]
-          subnets = json.loads(os.environ["ALL_SUBNETS_JSON"])
-
-          ordered_subnets = [primary_subnet] + [s for s in subnets if s != primary_subnet]
-          unique_subnets = []
-          seen = set()
-          for subnet in ordered_subnets:
-              if subnet and subnet not in seen:
-                  seen.add(subnet)
-                  unique_subnets.append(subnet)
-
-          config = [
-              {
-                  "imageId": image_id,
-                  "subnetId": subnet,
-                  "securityGroupId": security_group_id,
-                  "region": region,
-              }
-              for subnet in unique_subnets
-          ]
-          print(json.dumps(config, separators=(",", ":")))
-          PY
-          )
-          echo "AWS_AVAILABILITY_ZONES_CONFIG=$AWS_AVAILABILITY_ZONES_CONFIG" >> "$GITHUB_ENV"
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@a6dbcefcf8a31a861f5e078bb153ed332130c512  # v2.4.3
         with:
           mode: start
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          availability-zones-config: ${{ env.AWS_AVAILABILITY_ZONES_CONFIG }}
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          security-group-id: ${{ env.AWS_SECURITY_GROUP_IDS }}
+          availability-zones-config: >
+            [
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
+              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
+            ]
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},


### PR DESCRIPTION
## Summary

- Upgrade EC2 instance type from `g6e.2xlarge` to `g7e.2xlarge`
- Replace dynamic subnet discovery (which required `ec2:DescribeSecurityGroups` / `ec2:DescribeSubnets` IAM permissions the runner role doesn't have) with static `availability-zones-config` listing us-east-2a and us-east-2b subnets
- The `ec2-github-runner` action (v2.4.3) tries each AZ sequentially and automatically falls back on `InsufficientInstanceCapacity` errors
- Exclude us-east-2c as `g7e.2xlarge` is not available in that AZ

Supersedes #1664, #1666 and their reverts.

## Test plan

- [x] Verified us-east-2a subnet launches successfully (fork CI run)
- [x] Verified us-east-2b subnet launches successfully (fork CI run with rotated order)
- [x] Verified us-east-2c correctly fails and falls back to next AZ (fork CI run)
- [ ] Merge queue run passes GPU tests on upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded AWS GPU testing infrastructure to newer instance types (g7e.2xlarge) for improved testing performance
  * Simplified CI/CD workflow configuration by hardcoding availability zones settings and removing dynamic setup steps
  * Enhanced workflow reliability and maintainability across GPU test pipelines through streamlined infrastructure configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->