### PR TITLE
[Warp Raytrace] Added Constant Color mode and changed config to an enum style

### DIFF
--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -61,7 +61,11 @@ class SensorTiledCameraBenchmark:
 
         self.tiled_camera_sensor = SensorTiledCamera(
             model=self.model,
-            config=SensorTiledCamera.Config(default_light=True, colors_per_shape=True, checkerboard_texture=True),
+            config=SensorTiledCamera.Config(
+                default_light=True,
+                color_mode=SensorTiledCamera.Config.ColorMode.RANDOM_PER_SHAPE,
+                checkerboard_texture=True,
+            ),
         )
         self.camera_rays = self.tiled_camera_sensor.compute_pinhole_camera_rays(
             resolution, resolution, math.radians(45.0)

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import Any
 
 import numpy as np
 import warp as wp
@@ -134,9 +133,13 @@ class SensorTiledCamera:
 
     @dataclass
     class Config:
+        """Rendering configuration."""
+
         class ColorMode(enum.IntEnum):
+            """Color Modes for Config.color_mode."""
+
             MODEL_COLOR = 0
-            """Assign a colors from model."""
+            """Assign colors from model."""
 
             CONSTANT_COLOR = 1
             """Assign a constant color to all shapes."""
@@ -147,7 +150,8 @@ class SensorTiledCamera:
             RANDOM_PER_WORLD = 3
             """Assign a random color palette per world."""
 
-        """Rendering configuration."""
+            VIEWER_COLOR = 4
+            """Assign colors from model and fall back on viewer if none is defined."""
 
         checkerboard_texture: bool = False
         """Apply a checkerboard texture to all shapes."""
@@ -159,7 +163,10 @@ class SensorTiledCamera:
         """Enable shadows for the default light (requires ``default_light``)."""
 
         color_mode: ColorMode = ColorMode.MODEL_COLOR
-        """Color mode."""
+        """Color mode for color and albedo image outputs."""
+
+        constant_color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
+        """Color for constant color mode."""
 
         backface_culling: bool = True
         """Cull back-facing triangles."""
@@ -241,13 +248,15 @@ class SensorTiledCamera:
                 self.create_default_light(config.default_light_shadows)
 
         if config is None or config.color_mode == SensorTiledCamera.Config.ColorMode.MODEL_COLOR:
-            self.assign_colors_from_model()
+            self.assign_colors_from_model(False, config.constant_color)
+        elif config.color_mode == SensorTiledCamera.Config.ColorMode.VIEWER_COLOR:
+            self.assign_colors_from_model(True, config.constant_color)
         elif config.color_mode == SensorTiledCamera.Config.ColorMode.RANDOM_PER_WORLD:
             self.assign_random_colors_per_world()
         elif config.color_mode == SensorTiledCamera.Config.ColorMode.RANDOM_PER_SHAPE:
             self.assign_random_colors_per_shape()
         elif config.color_mode == SensorTiledCamera.Config.ColorMode.CONSTANT_COLOR:
-            self.assign_constant_color((1.0, 1.0, 1.0, 1.0))
+            self.assign_constant_color(config.constant_color)
         else:
             raise ValueError(f"Unsupported color_mode: {config.color_mode!r}")
 
@@ -432,9 +441,30 @@ class SensorTiledCamera:
         """
         self.render_context.utils.assign_constant_color(color)
 
-    def assign_colors_from_model(self):
-        """Assign a colors from model."""
-        colors = [(*self.__get_shape_color(i, shape), 1.0) for i, shape in enumerate(self.model.shape_source)]
+    def assign_colors_from_model(
+        self, use_viewer_color: bool = False, fallback_color: tuple[float, float, float, float] | None = None
+    ):
+        """Assign a colors from model.
+
+        Args:
+            use_viewer_color: use color from viewer if none is defined in the model.
+        """
+
+        colors = []
+        for i, shape in enumerate(self.model.shape_source):
+            color = getattr(shape, "color", None)
+            if color is not None:
+                colors.append((*color, 1.0))
+            elif use_viewer_color:
+                from newton.viewer import ViewerNull  # noqa: PLC0415
+
+                viewer_color = ViewerNull._shape_color_map(i)
+                colors.append((*viewer_color, 1.0))
+            elif fallback_color is not None:
+                colors.append(fallback_color)
+            else:
+                colors.append((1.0, 1.0, 1.0, 1.0))
+
         self.render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.render_context.device)
 
     def create_default_light(self, enable_shadows: bool = True):
@@ -530,20 +560,3 @@ class SensorTiledCamera:
             Array of shape ``(world_count, camera_count, height, width)``, dtype ``uint32``.
         """
         return self.render_context.create_albedo_image_output(width, height, camera_count)
-
-    def __get_shape_color(self, index: int, shape: Any):
-        SHAPE_COLOR_MAP = [
-            (68 / 255.0, 119 / 255.0, 170 / 255.0),  # blue
-            (102 / 255.0, 204 / 255.0, 238 / 255.0),  # cyan
-            (34 / 255.0, 136 / 255.0, 51 / 255.0),  # green
-            (204 / 255.0, 187 / 255.0, 68 / 255.0),  # yellow
-            (238 / 255.0, 102 / 255.0, 119 / 255.0),  # red
-            (170 / 255.0, 51 / 255.0, 119 / 255.0),  # magenta
-            (187 / 255.0, 187 / 255.0, 187 / 255.0),  # grey
-            (238 / 255.0, 153 / 255.0, 51 / 255.0),  # orange
-            (0 / 255.0, 153 / 255.0, 136 / 255.0),  # teal
-        ]
-
-        if color := getattr(shape, "color", None):
-            return color
-        return SHAPE_COLOR_MAP[index % len(SHAPE_COLOR_MAP)]

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -139,10 +139,10 @@ class SensorTiledCamera:
             """Color Modes for Config.color_mode."""
 
             MODEL_COLOR = 0
-            """Assign colors from model."""
+            """Assign colors from model, falling back to :attr:`~Config.constant_color` for shapes without a defined color."""
 
             CONSTANT_COLOR = 1
-            """Assign a constant color to all shapes."""
+            """Assign :attr:`~Config.constant_color` to all shapes."""
 
             RANDOM_PER_SHAPE = 2
             """Assign a random color per shape."""
@@ -166,7 +166,8 @@ class SensorTiledCamera:
         """Color mode for color and albedo image outputs."""
 
         constant_color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0)
