### PR TITLE
Adding color/texture reading to usd.utils.get_mesh

### DIFF
--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1136,7 +1136,7 @@ def get_mesh(
         color=material_props.get("color"),
         texture=material_props.get("texture"),
         metallic=material_props.get("metallic"),
-        roughness=material_props.get("roughness")
+        roughness=material_props.get("roughness"),
     )
     if return_uv_indices:
         return mesh_out, uv_indices


### PR DESCRIPTION
The `usd.utils.get_mesh` function did not read the color and texture from the material, this PR uses the existing `resolve_material_properties_for_prim` function to fix that.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meshes now automatically incorporate per-prim material properties (color, texture, metallic, roughness) so visuals reflect bound materials more accurately.
  * Material metadata is propagated into mesh creation, improving rendering fidelity without additional configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->