### PR TITLE
Fix GL viewer color editing with newer imgui_bundle

### DIFF
--- a/newton/_src/viewer/gl/imgui_compat.py
+++ b/newton/_src/viewer/gl/imgui_compat.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility helpers for imgui_bundle API drift."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _color_components(color: Any) -> tuple[float, float, float, float]:
+    """Normalize RGB/RGBA tuple-like or ImVec-like values to four floats."""
+    if all(hasattr(color, attr) for attr in ("x", "y", "z")):
+        return (
+            float(color.x),
+            float(color.y),
+            float(color.z),
+            float(getattr(color, "w", 1.0)),
+        )
+
+    try:
+        values = tuple(color)
+    except TypeError as exc:
+        raise TypeError(f"Unsupported color value {color!r}") from exc
+
+    if len(values) == 3:
+        return (float(values[0]), float(values[1]), float(values[2]), 1.0)
+    if len(values) == 4:
+        return (float(values[0]), float(values[1]), float(values[2]), float(values[3]))
+    raise ValueError(f"Expected 3 or 4 color components, got {len(values)} from {color!r}")
+
+
+def to_imgui_color4(imgui: Any, color: Any):
+    """Build an ``ImVec4`` from a tuple-like or ImVec-like color."""
+    return imgui.ImVec4(*_color_components(color))
+
+
+def to_rgb_tuple(color: Any) -> tuple[float, float, float]:
+    """Convert an imgui color or tuple-like value back to an RGB tuple."""
+    r, g, b, _a = _color_components(color)
+    return (r, g, b)
+
+
+def color_edit3_tuple(imgui: Any, label: str, color: Any, *, flags: int = 0) -> tuple[bool, tuple[float, float, float]]:
+    """Run ``color_edit3`` while storing renderer colors as plain RGB tuples."""
+    changed, edited = imgui.color_edit3(label, to_imgui_color4(imgui, color), flags)
+    return changed, to_rgb_tuple(edited)

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -30,6 +30,7 @@ from ..core.types import nparray, override
 from ..utils.render import copy_rgb_frame_uint8
 from .camera import Camera
 from .gl.gui import UI
+from .gl.imgui_compat import color_edit3_tuple
 from .gl.opengl import LinesGL, MeshGL, MeshInstancerGL, RendererGL
 from .picking import Picking
 from .viewer import ViewerBase
@@ -1692,11 +1693,13 @@ class ViewerGL(ViewerBase):
                 changed, self.renderer.draw_wireframe = imgui.checkbox("Wireframe", self.renderer.draw_wireframe)
 
                 # Light color
-                changed, self.renderer._light_color = imgui.color_edit3("Light Color", self.renderer._light_color)
+                changed, self.renderer._light_color = color_edit3_tuple(
+                    imgui, "Light Color", self.renderer._light_color
+                )
                 # Sky color
-                changed, self.renderer.sky_upper = imgui.color_edit3("Sky Color", self.renderer.sky_upper)
+                changed, self.renderer.sky_upper = color_edit3_tuple(imgui, "Sky Color", self.renderer.sky_upper)
                 # Ground color
-                changed, self.renderer.sky_lower = imgui.color_edit3("Ground Color", self.renderer.sky_lower)
+                changed, self.renderer.sky_lower = color_edit3_tuple(imgui, "Ground Color", self.renderer.sky_lower)
 
             # Wind Effects section
             if self.wind is not None:

--- a/newton/tests/test_imgui_compat.py
+++ b/newton/tests/test_imgui_compat.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from newton._src.viewer.gl.imgui_compat import color_edit3_tuple, to_imgui_color4, to_rgb_tuple
+
+
+class _FakeImVec4:
+    def __init__(self, x: float, y: float, z: float, w: float):
+        self.x = x
+        self.y = y
+        self.z = z
+        self.w = w
+
+
+class _FakeImgui:
+    ImVec4 = _FakeImVec4
+
+    def __init__(self):
+        self.last_color = None
+
+    def color_edit3(self, label, color, flags=0):
+        self.last_color = color
+        return True, self.ImVec4(color.x * 0.5, color.y * 0.5, color.z * 0.5, color.w)
+
+
+class TestImguiCompat(unittest.TestCase):
+    def test_to_imgui_color4_accepts_rgb_tuple(self):
+        imgui = _FakeImgui()
+        color = to_imgui_color4(imgui, (0.1, 0.2, 0.3))
+        self.assertIsInstance(color, _FakeImVec4)
+        self.assertEqual((color.x, color.y, color.z, color.w), (0.1, 0.2, 0.3, 1.0))
+
+    def test_to_rgb_tuple_accepts_imvec4_like(self):
+        color = _FakeImVec4(0.4, 0.5, 0.6, 1.0)
+        self.assertEqual(to_rgb_tuple(color), (0.4, 0.5, 0.6))
+
+    def test_color_edit3_tuple_round_trips_to_rgb_tuple(self):
+        imgui = _FakeImgui()
+        changed, color = color_edit3_tuple(imgui, "Light Color", (1.0, 0.8, 0.6))
+        self.assertTrue(changed)
+        self.assertIsInstance(imgui.last_color, _FakeImVec4)
+        self.assertEqual(color, (0.5, 0.4, 0.3))
+
+    def test_invalid_color_arity_raises(self):
+        imgui = _FakeImgui()
+        with self.assertRaises(ValueError):
+            to_imgui_color4(imgui, (0.1, 0.2))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- make the GL viewer pass explicit `ImVec4` values into `imgui.color_edit3()`
- keep renderer colors stored as plain RGB tuples after editing
- add a small compatibility helper and regression test for tuple-like and ImVec-like color values

## Reproduction
This was reproduced on current `main` (`17b024335aa1dc0d5939c9950edcab28ce9f07e3`) in a local GUI environment with:
- `imgui_bundle 1.92.600`
- `pyglet 2.x`

Before this patch, opening a `ViewerGL` window and reaching the first left-panel UI render loop crashed with:

```text
TypeError: color_edit3(): incompatible function arguments.
```

The failing call path was in `ViewerGL._render_left_panel()` when tuple-backed renderer colors were passed directly into `imgui.color_edit3()`.

## Why now
The viewer code was relying on older `imgui_bundle` binding behavior that accepted raw Python tuples. The current nanobind API expects an `ImVec4`-style object instead. Newton's dependency spec allows newer `imgui_bundle` versions, so this surfaced as environments drifted forward.

## Validation
- `python3 -m pytest newton/tests/test_imgui_compat.py -q` -> `4 passed`
- reran the same `ViewerGL` path after the fix; the viewer now stays up past startup and into the live render loop instead of failing in `color_edit3()`