### PR TITLE
Add newton-api-design skill for API convention review

### DIFF
--- a/.claude/skills/newton-api-design/SKILL.md
+++ b/.claude/skills/newton-api-design/SKILL.md
@@ -86,7 +86,7 @@ For compound arrays, list per-component units:
 """[0] k_mu [Pa], [1] k_lambda [Pa], ..."""
 ```
 
-Warp array dtypes are documented in docstrings, not in type hints. Signatures use `wp.array | None`.
+For **public API** attributes and method signatures, use bare `wp.array | None` and document the concrete dtype in the docstring (e.g., `dtype :class:\`vec3\``). Warp kernel parameters require concrete dtypes inline (`wp.array(dtype=wp.vec3)`) per AGENTS.md.
 
 ## Quick Checklist
 


### PR DESCRIPTION
## Description

Adds a Claude Code skill (`.claude/skills/newton-api-design/SKILL.md`) that encodes Newton's detailed API design conventions — builder method signatures, parameter naming, docstring formats, and array documentation patterns.

### Why?

We previously trimmed detailed API design guidance from `AGENTS.md` (#1849) because those instructions were too specific for general contributor use and bloated the always-loaded context. However, these conventions are critical when designing or reviewing public API surfaces:

- Builder method parameter ordering (`body`, `xform`, shape-specific params, `cfg`, `as_site`, `label`, `custom_attributes`)
- Canonical parameter names (`xform` not `transform`, `cfg` not `config`)
- `None` defaults instead of constructed objects
- `IntEnum` for nested enumerations
- Dataclass field docstring placement
- Array documentation format (shape, dtype, SI units)

A skill is the right home for this — it's loaded **on demand** rather than injected into every conversation, keeping the base context lean while making the conventions available when needed.

### Usage

Invoke the skill with `/newton-api-design`:

```
❯ /newton-api-design

● Using newton-api-design skill to review API conventions.

  How can I help you with Newton's API design? Here are some things I can do:

  - Review new or existing public API for conformance to Newton conventions
  - Design method signatures, class structures, or enums following project patterns
  - Check parameter naming (xform, cfg, body, label), defaults, docstrings,
    and array documentation

  What would you like to work on?
```

You can also pass arguments directly:

```
❯ /newton-api-design check all public interfaces on the ShapeConfig class
```

The skill is also triggered automatically by Claude Code when it detects API design work (adding methods, reviewing signatures, etc.).

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

N/A — no user-facing API changes.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

N/A — this adds a Claude Code skill file only (Markdown), no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Newton API design standards and conventions to guide public API reviews.
  * Specifies builder method signature patterns, parameter naming and default-value conventions, and placement of field/docstring guidance.
  * Defines array documentation format (shape, dtype, units), nested-class/enum usage, and a quick checklist for consistent API design reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->