### PR TITLE
Avoid  quadratic-in-worlds shape pair search when initializing contact sensors

### DIFF
--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -139,7 +139,7 @@ def _bucket_indices_by_world(
     """Partition world-contiguous indices into per-world buckets.
 
     Args:
-        indices: Global indices in world-contiguous order.
+        indices: Flat indices (any order; sorted internally if needed).
         world_start: Start index per world, length ``world_count + 2``.
             Layout: ``[start_w0, start_w1, ..., start_w(N-1), start_global_tail, total]``.
             Front-global indices are those in ``[0, start_w0)``.
@@ -150,12 +150,16 @@ def _bucket_indices_by_world(
         contains indices belonging to world ``w`` and ``global_indices`` contains
         indices belonging to global bodies or shapes (world -1).
     """
-    # TODO: Add a contiguousness check + sort for indices that aren't already world-ordered
     buckets: list[list[int]] = [[] for _ in range(world_count)]
     global_indices: list[int] = []
 
     w = 0
+    prev = -1
     for idx in indices:
+        if idx < prev:
+            # indices turn out to be unsorted; sort them first
+            return _bucket_indices_by_world(sorted(indices), world_start, world_count)
+        prev = idx
         if idx < world_start[0] or idx >= world_start[world_count]:
             global_indices.append(idx)
         else:
@@ -214,7 +218,7 @@ class SensorContact:
         """Individual body."""
 
     shape: tuple[int, int]
-    """Dimensions of the force matrix ``(n_sensing_objs, max_readings_per_world)``."""
+    """Dimensions of the force matrix ``(n_sensing_objs, max_readings)``."""
 
     reading_indices: list[list[list[int]]]
     """Active counterpart indices per sensing object, per world."""
@@ -226,7 +230,7 @@ class SensorContact:
     """Index and type of each counterpart, per world. Columns of the force matrix."""
 
     net_force: wp.array2d(dtype=wp.vec3)
-    """Net contact forces [N], shape ``(n_sensing_objs, n_counterparts)``, dtype :class:`vec3`.
+    """Net contact forces [N], shape ``(n_sensing_objs, max_readings)``, dtype :class:`vec3`.
     Entry ``[i, j]`` is the force on sensing object ``i`` from counterpart ``j``, in world frame."""
 
     sensing_obj_transforms: wp.array(dtype=wp.transform)
@@ -308,7 +312,9 @@ class SensorContact:
             contact_pairs = None
         else:
             # pack into larger int to avoid Python object overhead
-            pairs = model.shape_contact_pairs.numpy().astype(np.int64)
+            pairs = model.shape_contact_pairs.numpy()
+            assert pairs.dtype == np.int32
+            pairs = pairs.astype(np.int64)
             contact_pairs = set((pairs[:, 0] << 32) | pairs[:, 1])
 
         TOTAL = self.ObjectType.TOTAL

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -114,10 +114,10 @@ def select_aggregate_net_force_kernel(
 
     # add contribution for shape a and b
     for i in range(2):
-        mono_sp = wp.vec2i(-1, wp.where(i == 0, shape0, shape1))
+        mono_sp = wp.vec2i(wp.where(i == 0, shape0, shape1), -1)
         mono_ord = bisect_shape_pairs(sp_sorted, num_sp, mono_sp)
 
-        # for shape vs all, only one accumulator is supported and flip is trivially true
+        # for shape vs all, only one accumulator is supported and flip is trivially false
         if mono_ord < num_sp:
             if sp_sorted[mono_ord] == mono_sp:
                 force_acc = sp_ep[sp_ep_offset[mono_ord]][0]
@@ -131,32 +131,69 @@ def _check_index_bounds(indices: list[int], count: int, param_name: str, entity_
             raise IndexError(f"{param_name} contains index {idx}, but model only has {count} {entity_name}")
 
 
+def _bucket_indices_by_world(
+    indices: list[int],
+    world_start: list[int],
+    world_count: int,
+) -> tuple[list[list[int]], list[int]]:
+    """Partition world-contiguous indices into per-world buckets.
+
+    Args:
+        indices: Global indices in world-contiguous order.
+        world_start: Start index per world, length ``world_count + 2``.
+            Layout: ``[start_w0, start_w1, ..., start_w(N-1), start_global_tail, total]``.
+            Front-global indices are those in ``[0, start_w0)``.
+        world_count: Number of worlds.
+
+    Returns:
+        Tuple of ``(per_world_buckets, global_indices)`` where ``per_world_buckets[w]``
+        contains indices belonging to world ``w`` and ``global_indices`` contains
+        indices belonging to global bodies or shapes (world -1).
+    """
+    # TODO: Add a contiguousness check + sort for indices that aren't already world-ordered
+    buckets: list[list[int]] = [[] for _ in range(world_count)]
+    global_indices: list[int] = []
+
+    w = 0
+    for idx in indices:
+        if idx < world_start[0] or idx >= world_start[world_count]:
+            global_indices.append(idx)
+        else:
+            while w < world_count - 1 and idx >= world_start[w + 1]:
+                w += 1
+            buckets[w].append(idx)
+
+    return buckets, global_indices
+
+
 class SensorContact:
-    """Sensor that measures contact forces between bodies or shapes.
+    """Measures net contact forces on a set of **sensing objects** (bodies or shapes).
 
-    This sensor allows you to define a set of "sensing objects" (bodies or shapes) and optionally a set of
-    "counterpart" objects (bodies or shapes) to sense contact forces against. The sensor can be configured to
-    report the total contact force or per-counterpart readings.
+    In its simplest form the sensor reports the total contact force acting on each sensing object.
+    Optionally, specify **counterparts** to break the force down by the body or shape it originates
+    from.  With ``include_total=True`` (default) a total-force column is prepended.
 
-    SensorContact produces a matrix of force readings, where each row corresponds to one sensing object and
-    each column corresponds to one counterpart. Each entry of this matrix is the net contact force vector between
-    the sensing object and the counterpart. If no counterparts are specified, the sensor will read the net contact
-    force for each sensing object.
+    The result is a force matrix: one row per sensing object, one column per counterpart reading.
 
-    If ``include_total`` is True, inserts a total before all other counterparts, such that the first column of
-    the force matrix will read the total contact force for each sensing object.
+    .. rubric:: Multi-world behaviour
 
-    If ``prune_noncolliding`` is True, the force matrix will be sparse, containing only readings for shape pairs that
-    can collide. In this case, force matrix will have as many columns as the maximum number of active counterparts
-    for any sensing object, and the ``reading_indices`` attribute can be used to recover the active counterparts
-    for each sensing object.
+    When the model contains multiple worlds, pair tables are built per-world.  Cross-world shape
+    pairs are excluded — only within-world and global counterparts (e.g. ground plane) contribute.
+    Global bodies and shapes cannot be sensing objects.
 
-    .. rubric:: Terms used
+    The force matrix has shape ``(sum_of_sensors_across_worlds, max_readings)`` where
+    ``max_readings`` is the maximum counterpart count of any single world.  Rows are
+    world-contiguous (world 0 first, then world 1, …).  Columns beyond a world's own reading
+    count are zero-padded.
 
-    - **Sensing Object**: The body or shape "carrying" a contact sensor.
-    - **Counterpart**: The other body or shape involved in a contact interaction with a sensing object.
-    - **Force Matrix**: The matrix organizing the force data by rows of sensing objects and columns of counterparts.
-    - **Force Reading**: An individual force measurement within the matrix.
+    :attr:`sensing_objs`, :attr:`counterparts`, and :attr:`reading_indices` are per-world nested
+    lists indexed as ``attr[world][i]``.
+
+    .. rubric:: Terms
+
+    - **Sensing object** — body or shape carrying a contact sensor.
+    - **Counterpart** — the other body or shape in a contact interaction.
+    - **Force reading** — one entry of the force matrix (:class:`vec3`).
 
     Parameters that select bodies or shapes accept label patterns — see :ref:`label-matching`.
 
@@ -177,16 +214,16 @@ class SensorContact:
         """Individual body."""
 
     shape: tuple[int, int]
-    """Dimensions of the force matrix ``(n_sensing_objs, n_counterparts)``."""
+    """Dimensions of the force matrix ``(n_sensing_objs, max_readings_per_world)``."""
 
-    reading_indices: list[list[int]]
-    """Active counterpart indices per sensing object (when ``prune_noncolliding`` is True)."""
+    reading_indices: list[list[list[int]]]
+    """Active counterpart indices per sensing object, per world."""
 
-    sensing_objs: list[tuple[int, "SensorContact.ObjectType"]]
-    """Index and type of each sensing object. Rows of the force matrix."""
+    sensing_objs: list[list[tuple[int, "SensorContact.ObjectType"]]]
+    """Index and type of each sensing object, per world. Rows of the force matrix."""
 
-    counterparts: list[tuple[int, "SensorContact.ObjectType"]]
-    """Index and type of each counterpart. Columns of the force matrix."""
+    counterparts: list[list[tuple[int, "SensorContact.ObjectType"]]]
+    """Index and type of each counterpart, per world. Columns of the force matrix."""
 
     net_force: wp.array2d(dtype=wp.vec3)
     """Net contact forces [N], shape ``(n_sensing_objs, n_counterparts)``, dtype :class:`vec3`.
@@ -205,7 +242,6 @@ class SensorContact:
         counterpart_bodies: str | list[str] | list[int] | None = None,
         counterpart_shapes: str | list[str] | list[int] | None = None,
         include_total: bool = True,
-        prune_noncolliding: bool = False,
         verbose: bool | None = None,
         request_contact_attributes: bool = True,
     ):
