### PR TITLE
Add scheduled weekly multi-GPU tests on g7e.12xlarge

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -5,12 +5,13 @@ name: GPU Unit Tests on AWS EC2 (Reusable)
 #   - pr_target_aws_gpu_tests.yml (for pull requests)
 #   - merge_queue_aws_gpu.yml (for merge groups)
 #   - push_aws_gpu.yml (for pushes to main/release branches)
+#   - scheduled_weekly_gpu_tests.yml (for weekly multi-GPU tests)
 
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
-  AWS_INSTANCE_TYPE: g7e.2xlarge
-  AWS_VOLUME_SIZE: 92
+  AWS_INSTANCE_TYPE: ${{ inputs.instance-type || 'g7e.2xlarge' }}
+  AWS_VOLUME_SIZE: ${{ inputs.volume-size || '92' }}
   AWS_VOLUME_TYPE: gp3
   AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
@@ -25,6 +26,16 @@ on:
         required: false
         type: string
         default: ''
+      instance-type:
+        description: 'EC2 instance type'
+        required: false
+        type: string
+        default: 'g7e.2xlarge'
+      volume-size:
+        description: 'EBS volume size in GB'
+        required: false
+        type: string
+        default: '92'
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
@@ -78,6 +89,11 @@ jobs:
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
             ]
+          pre-runner-script: |
+            if [ -d /opt/dlami/nvme ]; then
+              mkdir -p /opt/dlami/nvme/actions-runner/_work
+              ln -s /opt/dlami/nvme/actions-runner/_work /actions-runner/_work
+            fi
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},

--- a/.github/workflows/scheduled_weekly_gpu_tests.yml
+++ b/.github/workflows/scheduled_weekly_gpu_tests.yml
@@ -1,0 +1,18 @@
+name: Scheduled Weekly GPU Tests
+
+on:
+  schedule:
+    - cron: '0 8 * * 0'  # Sunday 8 AM UTC
+  workflow_dispatch:
+
+jobs:
+  gpu-tests:
+    if: github.repository == 'newton-physics/newton'
+    uses: ./.github/workflows/aws_gpu_tests.yml
+    with:
+      instance-type: g7e.12xlarge  # 2x NVIDIA RTX PRO 6000 Blackwell Server Edition, 48 vCPUs
+      volume-size: '92'
+    permissions:
+      id-token: write
+      contents: read
+    secrets: inherit


### PR DESCRIPTION
## Description

Closes #1976

Add a weekly scheduled workflow that runs Newton's test suite on a `g7e.12xlarge` instance (2x NVIDIA RTX PRO 6000, 48 vCPUs) to catch multi-GPU regressions that don't surface on the single-GPU CI.

Changes:
- **Parameterize `aws_gpu_tests.yml`** with `instance-type` and `volume-size` inputs (defaults match current values — existing callers unaffected)
- **Create `scheduled_weekly_gpu_tests.yml`** — runs Sundays at 8 AM UTC via cron + manual `workflow_dispatch`
- **Symlink runner workspace to NVMe** via `pre-runner-script` for faster I/O on instances with local NVMe storage

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- Tested on fork (`shi-eric/newton`) with push trigger on `ershi/test-nightly-gpu` branch
- Verified NVMe symlink works: checkout lands on `/opt/dlami/nvme/actions-runner/_work/`
- Verified existing callers (`push_aws_gpu.yml`, `pr_target_aws_gpu_tests.yml`, `merge_queue_aws_gpu.yml`) don't pass new inputs and get defaults
- Confirmed CUDA errors on `_cuda_1` tests are pre-existing multi-GPU bugs unrelated to NVMe change (reproduced with and without symlink)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Parameterized GPU test workflow to allow selecting instance type and volume size at runtime (with sensible defaults).
  * Added a weekly scheduled GPU test run (cron + manual trigger) to ensure regular automated performance validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->