-        """Color for constant color mode."""
+        """RGBA color used by :attr:`~ColorMode.CONSTANT_COLOR` (applied to all shapes) and
+        :attr:`~ColorMode.MODEL_COLOR` (fallback for shapes without a model-defined color)."""
 
         backface_culling: bool = True
         """Cull back-facing triangles."""

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -248,6 +248,8 @@ class SensorTiledCamera:
             self.assign_random_colors_per_shape()
         elif config.color_mode == SensorTiledCamera.Config.ColorMode.CONSTANT_COLOR:
             self.assign_constant_color((1.0, 1.0, 1.0, 1.0))
+        else:
+            raise ValueError(f"Unsupported color_mode: {config.color_mode!r}")
 
     def sync_transforms(self, state: State):
         """Synchronize shape transforms from the simulation state.

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import enum
 from dataclasses import dataclass
 from typing import Any
 
@@ -133,6 +134,19 @@ class SensorTiledCamera:
 
     @dataclass
     class Config:
+        class ColorMode(enum.IntEnum):
+            MODEL_COLOR = 0
+            """Assign a colors from model."""
+
+            CONSTANT_COLOR = 1
+            """Assign a constant color to all shapes."""
+
+            RANDOM_PER_SHAPE = 2
+            """Assign a random color per shape."""
+
+            RANDOM_PER_WORLD = 3
+            """Assign a random color palette per world."""
+
         """Rendering configuration."""
 
         checkerboard_texture: bool = False
@@ -144,11 +158,8 @@ class SensorTiledCamera:
         default_light_shadows: bool = False
         """Enable shadows for the default light (requires ``default_light``)."""
 
-        colors_per_world: bool = False
-        """Assign a random color palette per world."""
-
-        colors_per_shape: bool = False
-        """Assign a random color per shape (ignored when ``colors_per_world`` is True)."""
+        color_mode: ColorMode = ColorMode.MODEL_COLOR
+        """Color mode."""
 
         backface_culling: bool = True
         """Cull back-facing triangles."""
@@ -204,9 +215,6 @@ class SensorTiledCamera:
         self.render_context.shape_world_index = self.model.shape_world
         self.render_context.gaussians_data = self.model.gaussians_data
 
-        colors = [(*self.__get_shape_color(i, shape), 1.0) for i, shape in enumerate(self.model.shape_source)]
-        self.render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.render_context.device)
-
         num_enabled_shapes = wp.zeros(1, dtype=wp.int32, device=self.render_context.device)
         wp.launch(
             kernel=compute_enabled_shapes,
@@ -231,10 +239,15 @@ class SensorTiledCamera:
                 self.assign_checkerboard_material_to_all_shapes()
             if config.default_light:
                 self.create_default_light(config.default_light_shadows)
-            if config.colors_per_world:
-                self.assign_random_colors_per_world()
-            elif config.colors_per_shape:
-                self.assign_random_colors_per_shape()
+
+        if config is None or config.color_mode == SensorTiledCamera.Config.ColorMode.MODEL_COLOR:
+            self.assign_colors_from_model()
+        elif config.color_mode == SensorTiledCamera.Config.ColorMode.RANDOM_PER_WORLD:
+            self.assign_random_colors_per_world()
+        elif config.color_mode == SensorTiledCamera.Config.ColorMode.RANDOM_PER_SHAPE:
+            self.assign_random_colors_per_shape()
+        elif config.color_mode == SensorTiledCamera.Config.ColorMode.CONSTANT_COLOR:
+            self.assign_constant_color((1.0, 1.0, 1.0, 1.0))
 
     def sync_transforms(self, state: State):
         """Synchronize shape transforms from the simulation state.
