### PR TITLE
Fix overlapping humanoids in recording example

### DIFF
--- a/newton/examples/basic/example_recording.py
+++ b/newton/examples/basic/example_recording.py
@@ -45,7 +45,7 @@ class Example:
         self.sim_dt = self.frame_dt / self.sim_substeps
 
         self.viewer = viewer
-        self.world_count = 1000
+        self.world_count = 100
 
         # Set numpy random seed for reproducibility
         self.seed = 123
@@ -65,16 +65,12 @@ class Example:
         # Joint initial positions
         articulation_builder.joint_q[:7] = [0.0, 0.0, 1.5, *start_rot]
 
-        spacing = 3.0
-        sqn = int(wp.ceil(wp.sqrt(float(self.world_count))))
-
         builder = newton.ModelBuilder()
-        for i in range(self.world_count):
-            pos = wp.vec3((i % sqn) * spacing, (i // sqn) * spacing, 0.0)
+        for _i in range(self.world_count):
             articulation_builder.joint_q[7:] = self.rng.uniform(
                 -1.0, 1.0, size=(len(articulation_builder.joint_q) - 7,)
             ).tolist()
-            builder.add_world(articulation_builder, xform=wp.transform(pos, wp.quat_identity()))
+            builder.add_world(articulation_builder)
         builder.add_ground_plane()
 
         # Finalize model


### PR DESCRIPTION
## Description

Remove explicit `xform` spacing from `add_world()` calls in the recording example. The manual grid layout conflicts with the viewer's built-in world spacing, causing humanoids to overlap and interlock into clumps. Letting the viewer handle world placement produces a clean, evenly-spaced grid.

Closes #1833

<img width="1931" height="1112" alt="image" src="https://github.com/user-attachments/assets/aa6e693e-24ac-4a96-8940-9de4b21046ce" />

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

N/A — no API changes.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the basic example by reducing simulated worlds from 1000 to 100 and streamlining world placement logic to use default builder placement instead of custom grid positioning. The example now runs more efficiently while maintaining joint randomization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->