### PR TITLE
Add standalone viewer entry point (newton-viewer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add brick stacking example
 - Add box pyramid example and ASV benchmark for dense convex-on-convex contacts
 - Add plotting example showing how to access and visualize per-step simulation diagnostics
+- Add standalone viewer entry point (`newton-viewer` / `python -m newton.viewer`) for loading and simulating USD, URDF, and MJCF files with drag-and-drop, solver selection, and ground plane toggle
 - Add `exposure` property to GL renderer
 - Add `snap_to` argument to `ViewerGL.log_gizmo()` to snap gizmos to a target world transform when the user releases them
 - Expose `gizmo_is_using` attribute to detect whether a gizmo is actively being dragged

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -956,6 +956,7 @@ class RendererGL:
                 resizable=True,
                 vsync=vsync,
                 visible=not headless,
+                file_drops=True,
                 config=config,
             )
             gl.glEnable(gl.GL_MULTISAMPLE)
@@ -970,6 +971,7 @@ class RendererGL:
                 resizable=True,
                 vsync=vsync,
                 visible=not headless,
+                file_drops=True,
             )
             self.msaa_samples = 0
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -990,6 +990,7 @@ class RendererGL:
         self._last_x, self._last_y = self._screen_width // 2, self._screen_height // 2
         self._key_callbacks = []
         self._key_release_callbacks = []
+        self._file_drop_callbacks = []
 
         self._env_texture = None
         self._env_intensity = 1.0
@@ -1289,6 +1290,8 @@ class RendererGL:
         self.window.on_mouse_drag = self._on_mouse_drag
         self.window.on_mouse_motion = self._on_mouse_motion
 
+        self.window.push_handlers(on_file_drop=self._on_file_drop)
+
     def register_key_press(self, callback):
         """Register a callback for key press events.
 
@@ -1356,6 +1359,19 @@ class RendererGL:
     def register_update(self, callback):
         """Register a per-frame update callback receiving dt (seconds)."""
         self._update_callbacks.append(callback)
+
+    def register_file_drop(self, callback):
+        """Register a callback for file drop events.
+
+        Args:
+            callback: Function that takes (x, y, paths) parameters,
+                      where paths is a list of file path strings.
+        """
+        self._file_drop_callbacks.append(callback)
+
+    def _on_file_drop(self, x, y, paths):
+        for callback in self._file_drop_callbacks:
+            callback(x, y, paths)
 
     def _on_key_press(self, symbol, modifiers):
         # update key state

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -1635,7 +1635,7 @@ class ViewerGL(ViewerBase):
         elif symbol == pyglet.window.key.R:
             if self.on_reset is not None:
                 self.on_reset()
-        elif symbol == pyglet.window.key.PERIOD:
+        elif symbol in (pyglet.window.key.PERIOD, pyglet.window.key.RIGHT):
             self.step_once()
 
     def on_key_release(self, symbol: int, modifiers: int):

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -245,6 +245,8 @@ class ViewerGL(ViewerBase):
         self.on_reset: Callable[[], None] | None = None
         self.on_solver_change: Callable[[str], None] | None = None
         self._step_requested = False
+        self._error_message: str | None = None
+        self._error_popup_pending = False
 
         # Camera movement settings
         self._camera_speed = 0.04
@@ -1224,7 +1226,14 @@ class ViewerGL(ViewerBase):
 
             # Render the UI
             self._render_ui()
+            self._render_error_popup()
 
+            self.ui.end_frame()
+            self.ui.render()
+        elif self.ui and self.ui.is_available and self._error_message is not None:
+            # Render error popup even when the rest of the UI is hidden
+            self.ui.begin_frame()
+            self._render_error_popup()
             self.ui.end_frame()
             self.ui.render()
 
@@ -1352,6 +1361,15 @@ class ViewerGL(ViewerBase):
             self._step_requested = False
             return True
         return False
+
+    def show_error(self, message: str):
+        """Display a dismissible error popup in the viewer.
+
+        Args:
+            message: Error message to display.
+        """
+        self._error_message = message
+        self._error_popup_pending = True
 
     @override
     def close(self):
@@ -1885,6 +1903,23 @@ class ViewerGL(ViewerBase):
                 del self._gizmo_active[gid]
 
         self.gizmo_is_using = giz.is_using_any()
+
+    def _render_error_popup(self):
+        """Render the error popup if an error message is pending."""
+        if self._error_message is None or not self.ui:
+            return
+        imgui = self.ui.imgui
+        if self._error_popup_pending:
+            imgui.open_popup("Error")
+            self._error_popup_pending = False
+        if imgui.begin_popup_modal("Error", True)[0]:
+            imgui.text_wrapped(self._error_message)
+            if imgui.button("OK"):
+                self._error_message = None
+                imgui.close_current_popup()
+            imgui.end_popup()
+        else:
+            self._error_message = None  # closed via X
 
     def _render_ui(self):
         """

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -252,6 +252,7 @@ class ViewerGL(ViewerBase):
         self._step_requested = False
         self._error_message: str | None = None
         self._error_popup_pending = False
+        self._status_message: str | None = None
 
         # Camera movement settings
         self._camera_speed = 0.04
