### PR TITLE
Update author email to developers@newton-physics.org

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "newton"
 dynamic = ["version"]
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
-authors = [{ name = "Newton Developers", email = "warp-python@nvidia.com" }]
+authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## Description

Update the project author email in `pyproject.toml` from the legacy `warp-python@nvidia.com` to the new `developers@newton-physics.org`.

Other email addresses in the codebase were reviewed and don't need changes:
- `.github/workflows/` — standard `actions@github.com` for GitHub Actions git config
- `docs/guide/installation.rst` — `git@github.com` SSH URL (not an email)
- `newton/tests/test_download_assets.py` — `ci@newton.dev` test fixture

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project contact email in metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->