### PR TITLE
Fix inaccuracies and restructure usd_parsing.rst

### DIFF
--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -97,7 +97,7 @@ The following tables show examples of how solver-specific attributes are mapped 
 
 **PhysX Attribute Remapping Examples:**
 
-The table below demonstrates PhysX attribute remapping with both direct mapping and transformation examples:
+The table below shows PhysX attribute remapping examples:
 
 .. list-table:: PhysX Attribute Remapping
    :header-rows: 1
@@ -108,9 +108,6 @@ The table below demonstrates PhysX attribute remapping with both direct mapping 
      - **Transformation**
    * - ``physxJoint:armature``
      - ``armature``
-     - Direct mapping
-   * - ``physxScene:timeStepsPerSecond``
-     - ``time_steps_per_second``
      - Direct mapping
    * - ``physxArticulation:enabledSelfCollisions``
      - ``self_collision_enabled`` (per articulation)
@@ -135,6 +132,8 @@ The parser resolves ``self_collision_enabled`` from either ``newton:selfCollisio
 
 **MuJoCo Attribute Remapping Examples:**
 
+The table below shows MuJoCo attribute remapping examples, including both direct mappings and transformations:
+
 .. list-table:: MuJoCo Attribute Remapping
    :header-rows: 1
    :widths: 30 30 40
@@ -145,9 +144,9 @@ The parser resolves ``self_collision_enabled`` from either ``newton:selfCollisio
    * - ``mjc:armature``
      - ``armature``
      - Direct mapping
-   * - ``mjc:option:timestep``
-     - ``time_steps_per_second``
-     - ``int(1 / timestep)``
+   * - ``mjc:margin``, ``mjc:gap``
+     - ``margin``
+     - ``margin = mjc:margin - mjc:gap``
 
 **Example USD with remapped attributes:**
 
@@ -161,7 +160,6 @@ The following USD example demonstrates how PhysX attributes are authored in a US
        prepend apiSchemas = ["PhysxSceneAPI"]
    ) {
        # PhysX scene settings that Newton can understand
-       uint physxScene:timeStepsPerSecond = 120  # → time_steps_per_second = 120
        uint physxScene:maxVelocityIterationCount = 16  # → max_solver_iterations = 16
    }
 


### PR DESCRIPTION
## Description

Fixes several inaccuracies and restructures the `docs/concepts/usd_parsing.rst` doc page.

**Factual fixes:**
- Replace wrong `mjc:solref` formula row in MuJoCo remapping table with a correct `mjc:option:timestep` → `time_steps_per_second` example
- Fix `physxScene:timeStepsPerSecond` Newton equivalent (`time_step` → `time_steps_per_second`, transformation is direct not `1/x`)
- Fix `physxCollision:contactOffset` USDA example: gap is `contactOffset - restOffset`, not `contactOffset` alone; show both attributes with asymmetric values
- Rewrite priority-based resolution hierarchy to accurately describe the three fallback layers and remove reference to internal `Resolver.get_value()` API
- Fix `newton:hullVertexLimit` → `newton:maxHullVertices` in solver-specific namespace table

**Structural improvements:**
- Group schema resolver subsections (remapping, priority resolution, attribute collection) under a single "Schema Resolvers" section so the experimental note covers all three
- Move custom attributes into its own top-level section
- Drop numbered section prefixes; promote "Limitations" to a proper top-level section
- Add brief intro paragraph to the Schema Resolvers section
- Replace "See the next section" with explicit `:ref:\`schema_resolvers\`` cross-reference

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra docs sphinx-build -b html docs docs/_build/html
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced and clarified the "Schema Resolvers" concept and resolver priority rules (authored values, importer defaults, approximated defaults).
  * Expanded and updated attribute remapping guidance and examples for various solvers (PhysX, MuJoCo, USD).
  * Renamed and reorganized sections on custom attributes, namespacing, and attribute collection; improved threading/environment guidance.
  * General cleanup of wording, formatting, and examples for consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->