### PR TITLE
Clip camera rotation to [-180, 180] in GL viewer

### DIFF
--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -478,8 +478,8 @@ class ViewerGL(ViewerBase):
             yaw: The camera yaw.
         """
         self.camera.pos = pos
-        self.camera.pitch = pitch
-        self.camera.yaw = yaw
+        self.camera.pitch = max(min(pitch, 89.0), -89.0)
+        self.camera.yaw = (yaw + 180.0) % 360.0 - 180.0
 
     @override
     def log_mesh(
@@ -1279,8 +1279,8 @@ class ViewerGL(ViewerBase):
 
             # Map screen-space right drag to a right turn (clockwise),
             # independent of world up-axis convention.
-            self.camera.yaw -= dx
-            self.camera.pitch += dy
+            self.camera.yaw = (self.camera.yaw - dx + 180.0) % 360.0 - 180.0
+            self.camera.pitch = max(min(self.camera.pitch + dy, 89.0), -89.0)
 
         if buttons & pyglet.window.mouse.RIGHT and self.picking_enabled:
             fb_x, fb_y = self._to_framebuffer_coords(x, y)


### PR DESCRIPTION
## Description

Wrap yaw to [-180, 180) and clamp pitch to [-89, 89] when updating camera angles via mouse drag or `set_camera()`. The trig functions are periodic so the rendering was unaffected, but the debug overlay displayed unbounded values.

Closes #1933

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_viewer
```

All 49 viewer tests pass.

## Bug fix

**Steps to reproduce:**

1. Run any example with the GL viewer
2. Click and drag to rotate the camera several full turns
3. Observe yaw/pitch values in the debug overlay exceed ±360°

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced 3D viewer camera control stability by constraining pitch rotation and normalizing yaw range to prevent unusual viewing angles during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->