### PR TITLE
Change default joint armature from 0.01 to 0

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -379,7 +379,7 @@ class ModelBuilder:
             target_vel: float = 0.0,
             target_ke: float = 0.0,
             target_kd: float = 0.0,
-            armature: float = 1e-2,
+            armature: float = 0.0,
             effort_limit: float = 1e6,
             velocity_limit: float = 1e6,
             friction: float = 0.0,
@@ -406,7 +406,7 @@ class ModelBuilder:
             self.target_kd = target_kd
             """The derivative gain of the target drive PD controller. Defaults to 0.0."""
             self.armature = armature
-            """Artificial inertia added around the joint axis. Defaults to 1e-2."""
+            """Artificial inertia added around the joint axis [kg·m² or kg]. Defaults to 0."""
             self.effort_limit = effort_limit
             """Maximum effort (force or torque) the joint axis can exert. Defaults to 1e6."""
             self.velocity_limit = velocity_limit

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -57,7 +57,7 @@ class SchemaResolverNewton(SchemaResolver):
         },
         PrimType.JOINT: {
             # warning: there is no NewtonJointAPI, none of these are schema attributes
-            "armature": SchemaAttribute("newton:armature", 1.0e-2),
+            "armature": SchemaAttribute("newton:armature", 0.0),
             "friction": SchemaAttribute("newton:friction", 0.0),
             "limit_linear_ke": SchemaAttribute("newton:linear:limitStiffness", 1.0e4),
             "limit_angular_ke": SchemaAttribute("newton:angular:limitStiffness", 1.0e4),

--- a/newton/tests/test_schema_resolver.py
+++ b/newton/tests/test_schema_resolver.py
@@ -702,7 +702,7 @@ class TestSchemaResolver(unittest.TestCase):
 
         # Test 3: No authored value, no explicit default, use Newton mapping default
         val3 = resolver_newton_only.get_value(joint_with_physx_armature, PrimType.JOINT, "armature", default=None)
-        self.assertAlmostEqual(val3, 1.0e-2, places=6)
+        self.assertAlmostEqual(val3, 0.0, places=6)
 
         # Test 3b: Use SchemaResolverMjc only - should return SchemaResolverMjc armature default (0.0)
         resolver_mjc_only = SchemaResolverManager([SchemaResolverMjc()])


### PR DESCRIPTION
## Summary

- Newton's `JointDofConfig` defaulted to `armature=0.01`, diverging from MuJoCo's default of `0.0`
- MJCF models that omit armature (relying on MuJoCo's zero default) silently acquired non-zero armature in Newton, producing different dynamics
- Set the default to `0.0` in both `JointDofConfig` and the Newton USD schema to match MuJoCo behavior

## Impact

**Low risk.** All existing examples that need non-zero armature already set it explicitly (cartpole=0.1, anymal=0.06, panda=[0.1, 0.5], basic_urdf=0.01, etc.). Only SolverMuJoCo and SolverFeatherstone use armature — SolverXPBD and SolverVBD ignore it. Armature is added to inertia matrices (never divided), so zero is mathematically safe.

The only examples potentially affected are those loading URDFs (which don't have armature) with SolverMuJoCo/Featherstone — these were silently getting 0.01 before and will now get 0. The MJCF/USD importers and schema resolvers already had 0.0 as the MuJoCo-side default; this change aligns the Newton-side default.

## Test plan

- [x] Full test suite: only `test_schema_resolver.test_layered_fallback_behavior` needed updating (assertion from 0.01 to 0.0)
- [x] All 24 schema resolver tests pass
- [x] Verified menagerie robots with explicit armature (UR5e, Booster T1) still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Behavior Changes**
  * Updated the default armature parameter from 0.01 to 0.0 for joint configurations, reducing artificial inertia when not explicitly specified.
  * Adjusted default behavior across joint configuration APIs to use zero artificial inertia by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->