### PR TITLE
Add custom physics callback support to MuJoCo solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add support for custom physics callbacks in the MuJoCo solver
 - Add 3D texture-based SDF, replacing NanoVDB volumes in the mesh-mesh collision pipeline for improved performance and CPU compatibility.
 - Add `--benchmark [SECONDS]` flag to examples for headless FPS measurement with warmup
 - Interactive example browser in the GL viewer with tree-view navigation and switch/reset support
@@ -75,6 +76,7 @@
 - Fix inertia box wireframe rotation for isotropic and axisymmetric bodies in viewer
 - Implicit MPM solver now uses `mass=0` for kinematic particles instead of `ACTIVE` flag
 - Fix `get_tetmesh()` winding order for left-handed USD meshes
+- Fix ``AttributeError`` when constructing ``SolverMuJoCo`` with dictionary-based ``callbacks`` arguments that occur from configuration serialization systems like IsaacLab
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any
 
@@ -2780,6 +2780,7 @@ class SolverMuJoCo(SolverBase):
         use_mujoco_contacts: bool = True,
         include_sites: bool = True,
         skip_visual_only_geoms: bool = True,
+        callbacks: Any | None = None,
     ):
         """
         Solver options (e.g., ``impratio``) follow this resolution priority:
@@ -2818,6 +2819,9 @@ class SolverMuJoCo(SolverBase):
             use_mujoco_contacts: If True, use the MuJoCo contact solver. If False, use the Newton contact solver (newton contacts must be passed in through the step function in that case).
             include_sites: If ``True`` (default), Newton shapes marked with ``ShapeFlags.SITE`` are exported as MuJoCo sites. Sites are non-colliding reference points used for sensor attachment, debugging, or as frames of reference. If ``False``, sites are skipped during export. Defaults to ``True``.
             skip_visual_only_geoms: If ``True`` (default), geometries used only for visualization (i.e. not involved in collision) are excluded from the exported MuJoCo spec. This avoids mismatches with models that use explicit ``<contact>`` definitions for collision geometry.
+            callbacks: Optional MuJoCo Warp callback configuration. Accepts either a
+                :class:`mujoco_warp.Callback` instance or a mapping of callback fields
+                used to construct one.
         """
         super().__init__(model)
 
@@ -2938,6 +2942,13 @@ class SolverMuJoCo(SolverBase):
 
         if self.mjw_model is not None:
             self.mjw_model.opt.run_collision_detection = use_mujoco_contacts
+            if callbacks is not None:
+                if isinstance(callbacks, Mapping):
+                    from mujoco_warp._src.types import Callback
+
+                    self.mjw_model.callback = Callback(**dict(callbacks))
+                else:
+                    self.mjw_model.callback = callbacks
 
     @event_scope
     def _mujoco_warp_step(self):

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 import unittest
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 
 import numpy as np  # For numerical operations and random values
 import warp as wp
@@ -8272,6 +8273,71 @@ class TestEqualityWeldConstraintDefaults(unittest.TestCase):
             )
         finally:
             os.unlink(xml_path)
+
+
+class TestMuJoCoSolverCallbacks(unittest.TestCase):
+    """Tests for the callbacks parameter of SolverMuJoCo."""
+
+    def _make_model(self):
+        builder = newton.ModelBuilder()
+        link = builder.add_link(mass=1.0, com=wp.vec3(0.0, 0.0, 0.0), inertia=wp.mat33(np.eye(3)))
+        joint = builder.add_joint_revolute(-1, link)
+        builder.add_articulation([joint])
+        return builder.finalize()
+
+    def test_callbacks_none_by_default(self):
+        """Callbacks are not set when None is passed (default)."""
+        from mujoco_warp._src.types import Callback
+
+        model = self._make_model()
+        solver = SolverMuJoCo(model)
+        self.assertIsInstance(solver.mjw_model.callback, Callback)
+        self.assertIsNone(solver.mjw_model.callback.control)
+        self.assertIsNone(solver.mjw_model.callback.passive)
+
+    def test_callbacks_with_callback_instance(self):
+        """A Callback instance is assigned directly."""
+        from mujoco_warp._src.types import Callback
+
+        def my_control(m, d):
+            pass
+
+        model = self._make_model()
+        cb = Callback(control=my_control)
+        solver = SolverMuJoCo(model, callbacks=cb)
+        self.assertIs(solver.mjw_model.callback, cb)
+        self.assertIs(solver.mjw_model.callback.control, my_control)
+
+    def test_callbacks_with_dict(self):
+        """A dict of callback fields constructs a Callback."""
+        model = self._make_model()
+        solver = SolverMuJoCo(model, callbacks={"control": lambda m, d: None})
+        self.assertIsNotNone(solver.mjw_model.callback.control)
+        self.assertIsNone(solver.mjw_model.callback.passive)
+
+    def test_callbacks_with_mapping(self):
+        """A non-dict Mapping is accepted and constructs a Callback."""
+
+        class CallbackMapping(Mapping):
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def __len__(self):
+                return len(self._data)
+
+        def my_passive(m, d):
+            pass
+
+        model = self._make_model()
+        solver = SolverMuJoCo(model, callbacks=CallbackMapping({"passive": my_passive}))
+        self.assertIs(solver.mjw_model.callback.passive, my_passive)
+        self.assertIsNone(solver.mjw_model.callback.control)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Newton now supports passing `mujoco_warp.Callback` objects to its MuJoCo solver. This allows users to easily inject custom physics behaviors such as aerodynamic forces, control laws, and actuator dynamics into the simulation pipeline.

## Description

[https://github.com/google-deepmind/mujoco_warp/pull/1168](https://github.com/google-deepmind/mujoco_warp/pull/1168) (in `mujoco-warp>=3.6.0`) introduced physics callbacks to MuJoCo Warp, bringing it in line with the base MuJoCo.  This PR exposes this through implementable callbacks.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

 ```
uv run --extra dev -m newton.tests -k TestMuJoCoSolverCallbacks
 ```

## New feature / API change

```python
import warp as wp
import newton
from newton.solvers import SolverMuJoCo

# Build a simple model
builder = newton.ModelBuilder()
link = builder.add_link(mass=1.0, com=wp.vec3(), inertia=wp.mat33(1.0, 0, 0, 0, 1.0, 0, 0, 0, 1.0))
joint = builder.add_joint_revolute(-1, link)
builder.add_articulation([joint])
model = builder.finalize()

# Define a custom control callback
def my_control(m, d):
    """Apply a sinusoidal torque to every actuator."""
    wp.launch(apply_torque_kernel, dim=m.nu, inputs=[d.ctrl, d.time])

# Pass callbacks as a Callback instance
from mujoco_warp._src.types import Callback
solver = SolverMuJoCo(model, callbacks=Callback(control=my_control))

# Or equivalently, pass as a dict
solver = SolverMuJoCo(model, callbacks={"control": my_control})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom physics callbacks in the MuJoCo solver.

* **Bug Fixes**
  * Fixed an error when constructing the MuJoCo solver using dictionary-like callback configurations (serialization scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->