### PR TITLE
Rename examples to follow prefix-first naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ uv sync --extra examples
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_rolling_cloth.py">
-        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_cloth_rolling_cloth.jpg" alt="Rolling Cloth">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_rollers.py">
+        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_cloth_rolling_cloth.jpg" alt="Cloth Rollers">
       </a>
     </td>
   </tr>
@@ -298,7 +298,27 @@ uv sync --extra examples
       <code>uv run -m newton.examples cloth_twist</code>
     </td>
     <td align="center" width="33%">
-      <code>uv run -m newton.examples rolling_cloth</code>
+      <code>uv run -m newton.examples cloth_rollers</code>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_poker_cards.py">
+        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_multiphysics_poker_cards_stacking.jpg" alt="Cloth Poker Cards">
+      </a>
+    </td>
+    <td align="center" width="33%">
+    </td>
+    <td align="center" width="33%">
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <code>uv run -m newton.examples cloth_poker_cards</code>
+    </td>
+    <td align="center" width="33%">
+    </td>
+    <td align="center" width="33%">
     </td>
   </tr>
   <tr>
@@ -517,8 +537,8 @@ uv sync --extra examples
   </tr>
   <tr>
     <td align="center" width="33%">
-      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_falling_gift.py">
-        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_multiphysics_falling_gift.jpg" alt="Falling Gift">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_softbody_gift.py">
+        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_multiphysics_falling_gift.jpg" alt="Softbody Gift">
       </a>
     </td>
     <td align="center" width="33%">
@@ -527,20 +547,16 @@ uv sync --extra examples
       </a>
     </td>
     <td align="center" width="33%">
-      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_poker_cards_stacking.py">
-        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_multiphysics_poker_cards_stacking.jpg" alt="Poker Cards Stacking">
-      </a>
     </td>
   </tr>
   <tr>
     <td align="center" width="33%">
-      <code>uv run -m newton.examples falling_gift</code>
+      <code>uv run -m newton.examples softbody_gift</code>
     </td>
     <td align="center" width="33%">
       <code>uv run -m newton.examples softbody_dropping_to_cloth</code>
     </td>
     <td align="center" width="33%">
-      <code>uv run -m newton.examples poker_cards_stacking</code>
     </td>
   </tr>
   <tr>

--- a/newton/examples/cloth/example_cloth_poker_cards.py
+++ b/newton/examples/cloth/example_cloth_poker_cards.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ###########################################################################
-# Example Poker Cards Stacking
+# Cloth Poker Cards
 #
 # This simulation demonstrates 52 poker cards (13 ranks x 4 suits) dropping
 # and stacking on a cube, then being knocked off by a sphere. The cards use
@@ -26,7 +26,7 @@
 # - Height: 8.89 cm (3.5 inches) = 0.0889 m
 # - Resolution: 4x6 cells per card
 #
-# Command: uv run -m newton.examples multiphysics.example_poker_cards_stacking
+# Command: uv run -m newton.examples cloth_poker_cards
 #
 ###########################################################################
 

--- a/newton/examples/cloth/example_cloth_rollers.py
+++ b/newton/examples/cloth/example_cloth_rollers.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 ###########################################################################
-# Treadmill Cloth Simulation
+# Cloth Rollers
 #
 # A rolled cloth mesh that unrolls as the inner seam rotates.
-# Command: uv run -m newton.examples cloth.example_rolling_cloth
+# Command: uv run -m newton.examples cloth_rollers
 #
 ###########################################################################
 

--- a/newton/examples/multiphysics/example_softbody_gift.py
+++ b/newton/examples/multiphysics/example_softbody_gift.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 ###########################################################################
-# Example Falling Gift
+# Softbody Gift
 #
 # This simulation demonstrates four stacked soft body blocks with two cloth
 # straps wrapped around them. The blocks fall under gravity, and the cloth
 # straps hold them together.
 #
-# Command: uv run -m newton.examples.multiphysics.example_falling_gift
+# Command: uv run -m newton.examples softbody_gift
 #
 ###########################################################################
 

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -343,7 +343,7 @@ add_example_test(
 )
 add_example_test(
     TestClothExamples,
-    name="cloth.example_rolling_cloth",
+    name="cloth.example_cloth_rollers",
     devices=cuda_test_devices,
     test_options={"num-frames": 200},
     use_viewer=True,
@@ -717,14 +717,14 @@ class TestMultiphysicsExamples(unittest.TestCase):
 
 add_example_test(
     TestMultiphysicsExamples,
-    name="multiphysics.example_falling_gift",
+    name="multiphysics.example_softbody_gift",
     devices=cuda_test_devices,
     test_options={"num-frames": 200},
     use_viewer=True,
 )
 add_example_test(
     TestMultiphysicsExamples,
-    name="multiphysics.example_poker_cards_stacking",
+    name="cloth.example_cloth_poker_cards",
     devices=cuda_test_devices,
     test_options={"num-frames": 30},
     use_viewer=True,


### PR DESCRIPTION
## Summary
  - `rolling_cloth` → `cloth_rollers` (stays in `cloth/`)
  - `falling_gift` → `softbody_gift` (stays in `multiphysics/`)
  - `poker_cards_stacking` → `cloth_poker_cards` (moved from `multiphysics/` to `cloth/`)

  Updates README.md tables and `test_examples.py` references accordingly.

  ## Context
  Per Miles's feedback: examples should use prefix-first naming (`cloth_*`, `softbody_*`, `mpm_*`) so they
  group together in autocomplete and `uv run -m newton.examples` listings. Poker cards moved to `cloth/` since
   the primary thing demonstrated is cloth collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example descriptions and references in documentation.
  * Reorganized cloth examples with revised naming.
  * Added new Cloth Poker Cards example.

* **Chores**
  * Restructured example registrations and test references to align with documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->