@@ -226,8 +262,6 @@ class SensorContact:
                 against shape labels, or list of patterns where any one matches.
             include_total: If True and counterparts are specified, add a reading for the total contact force for
                 each sensing object. Does nothing when no counterparts are specified.
-            prune_noncolliding: If True, omit force readings for shape pairs that never collide from the force
-                matrix. Does nothing when no counterparts are specified.
             verbose: If True, print details. If None, uses ``wp.config.verbose``.
             request_contact_attributes: If True (default), transparently request the extended contact attribute ``force`` from the model.
         """
@@ -270,11 +304,55 @@ class SensorContact:
             c_shapes = [self.ObjectType.TOTAL]
             c_bodies = []
 
-        contact_pairs = set(map(tuple, model.shape_contact_pairs.list())) if prune_noncolliding else None
-
-        sp_sorted, sp_reading, self.shape, self.reading_indices, self.sensing_objs, self.counterparts = (
-            self._assemble_sensor_mappings(s_bodies, s_shapes, c_bodies, c_shapes, model.body_shapes, contact_pairs)
+        contact_pairs = (
+            set(map(tuple, model.shape_contact_pairs.list()))
+            if getattr(model, "shape_contact_pairs", None) is not None
+            else None
         )
+
+        TOTAL = self.ObjectType.TOTAL
+        wc = model.world_count
+        shape_ws = model.shape_world_start.list()
+        body_ws = model.body_world_start.list()
+
+        def bucket(indices, ws):
+            real = [x for x in indices if x is not TOTAL]
+            if wc <= 1:
+                return [real], []
+            return _bucket_indices_by_world(real, ws, wc) if real else ([[] for _ in range(wc)], [])
+
+        s_body_b, s_body_g = bucket(s_bodies, body_ws)
+        s_shape_b, s_shape_g = bucket(s_shapes, shape_ws)
+        if s_body_g or s_shape_g:
+            raise ValueError(
+                "Global bodies/shapes (world=-1) cannot be sensing objects. "
+                f"Global body indices: {s_body_g}, global shape indices: {s_shape_g}"
+            )
+
+        c_body_b, c_body_g = bucket(c_bodies, body_ws)
+        c_shape_b, c_shape_g = bucket(c_shapes, shape_ws)
+
+        per_world_results = []
+        for w in range(wc):
+            wb = ([TOTAL] if TOTAL in c_bodies else []) + c_body_g + c_body_b[w]
+            wsh = ([TOTAL] if TOTAL in c_shapes else []) + c_shape_g + c_shape_b[w]
+            per_world_results.append(
+                self._assemble_sensor_mappings(s_body_b[w], s_shape_b[w], wb, wsh, model.body_shapes, contact_pairs)
+            )
+
+        max_r = max((r[2] for r in per_world_results), default=0)
+        self.sensing_objs = [r[4] for r in per_world_results]
+        self.counterparts = [r[5] for r in per_world_results]
+        self.reading_indices = [r[3] for r in per_world_results]
+
+        sp_sorted, sp_reading = [], []
+        row = 0
+        for sp_w, raw_w, _, _, so_w, _ in per_world_results:
+            for entries in raw_w:
+                sp_reading.append([((row + s) * max_r + r, f) for s, r, f in entries])
+            sp_sorted.extend(sp_w)
+            row += len(so_w)
+        self.shape = (row, max_r)
 
         # initialize warp arrays
         self._n_shape_pairs: int = len(sp_sorted)
@@ -288,10 +366,11 @@ class SensorContact:
         self.net_force = self._net_force.reshape(self.shape)
 
         # build sensing object transform data
-        n_sensing = len(self.sensing_objs)
-        sensing_indices = [idx for idx, _ in self.sensing_objs]
-        sensing_obj_types = [obj_type.value for _, obj_type in self.sensing_objs]
-        assert all(idx >= 0 and t != self.ObjectType.TOTAL for idx, t in self.sensing_objs), (
+        flat_sensing = [obj for world_objs in self.sensing_objs for obj in world_objs]
+        n_sensing = len(flat_sensing)
+        sensing_indices = [idx for idx, _ in flat_sensing]
+        sensing_obj_types = [obj_type.value for _, obj_type in flat_sensing]
+        assert all(idx >= 0 and t != self.ObjectType.TOTAL for idx, t in flat_sensing), (
             "Sensing objects must not be TOTAL and indices must be non-negative"
         )
 
@@ -312,7 +391,7 @@ class SensorContact:
             contacts: The contact data to evaluate.
         """
         # update sensing object transforms
