### PR TITLE
Fix get_tetmesh() winding order for left-handed USD meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Decompose loop joint constraints by DOF type (WELD for fixed, CONNECT-pair for revolute, single CONNECT for ball) instead of always emitting 2x CONNECT
 - Fix inertia box wireframe rotation for isotropic and axisymmetric bodies in viewer
 - Implicit MPM solver now uses `mass=0` for kinematic particles instead of `ACTIVE` flag
+- Fix `get_tetmesh()` winding order for left-handed USD meshes
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1195,13 +1195,11 @@ def get_tetmesh(prim: Usd.Prim) -> TetMesh:
     tet_indices = np.array(tet_indices_attr, dtype=np.int32).flatten()
 
     # Flip winding order for left-handed meshes (e.g. Houdini exports)
-    orientation_attr = tet_mesh.GetOrientationAttr()
-    if orientation_attr:
-        handedness = orientation_attr.Get()
-        if handedness and handedness.lower() == "lefthanded":
-            tet_indices = tet_indices.reshape(-1, 4)
-            tet_indices[:, [1, 2]] = tet_indices[:, [2, 1]]
-            tet_indices = tet_indices.flatten()
+    handedness = tet_mesh.GetOrientationAttr().Get()
+    if handedness and handedness.lower() == "lefthanded" and tet_indices.size % 4 == 0:
+        tet_indices = tet_indices.reshape(-1, 4)
+        tet_indices[:, [1, 2]] = tet_indices[:, [2, 1]]
+        tet_indices = tet_indices.reshape(-1)
 
     # Try to read physics material properties if bound
     k_mu = None

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -7545,6 +7545,29 @@ class TestTetMesh(unittest.TestCase):
         assert_np_equal(tm.tet_indices[4:], np.array([1, 2, 3, 4], dtype=np.int32))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_get_tetmesh_left_handed(self):
+        """Test that left-handed TetMesh orientation flips winding order."""
+        from pxr import Usd
+
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(
+            """#usda 1.0
+def TetMesh "LeftHandedTet" ()
+{
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 1)]
+    int4[] tetVertexIndices = [(0, 1, 2, 3), (1, 2, 3, 4)]
+}
+"""
+        )
+        prim = stage.GetPrimAtPath("/LeftHandedTet")
+        tm = usd.get_tetmesh(prim)
+
+        # Indices 1 and 2 of each tet should be swapped compared to the original
+        assert_np_equal(tm.tet_indices[:4], np.array([0, 2, 1, 3], dtype=np.int32))
+        assert_np_equal(tm.tet_indices[4:], np.array([1, 3, 2, 4], dtype=np.int32))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_tetmesh_create_from_usd(self):
         """Test TetMesh.create_from_usd() static factory method."""
         from pxr import Usd


### PR DESCRIPTION
## Description

`get_tetmesh()` now checks the `orientation` attribute on TetMesh prims. When orientation is `leftHanded` (e.g. Houdini exports), it swaps tet indices 1 and 2 to convert to right-handed winding order expected by Newton.

Without this fix, all tetrahedra from left-handed USD files are detected as inverted and discarded, resulting in `tet_count=0`.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Load a Houdini-exported USD containing TetMesh prims with `orientation: leftHanded`:

```python
import newton
import newton.usd
from pxr import Usd

stage = Usd.Stage.Open("Human.usd")
prim = stage.GetPrimAtPath("/Human/muscle/arms/R_bicepsBrachialis/R_bicepsBrachialis_Tet")
tetmesh = newton.usd.get_tetmesh(prim)

builder = newton.ModelBuilder()
tetmesh.custom_attributes = None
builder.add_soft_mesh(
    pos=wp.vec3(0, 0, 0), rot=wp.quat_identity(), scale=1.0,
    vel=wp.vec3(0, 0, 0), mesh=tetmesh, density=1000.0,
    k_mu=5000.0, k_lambda=5000.0, k_damp=10.0,
)
model = builder.finalize()
print(model.tet_count)  # Should be > 0, was 0 before fix
```

## Bug fix

**Steps to reproduce:**

1. Export a TetMesh from Houdini (which uses left-handed winding by default)
2. Load via `newton.usd.get_tetmesh(prim)`
3. Add to model via `builder.add_soft_mesh(mesh=tetmesh, ...)`
4. Observe `model.tet_count == 0` and "inverted tetrahedral element" warnings for every tet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tetrahedral mesh winding for left-handed geometry to ensure tetrahedral connectivity is oriented properly without changing vertex positions or materials.
* **Documentation**
  * Added changelog entry noting the fix for left-handed tetrahedral mesh orientation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->