### PR TITLE
ci: cache Warp kernels with actions/cache

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -132,11 +132,20 @@ jobs:
       - name: Set up Python
         run: uv python install
 
+      - name: Restore Warp kernel cache
+        if: github.event_name != 'merge_group'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+        with:
+          path: /actions-runner/.cache/warp
+          key: warp-kernels-gpu-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          restore-keys: |
+            warp-kernels-gpu-
+
       - name: Check disk space
         run: df -h
 
       - name: Run Tests
-        run: uv run --extra dev --extra torch-cu13 -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
+        run: uv run --extra dev --extra torch-cu13 -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
       - name: Check disk space (post-test)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,19 @@ jobs:
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
           python-version-file: ".python-version"
+      - name: Restore Warp kernel cache
+        if: github.event_name != 'merge_group'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
+        with:
+          path: |
+            ~/.cache/warp
+            ~/Library/Caches/warp
+            ~\AppData\Local\NVIDIA\warp\Cache
+          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          restore-keys: |
+            warp-kernels-${{ runner.os }}-${{ runner.arch }}-
       - name: Run Tests
-        run: uv run --extra dev -m newton.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
+        run: uv run --extra dev -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
         with:


### PR DESCRIPTION
## Description

Cache compiled Warp kernels across CI runs using `actions/cache`, reducing wall-clock test times by 7-30% depending on platform.

Warp JIT-compiles GPU/CPU kernels on first use and stores them in a content-addressed cache (`~/.cache/warp/{version}/`). Each compiled module is stored in a directory named by its SHA-256 hash (derived from kernel source, function call graph, config options, and build mode). This means changed code always produces a new hash and compiles fresh, while unchanged kernels are loaded from cache in <1ms.

Currently, every CI run clears the kernel cache and recompiles all ~300-500 modules from scratch. This PR persists the cache between runs, eliminating redundant recompilation of unchanged kernels.

**Changes:**
- **`aws_gpu_tests.yml`**: Add `actions/cache` for `/actions-runner/.cache/warp`, pass `--no-cache-clear` to test runner
- **`ci.yml`**: Add `actions/cache` for Warp cache paths across all platforms (Linux, macOS, Windows), pass `--no-cache-clear` to test runner

**Key design decisions:**
- **Cache key**: `warp-kernels-{os}-{arch}-{hash(uv.lock, newton/**/*.py)}` with `restore-keys` prefix fallback. The exact key captures dependency versions + all Python source. On typical PRs the exact key misses (some `.py` changed) but `restore-keys` matches the most recent cache — Warp's internal hashing handles the rest, loading unchanged kernels from cache and compiling only changed ones.
- **Merge queue exclusion**: Cache is skipped for `merge_group` events (`if: github.event_name != 'merge_group'`) so the merge queue always gets a clean build for correctness. PR and push events use the cache for fast feedback.
- **`--no-cache-clear`**: The test runner clears the Warp kernel cache by default. This flag preserves the restored cache. Without a restored cache (e.g., merge queue), the flag is harmless (nothing to clear).
- **Separate cache for GPU vs CPU**: GPU tests use a `warp-kernels-gpu-` prefix (compiles both CPU and CUDA kernels), CPU tests use `warp-kernels-{OS}-{arch}-` per platform.
- **No benchmark caching**: Benchmarks (`aws_gpu_benchmarks.yml`) are not cached — the benefit was marginal (15%) and benchmarks run less frequently.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

> CI-only change — no user-facing code, docs, or changelog impact.

## Test plan

Tested on `shi-eric/newton` fork by triggering each workflow twice via `workflow_dispatch` — first run to populate the cache (cold), second run to measure speedup (warm).

**Results:**

| Platform | Cold | Warm | Saved |
|---|---|---|---|
| EC2 GPU (g7e.2xlarge) | 22m17s | 17m55s | **4m22s (20%)** |
| ubuntu-latest | 27m03s | 18m48s | **8m15s (30%)** |
| windows-latest | 24m21s | 20m08s | **4m13s (17%)** |
| ubuntu-24.04-arm | 18m56s | 17m41s | **1m15s (7%)** |
| macos-latest | 17m50s | 13m49s | **4m01s (22%)** |

Wall-clock savings vary by platform because test parallelism partially masks compilation time. The biggest win is on ubuntu-latest where the 2-core runner has less parallelism to hide the compilation overhead.

Also verified `merge_group` conditional via debug step — `github.event_name` correctly evaluated on all 4 CPU platforms, confirming the cache will be skipped in the merge queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline to improve test execution efficiency through enhanced caching mechanisms for build artifacts across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->