### PR TITLE
Fix gizmo following issue

### DIFF
--- a/newton/examples/ik/example_ik_custom.py
+++ b/newton/examples/ik/example_ik_custom.py
@@ -241,7 +241,7 @@ class Example:
         )
 
         # Variables the solver will update
-        self.joint_q = wp.array(self.model.joint_q, shape=(1, self.model.joint_coord_count))
+        self.joint_q = self.model.joint_q.reshape((1, self.model.joint_coord_count))
 
         self.ik_iters = 10
         self.ik_solver = ik.IKSolver(
@@ -270,7 +270,6 @@ class Example:
     def simulate(self):
         self.ik_solver.reset()
         self.ik_solver.step(self.joint_q, self.joint_q, iterations=self.ik_iters)
-        wp.copy(self.model.joint_q, self.joint_q)
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transforms and push into IK objectives."""

--- a/newton/examples/ik/example_ik_franka.py
+++ b/newton/examples/ik/example_ik_franka.py
@@ -95,7 +95,7 @@ class Example:
         )
 
         # Variables the solver will update
-        self.joint_q = wp.array(self.model.joint_q, shape=(1, self.model.joint_coord_count))
+        self.joint_q = self.model.joint_q.reshape((1, self.model.joint_coord_count))
 
         self.ik_iters = 24
         self.solver = ik.IKSolver(
@@ -120,7 +120,6 @@ class Example:
 
     def simulate(self):
         self.solver.step(self.joint_q, self.joint_q, iterations=self.ik_iters)
-        wp.copy(self.model.joint_q, self.joint_q)
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transform and push into IK objectives."""

--- a/newton/examples/ik/example_ik_h1.py
+++ b/newton/examples/ik/example_ik_h1.py
@@ -112,7 +112,7 @@ class Example:
         )
 
         # Variables the solver will update
-        self.joint_q = wp.array(self.model.joint_q, shape=(1, self.model.joint_coord_count))
+        self.joint_q = self.model.joint_q.reshape((1, self.model.joint_coord_count))
 
         self.ik_iters = 24
         self.solver = ik.IKSolver(
@@ -137,7 +137,6 @@ class Example:
 
     def simulate(self):
         self.solver.step(self.joint_q, self.joint_q, iterations=self.ik_iters)
-        wp.copy(self.model.joint_q, self.joint_q)
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transforms and push into IK objectives."""


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
wp.array constructor is inconsistent on cpu and gpu ( on cpu unless copy parameter is set to non default False it creates a copy instead of view. This leads to the need to do copy in the loop to follow gizmo. This was changed to the use of reshape due to consistency in view creation