### PR TITLE
Add ScopedDevice wrapper for mujoco_warp API calls

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3066,12 +3066,14 @@ class SolverMuJoCo(SolverBase):
             need_const_0 = True
             need_length_range = True
 
-        if need_length_range:
-            self._mujoco_warp.set_length_range(self.mjw_model, self.mjw_data)
-        if need_const_fixed:
-            self._mujoco_warp.set_const_fixed(self.mjw_model, self.mjw_data)
-        if need_const_0:
-            self._mujoco_warp.set_const_0(self.mjw_model, self.mjw_data)
+        if need_length_range or need_const_fixed or need_const_0:
+            with wp.ScopedDevice(self.model.device):
+                if need_length_range:
+                    self._mujoco_warp.set_length_range(self.mjw_model, self.mjw_data)
+                if need_const_fixed:
+                    self._mujoco_warp.set_const_fixed(self.mjw_model, self.mjw_data)
+                if need_const_0:
+                    self._mujoco_warp.set_const_0(self.mjw_model, self.mjw_data)
 
     def _create_inverse_shape_mapping(self):
         """
@@ -6002,7 +6004,8 @@ class SolverMuJoCo(SolverBase):
 
         if self._viewer.is_running():
             if not self.use_mujoco_cpu:
-                self._mujoco_warp.get_data_into(self.mj_data, self.mj_model, self.mjw_data)
+                with wp.ScopedDevice(self.model.device):
+                    self._mujoco_warp.get_data_into(self.mj_data, self.mj_model, self.mjw_data)
 
             self._viewer.sync()
 


### PR DESCRIPTION
## Description

Wrap mujoco_warp API calls in `notify_model_changed()` and the viewer sync path with `wp.ScopedDevice(self.model.device)` to ensure the correct device context. The `step()` and build paths already use `ScopedDevice`, but these two call sites were missing it.

**Affected call sites:**
- `set_length_range`, `set_const_fixed`, `set_const_0` in `notify_model_changed()`
- `get_data_into` in the MuJoCo viewer sync path

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Verified by inspection that all `_mujoco_warp` API calls now have a `ScopedDevice` wrapper, matching the existing pattern in `step()` and the build path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in MuJoCo solver state management and data transfer operations to ensure proper device context handling during model updates and viewer rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->