@@ -1232,13 +1233,15 @@ class ViewerGL(ViewerBase):
             # Render the UI
             self._render_ui()
             self._render_error_popup()
+            self._render_status_overlay()
 
             self.ui.end_frame()
             self.ui.render()
-        elif self.ui and self.ui.is_available and self._error_message is not None:
-            # Render error popup even when the rest of the UI is hidden
+        elif self.ui and self.ui.is_available and (self._error_message is not None or self._status_message is not None):
+            # Render overlays even when the rest of the UI is hidden
             self.ui.begin_frame()
             self._render_error_popup()
+            self._render_status_overlay()
             self.ui.end_frame()
             self.ui.render()
 
@@ -1375,6 +1378,18 @@ class ViewerGL(ViewerBase):
         """
         self._error_message = message
         self._error_popup_pending = True
+
+    def show_status(self, message: str):
+        """Show a centered status overlay (e.g. "Loading...").
+
+        Call :meth:`clear_status` to remove it.  Rendering a frame while
+        the status is set will display the message as a centered overlay.
+        """
+        self._status_message = message
+
+    def clear_status(self):
+        """Remove the status overlay set by :meth:`show_status`."""
+        self._status_message = None
 
     @override
     def close(self):
@@ -1925,6 +1940,28 @@ class ViewerGL(ViewerBase):
             imgui.end_popup()
         else:
             self._error_message = None  # closed via X
+
+    def _render_status_overlay(self):
+        """Render a centered status message overlay."""
+        if self._status_message is None or not self.ui:
+            return
+        imgui = self.ui.imgui
+        viewport = imgui.get_main_viewport()
+        text_size = imgui.calc_text_size(self._status_message)
+        pos_x = viewport.pos.x + (viewport.size.x - text_size.x) * 0.5
+        pos_y = viewport.pos.y + (viewport.size.y - text_size.y) * 0.5
+        imgui.set_next_window_pos(imgui.ImVec2(pos_x, pos_y))
+        imgui.set_next_window_bg_alpha(0.7)
+        flags = (
+            imgui.WindowFlags_.no_decoration
+            | imgui.WindowFlags_.always_auto_resize
+            | imgui.WindowFlags_.no_saved_settings
+            | imgui.WindowFlags_.no_focus_on_appearing
+            | imgui.WindowFlags_.no_nav
+        )
+        if imgui.begin("##status_overlay", None, flags)[0]:
+            imgui.text(self._status_message)
+        imgui.end()
 
     def _render_ui(self):
         """

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import ctypes
+import os
 import re
 import time
 from collections.abc import Callable, Sequence
@@ -249,7 +250,7 @@ class ViewerGL(ViewerBase):
         self._solver_idx: int = 0
         self._ground_enabled: bool = False
         self._file_info: dict | None = None
-        self._step_requested = False
+        self._step_requested: bool = False
         self._error_message: str | None = None
         self._error_popup_pending = False
         self._status_message: str | None = None
@@ -488,7 +489,12 @@ class ViewerGL(ViewerBase):
                 wp.load_module(module=_raycast_module, device=model.device)
                 wp.load_module(module="newton._src.viewer.kernels", device=model.device)
             except Exception:
-                pass
+                import warnings  # noqa: PLC0415
+
+                warnings.warn(
+                    "Failed to precompile picking kernels; picking may be slow or unavailable",
+                    stacklevel=1,
+                )
 
         # Build packed arrays for batched GPU rendering of shape instances
         self._build_packed_vbo_arrays()
@@ -1227,19 +1233,11 @@ class ViewerGL(ViewerBase):
         # Always update FPS tracking, even if UI is hidden
         self._update_fps()
 
-        if self.ui and self.ui.is_available and self.show_ui:
+        has_overlay = self._error_message is not None or self._status_message is not None
+        if self.ui and self.ui.is_available and (self.show_ui or has_overlay):
             self.ui.begin_frame()
-
-            # Render the UI
-            self._render_ui()
-            self._render_error_popup()
-            self._render_status_overlay()
-
-            self.ui.end_frame()
-            self.ui.render()
-        elif self.ui and self.ui.is_available and (self._error_message is not None or self._status_message is not None):
-            # Render overlays even when the rest of the UI is hidden
-            self.ui.begin_frame()
+            if self.show_ui:
+                self._render_ui()
             self._render_error_popup()
             self._render_status_overlay()
             self.ui.end_frame()
@@ -2052,8 +2050,6 @@ class ViewerGL(ViewerBase):
                     # File info
                     if self._file_info is not None:
                         imgui.separator()
-                        import os  # noqa: PLC0415
-
                         imgui.text(f"File: {os.path.basename(self._file_info['path'])}")
                         imgui.text(f"Bodies: {self._file_info['body_count']}")
                         imgui.text(f"Joints: {self._file_info['joint_count']}")

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -238,6 +238,10 @@ class ViewerGL(ViewerBase):
         self.renderer.register_mouse_drag(self.on_mouse_drag)
         self.renderer.register_mouse_scroll(self.on_mouse_scroll)
         self.renderer.register_resize(self.on_resize)
