### PR TITLE
Use ubuntu-slim runner for license check workflow

### DIFF
--- a/.github/workflows/pr_license_check.yml
+++ b/.github/workflows/pr_license_check.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   check-licenses:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1


### PR DESCRIPTION
## Description

Switch the license check workflow from `ubuntu-latest` to `ubuntu-slim`. This job only runs grep/bash to check license headers, so it doesn't need the full runner image. The slim runner provisions faster.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Verified by triggering `workflow_dispatch` on the fork — the `ubuntu-slim` runner provisions successfully and all steps complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration infrastructure configuration for improved build efficiency while maintaining all security and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->