### PR TITLE
Clean up unused and internal-only kwargs in SolverMuJoCo

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -25,7 +25,7 @@ import numpy as np
 import warp as wp
 
 from ...core.types import MAXVAL, nparray, override, vec5, vec10
-from ...geometry import GeoType, Mesh, ShapeFlags
+from ...geometry import GeoType, ShapeFlags
 from ...sim import (
     ActuatorMode,
     Contacts,
@@ -2713,8 +2713,6 @@ class SolverMuJoCo(SolverBase):
         self,
         model: Model,
         *,
-        mjw_model: MjWarpModel | None = None,
-        mjw_data: MjWarpData | None = None,
         separate_worlds: bool | None = None,
         njmax: int | None = None,
         nconmax: int | None = None,
@@ -2737,8 +2735,6 @@ class SolverMuJoCo(SolverBase):
         magnetic: tuple | None = None,
         use_mujoco_cpu: bool = False,
         disable_contacts: bool = False,
-        default_actuator_gear: float | None = None,
-        actuator_gears: dict[str, float] | None = None,
         update_data_interval: int = 1,
         save_to_mjcf: str | None = None,
         ls_parallel: bool = False,
@@ -2755,8 +2751,6 @@ class SolverMuJoCo(SolverBase):
 
         Args:
             model (Model): the model to be simulated.
-            mjw_model (MjWarpModel | None): Optional pre-existing MuJoCo Warp model. If provided with `mjw_data`, conversion from Newton model is skipped.
-            mjw_data (MjWarpData | None): Optional pre-existing MuJoCo Warp data. If provided with `mjw_model`, conversion from Newton model is skipped.
             separate_worlds (bool | None): If True, each Newton world is mapped to a separate MuJoCo world. Defaults to `not use_mujoco_cpu`.
             njmax (int | None): Maximum number of constraints per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
             nconmax (int | None): Number of contact points per world. If None, a default value is estimated from the initial state. Note that the larger of the user-provided value or the default value is used.
@@ -2779,9 +2773,6 @@ class SolverMuJoCo(SolverBase):
             magnetic (tuple | None): Global magnetic flux vector (x, y, z). If None, uses model custom attribute or MuJoCo's default (0, -0.5, 0).
             use_mujoco_cpu (bool): If True, use the MuJoCo-C CPU backend instead of `mujoco_warp`.
             disable_contacts (bool): If True, disable contact computation in MuJoCo.
-            register_collision_groups (bool): If True, register collision groups from the Newton model in MuJoCo.
-            default_actuator_gear (float | None): Default gear ratio for all actuators. Can be overridden by `actuator_gears`.
-            actuator_gears (dict[str, float] | None): Dictionary mapping joint names to specific gear ratios, overriding the `default_actuator_gear`.
             update_data_interval (int): Frequency (in simulation steps) at which to update the MuJoCo Data object from the Newton state. If 0, Data is never updated after initialization.
             save_to_mjcf (str | None): Optional path to save the generated MJCF model file.
             ls_parallel (bool): If True, enable parallel line search in MuJoCo. Defaults to False.
@@ -2868,46 +2859,39 @@ class SolverMuJoCo(SolverBase):
         disableflags = 0
         if disable_contacts:
             disableflags |= mujoco.mjtDisableBit.mjDSBL_CONTACT
-        if mjw_model is not None and mjw_data is not None:
-            self.mjw_model = mjw_model
-            self.mjw_data = mjw_data
-            self.use_mujoco_cpu = False
-        else:
-            self.use_mujoco_cpu = use_mujoco_cpu
-            if separate_worlds is None:
-                separate_worlds = not use_mujoco_cpu and model.world_count > 1
-            with wp.ScopedTimer("convert_model_to_mujoco", active=False):
-                self._convert_to_mjc(
-                    model,
-                    disableflags=disableflags,
-                    disable_contacts=disable_contacts,
-                    separate_worlds=separate_worlds,
-                    njmax=njmax,
-                    nconmax=nconmax,
-                    iterations=iterations,
-                    ls_iterations=ls_iterations,
-                    ccd_iterations=ccd_iterations,
-                    sdf_iterations=sdf_iterations,
-                    sdf_initpoints=sdf_initpoints,
-                    cone=cone,
-                    jacobian=jacobian,
-                    impratio=impratio,
-                    tolerance=tolerance,
-                    ls_tolerance=ls_tolerance,
-                    ccd_tolerance=ccd_tolerance,
-                    density=density,
-                    viscosity=viscosity,
-                    wind=wind,
-                    magnetic=magnetic,
-                    solver=solver,
-                    integrator=integrator,
-                    default_actuator_gear=default_actuator_gear,
-                    actuator_gears=actuator_gears,
-                    target_filename=save_to_mjcf,
-                    ls_parallel=ls_parallel,
-                    include_sites=include_sites,
-                    skip_visual_only_geoms=skip_visual_only_geoms,
-                )
+        self.use_mujoco_cpu = use_mujoco_cpu
+        if separate_worlds is None:
+            separate_worlds = not use_mujoco_cpu and model.world_count > 1
+        with wp.ScopedTimer("convert_model_to_mujoco", active=False):
+            self._convert_to_mjc(
+                model,
+                disableflags=disableflags,
+                disable_contacts=disable_contacts,
+                separate_worlds=separate_worlds,
+                njmax=njmax,
+                nconmax=nconmax,
+                iterations=iterations,
+                ls_iterations=ls_iterations,
+                ccd_iterations=ccd_iterations,
+                sdf_iterations=sdf_iterations,
+                sdf_initpoints=sdf_initpoints,
+                cone=cone,
+                jacobian=jacobian,
+                impratio=impratio,
+                tolerance=tolerance,
+                ls_tolerance=ls_tolerance,
+                ccd_tolerance=ccd_tolerance,
+                density=density,
+                viscosity=viscosity,
+                wind=wind,
+                magnetic=magnetic,
+                solver=solver,
+                integrator=integrator,
+                target_filename=save_to_mjcf,
+                ls_parallel=ls_parallel,
+                include_sites=include_sites,
+                skip_visual_only_geoms=skip_visual_only_geoms,
+            )
         self.update_data_interval = update_data_interval
         self._step = 0
 
@@ -3494,13 +3478,8 @@ class SolverMuJoCo(SolverBase):
         cone: int | str | None = None,
         jacobian: int | str | None = None,
         target_filename: str | None = None,
-        default_actuator_args: dict | None = None,
-        default_actuator_gear: float | None = None,
-        actuator_gears: dict[str, float] | None = None,
-        actuated_axes: list[int] | None = None,
         skip_visual_only_geoms: bool = True,
         include_sites: bool = True,
-        mesh_maxhullvert: int | None = None,
         ls_parallel: bool = False,
     ) -> tuple[MjWarpModel, MjWarpData, MjModel, MjData]:
         """
@@ -3535,22 +3514,14 @@ class SolverMuJoCo(SolverBase):
             cone: Friction cone type ("pyramidal" or "elliptic"). If None, uses model custom attribute or Newton's default ("pyramidal").
             jacobian: Jacobian computation method ("dense", "sparse", or "auto"). If None, uses model custom attribute or MuJoCo default ("auto").
             target_filename: Optional path to save generated MJCF file.
-            default_actuator_args: Default actuator parameters.
-            default_actuator_gear: Default actuator gear ratio.
-            actuator_gears: Per-actuator gear ratios by name.
-            actuated_axes: List of DOF indices to actuate.
             skip_visual_only_geoms: If True, skip geoms that are visual-only.
             include_sites: If True, include sites in the model.
-            mesh_maxhullvert: Maximum vertices for convex hull meshes.
             ls_parallel: If True, enable parallel line search.
 
         Returns:
             tuple[MjWarpModel, MjWarpData, MjModel, MjData]: Model and data objects for
                 ``mujoco_warp`` and MuJoCo.
         """
