### PR TITLE
Lock body inertia after explicit MJCF <inertial> element

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -935,8 +935,8 @@ def parse_mjcf(
                         stacklevel=2,
                     )
 
-                # Add explicit mass and computed inertia to body
-                if inertia_computed:
+                # Add explicit mass and computed inertia to body (skip if inertia is locked by <inertial>)
+                if inertia_computed and not builder.body_lock_inertia[link]:
                     com_body = wp.transform_point(tf, com)
                     builder._update_body_mass(link, geom_mass_explicit, inertia_tensor, com_body, tf.q)
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2096,6 +2096,38 @@ class TestImportMjcfGeometry(unittest.TestCase):
         )
         self.assertAlmostEqual(builder.body_mass[body_idx], 5.0, places=5)
 
+    def test_inertial_locks_body_against_frame_geom_explicit_mass(self):
+        """Regression: explicit <inertial> must also block frame geoms with mass= attributes.
+
+        The explicit-mass code path in parse_shapes calls _update_body_mass
+        directly, so it must also check body_lock_inertia.
+        """
+        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="inertial_lock_explicit_mass_test">
+    <worldbody>
+        <body name="test_body" pos="0 0 1">
+            <freejoint/>
+            <inertial pos="0.1 0.2 0.3" mass="5.0" diaginertia="0.01 0.02 0.03"/>
+            <geom type="sphere" size="0.05" pos="0 0 0"/>
+            <frame pos="0.5 0.5 0.5">
+                <geom type="box" size="0.1 0.1 0.1" mass="2.0"/>
+            </frame>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content, parse_visuals=True)
+        body_idx = next(i for i, label in enumerate(builder.body_label) if label.endswith("test_body"))
+        com = builder.body_com[body_idx]
+        np.testing.assert_allclose(
+            [float(com[0]), float(com[1]), float(com[2])],
+            [0.1, 0.2, 0.3],
+            atol=1e-6,
+            err_msg="body_com must match <inertial> pos, not be shifted by frame geoms with explicit mass",
+        )
+        self.assertAlmostEqual(builder.body_mass[body_idx], 5.0, places=5)
+
 
 class TestImportMjcfSolverParams(unittest.TestCase):
     def test_solimplimit_parsing(self):


### PR DESCRIPTION
## Summary

- When a body has an explicit `<inertial>` element, MuJoCo ignores all geom-based mass contributions. Newton's MJCF importer processes child `<frame>` elements (which can contain geoms) *after* the `<inertial>` overwrite, so without locking `body_lock_inertia`, those frame geoms shift `body_com` away from the correct value.
- Set `body_lock_inertia=True` after processing `<inertial>` so subsequent shapes cannot modify the explicitly specified mass, COM, or inertia.
- Observed on Apptronik Apollo's wrist bodies, which have child `<frame>` elements containing visual mesh geoms.

## Test plan

- [x] Regression test `test_inertial_locks_body_against_frame_geom_mass` added — verifies `body_com` matches `<inertial>` pos when frame geoms are present
- [x] Verified test fails without fix (COM shifted from `[0.1, 0.2, 0.3]` to `[0.346, 0.385, 0.423]`)
- [x] All 171 MJCF import tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MJCF import now preserves explicit inertial definitions so subsequent geometries cannot alter a body's mass, inertia, or center of mass.
* **Tests**
  * Added regression tests validating that explicit inertial elements lock a body's mass and COM against frame/geometries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->