### PR TITLE
Fix multi-GPU illegal memory access in texture SDF tests

### DIFF
--- a/newton/tests/test_sdf_texture.py
+++ b/newton/tests/test_sdf_texture.py
@@ -921,7 +921,7 @@ def test_uint16_vs_nanovdb_distance(test, device):
     )
 
     mesh_copy = _create_box_mesh()
-    mesh_copy.build_sdf(max_resolution=64, narrow_band_range=(-0.1, 0.1), margin=0.05)
+    mesh_copy.build_sdf(max_resolution=64, narrow_band_range=(-0.1, 0.1), margin=0.05, device=device)
     nanovdb_data = mesh_copy.sdf.to_kernel_data()
 
     query_np = _generate_query_points(mesh, num_points=2000)
@@ -955,7 +955,7 @@ def test_uint16_vs_nanovdb_gradient(test, device):
     )
 
     mesh_copy = _create_box_mesh()
-    mesh_copy.build_sdf(max_resolution=64, narrow_band_range=(-0.1, 0.1), margin=0.05)
+    mesh_copy.build_sdf(max_resolution=64, narrow_band_range=(-0.1, 0.1), margin=0.05, device=device)
     nanovdb_data = mesh_copy.sdf.to_kernel_data()
 
     query_np = _generate_query_points(mesh, num_points=2000)


### PR DESCRIPTION
## Description

`test_uint16_vs_nanovdb_distance` and `test_uint16_vs_nanovdb_gradient` called
`mesh_copy.build_sdf()` without `device=device`, so the NanoVDB SDF was always
allocated on `cuda:0`. When the test runner parameterised these tests for
`cuda:1`, the sampling kernel dereferenced `cuda:0` volume pointers from a
`cuda:1` context, triggering CUDA error 700 (illegal memory access).

The fix adds `device=device` to both `build_sdf()` calls so the NanoVDB data
is allocated on the same device the test is running on.

Failure: https://github.com/newton-physics/newton/actions/runs/23399334631/job/68067963937

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Re-run the multi-GPU CI workflow. The three errors in `test_sdf_texture.TestTextureSDF` should be gone:
- `test_uint16_vs_nanovdb_distance_cuda_1`
- `test_uint16_vs_nanovdb_gradient_cuda_0` (cascading from poisoned CUDA context)
- `test_uint16_vs_nanovdb_gradient_cuda_1`

## Bug fix

**Steps to reproduce:**

1. Run the test suite on a machine with 2+ CUDA devices
2. `test_uint16_vs_nanovdb_distance_cuda_1` hits CUDA error 700
3. Subsequent `cuda_0`/`cuda_1` gradient tests also fail due to poisoned CUDA context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test robustness and consistency by updating SDF texture test suite with explicit device configuration specifications in NanoVDB reference builds. Distance and gradient comparison tests now receive explicit device parameters instead of relying on implicit default device selection, enhancing predictability and ensuring reliable behavior across diverse execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->