### PR TITLE
Fix Removal of Loop Closure with Collapse Fixed Joints

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4534,13 +4534,18 @@ class ModelBuilder:
             for child in body_children[child_body]:
                 if not visited[child]:
                     dfs(child_body, child, incoming_xform, last_dynamic_body)
-                elif (child_body, child) in joint_data and child not in body_merged_parent:
+                elif (child_body, child) in joint_data:
                     # Loop-closing joint: child was already visited via another path.
                     # Retain the joint but don't re-process the child body.
                     loop_joint = joint_data[(child_body, child)]
                     if loop_joint["type"] != JointType.FIXED:
                         loop_joint["parent_xform"] = incoming_xform * loop_joint["parent_xform"]
                         loop_joint["parent"] = last_dynamic_body
+                        if child in body_merged_parent:
+                            # Child was merged into another body — remap child and adjust child_xform
+                            merge_xform = body_merged_transform[child]
+                            loop_joint["child_xform"] = merge_xform * loop_joint["child_xform"]
+                            loop_joint["child"] = body_merged_parent[child]
                         retained_joints.append(loop_joint)
 
         for body in body_children[-1]:

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -759,41 +759,65 @@ class TestModelJoints(unittest.TestCase):
         self.assertIn("Skipped joint fixed_1 has a child body_2 with zero or negative mass", str(cm.warning))
 
     def test_collapse_fixed_joints_preserves_loop_closure(self):
-        """Test that collapse_fixed_joints retains loop-closing joints."""
-        builder = ModelBuilder()
+        """Test that collapse_fixed_joints retains loop-closing joints.
 
+        Covers two symmetric cases:
+        1. The merged-away body is the loop joint's *parent* (parent remapping).
+        2. The merged-away body is the loop joint's *child* (child remapping).
+        """
+
+        # --- Case 1: merged body is the loop joint's parent ---
         # world --(free)--> b0 --(revolute)--> b1 --(fixed)--> b2 --(revolute, loop)--> b0
-        b0 = builder.add_link(mass=1.0)
+        # After collapse b2 merges into b1; loop joint parent must remap b2 -> b1
+        builder = ModelBuilder()
+        b0 = builder.add_link(label="b0", mass=1.0)
         j0 = builder.add_joint_free(parent=-1, child=b0)
-        b1 = builder.add_link(mass=1.0)
+        b1 = builder.add_link(label="b1", mass=1.0)
         j1 = builder.add_joint_revolute(parent=b0, child=b1, axis=wp.vec3(0, 0, 1))
-        b2 = builder.add_link(mass=1.0)
+        b2 = builder.add_link(label="b2", mass=1.0)
         j2 = builder.add_joint_fixed(parent=b1, child=b2)
-        _j_loop = builder.add_joint_revolute(parent=b2, child=b0, axis=wp.vec3(0, 0, 1))
+        builder.add_joint_revolute(parent=b2, child=b0, axis=wp.vec3(0, 0, 1), label="loop_b2_b0")
         builder.add_articulation([j0, j1, j2])
-
-        self.assertEqual(builder.joint_count, 4)
-        self.assertEqual(builder.body_count, 3)
 
         builder.collapse_fixed_joints()
 
-        # fixed b1->b2 collapsed, b2 merged into b1 -> 2 bodies, 3 joints
         self.assertEqual(builder.body_count, 2)
         self.assertEqual(builder.joint_count, 3)
+        self.assertIn("loop_b2_b0", builder.joint_label)
+        loop_i = builder.joint_label.index("loop_b2_b0")
         self.assertEqual(
-            builder.joint_type.count(newton.JointType.REVOLUTE), 2, "Loop-closing revolute joint was dropped"
+            builder.joint_parent[loop_i],
+            builder.body_label.index("b1"),
+            "Loop joint parent should be remapped from b2 to b1",
+        )
+        self.assertEqual(
+            builder.joint_child[loop_i], builder.body_label.index("b0"), "Loop joint child (b0) should be unchanged"
         )
 
