### PR TITLE
Add Per-Axis Gizmo Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add brick stacking example
 - Add box pyramid example and ASV benchmark for dense convex-on-convex contacts
 - Expose `gizmo_is_using` attribute to detect whether a gizmo is actively being dragged
+- Add per-axis gizmo filtering via `translate`/`rotate` parameters on `log_gizmo`
 
 ### Changed
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 import sys
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -26,7 +27,7 @@ import warp as wp
 import newton
 from newton.utils import compute_world_offsets, solidify_mesh
 
-from ..core.types import MAXVAL, nparray
+from ..core.types import MAXVAL, Axis, nparray
 from .kernels import compute_hydro_contact_surface_lines, estimate_world_extents
 
 
@@ -834,13 +835,20 @@ class ViewerBase(ABC):
         self,
         name: str,
         transform: wp.transform,
+        translate: Sequence[Axis] | None = None,
+        rotate: Sequence[Axis] | None = None,
     ):
-        """
-        Log a gizmo GUI element for the given name and transform.
+        """Log a gizmo GUI element for the given name and transform.
 
         Args:
             name: The name of the gizmo.
             transform: The transform of the gizmo.
+            translate: Axes on which the translation handles are shown.
+                Defaults to all axes when ``None``. Pass an empty sequence
+                to hide all translation handles.
+            rotate: Axes on which the rotation rings are shown.
+                Defaults to all axes when ``None``. Pass an empty sequence
+                to hide all rotation rings.
         """
         return
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import ctypes
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from importlib import metadata
 from typing import Any, Literal
 
@@ -28,7 +28,7 @@ import warp as wp
 import newton as nt
 from newton.selection import ArticulationView
 
-from ..core.types import nparray, override
+from ..core.types import Axis, nparray, override
 from ..utils.render import copy_rgb_frame_uint8
 from .camera import Camera
 from .gl.gui import UI
@@ -353,15 +353,20 @@ class ViewerGL(ViewerBase):
         self,
         name: str,
         transform: wp.transform,
+        translate: Sequence[Axis] | None = None,
+        rotate: Sequence[Axis] | None = None,
     ):
         """Log or update a transform gizmo for the current frame.
 
         Args:
             name: Unique gizmo path/name.
             transform: Gizmo world transform.
+            translate: Axes on which the translation handles are shown.
+            rotate: Axes on which the rotation rings are shown.
         """
-        # Store for this frame; call this every frame you want it drawn/active
-        self._gizmo_log[name] = transform
+        t = (Axis.X, Axis.Y, Axis.Z) if translate is None else tuple(set(translate))
+        r = (Axis.X, Axis.Y, Axis.Z) if rotate is None else tuple(set(rotate))
+        self._gizmo_log[name] = (transform, t, r)
 
     @override
     def clear_model(self):
@@ -1715,23 +1720,49 @@ class ViewerGL(ViewerBase):
         view = self.camera.get_view_matrix().reshape(4, 4).transpose()
         proj = self.camera.get_projection_matrix().reshape(4, 4).transpose()
 
+        def m44_to_mat16(m):
+            """Row-major 4x4 -> giz.Matrix16 (column-major, 16 floats)."""
+            m = np.asarray(m, dtype=np.float32).reshape(4, 4)
+            return giz.Matrix16(m.flatten(order="F").tolist())
+
+        view_ = m44_to_mat16(view)
+        proj_ = m44_to_mat16(proj)
+
+        axis_translate = {
+            Axis.X: giz.OPERATION.translate_x,
+            Axis.Y: giz.OPERATION.translate_y,
+            Axis.Z: giz.OPERATION.translate_z,
+        }
+        axis_rotate = {
+            Axis.X: giz.OPERATION.rotate_x,
+            Axis.Y: giz.OPERATION.rotate_y,
+            Axis.Z: giz.OPERATION.rotate_z,
+        }
+
         # Draw & mutate each gizmo
-        for gid, transform in self._gizmo_log.items():
+        for gid, (transform, translate, rotate) in self._gizmo_log.items():
+            # Use compound ops when all axes are active (includes plane handles).
+            if len(translate) == 3:
+                t_ops = (giz.OPERATION.translate,)
+            else:
+                t_ops = tuple(axis_translate[a] for a in translate if a in axis_translate)
+
+            if len(rotate) == 3:
+                r_ops = (giz.OPERATION.rotate,)
+            else:
+                r_ops = tuple(axis_rotate[a] for a in rotate if a in axis_rotate)
+
+            ops = t_ops + r_ops
+            if not ops:
+                continue
+
             giz.push_id(str(gid))
 
             M = wp.transform_to_matrix(transform)
-
-            def m44_to_mat16(m):
-                """Row-major 4x4 -> giz.Matrix16 (column-major, 16 floats)."""
-                m = np.asarray(m, dtype=np.float32).reshape(4, 4)
-                return giz.Matrix16(m.flatten(order="F").tolist())
-
-            view_ = m44_to_mat16(view)
-            proj_ = m44_to_mat16(proj)
             M_ = m44_to_mat16(M)
 
-            giz.manipulate(view_, proj_, giz.OPERATION.rotate, giz.MODE.world, M_, None, None)
-            giz.manipulate(view_, proj_, giz.OPERATION.translate, giz.MODE.world, M_, None, None)
+            for op in ops:
+                giz.manipulate(view_, proj_, op, giz.MODE.world, M_, None, None)
 
             M[:] = M_.values.reshape(4, 4, order="F")
             transform[:] = wp.transform_from_matrix(M)


### PR DESCRIPTION
## Description

The API `log_gizmo()` should support specifying what components to display, e.g.: only the translate components if we don't need rotation, or only the Y-axis rotate component, etc.

Closes #2120.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed gizmo usage state to detect when a gizmo is actively being manipulated
  * Added per-axis filtering for gizmo operations, enabling selective control over translation and rotation axes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->