### PR TITLE
Update warp-lang nightly to 1.12.0.dev20260217

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.12.0.dev20260127 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.12.0.dev20260217 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.5.0",
     "python -m pip install -U mujoco-warp==3.5.0",
     "python -m pip install -U torch==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129",

--- a/uv.lock
+++ b/uv.lock
@@ -5409,17 +5409,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.0.dev20260127"
+version = "1.12.0.dev20260217"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260127-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d8626967d10b9948bf55b96fc2be6f9ed8f7e1fc89996dfda63c8674b4080456" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260127-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f541ea7febda2be20b9a6ee2f2a09abcf386dfcbb04738e16e9fac6d0a319902" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260127-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:3a7b4eb65f5ce9159b0f3a8440694e63131eaa7d90694b5acdd2cbc472fca00b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260127-py3-none-win_amd64.whl", hash = "sha256:213e93703e801a3db50e01d85c01228750137ff782a5a89fa058e4fca92e5dcb" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260217-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d2e3d6e4f3fcfc43a7e006b0935950b8ae8ce35c36918e305a2963b6039fc0f5" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260217-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f4c982a2b5ba2c7fd6e8eaf023ced08e89210f1c0d90bececceb0416ecdb2a60" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260217-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:844c663ee93f65fc1aac98d5bbc865bef9ae7c0f4f5a298f84aa4c4d49e6c188" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260217-py3-none-win_amd64.whl", hash = "sha256:c20f3822ba00c6a6b70579655603c7d871f566f59af1699f9d202ef570305a17" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump pinned `warp-lang` nightly from `1.12.0.dev20260127` to `1.12.0.dev20260217` in `uv.lock` and `asv.conf.json`

## Test plan
- [ ] CI passes with the new warp nightly version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to a newer pre-release version (minor bump).
  * Change is limited to build/dev configuration; no public API or exported behavior changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->