+        self.renderer.register_file_drop(self._on_file_drop)
+
+        # Standalone viewer callbacks
+        self.on_file_drop: Callable[[str], None] | None = None
 
         # Camera movement settings
         self._camera_speed = 0.04
@@ -1594,6 +1598,11 @@ class ViewerGL(ViewerBase):
             modifiers: Active modifier bitmask for this event.
         """
         pass
+
+    def _on_file_drop(self, x: int, y: int, paths: list[str]):
+        """Handle file drop events from pyglet."""
+        if self.on_file_drop is not None and paths:
+            self.on_file_drop(paths[0])
 
     def _frame_camera_on_model(self):
         """

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -242,6 +242,9 @@ class ViewerGL(ViewerBase):
 
         # Standalone viewer callbacks
         self.on_file_drop: Callable[[str], None] | None = None
+        self.on_reset: Callable[[], None] | None = None
+        self.on_solver_change: Callable[[str], None] | None = None
+        self._step_requested = False
 
         # Camera movement settings
         self._camera_speed = 0.04
@@ -1332,6 +1335,24 @@ class ViewerGL(ViewerBase):
         """
         return self._paused
 
+    def step_once(self) -> bool:
+        """Request a single simulation step.
+
+        If the viewer is paused, sets a flag that the caller's simulation
+        loop can check via ``consume_step_request()``.
+        """
+        if self._paused:
+            self._step_requested = True
+            return True
+        return False
+
+    def consume_step_request(self) -> bool:
+        """Return True and clear if a single-step was requested."""
+        if self._step_requested:
+            self._step_requested = False
+            return True
+        return False
+
     @override
     def close(self):
         """
@@ -1588,6 +1609,11 @@ class ViewerGL(ViewerBase):
         elif symbol == pyglet.window.key.ESCAPE:
             # Exit with Escape key
             self.renderer.close()
