### PR TITLE
Disable dynamics testing for UR5e and Apollo tests to avoid CI flakiness

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2399,7 +2399,8 @@ class TestMenagerie_UniversalRobotsUr5e(TestMenagerieMJCF):
 
     control_strategy = StructuredControlStrategy(seed=42)
     num_worlds = 34
-    num_steps = 500
+    # num_steps = 500  # Disabled to avoid CI flakiness
+    num_steps = 0
 
     # Backfill eliminates model compilation differences (inertia re-diagonalization).
     # Contact injection bypasses non-deterministic contact ordering in broadphase.
@@ -2691,7 +2692,8 @@ class TestMenagerie_ApptronikApollo(TestMenagerieMJCF):
     control_strategy = StructuredControlStrategy(seed=42)
     backfill_model = True
     use_cuda_graph = True
-    num_steps = 100
+    # num_steps = 100  # Disabled to avoid CI flakiness
+    num_steps = 0
     njmax = 128  # initial 63 constraints may grow during stepping
     discard_visual = False
     parse_visuals = True


### PR DESCRIPTION
Set `num_steps` to 0 for `TestMenagerie_UniversalRobotsUr5e` and `TestMenagerie_ApptronikApollo` to avoid CI flakiness. The tests still verify model equivalence (structure and parameters) but skip the flaky dynamics simulation loop.

With `num_steps=0`, the simulation loop `for step in range(max_steps)` never executes, so no dynamics steps or comparisons are performed. The model comparison (which happens before the loop) still runs to verify model structure equivalence.

Old values are preserved as comments for easy restoration if needed.

Also adds typos allowlist entries for IIT, PN, PNDbotics, and Robotis to fix pre-existing false positives in the test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced MUJOCO Menagerie test stability and CI reliability through configuration adjustments to reduce intermittent test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->