### PR TITLE
Fix CONNECT constraint anchor update via notify_model_changed

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3067,6 +3067,7 @@ class SolverMuJoCo(SolverBase):
         if flags & SolverNotifyFlags.CONSTRAINT_PROPERTIES:
             self._update_eq_properties()
             self._update_mimic_eq_properties()
+            need_const_0 = True
         if flags & SolverNotifyFlags.TENDON_PROPERTIES:
             self._update_tendon_properties()
             need_const_0 = True
@@ -3085,6 +3086,11 @@ class SolverMuJoCo(SolverBase):
                 self.mj_model.dof_solref[:] = self.mjw_model.dof_solref.numpy()[0]
                 self.mj_model.qpos0[:] = self.mjw_model.qpos0.numpy()[0]
                 self.mj_model.qpos_spring[:] = self.mjw_model.qpos_spring.numpy()[0]
+
+            # Sync eq_data before mj_setConst so it can recompute derived
+            # fields (e.g. body2-frame anchor for CONNECT constraints).
+            if flags & SolverNotifyFlags.CONSTRAINT_PROPERTIES:
+                self.mj_model.eq_data[:] = self.mjw_model.eq_data.numpy()[0]
 
             if need_length_range or need_const_fixed or need_const_0:
                 self._mujoco.mj_setConst(self.mj_model, self.mj_data)
@@ -5872,6 +5878,7 @@ class SolverMuJoCo(SolverBase):
             ],
             device=self.model.device,
         )
