### PR TITLE
Fix inverted scroll direction in GL viewer left panel

### DIFF
--- a/newton/_src/viewer/gl/gui.py
+++ b/newton/_src/viewer/gl/gui.py
@@ -58,7 +58,14 @@ class UI:
 
         # Fix inverted scroll direction in the pyglet imgui backend before
         # attaching callbacks so pyglet captures the corrected handler.
-        self.impl.on_mouse_scroll = self._on_mouse_scroll
+        # The replacement must be named "on_mouse_scroll" because pyglet
+        # matches handlers by __name__.
+        io = self.io
+
+        def on_mouse_scroll(x, y, scroll_x, scroll_y):
+            io.add_mouse_wheel_event(scroll_x, scroll_y)
+
+        self.impl.on_mouse_scroll = on_mouse_scroll
         self.impl._attach_callbacks(self.window)
 
         # Set up proper DPI scaling for high-DPI displays
@@ -261,9 +268,6 @@ class UI:
         style.set_color_(self.imgui.Col_.nav_windowing_dim_bg, self.imgui.ImVec4(0.196078434586525, 0.1764705926179886, 0.5450980663299561, 0.501960813999176))
         style.set_color_(self.imgui.Col_.modal_window_dim_bg, self.imgui.ImVec4(0.196078434586525, 0.1764705926179886, 0.5450980663299561, 0.501960813999176))
         # fmt: on
-
-    def _on_mouse_scroll(self, x, y, scroll_x, scroll_y):
-        self.io.add_mouse_wheel_event(scroll_x, scroll_y)
 
     def begin_frame(self):
         """Renders a single frame of the UI. This should be called from the main render loop."""


### PR DESCRIPTION
## Description

The imgui_bundle pyglet backend negates the `scroll_y` value when forwarding mouse wheel events to imgui (`add_mouse_wheel_event(0, -scroll)`), causing the GL viewer's left panel to scroll in the wrong direction.

Fix by creating the pyglet imgui renderer with `attach_callbacks=False`, overriding `on_mouse_scroll` with a corrected handler that passes scroll deltas through without negation, then calling `_attach_callbacks` so pyglet captures the fixed handler.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run -m newton.examples basic_shapes
```
Scroll with the mouse wheel over the left panel — content should scroll in the natural direction.

## Bug fix

**Steps to reproduce:**

1. `uv run -m newton.examples basic_shapes`
2. Hover over the left panel
3. Scroll down with the mouse wheel
4. Observe the panel scrolls up instead of down

**Root cause:** The `imgui_bundle` pyglet backend's `on_mouse_scroll` handler negates `scroll_y` before passing it to imgui, inverting the scroll direction. Pyglet and imgui use the same sign convention (positive = scroll up), so the negation is a bug in the upstream backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inverted scroll wheel behavior in the viewer interface.

* **API Changes**
  * Updated renderer initialization signature to include callback attachment control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->