### PR TITLE
Update Kamino README docs links

### DIFF
--- a/newton/_src/solvers/kamino/README.md
+++ b/newton/_src/solvers/kamino/README.md
@@ -30,7 +30,7 @@ Kamino is being developed and maintained by [Disney Research](https://www.disney
 
 ### Installing
 
-For plain users, the official [installation instructions](https://newton-physics.github.io/newton/guide/installation.html) of Newton are recommended.
+For plain users, the official [installation instructions](https://newton-physics.github.io/newton/latest/guide/installation.html) of Newton are recommended.
 
 For developers, please refer to the [Development](#development) section below.
 
@@ -66,7 +66,7 @@ Development of Kamino requires the installation of [Newton](https://github.com/n
 The first step involves setting-up a python environment.
 
 The simplest is to create a new `virtualenv`. Alternatively one could
-follow the [instructions](https://newton-physics.github.io/newton/guide/installation.html) from Newton.
+follow the [instructions](https://newton-physics.github.io/newton/latest/guide/installation.html) from Newton.
 
 ### Virtual environments using `pyenv`
 Because we're working on a fork of the main Newton repository, it can be useful to create two `virtualenv|conda|uv` environments.


### PR DESCRIPTION
## Description

Update the remaining non-versioned Newton documentation links in the Kamino README to point at the versioned `latest` docs URLs.

Related to #1567.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Open `newton/_src/solvers/kamino/README.md`.
2. Follow the installation links in the "Installing" or "Development" sections.
3. Observe that they use the old non-versioned docs paths and rely on the docs redirect page.

**Minimal reproduction:**

```python
from pathlib import Path

readme = Path("newton/_src/solvers/kamino/README.md").read_text()
assert "https://newton-physics.github.io/newton/guide/installation.html" in readme
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links in developer guides to reference the latest version of installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->