-        n = len(self.sensing_objs)
+        n = sum(len(world_objs) for world_objs in self.sensing_objs)
         if n > 0 and state is not None and state.body_q is not None:
             wp.launch(
                 compute_sensing_obj_transforms_kernel,
@@ -343,8 +422,10 @@ class SensorContact:
         counterpart_bodies: "list[int | SensorContact.ObjectType]",
         counterpart_shapes: "list[int | SensorContact.ObjectType]",
         body_shapes: dict[int, list[int]],
-        shape_contact_pairs: set[tuple[int, int]] | None,
+        shape_contact_pairs: set[tuple[int, int]] | None = None,
     ):
+        """Given bodies and shapes for sensing objects and counterparts, build the
+        shape_pair -> reading index mapping"""
         TOTAL = cls.ObjectType.TOTAL
 
         # TOTAL, then bodies, then shapes
@@ -358,14 +439,6 @@ class SensorContact:
             entities = [TOTAL] * has_total + body + shape
             indices = [-1] * has_total + body_idx + shape_idx
             return list(zip(indices, obj_type, strict=True)), entities
-
-        def get_colliding_sps(a, b) -> dict[tuple[int, int], bool]:
-            all_pairs_flip = {
-                (min(pair), max(pair)): min(pair) == pair[1] for pair in itertools.product(a, b) if pair[0] != pair[1]
-            }
-            if shape_contact_pairs is None:
-                return all_pairs_flip
-            return {pair: all_pairs_flip[pair] for pair in shape_contact_pairs.intersection(all_pairs_flip)}
 
         sensing_obj_kinds, sensing_objs = expand_bodies(sensing_obj_bodies, sensing_obj_shapes)
         counterpart_kinds, counterparts = expand_bodies(counterpart_bodies, counterpart_shapes)
