### PR TITLE
Fix inaccuracies in sites concept documentation

### DIFF
--- a/docs/concepts/sites.rst
+++ b/docs/concepts/sites.rst
@@ -69,7 +69,7 @@ Sites can also be attached to the world frame (body=-1) to create fixed referenc
 Alternative: Using Shape Methods with ``as_site=True``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Sites can also be created using shape creation methods (``add_shape_sphere``, ``add_shape_box``, ``add_shape_capsule``, ``add_shape_cylinder``) by passing ``as_site=True``. This is particularly useful when programmatically generating shapes or conditionally creating sites:
+Sites can also be created using shape creation methods (``add_shape_sphere``, ``add_shape_box``, ``add_shape_capsule``, ``add_shape_cylinder``, ``add_shape_ellipsoid``, ``add_shape_cone``) by passing ``as_site=True``. This is particularly useful when programmatically generating shapes or conditionally creating sites:
 
 .. testcode:: sites-shape-methods
 
@@ -100,7 +100,7 @@ Sites can also be created using shape creation methods (``add_shape_sphere``, ``
        label="measurement_point"
    )
 
-When ``as_site=True``, the shape is automatically configured with all site invariants (no collision, zero density, collision_group=0), regardless of any custom configuration passed
+When ``as_site=True``, the shape is automatically configured with all site invariants (no collision, zero density, collision_group=0), regardless of any custom configuration passed.
 
 Importing Sites
 ---------------
@@ -173,7 +173,7 @@ By default, both ``load_sites`` and ``load_visual_shapes`` are set to ``True``.
 Using Sites with Sensors
 ------------------------
 
-Sites are commonly used as reference frames for sensors, particularly the ``SensorFrameTransform`` which computes relative poses between objects and reference frames.
+Sites are commonly used as reference frames for sensors, particularly :class:`~newton.sensors.SensorFrameTransform` which computes relative poses between objects and reference frames.
 
 For detailed information on using sites with sensors, see :doc:`sensors`.
 
@@ -195,16 +195,16 @@ When using ``SolverMuJoCo``, Newton sites are automatically exported to MuJoCo's
    # Create MuJoCo solver (sites are exported by default)
    solver = SolverMuJoCo(model)
 
-Sites are exported with their visual properties (color, size) and can be used with MuJoCo's native sensors and actuators. To disable site export, pass ``include_sites=False`` to the ``convert_to_mjc()`` method if calling it manually.
+Sites are exported with their visual properties (color, size) and can be used with MuJoCo's native sensors and actuators. To disable site export, pass ``include_sites=False`` to :class:`~newton.solvers.SolverMuJoCo`.
 
 Implementation Details
 ----------------------
 
-Sites are internally represented as shapes with the ``ShapeFlags.SITE`` flag set. This allows them to leverage Newton's existing shape infrastructure while maintaining distinct behavior:
+Sites are internally represented as shapes with the :attr:`~newton.ShapeFlags.SITE` flag set. This allows them to leverage Newton's existing shape infrastructure while maintaining distinct behavior:
 
 * Sites are filtered out from collision detection pipelines
 * Site density is automatically set to zero during creation
-* Sites can be queried and filtered using the Selection API with shape-frequency operations
+* Sites can be identified at runtime by checking the :attr:`~newton.ShapeFlags.SITE` flag on ``model.shape_flags``
 
 This implementation approach provides maximum flexibility while keeping the codebase maintainable and avoiding duplication.
 


### PR DESCRIPTION
## Description

Fix several inaccuracies and improve cross-references in `docs/concepts/sites.rst`.

Addresses #1905 (part of #1896).

Changes:
- Add `add_shape_ellipsoid` and `add_shape_cone` to the list of shape methods supporting `as_site=True`
- Fix missing period at end of sentence
- Use Sphinx cross-refs for `SensorFrameTransform` and `ShapeFlags.SITE` instead of plain text
- Reference `SolverMuJoCo` constructor parameter instead of the internal `convert_to_mjc()` method for disabling site export
- Replace inaccurate Selection API claim with accurate description of runtime site identification via `model.shape_flags`

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra docs --extra sim sphinx-build -W -b doctest -D 'exclude_patterns=tutorials/*,_build' -D 'nbsphinx_execute=never' docs docs/_build/doctest docs/concepts/sites.rst
```

All 4 doctests pass (sites-basic, sites-world, sites-shape-methods, sites-mujoco).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify which shape types (including ellipsoid and cone) support site creation functionality.
  * Improved guidance for MuJoCo integration and runtime site identification procedures.
  * Enhanced documentation formatting with explicit references to relevant classes and configuration flags for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->