### PR TITLE
Fix ViewerGL rendering for non-Z-up coordinate systems

### DIFF
--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1001,8 +1001,7 @@ class RendererGL:
         self._frame_fbo = None
         self._frame_pbo = None
 
-        self._sun_direction = np.array((0.2, -0.3, 0.8))
-        self._sun_direction /= np.linalg.norm(self._sun_direction)
+        self._sun_direction = None  # set on first render based on camera up_axis
 
         self._light_color = (1.0, 1.0, 1.0)
 
@@ -1065,6 +1064,16 @@ class RendererGL:
         gl.glDepthRange(0.0, 1.0)
 
         self.camera = camera
+
+        # Lazy-init sun direction based on camera up axis
+        if self._sun_direction is None:
+            _sun_dirs = {
+                0: np.array((0.8, 0.2, -0.3)),  # X-up
+                1: np.array((0.2, 0.8, -0.3)),  # Y-up
+                2: np.array((0.2, -0.3, 0.8)),  # Z-up
+            }
+            d = _sun_dirs.get(camera.up_axis, _sun_dirs[2])
+            self._sun_direction = d / np.linalg.norm(d)
 
         # Store matrices for other methods
         self._view_matrix = self.camera.get_view_matrix()
@@ -1701,6 +1710,7 @@ class RendererGL:
             sky_upper=self.sky_upper,
             sky_lower=self.sky_lower,
             sun_direction=self._sun_direction,
+            up_axis=self.camera.up_axis,
         )
 
         gl.glBindVertexArray(self._sky_vao)

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -417,10 +417,12 @@ uniform vec3 sky_lower;
 uniform float far_plane;
 
 uniform vec3 sun_direction;
+uniform int up_axis;
 
 void main()
 {
-    float height = max(0.0, (FragPos.z/far_plane));//*0.5 + 0.5);
+    float h = up_axis == 0 ? FragPos.x : (up_axis == 1 ? FragPos.y : FragPos.z);
+    float height = max(0.0, h / far_plane);
     vec3 sky = mix(sky_lower, sky_upper, height);
 
     float diff = max(dot(sun_direction, normalize(FragPos)), 0.0);
@@ -598,6 +600,7 @@ class ShaderSky(ShaderGL):
             self.loc_far_plane = self._get_uniform_location("far_plane")
             self.loc_view_pos = self._get_uniform_location("view_pos")
             self.loc_sun_direction = self._get_uniform_location("sun_direction")
+            self.loc_up_axis = self._get_uniform_location("up_axis")
 
     def update(
         self,
@@ -608,6 +611,7 @@ class ShaderSky(ShaderGL):
         sky_upper: tuple[float, float, float],
         sky_lower: tuple[float, float, float],
         sun_direction: tuple[float, float, float],
+        up_axis: int = 2,
     ):
         """Update all shader uniforms."""
         with self:
@@ -621,6 +625,7 @@ class ShaderSky(ShaderGL):
             self._gl.glUniform3f(self.loc_sky_upper, *sky_upper)
             self._gl.glUniform3f(self.loc_sky_lower, *sky_lower)
             self._gl.glUniform3f(self.loc_sun_direction, *sun_direction)
+            self._gl.glUniform1i(self.loc_up_axis, up_axis)
 
 
 class ShadowShader(ShaderGL):


### PR DESCRIPTION
The sun direction was hardcoded to (0.2, -0.3, 0.8) which only looks correct with Z-up.  Now it is lazily initialized on first render based on Camera.up_axis so the dominant component always points along the up direction.

The sky fragment shader also hardcoded FragPos.z for the gradient height.  Added a `uniform int up_axis` so it picks the correct component (X, Y, or Z) for any up-axis convention.

<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sky and sun direction now adapt dynamically to the camera's orientation, with lighting computations driven by the current up-axis for consistent visuals.

* **Bug Fixes**
  * Sun direction is initialized lazily on first render to prevent incorrect lighting before the camera orientation is known.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->