@@ -383,9 +456,18 @@ class SensorContact:
             reading_idx = 0
             for counterpart_idx, counterpart in enumerate(counterparts):
                 if counterpart is TOTAL:
-                    sp_flips = dict.fromkeys(itertools.product((-1,), sensing_obj), True)
-                elif not (sp_flips := get_colliding_sps(sensing_obj, counterpart)):
-                    continue
+                    # all shapes contribute
+                    # TODO: skip non-colliding shapes
+                    sp_flips = dict.fromkeys(((s, -1) for s in sensing_obj), False)
+                else:
+                    # skip irrelevant shape pairs to keep sp list short
+                    sp_flips = {
+                        (min(pair), max(pair)): min(pair) == pair[1]
+                        for pair in itertools.product(sensing_obj, counterpart)
+                        if pair[0] != pair[1]
+                    }
+                    if shape_contact_pairs is not None:
+                        sp_flips = {sp: f for sp, f in sp_flips.items() if sp in shape_contact_pairs}
 
                 for sp, flip in sp_flips.items():
                     sp_to_reading[sp].append((sensing_obj_idx, reading_idx, flip))
@@ -394,20 +476,12 @@ class SensorContact:
             counterpart_indices.append(sens_counterparts)
 
         # maximum number of readings for any sensing object
