### PR TITLE
Adjust pytorch installation instruction

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -171,7 +171,7 @@ to check the supported CUDA version (shown in the top-right corner of the output
 
 .. code-block:: console
 
-    pip install --pre newton[torch-cu12] --extra-index-url https://download.pytorch.org/whl/cu128
+    pip install newton[torch-cu12] --extra-index-url https://download.pytorch.org/whl/cu128
     python -m newton.examples robot_anymal_c_walk
 
 See a list of all available examples:


### PR DESCRIPTION
## Description

Changed instruction to install pytorch to make it work on windows.
This will address #1888.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to reference CUDA 13.x and the matching PyTorch wheel selection.
  * Revised the package install example to include an additional PyTorch wheel index for correct CUDA-enabled dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->