### PR TITLE
Improve helper of example

### DIFF
--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -431,37 +431,59 @@ def create_parser():
         help="Whether to run the example in test mode.",
     )
     parser.add_argument(
+        "--quiet",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Suppress Warp compilation messages.",
+    )
+
+    return parser
+
+
+def add_broad_phase_arg(parser):
+    """Add ``--broad-phase`` argument to *parser*."""
+    parser.add_argument(
         "--broad-phase",
         type=str,
         default="explicit",
         choices=["nxn", "sap", "explicit"],
         help="Broad phase for collision detection.",
     )
+    return parser
+
+
+def add_mujoco_contacts_arg(parser):
+    """Add ``--use-mujoco-contacts`` argument to *parser*."""
+    import argparse  # noqa: PLC0415  — needed for BooleanOptionalAction
+
     parser.add_argument(
         "--use-mujoco-contacts",
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Use MuJoCo's native contact solver instead of Newton contacts (default: use Newton contacts).",
     )
-    parser.add_argument(
-        "--max-worlds",
-        type=int,
-        default=None,
-        help="Maximum number of worlds to render (for performance with many environments).",
-    )
-    parser.add_argument(
-        "--quiet",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Suppress Warp compilation messages.",
-    )
+    return parser
+
+
+def add_world_count_arg(parser):
+    """Add ``--world-count`` argument to *parser*."""
     parser.add_argument(
         "--world-count",
         type=int,
         default=1,
         help="Number of simulation worlds.",
     )
+    return parser
 
+
+def add_max_worlds_arg(parser):
+    """Add ``--max-worlds`` argument to *parser*."""
+    parser.add_argument(
+        "--max-worlds",
+        type=int,
+        default=None,
+        help="Maximum number of worlds to render (for performance with many environments).",
+    )
     return parser
 
 
@@ -584,4 +606,16 @@ if __name__ == "__main__":
     main()
 
 
-__all__ = ["create_parser", "default_args", "get_examples", "init", "run", "test_body_state", "test_particle_state"]
+__all__ = [
+    "add_broad_phase_arg",
+    "add_max_worlds_arg",
+    "add_mujoco_contacts_arg",
+    "add_world_count_arg",
+    "create_parser",
+    "default_args",
+    "get_examples",
+    "init",
+    "run",
+    "test_body_state",
+    "test_particle_state",
+]

--- a/newton/examples/basic/example_basic_urdf.py
+++ b/newton/examples/basic/example_basic_urdf.py
@@ -153,6 +153,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=100)
         return parser
 

--- a/newton/examples/basic/example_recording.py
+++ b/newton/examples/basic/example_recording.py
@@ -29,8 +29,6 @@
 import numpy as np
 import warp as wp
 
-wp.set_module_options({"enable_backward": False})
-
 import newton
 import newton.examples
 

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -415,6 +415,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=20)
         parser.add_argument(
             "--solver",

--- a/newton/examples/contacts/example_nut_bolt_sdf.py
+++ b/newton/examples/contacts/example_nut_bolt_sdf.py
@@ -387,6 +387,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=100)
         parser.add_argument(
             "--solver",

--- a/newton/examples/ik/example_ik_cube_stacking.py
+++ b/newton/examples/ik/example_ik_cube_stacking.py
@@ -700,6 +700,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_mujoco_contacts_arg(parser)
         parser.set_defaults(world_count=16)
         parser.add_argument("--cube-count", type=int, default=3, help="Total number of cubes to stack.")
         parser.add_argument("--verbose", action="store_true", help="Enable verbose output.")

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -250,6 +250,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=100)
         return parser
 

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -26,8 +26,6 @@
 import torch
 import warp as wp
 
-wp.set_module_options({"enable_backward": False})
-
 import newton
 import newton.examples
 import newton.utils
@@ -349,10 +347,16 @@ class Example:
             indices=[0],
         )
 
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        newton.examples.add_mujoco_contacts_arg(parser)
+        return parser
+
 
 if __name__ == "__main__":
