### PR TITLE
Fix issues in ik custom example

### DIFF
--- a/newton/examples/ik/example_ik_custom.py
+++ b/newton/examples/ik/example_ik_custom.py
@@ -65,7 +65,7 @@ def _collision_residuals(
     # Softplus of penetration depth to keep it smooth
     dist = wp.length(ee_pos - c)
     delta = (link_radius + r_obs) - dist
-    margin = 0.05
+    margin = 0.15
     pen = wp.log(1.0 + wp.exp(delta / margin)) * margin
 
     residuals[row_idx, start_idx] = weight * pen
@@ -229,7 +229,7 @@ class Example:
                     link_radius=link_radius,
                     obstacle_centers=self.obstacle_centers,
                     obstacle_radii=self.obstacle_radii,
-                    weight=10.0,
+                    weight=50.0,
                 )
             )
 
@@ -273,8 +273,10 @@ class Example:
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transforms and push into IK objectives."""
-        # Update EE target
-        self.pos_obj.set_target_position(0, wp.transform_get_translation(self.ee_tf))
+        # Update EE target (clamp z to ground)
+        pos = wp.transform_get_translation(self.ee_tf)
+        pos = wp.vec3(pos[0], pos[1], max(pos[2], 0.11))
+        self.pos_obj.set_target_position(0, pos)
         q = wp.transform_get_rotation(self.ee_tf)
         self.rot_obj.set_target_rotation(0, wp.vec4(q[0], q[1], q[2], q[3]))
 

--- a/newton/examples/ik/example_ik_franka.py
+++ b/newton/examples/ik/example_ik_franka.py
@@ -120,11 +120,12 @@ class Example:
 
     def simulate(self):
         self.solver.step(self.joint_q, self.joint_q, iterations=self.ik_iters)
-        wp.copy(self.model.joint_q, self.joint_q)
 
     def _push_targets_from_gizmos(self):
         """Read gizmo-updated transform and push into IK objectives."""
-        self.pos_obj.set_target_position(0, wp.transform_get_translation(self.ee_tf))
+        pos = wp.transform_get_translation(self.ee_tf)
+        pos = wp.vec3(pos[0], pos[1], max(pos[2], 0.11))
+        self.pos_obj.set_target_position(0, pos)
         q = wp.transform_get_rotation(self.ee_tf)
         self.rot_obj.set_target_rotation(0, wp.vec4(q[0], q[1], q[2], q[3]))
 


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined collision avoidance in IK examples with improved penalty smoothing and increased weighting.
  * Added minimum height constraints for end-effector targets during inverse kinematics optimization.
  * Optimized IK solver state management and gizmo-based target updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->