### PR TITLE
Improve H1 example

### DIFF
--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -55,13 +55,11 @@ class Example:
         h1.default_shape_cfg.mu = 0.75
 
         asset_path = newton.utils.download_asset("unitree_h1")
-        asset_file = str(asset_path / "usd" / "h1_minimal.usda")
+        asset_file = str(asset_path / "usd_structured" / "h1.usda")
         h1.add_usd(
             asset_file,
             ignore_paths=["/GroundPlane"],
-            collapse_fixed_joints=False,
             enable_self_collisions=False,
-            hide_collision_shapes=True,
         )
         # approximate meshes for faster collision detection
         h1.approximate_meshes("bounding_box")
@@ -84,7 +82,7 @@ class Example:
             iterations=100,
             ls_iterations=50,
             njmax=100,
-            nconmax=50,
+            nconmax=210,
             use_mujoco_contacts=args.use_mujoco_contacts if args else False,
         )
 


### PR DESCRIPTION
Switch to use the H1 USD file converted from MJCF that has correctly aligned inertia tensors.

| Before | After |
| --- | --- |
| <img height="300" alt="image" src="https://github.com/user-attachments/assets/eb8af72e-6e46-488b-8ac7-22515cbc1635" /> | <img height="300" alt="image" src="https://github.com/user-attachments/assets/9269e3db-439b-4d9b-be95-f552e3142cec" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `ModelBuilder.add_usd()` method signature updated; `collapse_fixed_joints` and `hide_collision_shapes` parameters removed.

* **Improvements**
  * Enhanced solver configuration with updated collision constraint handling for improved simulation performance.
  * Updated to structured USD asset format for robot models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->