### PR TITLE
Reduce default test runner verbosity

### DIFF
--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -83,8 +83,8 @@ def main(argv=None):
         python -m newton.tests -k 'mgpu' -k 'cuda'
         """,
     )
-    # parser.add_argument("-v", "--verbose", action="store_const", const=2, default=1, help="Verbose output")
-    parser.add_argument("-q", "--quiet", dest="verbose", action="store_const", const=0, default=2, help="Quiet output")
+    parser.add_argument("-v", "--verbose", action="store_const", const=2, default=1, help="Verbose output")
+    parser.add_argument("-q", "--quiet", dest="verbose", action="store_const", const=0, default=1, help="Quiet output")
     parser.add_argument("-f", "--failfast", action="store_true", default=False, help="Stop on first fail or error")
     parser.add_argument(
         "-b", "--buffer", action="store_true", default=False, help="Buffer stdout and stderr during tests"
@@ -571,38 +571,41 @@ class ParallelTextTestResult(unittest.TextTestResult):
         if self.showAll:
             self.stream.writeln(f"{self.getDescription(test)} ...")
             self.stream.flush()
+        elif self.dots:
+            self.stream.writeln(f"{test} ...")
+            self.stream.flush()
         super(unittest.TextTestResult, self).startTest(test)
 
-    def _add_helper(self, test, dots_message, show_all_message):
+    def _add_helper(self, test, show_all_message):
         if self.showAll:
             self.stream.writeln(f"{self.getDescription(test)} ... {show_all_message}")
         elif self.dots:
-            self.stream.write(dots_message)
+            self.stream.writeln(f"{test} ... {show_all_message}")
         self.stream.flush()
 
     def addSuccess(self, test):
         super(unittest.TextTestResult, self).addSuccess(test)
-        self._add_helper(test, ".", "ok")
+        self._add_helper(test, "ok")
 
     def addError(self, test, err):
         super(unittest.TextTestResult, self).addError(test, err)
-        self._add_helper(test, "E", "ERROR")
+        self._add_helper(test, "ERROR")
 
     def addFailure(self, test, err):
         super(unittest.TextTestResult, self).addFailure(test, err)
-        self._add_helper(test, "F", "FAIL")
+        self._add_helper(test, "FAIL")
 
     def addSkip(self, test, reason):
         super(unittest.TextTestResult, self).addSkip(test, reason)
-        self._add_helper(test, "s", f"skipped {reason!r}")
+        self._add_helper(test, f"skipped {reason!r}")
 
     def addExpectedFailure(self, test, err):
         super(unittest.TextTestResult, self).addExpectedFailure(test, err)
-        self._add_helper(test, "x", "expected failure")
+        self._add_helper(test, "expected failure")
 
     def addUnexpectedSuccess(self, test):
         super(unittest.TextTestResult, self).addUnexpectedSuccess(test)
-        self._add_helper(test, "u", "unexpected success")
+        self._add_helper(test, "unexpected success")
 
     def printErrors(self):
         pass

--- a/newton/tests/unittest_utils.py
+++ b/newton/tests/unittest_utils.py
@@ -448,14 +448,17 @@ class ParallelJunitTestResult(unittest.TextTestResult):
         if self.showAll:
             self.stream.writeln(f"{self.getDescription(test)} ...")
             self.stream.flush()
+        elif self.dots:
+            self.stream.writeln(f"{test} ...")
+            self.stream.flush()
         self.start_time = time.perf_counter_ns()
         super(unittest.TextTestResult, self).startTest(test)
 
-    def _add_helper(self, test, dots_message, show_all_message):
+    def _add_helper(self, test, show_all_message):
         if self.showAll:
             self.stream.writeln(f"{self.getDescription(test)} ... {show_all_message}")
         elif self.dots:
-            self.stream.write(dots_message)
+            self.stream.writeln(f"{test} ... {show_all_message}")
         self.stream.flush()
 
     def _record_test(self, test, code, message=None, details=None):
@@ -464,38 +467,38 @@ class ParallelJunitTestResult(unittest.TextTestResult):
 
     def addSuccess(self, test):
         super(unittest.TextTestResult, self).addSuccess(test)
-        self._add_helper(test, ".", "ok")
+        self._add_helper(test, "ok")
         self._record_test(test, "OK")
 
     def addError(self, test, err):
         super(unittest.TextTestResult, self).addError(test, err)
-        self._add_helper(test, "E", "ERROR")
+        self._add_helper(test, "ERROR")
         self._record_test(test, "ERROR", str(err[1]), self._exc_info_to_string(err, test))
 
     def addFailure(self, test, err):
         super(unittest.TextTestResult, self).addFailure(test, err)
-        self._add_helper(test, "F", "FAIL")
+        self._add_helper(test, "FAIL")
         self._record_test(test, "FAIL", str(err[1]), self._exc_info_to_string(err, test))
 
     def addSkip(self, test, reason):
         super(unittest.TextTestResult, self).addSkip(test, reason)
-        self._add_helper(test, "s", f"skipped {reason!r}")
+        self._add_helper(test, f"skipped {reason!r}")
         self._record_test(test, "SKIP", reason)
 
     def addExpectedFailure(self, test, err):
         super(unittest.TextTestResult, self).addExpectedFailure(test, err)
-        self._add_helper(test, "x", "expected failure")
+        self._add_helper(test, "expected failure")
         self._record_test(test, "OK", "expected failure")
 
     def addUnexpectedSuccess(self, test):
         super(unittest.TextTestResult, self).addUnexpectedSuccess(test)
-        self._add_helper(test, "u", "unexpected success")
+        self._add_helper(test, "unexpected success")
         self._record_test(test, "FAIL", "unexpected success")
 
     def addSubTest(self, test, subtest, err):
         super(unittest.TextTestResult, self).addSubTest(test, subtest, err)
         if err is not None:
-            self._add_helper(test, "E", "ERROR")
+            self._add_helper(test, "ERROR")
             # err is (class, error, traceback)
             self._record_test(test, "FAIL", str(err[1]), self._exc_info_to_string(err, test))
 


### PR DESCRIPTION
## Summary
- Lower default verbosity from 2 (`showAll`) to 1, which suppresses docstring echoing (e.g. "Test that global entities (world -1) are not affected by world offsets...") from test output
- At verbosity 1, print test names with results (`test_foo (Module) ... ok`) instead of bare dots, keeping output readable alongside interleaved Warp module-load messages
- Print test names at `startTest` so interpreter crashes can be correlated to the last test that began running
- Uncomment the `-v` flag so users can opt into the old verbose behavior

## Test plan
- [ ] Run `uv run --extra dev -m newton.tests -k test_model` and verify default output shows test names without docstrings
- [ ] Run with `-v` and verify docstrings are included in output
- [ ] Run with `-q` and verify quiet mode still suppresses per-test output
- [ ] Verify CI workflows (which pass no verbosity flags) produce readable logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled command-line verbosity options (-v/--verbose and -q/--quiet) for customizable test output control
  * Improved test result formatting with enhanced status message clarity
  * Strengthened consistency in test reporting across all display modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->