### PR TITLE
fix: use os.path.join for cross-platform path construction

### DIFF
--- a/newton/_src/solvers/kamino/examples/__init__.py
+++ b/newton/_src/solvers/kamino/examples/__init__.py
@@ -15,7 +15,7 @@ from .._src.utils import logger as msg
 
 
 def get_examples_output_path() -> str:
-    path = os.path.dirname(os.path.realpath(__file__)) + "/output"
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
     if not os.path.exists(path):
         os.makedirs(path)
     return path


### PR DESCRIPTION
Replace string concatenation with `os.path.join()` in `kamino/examples/__init__.py` for proper cross-platform path construction.

Before: `os.path.dirname(os.path.realpath(__file__)) + "/output"`
After: `os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")`

Python on Windows tolerates mixed separators, so this was functional but not idiomatic. This was the only filesystem path concatenation issue found in the codebase — other `+ "/"` usages are correctly operating on URLs, URIs, or USD prim paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability for path construction methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->