### PR TITLE
Add enable_backward option in all benchmark files

### DIFF
--- a/asv/benchmarks/compilation/bench_example_load.py
+++ b/asv/benchmarks/compilation/bench_example_load.py
@@ -18,6 +18,7 @@ import sys
 
 import warp as wp
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 from asv_runner.benchmarks.mark import skip_benchmark_if

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -16,6 +16,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 import newton

--- a/asv/benchmarks/simulation/bench_cloth.py
+++ b/asv/benchmarks/simulation/bench_cloth.py
@@ -16,6 +16,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 import newton.examples

--- a/asv/benchmarks/simulation/bench_contacts.py
+++ b/asv/benchmarks/simulation/bench_contacts.py
@@ -16,6 +16,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 import importlib

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -16,6 +16,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 import newton

--- a/asv/benchmarks/simulation/bench_selection.py
+++ b/asv/benchmarks/simulation/bench_selection.py
@@ -16,8 +16,8 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
-
 
 import newton
 import newton.examples

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -16,6 +16,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
+wp.config.enable_backward = False
 wp.config.quiet = True
 
 import math


### PR DESCRIPTION
## Description
Added  `wp.config.enable_backward = False` to all benchmark files that not already had it.
Results is faster time to run the benchmark suite without affecting benchmark reported time.
To test the change, I deleted the `.cache/warp` and timed the asv command in the main branch and this branch:

Fast benchmark suite on my RTX 4080:
9m41.197s  => 8m20.842s
~80s faster

Full benchmark suite on my RTX 4080:
38m27.773s  => 37m36.665s
~50s faster

Fast benchmark suite on L40:
20m22.528s  => 18m4.540s
~140s faster

Full benchmark suite on L40:
83m38.449s => 81m14.186s
~140s faster

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configurations across simulation and compilation test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->