### PR TITLE
Update warp-lang dependency to 1.12.0rc1

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.12.0.dev20260218 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.12.0rc1 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.5.0",
     "python -m pip install -U mujoco-warp==3.5.0",
     "python -m pip install -U torch==2.8.0+cu129 --index-url https://download.pytorch.org/whl/cu129",

--- a/uv.lock
+++ b/uv.lock
@@ -5422,17 +5422,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.0.dev20260218"
+version = "1.12.0rc1"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260218-py3-none-macosx_11_0_arm64.whl", hash = "sha256:de2f4f16e2c75b52d5c1d01702948e16fac0f14454a269b58442b87061edd93b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260218-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:fa744d509d7613c6a8d4796259040a844ba8bb23fc07aec42f4e690a00e29c95" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260218-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d2e1861927753fe623deaa7bdb18f87ed89aa2b144436992972855cfd47b6117" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0.dev20260218-py3-none-win_amd64.whl", hash = "sha256:bb4cb251b4bed38f7f61127058091e5ac11136e1da92c54ae3a1bed05104331f" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c4497f686d7622db3b75a18db45e917c0b9fe3a22f40cd8ffb1d4d5592270588" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ed17847be41ea74d44e0934d0d323071cd8d3a6cb859afd8ec00755ab83a0a6f" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e9913e808968791b46595db53e340b5fbbff8c76a099a00ff1887bafe45d8fa4" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc1-py3-none-win_amd64.whl", hash = "sha256:6a809a546b4cbfbbb5139e1ae515c8f7bd82f9b8567278053fab57e1dddd834b" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update warp-lang from dev build (1.12.0.dev20260218) to release candidate (1.12.0rc1)
- Update both `uv.lock` and `asv.conf.json` to use the new version

## Test plan
- [ ] Verify CI passes with the new warp-lang version
- [ ] Verify ASV benchmarks can install the correct warp version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency version to release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->