### PR TITLE
Fix tiled camera example failing on headless CI

### DIFF
--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -28,7 +28,6 @@ import ctypes
 import math
 import random
 
-import OpenGL.GL as gl
 import warp as wp
 from pxr import Usd
 
@@ -286,10 +285,14 @@ class Example:
         )
 
     def create_texture(self):
+        from pyglet import gl  # noqa: PLC0415
+
         width = self.sensor_render_width * self.worlds_per_row
         height = self.sensor_render_height * self.worlds_per_col
 
-        self.texture_id = gl.glGenTextures(1)
+        texture_id = gl.GLuint()
+        gl.glGenTextures(1, texture_id)
+        self.texture_id = texture_id.value
 
         gl.glBindTexture(gl.GL_TEXTURE_2D, self.texture_id)
         gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
@@ -298,7 +301,9 @@ class Example:
         gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_RGBA8, width, height, 0, gl.GL_RGBA, gl.GL_UNSIGNED_BYTE, None)
         gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
 
-        self.pixel_buffer = gl.glGenBuffers(1)
+        pixel_buffer = gl.GLuint()
+        gl.glGenBuffers(1, pixel_buffer)
+        self.pixel_buffer = pixel_buffer.value
         gl.glBindBuffer(gl.GL_PIXEL_UNPACK_BUFFER, self.pixel_buffer)
         gl.glBufferData(gl.GL_PIXEL_UNPACK_BUFFER, width * height * 4, None, gl.GL_DYNAMIC_DRAW)
         gl.glBindBuffer(gl.GL_PIXEL_UNPACK_BUFFER, 0)
@@ -308,6 +313,8 @@ class Example:
     def update_texture(self):
         if not self.texture_id:
             return
+
+        from pyglet import gl  # noqa: PLC0415
 
         texture_buffer = self.texture_buffer.map(
             dtype=wp.uint8,


### PR DESCRIPTION
## Description

Fixes #1853

`example_sensor_tiled_camera` fails on headless CI machines because `import OpenGL.GL as gl` is at module level. This import executes immediately when the test subprocess starts — before `--viewer null` is parsed — causing an `ImportError` on machines without OpenGL libraries.

OpenGL is only used in `create_texture()` and `update_texture()`, both already guarded by `isinstance(self.viewer, ViewerGL)` checks that prevent execution under `--viewer null`. This PR moves the import into those two methods as lazy imports.

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

N/A — no API changes.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenGL resource handling in the sensor example to use safer, deferred initialization and more robust texture/buffer management.
  * Optimized initialization and update paths to reduce risk of resource errors and improve stability during rendering.
  * No changes to public interfaces or exported behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->