### PR TITLE
Fix inertia warnings in allegro hand example

### DIFF
--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -31,6 +31,7 @@
 
 import numpy as np
 import warp as wp
+from pxr import Gf, Usd, UsdPhysics
 
 import newton
 import newton.examples
@@ -98,8 +99,20 @@ class Example:
 
         asset_path = newton.utils.download_asset("wonik_allegro")
         asset_file = str(asset_path / "usd" / "allegro_left_hand_with_cube.usda")
+
+        # Author diagonal inertia on the DexCube to prevent USD from emitting
+        # a spurious "possibly invalid inertia tensor" warning during
+        # ComputeMassProperties (the cube's colliders are behind a composed
+        # reference that USD cannot discover).
+        # I = 1/6 * m * a^2, m=0.216 kg, a=0.072 m (0.06 * 1.2 parent scale).
+        stage = Usd.Stage.Open(asset_file)
+        cube_prim = stage.GetPrimAtPath("/World/envs/env_0/object/DexCube")
+        mass_api = UsdPhysics.MassAPI(cube_prim)
+        inertia = 1.0 / 6.0 * 0.216 * 0.072**2
+        mass_api.GetDiagonalInertiaAttr().Set(Gf.Vec3f(inertia, inertia, inertia))
+
         allegro_hand.add_usd(
-            asset_file,
+            stage,
             xform=wp.transform(wp.vec3(0, 0, 0.5)),
             enable_self_collisions=False,
             ignore_paths=[".*Dummy", ".*CollisionPlane"],


### PR DESCRIPTION
## Description

Author diagonal inertia on the DexCube prim before loading the USD stage in the allegro hand example. The cube's colliders sit behind a composed reference marked `instanceable = true`, so USD's `ComputeMassProperties` cannot traverse into the instance to discover them and emits a spurious "possibly invalid inertia tensor" warning. Authoring the correct inertia (`I = 1/6 · m · a²`, `m = 0.216 kg`, `a = 0.072 m`) also eliminates Newton's "authored mass and density without authored diagonalInertia" warning.

Closes #1843

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k allegro
```

## Bug fix

**Steps to reproduce:**

1. `uv run -m newton.examples robot_allegro_hand`
2. Observe two warnings at startup:
   - `Warning: The rigid body at /World/envs/env_0/object/DexCube has a possibly invalid inertia tensor of {1.0, 1.0, 1.0}...`
   - `UserWarning: Body /World/envs/env_0/object/DexCube: authored mass and density without authored diagonalInertia.`

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
asset_path = newton.utils.download_asset("wonik_allegro")
asset_file = str(asset_path / "usd" / "allegro_left_hand_with_cube.usda")
builder.add_usd(asset_file, hide_collision_shapes=True)
# Two warnings appear from the DexCube body
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved physics simulation in example code with enhanced mass and inertia property configuration for increased physical accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->