### PR TITLE
Fix option parsing with multiple <option> elements from includes

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -333,12 +333,15 @@ def parse_mjcf(
 
     # Parse MJCF compiler and option tags for ONCE and WORLD frequency custom attributes
     # WORLD frequency attributes use index 0 here; they get remapped during add_world()
+    # Use findall for <option> to handle multiple elements after include expansion
+    # (later values override earlier ones, matching MuJoCo's merge behavior).
     if parse_mujoco_options:
         builder_custom_attr_option: list[ModelBuilder.CustomAttribute] = builder.get_custom_attributes_by_frequency(
             [AttributeFrequency.ONCE, AttributeFrequency.WORLD]
         )
         if builder_custom_attr_option:
-            for elem in (compiler, root.find("option")):
+            option_elems = [compiler, *root.findall("option")]
+            for elem in option_elems:
                 if elem is not None:
                     parsed = parse_custom_attributes(elem.attrib, builder_custom_attr_option, "mjcf")
                     for key, value in parsed.items():


### PR DESCRIPTION
## Summary

- Fix MJCF parser to process all `<option>` elements after include expansion, not just the first one
- Previously `root.find("option")` only returned the first `<option>`, which after include expansion is typically from the included robot XML (missing scene-level settings like `iterations`/`ls_iterations`)
- Now uses `findall("option")` to iterate all elements, with later values overriding earlier ones — matching MuJoCo's native merge behavior (verified against `xml_native_reader.cc`)
- Affects any MJCF model loaded via `scene.xml` → `<include file="robot.xml"/>` where both files have `<option>` tags

## Test plan

- [ ] New `TestMjcfIncludeOptionMerge` tests (3 tests):
  - `test_option_from_included_file`: attributes from included `<option>` are parsed
  - `test_scene_option_overrides_included`: scene `<option>` overrides included values
  - `test_partial_option_preserves_unset`: unset attributes in later `<option>` keep values from earlier one
- [ ] Existing include tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MJCF option parsing to correctly handle multiple option elements from included files, with proper merge semantics where later values override earlier ones, aligning with MuJoCo specifications.

* **Tests**
  * Added comprehensive test coverage for MJCF option merging behavior across different scenarios, including option inheritance from included files and override precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->