### PR TITLE
Get rid of tkinter dependency

### DIFF
--- a/newton/examples/basic/example_replay_viewer.py
+++ b/newton/examples/basic/example_replay_viewer.py
@@ -118,15 +118,7 @@ class ReplayUI:
         imgui.text(self.selected_file if self.selected_file else "No file loaded")
 
         if imgui.button("Load Recording..."):
-            self.viewer.ui.open_load_file_dialog(
-                filetypes=[
-                    ("Recording files", ("*.json", "*.bin")),
-                    ("JSON files", "*.json"),
-                    ("Binary files", "*.bin"),
-                    ("All files", "*.*"),
-                ],
-                title="Select Recording File",
-            )
+            self.viewer.ui.open_load_file_dialog(title="Select Recording File")
 
         # Playback controls (only if recording is loaded)
         if self.total_frames > 0:


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->
Should fix https://github.com/newton-physics/newton/issues/1621. Needs testing since the example did not crash on my Windows machine even before the change.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * File dialogs (Open/Save) are now non-blocking, allowing continued UI interaction while dialogs are open.
  * File loading workflow in the replay viewer improved with better asynchronous dialog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->