### PR TITLE
Use PR number instead of head_ref in concurrency groups

### DIFF
--- a/.github/workflows/pr_target_aws_gpu_benchmarks.yml
+++ b/.github/workflows/pr_target_aws_gpu_benchmarks.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr_target_aws_gpu_tests.yml
+++ b/.github/workflows/pr_target_aws_gpu_tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Replace attacker-controlled `github.head_ref` (fork branch name) with `github.event.pull_request.number` in the concurrency group key for `pull_request_target` workflows.

`github.head_ref` is the branch name from the fork, fully controlled by the PR author. A malicious actor could craft a branch name that collides with another workflow's concurrency group, causing `cancel-in-progress: true` to cancel legitimate in-progress runs (DoS). `github.event.pull_request.number` is assigned by GitHub and is not attacker-controlled.

This is a hardening measure in response to the ongoing [hackerbot-claw](https://www.linuxfoundation.org/blog/protecting-open-source-securing-github-actions-against-the-hackerbot-claw-campaign) GitHub Actions exploitation campaign targeting `pull_request_target` workflows.

## Newton Migration Guide

N/A — CI-only change.

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request workflow management for GPU testing and benchmarking processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->