### PR TITLE
Fix Normal Flip in GL Fragment Shader (#2143)

### DIFF
--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -336,10 +336,8 @@ void main()
     // surface vectors
     vec3 N = normalize(Normal);
     vec3 V = normalize(view_pos - FragPos);
-    // Ensure normal faces the viewer regardless of winding order
-    if (dot(N, V) < 0.0) {
-        N = -N;
-    }
+    // Flip normal for backfacing triangles
+    if (!gl_FrontFacing) N = -N;
     vec3 L = normalize(sun_direction);
     vec3 H = normalize(V + L);
 


### PR DESCRIPTION
## Description

Silouhette rendering artifacts (see https://github.com/newton-physics/newton/issues/2143) are now addressed:

<img width="970" height="731" alt="Screenshot from 2026-03-19 08-53-31" src="https://github.com/user-attachments/assets/2a927bb1-d894-4636-8e35-26b23a46e138" />


Closes #2143.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rendering of back-facing surfaces with more robust shading calculations, reducing visual artifacts and enhancing overall display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->