-        n_readings = max(map(len, counterpart_indices)) if counterpart_indices else 0
+        n_readings = max(map(len, counterpart_indices), default=0)
 
         sp_sorted = sorted(sp_to_reading)
-        sp_reading = []
-        for sp in sp_sorted:
-            sp_reading.append(
-                [
-                    (sensing_obj_idx * n_readings + reading_idx, flip)
-                    for sensing_obj_idx, reading_idx, flip in sp_to_reading[sp]
-                ]
-            )
+        sp_reading_raw = [sp_to_reading[sp] for sp in sp_sorted]
 
-        shape = len(sensing_objs), n_readings
-        return sp_sorted, sp_reading, shape, counterpart_indices, sensing_obj_kinds, counterpart_kinds
+        return sp_sorted, sp_reading_raw, n_readings, counterpart_indices, sensing_obj_kinds, counterpart_kinds
 
     def _eval_net_force(self, contacts: Contacts):
         self._net_force.zero_()

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -304,11 +304,12 @@ class SensorContact:
             c_shapes = [self.ObjectType.TOTAL]
             c_bodies = []
 
-        contact_pairs = (
-            set(map(tuple, model.shape_contact_pairs.list()))
-            if getattr(model, "shape_contact_pairs", None) is not None
-            else None
-        )
+        if model.shape_contact_pairs is None:
+            contact_pairs = None
+        else:
+            # pack into larger int to avoid Python object overhead
+            pairs = model.shape_contact_pairs.numpy().astype(np.int64)
+            contact_pairs = set((pairs[:, 0] << 32) | pairs[:, 1])
 
         TOTAL = self.ObjectType.TOTAL
         wc = model.world_count
@@ -422,7 +423,7 @@ class SensorContact:
         counterpart_bodies: "list[int | SensorContact.ObjectType]",
         counterpart_shapes: "list[int | SensorContact.ObjectType]",
         body_shapes: dict[int, list[int]],
-        shape_contact_pairs: set[tuple[int, int]] | None = None,
+        shape_contact_pairs: set[int] | None = None,
     ):
         """Given bodies and shapes for sensing objects and counterparts, build the
         shape_pair -> reading index mapping"""
@@ -467,7 +468,7 @@ class SensorContact:
                         if pair[0] != pair[1]
                     }
                     if shape_contact_pairs is not None:
-                        sp_flips = {sp: f for sp, f in sp_flips.items() if sp in shape_contact_pairs}
+                        sp_flips = {sp: f for sp, f in sp_flips.items() if (sp[0] << 32) | sp[1] in shape_contact_pairs}
 
                 for sp, flip in sp_flips.items():
                     sp_to_reading[sp].append((sensing_obj_idx, reading_idx, flip))

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -150,8 +150,8 @@ class Example:
                 continue
 
             # color newly touched plate
-            plate = self.plate_contact_sensor.sensing_objs[i][0]
-            obj = self.plate_contact_sensor.counterparts[i][0]
+            plate = self.plate_contact_sensor.sensing_objs[0][i][0]
+            obj = self.plate_contact_sensor.counterparts[0][i][0]
             obj_key = self.model.shape_label[obj]
             self.plates_touched[i] = True
             print(f"Plate {self.model.shape_label[plate]} was touched by counterpart {obj_key}")

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -20,6 +20,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.sensors.sensor_contact import _bucket_indices_by_world
 from newton.sensors import SensorContact
 from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import assert_np_equal
@@ -30,6 +31,10 @@ class MockModel:
 
     def __init__(self, device=None):
         self.device = device or wp.get_device()
+        self.world_count = 1
+        self.shape_world_start = None
+        self.body_world_start = None
+        self.shape_contact_pairs = None
 
     def request_contact_attributes(self, *args):
         pass
@@ -83,6 +88,8 @@ class TestSensorContact(unittest.TestCase):
         model.body_shapes = [entity_A, entity_B]
         model.shape_body = wp.array([0, 0, 1], dtype=wp.int32, device=device)
         model.shape_transform = wp.zeros(3, dtype=wp.transform, device=device)
+        model.shape_world_start = wp.array([0, 3, 3], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 2, 2], dtype=wp.int32, device=device)
 
         contact_sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="*")
 
@@ -185,6 +192,8 @@ class TestSensorContact(unittest.TestCase):
         model.shape_transform = wp.array(
             [wp.transform_identity(), wp.transform_identity()], dtype=wp.transform, device=device
         )
