### PR TITLE
WIP Improve performance of `ModelBuilder.add_builder()`

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1573,11 +1573,11 @@ class ModelBuilder:
                 For example, (5.0, 5.0, 0.0) arranges copies in a 2D grid in the XY plane.
                 Defaults to (0.0, 0.0, 0.0).
         """
-        offsets = compute_world_offsets(world_count, spacing, self.up_axis)
         if all(s == 0.0 for s in spacing):
             for _ in range(world_count):
                 self.add_world(builder, xform=None)
         else:
+            offsets = compute_world_offsets(world_count, spacing, self.up_axis)
             xform = wp.transform_identity()
             for i in range(world_count):
                 xform[:3] = offsets[i]

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1574,10 +1574,14 @@ class ModelBuilder:
                 Defaults to (0.0, 0.0, 0.0).
         """
         offsets = compute_world_offsets(world_count, spacing, self.up_axis)
-        xform = wp.transform_identity()
-        for i in range(world_count):
-            xform[:3] = offsets[i]
-            self.add_world(builder, xform=xform)
+        if all(s == 0.0 for s in spacing):
+            for _ in range(world_count):
+                self.add_world(builder, xform=None)
+        else:
+            xform = wp.transform_identity()
+            for i in range(world_count):
+                xform[:3] = offsets[i]
+                self.add_world(builder, xform=xform)
 
     def add_articulation(
         self, joints: list[int], label: str | None = None, custom_attributes: dict[str, Any] | None = None

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2454,18 +2454,19 @@ class ModelBuilder:
 
         start_body_idx = self.body_count
         start_shape_idx = self.shape_count
-        for s, b in enumerate(builder.shape_body):
-            if b > -1:
-                new_b = b + start_body_idx
-                self.shape_body.append(new_b)
-                self.shape_transform.append(builder.shape_transform[s])
-            else:
-                self.shape_body.append(-1)
-                # apply offset transform to root bodies
-                if xform is not None:
-                    self.shape_transform.append(transform_mul(xform, builder.shape_transform[s]))
-                else:
+        if xform is None:
+            # Fast path: no transform to apply — extend in bulk
+            self.shape_body.extend_with_offset_nonnegative(builder.shape_body, start_body_idx)
+            self.shape_transform.extend(builder.shape_transform)
+        else:
+            for s, b in enumerate(builder.shape_body):
+                if b > -1:
+                    self.shape_body.append(b + start_body_idx)
                     self.shape_transform.append(builder.shape_transform[s])
+                else:
+                    self.shape_body.append(-1)
+                    # apply offset transform to root bodies
+                    self.shape_transform.append(transform_mul(xform, builder.shape_transform[s]))
 
         for b, shapes in builder.body_shapes.items():
             remapped_shapes = [s + start_shape_idx for s in shapes]

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2810,11 +2810,7 @@ class ModelBuilder:
             if merged is None:
                 if isinstance(freq_key, str):
                     # String frequency: copy list as-is (no offset for sequential data)
-                    if (
-                        scalar_int_fast_path
-                        and isinstance(attr.values, list)
-                        and not any(v is None for v in attr.values)
-                    ):
+                    if scalar_int_fast_path and isinstance(attr.values, list) and None not in attr.values:
                         if use_current_world:
                             mapped_values = [self.current_world] * len(attr.values)
                         elif value_offset == 0:
@@ -2826,7 +2822,7 @@ class ModelBuilder:
                 else:
                     # Enum frequency: remap dict indices with offset
                     enum_values = attr.values if isinstance(attr.values, dict) else {}
-                    if scalar_int_fast_path:
+                    if scalar_int_fast_path and None not in enum_values.values():
                         mapped_values = remap_scalar_int_dict(
                             enum_values, index_offset, value_offset, use_current_world
                         )
@@ -2862,7 +2858,7 @@ class ModelBuilder:
                 if not isinstance(merged.values, list):
                     merged.values = []
                 # String frequency: extend list with transformed values
-                if scalar_int_fast_path and isinstance(attr.values, list) and not any(v is None for v in attr.values):
+                if scalar_int_fast_path and isinstance(attr.values, list) and None not in attr.values:
                     if use_current_world:
                         new_values = [self.current_world] * len(attr.values)
                     elif value_offset == 0:
@@ -2877,7 +2873,7 @@ class ModelBuilder:
                     merged.values = {}
                 enum_values = attr.values if isinstance(attr.values, dict) else {}
                 # Enum frequency: update dict with remapped indices
-                if scalar_int_fast_path:
+                if scalar_int_fast_path and None not in enum_values.values():
                     new_indices = remap_scalar_int_dict(enum_values, index_offset, value_offset, use_current_world)
                 else:
                     remapped_indices = remap_indices(enum_values.keys(), index_offset)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2743,8 +2743,12 @@ class ModelBuilder:
 
         # Pre-build or reuse (attr, src_list) pairs from builder — cached so the 68 dict lookups
         # happen only on the first add_builder() call; reused cheaply on calls 2..N in replicate().
+        # Empty attrs are filtered out so the extend loop skips no-op calls (e.g. particle/soft-body
+        # attrs for a rigid-body-only builder).
         if _AB_SRCS_KEY not in builder_dict:
-            builder_dict[_AB_SRCS_KEY] = tuple((attr, builder_dict[attr]) for attr in _ALL_BUILDER_ATTRS)
+            builder_dict[_AB_SRCS_KEY] = tuple(
+                (attr, src) for attr in _ALL_BUILDER_ATTRS if (src := builder_dict[attr])
+            )
 
         # Extend all plain-copy attributes using __dict__ access (faster than getattr for instance attrs).
         if label_prefix is None:

--- a/newton/_src/sim/utils.py
+++ b/newton/_src/sim/utils.py
@@ -32,6 +32,12 @@ _NUMPY_THRESHOLD: int = 16
 # Cached at module level so extend_with_offset* can use count+offset frombuffer without
 # recomputing the constant on every call.
 _INTC_ITEMSIZE: int = np.dtype(np.intc).itemsize
+# Guard the shared-memory assumption: array.array('i') and np.intc must have the same
+# itemsize for np.frombuffer(..., dtype=np.intc) over array.array('i') data to be correct.
+assert array("i").itemsize == _INTC_ITEMSIZE, (
+    f"array 'i' itemsize ({array('i').itemsize}) != np.intc itemsize ({_INTC_ITEMSIZE}); "
+    "np.frombuffer on array.array('i') data with dtype=np.intc is unsafe on this platform"
+)
 
 
 class _IntIndexList(MutableSequence):

--- a/newton/_src/sim/utils.py
+++ b/newton/_src/sim/utils.py
@@ -127,6 +127,12 @@ class _IntIndexList(MutableSequence):
     def tolist(self) -> list[int]:
         return self._data.tolist()
 
+    def __array__(self, dtype=None, copy=None):
+        arr = np.frombuffer(self._data, dtype=np.intc)
+        if dtype is None or np.dtype(dtype) == np.dtype(np.intc):
+            return arr.copy()
+        return arr.astype(dtype)
+
     def extend_with_offset(self, values: Iterable[int], offset: int) -> None:
         if isinstance(values, _IntIndexList):
             if not values._data:

--- a/newton/_src/sim/utils.py
+++ b/newton/_src/sim/utils.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal utilities for simulation builder index containers."""
+
+from __future__ import annotations
+
+from array import array
+from collections.abc import Iterable
+from typing import SupportsIndex, overload
+
+import numpy as np
+
+
+class IntIndexList(list[int]):
+    """Compact list-like storage for 1D integer indices."""
+
+    __slots__ = ("_data",)
+    __hash__ = None
+
+    def __init__(self, values: Iterable[int] | None = None):
+        self._data = array("i")
+        if values is not None:
+            self.extend(values)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> int: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> list[int]: ...
+
+    def __getitem__(self, idx: SupportsIndex | slice) -> int | list[int]:
+        if isinstance(idx, slice):
+            return self._data[idx].tolist()
+        return self._data[idx]
+
+    @overload
+    def __setitem__(self, idx: SupportsIndex, value: int) -> None: ...
+
+    @overload
+    def __setitem__(self, idx: slice, value: Iterable[int]) -> None: ...
+
+    def __setitem__(self, idx: SupportsIndex | slice, value: int | Iterable[int]) -> None:
+        if isinstance(idx, slice):
+            if isinstance(value, IntIndexList):
+                self._data[idx] = value._data
+            elif isinstance(value, Iterable):
+                self._data[idx] = array("i", (int(v) for v in value))
+            else:
+                raise TypeError("iterable assignment expected for slice index")
+            return
+        if isinstance(value, Iterable):
+            raise TypeError("int assignment expected for scalar index")
+        self._data[idx] = int(value)
+
+    def __contains__(self, value: object) -> bool:
+        if isinstance(value, (int, np.integer)) and not isinstance(value, (bool, np.bool_)):
+            return int(value) in self._data
+        return False
+
+    def __repr__(self) -> str:
+        return repr(self._data.tolist())
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, IntIndexList):
+            return self._data == other._data
+        if isinstance(other, array):
+            return self._data == other
+        if isinstance(other, (list, tuple)):
+            return self._data.tolist() == list(other)
+        return NotImplemented
+
+    def __copy__(self):
+        out = IntIndexList()
+        out._data = self._data[:]
+        return out
+
+    def __deepcopy__(self, memo):
+        return self.__copy__()
+
+    def copy(self):
+        return self.__copy__()
+
+    def append(self, value: int) -> None:
+        self._data.append(int(value))
+
+    def extend(self, values: Iterable[int]) -> None:
+        if isinstance(values, IntIndexList):
+            self._data.extend(values._data)
+            return
+        append = self._data.append
+        for value in values:
+            append(int(value))
+
+    def clear(self) -> None:
+        self._data = array("i")
+
+    def tolist(self) -> list[int]:
+        return self._data.tolist()
+
+    def extend_with_offset(self, values: Iterable[int], offset: int) -> None:
+        if isinstance(values, IntIndexList):
+            if not values._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(values._data)
+            if offset != 0:
+                np.frombuffer(self._data, dtype=np.intc)[start:] += int(offset)
+            return
+
+        offset = int(offset)
+        append = self._data.append
+        if offset == 0:
+            for value in values:
+                append(int(value))
+            return
+
+        for value in values:
+            append(int(value) + offset)
+
+    def extend_with_offset_except(self, values: Iterable[int], offset: int, sentinel: int = -1) -> None:
+        if isinstance(values, IntIndexList):
+            if not values._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(values._data)
+            if offset != 0:
+                new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                new_data[new_data != int(sentinel)] += int(offset)
+            return
+
+        offset = int(offset)
+        sentinel = int(sentinel)
+        append = self._data.append
+        if offset == 0:
+            for value in values:
+                append(int(value))
+            return
+
+        for value in values:
+            value_int = int(value)
+            append(value_int if value_int == sentinel else value_int + offset)
+
+    def extend_with_offset_nonnegative(self, values: Iterable[int], offset: int) -> None:
+        if isinstance(values, IntIndexList):
+            if not values._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(values._data)
+            if offset != 0:
+                new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                new_data[new_data >= 0] += int(offset)
+            return
+
+        offset = int(offset)
+        append = self._data.append
+        if offset == 0:
+            for value in values:
+                append(int(value))
+            return
+
+        for value in values:
+            value_int = int(value)
+            append(value_int + offset if value_int >= 0 else value_int)
+
+
+class IntIndexList2D(list[tuple[int, ...]]):
+    """Compact list-like storage for fixed-width integer tuples."""
+
+    __slots__ = ("_data", "_width")
+    __hash__ = None
+
+    def __init__(self, rows: Iterable[Iterable[int]] | None = None, width: int = 2):
+        self._width = int(width)
+        if self._width <= 0:
+            raise ValueError("width must be positive")
+        self._data = array("i")
+        if rows is not None:
+            self.extend(rows)
+
+    def __len__(self) -> int:
+        return len(self._data) // self._width
+
+    def __iter__(self):
+        data = self._data
+        width = self._width
+        for i in range(0, len(data), width):
+            yield tuple(data[i : i + width])
+
+    @overload
+    def __getitem__(self, idx: SupportsIndex) -> tuple[int, ...]: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> list[tuple[int, ...]]: ...
+
+    def __getitem__(self, idx: SupportsIndex | slice) -> tuple[int, ...] | list[tuple[int, ...]]:
+        row_count = len(self)
+        if isinstance(idx, slice):
+            start, stop, step = idx.indices(row_count)
+            return [self[i] for i in range(start, stop, step)]
+
+        idx_int = int(idx)
+        if idx_int < 0:
+            idx_int += row_count
+        if idx_int < 0 or idx_int >= row_count:
+            raise IndexError("index out of range")
+
+        base_idx = idx_int * self._width
+        return tuple(self._data[base_idx : base_idx + self._width])
+
+    @overload
+    def __setitem__(self, idx: SupportsIndex, value: Iterable[int]) -> None: ...
+
+    @overload
+    def __setitem__(self, idx: slice, value: Iterable[Iterable[int]]) -> None: ...
+
+    def __setitem__(self, idx: SupportsIndex | slice, value: Iterable[int] | Iterable[Iterable[int]]) -> None:
+        if isinstance(idx, slice):
+            replacement = IntIndexList2D(value, width=self._width)
+            self._data[idx] = replacement._data
+            return
+
+        idx_int = int(idx)
+        row_count = len(self)
+        if idx_int < 0:
+            idx_int += row_count
+        if idx_int < 0 or idx_int >= row_count:
+            raise IndexError("index out of range")
+
+        row = tuple(int(v) for v in value)
+        if len(row) != self._width:
+            raise ValueError(f"row must have width {self._width}, got {len(row)}")
+        base_idx = idx_int * self._width
+        self._data[base_idx : base_idx + self._width] = array("i", row)
+
+    def __contains__(self, row: object) -> bool:
+        if not isinstance(row, tuple) or len(row) != self._width:
+            return False
+        try:
+            row_ints = tuple(int(v) for v in row)
+        except (TypeError, ValueError):
+            return False
+
+        data = self._data
+        width = self._width
+        for i in range(0, len(data), width):
+            if tuple(data[i : i + width]) == row_ints:
+                return True
+        return False
+
+    def __repr__(self) -> str:
+        return repr(self.tolist())
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, IntIndexList2D):
+            return self._width == other._width and self._data == other._data
+        if isinstance(other, (list, tuple)):
+            return self.tolist() == [tuple(row) for row in other]
+        return NotImplemented
+
+    def __copy__(self):
+        out = IntIndexList2D(width=self._width)
+        out._data = self._data[:]
+        return out
+
+    def __deepcopy__(self, memo):
+        return self.__copy__()
+
+    def copy(self):
+        return self.__copy__()
+
+    def append(self, row: Iterable[int]) -> None:
+        values = tuple(int(v) for v in row)
+        if len(values) != self._width:
+            raise ValueError(f"row must have width {self._width}, got {len(values)}")
+        self._data.extend(values)
+
+    def extend(self, rows: Iterable[Iterable[int]]) -> None:
+        if isinstance(rows, IntIndexList2D):
+            if rows._width != self._width:
+                raise ValueError(f"row width mismatch: expected {self._width}, got {rows._width}")
+            self._data.extend(rows._data)
+            return
+
+        for row in rows:
+            self.append(row)
+
+    def clear(self) -> None:
+        self._data = array("i")
+
+    def tolist(self) -> list[tuple[int, ...]]:
+        return list(self)
+
+    def extend_with_offset(self, rows: Iterable[Iterable[int]], offset: int) -> None:
+        if isinstance(rows, IntIndexList2D):
+            if rows._width != self._width:
+                raise ValueError(f"row width mismatch: expected {self._width}, got {rows._width}")
+            if not rows._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(rows._data)
+            if offset != 0:
+                np.frombuffer(self._data, dtype=np.intc)[start:] += int(offset)
+            return
+
+        offset = int(offset)
+        for row in rows:
+            self.append(int(v) + offset for v in row)
+
+    def extend_with_offset_except(self, rows: Iterable[Iterable[int]], offset: int, sentinel: int = -1) -> None:
+        if isinstance(rows, IntIndexList2D):
+            if rows._width != self._width:
+                raise ValueError(f"row width mismatch: expected {self._width}, got {rows._width}")
+            if not rows._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(rows._data)
+            if offset != 0:
+                new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                new_data[new_data != int(sentinel)] += int(offset)
+            return
+
+        offset = int(offset)
+        sentinel = int(sentinel)
+        for row in rows:
+            self.append(int(v) if int(v) == sentinel else int(v) + offset for v in row)
+
+    def extend_with_offset_nonnegative(self, rows: Iterable[Iterable[int]], offset: int) -> None:
+        if isinstance(rows, IntIndexList2D):
+            if rows._width != self._width:
+                raise ValueError(f"row width mismatch: expected {self._width}, got {rows._width}")
+            if not rows._data:
+                return
+
+            start = len(self._data)
+            self._data.extend(rows._data)
+            if offset != 0:
+                new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                new_data[new_data >= 0] += int(offset)
+            return
+
+        offset = int(offset)
+        for row in rows:
+            self.append(int(v) + offset if int(v) >= 0 else int(v) for v in row)

--- a/newton/_src/sim/utils.py
+++ b/newton/_src/sim/utils.py
@@ -24,7 +24,8 @@ from typing import SupportsIndex, overload
 import numpy as np
 
 # Below this element count, a Python loop is faster than np.frombuffer + vectorised add
-# (numpy has ~2 µs per-call overhead regardless of array size; Python loop breaks even ~n=22).
+# (numpy has ~2 µs per-call overhead regardless of array size; break-even measured ~n=22,
+# threshold set to 16 to leave headroom for variation across platforms).
 _NUMPY_THRESHOLD: int = 16
 
 
@@ -81,10 +82,10 @@ class _IntIndexList(MutableSequence):
         self._data[idx] = int(value)
 
     def __delitem__(self, idx: SupportsIndex | slice) -> None:
-        raise NotImplementedError("IntIndexList does not support item deletion")
+        raise NotImplementedError("_IntIndexList does not support item deletion")
 
     def insert(self, idx: SupportsIndex, value: int) -> None:
-        raise NotImplementedError("IntIndexList does not support insert; use append() or extend()")
+        raise NotImplementedError("_IntIndexList does not support insert; use append() or extend()")
 
     def __contains__(self, value: object) -> bool:
         if isinstance(value, (int, np.integer)) and not isinstance(value, (bool, np.bool_)):
@@ -109,7 +110,9 @@ class _IntIndexList(MutableSequence):
         return out
 
     def __deepcopy__(self, memo):
-        return self.__copy__()
+        out = self.__copy__()
+        memo[id(self)] = out
+        return out
 
     def copy(self):
         return self.__copy__()
@@ -325,10 +328,10 @@ class _IntIndexList2D(MutableSequence):
         self._data[base_idx : base_idx + self._width] = array("i", row)
 
     def __delitem__(self, idx: SupportsIndex | slice) -> None:
-        raise NotImplementedError("IntIndexList2D does not support item deletion")
+        raise NotImplementedError("_IntIndexList2D does not support item deletion")
 
     def insert(self, idx: SupportsIndex, value: Iterable[int]) -> None:
-        raise NotImplementedError("IntIndexList2D does not support insert; use append() or extend()")
+        raise NotImplementedError("_IntIndexList2D does not support insert; use append() or extend()")
 
     def __contains__(self, row: object) -> bool:
         if not isinstance(row, tuple) or len(row) != self._width:
@@ -361,7 +364,9 @@ class _IntIndexList2D(MutableSequence):
         return out
 
     def __deepcopy__(self, memo):
-        return self.__copy__()
+        out = self.__copy__()
+        memo[id(self)] = out
+        return out
 
     def copy(self):
         return self.__copy__()

--- a/newton/_src/sim/utils.py
+++ b/newton/_src/sim/utils.py
@@ -28,6 +28,11 @@ import numpy as np
 # threshold set to 16 to leave headroom for variation across platforms).
 _NUMPY_THRESHOLD: int = 16
 
+# itemsize of the 'i' typecode used by _IntIndexList._data (== np.dtype(np.intc).itemsize).
+# Cached at module level so extend_with_offset* can use count+offset frombuffer without
+# recomputing the constant on every call.
+_INTC_ITEMSIZE: int = np.dtype(np.intc).itemsize
+
 
 class _IntIndexList(MutableSequence):
     """Compact array-backed storage for 1D integer indices.
@@ -164,7 +169,8 @@ class _IntIndexList(MutableSequence):
                     for i in range(start, start + n):
                         data[i] += off
                 else:
-                    np.frombuffer(self._data, dtype=np.intc)[start:] += int(offset)
+                    _v = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
+                    _v += int(offset)
             return
 
         offset = int(offset)
@@ -194,7 +200,7 @@ class _IntIndexList(MutableSequence):
                         if data[i] != sent:
                             data[i] += off
                 else:
-                    new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                    new_data = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
                     new_data[new_data != int(sentinel)] += int(offset)
             return
 
@@ -226,7 +232,7 @@ class _IntIndexList(MutableSequence):
                         if data[i] >= 0:
                             data[i] += off
                 else:
-                    new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                    new_data = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
                     new_data[new_data >= 0] += int(offset)
             return
 
@@ -410,7 +416,8 @@ class _IntIndexList2D(MutableSequence):
                     for i in range(start, start + n):
                         data[i] += off
                 else:
-                    np.frombuffer(self._data, dtype=np.intc)[start:] += int(offset)
+                    _v = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
+                    _v += int(offset)
             return
 
         offset = int(offset)
@@ -444,7 +451,7 @@ class _IntIndexList2D(MutableSequence):
                         if data[i] != sent:
                             data[i] += off
                 else:
-                    new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                    new_data = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
                     new_data[new_data != int(sentinel)] += int(offset)
             return
 
@@ -479,7 +486,7 @@ class _IntIndexList2D(MutableSequence):
                         if data[i] >= 0:
                             data[i] += off
                 else:
-                    new_data = np.frombuffer(self._data, dtype=np.intc)[start:]
+                    new_data = np.frombuffer(self._data, dtype=np.intc, count=n, offset=start * _INTC_ITEMSIZE)
                     new_data[new_data >= 0] += int(offset)
             return
 


### PR DESCRIPTION
I noticed the slowest parts are the merging of the contact shape pairs, and the merging of custom attributes.
I'm trying to improve the speed through Python arrays, the handling of contact shape pairs got a 50x speed-up in my test of 512 G1 environments so far.

Fixes https://github.com/newton-physics/newton/issues/1675.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact, typed index containers in the simulation engine to improve storage efficiency and speed up index remapping during model merges.

* **Refactor**
  * Replaced many plain Python list-based index structures with the new containers across model-building and merging flows, preserving outward behavior while reducing memory use and improving merge/offset performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->