### PR TITLE
Add site-targeted actuator support to MuJoCo solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Export `ViewerBase` from `newton.viewer` public API
 - Add `custom_attributes` argument to `ModelBuilder.add_shape_convex_hull()`
 - Add RJ45 plug-socket insertion example with SDF contacts, latch joint, and interactive gizmo
+- Add site-targeted actuator support to MuJoCo solver
 
 ### Changed
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1199,6 +1199,14 @@ class SolverMuJoCo(SolverBase):
             except ValueError:
                 pass
 
+            # Check if the target matches a site shape label.  Sites are stored
+            # as shapes with the SITE flag in the builder.  We return a sentinel
+            # target_index of 0 here; the actual site name will be resolved by
+            # the SITE branch in ``_init_actuators`` via ``site_label_to_name``.
+            for i, label in enumerate(builder.shape_label):
+                if label == target_path and (builder.shape_flags[i] & ShapeFlags.SITE):
+                    return int(SolverMuJoCo.TrnType.SITE), 0, target_path
+
             return -1, -1, target_path
 
         def resolve_joint_dof_label(_: str, context: dict[str, Any]):
@@ -2492,6 +2500,7 @@ class SolverMuJoCo(SolverBase):
         selected_tendons: list[int],
         mjc_tendon_names: list[str],
         body_name_mapping: dict[int, str],
+        site_mapping: dict[int, str] | None = None,
     ) -> int:
         """Initialize MuJoCo general actuators from custom attributes.
 
@@ -2515,10 +2524,14 @@ class SolverMuJoCo(SolverBase):
                 Used to resolve CTRL_DIRECT joint actuators to their MuJoCo targets.
             mjc_joint_names: List of MuJoCo joint names indexed by MuJoCo joint index.
                 Used together with dof_to_mjc_joint to get the correct joint name.
-            body_name_mapping: Mapping from Newton body index to de-duplicated MuJoCo body name
+            body_name_mapping: Mapping from Newton body index to de-duplicated MuJoCo body name.
+            site_mapping: Mapping from Newton shape index (sites) to MuJoCo site name.
+                Used to resolve CTRL_DIRECT actuators targeting sites.
         Returns:
             int: Number of actuators added.
         """
+        if site_mapping is None:
+            site_mapping = {}
         mujoco = self._mujoco
 
         mujoco_attrs = getattr(model, "mujoco", None)
@@ -2538,6 +2551,13 @@ class SolverMuJoCo(SolverBase):
         joint_dof_label_arr = getattr(mujoco_attrs, "joint_dof_label", None)
         tendon_label_arr = getattr(mujoco_attrs, "tendon_label", None)
 
+        # Build reverse lookup from shape label (prim path) to site name
+        # so we can resolve actuator target labels that reference sites.
+        site_label_to_name: dict[str, str] = {}
+        for shape_idx, site_name in site_mapping.items():
+            if shape_idx < len(model.shape_label):
+                site_label_to_name[model.shape_label[shape_idx]] = site_name
+
         def resolve_target_from_label(target_label: str) -> tuple[int, int]:
             if isinstance(joint_dof_label_arr, list):
                 try:
@@ -2549,6 +2569,11 @@ class SolverMuJoCo(SolverBase):
                     return int(SolverMuJoCo.TrnType.TENDON), tendon_label_arr.index(target_label)
                 except ValueError:
                     pass
+            # Check if the target label matches a site shape label.
+            # For site targets, return trntype=SITE with target_idx=0
+            # (the actual site name is resolved in the SITE branch below).
+            if target_label in site_label_to_name:
+                return int(SolverMuJoCo.TrnType.SITE), 0
             return -1, -1
 
         # Pre-fetch range/limited arrays to avoid per-element .numpy() calls
@@ -2655,8 +2680,25 @@ class SolverMuJoCo(SolverBase):
                             "not present in the MuJoCo export."
                         )
                     continue
