### PR TITLE
Clean up inertia.py function arguments to match Mesh.create_* API

### DIFF
--- a/docs/api/newton_geometry.rst
+++ b/docs/api/newton_geometry.rst
@@ -33,7 +33,7 @@ newton.geometry
    collide_sphere_capsule
    collide_sphere_cylinder
    collide_sphere_sphere
-   compute_shape_inertia
+   compute_inertia_shape
    create_empty_sdf_data
    remesh_mesh
    sdf_box

--- a/newton/_src/geometry/__init__.py
+++ b/newton/_src/geometry/__init__.py
@@ -31,7 +31,7 @@ from .collision_primitive import (
     collide_sphere_sphere,
 )
 from .flags import ParticleFlags, ShapeFlags
-from .inertia import compute_shape_inertia, compute_sphere_inertia, transform_inertia
+from .inertia import compute_inertia_shape, compute_inertia_sphere, transform_inertia
 from .sdf_utils import SDF
 from .terrain_generator import create_mesh_heightfield, create_mesh_terrain
 from .types import (
@@ -63,9 +63,9 @@ __all__ = [
     "collide_sphere_capsule",
     "collide_sphere_cylinder",
     "collide_sphere_sphere",
-    "compute_shape_inertia",
+    "compute_inertia_shape",
+    "compute_inertia_sphere",
     "compute_shape_radius",
-    "compute_sphere_inertia",
     "create_mesh_heightfield",
     "create_mesh_terrain",
     "test_group_pair",

--- a/newton/_src/geometry/inertia.py
+++ b/newton/_src/geometry/inertia.py
@@ -30,7 +30,7 @@ from .types import (
 )
 
 
-def compute_sphere_inertia(density: float, radius: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_sphere(density: float, radius: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid sphere
 
     Args:
@@ -52,7 +52,7 @@ def compute_sphere_inertia(density: float, radius: float) -> tuple[float, wp.vec
     return (m, wp.vec3(), I)
 
 
-def compute_capsule_inertia(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_capsule(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid capsule extending along the z-axis
 
     Args:
@@ -85,7 +85,7 @@ def compute_capsule_inertia(density: float, radius: float, half_height: float) -
     return (m, wp.vec3(), I)
 
 
-def compute_cylinder_inertia(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_cylinder(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid cylinder extending along the z-axis
 
     Args:
@@ -111,7 +111,7 @@ def compute_cylinder_inertia(density: float, radius: float, half_height: float) 
     return (m, wp.vec3(), I)
 
 
-def compute_cone_inertia(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_cone(density: float, radius: float, half_height: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid cone extending along the z-axis
 
     Args:
@@ -142,7 +142,7 @@ def compute_cone_inertia(density: float, radius: float, half_height: float) -> t
     return (m, com, I)
 
 
-def compute_ellipsoid_inertia(density: float, rx: float, ry: float, rz: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_ellipsoid(density: float, rx: float, ry: float, rz: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid ellipsoid
 
     The ellipsoid is centered at the origin with semi-axes rx, ry, rz along the x, y, z axes respectively.
@@ -174,7 +174,7 @@ def compute_ellipsoid_inertia(density: float, rx: float, ry: float, rz: float) -
     return (m, wp.vec3(), I)
 
 
-def compute_box_inertia_from_mass(mass: float, hx: float, hy: float, hz: float) -> wp.mat33:
+def compute_inertia_box_from_mass(mass: float, hx: float, hy: float, hz: float) -> wp.mat33:
     """Helper to compute 3x3 inertia matrix of a solid box with given mass and half-extents.
 
     Args:
@@ -196,7 +196,7 @@ def compute_box_inertia_from_mass(mass: float, hx: float, hy: float, hz: float) 
     return I
 
 
-def compute_box_inertia(density: float, hx: float, hy: float, hz: float) -> tuple[float, wp.vec3, wp.mat33]:
+def compute_inertia_box(density: float, hx: float, hy: float, hz: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid box
 
     Args:
@@ -212,7 +212,7 @@ def compute_box_inertia(density: float, hx: float, hy: float, hz: float) -> tupl
 
     v = 8.0 * hx * hy * hz
     m = density * v
-    I = compute_box_inertia_from_mass(m, hx, hy, hz)
+    I = compute_inertia_box_from_mass(m, hx, hy, hz)
 
     return (m, wp.vec3(), I)
 
@@ -331,7 +331,7 @@ def compute_hollow_mesh_inertia(
     wp.atomic_add(second, 0, s_total)
 
 
-def compute_mesh_inertia(
+def compute_inertia_mesh(
     density: float,
     vertices: list,
     indices: list,
@@ -462,7 +462,7 @@ def transform_inertia(m: float, I: wp.mat33, p: wp.vec3, q: wp.quat) -> wp.mat33
     )
 
 
-def compute_shape_inertia(
+def compute_inertia_shape(
     type: int,
     scale: Vec3,
     src: Mesh | Heightfield | None,
@@ -487,48 +487,48 @@ def compute_shape_inertia(
         return 0.0, wp.vec3(), wp.mat33()
 
     if type == GeoType.SPHERE:
-        solid = compute_sphere_inertia(density, scale[0])
+        solid = compute_inertia_sphere(density, scale[0])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow sphere geom"
-            hollow = compute_sphere_inertia(density, scale[0] - thickness)
+            hollow = compute_inertia_sphere(density, scale[0] - thickness)
             return solid[0] - hollow[0], solid[1], solid[2] - hollow[2]
     elif type == GeoType.BOX:
         # scale stores half-extents (hx, hy, hz)
-        solid = compute_box_inertia(density, scale[0], scale[1], scale[2])
+        solid = compute_inertia_box(density, scale[0], scale[1], scale[2])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow box geom"
-            hollow = compute_box_inertia(density, scale[0] - thickness, scale[1] - thickness, scale[2] - thickness)
+            hollow = compute_inertia_box(density, scale[0] - thickness, scale[1] - thickness, scale[2] - thickness)
             return solid[0] - hollow[0], solid[1], solid[2] - hollow[2]
     elif type == GeoType.CAPSULE:
         # scale[0] = radius, scale[1] = half_height
-        solid = compute_capsule_inertia(density, scale[0], scale[1])
+        solid = compute_inertia_capsule(density, scale[0], scale[1])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow capsule geom"
-            hollow = compute_capsule_inertia(density, scale[0] - thickness, scale[1] - thickness)
+            hollow = compute_inertia_capsule(density, scale[0] - thickness, scale[1] - thickness)
             return solid[0] - hollow[0], solid[1], solid[2] - hollow[2]
     elif type == GeoType.CYLINDER:
         # scale[0] = radius, scale[1] = half_height
-        solid = compute_cylinder_inertia(density, scale[0], scale[1])
+        solid = compute_inertia_cylinder(density, scale[0], scale[1])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow cylinder geom"
-            hollow = compute_cylinder_inertia(density, scale[0] - thickness, scale[1] - thickness)
+            hollow = compute_inertia_cylinder(density, scale[0] - thickness, scale[1] - thickness)
             return solid[0] - hollow[0], solid[1], solid[2] - hollow[2]
     elif type == GeoType.CONE:
         # scale[0] = radius, scale[1] = half_height
-        solid = compute_cone_inertia(density, scale[0], scale[1])
+        solid = compute_inertia_cone(density, scale[0], scale[1])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow cone geom"
-            hollow = compute_cone_inertia(density, scale[0] - thickness, scale[1] - thickness)
+            hollow = compute_inertia_cone(density, scale[0] - thickness, scale[1] - thickness)
             m_shell = solid[0] - hollow[0]
             if m_shell <= 0.0:
                 raise ValueError(
@@ -553,12 +553,12 @@ def compute_shape_inertia(
             return m_shell, wp.vec3(*com_shell), wp.mat33(*I_shell.flatten())
     elif type == GeoType.ELLIPSOID:
         # scale stores semi-axes (rx, ry, rz)
-        solid = compute_ellipsoid_inertia(density, scale[0], scale[1], scale[2])
+        solid = compute_inertia_ellipsoid(density, scale[0], scale[1], scale[2])
         if is_solid:
             return solid
         else:
             assert isinstance(thickness, float), "thickness must be a float for a hollow ellipsoid geom"
-            hollow = compute_ellipsoid_inertia(
+            hollow = compute_inertia_ellipsoid(
                 density, scale[0] - thickness, scale[1] - thickness, scale[2] - thickness
             )
             return solid[0] - hollow[0], solid[1], solid[2] - hollow[2]
@@ -591,7 +591,7 @@ def compute_shape_inertia(
             assert isinstance(src, Mesh), "src must be a Mesh for mesh or convex hull shapes"
             # fall back to computing inertia from mesh geometry
             vertices = np.array(src.vertices) * np.array(scale)
-            m, c, I, _vol = compute_mesh_inertia(density, vertices, src.indices, is_solid, thickness)
+            m, c, I, _vol = compute_inertia_mesh(density, vertices, src.indices, is_solid, thickness)
             return m, c, I
     raise ValueError(f"Unsupported shape type: {type}")
 

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -150,7 +150,7 @@ class Mesh:
             texture: Optional texture path/URL or image data (H, W, C).
             sdf: Optional prebuilt SDF object owned by this mesh.
         """
-        from .inertia import compute_mesh_inertia  # noqa: PLC0415
+        from .inertia import compute_inertia_mesh  # noqa: PLC0415
 
         self._vertices = np.array(vertices, dtype=np.float32).reshape(-1, 3)
         self._indices = np.array(indices, dtype=np.int32).flatten()
@@ -173,7 +173,7 @@ class Mesh:
         self.sdf = sdf
 
         if compute_inertia:
-            self.mass, self.com, self.I, _ = compute_mesh_inertia(1.0, vertices, indices, is_solid=is_solid)
+            self.mass, self.com, self.I, _ = compute_inertia_mesh(1.0, vertices, indices, is_solid=is_solid)
         else:
             self.I = wp.mat33(np.eye(3))
             self.mass = 1.0

--- a/newton/_src/geometry/utils.py
+++ b/newton/_src/geometry/utils.py
@@ -23,7 +23,7 @@ import numpy as np
 import warp as wp
 
 from ..core.types import Vec3, nparray
-from .inertia import compute_mesh_inertia
+from .inertia import compute_inertia_mesh
 from .types import (
     GeoType,
     Heightfield,
@@ -226,7 +226,7 @@ def compute_inertia_obb(
     hull_indices = hull_faces.flatten()
 
     # Step 2: Compute mesh inertia
-    _mass, com, inertia_tensor, _volume = compute_mesh_inertia(
+    _mass, com, inertia_tensor, _volume = compute_inertia_mesh(
         density=1.0,  # Unit density
         vertices=hull_vertices.tolist(),
         indices=hull_indices.tolist(),
@@ -656,7 +656,7 @@ def remesh_mesh(
         mesh.vertices = vertices
         mesh.indices = indices.flatten()
         if recompute_inertia:
-            mesh.mass, mesh.com, mesh.I, _ = compute_mesh_inertia(1.0, vertices, indices, is_solid=mesh.is_solid)
+            mesh.mass, mesh.com, mesh.I, _ = compute_inertia_mesh(1.0, vertices, indices, is_solid=mesh.is_solid)
     else:
         return mesh.copy(vertices=vertices, indices=indices, recompute_inertia=recompute_inertia)
     return mesh

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -50,7 +50,7 @@ from ..geometry import (
     Mesh,
     ParticleFlags,
     ShapeFlags,
-    compute_shape_inertia,
+    compute_inertia_shape,
     compute_shape_radius,
     transform_inertia,
 )
@@ -4722,7 +4722,7 @@ class ModelBuilder:
                     self.add_shape_collision_filter_pair(shape, child_shape)
 
         if not is_static and cfg.density > 0.0 and body >= 0 and not self.body_lock_inertia[body]:
-            (m, c, I) = compute_shape_inertia(type, scale, src, cfg.density, cfg.is_solid, cfg.thickness)
+            (m, c, I) = compute_inertia_shape(type, scale, src, cfg.density, cfg.is_solid, cfg.thickness)
             com_body = wp.transform_point(xform, c)
             self._update_body_mass(body, m, I, com_body, xform.q)
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -28,7 +28,7 @@ import warp as wp
 
 from ..core import quat_between_axes
 from ..core.types import Axis, Transform
-from ..geometry import GeoType, Mesh, ShapeFlags, compute_shape_inertia, compute_sphere_inertia
+from ..geometry import GeoType, Mesh, ShapeFlags, compute_inertia_shape, compute_inertia_sphere
 from ..sim.builder import ModelBuilder
 from ..sim.joints import ActuatorMode
 from ..sim.model import Model
@@ -1691,7 +1691,7 @@ def parse_usd(
             )
             return None
 
-        shape_volume, _, _ = compute_shape_inertia(shape_geo_type, shape_scale, shape_src, density=1.0)
+        shape_volume, _, _ = compute_inertia_shape(shape_geo_type, shape_scale, shape_src, density=1.0)
         if shape_volume <= 0.0:
             warnings.warn(
                 f"Skipping collider {prim.GetPath()}: unable to derive positive collider volume from authored shape parameters.",
@@ -1776,7 +1776,7 @@ def parse_usd(
         geometry (box/sphere/capsule/cylinder/cone/mesh) when collider-authored MassAPI mass
         properties are not available.
         """
-        shape_mass, shape_com, shape_inertia = compute_shape_inertia(
+        shape_mass, shape_com, shape_inertia = compute_inertia_shape(
             shape_geo_type, shape_scale, shape_src, density=1.0
         )
         if shape_mass <= 0.0:
@@ -2181,7 +2181,7 @@ def parse_usd(
                     density = default_shape_density  # kg/m³
                     volume = mass / density
                     radius = (3.0 * volume / (4.0 * np.pi)) ** (1.0 / 3.0)
-                    _, _, I_default = compute_sphere_inertia(density, radius)
+                    _, _, I_default = compute_inertia_sphere(density, radius)
 
                     # Apply parallel axis theorem if center of mass is offset
                     com = builder.body_com[body_id]

--- a/newton/geometry.py
+++ b/newton/geometry.py
@@ -30,7 +30,7 @@ from ._src.geometry import (
     collide_sphere_cylinder,
     collide_sphere_sphere,
 )
-from ._src.geometry.inertia import compute_shape_inertia, transform_inertia
+from ._src.geometry.inertia import compute_inertia_shape, transform_inertia
 from ._src.geometry.kernels import sdf_box, sdf_capsule, sdf_cone, sdf_cylinder, sdf_mesh, sdf_plane, sdf_sphere
 from ._src.geometry.narrow_phase import NarrowPhase
 from ._src.geometry.sdf_hydroelastic import HydroelasticSDF
@@ -55,7 +55,7 @@ __all__ = [
     "collide_sphere_capsule",
     "collide_sphere_cylinder",
     "collide_sphere_sphere",
-    "compute_shape_inertia",
+    "compute_inertia_shape",
     "create_empty_sdf_data",
     "remesh_mesh",
     "sdf_box",


### PR DESCRIPTION
## Summary

Fixes #925 by renaming abbreviated parameter names in `inertia.py` to full descriptive names that match `newton.Mesh.create_*` method conventions:

- `compute_sphere_inertia`: `r` → `radius`
- `compute_capsule_inertia`: `r` → `radius`, `h` (full height) → `half_height`
- `compute_cylinder_inertia`: `r` → `radius`, `h` (full height) → `half_height`
- `compute_cone_inertia`: `r` → `radius`, `h` (full height) → `half_height`
- `compute_ellipsoid_inertia`: `a, b, c` → `rx, ry, rz`
- `compute_box_inertia_from_mass`: `w, h, d` (full dims) → `hx, hy, hz` (half-extents)
- `compute_box_inertia`: `w, h, d` (full dims) → `hx, hy, hz` (half-extents)

The `half_height` and `hx/hy/hz` parameters now use the same half-extent semantics as `Mesh.create_capsule`, `Mesh.create_cylinder`, `Mesh.create_cone`, and `Mesh.create_box`. The `compute_shape_inertia` internal dispatcher is updated to pass scale values (already stored as half-extents/half-heights in the builder) directly without the previous doubling conversion.

## Test plan

- [x] All 17 `TestInertia` tests pass with updated call sites
- [x] Pre-commit (ruff format, typos) passes
- [x] Math verified analytically for each shape: sphere, capsule, cylinder, cone, box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Public geometry inertia APIs clarified to use explicit radius and half-height / half-extent conventions; inertia, mass, and center-of-mass outputs updated to reflect the new parameter semantics.

* **Tests**
  * Inertia tests updated for the new parameter conventions and expected values; added a hollow-cone inertia test and helper mesh generation to validate mass, center-of-mass, and inertia against a mesh-based reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->