+        model.shape_world_start = wp.array([0, 2, 2], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 2, 2], dtype=wp.int32, device=device)
 
         sensor = SensorContact(model, sensing_obj_bodies="*")
 
@@ -215,6 +224,8 @@ class TestSensorContact(unittest.TestCase):
         model.shape_label = ["s0", "s1"]
         # shape 0 belongs to body 0, shape 1 is a ground shape (body -1)
         model.shape_body = wp.array([0, -1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 1, 2], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 1, 1], dtype=wp.int32, device=device)
 
         shape0_local = wp.transform(wp.vec3(0.5, 0.25, 0.125), wp.quat_identity())
         shape1_local = wp.transform(wp.vec3(10.0, 20.0, 30.0), wp.quat_identity())
@@ -238,6 +249,168 @@ class TestSensorContact(unittest.TestCase):
         assert_np_equal(transforms[0][:3], [1.5, 2.25, 3.125])
         # ground shape (body_idx == -1): shape_transform only -> (10, 20, 30)
         assert_np_equal(transforms[1][:3], [10.0, 20.0, 30.0])
+
+    def test_bucket_indices_by_world(self):
+        """Indices are correctly bucketed by world using world_start."""
+
+        # world_start layout: [start_w0, start_w1, start_global_tail, total]
+        # world 0: shapes [0,1,2], world 1: shapes [3,4,5], global tail: shapes [6,7]
+        world_count = 2
+        shape_world_start = [0, 3, 6, 8]
+
+        indices = [0, 1, 4, 5, 7]
+        buckets, global_indices = _bucket_indices_by_world(indices, shape_world_start, world_count)
+
+        self.assertEqual(len(buckets), 2)
+        self.assertEqual(buckets[0], [0, 1])
+        self.assertEqual(buckets[1], [4, 5])
+        self.assertEqual(global_indices, [7])
+
+    def test_bucket_indices_global_front(self):
+        """Global indices at the front of the array are correctly identified."""
+
+        # Front globals: [0,1], world 0: [2,3,4], world 1: [5,6,7], tail globals: [8,9]
+        world_count = 2
+        shape_world_start = [2, 5, 8, 10]
+
+        indices = [0, 3, 8]
+        buckets, global_indices = _bucket_indices_by_world(indices, shape_world_start, world_count)
+
+        self.assertEqual(buckets[0], [3])
+        self.assertEqual(buckets[1], [])
+        self.assertEqual(sorted(global_indices), [0, 8])
+
+    def test_per_world_attributes(self):
+        """sensing_objs, counterparts, reading_indices are nested per-world."""
+        device = wp.get_device()
+
+        model = MockModel()
+        model.body_label = ["A", "B"]
+        model.body_shapes = {-1: [], 0: (0,), 1: (1,)}
+        model.shape_label = ["s0", "s1"]
+        model.shape_body = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_transform = wp.zeros(2, dtype=wp.transform, device=device)
+        model.world_count = 2
+        model.body_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+
+        sensor = SensorContact(model, sensing_obj_bodies="*")
+
+        self.assertIsInstance(sensor.sensing_objs, list)
+        self.assertEqual(len(sensor.sensing_objs), 2)  # 2 worlds
+        self.assertIsInstance(sensor.sensing_objs[0], list)
+
+        self.assertEqual(len(sensor.sensing_objs[0]), 1)
+        self.assertEqual(sensor.sensing_objs[0][0], (0, SensorContact.ObjectType.BODY))
+
+        self.assertEqual(len(sensor.sensing_objs[1]), 1)
+        self.assertEqual(sensor.sensing_objs[1][0], (1, SensorContact.ObjectType.BODY))
+
+    def test_multi_world_no_cross_world_pairs(self):
+        """Per-world construction produces no cross-world shape pairs."""
+        device = wp.get_device()
+
+        model = MockModel()
+        model.body_label = ["A", "B"]
+        model.body_shapes = {-1: [2], 0: (0,), 1: (1,)}
+        model.shape_label = ["s0", "s1", "ground"]
+        model.shape_body = wp.array([0, 1, -1], dtype=wp.int32, device=device)
+        model.shape_transform = wp.zeros(3, dtype=wp.transform, device=device)
+        model.world_count = 2
+        model.body_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world = wp.array([0, 1, -1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 2, 3], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+
+        sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="*")
+
+        sp_sorted = sensor._sp_sorted.numpy()
+        for pair in sp_sorted:
+            s0, s1 = int(pair[0]), int(pair[1])
+            self.assertFalse(
+                s0 >= 0 and s1 >= 0 and {s0, s1} == {0, 1},
+                f"Cross-world pair found: ({s0}, {s1})",
+            )
+
+        sp_set = {tuple(int(x) for x in p) for p in sp_sorted if int(p[1]) >= 0}
+        # Each body's shape should pair with global ground shape (2),
+        # but not with shapes from other worlds
+        self.assertIn((0, 2), sp_set)
+        self.assertIn((1, 2), sp_set)
+
+    def test_multi_world_total_force(self):
+        """Total force accumulates correctly with per-world pair tables."""
+        device = wp.get_device()
+
+        model = MockModel()
+        model.body_label = ["A", "B"]
+        model.body_shapes = {-1: [], 0: (0,), 1: (1,)}
+        model.shape_label = ["s0", "s1"]
+        model.shape_body = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_transform = wp.zeros(2, dtype=wp.transform, device=device)
+        model.world_count = 2
+        model.body_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+
+        sensor = SensorContact(model, sensing_obj_bodies="*")
+
+        contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[3.0])
+        sensor.update(None, contacts)
+
+        forces = sensor.net_force.numpy()
+        np.testing.assert_allclose(forces[0, 0], [0, 0, 3.0], atol=1e-5)
+        np.testing.assert_allclose(forces[1, 0], [0, 0, -3.0], atol=1e-5)
+
+    def test_global_sensing_object_raises(self):
+        """Global entities as sensing objects raise ValueError."""
+        device = wp.get_device()
+
+        model = MockModel()
+        model.body_label = ["A"]
+        model.body_shapes = {-1: [1], 0: (0,)}
+        model.shape_label = ["s0", "ground"]
+        model.shape_body = wp.array([0, -1], dtype=wp.int32, device=device)
+        model.shape_transform = wp.zeros(2, dtype=wp.transform, device=device)
+        model.world_count = 2
+        model.body_world = wp.array([0], dtype=wp.int32, device=device)
+        model.shape_world = wp.array([0, -1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 1, 2], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 1, 1], dtype=wp.int32, device=device)
+
+        with self.assertRaises(ValueError):
+            SensorContact(model, sensing_obj_shapes="*")  # "*" matches ground too
+
+    def test_global_counterpart_in_all_worlds(self):
+        """Global counterparts (e.g., ground) appear in every world's counterpart bucket."""
+        device = wp.get_device()
+
+        model = MockModel()
+        model.body_label = ["A", "B"]
+        model.body_shapes = {-1: [2], 0: (0,), 1: (1,)}
+        model.shape_label = ["s0", "s1", "ground"]
+        model.shape_body = wp.array([0, 1, -1], dtype=wp.int32, device=device)
+        model.shape_transform = wp.zeros(3, dtype=wp.transform, device=device)
+        model.world_count = 2
+        model.body_world = wp.array([0, 1], dtype=wp.int32, device=device)
+        model.shape_world = wp.array([0, 1, -1], dtype=wp.int32, device=device)
+        model.shape_world_start = wp.array([0, 1, 2, 3], dtype=wp.int32, device=device)
+        model.body_world_start = wp.array([0, 1, 2, 2], dtype=wp.int32, device=device)
+
+        sensor = SensorContact(
+            model,
+            sensing_obj_bodies="*",
+            counterpart_shapes=["ground"],
+            include_total=False,
+        )
+
+        # Both worlds should have the ground as a counterpart
+        for w in range(2):
+            counterpart_indices = [idx for idx, _ in sensor.counterparts[w]]
+            self.assertIn(2, counterpart_indices, f"World {w} missing ground counterpart")
 
 
 class TestSensorContactMuJoCo(unittest.TestCase):


### PR DESCRIPTION
## Description

This PR changes the construction of the contact sensor to make use of worlds to avoid a quadratic setup cost.

#resolves #1997

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced sensor contact system to support multi-world simulations with reorganized data structures for sensing objects, counterparts, and readings.
  * Updated shape matrix semantics to accommodate variable readings per world.
  * Removed the `prune_noncolliding` parameter in favor of explicit per-world bucketing logic.

* **Tests**
  * Added comprehensive tests for multi-world bucketing, cross-world validation, and per-world force calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->