### PR TITLE
Fix parser creation in sensor tiled camera example

### DIFF
--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -561,20 +561,25 @@ class Example:
 
         imgui.end()
 
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument(
+            "--ply",
+            help="Gaussian filename.",
+        )
+        parser.add_argument(
+            "-min",
+            "--min-response",
+            type=float,
+            default=0.1,
+            help="Gaussian min response.",
+        )
+        return parser
+
 
 if __name__ == "__main__":
-    parser = newton.examples.create_parser()
-    parser.add_argument(
-        "--ply",
-        help="Gaussian Filename",
-    )
-    parser.add_argument(
-        "-min",
-        "--min-response",
-        type=float,
-        default=0.1,
-        help="Gaussian min response",
-    )
+    parser = Example.create_parser()
 
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init(parser)


### PR DESCRIPTION
## Summary
Fix `sensor_tiled_camera` example-browser startup by registering its custom CLI args in the example parser.

## Problem
`newton.examples.sensors.example_sensor_tiled_camera` reads `args.ply` and `args.min_response`, but those arguments were only added in the module’s `__main__` block. The example browser and `newton/tests/test_example_browser.py` instantiate examples through `Example.create_parser()` and `newton.examples.default_args()`, so those fields were missing and the example failed on switch/reset with `AttributeError: 'Namespace' object has no attribute 'ply'`.

## Fix
Add `Example.create_parser()` to `newton/examples/sensors/example_sensor_tiled_camera.py` and register `--ply` plus `--min-response` there. Update the module entrypoint to reuse `Example.create_parser()` so browser instantiation and direct CLI execution share the same argument definitions.

## Validation
Ran `uv run python newton/tests/test_example_browser.py "sensor_tiled_camera" --frames 1`; both switch and reset passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal structure of example code for better organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->