### PR TITLE
Add mapped comparison for sparse tendon Jacobian structure

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1958,6 +1958,13 @@ class TestMenagerieBase(unittest.TestCase):
         Override in subclasses where DOF ordering may differ.
         """
 
+    def _compare_tendon_jacobian_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
+        """Compare sparse tendon Jacobian structure (ten_J_colind, ten_J_rowadr, ten_J_rownnz).
+
+        Default: no-op (covered by compare_mjw_models for same-order pipelines).
+        Override in subclasses where DOF ordering may differ.
+        """
+
     def _compare_compiled_fields(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare compilation-dependent fields at relaxed tolerance.
 
@@ -2106,6 +2113,7 @@ class TestMenagerieBase(unittest.TestCase):
         self._compare_body_physics(newton_solver.mjw_model, native_mjw_model)
         self._compare_dof_physics(newton_solver.mjw_model, native_mjw_model)
         self._compare_mass_matrix_structure(newton_solver.mjw_model, native_mjw_model)
+        self._compare_tendon_jacobian_structure(newton_solver.mjw_model, native_mjw_model)
         self._compare_actuator_physics(newton_solver.mjw_model, native_mjw_model)
         self._compare_compiled_fields(newton_solver.mjw_model, native_mjw_model)
 

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -853,6 +853,62 @@ def compare_mass_matrix_structure_mapped(
     )
 
 
+def compare_tendon_jacobian_structure_mapped(
+    newton_mjw: Any,
+    native_mjw: Any,
+    dof_map: dict[int, int],
+) -> None:
+    """Compare sparse tendon Jacobian sparsity pattern under DOF reordering.
+
+    The tendon Jacobian ten_J uses CSR-like format (ten_J_rowadr, ten_J_rownnz,
+    ten_J_colind) where rows are tendons and columns are DOF indices.  When DOF
+    ordering differs the column indices are permuted but structurally equivalent.
+
+    Gracefully skips if the fields are absent (older mujoco_warp without sparse
+    ten_J support).
+
+    Args:
+        dof_map: native_dof_idx -> newton_dof_idx.
+    """
+    if not hasattr(native_mjw, "ten_J_colind") or not hasattr(newton_mjw, "ten_J_colind"):
+        return
+
+    ntendon = native_mjw.ntendon
+    assert newton_mjw.ntendon == ntendon, f"ntendon mismatch: newton={newton_mjw.ntendon} vs native={ntendon}"
+
+    if ntendon == 0:
+        return
+
+    newton_rowadr = newton_mjw.ten_J_rowadr.numpy().flatten()
+    newton_rownnz = newton_mjw.ten_J_rownnz.numpy().flatten()
+    newton_colind = newton_mjw.ten_J_colind.numpy().flatten()
+    native_rowadr = native_mjw.ten_J_rowadr.numpy().flatten()
+    native_rownnz = native_mjw.ten_J_rownnz.numpy().flatten()
+    native_colind = native_mjw.ten_J_colind.numpy().flatten()
+
+    inv_dof_map = {v: k for k, v in dof_map.items()}
+
+    mismatches = []
+    for t in range(ntendon):
+        nat_start = int(native_rowadr[t])
+        nat_nnz = int(native_rownnz[t])
+        native_cols = {int(native_colind[nat_start + k]) for k in range(nat_nnz)}
+
+        nw_start = int(newton_rowadr[t])
+        nw_nnz = int(newton_rownnz[t])
+        newton_cols_raw = [int(newton_colind[nw_start + k]) for k in range(nw_nnz)]
+        newton_cols = {inv_dof_map.get(c, -1) for c in newton_cols_raw}
+
+        if native_cols != newton_cols:
+            mismatches.append(
+                f"tendon {t}: native cols={sorted(native_cols)}, newton cols (remapped)={sorted(newton_cols)}"
+            )
+
+    assert not mismatches, f"Tendon Jacobian sparsity mismatch for {len(mismatches)}/{ntendon} tendons:\n" + "\n".join(
+        mismatches[:10]
+    )
+
+
 ACTUATOR_SKIP_FIELDS: set[str] = {
     "actuator_plugin",
     "actuator_user",
@@ -981,6 +1037,10 @@ class TestMenagerieUSD(TestMenagerieBase):
         "jnt_",
         # Sparse mass matrix structure: DOF-indexed, compared via _compare_mass_matrix_structure
         "M_",
+        # Sparse tendon Jacobian structure: DOF-indexed, compared via _compare_tendon_jacobian_structure
+        "ten_J_",
+        "nJten",
+        "max_ten_J_rownnz",
         # Cholesky permutation: derived from body/DOF tree ordering
         "mapM2M",
         "qLD_updates",
@@ -1083,6 +1143,10 @@ class TestMenagerieUSD(TestMenagerieBase):
     def _compare_mass_matrix_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare sparse mass matrix structure using DOF index mapping."""
         compare_mass_matrix_structure_mapped(newton_mjw, native_mjw, self._dof_map)
+
+    def _compare_tendon_jacobian_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
+        """Compare sparse tendon Jacobian structure using DOF index mapping."""
+        compare_tendon_jacobian_structure_mapped(newton_mjw, native_mjw, self._dof_map)
 
     def _compare_actuator_physics(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare actuator fields using name-based index mapping."""


### PR DESCRIPTION
## Description

mujoco_warp `main` (post-3.6.0, google-deepmind/mujoco_warp#1119) changed `ten_J` from a dense `(ntendon, nv)` array to a sparse CSR-like representation with new Model fields: `ten_J_rownnz`, `ten_J_rowadr`, `ten_J_colind`, `nJten`, `max_ten_J_rownnz`.

These fields contain DOF column indices, which differ when Newton's MjSpec produces a different joint order than native MJCF loading (as happens in the USD pipeline). The nightly CI was failing on `TestMenagerieUSD_ShadowHand.test_simulation_equivalence` because `compare_mjw_models` was comparing the raw `ten_J_colind` values without DOF remapping.

This PR adds `compare_tendon_jacobian_structure_mapped`, following the same pattern as the existing `compare_mass_matrix_structure_mapped`. The new fields are skipped from the generic `compare_mjw_models` pass and compared via a dedicated mapped hook. A `hasattr` guard ensures graceful no-op on released mujoco_warp (≤ 3.6.0) where the fields don't exist.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Verified on both released mujoco_warp 3.6.0 and latest `main` (`4839fc70`):

```
uv run --extra dev -m newton.tests -k "test_menagerie_usd_mujoco.TestMenagerieUSD_ShadowHand"
```

## Bug fix

**Steps to reproduce:**

1. Install mujoco_warp from source: `uv pip install --reinstall-package mujoco-warp "mujoco-warp @ git+https://github.com/google-deepmind/mujoco_warp.git"`
2. Run: `uv run --extra dev -m newton.tests -k "test_menagerie_usd_mujoco.TestMenagerieUSD_ShadowHand"`
3. `test_simulation_equivalence` fails with `ten_J_colind` mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced MuJoCo model validation testing with improved structure comparison capabilities.
  * Added validation for model equivalence when component ordering differs between implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->