### PR TITLE
Fix minimum-deps CI: add constraint-dependencies for unbounded transitive deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,22 @@ conflicts = [
         { extra = "torch-cu13" },
     ],
 ]
+# Lower bounds for transitive deps whose upstream packages set no floor.
+# Only affects `uv lock --resolution lowest` (minimum-deps CI).
+constraint-dependencies = [
+    "absl-py>=1.0.0",        # mujoco→; <1.0 requires Python 2.7/3.4
+    "appnope>=0.1.0",        # ipykernel→; 0.0.x fails to build on non-macOS
+    "bleach>=5.0.0",          # nbconvert→; ancient sdists fail with modern Python
+    "configargparse>=1.0",    # open3d→; <1.0 requires pypandoc to build
+    "lxml>=5.0.0",            # yourdfpy→; ancient sdists use Python 2 syntax
+    "munch>=4.0.0",           # imgui-bundle→; <4.0 fails with modern setuptools
+    "py>=1.11.0",             # docs deps→; <1.11 fails on Python 3.12
+    "pympler>=1.0.0",         # asv→; <1.0 doesn't support Python 3.12
+    "pyparsing>=3.0.0",       # matplotlib→; <3.0 uses removed collections.MutableMapping
+    "python-json-logger>=2.0.0",  # jupyter→; ancient sdists fail to build
+    "tabulate>=0.8.0",        # asv→; <0.8 missing README.rst in sdist
+    "wheel>=0.37.0",          # asv→; ancient sdists fail to build
+]
 
 [tool.uv.sources]
 warp-lang = { index = "nvidia" }

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,22 @@ conflicts = [[
     { package = "newton", extra = "torch-cu13" },
 ]]
 
+[manifest]
+constraints = [
+    { name = "absl-py", specifier = ">=1.0.0" },
+    { name = "appnope", specifier = ">=0.1.0" },
+    { name = "bleach", specifier = ">=5.0.0" },
+    { name = "configargparse", specifier = ">=1.0" },
+    { name = "lxml", specifier = ">=5.0.0" },
+    { name = "munch", specifier = ">=4.0.0" },
+    { name = "py", specifier = ">=1.11.0" },
+    { name = "pympler", specifier = ">=1.0.0" },
+    { name = "pyparsing", specifier = ">=3.0.0" },
+    { name = "python-json-logger", specifier = ">=2.0.0" },
+    { name = "tabulate", specifier = ">=0.8.0" },
+    { name = "wheel", specifier = ">=0.37.0" },
+]
+
 [[package]]
 name = "absl-py"
 version = "2.3.1"


### PR DESCRIPTION
## Description

The weekly **Newton + Minimum Dependency Versions** CI workflow
(`scheduled_nightly_minimum_deps_tests.yml`) has been failing because
`uv lock --resolution lowest` picks ancient sdist versions of transitive
dependencies that cannot build on Python 3.12.

The root cause is that several upstream packages (mujoco, imgui-bundle,
open3d, etc.) declare dependencies without lower bounds.  When uv
resolves to the absolute lowest version, it selects packages like
`munch==2.0.1`, `absl-py==0.1.0`, `lxml==1.3.2`, etc., which all fail
to build with modern Python/setuptools.

This PR adds `[tool.uv] constraint-dependencies` entries to set
buildable floors for 12 transitive packages.  This mechanism only
affects `--resolution lowest` — the normal lockfile is unchanged.

Failing run: https://github.com/newton-physics/newton/actions/runs/23148386483

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

Not user-facing — CI-only fix.

## Test plan

Verified locally by running the same steps as the CI workflow:

```bash
uv lock --resolution lowest          # resolves 242 packages successfully
uv run --extra dev -m newton.tests   # 2680 tests, 7 pre-existing failures
```

Also confirmed `uv lock` (normal resolution) produces an identical
lockfile — no impact on regular development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved dependency resolution configuration by adding minimum version constraints for transitive dependencies to ensure more stable and consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->