### PR TITLE
Skip IK cube stacking example test

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -527,6 +527,11 @@ add_example_test(
     use_viewer=True,
 )
 
+# Skip until the IK cube stacking example is stabilized
+for _attr in list(vars(TestIKExamples)):
+    if _attr.startswith("test_ik.example_ik_cube_stacking"):
+        setattr(TestIKExamples, _attr, unittest.skip("Unstable test")(getattr(TestIKExamples, _attr)))
+
 
 class TestSelectionAPIExamples(unittest.TestCase):
     pass


### PR DESCRIPTION
## Summary
- Skip `test_ik.example_ik_cube_stacking_cuda_0` which is currently unstable
- Uses `unittest.skip` so the test is cleanly skipped in CI without affecting the test suite outcome

## Test plan
- [x] Verified the test is reported as `skipped` when running `uv run --extra dev -m newton.tests -k test_ik.example_ik_cube_stacking`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked IK cube stacking example tests as skipped due to instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->