### PR TITLE
Run gc.collect and release CUDA mempool memory between tests to reduce peak RSS

### DIFF
--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -579,8 +579,9 @@ class ParallelTextTestResult(unittest.TextTestResult):
 
     def stopTest(self, test):
         super().stopTest(test)
-        # Release unused CUDA mempool memory back to the OS after each test
-        # to reduce peak host RSS in parallel test runs (see issue #1881).
+        # Force garbage collection of CPU-side allocations and release unused
+        # CUDA mempool memory to reduce peak host RSS in parallel test runs
+        # (see issue #1881).
         import gc  # noqa: PLC0415
 
         gc.collect()

--- a/newton/tests/unittest_utils.py
+++ b/newton/tests/unittest_utils.py
@@ -510,8 +510,9 @@ class ParallelJunitTestResult(unittest.TextTestResult):
 
     def stopTest(self, test):
         super().stopTest(test)
-        # Release unused CUDA mempool memory back to the OS after each test
-        # to reduce peak host RSS in parallel test runs (see issue #1881).
+        # Force garbage collection of CPU-side allocations and release unused
+        # CUDA mempool memory to reduce peak host RSS in parallel test runs
+        # (see issue #1881).
         import gc  # noqa: PLC0415
 
         gc.collect()


### PR DESCRIPTION
## Description

Force garbage collection of unreferenced Python objects (dead models/solvers/states
holding CPU-side host arrays) and release unused CUDA mempool allocations after
each test method by adding `stopTest()` to both `ParallelTextTestResult` and
`ParallelJunitTestResult`.

`gc.collect()` is the primary mechanism — it reclaims host memory from objects
the cyclic GC hasn't collected yet. The mempool threshold change is a secondary
safeguard that releases retained device memory back to the OS.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Profiled all 311 test classes before and after using a memory profiling script
(`resource.getrusage` peak RSS per subprocess). Key results:

| Test Class | Tests | Before (MB) | After (MB) | Reduction |
|---|---:|---:|---:|---:|
| `TestBodyForce` | 364 | 1898 | 651 | -66% |
| `TestPhysicsValidation` | 48 | 2135 | 980 | -54% |
| `TestJointController` | 41 | 2125 | 999 | -53% |
| `TestAnymalReset` | 4 | 1995 | 704 | -65% |
| `TestControlForce` (up_axis) | 18 | 1914 | 667 | -65% |
| `TestMujocoSpatialTendon` | 10 | 1884 | 761 | -60% |
| `TestMuJoCoSiteExport` | 7 | 1087 | 561 | -48% |
| `TestToleranceClamping` | 2 | 1074 | 561 | -48% |

Isolated experiment on `TestBodyForce` and `TestControlForce` confirmed
`gc.collect()` alone accounts for essentially all RSS reduction (~1300 MB
and ~1150 MB respectively); the mempool threshold change adds ~0 MB within
measurement noise.

Previously 10 classes exceeded 1.8 GB; now only 2 do (both dominated by a
single large test, not accumulation). On a 16 GB machine with 8 parallel
workers, worst-case memory pressure drops significantly.

## Bug fix

**Steps to reproduce:**

1. Run the full test suite on a machine with 16 GB RAM
2. Observe `A process in the process pool was terminated abruptly` errors
   due to memory exhaustion

Unreferenced Python objects holding CPU-side allocations (host arrays from
dead models, solvers, and states) accumulate within each worker process
because the cyclic GC doesn't collect them often enough. The CUDA memory
pool also retains freed device allocations, adding minor driver-side host
overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test runner memory management: per-test cleanup now triggers garbage collection and releases unused GPU memory pools after each test. This reduces peak host memory usage, lowers memory contention during parallel test runs, and improves overall stability and resource efficiency of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->