-        if mesh_maxhullvert is None:
-            mesh_maxhullvert = Mesh.MAX_HULL_VERTICES
-
         if not model.joint_count:
             raise ValueError("The model must have at least one joint to be able to convert it to MuJoCo.")
 
@@ -3583,12 +3554,6 @@ class SolverMuJoCo(SolverBase):
             "gaintype": mujoco.mjtGain.mjGAIN_FIXED,
             "biastype": mujoco.mjtBias.mjBIAS_AFFINE,
         }
-        if default_actuator_args is not None:
-            actuator_args.update(default_actuator_args)
-        if default_actuator_gear is not None:
-            actuator_args["gear"][0] = default_actuator_gear
-        if actuator_gears is None:
-            actuator_gears = {}
 
         # Convert string enum values to integers using the static parser methods
         # (these methods handle both string and int inputs)
@@ -4080,8 +4045,7 @@ class SolverMuJoCo(SolverBase):
                     )
                 elif stype == GeoType.MESH or stype == GeoType.CONVEX_MESH:
                     mesh_src = model.shape_source[shape]
-                    # use mesh-specific maxhullvert or fall back to the default
-                    maxhullvert = getattr(mesh_src, "maxhullvert", mesh_maxhullvert)
+                    maxhullvert = mesh_src.maxhullvert
                     # apply scaling
                     size = shape_size[shape]
                     vertices = mesh_src.vertices * size