+        elif symbol == pyglet.window.key.R:
+            if self.on_reset is not None:
+                self.on_reset()
+        elif symbol == pyglet.window.key.PERIOD:
+            self.step_once()
 
     def on_key_release(self, symbol: int, modifiers: int):
         """

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -244,6 +244,11 @@ class ViewerGL(ViewerBase):
         self.on_file_drop: Callable[[str], None] | None = None
         self.on_reset: Callable[[], None] | None = None
         self.on_solver_change: Callable[[str], None] | None = None
+        self.on_ground_toggle: Callable[[bool], None] | None = None
+        self.solver_names: list[str] = []
+        self._solver_idx: int = 0
+        self._ground_enabled: bool = False
+        self._file_info: dict | None = None
         self._step_requested = False
         self._error_message: str | None = None
         self._error_popup_pending = False
@@ -1981,6 +1986,41 @@ class ViewerGL(ViewerBase):
 
                     # Pause simulation checkbox
                     changed, self._paused = imgui.checkbox("Pause", self._paused)
+
+                    # Simulation time
+                    imgui.text(f"Time: {self.time:.2f}s")
+
+                    # Solver dropdown
+                    if self.on_solver_change is not None and self.solver_names:
+                        changed, self._solver_idx = imgui.combo("Solver", self._solver_idx, self.solver_names)
+                        if changed:
+                            self.on_solver_change(self.solver_names[self._solver_idx])
+
+                    # Single-step and reset buttons
+                    if self._paused:
+                        if imgui.button("Step"):
+                            self.step_once()
+                    if self.on_reset is not None:
+                        if self._paused:
+                            imgui.same_line()
+                        if imgui.button("Reset"):
+                            self.on_reset()
+
+                    # Ground plane toggle
+                    if self.on_ground_toggle is not None:
+                        changed, self._ground_enabled = imgui.checkbox("Ground Plane", self._ground_enabled)
+                        if changed:
+                            self.on_ground_toggle(self._ground_enabled)
+
+                    # File info
+                    if self._file_info is not None:
+                        imgui.separator()
+                        import os  # noqa: PLC0415
+
+                        imgui.text(f"File: {os.path.basename(self._file_info['path'])}")
+                        imgui.text(f"Bodies: {self._file_info['body_count']}")
+                        imgui.text(f"Joints: {self._file_info['joint_count']}")
+                        imgui.text(f"Shapes: {self._file_info['shape_count']}")
 
                 # Visualization Controls section
                 imgui.set_next_item_open(True, imgui.Cond_.appearing)

--- a/newton/tests/test_standalone_viewer.py
+++ b/newton/tests/test_standalone_viewer.py
@@ -5,7 +5,8 @@ import os
 import unittest
 
 import newton
-from newton.viewer._standalone import SOLVER_MAP, SimState, _create_parser, load_file
+from newton.viewer import SOLVER_MAP, SimState, load_file
+from newton.viewer._standalone import _create_parser
 
 _ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "examples", "assets")
 

--- a/newton/tests/test_standalone_viewer.py
+++ b/newton/tests/test_standalone_viewer.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import unittest
+
+import newton
+from newton.viewer._standalone import SOLVER_MAP, SimState, _create_parser, load_file
+
+_ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "examples", "assets")
+
+
+class TestStandaloneViewer(unittest.TestCase):
+    """Tests for the standalone viewer file loading and argument parsing."""
+
+    def test_parser_defaults(self):
+        """Verify default argument values."""
+        args = _create_parser().parse_args([])
+        self.assertIsNone(args.file)
+        self.assertEqual(args.solver, "mujoco")
+        self.assertIsNone(args.device)
+        self.assertFalse(args.no_ground)
+
+    def test_parser_with_file(self):
+        """Verify file argument is parsed."""
+        args = _create_parser().parse_args(["test.usd"])
+        self.assertEqual(args.file, "test.usd")
+
+    def test_parser_solver_choices(self):
+        """Verify all SOLVER_MAP keys are valid CLI choices."""
+        for solver_name in SOLVER_MAP:
+            args = _create_parser().parse_args(["--solver", solver_name])
+            self.assertEqual(args.solver, solver_name)
+
+    def test_load_file_unsupported_format(self):
+        """Verify unsupported formats raise ValueError."""
+        with self.assertRaises(ValueError):
+            load_file("test.stl")
+
+    def test_load_usd_with_ground(self):
+        """Load a USD asset with ground plane and verify SimState."""
+        asset_path = os.path.join(_ASSETS_DIR, "cartpole_single_pendulum.usda")
+        if not os.path.exists(asset_path):
+            self.skipTest(f"Asset not found: {asset_path}")
+        sim = load_file(asset_path, solver_name="mujoco", device="cpu", ground=True)
+        self.assertIsInstance(sim, SimState)
+        self.assertIsNotNone(sim.model)
+        self.assertIsNotNone(sim.solver)
+        self.assertGreater(sim.model.body_count, 0)
+        self.assertGreater(sim.dt, 0.0)
+        self.assertIsNone(sim.graph)  # CPU path, no CUDA graph
+
+    def test_load_usd_without_ground(self):
+        """Load a USD asset without ground plane."""
+        asset_path = os.path.join(_ASSETS_DIR, "cartpole_single_pendulum.usda")
+        if not os.path.exists(asset_path):
+            self.skipTest(f"Asset not found: {asset_path}")
+        sim = load_file(asset_path, solver_name="xpbd", device="cpu", ground=False)
+        self.assertIsInstance(sim, SimState)
+
+    def test_solver_map_classes_exist(self):
+        """Verify all solver classes in SOLVER_MAP actually exist."""
+        for solver_name, cls_name in SOLVER_MAP.items():
+            self.assertTrue(
+                hasattr(newton.solvers, cls_name),
+                f"Solver class {cls_name} for key '{solver_name}' not found in newton.solvers",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_standalone_viewer.py
+++ b/newton/tests/test_standalone_viewer.py
@@ -5,8 +5,7 @@ import os
 import unittest
 
 import newton
-from newton.viewer import SOLVER_MAP, SimState, load_file
-from newton.viewer._standalone import _create_parser
+from newton.viewer._standalone import SOLVER_MAP, SimState, _create_parser, load_file
 
 _ASSETS_DIR = os.path.join(os.path.dirname(__file__), "..", "examples", "assets")
 

--- a/newton/viewer/__init__.py
+++ b/newton/viewer/__init__.py
@@ -3,11 +3,9 @@
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
 from .._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
-from ._standalone import SOLVER_MAP, SimState, load_file, main
+from ._standalone import main
 
 __all__ = [
-    "SOLVER_MAP",
-    "SimState",
     "ViewerBase",
     "ViewerFile",
     "ViewerGL",
@@ -15,6 +13,5 @@ __all__ = [
     "ViewerRerun",
     "ViewerUSD",
     "ViewerViser",
-    "load_file",
     "main",
 ]

--- a/newton/viewer/__init__.py
+++ b/newton/viewer/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
-from ._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
+from .._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
 
 __all__ = [
     "ViewerBase",

--- a/newton/viewer/__init__.py
+++ b/newton/viewer/__init__.py
@@ -3,9 +3,11 @@
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
 from .._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
-from ._standalone import main
+from ._standalone import SOLVER_MAP, SimState, load_file, main
 
 __all__ = [
+    "SOLVER_MAP",
+    "SimState",
     "ViewerBase",
     "ViewerFile",
     "ViewerGL",
@@ -13,5 +15,6 @@ __all__ = [
     "ViewerRerun",
     "ViewerUSD",
     "ViewerViser",
+    "load_file",
     "main",
 ]

--- a/newton/viewer/__init__.py
+++ b/newton/viewer/__init__.py
@@ -3,6 +3,7 @@
 
 # Import all viewer classes (they handle missing dependencies at instantiation time)
 from .._src.viewer import ViewerBase, ViewerFile, ViewerGL, ViewerNull, ViewerRerun, ViewerUSD, ViewerViser
+from ._standalone import main
 
 __all__ = [
     "ViewerBase",
@@ -12,4 +13,5 @@ __all__ = [
     "ViewerRerun",
     "ViewerUSD",
     "ViewerViser",
+    "main",
 ]

--- a/newton/viewer/__main__.py
+++ b/newton/viewer/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Entry point for 'python -m newton.viewer [file]'."""
+
+from newton.viewer import main
+
+if __name__ == "__main__":
+    main()

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -276,7 +276,12 @@ def main():
         should_step = sim is not None and (not viewer.is_paused() or viewer.consume_step_request())
 
         if should_step:
