### PR TITLE
Add dependency resolution test to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,6 @@ on:
 
 jobs:
   minimal-import-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        # Test boundary versions: 3.10 (oldest, needs fallback), 3.12 (typing.override added), 3.14 (latest)
-        python-version: ["3.10", "3.12", "3.14"]
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -30,13 +25,20 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - name: Install uv and set the Python version
+      - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867  # v7.1.6
         with:
           version: "0.9.0"
-          python-version: ${{ matrix.python-version }}
-      - name: Test minimal import
-        run: uv run python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+      - name: Test minimal import (Python 3.10)
+        run: uv run --python 3.10 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+      - name: Test minimal import (Python 3.11)
+        run: uv run --python 3.11 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+      - name: Test minimal import (Python 3.12)
+        run: uv run --python 3.12 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+      - name: Test minimal import (Python 3.13)
+        run: uv run --python 3.13 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
+      - name: Test minimal import (Python 3.14)
+        run: uv run --python 3.14 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
 
   dependency-install-test:
     needs: minimal-import-test


### PR DESCRIPTION
## Description

Add a `dependency-install-test` job to CI that verifies `uv sync --extra dev` resolves correctly on all supported Python versions (3.10-3.13) across all 4 OS targets (ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest). This catches dependency version conflicts early — e.g., a package missing wheels for a supported Python version.

Also restructures CI into sequential stages to minimize runner concurrency:
1. `minimal-import-test` (1 runner) — consolidated from 3-runner matrix, now tests 3.10-3.14 sequentially on a single runner
2. `dependency-install-test` (4 runners) — new, one per OS, uses `uv sync --dry-run` for fast resolution-only checks
3. `newton-unittests` (4 runners) — unchanged, now gated on dependency resolution passing

Peak concurrent runners reduced from ~11 to 4.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Triggered the workflow via `workflow_dispatch` on a fork across multiple iterations:
- Verified minimal-import-test passes all 5 Python versions (3.10-3.14) on a single runner
- Verified dependency-install-test catches real issues (detected `open3d` missing wheels for Python 3.13 before #2070 was merged)
- Verified `needs:` chaining correctly gates unit tests on dependency resolution
- Verified `--dry-run` keeps job runtime under 40s per OS

```
gh workflow run ci.yml --ref shi-eric/ci-dependency-install-test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated testing across Python versions 3.10–3.14 and multiple operating systems (Linux, Windows, macOS) with enhanced environment validation and comprehensive dependency resolution checks to improve overall project reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->