### PR TITLE
Enable parallel Sphinx builds with -j auto

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -36,7 +36,7 @@ jobs:
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e  # v1.1.1
 
       - name: Build Sphinx documentation
-        run: uv run --extra docs --extra sim sphinx-build -b html docs docs/_build/html
+        run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
 
       - name: Deploy to gh-pages /latest/
         run: |

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Build Sphinx documentation
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'
-        run: uv run --extra docs --extra sim sphinx-build -b html docs docs/_build/html
+        run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
 
       - name: Deploy to gh-pages
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install pandoc
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e  # v1.1.1
       - name: Build Sphinx documentation
-        run: uv run --extra docs --extra sim sphinx-build -W -b html docs docs/_build/html
+        run: uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
       - name: Verify API docs are up-to-date
         run: |
           git diff --exit-code docs/api/ || {
@@ -42,4 +42,4 @@ jobs:
             exit 1
           }
       - name: Run Sphinx doctests
-        run: uv run --extra docs --extra sim sphinx-build -W -b doctest docs docs/_build/doctest
+        run: uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -239,7 +239,7 @@ To build the documentation locally, ensure you have the documentation dependenci
         .. code-block:: console
 
             rm -rf docs/_build
-            uv run --extra docs --extra sim sphinx-build -W -b html docs docs/_build/html
+            uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
 
     .. tab-item:: venv
         :sync: venv
@@ -373,14 +373,14 @@ The doctests can be run with:
 
         .. code-block:: console
 
-            uv run --extra docs --extra sim sphinx-build -W -b doctest docs docs/_build/doctest
+            uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest
 
     .. tab-item:: venv
         :sync: venv
 
         .. code:: console
 
-            python -m sphinx -W -b doctest docs docs/_build/doctest
+            python -m sphinx -j auto -W -b doctest docs docs/_build/doctest
 
 For more information, see the `sphinx.ext.doctest <https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html>`__
 documentation.


### PR DESCRIPTION
## Summary
- Add `-j auto` to all `sphinx-build` invocations across CI workflows (`docs-dev.yml`, `docs-release.yml`), the `docs/Makefile` default, and developer documentation commands in `development.rst`.
- Tested locally with 8 consecutive parallel builds — identical output (176 HTML files) to serial builds, with ~45% faster build times (~30s vs ~55s).

## Test plan
- [x] Verified 5 parallel builds (`-j auto`) all produce 176 HTML files with exit code 0
- [x] Verified 3 parallel builds with `-W` (warnings-as-errors) all pass clean
- [x] Verified parallel doctest build (`-j auto -W -b doctest`) passes
- [x] Diffed file lists between serial and parallel builds — identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled parallel documentation builds to improve build performance for CI workflows and local development. Documentation generation now runs faster while preserving existing output and checks, reducing feedback time for documentation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->