### PR TITLE
Skip non-MODEL custom attributes in finalize validation

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -9287,10 +9287,11 @@ class ModelBuilder:
                     # Safety fallback: use max observed length
                     custom_frequency_counts[freq_key] = max_len
 
-            # Relaxed validation: warn about attributes with fewer values than frequency count
+            # Warn about MODEL attributes with fewer values than expected (non-MODEL
+            # attributes are filled at runtime via _add_custom_attributes).
             for full_key, custom_attr in self.custom_attributes.items():
                 freq_key = custom_attr.frequency
-                if isinstance(freq_key, str):
+                if isinstance(freq_key, str) and custom_attr.assignment == Model.AttributeAssignment.MODEL:
                     attr_count = len(custom_attr.values) if custom_attr.values else 0
                     expected_count = custom_frequency_counts[freq_key]
                     if attr_count < expected_count:


### PR DESCRIPTION
## Summary

- Fix spurious `UserWarning` for CONTROL/STATE/CONTACT custom attributes during `finalize()`
- These attributes are populated at runtime (e.g., `mujoco:ctrl` with `ctrl_direct=True`), so having 0 values at build time is expected — not a problem

## Context

The validation added in the custom attribute system warns when an attribute has fewer values than its frequency count. This is correct for MODEL attributes (which should be populated during building), but CONTROL/STATE/CONTACT attributes are populated at runtime via `Control`/`State`/`Contacts` object creation. The warning was incorrectly flagging `mujoco:ctrl` (a CONTROL attribute) with messages like:

```
UserWarning: Custom attribute 'mujoco:ctrl' has 0 values but frequency 'mujoco:actuator' expects 986. Missing values will be filled with defaults.
```

## Test plan
- [x] Verified no warning with `ctrl_direct=True` model
- [x] MODEL attribute validation still works (checked code path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined validation of custom attributes to reduce false warnings during simulation configuration, now only warning for specific attribute assignment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->