### PR TITLE
Fix arg parsing in cable_bundle_hysteresis example

### DIFF
--- a/newton/examples/cable/example_cable_bundle_hysteresis.py
+++ b/newton/examples/cable/example_cable_bundle_hysteresis.py
@@ -24,8 +24,6 @@
 #
 ###########################################################################
 
-import argparse
-
 import numpy as np
 import warp as wp
 
@@ -434,28 +432,29 @@ class Example:
         """Test cable bundle hysteresis simulation for stability and correctness (called after simulation)."""
         pass
 
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument("--segments", type=int, default=40, help="Number of cable segments")
+        parser.add_argument("--no-dahl", action="store_true", help="Disable Dahl friction (purely elastic)")
+        parser.add_argument("--eps-max", type=float, default=2.0, help="Maximum plastic strain [rad]")
+        parser.add_argument("--tau", type=float, default=0.1, help="Memory decay length [rad]")
+        return parser
+
 
 if __name__ == "__main__":
-    # Parse arguments and initialize viewer
-    viewer, args = newton.examples.init()
-
-    # Parse example-specific arguments for Dahl friction experimentation
-    parser = argparse.ArgumentParser(description="Cable bundle hysteresis with Dahl friction")
-    parser.add_argument("--segments", type=int, default=40, help="Number of cable segments")
-    parser.add_argument("--no-dahl", action="store_true", help="Disable Dahl friction (purely elastic)")
-    parser.add_argument("--eps-max", type=float, default=2.0, help="Maximum plastic strain [rad]")
-    parser.add_argument("--tau", type=float, default=0.1, help="Memory decay length [rad]")
-    cli, _ = parser.parse_known_args()
+    parser = Example.create_parser()
+    viewer, args = newton.examples.init(parser)
 
     # Create example and run
     example = Example(
         viewer,
         args,
         num_cables=7,
-        segments=cli.segments,
-        with_dahl=not cli.no_dahl and cli.eps_max > 0.0 and cli.tau > 0.0,
-        eps_max=cli.eps_max,
-        tau=cli.tau,
+        segments=args.segments,
+        with_dahl=not args.no_dahl and args.eps_max > 0.0 and args.tau > 0.0,
+        eps_max=args.eps_max,
+        tau=args.tau,
     )
 
     newton.examples.run(example, args)


### PR DESCRIPTION
## Description
Argument parsing was different in cable_bundle_hysteresis compared to other example.
This fixes it.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan
Run the example with the --help flag and see that the argument are now properly recognized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified command-line argument handling in the cable bundle hysteresis example for improved maintainability.

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->