@@ -408,6 +421,19 @@ class SensorTiledCamera:
             seed: Random seed.
         """
         self.render_context.utils.assign_random_colors_per_shape(seed)
+
+    def assign_constant_color(self, color: tuple[float, float, float, float]):
+        """Assign a constant to all shapes.
+
+        Args:
+            color: rgba color values.
+        """
+        self.render_context.utils.assign_constant_color(color)
+
+    def assign_colors_from_model(self):
+        """Assign a colors from model."""
+        colors = [(*self.__get_shape_color(i, shape), 1.0) for i, shape in enumerate(self.model.shape_source)]
+        self.render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.render_context.device)
 
     def create_default_light(self, enable_shadows: bool = True):
         """Create a default directional light oriented at ``(-1, 1, -1)``.

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -331,6 +331,13 @@ class Utils:
         colors[:, -1] = 1.0
         self.__render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.__render_context.device)
 
+    def assign_constant_color(self, color: tuple[float, float, float, float]):
+        self.__render_context.shape_colors = wp.array(
+            np.full((self.__render_context.shape_count_total, 4), fill_value=color, dtype=wp.float32),
+            dtype=wp.vec4f,
+            device=self.__render_context.device,
+        )
+
     def create_default_light(self, enable_shadows: bool = True, direction: wp.vec3f | None = None):
         self.__render_context.config.enable_shadows = enable_shadows
         self.__render_context.lights_active = wp.array([True], dtype=wp.bool, device=self.__render_context.device)

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -211,7 +211,7 @@ class Example:
                 default_light_shadows=True,
                 checkerboard_texture=True,
                 backface_culling=True,
-                color_mode=SensorTiledCamera.Config.ColorMode.MODEL_COLOR,
+                color_mode=SensorTiledCamera.Config.ColorMode.VIEWER_COLOR,
             ),
         )
 

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -211,6 +211,7 @@ class Example:
                 default_light_shadows=True,
                 checkerboard_texture=True,
                 backface_culling=True,
+                color_mode=SensorTiledCamera.Config.ColorMode.MODEL_COLOR,
             ),
         )
 

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -111,7 +111,10 @@ class TestSensorTiledCamera(unittest.TestCase):
         tiled_camera_sensor = SensorTiledCamera(
             model=model,
             config=SensorTiledCamera.Config(
-                default_light=True, default_light_shadows=True, colors_per_shape=True, checkerboard_texture=True
+                default_light=True,
+                default_light_shadows=True,
+                color_mode=SensorTiledCamera.Config.ColorMode.RANDOM_PER_SHAPE,
+                checkerboard_texture=True,
             ),
         )
         camera_rays = tiled_camera_sensor.compute_pinhole_camera_rays(width, height, math.radians(45.0))


### PR DESCRIPTION
Added Constant Color mode and changed config to an enum style for the Tiled Camera Sensor's Warp Raytracer.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SensorTiledCamera gains selectable color modes (model-based, constant, random per shape/world, viewer-based).
  * Option to apply a uniform RGBA color across all shapes and to derive colors from model/viewer data.

* **Refactor**
  * Color configuration consolidated into an enumerated mode setting for clearer, more flexible color control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->