### PR TITLE
Precompile picking/raycast kernels on viewer init

### DIFF
--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -395,10 +395,13 @@ class ViewerGL(ViewerBase):
 
         # Precompile picking/raycast kernels to avoid JIT delay on first pick
         if model is not None:
-            from ..geometry import raycast as _raycast_module  # noqa: PLC0415
+            try:
+                from ..geometry import raycast as _raycast_module  # noqa: PLC0415
 
-            wp.load_module(module=_raycast_module, device=model.device)
-            wp.load_module(module="newton._src.viewer.kernels", device=model.device)
+                wp.load_module(module=_raycast_module, device=model.device)
+                wp.load_module(module="newton._src.viewer.kernels", device=model.device)
+            except Exception:
+                pass
 
         # Build packed arrays for batched GPU rendering of shape instances
         self._build_packed_vbo_arrays()


### PR DESCRIPTION
## Description

Calls `wp.load_module` for the raycast and viewer kernel modules during `set_model` so the first right-click pick in the GL viewer doesn't stall on JIT compilation. Wrapped in try/except for graceful fallback to JIT-on-first-pick if module loading fails.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

1. Clear Warp cache: `WARP_CACHE_ROOT=/tmp/claude/warp-cache-$$ uv run -m newton.examples basic_shapes`
2. Right-click to pick an object — should respond immediately without a compilation pause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness of object selection operations in the viewer by optimizing initial load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->