### PR TITLE
ci: symlink .local and .cache to NVMe on EC2 runners

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -83,6 +83,15 @@ jobs:
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
             ]
+          pre-runner-script: |
+            if [ -d /opt/dlami/nvme ]; then
+              mkdir -p /opt/dlami/nvme/actions-runner/_work
+              mkdir -p /opt/dlami/nvme/actions-runner/.local
+              mkdir -p /opt/dlami/nvme/actions-runner/.cache
+              ln -s /opt/dlami/nvme/actions-runner/_work /actions-runner/_work
+              ln -s /opt/dlami/nvme/actions-runner/.local /actions-runner/.local
+              ln -s /opt/dlami/nvme/actions-runner/.cache /actions-runner/.cache
+            fi
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -97,7 +97,11 @@ jobs:
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
+              mkdir -p /opt/dlami/nvme/actions-runner/.local
+              mkdir -p /opt/dlami/nvme/actions-runner/.cache
               ln -s /opt/dlami/nvme/actions-runner/_work /actions-runner/_work
+              ln -s /opt/dlami/nvme/actions-runner/.local /actions-runner/.local
+              ln -s /opt/dlami/nvme/actions-runner/.cache /actions-runner/.cache
             fi
           aws-resource-tags: >
             [

--- a/.github/workflows/scheduled_nightly_mujoco_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_mujoco_warp_tests.yml
@@ -72,6 +72,15 @@ jobs:
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
             ]
+          pre-runner-script: |
+            if [ -d /opt/dlami/nvme ]; then
+              mkdir -p /opt/dlami/nvme/actions-runner/_work
+              mkdir -p /opt/dlami/nvme/actions-runner/.local
+              mkdir -p /opt/dlami/nvme/actions-runner/.cache
+              ln -s /opt/dlami/nvme/actions-runner/_work /actions-runner/_work
+              ln -s /opt/dlami/nvme/actions-runner/.local /actions-runner/.local
+              ln -s /opt/dlami/nvme/actions-runner/.cache /actions-runner/.cache
+            fi
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
@@ -112,8 +121,15 @@ jobs:
       - name: Print mujoco-warp version info
         run: uv run --no-sync python -c "import mujoco_warp; print('mujoco_warp version:', getattr(mujoco_warp, '__version__', 'unknown'))"
 
+      - name: Check disk space
+        run: df -h
+
       - name: Run Tests
         run: uv run --no-sync -m newton.tests --junit-report-xml rspec.xml
+
+      - name: Check disk space (post-test)
+        if: always()
+        run: df -h
 
       - name: Test Summary
         if: ${{ !cancelled() }}

--- a/.github/workflows/scheduled_nightly_warp_tests.yml
+++ b/.github/workflows/scheduled_nightly_warp_tests.yml
@@ -114,6 +114,15 @@ jobs:
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
               {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
             ]
+          pre-runner-script: |
+            if [ -d /opt/dlami/nvme ]; then
+              mkdir -p /opt/dlami/nvme/actions-runner/_work
+              mkdir -p /opt/dlami/nvme/actions-runner/.local
+              mkdir -p /opt/dlami/nvme/actions-runner/.cache
+              ln -s /opt/dlami/nvme/actions-runner/_work /actions-runner/_work
+              ln -s /opt/dlami/nvme/actions-runner/.local /actions-runner/.local
+              ln -s /opt/dlami/nvme/actions-runner/.cache /actions-runner/.cache
+            fi
           aws-resource-tags: >
             [
               {"Key": "Name", "Value": "ec2-github-runner"},
@@ -149,8 +158,15 @@ jobs:
       - name: Update lock file with latest warp-lang nightly build
         run: uv lock -P warp-lang --prerelease allow
 
+      - name: Check disk space
+        run: df -h
+
       - name: Run Tests
         run: uv run --extra dev --extra torch-cu13 -m newton.tests --junit-report-xml rspec.xml
+
+      - name: Check disk space (post-test)
+        if: always()
+        run: df -h
 
       - name: Test Summary
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Description

Extend the `pre-runner-script` for all `ec2-github-runner` workflows to symlink `/actions-runner/.local` and `/actions-runner/.cache` to the instance NVMe storage (`/opt/dlami/nvme`), in addition to the existing `_work` symlink.

This moves uv/Python installs (`.local`) and the Warp kernel cache (`.cache`) onto the fast 1.7 TB NVMe drive instead of the smaller 92 GB gp3 EBS root volume. On a test run this shifted ~1.8 GB of additional I/O to NVMe (8.9 GB total vs 7.1 GB before) and reduced root volume usage from 29 GB to 21 GB.

Also adds consistent disk space reporting (`df -h` before and after tests) to the two nightly workflows that were missing it.

**Workflows updated:**
- `aws_gpu_tests.yml` — extended existing pre-runner-script with `.local` and `.cache` symlinks
- `aws_gpu_benchmarks.yml` — added full pre-runner-script
- `scheduled_nightly_mujoco_warp_tests.yml` — added full pre-runner-script + disk space reporting
- `scheduled_nightly_warp_tests.yml` — added full pre-runner-script + disk space reporting

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

> CI-only change — no user-facing code, docs, or changelog impact. Verified by triggering workflows on fork.

## Test plan

Manually triggered `aws_gpu_tests.yml` and `scheduled_nightly_mujoco_warp_tests.yml` via `workflow_dispatch` on fork (`shi-eric/newton`). Confirmed:

- NVMe symlinks are created correctly (all file paths resolve through `/opt/dlami/nvme/actions-runner/...`)
- Warp kernel cache lands on NVMe: `/opt/dlami/nvme/actions-runner/.cache/warp/1.12.0`
- NVMe usage increased from 7.1 GB → 8.9 GB (`.local` + `.cache` now on NVMe)
- Root EBS usage decreased from 29 GB → 21 GB
- GPU unit tests pass ✅
- The `if [ -d /opt/dlami/nvme ]` guard ensures no-op on instances without NVMe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure performance by configuring runners to leverage NVMe-backed storage for working directories and cache during test execution.
  * Added disk space monitoring to test workflows with diagnostics checks before test runs and post-completion to track resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->