### PR TITLE
Fix selection_materials friction having no effect across worlds

### DIFF
--- a/newton/examples/selection/example_selection_materials.py
+++ b/newton/examples/selection/example_selection_materials.py
@@ -63,7 +63,7 @@ def reset_materials_kernel(mu: wp.array3d(dtype=float), seed: int, shape_count: 
     else:
         rng = wp.rand_init(seed, world * shape_count + shape)
 
-    mu[world, arti, shape] = wp.randf(rng)  # random coefficient of friction
+    mu[world, arti, shape] = 0.5 + 0.5 * wp.randf(rng)  # random coefficient of friction
 
 
 class Example:
@@ -86,7 +86,7 @@ class Example:
 
         scene = newton.ModelBuilder()
 
-        scene.add_ground_plane()
+        scene.add_ground_plane(cfg=newton.ModelBuilder.ShapeConfig(mu=0.5))
         scene.replicate(world_template, world_count=self.world_count)
 
         # finalize model
@@ -205,9 +205,11 @@ class Example:
 
             # randomize materials
             if RANDOMIZE_PER_WORLD:
-                material_mu = torch.rand(self.ants.count, 1).unsqueeze(1).repeat(1, 1, self.ants.shape_count)
+                material_mu = 0.5 + 0.5 * torch.rand(self.ants.count, 1).unsqueeze(1).repeat(
+                    1, 1, self.ants.shape_count
+                )
             else:
-                material_mu = torch.rand((self.ants.count, 1, self.ants.shape_count))
+                material_mu = 0.5 + 0.5 * torch.rand((self.ants.count, 1, self.ants.shape_count))
         else:
             # flip velocities
             if self.reset_count % 2 == 0:


### PR DESCRIPTION
## Description

Closes #1850

MuJoCo combines contact friction using element-wise `max` of both contacting geoms (when priorities are equal, which is the default). The ground plane had the default `mu=1.0` while ant shape friction was randomized in `[0, 1)` via `wp.randf()`, so `max(1.0, rand_in_0_to_1)` always yielded `1.0` — all worlds behaved identically regardless of randomization.

**Fix:**
- Set ground plane friction to `0.5` via explicit `ShapeConfig(mu=0.5)`
- Shift randomized ant friction to `[0.5, 1.0)` so it always meets or exceeds the ground value
- Apply the same range fix to both the Warp kernel and PyTorch code paths

<img width="1934" height="1113" alt="image" src="https://github.com/user-attachments/assets/c3353872-738a-4497-82c2-90afb170474b" />

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date (N/A — no API changes)

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated material selection example with improved friction coefficient initialization and explicit ground plane physics configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->