### PR TITLE
Refactor installation guide for 1.0 release

### DIFF
--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -164,7 +164,7 @@ Pass ``--help`` to either run method below to see all available flags.
 Most tests run when the ``dev`` extras are installed. The tests using PyTorch
 to run inference on an RL policy are skipped if the ``torch`` dependency is
 not installed. In order to run these tests, include the ``torch-cu12`` or
-``torch-cu13`` extras following your CUDA version:
+``torch-cu13`` extras matching your NVIDIA driver's CUDA support:
 
 .. tab-set::
     :sync-group: env

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -115,7 +115,7 @@ See a list of all available examples:
 Quick Start
 ^^^^^^^^^^^
 
-After installing Newton with the ``examples`` or ``sim`` extra, you can build
+After installing Newton, you can build
 models, create solvers, and run simulations directly from Python. A typical
 workflow looks like this:
 


### PR DESCRIPTION
## Description

Refactors the installation and development guides in preparation for the 1.0 release.

- Restructures installation guide to make pip install from PyPI the primary recommended method
- Moves uv and source install instructions to the development guide
- Fixes mandatory dependencies (adds `newton-actuators`)
- Moves Extra Dependencies table to after the Quick Start
- Adds guidance on `torch-cu12` vs `torch-cu13` selection via `nvidia-smi`

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Built docs locally with:
```
uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
```
Build succeeded with no warnings related to these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded development guide with multi‑method setup (clone + two install workflows), OS‑specific instructions, environment syncing, dev extras guidance, and test/docs commands.
  * Streamlined installation guide to emphasize PyPI install, simplified extras guidance, CUDA variant selection for examples with nvidia‑smi check, and moved advanced/source/uv workflows into the development guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->