### PR TITLE
Fix inaccuracies in custom attributes concept documentation

### DIFF
--- a/docs/concepts/custom_attributes.rst
+++ b/docs/concepts/custom_attributes.rst
@@ -27,9 +27,9 @@ Overview
 
 Newton organizes simulation data into four primary objects, each containing flat arrays indexed by simulation entities: 
 
-* **Model Object** - Static configuration and physical properties that remain constant during simulation
-* **State Object** - Dynamic quantities that evolve during simulation
-* **Control Object** - Control inputs and actuator commands
+* **Model Object** (:class:`~newton.Model`) - Static configuration and physical properties that remain constant during simulation
+* **State Object** (:class:`~newton.State`) - Dynamic quantities that evolve during simulation
+* **Control Object** (:class:`~newton.Control`) - Control inputs and actuator commands
 * **Contact Object** (:class:`~newton.Contacts`) - Contact-specific properties
 
 Custom attributes extend these objects with user-defined arrays that follow the same indexing scheme as Newton's built-in attributes. The ``CONTACT`` assignment attaches attributes to the :class:`~newton.Contacts` object created during collision detection.


### PR DESCRIPTION
## Description

Fix several inaccuracies in `docs/concepts/custom_attributes.rst`.

Addresses #1909 (part of #1896).

Changes:
- Add "e.g." qualifier to `AttributeFrequency` enum list since only 6 of 16 values are shown
- Improve `parse_bool` description with cross-ref to `register_custom_attributes` and document accepted input types
- Fix stale USD example referencing undeclared `namespace_b` and non-existent attributes
- Add "e.g." qualifier to `references` type list since only a subset of built-in entity types is shown

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra docs --extra sim sphinx-build -b doctest -D 'exclude_patterns=tutorials/*,_build' -D 'nbsphinx_execute=never' docs docs/_build/doctest docs/concepts/custom_attributes.rst
```

All 5 doctests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded custom-attributes guide with detailed examples for defaults, dtype behavior (including string storage), and new pre-populated values format
  * Clarified frequency options (adds ONCE and string-based custom frequencies) and registration/validation rules
  * Added MJCF/URDF mapping and solver/MuJoCo behavior notes (including boolean parsing)
  * Improved USD namespaced attribute access, wildcard parsing examples, multi-world merging, and ArticulationView access notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->