### PR TITLE
Fix softbody examples table layout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,10 +577,18 @@ uv sync --extra examples
         <img src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_softbody_hanging.png" alt="Softbody Hanging">
       </a>
     </td>
+    <td align="center" width="33%">
+    </td>
+    <td align="center" width="33%">
+    </td>
   </tr>
   <tr>
     <td align="center">
       <code>uv run -m newton.examples softbody_hanging</code>
+    </td>
+    <td align="center">
+    </td>
+    <td align="center">
     </td>
   </tr>
 </table>


### PR DESCRIPTION
## Summary
- Add empty placeholder `<td>` cells to the Softbody Examples table to maintain the three-column layout consistent with all other example sections in the README.

## Test plan
- [x] Verify the Softbody Examples section renders correctly on GitHub with a proper three-column table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated table formatting in the Softbody Examples section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->