### PR TITLE
Remove active development notice from overview page

### DIFF
--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -1,9 +1,6 @@
 .. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 .. SPDX-License-Identifier: CC-BY-4.0
 
-.. note::
-   Newton is in active development. APIs and features may change without notice or backwards compatibility.
-
 Newton Physics Documentation
 ============================
 


### PR DESCRIPTION
## Description

Remove the blanket "Newton is in active development. APIs and features may change without notice or backwards compatibility" disclaimer from the documentation landing page.

Closes #2015

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Documentation-only change — verified the notice is removed by inspecting the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the active development advisory from the project overview documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->