### PR TITLE
Update .gitattributes to use union merge strategy for CHANGELOG.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.jpg !text !filter !merge !diff
+CHANGELOG.md merge=union


### PR DESCRIPTION
Use `merge=union` strategy to hopefully prevent the merge conflicts we are seeing regarding the changelog. Although I'm not sure if GitHub will actually respect this merge rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for changelog merge handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->