### PR TITLE
[SensorTiledCamera] Deprecated colors_per_world and colors_per_shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add box pyramid example and ASV benchmark for dense convex-on-convex contacts
 
 ### Changed
+- Deprecated `SensorTiledCamera.Config.colors_per_world` and `SensorTiledCamera.Config.colors_per_shape`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 
 ### Deprecated
 
-- Deprecated `SensorTiledCamera.Config.colors_per_world` and `SensorTiledCamera.Config.colors_per_shape`
-
+- Deprecate `SensorTiledCamera.Config.colors_per_world` and `SensorTiledCamera.Config.colors_per_shape`; set colors directly on shape objects using `shape.color` instead
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
 - Add box pyramid example and ASV benchmark for dense convex-on-convex contacts
 
 ### Changed
-- Deprecated `SensorTiledCamera.Config.colors_per_world` and `SensorTiledCamera.Config.colors_per_shape`
 
 ### Deprecated
+
+- Deprecated `SensorTiledCamera.Config.colors_per_world` and `SensorTiledCamera.Config.colors_per_shape`
 
 ### Removed
 

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -206,7 +206,8 @@ class SensorTiledCamera:
 
         colors = []
         for shape in self.model.shape_source:
-            if color := getattr(shape, "color", None):
+            color = getattr(shape, "color", None)
+            if color is not None:
                 colors.append((*color, 1.0))
             else:
                 colors.append((1.0, 1.0, 1.0, 1.0))

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -15,9 +15,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
 import warnings
+from dataclasses import dataclass
 
 import numpy as np
 import warp as wp
@@ -405,7 +404,7 @@ class SensorTiledCamera:
         Args:
             seed: Random seed.
         """
-        warnings.warn("assign_random_colors_per_world is deprecated.", category=DeprecationWarning)
+        warnings.warn("assign_random_colors_per_world is deprecated.", category=DeprecationWarning, stacklevel=2)
         self.render_context.utils.assign_random_colors_per_world(seed)
 
     def assign_random_colors_per_shape(self, seed: int = 100):
@@ -414,7 +413,7 @@ class SensorTiledCamera:
         Args:
             seed: Random seed.
         """
-        warnings.warn("assign_random_colors_per_shape is deprecated.", category=DeprecationWarning)
+        warnings.warn("assign_random_colors_per_shape is deprecated.", category=DeprecationWarning, stacklevel=2)
         self.render_context.utils.assign_random_colors_per_shape(seed)
 
     def create_default_light(self, enable_shadows: bool = True):

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+import warnings
 
 import numpy as np
 import warp as wp
@@ -145,10 +146,10 @@ class SensorTiledCamera:
         """Enable shadows for the default light (requires ``default_light``)."""
 
         colors_per_world: bool = False
-        """Assign a random color palette per world."""
+        """DEPRECATED Assign a random color palette per world."""
 
         colors_per_shape: bool = False
-        """Assign a random color per shape (ignored when ``colors_per_world`` is True)."""
+        """DEPRECATED Assign a random color per shape (ignored when ``colors_per_world`` is True)."""
 
         backface_culling: bool = True
         """Cull back-facing triangles."""
@@ -204,7 +205,12 @@ class SensorTiledCamera:
         self.render_context.shape_world_index = self.model.shape_world
         self.render_context.gaussians_data = self.model.gaussians_data
 
-        colors = [(*self.__get_shape_color(i, shape), 1.0) for i, shape in enumerate(self.model.shape_source)]
+        colors = []
+        for shape in self.model.shape_source:
+            if color := getattr(shape, "color", None):
+                colors.append((*color, 1.0))
+            else:
+                colors.append((1.0, 1.0, 1.0, 1.0))
         self.render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.render_context.device)
 
         num_enabled_shapes = wp.zeros(1, dtype=wp.int32, device=self.render_context.device)
@@ -399,6 +405,7 @@ class SensorTiledCamera:
         Args:
             seed: Random seed.
         """
+        warnings.warn("assign_random_colors_per_world is deprecated.", category=DeprecationWarning)
         self.render_context.utils.assign_random_colors_per_world(seed)
 
     def assign_random_colors_per_shape(self, seed: int = 100):
@@ -407,6 +414,7 @@ class SensorTiledCamera:
         Args:
             seed: Random seed.
         """
+        warnings.warn("assign_random_colors_per_shape is deprecated.", category=DeprecationWarning)
         self.render_context.utils.assign_random_colors_per_shape(seed)
 
     def create_default_light(self, enable_shadows: bool = True):
@@ -502,20 +510,3 @@ class SensorTiledCamera:
             Array of shape ``(world_count, camera_count, height, width)``, dtype ``uint32``.
         """
         return self.render_context.create_albedo_image_output(width, height, camera_count)
-
-    def __get_shape_color(self, index: int, shape: Any):
-        SHAPE_COLOR_MAP = [
-            (68 / 255.0, 119 / 255.0, 170 / 255.0),  # blue
-            (102 / 255.0, 204 / 255.0, 238 / 255.0),  # cyan
-            (34 / 255.0, 136 / 255.0, 51 / 255.0),  # green
-            (204 / 255.0, 187 / 255.0, 68 / 255.0),  # yellow
-            (238 / 255.0, 102 / 255.0, 119 / 255.0),  # red
-            (170 / 255.0, 51 / 255.0, 119 / 255.0),  # magenta
-            (187 / 255.0, 187 / 255.0, 187 / 255.0),  # grey
-            (238 / 255.0, 153 / 255.0, 51 / 255.0),  # orange
-            (0 / 255.0, 153 / 255.0, 136 / 255.0),  # teal
-        ]
-
-        if color := getattr(shape, "color", None):
-            return color
-        return SHAPE_COLOR_MAP[index % len(SHAPE_COLOR_MAP)]

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -211,7 +211,7 @@ class Example:
                 default_light_shadows=True,
                 checkerboard_texture=True,
                 backface_culling=True,
-                colors_per_shape=True
+                colors_per_shape=True,
             ),
         )
 

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -211,6 +211,7 @@ class Example:
                 default_light_shadows=True,
                 checkerboard_texture=True,
                 backface_culling=True,
+                colors_per_shape=True
             ),
         )
 


### PR DESCRIPTION
## Description

Deprecated `colors_per_world` and `colors_per_shape` in `SensorTiledCamera`.
The examples and tests still use it for now - will remove it there once we have colors in the model themselves, otherwise we will lose all color from the example :)


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-shape color rendering for the tiled camera sensor (configurable).

* **Deprecations**
  * Two color configuration options are deprecated and now emit warnings when used; set colors directly on shapes instead.

* **Bug Fixes**
  * Color assignment now uses each shape's specified color or defaults to white when unspecified, ensuring consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->