### PR TITLE
Remove early-exit that breaks the world offsets when single-world model is visualized

### DIFF
--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -300,10 +300,6 @@ class ViewerBase(ABC):
 
     def _auto_compute_world_offsets(self):
         """Automatically compute world offsets based on model extents."""
-        # If only one world or no worlds, no offsets needed
-        if self._get_render_world_count() <= 1:
-            return
-
         max_extents = self._get_world_extents()
         if max_extents is None:
             return


### PR DESCRIPTION
## Description
This PR removes an unnecessary early-exit of `ViewerBase._auto_compute_world_offsets()` when there is only a single world. In this case the world offsets array is left `None` and causes `ViewerBase.log_contacts()` to access illegal memory and crash the process.

## Checklist
- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


## Bug fix
Run `examples/robot/example_robot_anymal_d.py` with `world_count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted world offset computation in the viewer to apply in additional scenarios, enabling positioning calculations across more configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->