### PR TITLE
api: export ViewerBase from newton.viewer

### DIFF
--- a/docs/api/newton_viewer.rst
+++ b/docs/api/newton_viewer.rst
@@ -12,6 +12,7 @@ newton.viewer
    :toctree: _generated
    :nosignatures:
 
+   ViewerBase
    ViewerFile
    ViewerGL
    ViewerNull

--- a/newton/_src/viewer/__init__.py
+++ b/newton/_src/viewer/__init__.py
@@ -26,6 +26,7 @@ Example usage:
     ```
 """
 
+from .viewer import ViewerBase
 from .viewer_file import ViewerFile
 from .viewer_gl import ViewerGL
 from .viewer_null import ViewerNull
@@ -34,6 +35,7 @@ from .viewer_usd import ViewerUSD
 from .viewer_viser import ViewerViser
 
 __all__ = [
+    "ViewerBase",
     "ViewerFile",
     "ViewerGL",
     "ViewerNull",

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -612,7 +612,7 @@ class ViewerBase(ABC):
             materials: wp.array(dtype=wp.vec4) or None (broadcasted if length 1)
             geo_thickness: Optional thickness used for hashing and solidification.
             geo_is_solid: If False, use shell-thickening for mesh-based geometry.
-            geo_src: Source geometry to use only when :paramref:`geo_type` is
+            geo_src: Source geometry to use only when ``geo_type`` is
                 :attr:`newton.GeoType.MESH`.
             hidden: If True, the shape will not be rendered
         """
@@ -697,7 +697,7 @@ class ViewerBase(ABC):
             geo_is_solid: Whether to render mesh geometry as a solid.
             geo_src: Source :class:`newton.Mesh` or
                 :class:`newton.Heightfield` data when required
-                by :paramref:`geo_type`.
+                by ``geo_type``.
             hidden: Whether the created mesh should be hidden.
         """
 

--- a/newton/viewer.py
+++ b/newton/viewer.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
-from ._src.viewer import ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
+from ._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
 
 __all__ = [
+    "ViewerBase",
     "ViewerFile",
     "ViewerGL",
     "ViewerNull",


### PR DESCRIPTION
## Summary

Export `ViewerBase` from `newton.viewer` as a public API symbol.

## Motivation

`ViewerBase` is the abstract base class for all 6 viewer backends and defines the common interface (`set_model`, `begin_frame`, `log_state`, `end_frame`, `is_running`, `is_paused`, `log_contacts`, `log_lines`, `log_points`, `log_scalar`, `log_array`, `set_camera`, `close`, etc.).

The visualization docs (`docs/guide/visualization.rst`) reference `:class:\~newton.viewer.ViewerBase` and its methods ~20 times, but the class was not exported — causing broken Sphinx cross-references in the built documentation.

Exporting it also enables users to write type-annotated code like:
```python
def run_sim(viewer: newton.viewer.ViewerBase, ...):
    ...
```

## Changes

- `newton/_src/viewer/__init__.py`: import and export `ViewerBase`
- `newton/viewer.py`: import and export `ViewerBase`  
- `docs/api/newton_viewer.rst`: regenerated via `generate_api.py` (now includes `ViewerBase`)

Addresses part of #2183.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ViewerBase` is now publicly available as part of the viewer module API and can be imported directly for use in applications.

* **Documentation**
  * Added comprehensive API documentation for `ViewerBase` to the official reference guides.
  * Improved docstring formatting in viewer methods for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->