### PR TITLE
Fix root fixed joint losing body transform in USD importer

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1594,8 +1594,34 @@ def parse_usd(
                         world_body_prim = stage.GetPrimAtPath(world_body_path) if world_body_path else None
                         if world_body_prim is not None and world_body_prim.IsValid():
                             world_body_xform = usd.get_transform(world_body_prim, local=False, xform_cache=xform_cache)
+                        elif not world_body_path:
+                            # JointDesc returned "" for the world-side body.
+                            # Check whether the USD joint targets a non-rigid
+                            # prim (e.g. a Ground xform): if so, localPose0
+                            # already carries its world-space transform and we
+                            # should use identity (the original behaviour).
+                            # If no such prim exists the root body's own pose
+                            # must be used to anchor the fixed joint.
+                            joint_prim = stage.GetPrimAtPath(joint_names[i])
+                            usd_joint = UsdPhysics.Joint(joint_prim)
+                            has_nonrigid_target = False
+                            for rel in (usd_joint.GetBody0Rel(), usd_joint.GetBody1Rel()):
+                                targets = rel.GetTargets()
+                                if targets:
+                                    t = str(targets[0])
+                                    if t not in body_ids:
+                                        has_nonrigid_target = True
+                                        break
+                            if has_nonrigid_target:
+                                world_body_xform = wp.transform_identity()
+                            else:
+                                root_joint_child = joint_edges[sorted_joints[0]][1]
+                                if bodies_follow_joint_ordering:
+                                    child_body_id = path_body_map[body_data[root_joint_child]["label"]]
+                                else:
+                                    child_body_id = art_bodies[root_joint_child]
+                                world_body_xform = wp.transform_inverse(incoming_world_xform) * builder.body_q[child_body_id]
                         else:
-                            # world-side path can be empty (body0 == ""); localPose0 already carries world-side pose
                             world_body_xform = wp.transform_identity()
                         root_frame_xform = (
                             wp.transform_inverse(articulation_root_xform)

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -688,6 +688,72 @@ class TestImportUsdJoints(unittest.TestCase):
         self.assertEqual(builder.joint_child[fixed_idx], root_idx)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_fixed_root_joint_preserves_body_transform(self):
+        """A fixed root joint to world must preserve the root body's position and rotation in joint_X_p."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        articulation = UsdGeom.Xform.Define(stage, "/World/Articulation")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+        root_pos = Gf.Vec3d(1.0, 2.0, 0.5)
+        root_rot = Gf.Quatf(0.5, 0.5, 0.5, 0.5)  # 120-deg rotation around (1,1,1)
+
+        root = UsdGeom.Xform.Define(stage, "/World/Articulation/Root")
+        root.AddTranslateOp().Set(root_pos)
+        root.AddOrientOp().Set(root_rot)
+        UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+        UsdPhysics.MassAPI.Apply(root.GetPrim()).GetMassAttr().Set(1.0)
+
+        link = UsdGeom.Xform.Define(stage, "/World/Articulation/Link")
+        link.AddTranslateOp().Set(root_pos + Gf.Vec3d(0.0, 0.0, 1.0))
+        UsdPhysics.RigidBodyAPI.Apply(link.GetPrim())
+        UsdPhysics.MassAPI.Apply(link.GetPrim()).GetMassAttr().Set(0.5)
+
+        fixed = UsdPhysics.FixedJoint.Define(stage, "/World/Articulation/FixedToWorld")
+        fixed.CreateBody0Rel().SetTargets([root.GetPath()])
+        fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+
+        revolute = UsdPhysics.RevoluteJoint.Define(stage, "/World/Articulation/Revolute")
+        revolute.CreateBody0Rel().SetTargets([root.GetPath()])
+        revolute.CreateBody1Rel().SetTargets([link.GetPath()])
+        revolute.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 1.0))
+        revolute.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        revolute.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        revolute.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        revolute.CreateAxisAttr().Set("Z")
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        model = builder.finalize()
+        state = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+        body_q = state.body_q.numpy()
+        root_idx = builder.body_label.index("/World/Articulation/Root")
+        np.testing.assert_allclose(
+            body_q[root_idx, :3],
+            [root_pos[0], root_pos[1], root_pos[2]],
+            atol=1e-4,
+            err_msg="Root body position must match USD prim translation",
+        )
+        img = root_rot.GetImaginary()
+        expected_quat = [img[0], img[1], img[2], root_rot.GetReal()]
+        np.testing.assert_allclose(
+            body_q[root_idx, 3:],
+            expected_quat,
+            atol=1e-4,
+            err_msg="Root body rotation must match USD prim orientation",
+        )
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_reversed_joint_unsupported_d6_raises(self):
         """Reversing a D6 joint should raise an error."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics


### PR DESCRIPTION
## Description

When a fixed root joint connects to the world and JointDesc returns ""
for the world-side body, the importer fell back to identity for
joint_X_p, discarding the root body's position and rotation from body_q.
This caused fixed-base articulations to ignore their USD prim transforms.

Distinguish two cases when world_body_path is empty:
- Non-rigid target exists (e.g. Ground xform): use identity since
  localPose0 already carries the transform.
- No non-rigid target: use the child body's pose relative to
  incoming_world_xform to correctly anchor the fixed joint.

- Fix `parse_usd` dropping root body position/rotation for fixed-base
  articulations when the root fixed joint's world-side body resolves to
  an empty path (no non-rigid anchor prim).
- Add unit test verifying root fixed joint preserves body translation
  and rotation through forward kinematics.


## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

uv run --extra dev -m newton.tests -k test_fixed_root_joint_preserves_body_transform

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

```
import numpy as np
import warp as wp
import newton
from pxr import Gf, Usd, UsdGeom, UsdPhysics


stage = Usd.Stage.CreateInMemory()
UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
UsdPhysics.Scene.Define(stage, "/physicsScene")

art = UsdGeom.Xform.Define(stage, "/Art")
UsdPhysics.ArticulationRootAPI.Apply(art.GetPrim())

root = UsdGeom.Xform.Define(stage, "/Art/Root")
root.AddTranslateOp().Set(Gf.Vec3d(1.0, 2.0, 0.5))
root.AddOrientOp().Set(Gf.Quatf(0.5, 0.5, 0.5, 0.5))
UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
UsdPhysics.MassAPI.Apply(root.GetPrim()).GetMassAttr().Set(1.0)

fixed = UsdPhysics.FixedJoint.Define(stage, "/Art/Fixed")
fixed.CreateBody0Rel().SetTargets([root.GetPath()])

builder = newton.ModelBuilder()
builder.add_usd(stage)
model = builder.finalize()
state = model.state()
newton.eval_fk(model, model.joint_q, model.joint_qd, state)

body_q = state.body_q.numpy()[0]
print(f"Position: {body_q[:3]}")  # Expected [1, 2, 0.5], got [0, 0, 0]
print(f"Rotation: {body_q[3:]}")  # Expected [0.5, 0.5, 0.5, 0.5], got [0, 0, 0, 1]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of joint world transforms when world targets are non-rigid or cannot be resolved, ensuring correct root joint positioning.

* **Tests**
  * Added tests verifying that fixed root joints correctly preserve body transforms and rotations during forward kinematics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->