### PR TITLE
Fix import error in VSCode tests due to local module import in unit t…

### DIFF
--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -18,11 +18,11 @@
 import unittest
 
 import numpy as np
-from unittest_utils import USD_AVAILABLE
 
 from newton import JointTargetMode, ModelBuilder
 from newton.solvers import SolverMuJoCo, SolverNotifyFlags
 from newton.tests import get_asset
+from newton.tests.unittest_utils import USD_AVAILABLE
 
 MJCF_ACTUATORS = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="test_actuators">


### PR DESCRIPTION
## Description
This uber-simple PR merely fixes a relative import in the effected file causing import errors in VSCode's testing utilities.

## Newton Migration Guide
Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test imports to align with internal test infrastructure reorganization; this cleans up test module resolution without changing test behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->