### PR TITLE
Override only MassAPI attributes that have been authored

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1219,7 +1219,9 @@ def parse_usd(
             body_specs[body_path] = rigid_body_desc
             prim = stage.GetPrimAtPath(prim_path)
 
-    # Bodies with MassAPI that need ComputeMassProperties fallback (missing mass or inertia).
+    # Bodies with MassAPI that need ComputeMassProperties fallback (no authored mass).
+    # When mass is not authored, ComputeMassProperties is needed to resolve body-level
+    # density into mass.  Bodies with authored mass use rescaled accumulated inertia instead.
     bodies_requiring_mass_properties_fallback: set[str] = set()
     if UsdPhysics.ObjectType.RigidBody in ret_dict:
         prim_paths, rigid_body_descs = ret_dict[UsdPhysics.ObjectType.RigidBody]
@@ -1235,9 +1237,7 @@ def parse_usd(
                 continue
 
             mass_api = UsdPhysics.MassAPI(prim)
-            has_authored_mass = mass_api.GetMassAttr().HasAuthoredValue()
-            has_authored_inertia = mass_api.GetDiagonalInertiaAttr().HasAuthoredValue()
-            if not (has_authored_mass and has_authored_inertia):
+            if not mass_api.GetMassAttr().HasAuthoredValue():
                 bodies_requiring_mass_properties_fallback.add(body_path)
 
     # Collect joint descriptions regardless of whether articulations are authored.
@@ -2137,56 +2137,71 @@ def parse_usd(
             has_authored_mass = mass_api.GetMassAttr().HasAuthoredValue()
             has_authored_inertia = mass_api.GetDiagonalInertiaAttr().HasAuthoredValue()
 
-            if has_authored_mass and has_authored_inertia:
+            # Override only explicitly authored MassAPI attributes; keep accumulated
+            # values from add_shape() for everything else.
+            if has_authored_mass:
+                shape_accumulated_mass = builder.body_mass[body_id]
                 mass = float(mass_api.GetMassAttr().Get())
-                i_diag = mass_api.GetDiagonalInertiaAttr().Get()
-                if mass_api.GetCenterOfMassAttr().HasAuthoredValue():
-                    com = mass_api.GetCenterOfMassAttr().Get()
-                else:
-                    com = Gf.Vec3f(0.0, 0.0, 0.0)
-                if mass_api.GetPrincipalAxesAttr().HasAuthoredValue():
-                    principal_axes = mass_api.GetPrincipalAxesAttr().Get()
-                else:
-                    principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
+                builder.body_mass[body_id] = mass
+                builder.body_inv_mass[body_id] = 1.0 / mass if mass > 0.0 else 0.0
+                # Scale accumulated inertia to match the authored mass.
+                if not has_authored_inertia and shape_accumulated_mass > 0.0 and mass > 0.0:
+                    scale = mass / shape_accumulated_mass
+                    builder.body_inertia[body_id] = wp.mat33(np.array(builder.body_inertia[body_id]) * scale)
+                    builder.body_inv_inertia[body_id] = wp.inverse(builder.body_inertia[body_id])
             else:
+                # No authored mass: use ComputeMassProperties to resolve body-level density.
                 rigid_body_api = UsdPhysics.RigidBodyAPI(prim)
                 mass, i_diag, com, principal_axes = rigid_body_api.ComputeMassProperties(
                     _get_collision_mass_information
                 )
-            # MassAPI bodies should always override any previously accumulated shape mass.
-            builder.body_mass[body_id] = mass
-            builder.body_inv_mass[body_id] = 1.0 / mass if mass > 0.0 else 0.0
-            builder.body_com[body_id] = wp.vec3(*com)
+                builder.body_mass[body_id] = mass
+                builder.body_inv_mass[body_id] = 1.0 / mass if mass > 0.0 else 0.0
+                if not mass_api.GetCenterOfMassAttr().HasAuthoredValue():
+                    builder.body_com[body_id] = wp.vec3(*com)
+                if not has_authored_inertia:
+                    i_diag_np = np.array(i_diag, dtype=np.float32)
+                    if np.linalg.norm(i_diag_np) > 0.0:
+                        i_rot = usd.from_gfquat(principal_axes)
+                        rot = np.array(wp.quat_to_matrix(i_rot), dtype=np.float32).reshape(3, 3)
+                        inertia = rot @ np.diag(i_diag_np) @ rot.T
+                        builder.body_inertia[body_id] = wp.mat33(inertia)
+                        if inertia.any():
+                            builder.body_inv_inertia[body_id] = wp.inverse(wp.mat33(*inertia))
+                        else:
+                            builder.body_inv_inertia[body_id] = wp.mat33(0.0)
 
-            i_diag_np = np.array(i_diag, dtype=np.float32)
-            if np.linalg.norm(i_diag_np) > 0.0:
-                i_rot = usd.from_gfquat(principal_axes)
-                rot = np.array(wp.quat_to_matrix(i_rot), dtype=np.float32).reshape(3, 3)
-                inertia = rot @ np.diag(i_diag_np) @ rot.T
-                builder.body_inertia[body_id] = wp.mat33(inertia)
-                if inertia.any():
-                    builder.body_inv_inertia[body_id] = wp.inverse(wp.mat33(*inertia))
-                else:
-                    builder.body_inv_inertia[body_id] = wp.mat33(0.0)
+            if has_authored_inertia:
+                i_diag_np = np.array(mass_api.GetDiagonalInertiaAttr().Get(), dtype=np.float32)
+                if np.linalg.norm(i_diag_np) > 0.0:
+                    if mass_api.GetPrincipalAxesAttr().HasAuthoredValue():
+                        principal_axes = mass_api.GetPrincipalAxesAttr().Get()
+                    else:
+                        principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
+                    i_rot = usd.from_gfquat(principal_axes)
+                    rot = np.array(wp.quat_to_matrix(i_rot), dtype=np.float32).reshape(3, 3)
+                    inertia = rot @ np.diag(i_diag_np) @ rot.T
+                    builder.body_inertia[body_id] = wp.mat33(inertia)
+                    if inertia.any():
+                        builder.body_inv_inertia[body_id] = wp.inverse(wp.mat33(*inertia))
+                    else:
+                        builder.body_inv_inertia[body_id] = wp.mat33(0.0)
 
-            # Assign nonzero inertia if mass is nonzero to make sure the body can be simulated
+            if mass_api.GetCenterOfMassAttr().HasAuthoredValue():
+                builder.body_com[body_id] = wp.vec3(*mass_api.GetCenterOfMassAttr().Get())
+
+            # Assign nonzero inertia if mass is nonzero to make sure the body can be simulated.
             I_m = np.array(builder.body_inertia[body_id])
             mass = builder.body_mass[body_id]
             if I_m.max() == 0.0:
                 if mass > 0.0:
-                    # Heuristic: assume a uniform density sphere with the given mass
-                    # For a sphere: I = (2/5) * m * r^2
-                    # Estimate radius from mass assuming reasonable density (e.g., water density ~1000 kg/m³)
-                    # This gives r = (3*m/(4*π*p))^(1/3)
-                    density = default_shape_density  # kg/m³
+                    density = default_shape_density  # kg/m^3
                     volume = mass / density
                     radius = (3.0 * volume / (4.0 * np.pi)) ** (1.0 / 3.0)
                     _, _, I_default = compute_inertia_sphere(density, radius)
 
-                    # Apply parallel axis theorem if center of mass is offset
                     com = builder.body_com[body_id]
                     if np.linalg.norm(com) > 1e-6:
-                        # I = I_cm + m * d² where d is distance from COM to body origin
                         d_squared = np.sum(com**2)
                         I_default += wp.mat33(mass * d_squared * np.eye(3, dtype=np.float32))
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2152,7 +2152,16 @@ def parse_usd(
             # inertia, which may already reflect the authored mass.
             if has_authored_inertia:
                 i_diag_np = np.array(mass_api.GetDiagonalInertiaAttr().Get(), dtype=np.float32)
-                if mass_api.GetPrincipalAxesAttr().HasAuthoredValue():
+                if np.any(i_diag_np < 0.0):
+                    warnings.warn(
+                        f"Body {body_path}: authored diagonal inertia contains negative values. "
+                        "Falling back to mass-computer result.",
+                        stacklevel=2,
+                    )
+                    has_authored_inertia = False
+                    i_diag_np = np.array(cmp_i_diag, dtype=np.float32)
+                    principal_axes = cmp_principal_axes
+                elif mass_api.GetPrincipalAxesAttr().HasAuthoredValue():
                     principal_axes = mass_api.GetPrincipalAxesAttr().Get()
                 else:
                     principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4355,6 +4355,56 @@ def Xform "Articulation" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_massapi_authored_mass_without_inertia_scales_to_uniform_density(self):
+        """Authored mass without inertia should produce inertia consistent with a uniform-density body.
+
+        Two identical 10 cm cube bodies that should both end up with 8 kg
+        mass and inertia I_diag = (1/6) * m * s^2:
+          A - density 8000 kg/m^3 on the collider shape
+          B - mass 8 kg on the body only, inertia via scaling
+        """
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        density = 8000.0
+        size = 0.1
+        mass = density * size**3
+        expected_i = (1.0 / 6.0) * mass * size**2
+
+        def create_body(name):
+            body = UsdGeom.Xform.Define(stage, f"/World/{name}")
+            UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+            collider = UsdGeom.Cube.Define(stage, f"/World/{name}/Collider")
+            collider.CreateSizeAttr().Set(size)
+            UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
+            return body.GetPrim(), collider.GetPrim()
+
+        # A: density on the collider shape derives mass and inertia.
+        body_prim, collider_prim = create_body("A")
+        UsdPhysics.MassAPI.Apply(body_prim)
+        UsdPhysics.MassAPI.Apply(collider_prim).CreateDensityAttr().Set(density)
+
+        # B: only mass authored on body, inertia scaled from shape accumulation.
+        body_prim, _ = create_body("B")
+        UsdPhysics.MassAPI.Apply(body_prim).CreateMassAttr().Set(mass)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+        idx_a = result["path_body_map"]["/World/A"]
+        idx_b = result["path_body_map"]["/World/B"]
+
+        for idx, name in ((idx_a, "A"), (idx_b, "B")):
+            self.assertAlmostEqual(builder.body_mass[idx], mass, places=5, msg=f"Body {name} mass")
+            inertia = np.array(builder.body_inertia[idx]).reshape(3, 3)
+            np.testing.assert_allclose(
+                np.diag(inertia), [expected_i] * 3, atol=1e-5, rtol=1e-5, err_msg=f"Body {name} inertia"
+            )
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_partial_body_applies_axis_rotation_in_compute_callback(self):
         """Compute fallback must rotate cone/capsule/cylinder mass frame for non-Z axes."""
         from pxr import Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4358,10 +4358,10 @@ def Xform "Articulation" (
     def test_massapi_authored_mass_without_inertia_scales_to_uniform_density(self):
         """Authored mass without inertia should produce inertia consistent with a uniform-density body.
 
-        Two identical 10 cm cube bodies that should both end up with 8 kg
-        mass and inertia I_diag = (1/6) * m * s^2:
-          A - density 8000 kg/m^3 on the collider shape
-          B - mass 8 kg on the body only, inertia via scaling
+        Two identical 0.1 [m] cube bodies that should both end up with 8 [kg]
+        mass and inertia I_diag = (1/6) * m * s^2 [kg*m^2]:
+          A - density 8000 [kg/m^3] on the collider shape
+          B - mass 8 [kg] on the body only, inertia via scaling
         """
         from pxr import Usd, UsdGeom, UsdPhysics
 


### PR DESCRIPTION
## Description
Modifies the MassAPI override logic in the USD importer to treat each authored attribute (mass, diagonalInertia, centerOfMass) independently. Previously, these were coupled in a two-branch structure that could discard individually authored values. This fixes:

- Accumulated center of mass reset to (0, 0, 0) when mass and inertia were authored but center of mass was not.
- Inertia replaced by the mass computer without regard for authored mass, instead of being scaled to match it.
- Authored inertia discarded when mass was not authored.
- Authored center of mass ignored when routed through the mass computer.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate import of mass, inertia and center-of-mass with authored values taking precedence and better fallback to computed properties.
  * If mass is authored but inertia is missing, inertia is scaled to match authored mass for consistent results.
  * Improved inertia fallback and COM handling (including correct parallel-axis correction) and clearer validation/warnings for invalid or missing physics data.

* **Tests**
  * Added a unit test verifying authored mass without authored inertia scales inertia using collider-provided density.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->