+            elif trntype == int(SolverMuJoCo.TrnType.SITE):
+                # Resolve site target: prefer label when available (USD path),
+                # then fall back to index-based lookup (MJCF/direct trnid path).
+                # Label-first avoids sentinel target_idx=0 colliding with a real site.
+                site_name = None
+                if target_label:
+                    site_name = site_label_to_name.get(target_label)
+                if site_name is None:
+                    site_name = site_mapping.get(target_idx)
+                if site_name is None:
+                    if wp.config.verbose:
+                        print(
+                            f"Warning: MuJoCo actuator {mujoco_act_idx} site target "
+                            f"'{target_label}' not found in site mapping"
+                        )
+                    continue
+                target_name = site_name
             else:
-                # TODO: Support site, slidercrank, and jointinparent transmission types
+                # TODO: Support slidercrank and jointinparent transmission types
                 if wp.config.verbose:
                     print(f"Warning: MuJoCo actuator {mujoco_act_idx} has unsupported trntype {trntype}")
                 continue
@@ -4254,6 +4296,42 @@ class SolverMuJoCo(SolverBase):
                                 if ss >= 0:
                                     tendon_required_shapes.add(ss)
 
+        # Collect shapes required by actuators targeting sites so they are not
+        # skipped when include_sites=False.  USD actuators may still carry
+        # sentinel trnid/trntype at this point (resolved later from
+        # actuator_target_label), so check labels first.
+        actuator_required_shapes: set[int] = set()
+        if mujoco_attrs is not None:
+            _act_trntype = getattr(mujoco_attrs, "actuator_trntype", None)
+            _act_trnid = getattr(mujoco_attrs, "actuator_trnid", None)
+            _act_target_label = getattr(mujoco_attrs, "actuator_target_label", None)
+            _act_world = getattr(mujoco_attrs, "actuator_world", None)
+            site_shape_by_label = {
+                label: idx
+                for idx, label in enumerate(model.shape_label)
+                if (shape_flags[idx] & ShapeFlags.SITE) and idx in selected_shapes_set
+            }
+            if _act_trntype is not None and _act_trnid is not None:
+                act_trntype_np = _act_trntype.numpy()
+                act_trnid_np = _act_trnid.numpy()
+                act_world_np = _act_world.numpy() if _act_world is not None else None
+                for ai in range(len(act_trntype_np)):
+                    if act_world_np is not None:
+                        aw = int(act_world_np[ai])
+                        if aw != first_world and aw >= 0:
+                            continue
+                    # Try label-based resolution first (covers USD deferred targets)
+                    idx = -1
+                    if isinstance(_act_target_label, list) and ai < len(_act_target_label):
+                        idx = site_shape_by_label.get(_act_target_label[ai], -1)
+                    # Fall back to trnid for MJCF/direct site actuators
+                    if idx < 0 and int(act_trntype_np[ai]) == int(SolverMuJoCo.TrnType.SITE):
+                        idx = int(act_trnid_np[ai, 0])
+                    if idx >= 0:
+                        actuator_required_shapes.add(idx)
+
+        required_shapes = tendon_required_shapes | actuator_required_shapes
+
         def add_geoms(newton_body_id: int):
             body = mj_bodies[body_mapping[newton_body_id]]
             shapes = model.body_shapes.get(newton_body_id)
@@ -4263,16 +4341,17 @@ class SolverMuJoCo(SolverBase):
                 if shape not in selected_shapes_set:
                     # skip shapes that are not selected for this world
                     continue
-                # Skip visual-only geoms, but don't skip sites or shapes needed by spatial tendons
+                # Skip visual-only geoms, but don't skip sites or shapes needed by
+                # spatial tendons or actuators.
                 is_site = shape_flags[shape] & ShapeFlags.SITE
                 if skip_visual_only_geoms and not is_site and not (shape_flags[shape] & ShapeFlags.COLLIDE_SHAPES):
-                    if shape not in tendon_required_shapes:
+                    if shape not in required_shapes:
                         continue
                 stype = shape_type[shape]
                 name = f"{model.shape_label[shape]}_{shape}"
 
                 if is_site:
