### PR TITLE
Skip trajectory replay when viewer is paused in diffsim examples

### DIFF
--- a/newton/examples/diffsim/example_diffsim_ball.py
+++ b/newton/examples/diffsim/example_diffsim_ball.py
@@ -183,6 +183,11 @@ class Example:
         assert all(np.diff(self.loss_history[:-1]) < -1e-3)
 
     def render(self):
+        if self.viewer.is_paused():
+            self.viewer.begin_frame(self.viewer.time)
+            self.viewer.end_frame()
+            return
+
         if self.frame > 0 and self.train_iter % 16 != 0:
             return
 

--- a/newton/examples/diffsim/example_diffsim_bear.py
+++ b/newton/examples/diffsim/example_diffsim_bear.py
@@ -303,6 +303,11 @@ class Example:
         self.train_iter += 1
 
     def render(self):
+        if self.viewer.is_paused():
+            self.viewer.begin_frame(self.viewer.time)
+            self.viewer.end_frame()
+            return
+
         # draw training run
         for i in range(self.sim_steps + 1):
             state = self.states[i * self.sim_substeps]

--- a/newton/examples/diffsim/example_diffsim_cloth.py
+++ b/newton/examples/diffsim/example_diffsim_cloth.py
@@ -188,6 +188,11 @@ class Example:
         assert most(np.diff(self.loss_history[:-1]) < -1.0)
 
     def render(self):
+        if self.viewer.is_paused():
+            self.viewer.begin_frame(self.viewer.time)
+            self.viewer.end_frame()
+            return
+
         if self.frame > 0 and self.train_iter % 4 != 0:
             return
 

--- a/newton/examples/diffsim/example_diffsim_soft_body.py
+++ b/newton/examples/diffsim/example_diffsim_soft_body.py
@@ -338,6 +338,11 @@ class Example:
         assert most(np.diff(self.loss_history) < -0.0, min_ratio=0.8)
 
     def render(self):
+        if self.viewer.is_paused():
+            self.viewer.begin_frame(self.viewer.time)
+            self.viewer.end_frame()
+            return
+
         if self.frame > 0 and self.train_iter % 10 != 0:
             return
 

--- a/newton/examples/diffsim/example_diffsim_spring_cage.py
+++ b/newton/examples/diffsim/example_diffsim_spring_cage.py
@@ -231,6 +231,11 @@ class Example:
         self.train_iter += 1
 
     def render(self):
+        if self.viewer.is_paused():
+            self.viewer.begin_frame(self.viewer.time)
+            self.viewer.end_frame()
+            return
+
         # for interactive viewing, we just render the final state at every frame
         if isinstance(self.viewer, newton.viewer.ViewerGL):
             start_frame = self.sim_steps


### PR DESCRIPTION
## Description

When pressing pause (Space key or checkbox) in ViewerGL, diffsim examples replay their entire optimization trajectory at full speed instead of pausing. This is because the `run()` loop skips `step()` when paused but still calls `render()`, and diffsim examples loop through all trajectory states in their `render()` method.

The fix adds a pause guard at the top of each affected example's `render()` method. When paused, it renders a single frame to keep the viewer responsive (event processing, camera interaction) without replaying the trajectory. This approach is local to the affected examples and doesn't change the shared `run()` loop behavior.

Closes #1852

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k example_diffsim
```

Manual verification:
1. `uv run -m newton.examples diffsim_ball` (or diffsim_cloth, diffsim_soft_body, diffsim_bear)
2. Press Space to pause — simulation and trajectory replay freeze
3. Press Space again — simulation resumes

## Bug fix

**Steps to reproduce:**

1. Run `uv run -m newton.examples diffsim_ball`
2. Press Space to pause
3. Observe the trajectory is replayed at full speed instead of pausing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering in differential simulation examples to properly respect the pause state, preventing unnecessary computations while the viewer is paused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->