### PR TITLE
Replace nparray type alias with np.ndarray for Sphinx compatibility

### DIFF
--- a/newton/_src/core/types.py
+++ b/newton/_src/core/types.py
@@ -63,8 +63,6 @@ Mat33 = list[float] | wp.mat33
 Transform = tuple[Vec3, Quat] | wp.transform
 """A 3D transformation represented as a tuple of 3D translation and rotation quaternion (in XYZW order)."""
 
-# type alias for numpy arrays
-nparray = np.ndarray[Any, np.dtype[Any]]
 
 # Warp vector types
 vec5 = wp.types.vector(length=5, dtype=wp.float32)

--- a/newton/_src/geometry/inertia.py
+++ b/newton/_src/geometry/inertia.py
@@ -10,7 +10,6 @@ import warnings
 import numpy as np
 import warp as wp
 
-from ..core.types import nparray
 from .types import (
     GeoType,
     Heightfield,
@@ -322,8 +321,8 @@ def compute_hollow_mesh_inertia(
 
 def compute_inertia_mesh(
     density: float,
-    vertices: list[Vec3] | nparray,
-    indices: list[int] | nparray,
+    vertices: list[Vec3] | np.ndarray,
+    indices: list[int] | np.ndarray,
     is_solid: bool = True,
     thickness: list[float] | float = 0.001,
 ) -> tuple[float, wp.vec3, wp.mat33, float]:

--- a/newton/_src/geometry/sdf_utils.py
+++ b/newton/_src/geometry/sdf_utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import warp as wp
 
-from ..core.types import MAXVAL, Axis, Devicelike, nparray
+from ..core.types import MAXVAL, Axis, Devicelike
 from .kernels import sdf_box, sdf_capsule, sdf_cone, sdf_cylinder, sdf_ellipsoid, sdf_sphere
 from .sdf_mc import get_mc_tables, int_to_vec3f, mc_calc_face, vec8f
 from .types import GeoType, Mesh
@@ -168,7 +168,7 @@ class SDF:
         data: SDFData,
         sparse_volume: wp.Volume | None = None,
         coarse_volume: wp.Volume | None = None,
-        block_coords: nparray | Sequence[wp.vec3us] | None = None,
+        block_coords: np.ndarray | Sequence[wp.vec3us] | None = None,
         texture_block_coords: Sequence[wp.vec3us] | None = None,
         texture_data: "TextureSDFData | None" = None,
         _coarse_texture: wp.Texture3D | None = None,
@@ -223,8 +223,8 @@ class SDF:
 
     @staticmethod
     def create_from_points(
-        points: nparray | Sequence[Sequence[float]],
-        indices: nparray | Sequence[int],
+        points: np.ndarray | Sequence[Sequence[float]],
+        indices: np.ndarray | Sequence[int],
         *,
         device: Devicelike | None = None,
         narrow_band_range: tuple[float, float] = (-0.1, 0.1),
@@ -382,7 +382,7 @@ class SDF:
         *,
         sparse_volume: wp.Volume | None = None,
         coarse_volume: wp.Volume | None = None,
-        block_coords: nparray | Sequence[wp.vec3us] | None = None,
+        block_coords: np.ndarray | Sequence[wp.vec3us] | None = None,
         center: Sequence[float] | None = None,
         half_extents: Sequence[float] | None = None,
         background_value: float = MAXVAL,

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import warp as wp
 
-from ..core.types import Axis, Devicelike, Vec2, Vec3, nparray, override
+from ..core.types import Axis, Devicelike, Vec2, Vec3, override
 from ..utils.texture import compute_texture_hash
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .sdf_utils import SDF
 
 
-def _normalize_texture_input(texture: str | os.PathLike[str] | nparray | None) -> str | nparray | None:
+def _normalize_texture_input(texture: str | os.PathLike[str] | np.ndarray | None) -> str | np.ndarray | None:
     """Normalize texture input for lazy storage.
 
     String paths and PathLike objects are stored as strings (no decoding).
@@ -114,17 +114,17 @@ class Mesh:
 
     def __init__(
         self,
-        vertices: Sequence[Vec3] | nparray,
-        indices: Sequence[int] | nparray,
-        normals: Sequence[Vec3] | nparray | None = None,
-        uvs: Sequence[Vec2] | nparray | None = None,
+        vertices: Sequence[Vec3] | np.ndarray,
+        indices: Sequence[int] | np.ndarray,
+        normals: Sequence[Vec3] | np.ndarray | None = None,
+        uvs: Sequence[Vec2] | np.ndarray | None = None,
         compute_inertia: bool = True,
         is_solid: bool = True,
         maxhullvert: int | None = None,
         color: Vec3 | None = None,
         roughness: float | None = None,
         metallic: float | None = None,
-        texture: str | nparray | None = None,
+        texture: str | np.ndarray | None = None,
         *,
         sdf: "SDF | None" = None,
     ):
@@ -576,7 +576,7 @@ class Mesh:
 
     @staticmethod
     def create_heightfield(
-        heightfield: nparray,
+        heightfield: np.ndarray,
         extent_x: float,
         extent_y: float,
         center_x: float = 0.0,
@@ -614,8 +614,8 @@ class Mesh:
 
     def copy(
         self,
-        vertices: Sequence[Vec3] | nparray | None = None,
-        indices: Sequence[int] | nparray | None = None,
+        vertices: Sequence[Vec3] | np.ndarray | None = None,
+        indices: Sequence[int] | np.ndarray | None = None,
         recompute_inertia: bool = False,
     ):
         """
@@ -768,11 +768,11 @@ class Mesh:
         self._color = value
 
     @property
-    def texture(self) -> str | nparray | None:
+    def texture(self) -> str | np.ndarray | None:
         return self._texture
 
     @texture.setter
-    def texture(self, value: str | nparray | None):
+    def texture(self, value: str | np.ndarray | None):
         # Store texture lazily: strings/paths are kept as-is, arrays are normalized
         self._texture = _normalize_texture_input(value)
         self._texture_hash = None
@@ -964,13 +964,15 @@ class TetMesh:
 
     def __init__(
         self,
-        vertices: Sequence[Vec3] | nparray,
-        tet_indices: Sequence[int] | nparray,
-        k_mu: nparray | float | None = None,
-        k_lambda: nparray | float | None = None,
-        k_damp: nparray | float | None = None,
+        vertices: Sequence[Vec3] | np.ndarray,
+        tet_indices: Sequence[int] | np.ndarray,
+        k_mu: np.ndarray | float | None = None,
+        k_lambda: np.ndarray | float | None = None,
+        k_damp: np.ndarray | float | None = None,
         density: float | None = None,
-        custom_attributes: ("dict[str, nparray] | dict[str, tuple[nparray, Model.AttributeFrequency]] | None") = None,
+        custom_attributes: (
+            "dict[str, np.ndarray] | dict[str, tuple[np.ndarray, Model.AttributeFrequency]] | None"
+        ) = None,
     ):
         """Construct a TetMesh from vertex positions and tet connectivity.
 
@@ -1030,7 +1032,7 @@ class TetMesh:
         self._cached_hash: int | None = None
 
     @staticmethod
-    def _broadcast_material(value: nparray | float | None, tet_count: int, name: str) -> np.ndarray | None:
+    def _broadcast_material(value: np.ndarray | float | None, tet_count: int, name: str) -> np.ndarray | None:
         if value is None:
             return None
         arr = np.asarray(value, dtype=np.float32)
@@ -1086,7 +1088,7 @@ class TetMesh:
         )
 
     @staticmethod
-    def compute_surface_triangles(tet_indices: nparray) -> np.ndarray:
+    def compute_surface_triangles(tet_indices: np.ndarray) -> np.ndarray:
         """Extract boundary triangles from tetrahedral element indices.
 
         Finds faces that belong to exactly one tetrahedron (boundary faces)
@@ -1138,12 +1140,12 @@ class TetMesh:
     # ---- Properties --------------------------------------------------------
 
     @property
-    def vertices(self) -> nparray:
+    def vertices(self) -> np.ndarray:
         """Vertex positions [m], shape (N, 3), float32."""
         return self._vertices
 
     @property
-    def tet_indices(self) -> nparray:
+    def tet_indices(self) -> np.ndarray:
         """Tetrahedral element indices, flattened, 4 per tet."""
         return self._tet_indices
 
@@ -1158,7 +1160,7 @@ class TetMesh:
         return len(self._vertices)
 
     @property
-    def surface_tri_indices(self) -> nparray:
+    def surface_tri_indices(self) -> np.ndarray:
         """Surface triangle indices (open faces), flattened, 3 per tri.
 
         Automatically computed from tet connectivity at construction time
@@ -1167,17 +1169,17 @@ class TetMesh:
         return self._surface_tri_indices
 
     @property
-    def k_mu(self) -> nparray | None:
+    def k_mu(self) -> np.ndarray | None:
         """Per-element first Lame parameter [Pa], shape (tet_count,) or None."""
         return self._k_mu
 
     @property
-    def k_lambda(self) -> nparray | None:
+    def k_lambda(self) -> np.ndarray | None:
         """Per-element second Lame parameter [Pa], shape (tet_count,) or None."""
         return self._k_lambda
 
     @property
-    def k_damp(self) -> nparray | None:
+    def k_damp(self) -> np.ndarray | None:
         """Per-element Rayleigh damping coefficient [-], shape (tet_count,) or None."""
         return self._k_damp
 
@@ -1471,7 +1473,7 @@ class Heightfield:
 
     def __init__(
         self,
-        data: Sequence[Sequence[float]] | nparray,
+        data: Sequence[Sequence[float]] | np.ndarray,
         nrow: int,
         ncol: int,
         hx: float = 1.0,
@@ -1615,11 +1617,11 @@ class Gaussian:
 
     def __init__(
         self,
-        positions: nparray,
-        rotations: nparray | None = None,
-        scales: nparray | None = None,
-        opacities: nparray | None = None,
-        sh_coeffs: nparray | None = None,
+        positions: np.ndarray,
+        rotations: np.ndarray | None = None,
+        scales: np.ndarray | None = None,
+        opacities: np.ndarray | None = None,
+        sh_coeffs: np.ndarray | None = None,
         sh_degree: int | None = None,
         min_response: float = 0.1,
     ):
@@ -1698,27 +1700,27 @@ class Gaussian:
         return self._positions.shape[0]
 
     @property
-    def positions(self) -> nparray:
+    def positions(self) -> np.ndarray:
         """Gaussian centers in local space [m], shape ``(N, 3)``, float."""
         return self._positions
 
     @property
-    def rotations(self) -> nparray:
+    def rotations(self) -> np.ndarray:
         """Quaternion orientations ``(x, y, z, w)``, shape ``(N, 4)``, float."""
         return self._rotations
 
     @property
-    def scales(self) -> nparray:
+    def scales(self) -> np.ndarray:
         """Per-axis linear scales, shape ``(N, 3)``, float."""
         return self._scales
 
     @property
-    def opacities(self) -> nparray:
+    def opacities(self) -> np.ndarray:
         """Opacity values ``[0, 1]``, shape ``(N,)``, float."""
         return self._opacities
 
     @property
-    def sh_coeffs(self) -> nparray | None:
+    def sh_coeffs(self) -> np.ndarray | None:
         """Spherical harmonic coefficients, shape ``(N, C)``, float."""
         return self._sh_coeffs
 
@@ -1808,7 +1810,7 @@ class Gaussian:
             raise ValueError("PLY Gaussian point cloud is missing required 'positions' attribute")
         positions = np.ascontiguousarray(np.asarray(positions, dtype=np.float32).reshape(-1, 3))
 
-        def _get_point_attr(name: str, width: int | None = None) -> nparray | None:
+        def _get_point_attr(name: str, width: int | None = None) -> np.ndarray | None:
             values = point_attrs.get(name)
             if values is None:
                 return None
@@ -1818,7 +1820,7 @@ class Gaussian:
                 return np.ascontiguousarray(values.reshape(-1))
             return np.ascontiguousarray(values.reshape(-1, width))
 
-        def _require_point_attr(name: str, message: str) -> nparray:
+        def _require_point_attr(name: str, message: str) -> np.ndarray:
             values = _get_point_attr(name)
             if values is None:
                 raise ValueError(message)
@@ -1917,7 +1919,7 @@ class Gaussian:
 
     # ---- Utility -------------------------------------------------------------
 
-    def compute_aabb(self) -> tuple[nparray, nparray]:
+    def compute_aabb(self) -> tuple[np.ndarray, np.ndarray]:
         """Compute axis-aligned bounding box of Gaussian centers.
 
         Returns:

--- a/newton/_src/geometry/utils.py
+++ b/newton/_src/geometry/utils.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 import numpy as np
 import warp as wp
 
-from ..core.types import Vec3, nparray
+from ..core.types import Vec3
 from .inertia import compute_inertia_mesh
 from .types import (
     GeoType,
@@ -115,7 +115,7 @@ def compute_shape_radius(geo_type: int, scale: Vec3, src: Mesh | Heightfield | N
         return 10.0
 
 
-def compute_aabb(vertices: nparray) -> tuple[Vec3, Vec3]:
+def compute_aabb(vertices: np.ndarray) -> tuple[Vec3, Vec3]:
     """Compute the axis-aligned bounding box of a set of vertices."""
     min_coords = np.min(vertices, axis=0)
     max_coords = np.max(vertices, axis=0)
@@ -123,8 +123,8 @@ def compute_aabb(vertices: nparray) -> tuple[Vec3, Vec3]:
 
 
 def compute_inertia_box_mesh(
-    vertices: nparray,
-    indices: nparray,
+    vertices: np.ndarray,
+    indices: np.ndarray,
     is_solid: bool = True,
 ) -> tuple[wp.vec3, wp.vec3, wp.quat]:
     """Compute the equivalent inertia box of a triangular mesh.
@@ -190,7 +190,7 @@ def compute_inertia_box_mesh(
     return wp.vec3(*np.array(com)), wp.vec3(*half_extents), rotation
 
 
-def compute_pca_obb(vertices: nparray) -> tuple[wp.transform, wp.vec3]:
+def compute_pca_obb(vertices: np.ndarray) -> tuple[wp.transform, wp.vec3]:
     """Compute the oriented bounding box of a set of vertices.
 
     Args:
@@ -261,7 +261,7 @@ def compute_pca_obb(vertices: nparray) -> tuple[wp.transform, wp.vec3]:
 
 
 def compute_inertia_obb(
-    vertices: nparray,
+    vertices: np.ndarray,
     num_angle_steps: int = 360,
 ) -> tuple[wp.transform, wp.vec3]:
     """
@@ -664,7 +664,7 @@ def remesh(
     method: RemeshingMethod = "quadratic",
     visualize: bool = False,
     **remeshing_kwargs: Any,
-) -> tuple[nparray, nparray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Remeshes a 3D triangular surface mesh using the specified method.
 
@@ -743,7 +743,7 @@ def remesh_mesh(
     return mesh
 
 
-def transform_points(points: nparray, transform: wp.transform, scale: Vec3 | None = None) -> nparray:
+def transform_points(points: np.ndarray, transform: wp.transform, scale: Vec3 | None = None) -> np.ndarray:
     if scale is not None:
         points = points * np.array(scale, dtype=np.float32)
     return points @ np.array(wp.quat_to_matrix(transform.q)).reshape(3, 3) + transform.p

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -31,7 +31,6 @@ from ..core.types import (
     Vec6,
     axis_to_vec3,
     flag_to_int,
-    nparray,
 )
 from ..geometry import (
     Gaussian,
@@ -6952,9 +6951,9 @@ class ModelBuilder:
 
     def add_triangles(
         self,
-        i: list[int] | nparray,
-        j: list[int] | nparray,
-        k: list[int] | nparray,
+        i: list[int] | np.ndarray,
+        j: list[int] | np.ndarray,
+        k: list[int] | np.ndarray,
         tri_ke: list[float] | None = None,
         tri_ka: list[float] | None = None,
         tri_kd: list[float] | None = None,
@@ -7826,9 +7825,9 @@ class ModelBuilder:
         vertices: list[Vec3] | None = None,
         indices: list[int] | None = None,
         density: float | None = None,
-        k_mu: float | nparray | None = None,
-        k_lambda: float | nparray | None = None,
-        k_damp: float | nparray | None = None,
+        k_mu: float | np.ndarray | None = None,
+        k_lambda: float | np.ndarray | None = None,
+        k_damp: float | np.ndarray | None = None,
         tri_ke: float = 0.0,
         tri_ka: float = 0.0,
         tri_kd: float = 0.0,

--- a/newton/_src/solvers/kamino/_src/core/shapes.py
+++ b/newton/_src/solvers/kamino/_src/core/shapes.py
@@ -9,9 +9,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from enum import IntEnum
 
+import numpy as np
 import warp as wp
 
-from .....core.types import Vec2, Vec3, nparray
+from .....core.types import Vec2, Vec3
 from .....geometry.types import GeoType, Heightfield, Mesh
 from .types import Descriptor, override, vec3f, vec4f
 
@@ -741,10 +742,10 @@ class MeshShape(ShapeDescriptor):
     that provides the necessary interfacing to be used with the Kamino solver.
 
     Attributes:
-        vertices (nparray): The vertices of the mesh.
-        indices (nparray): The triangle indices of the mesh.
-        normals (nparray | None): The vertex normals of the mesh.
-        uvs (nparray | None): The texture coordinates of the mesh.
+        vertices (np.ndarray): The vertices of the mesh.
+        indices (np.ndarray): The triangle indices of the mesh.
+        normals (np.ndarray | None): The vertex normals of the mesh.
+        uvs (np.ndarray | None): The texture coordinates of the mesh.
         color (Vec3 | None): The color of the mesh.
         is_solid (bool): Whether the mesh is solid.
         is_convex (bool): Whether the mesh is convex.
@@ -755,10 +756,10 @@ class MeshShape(ShapeDescriptor):
 
     def __init__(
         self,
-        vertices: Sequence[Vec3] | nparray,
-        indices: Sequence[int] | nparray,
-        normals: Sequence[Vec3] | nparray | None = None,
-        uvs: Sequence[Vec2] | nparray | None = None,
+        vertices: Sequence[Vec3] | np.ndarray,
+        indices: Sequence[int] | np.ndarray,
+        normals: Sequence[Vec3] | np.ndarray | None = None,
+        uvs: Sequence[Vec2] | np.ndarray | None = None,
         color: Vec3 | None = None,
         maxhullvert: int | None = None,
         compute_inertia: bool = True,
@@ -771,10 +772,10 @@ class MeshShape(ShapeDescriptor):
         Initialize the mesh shape descriptor.
 
         Args:
-            vertices (Sequence[Vec3] | nparray): The vertices of the mesh.
-            indices (Sequence[int] | nparray): The triangle indices of the mesh.
-            normals (Sequence[Vec3] | nparray | None): The vertex normals of the mesh.
-            uvs (Sequence[Vec2] | nparray | None): The texture coordinates of the mesh.
+            vertices (Sequence[Vec3] | np.ndarray): The vertices of the mesh.
+            indices (Sequence[int] | np.ndarray): The triangle indices of the mesh.
+            normals (Sequence[Vec3] | np.ndarray | None): The vertex normals of the mesh.
+            uvs (Sequence[Vec2] | np.ndarray | None): The texture coordinates of the mesh.
             color (Vec3 | None): The color of the mesh.
             maxhullvert (int): The maximum number of hull vertices for convex shapes.
             compute_inertia (bool): Whether to compute inertia for the mesh.
@@ -842,22 +843,22 @@ class MeshShape(ShapeDescriptor):
         return self._data
 
     @property
-    def vertices(self) -> nparray:
+    def vertices(self) -> np.ndarray:
         """Returns the vertices of the mesh."""
         return self._data.vertices
 
     @property
-    def indices(self) -> nparray:
+    def indices(self) -> np.ndarray:
         """Returns the indices of the mesh."""
         return self._data.indices
 
     @property
-    def normals(self) -> nparray | None:
+    def normals(self) -> np.ndarray | None:
         """Returns the normals of the mesh."""
         return self._data._normals
 
     @property
-    def uvs(self) -> nparray | None:
+    def uvs(self) -> np.ndarray | None:
         """Returns the UVs of the mesh."""
         return self._data._uvs
 

--- a/newton/_src/solvers/kamino/_src/utils/io/usd.py
+++ b/newton/_src/solvers/kamino/_src/utils/io/usd.py
@@ -11,7 +11,6 @@ from typing import Any
 import numpy as np
 import warp as wp
 
-from ......core.types import nparray
 from ......geometry.flags import ShapeFlags
 from ......usd import utils as usd_utils
 from ......utils.topology import topological_sort_undirected
@@ -290,7 +289,7 @@ class USDImporter:
         return wp.quat_from_matrix(R_g)
 
     @staticmethod
-    def _make_faces_from_counts(indices: nparray, counts: Iterable[int], prim_path: str) -> nparray:
+    def _make_faces_from_counts(indices: np.ndarray, counts: Iterable[int], prim_path: str) -> np.ndarray:
         faces = []
         face_id = 0
         for count in counts:
@@ -384,7 +383,7 @@ class USDImporter:
     def _from_gfquat(gfquat) -> wp.quatf:
         return wp.normalize(wp.quat(*gfquat.imaginary, gfquat.real))
 
-    def _parse_quat(self, prim, name, default=None) -> nparray | None:
+    def _parse_quat(self, prim, name, default=None) -> np.ndarray | None:
         attr = self._get_attribute(prim, name)
         if not attr or not attr.HasAuthoredValue():
             return default
@@ -398,7 +397,7 @@ class USDImporter:
             return quat
         return default
 
-    def _parse_vec(self, prim, name, default=None) -> nparray | None:
+    def _parse_vec(self, prim, name, default=None) -> np.ndarray | None:
         attr = self._get_attribute(prim, name)
         if not attr or not attr.HasAuthoredValue():
             return default

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import warp as wp
 
-from ...core.types import MAXVAL, nparray, override, vec5, vec10
+from ...core.types import MAXVAL, override, vec5, vec10
 from ...geometry import GeoType, ShapeFlags
 from ...sim import (
     BodyFlags,
@@ -3430,8 +3430,8 @@ class SolverMuJoCo(SolverBase):
     @staticmethod
     def _find_body_collision_filter_pairs(
         model: Model,
-        selected_bodies: nparray,
-        colliding_shapes: nparray,
+        selected_bodies: np.ndarray,
+        colliding_shapes: np.ndarray,
     ):
         """For shape collision filter pairs, find body collision filter pairs that are contained within."""
 
@@ -3465,8 +3465,8 @@ class SolverMuJoCo(SolverBase):
 
     @staticmethod
     def _color_collision_shapes(
-        model: Model, selected_shapes: nparray, visualize_graph: bool = False, shape_labels: list[str] | None = None
-    ) -> nparray:
+        model: Model, selected_shapes: np.ndarray, visualize_graph: bool = False, shape_labels: list[str] | None = None
+    ) -> np.ndarray:
         """
         Find a graph coloring of the collision filter pairs in the model.
         Shapes within the same color cannot collide with each other.
@@ -3479,7 +3479,7 @@ class SolverMuJoCo(SolverBase):
             shape_labels: The labels of the shapes, only used for visualization.
 
         Returns:
-            nparray: An integer array of shape (num_shapes,), where each element is the color of the corresponding shape.
+            np.ndarray: An integer array of shape (num_shapes,), where each element is the color of the corresponding shape.
         """
         # we first create a mapping from selected shape to local color shape index
         # to reduce the number of nodes in the graph to only the number of selected shapes
@@ -3711,7 +3711,7 @@ class SolverMuJoCo(SolverBase):
             # For Warp kernel equivalent, see quat_wxyz_to_xyzw() in kernels.py
             return [q[1], q[2], q[3], q[0]]
 
-        def fill_arr_from_dict(arr: nparray, d: dict[int, Any]):
+        def fill_arr_from_dict(arr: np.ndarray, d: dict[int, Any]):
             # fast way to fill an array from a dictionary
             # keys and values can also be tuples of integers
             keys = np.array(list(d.keys()), dtype=int)
@@ -3890,7 +3890,7 @@ class SolverMuJoCo(SolverBase):
         # retrieve MuJoCo-specific attributes
         mujoco_attrs = getattr(model, "mujoco", None)
 
-        def get_custom_attribute(name: str) -> nparray | None:
+        def get_custom_attribute(name: str) -> np.ndarray | None:
             if mujoco_attrs is None:
                 return None
             attr = getattr(mujoco_attrs, name, None)

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import numpy as np
 import warp as wp
 
-from ..core.types import Axis, AxisType, nparray
+from ..core.types import Axis, AxisType
 from ..geometry import Gaussian, Mesh
 from ..sim.model import Model
 
@@ -217,14 +217,14 @@ def get_quat(prim: Usd.Prim, name: str, default: wp.quat | None = None) -> wp.qu
 
 
 @overload
-def get_vector(prim: Usd.Prim, name: str, default: nparray) -> nparray: ...
+def get_vector(prim: Usd.Prim, name: str, default: np.ndarray) -> np.ndarray: ...
 
 
 @overload
-def get_vector(prim: Usd.Prim, name: str, default: None = None) -> nparray | None: ...
+def get_vector(prim: Usd.Prim, name: str, default: None = None) -> np.ndarray | None: ...
 
 
-def get_vector(prim: Usd.Prim, name: str, default: nparray | None = None) -> nparray | None:
+def get_vector(prim: Usd.Prim, name: str, default: np.ndarray | None = None) -> np.ndarray | None:
     """
     Get a vector attribute value from a USD prim, validating that all components are finite.
 
@@ -679,7 +679,7 @@ def corner_angles(face_pos: np.ndarray) -> np.ndarray:
     return angles
 
 
-def fan_triangulate_faces(counts: nparray, indices: nparray) -> nparray:
+def fan_triangulate_faces(counts: np.ndarray, indices: np.ndarray) -> np.ndarray:
     """
     Perform fan triangulation on polygonal faces.
 

--- a/newton/_src/utils/texture.py
+++ b/newton/_src/utils/texture.py
@@ -11,8 +11,6 @@ from urllib.request import urlopen
 
 import numpy as np
 
-from ..core.types import nparray
-
 _texture_url_cache: dict[str, bytes] = {}
 
 
@@ -41,7 +39,7 @@ def _download_texture_from_file_bytes(url: str) -> bytes | None:
         return None
 
 
-def load_texture_from_file(texture_path: str | None) -> nparray | None:
+def load_texture_from_file(texture_path: str | None) -> np.ndarray | None:
     """Load a texture image from disk or URL into a numpy array.
 
     Args:
@@ -72,7 +70,7 @@ def load_texture_from_file(texture_path: str | None) -> nparray | None:
         return None
 
 
-def load_texture(texture: str | os.PathLike[str] | nparray | None) -> nparray | None:
+def load_texture(texture: str | os.PathLike[str] | np.ndarray | None) -> np.ndarray | None:
     """Normalize a texture input into a contiguous image array.
 
     Args:
@@ -97,12 +95,12 @@ def load_texture(texture: str | os.PathLike[str] | nparray | None) -> nparray | 
 
 
 def normalize_texture(
-    texture_image: nparray | None,
+    texture_image: np.ndarray | None,
     *,
     flip_vertical: bool = False,
     require_channels: bool = False,
     scale_unit_range: bool = True,
-) -> nparray | None:
+) -> np.ndarray | None:
     """Normalize a texture array for rendering.
 
     Args:
@@ -138,7 +136,7 @@ def normalize_texture(
     return np.ascontiguousarray(image)
 
 
-def compute_texture_hash(texture: str | os.PathLike[str] | nparray | None) -> int:
+def compute_texture_hash(texture: str | os.PathLike[str] | np.ndarray | None) -> int:
     """Compute a stable hash for a texture (path or array).
 
     Args:

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -15,7 +15,7 @@ import warp as wp
 import newton
 from newton.utils import compute_world_offsets, solidify_mesh
 
-from ..core.types import MAXVAL, Axis, nparray
+from ..core.types import MAXVAL, Axis
 from .kernels import compute_hydro_contact_surface_lines, estimate_world_extents
 
 
@@ -120,7 +120,7 @@ class ViewerBase(ABC):
 
         # Per-shape color buffer and indexing
         self.model_shape_color: wp.array(dtype=wp.vec3) = None
-        self._shape_to_slot: nparray | None = None
+        self._shape_to_slot: np.ndarray | None = None
         self._shape_to_batch: list[ViewerBase.ShapeInstances | None] | None = None
 
         # Isomesh cache for SDF collision visualization
@@ -131,7 +131,7 @@ class ViewerBase(ABC):
         self._gaussian_instances: list[tuple[str, newton.Gaussian, int, wp.transform, int, int, bool]] = []
         self._sdf_isomesh_instances: dict[int, ViewerBase.ShapeInstances] = {}
         self._sdf_isomesh_populated: bool = False
-        self._shape_sdf_index_host: nparray | None = None
+        self._shape_sdf_index_host: np.ndarray | None = None
 
     def set_model(self, model: newton.Model | None, max_worlds: int | None = None):
         """
@@ -586,7 +586,7 @@ class ViewerBase(ABC):
         self,
         name: str,
         geo_type: int,
-        geo_scale: float | tuple[float, ...] | list[float] | nparray,
+        geo_scale: float | tuple[float, ...] | list[float] | np.ndarray,
         xforms: wp.array(dtype=wp.transform),
         colors: wp.array(dtype=wp.vec3) | None = None,
         materials: wp.array(dtype=wp.vec4) | None = None,
@@ -997,7 +997,7 @@ class ViewerBase(ABC):
         return
 
     @abstractmethod
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """
         Log a numeric array for backend-specific visualization utilities.
 

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -13,7 +13,7 @@ import numpy as np
 import warp as wp
 from warp._src import types as warp_types
 
-from ..core.types import nparray, override
+from ..core.types import override
 from ..geometry import Mesh
 from ..sim import Model, State
 from .viewer import ViewerBase
@@ -1328,7 +1328,7 @@ class ViewerFile(ViewerBase):
         pass
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """File viewer does not visualize generic arrays.
 
         Args:

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -16,7 +16,7 @@ import warp as wp
 import newton as nt
 from newton.selection import ArticulationView
 
-from ..core.types import Axis, nparray, override
+from ..core.types import Axis, override
 from ..utils.render import copy_rgb_frame_uint8
 from .camera import Camera
 from .gl.gui import UI
@@ -1004,7 +1004,7 @@ class ViewerGL(ViewerBase):
             cache["colors_uploaded"] = True
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """
         Log a generic array for visualization (not implemented).
 

--- a/newton/_src/viewer/viewer_null.py
+++ b/newton/_src/viewer/viewer_null.py
@@ -11,7 +11,7 @@ import warp as wp
 
 import newton
 
-from ..core.types import nparray, override
+from ..core.types import override
 from .viewer import ViewerBase
 
 
@@ -226,7 +226,7 @@ class ViewerNull(ViewerBase):
         pass
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """
         No-op implementation for logging a generic array.
 

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -12,7 +12,7 @@ import warp as wp
 
 import newton
 
-from ..core.types import nparray, override
+from ..core.types import override
 from ..utils.mesh import compute_vertex_normals
 from ..utils.texture import load_texture, normalize_texture
 from .viewer import ViewerBase, is_jupyter_notebook
@@ -547,7 +547,7 @@ class ViewerRerun(ViewerBase):
         rr.log(name, rr.LineStrips3D(line_strips, **rr_kwargs), static=not self.keep_historical_data)
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """
         Log a generic array for visualization.
 

--- a/newton/_src/viewer/viewer_usd.py
+++ b/newton/_src/viewer/viewer_usd.py
@@ -11,7 +11,7 @@ import warp as wp
 
 import newton
 
-from ..core.types import nparray, override
+from ..core.types import override
 
 try:
     from pxr import Gf, Sdf, Usd, UsdGeom, Vt
@@ -337,13 +337,13 @@ class ViewerUSD(ViewerBase):
         name: str,
         mesh: str,
         xforms: wp.array(dtype=wp.transform) | None,
-        scales: wp.array(dtype=wp.vec3) | nparray | None,
+        scales: wp.array(dtype=wp.vec3) | np.ndarray | None,
         colors: (
             wp.array(dtype=wp.vec3)
             | wp.array(dtype=wp.float32)
             | tuple[float, float, float]
             | list[float]
-            | nparray
+            | np.ndarray
             | None
         ),
         materials: wp.array(dtype=wp.vec4) | None,
@@ -585,7 +585,7 @@ class ViewerUSD(ViewerBase):
         return instancer.GetPath()
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """
         Log array data (not implemented for USD backend).
 

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -14,7 +14,7 @@ import warp as wp
 
 import newton
 
-from ..core.types import nparray, override
+from ..core.types import override
 from ..utils.texture import load_texture, normalize_texture
 from .viewer import ViewerBase, is_jupyter_notebook
 
@@ -897,7 +897,7 @@ class ViewerViser(ViewerBase):
         self._scene_handles[name] = handle
 
     @override
-    def log_array(self, name: str, array: wp.array(dtype=Any) | nparray):
+    def log_array(self, name: str, array: wp.array(dtype=Any) | np.ndarray):
         """Viser viewer does not visualize generic arrays.
 
         Args:


### PR DESCRIPTION
## Description

Remove the `nparray` type alias from `newton._src.core.types` and replace all usages across 18 files with `np.ndarray`.

The alias was defined as:
```python
nparray = np.ndarray[Any, np.dtype[Any]]
```

**Why this change:**

1. **Redundant type alias**: `np.ndarray[Any, np.dtype[Any]]` is equivalent to bare `np.ndarray` — the generic parameters don't narrow the type. Removing the indirection simplifies the codebase.

2. **Sphinx documentation**: Sphinx cannot resolve `nparray` as a cross-reference in generated API docs. Using `np.ndarray` directly allows it to link to numpy documentation via the existing intersphinx mapping. This is groundwork for eventually enabling `nitpicky = True` in Sphinx.

This change affects **only type annotations** — no runtime behavior changes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

Not a user-facing change — internal type alias only.

## Test plan

1. All 18 modified files pass `py_compile` (no syntax errors)
2. `uv run --extra docs sphinx-build -b html docs docs/_build/html --keep-going` succeeds
3. `pre-commit run --all-files` passes (ruff lint + format)
4. Confirmed `np.ndarray` resolves via intersphinx to numpy docs