-            if sim.graph:
+            # Fall back to direct simulation when interactive forces are
+            # active (picking, wind) since those can't be baked into a graph.
+            use_graph = sim.graph and not (
+                viewer.picking_enabled and viewer.picking is not None and viewer.picking.is_picking()
+            )
+            if use_graph:
                 wp.capture_launch(sim.graph)
             else:
                 _simulate_with_forces(sim, viewer)

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -213,9 +213,17 @@ def main():
     solver_name = args.solver
     ground = not args.no_ground
 
+    def _flush_frame():
+        """Render one frame so the status overlay appears on screen."""
+        viewer.begin_frame(sim.sim_time if sim else 0.0)
+        viewer.end_frame()
+
     def load_and_setup(path: str):
         nonlocal sim
+        viewer.show_status(f"Loading {os.path.basename(path)}...")
+        _flush_frame()
         new_sim = load_file(path, solver_name=solver_name, device=args.device, ground=ground)
+        viewer.clear_status()
         viewer.set_model(new_sim.model)
         viewer._file_info = {
             "path": path,

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -77,14 +77,22 @@ def load_file(
         raise ValueError(f"Unsupported file format: '{ext}'. Expected .usd, .usda, .usdc, .urdf, .xml, or .mjcf")
 
     if ground:
-        # Place ground plane at the lowest body position in the asset
-        min_z = 0.0
-        for q in builder.body_q:
-            z = float(q[2])  # transform layout: [px, py, pz, qx, qy, qz, qw]
-            if z < min_z:
-                min_z = z
+        # Place ground plane below the lowest shape in the asset.
+        # For each shape, estimate its world-space lower Z bound from
+        # the body position, shape offset, and the shape's largest scale
+        # dimension (conservative bounding sphere radius).
+        ground_z = 0.0
+        for i in range(len(builder.shape_transform)):
+            body = builder.shape_body[i]
+            body_z = float(builder.body_q[body][2]) if body >= 0 else 0.0
+            shape_z = float(builder.shape_transform[i][2])
+            scale = builder.shape_scale[i]
+            radius = max(abs(float(scale[0])), abs(float(scale[1])), abs(float(scale[2])))
+            lower_z = body_z + shape_z - radius
+            if lower_z < ground_z:
+                ground_z = lower_z
         # plane equation (0,0,1,-h) defines z = h
-        builder.add_shape_plane(plane=(0.0, 0.0, 1.0, -min_z))
+        builder.add_shape_plane(plane=(0.0, 0.0, 1.0, -ground_z))
 
     model = builder.finalize(device=device)
     solver = _create_solver(solver_name, model)

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import traceback
 from dataclasses import dataclass
 
 import warp as wp
@@ -129,29 +130,24 @@ def load_file(
     return sim
 
 
-def _simulate(sim: SimState):
+def _simulate(sim: SimState, viewer=None):
     """Run one frame of simulation (sim_substeps steps).
 
     Used both for direct execution (CPU) and inside wp.ScopedCapture()
     for CUDA graph recording.  During graph capture, Python executes
     normally (including attribute swaps on sim) while CUDA records kernel
-    launches — so the swapped attribute references correctly resolve to
+    launches -- so the swapped attribute references correctly resolve to
     alternating GPU buffers in the captured graph.
 
-    This is the same pattern used by all existing Newton examples.
+    Args:
+        sim: Simulation state to advance.
+        viewer: Optional viewer for applying interactive forces (picking,
+            wind).  Ignored during CUDA graph capture.
     """
     for _ in range(sim.sim_substeps):
         sim.state_0.clear_forces()
-        sim.model.collide(sim.state_0, sim.contacts)
-        sim.solver.step(sim.state_0, sim.state_1, sim.control, sim.contacts, sim.sim_dt)
-        sim.state_0, sim.state_1 = sim.state_1, sim.state_0
-
-
-def _simulate_with_forces(sim: SimState, viewer):
-    """CPU-only simulation path that includes viewer interactive forces."""
-    for _ in range(sim.sim_substeps):
-        sim.state_0.clear_forces()
-        viewer.apply_forces(sim.state_0)
+        if viewer is not None:
+            viewer.apply_forces(sim.state_0)
         sim.model.collide(sim.state_0, sim.contacts)
         sim.solver.step(sim.state_0, sim.state_1, sim.control, sim.contacts, sim.sim_dt)
         sim.state_0, sim.state_1 = sim.state_1, sim.state_0
@@ -238,38 +234,40 @@ def main():
         viewer._ground_enabled = ground
         sim = new_sim
 
+    def _reload_current():
+        """Reload the current file, showing errors in the viewer."""
+        if sim is not None:
+            try:
+                load_and_setup(sim.path)
+            except Exception as e:
+                traceback.print_exc()
+                viewer.clear_status()
+                viewer.show_error(str(e))
+
     def on_drop(path: str):
-        nonlocal sim
         try:
             load_and_setup(path)
         except Exception as e:
+            traceback.print_exc()
+            viewer.clear_status()
             viewer.show_error(str(e))
 
     def on_reset():
         if sim is not None:
             sim.state_0.assign(sim.initial_state)
             sim.sim_time = 0.0
-            # Re-capture graph after state reset
             if sim.model.device.is_cuda:
                 sim.graph = _capture_graph(sim)
 
     def on_solver_change(new_solver: str):
         nonlocal solver_name
         solver_name = new_solver
-        if sim is not None:
-            try:
-                load_and_setup(sim.path)
-            except Exception as e:
-                viewer.show_error(str(e))
+        _reload_current()
 
     def on_ground_toggle(enabled: bool):
         nonlocal ground
         ground = enabled
-        if sim is not None:
-            try:
-                load_and_setup(sim.path)
-            except Exception as e:
-                viewer.show_error(str(e))
+        _reload_current()
 
     viewer.on_file_drop = on_drop
     viewer.on_reset = on_reset
@@ -281,6 +279,8 @@ def main():
         try:
             load_and_setup(args.file)
         except Exception as e:
+            traceback.print_exc()
+            viewer.clear_status()
             viewer.show_error(str(e))
 
     # Main loop
@@ -288,16 +288,21 @@ def main():
         should_step = sim is not None and (not viewer.is_paused() or viewer.consume_step_request())
 
         if should_step:
-            # Fall back to direct simulation when interactive forces are
-            # active (picking, wind) since those can't be baked into a graph.
-            use_graph = sim.graph and not (
-                viewer.picking_enabled and viewer.picking is not None and viewer.picking.is_picking()
-            )
-            if use_graph:
-                wp.capture_launch(sim.graph)
-            else:
-                _simulate_with_forces(sim, viewer)
-            sim.sim_time += sim.dt
+            try:
+                # Fall back to direct simulation when interactive forces are
+                # active (picking, wind) since those can't be baked into a graph.
+                use_graph = sim.graph and not (
+                    viewer.picking_enabled and viewer.picking is not None and viewer.picking.is_picking()
+                )
+                if use_graph:
+                    wp.capture_launch(sim.graph)
+                else:
+                    _simulate(sim, viewer)
+                sim.sim_time += sim.dt
+            except Exception as e:
+                traceback.print_exc()
+                viewer.show_error(f"Simulation error: {e}")
+                viewer._paused = True
 
         viewer.begin_frame(sim.sim_time if sim else 0.0)
         if sim:

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone viewer entry point for loading and simulating physics assets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+
+import warp as wp
+
+import newton
+
+SOLVER_MAP = {
+    "mujoco": "SolverMuJoCo",
+    "xpbd": "SolverXPBD",
+    "featherstone": "SolverFeatherstone",
+    "semi-implicit": "SolverSemiImplicit",
+}
+
+
+@dataclass
+class SimState:
+    """Holds all simulation state for the standalone viewer."""
+
+    model: newton.Model
+    solver: object
+    control: newton.Control
+    state_0: newton.State
+    state_1: newton.State
+    initial_state: newton.State
+    contacts: newton.Contacts
+    graph: object | None
+    path: str
+    dt: float
+    sim_substeps: int
+    sim_dt: float
+    sim_time: float = 0.0
+
+
+def _create_solver(solver_name: str, model: newton.Model):
+    """Create a solver instance from a string name."""
+    cls_name = SOLVER_MAP[solver_name]
+    cls = getattr(newton.solvers, cls_name)
+    return cls(model)
+
+
+def load_file(
+    path: str,
+    solver_name: str = "mujoco",
+    device: str | None = None,
+    ground: bool = True,
+) -> SimState:
+    """Load a USD/URDF/MJCF file and build a ready-to-simulate SimState.
+
+    Args:
+        path: Path to asset file.
+        solver_name: Key into SOLVER_MAP.
+        device: Warp device string, or None for default.
+        ground: Whether to add a ground plane.
+
+    Returns:
+        A fully initialized SimState.
+    """
+    builder = newton.ModelBuilder()
+    ext = os.path.splitext(path)[1].lower()
+
+    if ext in (".usd", ".usda", ".usdc"):
+        builder.add_usd(path)
+    elif ext == ".urdf":
+        builder.add_urdf(path)
+    elif ext in (".xml", ".mjcf"):
+        builder.add_mjcf(path)
+    else:
+        raise ValueError(f"Unsupported file format: '{ext}'. Expected .usd, .usda, .usdc, .urdf, .xml, or .mjcf")
+
+    if ground:
+        builder.add_shape_plane()
+
+    model = builder.finalize(device=device)
+    solver = _create_solver(solver_name, model)
+    control = model.control()
+    state_0 = model.state()
+    state_1 = model.state()
+    initial_state = model.state()
+    contacts = model.contacts()
+
+    # Determine timestep and substeps
+    dt = getattr(model, "dt", 1.0 / 60.0) or 1.0 / 60.0
+    sim_substeps = max(1, round(dt * 120.0))
+    sim_dt = dt / sim_substeps
+
+    sim = SimState(
+        model=model,
+        solver=solver,
+        control=control,
+        state_0=state_0,
+        state_1=state_1,
+        initial_state=initial_state,
+        contacts=contacts,
+        graph=None,
+        path=path,
+        dt=dt,
+        sim_substeps=sim_substeps,
+        sim_dt=sim_dt,
+    )
+
+    # Capture CUDA graph
+    if model.device.is_cuda:
+        sim.graph = _capture_graph(sim)
+
+    return sim
+
+
+def _simulate(sim: SimState):
+    """Run one frame of simulation (sim_substeps steps).
+
+    Used both for direct execution (CPU) and inside wp.ScopedCapture()
+    for CUDA graph recording.  During graph capture, Python executes
+    normally (including attribute swaps on sim) while CUDA records kernel
+    launches — so the swapped attribute references correctly resolve to
+    alternating GPU buffers in the captured graph.
+
+    This is the same pattern used by all existing Newton examples.
+    """
+    for _ in range(sim.sim_substeps):
+        sim.state_0.clear_forces()
+        sim.model.collide(sim.state_0, sim.contacts)
+        sim.solver.step(sim.state_0, sim.state_1, sim.control, sim.contacts, sim.sim_dt)
+        sim.state_0, sim.state_1 = sim.state_1, sim.state_0
+
+
+def _simulate_with_forces(sim: SimState, viewer):
+    """CPU-only simulation path that includes viewer interactive forces."""
+    for _ in range(sim.sim_substeps):
+        sim.state_0.clear_forces()
+        viewer.apply_forces(sim.state_0)
+        sim.model.collide(sim.state_0, sim.contacts)
+        sim.solver.step(sim.state_0, sim.state_1, sim.control, sim.contacts, sim.sim_dt)
+        sim.state_0, sim.state_1 = sim.state_1, sim.state_0
+
+
+def _capture_graph(sim: SimState):
+    """Capture a CUDA graph for the simulation step."""
+    with wp.ScopedCapture() as capture:
+        _simulate(sim)
+    return capture.graph
+
+
+def _create_parser() -> argparse.ArgumentParser:
+    """Create argument parser for the standalone viewer."""
+    parser = argparse.ArgumentParser(
+        prog="newton-viewer",
+        description="Newton standalone viewer — load and simulate physics assets.",
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        default=None,
+        help="Path to a USD, URDF, or MJCF file to load.",
+    )
+    parser.add_argument(
+        "--solver",
+        type=str,
+        default="mujoco",
+        choices=list(SOLVER_MAP.keys()),
+        help="Solver backend (default: mujoco).",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Warp device (default: best available).",
+    )
+    parser.add_argument(
+        "--no-ground",
+        action="store_true",
+        default=False,
+        help="Do not add a ground plane.",
+    )
+    return parser
+
+
+def main():
+    """Main entry point for the standalone viewer."""
+    from newton.viewer import ViewerGL  # noqa: PLC0415
+
+    args = _create_parser().parse_args()
+
+    if args.device:
+        wp.set_device(args.device)
+
+    viewer = ViewerGL()
+    sim = None
+    solver_name = args.solver
+    ground = not args.no_ground
+
+    def load_and_setup(path: str):
+        nonlocal sim
+        new_sim = load_file(path, solver_name=solver_name, device=args.device, ground=ground)
+        viewer.set_model(new_sim.model)
+        sim = new_sim
+
+    def on_drop(path: str):
+        nonlocal sim
+        try:
+            load_and_setup(path)
+        except Exception as e:
+            viewer.show_error(str(e))
+
+    def on_reset():
+        if sim is not None:
+            sim.state_0.assign(sim.initial_state)
+            sim.sim_time = 0.0
+            # Re-capture graph after state reset
+            if sim.model.device.is_cuda:
+                sim.graph = _capture_graph(sim)
+
+    def on_solver_change(new_solver: str):
+        nonlocal solver_name
+        solver_name = new_solver
+        if sim is not None:
+            try:
+                load_and_setup(sim.path)
+            except Exception as e:
+                viewer.show_error(str(e))
+
+    viewer.on_file_drop = on_drop
+    viewer.on_reset = on_reset
+    viewer.on_solver_change = on_solver_change
+
+    # Load initial file if provided
+    if args.file:
+        try:
+            load_and_setup(args.file)
+        except Exception as e:
+            viewer.show_error(str(e))
+
+    # Main loop
+    while viewer.is_running():
+        should_step = sim is not None and (not viewer.is_paused() or viewer.consume_step_request())
+
+        if should_step:
+            if sim.graph:
+                wp.capture_launch(sim.graph)
+            else:
+                _simulate_with_forces(sim, viewer)
+            sim.sim_time += sim.dt
+
+        viewer.begin_frame(sim.sim_time if sim else 0.0)
+        if sim:
+            viewer.log_state(sim.state_0)
+        viewer.end_frame()

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -77,7 +77,14 @@ def load_file(
         raise ValueError(f"Unsupported file format: '{ext}'. Expected .usd, .usda, .usdc, .urdf, .xml, or .mjcf")
 
     if ground:
-        builder.add_shape_plane()
+        # Place ground plane at the lowest body position in the asset
+        min_z = 0.0
+        for q in builder.body_q:
+            z = float(q[2])  # transform layout: [px, py, pz, qx, qy, qz, qw]
+            if z < min_z:
+                min_z = z
+        # plane equation (0,0,1,-h) defines z = h
+        builder.add_shape_plane(plane=(0.0, 0.0, 1.0, -min_z))
 
     model = builder.finalize(device=device)
     solver = _create_solver(solver_name, model)

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -193,6 +193,7 @@ def main():
         wp.set_device(args.device)
 
     viewer = ViewerGL()
+    viewer.solver_names = list(SOLVER_MAP.keys())
     sim = None
     solver_name = args.solver
     ground = not args.no_ground
@@ -201,6 +202,13 @@ def main():
         nonlocal sim
         new_sim = load_file(path, solver_name=solver_name, device=args.device, ground=ground)
         viewer.set_model(new_sim.model)
+        viewer._file_info = {
+            "path": path,
+            "body_count": new_sim.model.body_count,
+            "joint_count": new_sim.model.joint_count,
+            "shape_count": new_sim.model.shape_count,
+        }
+        viewer._ground_enabled = ground
         sim = new_sim
 
     def on_drop(path: str):
@@ -227,9 +235,19 @@ def main():
             except Exception as e:
                 viewer.show_error(str(e))
 
+    def on_ground_toggle(enabled: bool):
+        nonlocal ground
+        ground = enabled
+        if sim is not None:
+            try:
+                load_and_setup(sim.path)
+            except Exception as e:
+                viewer.show_error(str(e))
+
     viewer.on_file_drop = on_drop
     viewer.on_reset = on_reset
     viewer.on_solver_change = on_solver_change
+    viewer.on_ground_toggle = on_ground_toggle
 
     # Load initial file if provided
     if args.file:

--- a/newton/viewer/_standalone.py
+++ b/newton/viewer/_standalone.py
@@ -213,17 +213,21 @@ def main():
     solver_name = args.solver
     ground = not args.no_ground
 
-    def _flush_frame():
-        """Render one frame so the status overlay appears on screen."""
-        viewer.begin_frame(sim.sim_time if sim else 0.0)
-        viewer.end_frame()
+    def _flush_status():
+        """Render two frames so the status overlay is visible (double-buffered)."""
+        for _ in range(2):
+            viewer.begin_frame(sim.sim_time if sim else 0.0)
+            viewer.end_frame()
 
     def load_and_setup(path: str):
         nonlocal sim
-        viewer.show_status(f"Loading {os.path.basename(path)}...")
-        _flush_frame()
+        basename = os.path.basename(path)
+        viewer.show_status(f"Loading {basename}...")
+        viewer.renderer.set_title(f"Newton Viewer — Loading {basename}...")
+        _flush_status()
         new_sim = load_file(path, solver_name=solver_name, device=args.device, ground=ground)
         viewer.clear_status()
+        viewer.renderer.set_title(f"Newton Viewer — {basename}")
         viewer.set_model(new_sim.model)
         viewer._file_info = {
             "path": path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "warp-lang>=1.12.0",
 ]
 
+[project.scripts]
+newton-viewer = "newton.viewer:main"
+
 [project.optional-dependencies]
 
 # Core simulation dependencies


### PR DESCRIPTION
## Description

Add a standalone viewer entry point (`newton-viewer` / `python -m newton.viewer`) that can load and simulate USD, URDF, and MJCF files directly — the Newton equivalent of `python -m mujoco.viewer`.

Launch with a file argument or drag-and-drop onto an empty viewer window. Includes solver selection, ground plane toggle, reset, single-step, and CUDA graph capture.

All new ViewerGL capabilities (callbacks for reset, single-step, drag-and-drop, error popups, status overlays) are backwards-compatible and available for examples to use.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
# Unit tests
uv run --extra dev -m newton.tests -k test_standalone_viewer

# Manual: load a file
python -m newton.viewer newton/examples/assets/cartpole_single_pendulum.usda

# Manual: empty viewer + drag-and-drop
python -m newton.viewer

# Manual: solver switching, ground plane toggle, reset (R), single-step (Period/Right Arrow)
```

## New feature / API change

```bash
# Console script (after pip install)
newton-viewer robot.usda

# Module invocation
python -m newton.viewer robot.usda

# With options
newton-viewer robot.urdf --solver xpbd --no-ground --device cuda:0
```

```python
# Programmatic use of new ViewerGL features (available to examples too)
viewer = newton.viewer.ViewerGL()
viewer.on_reset = lambda: print("reset!")
viewer.on_file_drop = lambda path: print(f"dropped {path}")
viewer.show_error("Something went wrong")
viewer.show_status("Loading...")
viewer.step_once()  # single-step when paused
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standalone viewer CLI tool (`newton-viewer` command) for loading and simulating USD, URDF, and MJCF assets
  * Drag-and-drop file loading support with runtime solver selection via UI
  * Ground plane toggle and single-step simulation controls
  * Error and status message overlays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->