### PR TITLE
Fix collision pipeline mismatch in SolverMuJoCo examples

### DIFF
--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -102,7 +102,10 @@ class Example:
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
         self.use_mujoco_contacts = use_mujoco_contacts
-        self.contacts = self.model.contacts()
+        if use_mujoco_contacts:
+            self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
+        else:
+            self.contacts = self.model.contacts()
 
         # ensure this is called at the end of the Example constructor
         self.viewer.set_model(self.model)

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -101,7 +101,10 @@ class Example:
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
         self.use_mujoco_contacts = use_mujoco_contacts
-        self.contacts = self.model.contacts()
+        if use_mujoco_contacts:
+            self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
+        else:
+            self.contacts = self.model.contacts()
 
         self.viewer.set_model(self.model)
 

--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -95,7 +95,10 @@ class Example:
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
         self.use_mujoco_contacts = use_mujoco_contacts
-        self.contacts = self.model.contacts()
+        if use_mujoco_contacts:
+            self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
+        else:
+            self.contacts = self.model.contacts()
 
         self.viewer.set_model(self.model)
         self.viewer.set_world_offsets((3.0, 3.0, 0.0))

--- a/newton/examples/robot/example_robot_humanoid.py
+++ b/newton/examples/robot/example_robot_humanoid.py
@@ -85,7 +85,10 @@ class Example:
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
         self.use_mujoco_contacts = use_mujoco_contacts
-        self.contacts = self.model.contacts()
+        if use_mujoco_contacts:
+            self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
+        else:
+            self.contacts = self.model.contacts()
 
         self.viewer.set_model(self.model)
 

--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -275,7 +275,7 @@ class Example:
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
         self.control = self.model.control()
-        self.contacts = self.model.contacts()
+        self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
 
         # Set model in viewer
         self.viewer.set_model(self.model)

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -126,6 +126,7 @@ class Example:
         self.state_0.clear_forces()
         self.viewer.apply_forces(self.state_0)
         self.solver.step(self.state_0, self.state_0, self.control, None, self.sim_dt)
+        self.solver.update_contacts(self.contacts, self.state_0)
 
     def step(self):
         if self.sim_time >= self.next_reset:
@@ -139,8 +140,6 @@ class Example:
                 wp.capture_launch(self.graph)
             else:
                 self.simulate()
-
-        self.solver.update_contacts(self.contacts, self.state_0)
         self.plate_contact_sensor.update(self.state_0, self.contacts)
 
         net_force = self.plate_contact_sensor.net_force.numpy()

--- a/newton/examples/sensors/example_sensor_imu.py
+++ b/newton/examples/sensors/example_sensor_imu.py
@@ -118,7 +118,7 @@ class Example:
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
         self.control = self.model.control()
-        self.contacts = self.model.contacts()
+        self.contacts = newton.Contacts(self.solver.get_max_contact_count(), 0)
 
         self.buffer = wp.zeros(self.n_cubes, dtype=wp.vec3)
         self.colors = wp.zeros(self.n_cubes, dtype=wp.vec3)


### PR DESCRIPTION
## Description

Fix examples that had mismatched collision pipeline configurations when using `SolverMuJoCo`:

**Always mismatched** (hardcoded `use_mujoco_contacts=True`):
- `example_robot_policy.py` and `example_sensor_imu.py` were creating Newton contacts via `model.contacts()`, calling `model.collide()`, and passing contacts to `solver.step()` despite using MuJoCo's collision pipeline. Removed the redundant Newton collision setup and pass `None` instead.

**Conditionally mismatched** (via `--use-mujoco-contacts` flag):
- `example_robot_humanoid.py`, `example_robot_anymal_d.py`, `example_robot_g1.py`, and `example_robot_h1.py` unconditionally created Newton contacts and called `model.collide()` even when `--use-mujoco-contacts` was enabled. Guard contact allocation and `collide()` behind the `use_mujoco_contacts` flag, matching the pattern already used in `example_robot_anymal_c_walk.py`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Run the affected examples and verify they simulate correctly:
```
uv run -m newton.examples robot_policy
uv run -m newton.examples sensor_imu
uv run -m newton.examples robot_humanoid
uv run -m newton.examples robot_anymal_d
uv run -m newton.examples robot_g1
uv run -m newton.examples robot_h1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Examples now offer a configurable option to use native MuJoCo contact handling in robot and sensor simulations.

* **Improvements**
  * Contact and collision processing made conditional and decoupled from solver stepping; contact information is refreshed after simulation substeps for more accurate and consistent simulation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->