### PR TITLE
docs(sim): document solver-specific kd damping conventions

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -419,8 +419,8 @@ class ModelBuilder:
             """The damping stiffness of the joint axis limits. Defaults to 1e1.
 
             **Warning:** The interpretation of this value varies by solver. With VBD,
-            the effective damping is `limit_kd × limit_ke`, which can be excessively
-            stiff with the default values (1e1 × 1e4 = 1e5). Consider using lower
+            the effective damping is `limit_kd * limit_ke`, which can be excessively
+            stiff with the default values (1e1 * 1e4 = 1e5). Consider using lower
             values for VBD (e.g., 0.1-1.0). See :attr:`Model.joint_limit_kd` for
             solver-specific semantics."""
             self.target_pos = target_pos

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -467,7 +467,7 @@ class Model:
         """Joint damping for target tracking. **Note:** Interpretation varies by solver:
 
         - **MuJoCo/SemiImplicit/Featherstone:** Absolute damping [N·s/m or N·m·s/rad]
-        - **VBD:** Dimensionless Rayleigh coefficient (effective damping = kd × ke)
+        - **VBD:** Dimensionless Rayleigh coefficient (effective damping = kd * ke)
         - **XPBD:** Raw damping, internally normalized by ke (gamma = kd / ke)
 
         Shape [joint_dof_count], float. See solver documentation for details."""
@@ -491,7 +491,7 @@ class Model:
         """Joint position limit damping. **Note:** Interpretation varies by solver:
 
         - **MuJoCo/SemiImplicit/Featherstone:** Absolute damping [N·s/m or N·m·s/rad]
-        - **VBD:** Dimensionless Rayleigh coefficient (effective damping = kd × ke)
+        - **VBD:** Dimensionless Rayleigh coefficient (effective damping = kd * ke)
         - **XPBD:** Raw damping, internally normalized by ke (gamma = kd / ke)
 
         Shape [joint_dof_count], float. See solver documentation for details."""


### PR DESCRIPTION
Fixes #2119

## Summary

The three solvers (VBD, XPBD, MuJoCo) interpret `joint_target_kd` and `joint_limit_kd` differently, but the model-level docstrings only documented one convention (absolute damping units).

## Changes

### model.py
- Updated `joint_target_kd` docstring to document:
  - **MuJoCo/SemiImplicit/Featherstone:** Absolute damping [N·s/m or N·m·s/rad]
  - **VBD:** Dimensionless Rayleigh coefficient (effective damping = kd × ke)
  - **XPBD:** Raw damping, internally normalized by ke (gamma = kd / ke)

- Updated `joint_limit_kd` docstring similarly

### builder.py
- Added warning in `JointAxis.limit_kd` about VBD's Rayleigh convention causing excessive stiffness with default values:
  - Default: limit_kd=1e1, limit_ke=1e4
  - VBD effective damping: 1e1 × 1e4 = 1e5
  - Recommendation: Use lower values for VBD (0.1-1.0)

## Impact

This is a documentation-only change. It addresses the cross-solver inconsistency concern raised in #2119, making the API more transparent for users switching between solvers.

## Testing

- Python syntax verified
- Documentation rendered correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded damping parameter documentation to describe solver-specific interpretations (absolute damping, dimensionless coefficients, and solver-normalized forms).
  * Clarified how joint target and joint limit damping are interpreted across different solvers (including notable differences).
  * Added guidance to consult solver docs when configuring damping values for expected runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->