### PR TITLE
Bump warp-lang minimum to >= 1.12.0

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.12.0rc2 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U warp-lang==1.12.0 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.5.0",
     "python -m pip install -U mujoco-warp==3.5.0.2",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.11.0",
+    "warp-lang>=1.12.0",
     "newton-actuators",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2990,7 +2990,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'torch-cu12'", specifier = ">=2.2.0" },
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'torch-cu13'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = ">=1.0.16" },
-    { name = "warp-lang", specifier = ">=1.11.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.12.0", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["dev", "docs", "examples", "importers", "notebook", "remesh", "sim", "torch-cu12", "torch-cu13"]
 
@@ -5800,17 +5800,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.0rc2"
+version = "1.12.0"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9974c01ee9cf32bf1e9b0db2641e0e102bed89f09b4e32ccc36ede286719b7b7" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:42555f41bc1e39ff34c13ab13ebd1d13032d2e9359d687bec6928ed4b5ee4eba" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc2-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:b098986f0d14900d6410baba72d9af085531a45a06558f598a2b4870776d461b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0rc2-py3-none-win_amd64.whl", hash = "sha256:1ff17cd177ffec372f1c7801dcc47fe8591493a48ea2f722e2303802a74ffe42" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c78c3701d5cad86c30ef5017410d294ec46a396bb0d502ee1c98743494f3a62f" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a1436f60a1881cd94f787e751a83fc0987626be2d3e2b4e74c64a6947c6d1266" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:a2d6decba693aba5b828573c4414fd6a3f4c4a934db9c322736ef2b3fa99fe76" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.0-py3-none-win_amd64.whl", hash = "sha256:697248edd2f1e2952f50e3db33b214af76173641a8894aacc467bed6dc247f8a" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bump the minimum `warp-lang` dependency from `>=1.11.0` to `>=1.12.0`.
- `pyproject.toml`: update specifier
- `uv.lock`: regenerated (now resolves to stable 1.12.0 instead of 1.12.0rc2)
- `asv.conf.json`: update pinned version from 1.12.0rc2 to 1.12.0 and drop `--pre` flag

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

CI should pass with warp-lang 1.12.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated warp-lang dependency to version 1.12.0, upgrading from 1.11.0 and transitioning from pre-release to the final release version across project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->