### PR TITLE
Fix default kp/kv for position and velocity actuators

### DIFF
--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2396,7 +2396,7 @@ def parse_mjcf(
 
             # Extract gains based on actuator type
             if actuator_type == "position":
-                kp = parse_float(merged_attrib, "kp", 0.0)
+                kp = parse_float(merged_attrib, "kp", 1.0)  # MuJoCo default kp=1
                 kv = parse_float(merged_attrib, "kv", 0.0)  # Optional velocity damping
                 gainprm = vec10(kp, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                 biasprm = vec10(0.0, -kp, -kv, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
@@ -2433,7 +2433,7 @@ def parse_mjcf(
                             builder.joint_target_kd[dof_idx] = kv
 
             elif actuator_type == "velocity":
-                kv = parse_float(merged_attrib, "kv", 0.0)
+                kv = parse_float(merged_attrib, "kv", 1.0)  # MuJoCo default kv=1
                 gainprm = vec10(kv, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                 biasprm = vec10(0.0, 0.0, -kv, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                 # Non-joint actuators (body, tendon, etc.) must use CTRL_DIRECT


### PR DESCRIPTION
## Summary

- MuJoCo defaults `kp=1` for `position` actuators and `kv=1` for `velocity` actuators. Newton's MJCF importer defaulted both to `0` when the MJCF (or class defaults) omitted the attribute, producing zero `biasprm` and effectively disabling position/velocity feedback.
- Observed on the Shadow Hand where 11 of 20 position actuators rely on class defaults that specify `ctrlrange`/`forcerange` but omit `kp`.

## Test plan

- [x] Regression tests in `TestActuatorDefaultKpKv` — 3 tests covering:
  - Position actuator without explicit `kp` gets `gainprm[0]=1`, `biasprm[1]=-1`
  - Velocity actuator without explicit `kv` gets `gainprm[0]=1`, `biasprm[2]=-1`
  - Position actuator using a class that omits `kp` still defaults to `kp=1`
- [x] Verified tests fail without fix (`biasprm` values are 0 instead of -1)
- [x] All 173 MJCF import tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified default control gains for position and velocity actuators when not explicitly specified.

* **Tests**
  * Added regression tests for default actuator control gains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->