### PR TITLE
Use canonical appdirs import path for Warp 1.12+

### DIFF
--- a/newton/_src/utils/download_assets.py
+++ b/newton/_src/utils/download_assets.py
@@ -13,10 +13,7 @@ import threading
 import time
 from pathlib import Path
 
-try:
-    from warp.thirdparty.appdirs import user_cache_dir
-except (ImportError, ModuleNotFoundError):
-    from warp._src.thirdparty.appdirs import user_cache_dir
+from warp._src.thirdparty.appdirs import user_cache_dir
 
 
 def _get_newton_cache_dir() -> str:

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -573,7 +573,7 @@ def initialize_test_process(lock, shared_index, args, temp_dir):
         import warp as wp  # noqa: PLC0415
 
         if args.no_shared_cache:
-            from warp.thirdparty import appdirs  # noqa: PLC0415
+            from warp._src.thirdparty import appdirs  # noqa: PLC0415
 
             if "WARP_CACHE_ROOT" in os.environ:
                 cache_root_dir = os.path.join(os.getenv("WARP_CACHE_ROOT"), f"{wp.config.version}-{worker_index:03d}")
@@ -583,6 +583,7 @@ def initialize_test_process(lock, shared_index, args, temp_dir):
                 )
 
             wp.config.kernel_cache_dir = cache_root_dir
+            os.makedirs(cache_root_dir, exist_ok=True)
 
             if not args.no_cache_clear:
                 wp.clear_lto_cache()


### PR DESCRIPTION
## Description

Warp moved `appdirs` from `warp.thirdparty` to `warp._src.thirdparty`. Since Newton requires Warp 1.12+, update both import sites to the new path and remove the unnecessary try/except fallback in `download_assets.py`.

Also creates per-worker cache directories before calling `wp.clear_kernel_cache()` to prevent `FileNotFoundError` when running tests with `--no-shared-cache`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests --no-shared-cache
```

All 2680 tests pass (143 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal dependency imports.

* **Tests**
  * Improved test infrastructure for parallel worker cache directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->