### PR TITLE
Change default friction coefficients to match MuJoCo

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -166,13 +166,13 @@ class ModelBuilder:
         """The friction damping coefficient. Used by SemiImplicit, Featherstone."""
         ka: float = 0.0
         """The contact adhesion distance. Used by SemiImplicit, Featherstone."""
-        mu: float = 0.5
+        mu: float = 1.0
         """The coefficient of friction. Used by all solvers."""
         restitution: float = 0.0
         """The coefficient of restitution. Used by XPBD. To take effect, enable restitution in solver constructor via ``enable_restitution=True``."""
-        mu_torsional: float = 0.25
+        mu_torsional: float = 0.005
         """The coefficient of torsional friction (resistance to spinning at contact point). Used by XPBD, MuJoCo."""
-        mu_rolling: float = 0.0005
+        mu_rolling: float = 0.0001
         """The coefficient of rolling friction (resistance to rolling motion). Used by XPBD, MuJoCo."""
         thickness: float = 1e-5
         """Outward offset from the shape's surface for collision detection.

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -95,6 +95,7 @@ def build_stacked_cubes_scene(
 
     builder = newton.ModelBuilder()
     builder.default_shape_cfg = newton.ModelBuilder.ShapeConfig(
+        mu=0.5,
         sdf_max_resolution=32,
         is_hydroelastic=True,
         sdf_narrow_band_range=(-narrow_band, narrow_band),

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2209,15 +2209,15 @@ class TestImportMjcf(unittest.TestCase):
         self.assertAlmostEqual(builder.shape_material_mu_torsional[2], 0.0, places=5)
         self.assertAlmostEqual(builder.shape_material_mu_rolling[2], 0.0, places=5)
 
-        # 1-element: friction="1.0" → others use ShapeConfig defaults (0.25, 0.0005)
+        # 1-element: friction="1.0" → others use ShapeConfig defaults (0.005, 0.0001)
         self.assertAlmostEqual(builder.shape_material_mu[3], 1.0, places=5)
-        self.assertAlmostEqual(builder.shape_material_mu_torsional[3], 0.25, places=5)
-        self.assertAlmostEqual(builder.shape_material_mu_rolling[3], 0.0005, places=5)
+        self.assertAlmostEqual(builder.shape_material_mu_torsional[3], 0.005, places=5)
+        self.assertAlmostEqual(builder.shape_material_mu_rolling[3], 0.0001, places=5)
 
-        # 2-element: friction="0.6 0.15" → torsional: 0.15, rolling uses default (0.0005)
+        # 2-element: friction="0.6 0.15" → torsional: 0.15, rolling uses default (0.0001)
         self.assertAlmostEqual(builder.shape_material_mu[4], 0.6, places=5)
         self.assertAlmostEqual(builder.shape_material_mu_torsional[4], 0.15, places=5)
-        self.assertAlmostEqual(builder.shape_material_mu_rolling[4], 0.0005, places=5)
+        self.assertAlmostEqual(builder.shape_material_mu_rolling[4], 0.0001, places=5)
 
     def test_mjcf_geom_solref_parsing(self):
         """Test MJCF geom solref parsing for contact stiffness/damping.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4637,6 +4637,7 @@ class TestMuJoCoMocapBodies(unittest.TestCase):
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 1e4
         builder.default_shape_cfg.kd = 1000.0
+        builder.default_shape_cfg.mu = 0.5
 
         # Create fixed-base (mocap) body at root (at origin)
         # This body will have a FIXED joint to the world, making it a mocap body in MuJoCo


### PR DESCRIPTION
## Summary
- Align `ShapeConfig` default friction values with MuJoCo defaults: `mu` 0.5→1.0, `mu_torsional` 0.25→0.005, `mu_rolling` 0.0005→0.0001
- Fix three tests that depended on old defaults by either updating expected values or pinning explicit friction where the test isn't about friction behavior
- All 2024 tests pass; examples that rely on defaults show only minor behavioral differences (verified numerically)

## Test plan
- [x] Full test suite passes (2024 tests, 0 failures)
- [x] All 95 example tests pass
- [x] Compared test_final values for 11 examples that rely on default friction between `main` and this branch — differences are small and within thresholds
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Adjusted default friction parameters for physics simulations, including base friction coefficient and torsional/rolling friction properties.

* **Tests**
  * Updated test expectations and configurations to align with new default friction parameter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->