### PR TITLE
Add explicit joint armature to allegro hand example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### Fixed
 
-- Add explicit joint armature to allegro hand example to restore stable contact behavior
-
 ## [1.0.0] - YYYY-MM-DD
 
 Initial public release.


### PR DESCRIPTION
## Description

The default joint armature was changed from 1e-2 to 0 in #1782, which destabilized contacts in the allegro hand example (cube falls through, fingers lose grip).

This adds explicit `armature=1e-2` on the revolute finger DOFs to restore the pre-#1782 behavior. The cube's free joint is left at armature=0, matching its original state (`JointDofConfig.create_unlimited()` hardcodes armature=0 regardless of the builder default).

**Root cause**: joint armature is added to the diagonal of the joint-space inertia matrix (qM), which flows into `body_invweight0` / `dof_invweight0` during model compilation. These inverse weights determine contact constraint impedance. With armature=0 on finger joints, the effective mass seen by the constraint solver drops, leading to softer contacts.

## Newton Migration Guide

- [x] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`