### PR TITLE
Fixes issue with mass properties on composed USDs

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2225,8 +2225,22 @@ def parse_usd(
                     # created by schema resolvers are not real USD prims). Fall back to
                     # builder-accumulated mass properties from add_shape_*() calls.
                     cmp_mass = builder.body_mass[body_id]
-                    cmp_i_diag = Gf.Vec3f(0.0, 0.0, 0.0)
                     cmp_com = builder.body_com[body_id]
+                    # When the body has an authored density, rescale accumulated mass
+                    # and inertia from the builder's default shape density to the
+                    # body-level density (USD body density overrides per-shape density).
+                    body_density_attr = mass_api.GetDensityAttr()
+                    if (
+                        body_density_attr.HasAuthoredValue()
+                        and float(body_density_attr.Get()) > 0.0
+                        and default_shape_density > 0.0
+                    ):
+                        density_scale = float(body_density_attr.Get()) / default_shape_density
+                        cmp_mass *= density_scale
+                        builder.body_inertia[body_id] = wp.mat33(
+                            np.array(builder.body_inertia[body_id]) * density_scale
+                        )
+                    cmp_i_diag = Gf.Vec3f(0.0, 0.0, 0.0)
                     cmp_principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
 
             # Inertia: authored diagonal + principal axes take precedence over mass computer.

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -1173,7 +1173,8 @@ class TestImportUsdPhysics(unittest.TestCase):
         When collision shapes live inside instanceable prims, USD's
         ComputeMassProperties cannot traverse into them and returns invalid results
         (mass < 0). The importer must fall back to the mass properties already
-        accumulated by the builder during add_shape_*() calls.
+        accumulated by the builder during add_shape_*() calls, and respect the
+        body-level authored density instead of the builder's default shape density.
         """
         from pxr import Usd, UsdGeom, UsdPhysics
 
@@ -1183,15 +1184,18 @@ class TestImportUsdPhysics(unittest.TestCase):
 
         # Create a prototype with a collision sphere (outside the body hierarchy).
         stage.OverridePrim("/Prototype_Collisions")
+        radius = 0.5
         sphere = UsdGeom.Sphere.Define(stage, "/Prototype_Collisions/sphere")
-        sphere.CreateRadiusAttr().Set(0.5)
+        sphere.CreateRadiusAttr().Set(radius)
         UsdPhysics.CollisionAPI.Apply(sphere.GetPrim())
 
-        # Create a rigid body with MassAPI applied but no values authored.
+        # Create a rigid body with MassAPI applied and only density authored.
+        body_density = 5.0
         body_xform = UsdGeom.Xform.Define(stage, "/World/Body")
         body_prim = body_xform.GetPrim()
         UsdPhysics.RigidBodyAPI.Apply(body_prim)
-        UsdPhysics.MassAPI.Apply(body_prim)
+        mass_api = UsdPhysics.MassAPI.Apply(body_prim)
+        mass_api.CreateDensityAttr().Set(body_density)
 
         # Reference the collision prototype as an instanceable prim.
         collisions = stage.DefinePrim("/World/Body/collisions")
@@ -1202,9 +1206,9 @@ class TestImportUsdPhysics(unittest.TestCase):
         builder.add_usd(stage)
 
         self.assertEqual(builder.body_count, 1)
-        self.assertGreater(
-            builder.body_mass[0], 0.0, "Body mass must be positive (not overwritten by failed ComputeMassProperties)"
-        )
+        # Expected mass = body_density * sphere_volume = 5 * (4/3 * pi * 0.5^3).
+        expected_mass = body_density * (4.0 / 3.0 * np.pi * radius**3)
+        np.testing.assert_allclose(builder.body_mass[0], expected_mass, rtol=1e-5)
         # Verify inertia is also positive (not garbage).
         inertia = np.array(builder.body_inertia[0]).reshape(3, 3)
         self.assertGreater(np.trace(inertia), 0.0, "Body inertia trace must be positive")


### PR DESCRIPTION
## Description

When a rigid body has PhysicsMassAPI applied but no authored mass/inertia/COM values, the importer calls UsdPhysics.RigidBodyAPI.ComputeMassProperties() to resolve them. However,  ComputeMassProperties cannot traverse into USD instanceable prims — it never discovers the collision shapes, never calls the mass information callback, and returns garbage values (mass=-1.0, uninitialized inertia and principal axes).                                                                                                                              

These invalid results then overwrite the correct mass properties that the builder had already accumulated from add_shape_*() calls, leaving bodies with negative mass and broken inertia.

This affects any USD asset that uses instanceable collision geometry (common in flattened Isaac Lab / IsaacSim exports) combined with unenriched PhysicsMassAPI schemas.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback for cases where computed mass properties are invalid, ensuring a safe, positive mass and inertia are used and honoring any authored body density.

* **Tests**
  * Added a regression test validating fallback mass/inertia computation for instanced colliders and that authored density is respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->