@@ -4281,18 +4245,14 @@ class SolverMuJoCo(SolverBase):
                     ai = qd_start + i
                     mode = joint_act_mode[ai]
 
-                    if (actuated_axes is None or ai in actuated_axes) and mode != int(ActuatorMode.NONE):
+                    if mode != int(ActuatorMode.NONE):
                         kp = joint_target_ke[ai]
                         kd = joint_target_kd[ai]
                         effort_limit = joint_effort_limit[ai]
-                        gear = actuator_gears.get(name)
                         args = {}
                         args.update(actuator_args)
                         args["gear"] = [0.0] * 6
-                        if gear is not None:
-                            args["gear"][i] = gear
-                        else:
-                            args["gear"][i] = 1.0
+                        args["gear"][i] = 1.0
                         args["forcerange"] = [-effort_limit, effort_limit]
 
                         template_dof = ai
@@ -4366,10 +4326,9 @@ class SolverMuJoCo(SolverBase):
                     if joint_dof_solimp is not None:
                         joint_params["solimp_friction"] = joint_dof_solimp[ai]
                     # Use actfrcrange to clamp total actuator force (P+D sum) on this joint
-                    if actuated_axes is None or ai in actuated_axes:
-                        effort_limit = joint_effort_limit[ai]
-                        joint_params["actfrclimited"] = True
-                        joint_params["actfrcrange"] = (-effort_limit, effort_limit)
+                    effort_limit = joint_effort_limit[ai]
+                    joint_params["actfrclimited"] = True
+                    joint_params["actfrcrange"] = (-effort_limit, effort_limit)
 
                     if joint_springref is not None:
                         joint_params["springref"] = joint_springref[ai]
@@ -4393,31 +4352,24 @@ class SolverMuJoCo(SolverBase):
                     num_mjc_joints += 1
 
                     mode = joint_act_mode[ai]
-                    if (actuated_axes is None or ai in actuated_axes) and mode != int(ActuatorMode.NONE):
+                    if mode != int(ActuatorMode.NONE):
                         kp = joint_target_ke[ai]
                         kd = joint_target_kd[ai]
-                        gear = actuator_gears.get(axname)
-                        if gear is not None:
-                            args = {}
-                            args.update(actuator_args)
-                            args["gear"] = [gear, 0.0, 0.0, 0.0, 0.0, 0.0]
-                        else:
-                            args = actuator_args
 
                         template_dof = ai
                         # Add position actuator if mode includes position
                         if mode == ActuatorMode.POSITION:
-                            args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
                             actuator_count += 1
                         elif mode == ActuatorMode.POSITION_VELOCITY:
-                            args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -4425,9 +4377,9 @@ class SolverMuJoCo(SolverBase):
 
                         # Add velocity actuator if mode includes velocity
                         if mode in (ActuatorMode.VELOCITY, ActuatorMode.POSITION_VELOCITY):
-                            args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 1] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(-(template_dof + 2))  # negative = velocity
@@ -4472,10 +4424,9 @@ class SolverMuJoCo(SolverBase):
                     if joint_dof_solimp is not None:
                         joint_params["solimp_friction"] = joint_dof_solimp[ai]
                     # Use actfrcrange to clamp total actuator force (P+D sum) on this joint
-                    if actuated_axes is None or ai in actuated_axes:
-                        effort_limit = joint_effort_limit[ai]
-                        joint_params["actfrclimited"] = True
-                        joint_params["actfrcrange"] = (-effort_limit, effort_limit)
+                    effort_limit = joint_effort_limit[ai]
+                    joint_params["actfrclimited"] = True
+                    joint_params["actfrcrange"] = (-effort_limit, effort_limit)
 
                     if joint_springref is not None:
                         joint_params["springref"] = np.rad2deg(joint_springref[ai])
