### PR TITLE
Add an installation note about imgui_bundle issue with python 3.10

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -120,6 +120,17 @@ with other packages:
             .venv\Scripts\Activate.ps1
             pip install "newton[examples]"
 
+.. note::
+
+    Users on Python 3.10 may experience issues when installing ``imgui_bundle`` (a dependency of the
+    ``examples`` extra). If you encounter installation errors, we recommend either upgrading to a later
+    Python version or using `uv <https://docs.astral.sh/uv/>`_ to install Newton:
+
+    .. code-block:: console
+
+        uv venv
+        uv pip install --pre newton[dev]
+
 Running Examples
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description
Added a note in the documentation.
Fix #1886.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Python 3.10 users experiencing imgui_bundle compatibility issues
  * Included troubleshooting recommendations and alternative installation instructions using the uv tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->