### PR TITLE
Update AGENTS.md: clarify test framework, fix wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
-# Newton Guidelines
+# Newton Development Guidelines
 
 - `newton/_src/` is internal. Examples and docs must not import from `newton._src`. Expose user-facing symbols via public modules (`newton/geometry.py`, `newton/solvers.py`, etc.).
 - Breaking changes require a deprecation first. Do not remove or rename public API symbols without deprecating them in a prior release.
 - Prefix-first naming for autocomplete: `ActuatorPD` (not `PDActuator`), `add_shape_sphere()` (not `add_sphere_shape()`).
 - Prefer nested classes for self-contained helper types/enums.
 - PEP 604 unions (`x | None`, not `Optional[x]`). Annotate Warp arrays with concrete dtypes (`wp.array(dtype=wp.vec3)`).
-- Google-style docstrings. Types in annotations, not docstrings. `Args:` use `name: description`.
+- Follow Google-style docstrings. Types in annotations, not docstrings. `Args:` use `name: description`.
   - Sphinx cross-refs (`:class:`, `:meth:`) with shortest possible targets. Prefer public API paths; never use `newton._src`.
   - SI units for physical quantities in public API docstrings: `"""Particle positions [m], shape [particle_count, 3]."""`. Joint-dependent: `[m or rad]`. Spatial vectors: `[N, N·m]`. Compound arrays: per-component. Skip non-physical fields.
 - Run `docs/generate_api.py` when adding public API symbols.
@@ -24,6 +24,9 @@ uv sync --extra examples
 uv run -m newton.examples basic_pendulum
 
 # Tests
+
+Always use `unittest`, not pytest.
+
 uv run --extra dev -m newton.tests
 uv run --extra dev -m newton.tests -k test_viewer_log_shapes           # specific test
 uv run --extra dev -m newton.tests -k test_basic.example_basic_shapes  # example test
@@ -44,4 +47,4 @@ uvx --with virtualenv asv run --launch-method spawn main^!
 - Follow the `Example` class format.
   - Implement `test_final()` — runs after the example completes to verify simulation state is valid.
   - Optionally implement `test_post_step()` — runs after every `step()` for per-step validation.
-- Register in `README.md` with uv command and a 320x320 jpg screenshot.
+- Register in `README.md` with `python -m newton.examples <name>` command and a 320x320 jpg screenshot.


### PR DESCRIPTION
## Description

Minor improvements to AGENTS.md:

- Add explicit "always use `unittest`, not pytest" guidance under the Tests section
- Improve wording: more descriptive title, consistent docstring bullet phrasing
- Specify `python -m newton.examples <name>` command for example registration in README

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

N/A — docs-only change, no user-facing behavior modified.

## Test plan

Documentation-only change; no tests needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated top-level documentation title to "Newton Development Guidelines".
  * Reworded guidance to "Follow Google-style docstrings" for clarity while keeping typing/Args conventions.
  * Changed recommended testing command to use unittest instead of pytest.
  * Revised example registration command to use "python -m newton.examples <name>".
  * Confirmed requirement for a 320×320 JPG screenshot in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->