### PR TITLE
Narrow .claude/ gitignore to allow tracking skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ rspec.xml
 .idea
 
 # Claude Code
-.claude/
+.claude/settings.local.json
+.claude/worktrees/
 .mcp.json
 
 # Claude Code sandbox artifacts (empty placeholder files created in repo root)


### PR DESCRIPTION
## Description

Replace the blanket `.claude/` gitignore with targeted ignores for `settings.local.json` and `worktrees/` so that shared config like Claude Code skills can be committed to the repo.

## Newton Migration Guide

N/A — no user-facing API changes.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to refine tracking of local development settings and workspace-related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->