### PR TITLE
Resolve inheritrange for position actuators in MJCF parser

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2152,7 +2152,9 @@ def parse_mjcf(
                 kv = parse_float(merged_attrib, "kv", 0.0)  # Optional velocity damping
                 gainprm = vec10(kp, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                 biasprm = vec10(0.0, -kp, -kv, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-                # Resolve inheritrange: copy target joint's range to ctrlrange
+                # Resolve inheritrange: copy target joint's range to ctrlrange.
+                # Uses only the first DOF (qd_start) since inheritrange is only
+                # meaningful for single-DOF joints (hinge, slide).
                 inheritrange = parse_float(merged_attrib, "inheritrange", 0.0)
                 if inheritrange > 0 and joint_name and qd_start >= 0:
                     lower = builder.joint_limit_lower[qd_start]

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -7176,5 +7176,41 @@ class TestActuatorInheritrange(unittest.TestCase):
         self.assertEqual(self.solver.mj_model.actuator_ctrllimited[0], 1)
 
 
+class TestActuatorInheritrangeFractional(unittest.TestCase):
+    """Verify fractional inheritrange scales ctrlrange around the midpoint."""
+
+    MJCF = """<?xml version="1.0" ?>
+    <mujoco>
+        <compiler angle="radian"/>
+        <worldbody>
+            <body name="base" pos="0 0 1">
+                <freejoint/>
+                <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+                <body name="child" pos="0 0 0.5">
+                    <joint name="j1" type="hinge" axis="0 1 0" range="-2.0 2.0"/>
+                    <geom type="box" size="0.05 0.05 0.05" mass="0.5"/>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="pos_half" joint="j1" kp="100" inheritrange="0.5"/>
+        </actuator>
+    </mujoco>"""
+
+    @classmethod
+    def setUpClass(cls):
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(cls.MJCF, ctrl_direct=True)
+        cls.model = builder.finalize()
+        cls.solver = SolverMuJoCo(cls.model)
+
+    def test_ctrlrange_is_half(self):
+        """ctrlrange should be half the joint range centered on the midpoint."""
+        # Joint range: [-2.0, 2.0], mean=0.0, half-width=2.0
+        # inheritrange=0.5 → radius = 2.0 * 0.5 = 1.0 → ctrlrange = [-1.0, 1.0]
+        cr = self.solver.mj_model.actuator_ctrlrange[0]
+        np.testing.assert_allclose(cr, [-1.0, 1.0], atol=1e-6)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Parse `inheritrange` on `<position>` actuators during MJCF import: compute `ctrlrange` from the target joint's limits and inject it into `merged_attrib` before custom attribute parsing
- The existing pipeline then sets `actuator_ctrlrange`, `actuator_has_ctrlrange`, and `actuator_ctrllimited` correctly
- Add unit test verifying `ctrlrange` and `ctrllimited` match expected values

## Test plan

- [x] `TestActuatorInheritrange` passes (ctrlrange matches joint range, ctrllimited=1)
- [x] `TestActuatorDampratio` still passes (no regression)
- [x] `TestMenagerie_UniversalRobotsUr5e` passes
- [x] `TestMenagerie_ApptronikApollo` passes
- [x] Verified G1 ctrlrange matches native MuJoCo within 1e-7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Position actuators can inherit a control range from their target joint limits when an inheritrange value is set; actuators are marked as range-limited and their control range is constrained accordingly (supports fractional inherit values).

* **Tests**
  * Added unit tests validating full and fractional control-range inheritance and that actuators are flagged as limited when inheritance produces a range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->