### PR TITLE
Fix issue with mesh in rerun viewer

### DIFF
--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -240,6 +240,22 @@ class ViewerRerun(ViewerBase):
             backface_culling (bool): Whether to enable backface culling (unused).
         """
         if hidden:
+            # Cache minimal mesh data so log_instances can reference template geometry
+            # created by _populate_geometry (which uses hidden=True for instance templates).
+            points_np = self._to_numpy(points).astype(np.float32)
+            indices_np = self._to_numpy(indices).astype(np.uint32)
+            if indices_np.ndim == 1:
+                indices_np = indices_np.reshape(-1, 3)
+            normals_np = self._to_numpy(normals) if normals is not None else None
+            self._meshes[name] = {
+                "points": points_np,
+                "indices": indices_np,
+                "normals": normals_np,
+                "uvs": None,
+                "texture_image": None,
+                "texture_buffer": None,
+                "texture_format": None,
+            }
             return
 
         assert isinstance(points, wp.array)

--- a/newton/tests/test_viewer_rerun_hidden.py
+++ b/newton/tests/test_viewer_rerun_hidden.py
@@ -67,8 +67,8 @@ class TestViewerRerunHidden(unittest.TestCase):
         arr.__len__ = lambda self_: len(np_data)
         return arr
 
-    def test_log_mesh_hidden_skips_registration(self):
-        """log_mesh(hidden=True) should not store the mesh in _meshes."""
+    def test_log_mesh_hidden_skips_log(self):
+        """log_mesh(hidden=True) should store the mesh in _meshes but not render them."""
         viewer = self._create_viewer()
 
         points = self._make_mock_wp_array([[0, 0, 0], [1, 0, 0], [0, 1, 0]])
@@ -77,7 +77,8 @@ class TestViewerRerunHidden(unittest.TestCase):
         with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
             viewer.log_mesh("hidden_mesh", points, indices, hidden=True)
 
-        self.assertNotIn("hidden_mesh", viewer._meshes)
+        self.assertIn("hidden_mesh", viewer._meshes)
+        self.mock_rr.log.assert_not_called()
 
     def test_log_instances_hidden_clears_entity(self):
         """log_instances(hidden=True) should clear a previously visible entity."""


### PR DESCRIPTION
## Description
The rerun viewer was not working on simple example such as:
```
uv run --extra examples -m newton.examples robot_g1 --world-count 2 --viewer rerun
```
Claude solved the issue, but I am not familiar enough with the code to be confident that it is the best way to do solve the issue..

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hidden meshes are now stored internally while remaining hidden from rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->