### PR TITLE
Fix USD root joint incoming_xform for fixed-base articulations

### DIFF
--- a/newton/examples/assets/sensor_contact_scene.usda
+++ b/newton/examples/assets/sensor_contact_scene.usda
@@ -70,7 +70,7 @@ def Xform "env" (
 
     def PhysicsFixedJoint "AnchorJoint" {
         rel physics:body1 = </env/Anchor>
-        point3f physics:localPos0 = (0, 0, 0)
+        point3f physics:localPos0 = (0, 0, 0.01)
         point3f physics:localPos1 = (0, 0, 0)
     }
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6852,7 +6852,7 @@ class TestOverrideRootXform(unittest.TestCase):
         root = UsdGeom.Xform.Define(stage, "/World/env/Robot")
         UsdPhysics.ArticulationRootAPI.Apply(root.GetPrim())
 
-        ground = UsdGeom.Xform.Define(stage, "/World/env/Robot/Ground")
+        ground = UsdGeom.Xform.Define(stage, "/World/env/Ground")
         ground.AddTranslateOp().Set(Gf.Vec3d(0.0, 0.0, 0.5))
 
         base = UsdGeom.Xform.Define(stage, "/World/env/Robot/Base")
@@ -6860,7 +6860,7 @@ class TestOverrideRootXform(unittest.TestCase):
         UsdPhysics.MassAPI.Apply(base.GetPrim()).GetMassAttr().Set(1.0)
 
         fixed = UsdPhysics.FixedJoint.Define(stage, "/World/env/Robot/WorldJoint")
-        fixed.CreateBody0Rel().SetTargets(["/World/env/Robot/Ground"])
+        fixed.CreateBody0Rel().SetTargets(["/World/env/Ground"])
         fixed.CreateBody1Rel().SetTargets(["/World/env/Robot/Base"])
         fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
         fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
@@ -6891,14 +6891,16 @@ class TestOverrideRootXform(unittest.TestCase):
         builder = newton.ModelBuilder()
         builder.add_usd(stage, xform=wp.transform((5.0, 0.0, 0.0), wp.quat_identity()))
 
+        self.assertIn("/World/env/Robot/WorldJoint", builder.joint_label)
+
         model = builder.finalize()
         state = model.state()
         newton.eval_fk(model, model.joint_q, model.joint_qd, state)
 
         body_q = state.body_q.numpy()
         base_idx = builder.body_label.index("/World/env/Robot/Base")
-        # xform (5,0,0) composed with ancestor (100,200,0) => (105, 200, 0)
-        np.testing.assert_allclose(body_q[base_idx, :3], [105.0, 200.0, 0.0], atol=1e-4)
+        # xform (5,0,0) composed with Ground world xform (100,200,0.5) => (105, 200, 0.5)
+        np.testing.assert_allclose(body_q[base_idx, :3], [105.0, 200.0, 0.5], atol=1e-4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_world_joint_override_root_xform(self):
@@ -6909,9 +6911,10 @@ class TestOverrideRootXform(unittest.TestCase):
         builder.add_usd(
             stage,
             xform=wp.transform((5.0, 0.0, 0.0), wp.quat_identity()),
-            floating=False,
             override_root_xform=True,
         )
+
+        self.assertIn("/World/env/Robot/WorldJoint", builder.joint_label)
 
         model = builder.finalize()
         state = model.state()
@@ -6919,7 +6922,8 @@ class TestOverrideRootXform(unittest.TestCase):
 
         body_q = state.body_q.numpy()
         base_idx = builder.body_label.index("/World/env/Robot/Base")
-        np.testing.assert_allclose(body_q[base_idx, :3], [5.0, 0.0, 0.0], atol=1e-4)
+        # override rebases at xform; Ground z=0.5 offset from articulation root is preserved
+        np.testing.assert_allclose(body_q[base_idx, :3], [5.0, 0.0, 0.5], atol=1e-4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_world_joint_override_with_rotation(self):
@@ -6932,9 +6936,10 @@ class TestOverrideRootXform(unittest.TestCase):
         builder.add_usd(
             stage,
             xform=wp.transform((5.0, 0.0, 0.0), quat),
-            floating=False,
             override_root_xform=True,
         )
+
+        self.assertIn("/World/env/Robot/WorldJoint", builder.joint_label)
 
         model = builder.finalize()
         state = model.state()
@@ -6942,11 +6947,12 @@ class TestOverrideRootXform(unittest.TestCase):
 
         body_q = state.body_q.numpy()
         base_idx = builder.body_label.index("/World/env/Robot/Base")
-        np.testing.assert_allclose(body_q[base_idx, :3], [5.0, 0.0, 0.0], atol=1e-4)
+        # override rebases at xform; Ground z=0.5 offset preserved
+        np.testing.assert_allclose(body_q[base_idx, :3], [5.0, 0.0, 0.5], atol=1e-4)
 
         link_idx = builder.body_label.index("/World/env/Robot/Link")
         # Link at Z+1 from Base; 90° Z-rotation doesn't affect Z offset
-        np.testing.assert_allclose(body_q[link_idx, :3], [5.0, 0.0, 1.0], atol=1e-4)
+        np.testing.assert_allclose(body_q[link_idx, :3], [5.0, 0.0, 1.5], atol=1e-4)
 
 
 class TestImportUsdMeshNormals(unittest.TestCase):


### PR DESCRIPTION
Compute incoming_xform from the actual body0 world transform when a fixed joint connects a non-body prim (above the articulation root) to the root body. Previously the root joint received the articulation transform directly, which was incorrect when the non-body prim had its own transform.

Add tests for the world-joint code path with default, override, and rotated xform variants.

Made-with: Cursor

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed root-joint transform handling for articulations without an explicit base or floating base so the root pose now correctly composes world and incoming transforms and respects root override behavior.

* **Tests**
  * Added tests for world-root joint scenarios: default composition, override placement, and override with rotation.

* **Examples**
  * Adjusted example scene joint anchor position (local z-offset increased by 0.01).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->