@@ -4499,31 +4450,24 @@ class SolverMuJoCo(SolverBase):
                     num_mjc_joints += 1
 
                     mode = joint_act_mode[ai]
-                    if (actuated_axes is None or ai in actuated_axes) and mode != int(ActuatorMode.NONE):
+                    if mode != int(ActuatorMode.NONE):
                         kp = joint_target_ke[ai]
                         kd = joint_target_kd[ai]
-                        gear = actuator_gears.get(axname)
-                        if gear is not None:
-                            args = {}
-                            args.update(actuator_args)
-                            args["gear"] = [gear, 0.0, 0.0, 0.0, 0.0, 0.0]
-                        else:
-                            args = actuator_args
 
                         template_dof = ai
                         # Add position actuator if mode includes position
                         if mode == ActuatorMode.POSITION:
-                            args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
                             actuator_count += 1
                         elif mode == ActuatorMode.POSITION_VELOCITY:
-                            args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -4531,9 +4475,9 @@ class SolverMuJoCo(SolverBase):
 
                         # Add velocity actuator if mode includes velocity
                         if mode in (ActuatorMode.VELOCITY, ActuatorMode.POSITION_VELOCITY):
-                            args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-                            args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **args)
+                            actuator_args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+                            actuator_args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
+                            spec.add_actuator(target=axname, **actuator_args)
                             axis_to_actuator[ai, 1] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(-(template_dof + 2))  # negative = velocity


### PR DESCRIPTION
## Summary

Remove 7 parameters from `SolverMuJoCo.__init__` and `_convert_to_mjc` that are unused, have no external callers, or were never implemented. This reduces the public API surface from 32 to 28 kwargs and removes dead code from the internal conversion method.

## Changes

### Removed from `__init__` (public API)

| Parameter | Justification |
|---|---|
| `mjw_model` / `mjw_data` | Bypass path that skipped model conversion entirely. **No external callers exist** (not used in any test, example, or benchmark). The code path was fragile — it silently assumed all internal mappings (`mjc_body_to_newton`, `mjc_jnt_to_newton_dof`, etc.) were already set up, which is undocumented and error-prone. Users who need to supply a pre-built MuJoCo model can be supported via a dedicated `classmethod` (e.g. `from_mjw()`) in the future. |
| `default_actuator_gear` / `actuator_gears` | Per-joint gear ratio overrides. **No external callers exist.** The default gear of 1.0 is always correct for Newton's PD/PID actuator model because the actual gains are baked into `gainprm`/`biasprm`. A non-1.0 gear would silently scale forces in a way that conflicts with the `joint_target_ke`/`joint_target_kd` values from the Newton model. |

### Removed from `_convert_to_mjc` (internal API)

| Parameter | Justification |
|---|---|
| `default_actuator_args` | Dict for overriding MuJoCo actuator spec fields. Never exposed in `__init__`, **no external callers**. |
| `actuated_axes` | List restricting which DOFs get actuators. Never exposed in `__init__`, **no external callers**. The guard was always `actuated_axes is None` (i.e. "actuate everything"), so removing it is a no-op. |
| `mesh_maxhullvert` | Override for convex hull vertex limit. Never exposed in `__init__`, **no external callers**. `Mesh` objects already carry their own `maxhullvert` attribute, making this redundant. Removing it also drops the now-unused `Mesh` import (auto-fixed by ruff). |

### Docstring fix

Removed `register_collision_groups` — a ghost kwarg that appeared in the docstring but was **never present in the function signature or implementation**.

## Testing

- All 151 `test_mujoco_solver` tests pass
- All 18 `test_joint_drive` tests pass
- All 7 `test_sites_mujoco` tests pass
- Pre-commit (ruff, ruff-format, typos) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed constructor parameters for pre-existing MuJoCo models/data; model is now automatically constructed.
  * Removed per-actuator gear customization and per-axis actuator gating parameters.
  * Removed per-mesh hull vertex configuration options.

* **Refactor**
  * Simplified MuJoCo solver initialization and configuration flow for streamlined usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->