### PR TITLE
Add scheduled CI for nightly mujoco-warp from source

### DIFF
--- a/.github/workflows/scheduled_nightly_mujoco_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_mujoco_warp_tests.yml
@@ -13,7 +13,7 @@ env:
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
-  AWS_ROLE_DURATION: 1800
+  AWS_ROLE_DURATION: 7200
 
 on:
   schedule:


### PR DESCRIPTION
## Description

Add a daily GitHub Actions workflow that tests Newton against the latest
mujoco-warp built from source (`google-deepmind/mujoco_warp` HEAD).

This complements the existing Warp nightly workflow. The workflow:
- Runs daily at 12 PM UTC (staggered 1 hour after the Warp nightly)
- Spins up a GPU EC2 instance using the same infrastructure as existing workflows
- Installs Newton via `uv sync`, then overrides mujoco-warp with a git install
- Uses `uv run --no-sync` to preserve the source-built mujoco-warp during tests
- Supports `workflow_dispatch` for manual triggers

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Trigger via `workflow_dispatch` after merge to verify the workflow runs correctly.