### PR TITLE
Update year in license file

### DIFF
--- a/.licenserc-docs.yaml
+++ b/.licenserc-docs.yaml
@@ -4,7 +4,7 @@ header:
     copyright-owner: The Newton Developers
 
     content: |
-      SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+      SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
       SPDX-License-Identifier: CC-BY-4.0
 
     pattern: |

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -4,7 +4,7 @@ header:
     copyright-owner: The Newton Developers
 
     license: |
-      # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+      # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
       # SPDX-License-Identifier: Apache-2.0
       #
       # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description
Update year 2025 -> 2026 in license files.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year from 2025 to 2026 in license configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->