+
 
     def _update_mimic_eq_properties(self):
         """Update mimic constraint properties in the MuJoCo model.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -3722,6 +3722,95 @@ class TestMuJoCoSolverEqualityConstraintProperties(TestMuJoCoSolverPropertiesBas
                 err_msg=f"World {w}: CONNECT second anchor (data[3:6]) was incorrectly overwritten",
             )
 
+    def _build_connect_anchor_model(self):
+        """Build a model with a CONNECT constraint for anchor update tests."""
+        builder = newton.ModelBuilder(gravity=0.0)
+
+        root = builder.add_link(mass=0.0, inertia=wp.mat33(0.0))
+        j_root = builder.add_joint_fixed(parent=-1, child=root)
+
+        b1 = builder.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        j1 = builder.add_joint_prismatic(axis=0, parent=root, child=b1)
+
+        b2 = builder.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        j2 = builder.add_joint_prismatic(axis=0, parent=root, child=b2)
+
+        builder.add_articulation(joints=[j_root, j1, j2])
+        builder.add_equality_constraint_connect(
+            body1=b1, body2=b2, anchor=(1.0, 0.0, 0.0),
+        )
+        return builder.finalize()
+
+    def _check_connect_anchor_update(self, solver):
+        """Verify anchor update recomputes eq_data[3:6] on the given solver."""
+        # Capture initial eq_data — anchor=(1,0,0) should give data[3:6]=(1,0,0)
+        # since both bodies are at the origin in qpos0.
+        initial_eq_data = solver.mjw_model.eq_data.numpy().copy()
+        np.testing.assert_allclose(
+            initial_eq_data[0, 0, 0:3], [1.0, 0.0, 0.0], atol=1e-6,
+            err_msg="Initial data[0:3] should be anchor (1,0,0)",
+        )
+        np.testing.assert_allclose(
+            initial_eq_data[0, 0, 3:6], [1.0, 0.0, 0.0], atol=1e-6,
+            err_msg="Initial data[3:6] should be (1,0,0) for co-located bodies",
+        )
+
+        # Update anchor to (0.5, 0, 0).
+        solver.model.equality_constraint_anchor.assign(
+            np.array([[0.5, 0.0, 0.0]], dtype=np.float32),
+        )
+        solver.notify_model_changed(SolverNotifyFlags.CONSTRAINT_PROPERTIES)
+
+        updated_eq_data = solver.mjw_model.eq_data.numpy()
+        np.testing.assert_allclose(
+            updated_eq_data[0, 0, 0:3], [0.5, 0.0, 0.0], atol=1e-6,
+            err_msg="Updated data[0:3] should be new anchor (0.5,0,0)",
+        )
+        np.testing.assert_allclose(
+            updated_eq_data[0, 0, 3:6], [0.5, 0.0, 0.0], atol=1e-6,
+            err_msg="Updated data[3:6] should be recomputed to (0.5,0,0)",
+        )
+
+    def test_eq_data_connect_anchor_update(self):
+        """Test that updating the CONNECT anchor recomputes eq_data[3:6] (GPU path)."""
+        model = self._build_connect_anchor_model()
+        solver = SolverMuJoCo(
+            model, iterations=100, ls_iterations=50, disable_contacts=True,
+        )
+        self._check_connect_anchor_update(solver)
+
+    def test_eq_data_connect_anchor_update_cpu(self):
+        """Test that updating the CONNECT anchor recomputes eq_data[3:6] (CPU path)."""
+        model = self._build_connect_anchor_model()
+        solver = SolverMuJoCo(
+            model, iterations=100, ls_iterations=50, disable_contacts=True,
+            use_mujoco_cpu=True,
+        )
+
+        # On the CPU path, mj_setConst writes to mj_model.eq_data.
+        np.testing.assert_allclose(
+            solver.mj_model.eq_data[0, 0:3], [1.0, 0.0, 0.0], atol=1e-6,
+            err_msg="Initial data[0:3] should be anchor (1,0,0)",
+        )
+        np.testing.assert_allclose(
+            solver.mj_model.eq_data[0, 3:6], [1.0, 0.0, 0.0], atol=1e-6,
+            err_msg="Initial data[3:6] should be (1,0,0) for co-located bodies",
+        )
+
+        model.equality_constraint_anchor.assign(
+            np.array([[0.5, 0.0, 0.0]], dtype=np.float32),
+        )
+        solver.notify_model_changed(SolverNotifyFlags.CONSTRAINT_PROPERTIES)
+
+        np.testing.assert_allclose(
+            solver.mj_model.eq_data[0, 0:3], [0.5, 0.0, 0.0], atol=1e-6,
+            err_msg="Updated data[0:3] should be new anchor (0.5,0,0)",
+        )
+        np.testing.assert_allclose(
+            solver.mj_model.eq_data[0, 3:6], [0.5, 0.0, 0.0], atol=1e-6,
+            err_msg="Updated data[3:6] should be recomputed to (0.5,0,0)",
+        )
+
 
 class TestMuJoCoSolverFixedTendonProperties(TestMuJoCoSolverPropertiesBase):
     """Test fixed tendon property replication and runtime updates across multiple worlds."""


### PR DESCRIPTION
## Description

Fix updating the anchor of a CONNECT equality constraint at runtime.  When
`equality_constraint_anchor` is modified and `notify_model_changed(CONSTRAINT_PROPERTIES)`
is called, the derived `eq_data[3:6]` (anchor in body2's local frame) was not recomputed,
causing the constraint to pin two inconsistent points.

Closes #2129

**Blocked on:** mujoco_warp dependency update — this PR requires
google-deepmind/mujoco_warp#1256 which adds `eq_data` recomputation to
`set_const_0`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_eq_data_connect_anchor_update
uv run --extra dev -m newton.tests -k test_mujoco_solver
```

## Bug fix

**Steps to reproduce:**

1. Create a model with a CONNECT equality constraint with `anchor=(1,0,0)`
2. Simulate for N steps
3. Update anchor to `(0.5,0,0)` via `model.equality_constraint_anchor.assign()`
4. Call `solver.notify_model_changed(SolverNotifyFlags.CONSTRAINT_PROPERTIES)`
5. Reset state and simulate again
6. Observe different results compared to a fresh model built with `anchor=(0.5,0,0)`

**Minimal reproduction:**

See reproduction script in #2129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved constraint synchronization to ensure equality constraint properties updated at runtime are properly reflected in both CPU and GPU execution paths, with correct recomputation of derived constraint fields.

* **Tests**
  * Added test coverage for runtime equality constraint anchor updates across CPU and GPU execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->