### PR TITLE
Fix contact force graph clipping in sensor_contact example

### DIFF
--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -167,6 +167,7 @@ class Example:
         self.next_reset = self.sim_time + self.reset_interval
         self.viewer.update_shape_colors({self.shape_map[s]: v for s, v in self.shape_colors.items()})
         self.plates_touched = 2 * [False]
+        self.plot_window.reset()
 
         print("Resetting")
         # Restore initial joint positions and velocities in-place.
@@ -221,6 +222,10 @@ class ViewerPlot:
             self.data[0] = sum(self.cache) / self.avg
             self.data = np.roll(self.data, -1)
             self.cache.clear()
+
+    def reset(self):
+        self.data.fill(0)
+        self.cache.clear()
 
     def render(self, imgui):
         """


### PR DESCRIPTION
## Description

Fix the contact force graph in the `sensor_contact` example so the right edge is no longer clipped. The graph `graph_size` width (400px) matched the window width, but ImGui window padding made the content area narrower, hiding the rightmost portion of the plot. Since new data scrolls in from the right, this created a misleading time delay — contact forces at time T were not visible until T + Dt.

Uses `imgui.get_content_region_avail()` to fit the graph width to the actual content area.

Closes #1913

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run -m newton.examples sensor_contact
```

Visually confirm the contact force graph extends to the right edge of the plot window without clipping, and that force values appear immediately when contacts occur.

## Bug fix

**Steps to reproduce:**

1. `uv run -m newton.examples sensor_contact`
2. Observe the "Flap Contact Force" graph — the rightmost portion is clipped
3. Contact forces at time T are not visible until T + Dt because the most recent data points are hidden behind the clipped right edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Flap contact force plot now auto-fills available width while preserving its original height for a more responsive layout.
  * Plot labeling simplified for a cleaner, less cluttered visualization.
  * Added a reset action to clear plotted data and cache, restoring the plot to an empty state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->