-    # Parse arguments and initialize viewer
-    viewer, args = newton.examples.init()
+    parser = Example.create_parser()
+    viewer, args = newton.examples.init(parser)
 
     example = Example(viewer, args)
 

--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -171,6 +171,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_mujoco_contacts_arg(parser)
         parser.set_defaults(world_count=8)
         return parser
 

--- a/newton/examples/robot/example_robot_cartpole.py
+++ b/newton/examples/robot/example_robot_cartpole.py
@@ -192,6 +192,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=100)
         return parser
 

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -166,6 +166,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_mujoco_contacts_arg(parser)
         parser.set_defaults(world_count=4)
         return parser
 

--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -160,6 +160,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_mujoco_contacts_arg(parser)
         parser.set_defaults(world_count=4)
         return parser
 

--- a/newton/examples/robot/example_robot_humanoid.py
+++ b/newton/examples/robot/example_robot_humanoid.py
@@ -152,6 +152,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_mujoco_contacts_arg(parser)
         parser.set_defaults(world_count=4)
         return parser
 

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -531,6 +531,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(num_frames=720)
         parser.set_defaults(world_count=1)
         parser.add_argument(

--- a/newton/examples/robot/example_robot_ur10.py
+++ b/newton/examples/robot/example_robot_ur10.py
@@ -210,6 +210,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=100)
         return parser
 

--- a/newton/examples/selection/example_selection_articulations.py
+++ b/newton/examples/selection/example_selection_articulations.py
@@ -310,6 +310,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=16)
         return parser
 

--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -231,6 +231,8 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        newton.examples.add_max_worlds_arg(parser)
         parser.set_defaults(world_count=16)
         return parser
 

--- a/newton/examples/selection/example_selection_materials.py
+++ b/newton/examples/selection/example_selection_materials.py
@@ -270,6 +270,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=16)
         return parser
 

--- a/newton/examples/selection/example_selection_multiple.py
+++ b/newton/examples/selection/example_selection_multiple.py
@@ -288,6 +288,7 @@ class Example:
     @staticmethod
     def create_parser():
         parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
         parser.set_defaults(world_count=16)
         return parser
 


### PR DESCRIPTION
## Description
Change how helper are handled.
We have now arg parser that are present in all example together, and then we have example specific arg parser.
This makes sure that we have the correct list of argument for all example.
This partially fixes #1954.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan
Run the helper for all the example.

## Bug fix

Run 
```
uv run --extra examples -m newton.examples basic_heightfield --help
```
Got argument that is unrelated to the example:
```
usage: newton.examples.basic.example_basic_heightfield [-h] [--device DEVICE] [--viewer {gl,usd,rerun,null,viser}]
                                                       [--rerun-address RERUN_ADDRESS] [--output-path OUTPUT_PATH]
                                                       [--num-frames NUM_FRAMES] [--headless | --no-headless] [--test | --no-test]
                                                       [--broad-phase {nxn,sap,explicit}]
                                                       [--use-mujoco-contacts | --no-use-mujoco-contacts] [--max-worlds MAX_WORLDS]
                                                       [--quiet | --no-quiet] [--world-count WORLD_COUNT] [--solver {xpbd,mujoco}]
```

After the change:
```
usage: newton.examples.basic.example_basic_heightfield [-h] [--device DEVICE] [--viewer {gl,usd,rerun,null,viser}]
                                                       [--rerun-address RERUN_ADDRESS] [--output-path OUTPUT_PATH]
                                                       [--num-frames NUM_FRAMES] [--headless | --no-headless] [--test | --no-test]
                                                       [--quiet | --no-quiet] [--solver {xpbd,mujoco}]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new command-line options to examples: `--world-count`, `--mujoco-contacts`, `--max-worlds`, and `--broad-phase` for enhanced runtime configurability.
  * Introduced `--quiet` flag to suppress compilation messages during example execution.

* **Refactor**
  * Streamlined example initialization patterns and simplified backward differentiation handling across examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->