-        # loop joint parent must be re-mapped from b2 to b1 (now body index 1)
-        loop_parent = builder.joint_parent[-1]
-        self.assertEqual(loop_parent, 1, "Loop joint parent was not re-mapped to the merged body")
+        # --- Case 2: merged body is the loop joint's child ---
+        # world --(free)--> b0 --(fixed)--> b1
+        # world --(free)--> b2 --(revolute, loop)--> b1
+        # After collapse b1 merges into b0; loop joint child must remap b1 -> b0
+        builder = ModelBuilder()
+        b0 = builder.add_link(label="b0", mass=1.0)
+        j0 = builder.add_joint_free(parent=-1, child=b0)
+        b1 = builder.add_link(label="b1", mass=1.0)
+        j_fixed = builder.add_joint_fixed(parent=b0, child=b1, label="fixed_b0_b1")
+        b2 = builder.add_link(label="b2", mass=1.0)
+        j2 = builder.add_joint_free(parent=-1, child=b2)
+        builder.add_joint_revolute(parent=b2, child=b1, axis=wp.vec3(0, 0, 1), label="loop_b2_b1")
+        builder.add_articulation([j0, j_fixed])
+        builder.add_articulation([j2])
 
-        # expected DOFs: free(6) + revolute(1) + revolute(1) = 8
-        self.assertEqual(builder.joint_dof_count, 8)
-        self.assertEqual(len(builder.joint_qd), 8)
-        self.assertEqual(len(builder.joint_velocity_limit), 8)
-        self.assertEqual(len(builder.joint_friction), 8)
-        self.assertEqual(builder.joint_coord_count, len(builder.joint_q))
+        builder.collapse_fixed_joints()
+
+        # b1 is merged into b0 -> 2 bodies (b0, b2)
+        self.assertEqual(builder.body_count, 2)
+        # the loop joint survives and is remapped from b2 -> b1 to b2 -> b0
+        self.assertIn("loop_b2_b1", builder.joint_label)
+        loop_i = builder.joint_label.index("loop_b2_b1")
+        self.assertEqual(builder.joint_parent[loop_i], builder.body_label.index("b2"))
+        self.assertEqual(builder.joint_child[loop_i], builder.body_label.index("b0"))
 
     def test_articulation_validation_contiguous(self):
         """Test that articulation requires contiguous joint indices"""


### PR DESCRIPTION
## Description

  Fix `collapse_fixed_joints()` dropping loop-closing joints when the parent body was merged during DFS,
  and leaving per-DOF arrays inconsistent after the rebuild.
  
  This is also rather a bug report than probably the best possible fix for this problem !

  ## Checklist

  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [ ] `CHANGELOG.md` has been updated (if user-facing change)

  ## Test plan

  uv run --extra dev -m newton.tests -k test_collapse_fixed_joints_preserves_loop_closure

  Verified the test fails without the fix and passes with it.

  ## Bug fix

  `collapse_fixed_joints()` silently removed loop-closing joints whose child body was already visited in
  the DFS traversal, and left `joint_dof_count` out of sync with per-DOF arrays.

  **Steps to reproduce:**

  1. Build a model with a kinematic loop where a fixed joint sits between the loop-closing joint's parent
  and the tree root
  2. Call `builder.collapse_fixed_joints()`
  3. Loop-closing joint is missing, `joint_dof_count != len(joint_qd)`

See added test example

  **Minimal reproduction:**

  uv run --extra dev -m newton.tests -k test_collapse_fixed_joints_preserves_loop_closure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of loop-closing joints during model structure rebuilds so loop joints are preserved and remapped when bodies are merged.
  * Ensured degree-of-freedom and coordinate counts and per-DOF arrays remain consistent after joints are rebuilt.

* **Tests**
  * Added a unit test verifying loop-closure preservation when collapsing fixed joints in articulated models, covering parent- and child-remapping cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->