### PR TITLE
Improve inertia in sensor_contact example

### DIFF
--- a/newton/examples/assets/sensor_contact_scene.usda
+++ b/newton/examples/assets/sensor_contact_scene.usda
@@ -37,9 +37,6 @@ def Xform "env" (
         double3 xformOp:translate = (0, 0, 0.01)
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
 
-        float3 physics:diagonalInertia = (10, 10, 10)
-        float physics:mass = 100
-
     }
 
     def Cube "Flap" (


### PR DESCRIPTION
## Description
Removed non-physical mass and inertia in `sensor_contact_scene.usda`.
Part of #2028.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan
Run:
```
uv run --extra examples -m newton.examples sensor_contact
```
Look that there is no unexpected inertia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted physics configuration in sensor scene assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->