-                    if not include_sites and shape not in tendon_required_shapes:
+                    if not include_sites and shape not in required_shapes:
                         continue
 
                     # Map unsupported site types to SPHERE
@@ -5049,6 +5128,7 @@ class SolverMuJoCo(SolverBase):
             selected_tendons,
             mjc_tendon_names,
             body_name_mapping,
+            site_mapping,
         )
 
         # Convert actuator mapping lists to warp arrays

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2473,6 +2473,7 @@ def parse_mjcf(
             joint_name = merged_attrib.get("joint")
             body_name = merged_attrib.get("body")
             tendon_name = merged_attrib.get("tendon")
+            site_name = merged_attrib.get("site")
 
             # Sanitize names to match how they were stored in the builder
             if joint_name:
@@ -2481,6 +2482,8 @@ def parse_mjcf(
                 body_name = sanitize_name(body_name)
             if tendon_name:
                 tendon_name = sanitize_name(tendon_name)
+            if site_name:
+                site_name = sanitize_name(site_name)
 
             # Determine transmission type and target
             trntype = 0  # Default: joint
@@ -2530,9 +2533,19 @@ def parse_mjcf(
                 target_idx = tendon_idx
                 target_name_for_log = tendon_name
                 trntype = 2  # TrnType.TENDON
+            elif site_name:
+                # Site transmission (trntype=3)
+                site_idx = site_name_to_idx.get(site_name)
+                if site_idx is None:
+                    if verbose:
+                        print(f"Warning: {actuator_type} actuator references unknown site '{site_name}'")
+                    continue
+                target_idx = site_idx
+                target_name_for_log = site_name
+                trntype = 3  # TrnType.SITE
             else:
                 if verbose:
-                    print(f"Warning: {actuator_type} actuator has no joint, body, or tendon target, skipping")
+                    print(f"Warning: {actuator_type} actuator has no joint, body, site, or tendon target, skipping")
                 continue
 
             act_name = merged_attrib.get("name", f"{actuator_type}_{target_name_for_log}")

--- a/newton/tests/assets/site_actuator_mjc.usda
+++ b/newton/tests/assets/site_actuator_mjc.usda
@@ -1,0 +1,161 @@
+#usda 1.0
+(
+    customLayerData = {
+        string creator = "Newton test fixture"
+    }
+    defaultPrim = "test_site_actuator"
+    doc = """Minimal scene with an MjcActuator targeting a site (MjcSiteAPI)."""
+    kilogramsPerUnit = 1
+    metersPerUnit = 1
+    upAxis = "Z"
+)
+
+def Xform "test_site_actuator" (
+    apiSchemas = ["GeomModelAPI"]
+    assetInfo = {
+        string name = "test_site_actuator"
+    }
+    kind = "component"
+)
+{
+    float3[] extentsHint = [(-4, -4, -1), (4, 4, 0.645), (3.4028235e38, 3.4028235e38, 3.4028235e38), (-3.4028235e38, -3.4028235e38, -3.4028235e38), (3.4028235e38, 3.4028235e38, 3.4028235e38), (-3.4028235e38, -3.4028235e38, -3.4028235e38), (-0.2, -0.1, -0.05), (0.2, 0.1, 0.61)]
+
+    def Scope "Geometry"
+    {
+        def Plane "floor" (
+            apiSchemas = ["PhysicsCollisionAPI", "MjcCollisionAPI", "MaterialBindingAPI"]
+        )
+        {
+            uniform token axis = "Z"
+            float3[] extent = [(-4, -4, -0), (4, 4, 0)]
+            double length = 8
+            rel material:binding:physics = </test_site_actuator/Physics/PhysicsMaterial>
+            double width = 8
+            quatf xformOp:orient = (1, 0, 0, 0)
+            float3 xformOp:scale = (1, 1, 1)
+            double3 xformOp:translate = (0, 0, -1)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+        }
+
+        def Xform "cart" (
+            apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsArticulationRootAPI"]
+        )
+        {
+            quatf xformOp:orient = (1, 0, 0, 0)
+            float3 xformOp:scale = (1, 1, 1)
+            double3 xformOp:translate = (0, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+            def Cube "cart" (
+                apiSchemas = ["PhysicsCollisionAPI", "MjcCollisionAPI", "MaterialBindingAPI"]
+            )
+            {
+                float3[] extent = [(-1, -1, -1), (1, 1, 1)]
+                rel material:binding:physics = </test_site_actuator/Physics/PhysicsMaterial>
+                double size = 2
+                quatf xformOp:orient = (1, 0, 0, 0)
+                float3 xformOp:scale = (0.2, 0.1, 0.05)
+                double3 xformOp:translate = (0, 0, 0)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+            }
+
+            def Xform "pole" (
+                apiSchemas = ["PhysicsRigidBodyAPI"]
+            )
+            {
+                quatf xformOp:orient = (1, 0, 0, 0)
+                float3 xformOp:scale = (1, 1, 1)
+                double3 xformOp:translate = (0, 0, 0)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+                def Capsule "cpole" (
+                    apiSchemas = ["PhysicsCollisionAPI", "MjcCollisionAPI", "MaterialBindingAPI"]
+                )
+                {
+                    uniform token axis = "Z"
+                    float3[] extent = [(-0.045, -0.045, -0.345), (0.045, 0.045, 0.345)]
+                    double height = 0.6
+                    rel material:binding:physics = </test_site_actuator/Physics/PhysicsMaterial>
+                    double radius = 0.045
+                    quatf xformOp:orient = (6.123234e-17, 1, 0, 0)
+                    float3 xformOp:scale = (1, 1, 1)
+                    double3 xformOp:translate = (0, 0, 0.3)
+                    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+                }
+
+                def Sphere "tip" (
+                    apiSchemas = ["MjcSiteAPI"]
+                )
+                {
+                    float3[] extent = [(-0.01, -0.01, -0.01), (0.01, 0.01, 0.01)]
+                    uniform token purpose = "guide"
+                    double radius = 0.01
+                    quatf xformOp:orient = (1, 0, 0, 0)
+                    float3 xformOp:scale = (1, 1, 1)
+                    double3 xformOp:translate = (0.001, 0, 0.6)
+                    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+                }
+
+                def PhysicsRevoluteJoint "hinge" (
+                    apiSchemas = ["MjcJointAPI"]
+                )
+                {
+                    uniform double mjc:damping = 0.05
+                    uniform double[] mjc:solreflimit = [0.08, 1]
+                    uniform token physics:axis = "Y"
+                    rel physics:body0 = </test_site_actuator/Geometry/cart>
+                    rel physics:body1 = </test_site_actuator/Geometry/cart/pole>
+                    point3f physics:localPos0 = (0, 0, 0)
+                    point3f physics:localPos1 = (0, 0, 0)
+                    quatf physics:localRot0 = (1, 0, 0, 0)
+                    quatf physics:localRot1 = (1, 0, 0, 0)
+                }
+            }
+
+            def PhysicsPrismaticJoint "slider" (
+                apiSchemas = ["MjcJointAPI"]
+            )
+            {
+                uniform double mjc:damping = 0.05
+                uniform double[] mjc:solreflimit = [0.08, 1]
+                uniform token physics:axis = "X"
+                rel physics:body0 = </test_site_actuator>
+                rel physics:body1 = </test_site_actuator/Geometry/cart>
+                point3f physics:localPos0 = (0, 0, 0)
+                point3f physics:localPos1 = (0, 0, 0)
+                quatf physics:localRot0 = (1, 0, 0, 0)
+                quatf physics:localRot1 = (1, 0, 0, 0)
+                float physics:lowerLimit = -1
+                float physics:upperLimit = 1
+            }
+        }
+    }
+
+    def Scope "Physics"
+    {
+        def Material "PhysicsMaterial" (
+            apiSchemas = ["PhysicsMaterialAPI", "MjcMaterialAPI"]
+        )
+        {
+            uniform double mjc:rollingfriction = 0.1
+            uniform double mjc:torsionalfriction = 0.1
+            float physics:dynamicFriction = 1
+        }
+
+        def MjcActuator "site_force"
+        {
+            uniform double[] mjc:gear = [0, 0, 10, 0, 0, 2]
+            rel mjc:target = </test_site_actuator/Geometry/cart/pole/tip>
+        }
+    }
+}
+
+def PhysicsScene "PhysicsScene" (
+    apiSchemas = ["MjcSceneAPI"]
+)
+{
+    uniform token mjc:compiler:inertiaFromGeom = "true"
+    uniform double mjc:option:timestep = 0.01
+    vector3f physics:gravityDirection = (0, 0, -1)
+    float physics:gravityMagnitude = 9.81
+}

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -609,5 +609,133 @@ class TestMuJoCoActuators(unittest.TestCase):
         np.testing.assert_array_equal(solver.mjw_model.actuator_trntype.numpy(), [0])
 
 
+MJCF_SITE_ACTUATOR = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test_site_actuator">
+    <option gravity="0 0 -9.81"/>
+    <worldbody>
+        <body name="base" pos="0 0 1">
+            <freejoint name="root"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+            <site name="sensor_site" pos="0.1 0 0"/>
+            <body name="arm" pos="0.2 0 0">
+                <joint name="elbow" axis="0 1 0" type="hinge"/>
+                <geom type="box" size="0.05 0.05 0.2" mass="0.5"/>
+                <site name="ee_site" pos="0 0 0.2"/>
+            </body>
+        </body>
+    </worldbody>
+    <actuator>
+        <general name="site_motor" site="ee_site" gainprm="25 0 0" biasprm="0 -25 -2"/>
+        <motor name="elbow_motor" joint="elbow"/>
+    </actuator>
+</mujoco>
+"""
+
+
+class TestMuJoCoSiteActuators(unittest.TestCase):
+    """Tests for site-targeted actuator support in SolverMuJoCo."""
+
+    def test_site_actuator_parsed_from_mjcf(self):
+        """Site actuator is correctly parsed with trntype=SITE from MJCF."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        model = builder.finalize()
+
+        trntype = model.mujoco.actuator_trntype.numpy()
+
+        # Find the site actuator among all parsed actuators
+        site_trntype = int(SolverMuJoCo.TrnType.SITE)
+        site_indices = [i for i in range(len(trntype)) if trntype[i] == site_trntype]
+        self.assertEqual(len(site_indices), 1, "Expected exactly one SITE actuator")
+
+        gainprm = model.mujoco.actuator_gainprm.numpy()
+        np.testing.assert_allclose(gainprm[site_indices[0], :3], [25.0, 0.0, 0.0], atol=1e-5)
+
+    def test_site_actuator_exported_to_mujoco(self):
+        """Site actuator is exported to MuJoCo model with correct trntype and target."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mj_model = solver.mj_model
+
+        # At least 2 actuators: site_motor and elbow_motor
+        self.assertGreaterEqual(mj_model.nu, 2)
+
+        # Find the actuator with site transmission type (mjTRN_SITE = 4 in native MuJoCo)
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts = [i for i in range(mj_model.nu) if mj_model.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(site_acts), 1, "Expected exactly one site actuator in MuJoCo model")
+
+        mj_idx = site_acts[0]
+        np.testing.assert_allclose(mj_model.actuator_gainprm[mj_idx, :3], [25.0, 0.0, 0.0], atol=1e-5)
+        np.testing.assert_allclose(mj_model.actuator_biasprm[mj_idx, :3], [0.0, -25.0, -2.0], atol=1e-5)
+
+        # The trnid should point to a valid site index
+        site_id = mj_model.actuator_trnid[mj_idx, 0]
+        self.assertGreaterEqual(site_id, 0)
+        self.assertLess(site_id, mj_model.nsite)
+
+    def test_site_actuator_matches_native_mujoco(self):
+        """Site actuator properties match native MuJoCo loading."""
+        native_model = SolverMuJoCo.import_mujoco()[0].MjModel.from_xml_string(MJCF_SITE_ACTUATOR)
+
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        newton_mj = solver.mj_model
+
+        self.assertEqual(native_model.nu, newton_mj.nu)
+
+        for i in range(native_model.nu):
+            self.assertEqual(
+                native_model.actuator_trntype[i],
+                newton_mj.actuator_trntype[i],
+                f"Actuator {i} trntype mismatch",
+            )
+            np.testing.assert_array_equal(
+                native_model.actuator_trnid[i],
+                newton_mj.actuator_trnid[i],
+                err_msg=f"Actuator {i} trnid mismatch",
+            )
+            np.testing.assert_allclose(
+                native_model.actuator_gainprm[i, :3],
+                newton_mj.actuator_gainprm[i, :3],
+                atol=1e-5,
+            )
+            np.testing.assert_allclose(
+                native_model.actuator_biasprm[i, :3],
+                newton_mj.actuator_biasprm[i, :3],
+                atol=1e-5,
+            )
+
+    def test_site_actuator_with_include_sites_false(self):
+        """Site actuator is resolved even when include_sites=False."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True, include_sites=False)
+        mj_model = solver.mj_model
+
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts = [i for i in range(mj_model.nu) if mj_model.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(site_acts), 1, "Site actuator should be exported even with include_sites=False")
+
+        mj_idx = site_acts[0]
+        np.testing.assert_allclose(mj_model.actuator_gainprm[mj_idx, :3], [25.0, 0.0, 0.0], atol=1e-5)
+
+        site_id = mj_model.actuator_trnid[mj_idx, 0]
+        self.assertGreaterEqual(site_id, 0)
+        self.assertLess(site_id, mj_model.nsite)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -6,6 +6,7 @@
 import unittest
 
 import numpy as np
+import warp as wp
 
 from newton import JointTargetMode, ModelBuilder
 from newton.solvers import SolverMuJoCo, SolverNotifyFlags
@@ -735,6 +736,189 @@ class TestMuJoCoSiteActuators(unittest.TestCase):
         site_id = mj_model.actuator_trnid[mj_idx, 0]
         self.assertGreaterEqual(site_id, 0)
         self.assertLess(site_id, mj_model.nsite)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_site_actuator_from_usd(self):
+        """Site actuator is parsed from a USD MjcActuator prim targeting a MjcSiteAPI prim."""
+        builder = ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(get_asset("site_actuator_mjc.usda"))
+        model = builder.finalize()
+
+        # USD parse should yield exactly one actuator with trntype=SITE
+        site_trntype = int(SolverMuJoCo.TrnType.SITE)
+        trntype = model.mujoco.actuator_trntype.numpy()
+        site_indices = [i for i in range(len(trntype)) if trntype[i] == site_trntype]
+        self.assertEqual(len(site_indices), 1, "Expected exactly one SITE actuator parsed from USD")
+
+        solver = SolverMuJoCo(model, separate_worlds=False)
+        mj_model = solver.mj_model
+
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts = [i for i in range(mj_model.nu) if mj_model.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(site_acts), 1, "Expected exactly one site actuator in MuJoCo model")
+
+        mj_idx = site_acts[0]
+        site_id = mj_model.actuator_trnid[mj_idx, 0]
+        self.assertGreaterEqual(site_id, 0)
+        self.assertLess(site_id, mj_model.nsite)
+
+        # 6-DoF gear round-trips from USD `uniform double[] mjc:gear = [0, 0, 10, 0, 0, 2]`
+        np.testing.assert_allclose(mj_model.actuator_gear[mj_idx, :6], [0.0, 0.0, 10.0, 0.0, 0.0, 2.0], atol=1e-5)
+
+    def test_site_actuator_applies_force_at_site(self):
+        """Stepping with a site actuator produces qfrc_actuator matching native MuJoCo."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        builder.request_state_attributes("mujoco:qfrc_actuator")
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+
+        import mujoco
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+
+        # Identify the Newton-side actuator ordering so we can set matching ctrl
+        # values on Newton and native MuJoCo.
+        newton_trntype = model.mujoco.actuator_trntype.numpy()
+        site_trntype = int(SolverMuJoCo.TrnType.SITE)
+        newton_site_idx = int(np.where(newton_trntype == site_trntype)[0][0])
+        newton_joint_idx = int(np.where(newton_trntype != site_trntype)[0][0])
+
+        ctrl = np.zeros(model.mujoco.actuator_trntype.shape[0], dtype=np.float32)
+        ctrl[newton_site_idx] = 0.5  # site-actuator input
+        ctrl[newton_joint_idx] = 0.7  # joint-motor input
+        control.mujoco.ctrl = wp.array(ctrl, dtype=wp.float32, device=model.device)
+
+        solver.step(state_0, state_1, control, None, dt=0.001)
+        qfrc_newton = state_1.mujoco.qfrc_actuator.numpy()
+
+        # Native MuJoCo reference: mj_forward with the same ctrl mapped through
+        # the MuJoCo-side actuator ordering (which may permute Newton's).
+        native_model = SolverMuJoCo.import_mujoco()[0].MjModel.from_xml_string(MJCF_SITE_ACTUATOR)
+        data = mujoco.MjData(native_model)
+        mjc_to_newton = solver.mjc_actuator_to_newton_idx.numpy()
+        for mj_idx in range(native_model.nu):
+            data.ctrl[mj_idx] = ctrl[mjc_to_newton[mj_idx]]
+        mujoco.mj_forward(native_model, data)
+        qfrc_native = np.array(data.qfrc_actuator)
+
+        self.assertGreater(
+            float(np.max(np.abs(qfrc_native))),
+            0.0,
+            "Test fixture must produce a nonzero reference qfrc for the assertion to be meaningful",
+        )
+        np.testing.assert_allclose(qfrc_newton, qfrc_native, atol=1e-4)
+
+    def test_site_actuator_multiworld_separate(self):
+        """With separate_worlds=True, site actuators in each world are dispatched correctly."""
+        robot_builder = ModelBuilder()
+        robot_builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+
+        main_builder = ModelBuilder()
+        main_builder.add_world(robot_builder)
+        main_builder.add_world(robot_builder)
+        model = main_builder.finalize()
+
+        # actuator_world should partition actuators between the two worlds.
+        actuator_world = model.mujoco.actuator_world.numpy()
+        per_world = len(actuator_world) // 2
+        self.assertGreater(per_world, 0)
+        for i in range(per_world):
+            self.assertEqual(actuator_world[i], 0, f"Actuator {i} should belong to world 0")
+        for i in range(per_world, 2 * per_world):
+            self.assertEqual(actuator_world[i], 1, f"Actuator {i} should belong to world 1")
+
+        # Construction must not raise -- exercises the per-world shape filter
+        # for SITE trntype in _init_mjc_model_for_world.
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True, separate_worlds=True)
+
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts_per_world = [
+            i for i in range(solver.mj_model.nu) if solver.mj_model.actuator_trntype[i] == mj_site_trntype
+        ]
+        self.assertEqual(
+            len(site_acts_per_world),
+            1,
+            "Each separate_worlds=True MuJoCo model should export exactly one site actuator",
+        )
+
+    def test_site_actuator_required_shape_preserved_with_include_sites_false(self):
+        """With include_sites=False, the site shape referenced by an actuator is still exported."""
+        builder = ModelBuilder()
+        builder.add_mjcf(MJCF_SITE_ACTUATOR, ctrl_direct=True)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True, include_sites=False)
+        mj_model = solver.mj_model
+
+        # The referenced site must have survived the `include_sites=False` filter
+        # because the actuator declared it as required.
+        self.assertGreaterEqual(mj_model.nsite, 1, "Actuator-referenced site must be preserved")
+
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts = [i for i in range(mj_model.nu) if mj_model.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(site_acts), 1)
+        mj_idx = site_acts[0]
+
+        # The actuator's trnid must point at a site that actually exists in the
+        # exported MuJoCo model (verifies the shape was not silently dropped).
+        site_id = int(mj_model.actuator_trnid[mj_idx, 0])
+        self.assertGreaterEqual(site_id, 0)
+        self.assertLess(site_id, mj_model.nsite)
+        self.assertGreaterEqual(int(mj_model.site_bodyid[site_id]), 0)
+
+    def test_site_actuator_6dof_gear_mjcf(self):
+        """Non-trivial 6-DoF gear on a site actuator round-trips through MJCF."""
+        mjcf_6dof_gear = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test_site_gear">
+    <option gravity="0 0 -9.81"/>
+    <worldbody>
+        <body name="base" pos="0 0 1">
+            <freejoint name="root"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+            <site name="wrench_site" pos="0 0 0.1"/>
+        </body>
+    </worldbody>
+    <actuator>
+        <general name="wrench" site="wrench_site" gear="1 2 3 4 5 6"/>
+    </actuator>
+</mujoco>
+"""
+
+        builder = ModelBuilder()
+        builder.add_mjcf(mjcf_6dof_gear, ctrl_direct=True)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        newton_mj = solver.mj_model
+
+        import mujoco
+
+        mj_site_trntype = mujoco.mjtTrn.mjTRN_SITE
+        site_acts = [i for i in range(newton_mj.nu) if newton_mj.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(site_acts), 1)
+        mj_idx = site_acts[0]
+        np.testing.assert_allclose(newton_mj.actuator_gear[mj_idx, :6], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], atol=1e-5)
+
+        # Parity check: native MuJoCo sees the same gear vector on its site actuator.
+        native_model = SolverMuJoCo.import_mujoco()[0].MjModel.from_xml_string(mjcf_6dof_gear)
+        native_site_acts = [i for i in range(native_model.nu) if native_model.actuator_trntype[i] == mj_site_trntype]
+        self.assertEqual(len(native_site_acts), 1)
+        np.testing.assert_allclose(
+            newton_mj.actuator_gear[mj_idx, :6],
+            native_model.actuator_gear[native_site_acts[0], :6],
+            atol=1e-5,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`resolve_actuator_target` now checks `builder.shape_label` for shapes with `ShapeFlags.SITE` so that `MjcActuator` prims targeting sites are correctly resolved as `TrnType.SITE` during USD parsing.

Pass `site_mapping` into `_init_actuators`, build a `site_label_to_name` reverse lookup, and handle `TrnType.SITE` actuators by matching the actuator target label to the exported MuJoCo site name.

## Description

Add actuators that can be attached to `SITE`s.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```sh
# All site actuator tests (new)
uv run --extra dev -m newton.tests -k TestMuJoCoSiteActuators
```

## New feature / API change

```python
import warp as wp
from newton import ModelBuilder
from newton.solvers import SolverMuJoCo

builder = ModelBuilder()
builder.add_mjcf("""
<mujoco>
  <worldbody>
    <body name="arm" pos="0 0 1">
      <joint name="shoulder" type="hinge" axis="0 1 0"/>
      <geom type="capsule" size="0.05" fromto="0 0 0 0.3 0 0" mass="1"/>
      <site name="end_effector" pos="0.3 0 0"/>
    </body>
  </worldbody>
  <actuator>
    <general name="ee_force" site="end_effector" gainprm="50 0 0" biasprm="0 -50 -5"/>
  </actuator>
</mujoco>
""", ctrl_direct=True)

model = builder.finalize()
solver = SolverMuJoCo(model, iterations=10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MuJoCo solver now supports actuators that target sites and ensures site-referenced shapes are preserved during export (even when sites are disabled).

* **Tests**
  * Added unit tests validating site-targeted actuator parsing, export, parameter parity with native MuJoCo, and behavior when sites are excluded.

* **Documentation**
  * CHANGELOG updated to document site-targeted actuator support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->