### PR TITLE
Prevent CUDA error cascade on multi-GPU test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Bump `mujoco` and `mujoco-warp` dependencies to `~=3.7.0` (`mujoco-warp` requires `>=3.7.0.1`)
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
+- Disable process reuse in the test runner on multi-GPU systems to prevent CUDA errors from cascading across test suites, keeping process reuse enabled on single-GPU systems for faster throughput
 
 ### Fixed
 

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -233,6 +233,7 @@ def main(argv=None):
                     # NVIDIA Modification added concurrent.futures
                     with concurrent.futures.ProcessPoolExecutor(
                         max_workers=process_count,
+                        max_tasks_per_child=1,
                         mp_context=multiprocessing.get_context(method="spawn"),
                         initializer=initialize_test_process,
                         initargs=(manager.Lock(), shared_index, args, temp_dir),

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -120,7 +120,9 @@ def main(argv=None):
         "--disable-process-pooling",
         action="store_true",
         default=False,
-        help="Do not reuse processes used to run test suites",
+        help="Do not reuse processes used to run test suites. "
+        "Only affects the multiprocessing.Pool backend (--disable-concurrent-futures). "
+        "The concurrent.futures backend always uses max_tasks_per_child=1 on Python 3.11+.",
     )
     group_parallel.add_argument(
         "--disable-concurrent-futures",
@@ -231,12 +233,12 @@ def main(argv=None):
                         results = pool.map(test_manager.run_tests, test_suites)
                 else:
                     # NVIDIA Modification added concurrent.futures
-                    executor_kwargs = dict(
-                        max_workers=process_count,
-                        mp_context=multiprocessing.get_context(method="spawn"),
-                        initializer=initialize_test_process,
-                        initargs=(manager.Lock(), shared_index, args, temp_dir),
-                    )
+                    executor_kwargs = {
+                        "max_workers": process_count,
+                        "mp_context": multiprocessing.get_context(method="spawn"),
+                        "initializer": initialize_test_process,
+                        "initargs": (manager.Lock(), shared_index, args, temp_dir),
+                    }
                     if sys.version_info >= (3, 11):
                         executor_kwargs["max_tasks_per_child"] = 1
                     with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -120,9 +120,9 @@ def main(argv=None):
         "--disable-process-pooling",
         action="store_true",
         default=False,
-        help="Do not reuse processes used to run test suites. "
-        "Only affects the multiprocessing.Pool backend (--disable-concurrent-futures). "
-        "The concurrent.futures backend always uses max_tasks_per_child=1 on Python 3.11+.",
+        help="Do not reuse processes used to run test suites (max_tasks_per_child=1). "
+        "For the concurrent.futures backend, this is also enabled automatically when "
+        "multiple CUDA devices are detected.",
     )
     group_parallel.add_argument(
         "--disable-concurrent-futures",
@@ -239,7 +239,7 @@ def main(argv=None):
                         "initializer": initialize_test_process,
                         "initargs": (manager.Lock(), shared_index, args, temp_dir),
                     }
-                    if sys.version_info >= (3, 11):
+                    if sys.version_info >= (3, 11) and (args.disable_process_pooling or wp.get_cuda_device_count() > 1):
                         executor_kwargs["max_tasks_per_child"] = 1
                     with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
                         test_manager = ParallelTestManager(manager, args, temp_dir)

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -231,13 +231,15 @@ def main(argv=None):
                         results = pool.map(test_manager.run_tests, test_suites)
                 else:
                     # NVIDIA Modification added concurrent.futures
-                    with concurrent.futures.ProcessPoolExecutor(
+                    executor_kwargs = dict(
                         max_workers=process_count,
-                        max_tasks_per_child=1,
                         mp_context=multiprocessing.get_context(method="spawn"),
                         initializer=initialize_test_process,
                         initargs=(manager.Lock(), shared_index, args, temp_dir),
-                    ) as executor:
+                    )
+                    if sys.version_info >= (3, 11):
+                        executor_kwargs["max_tasks_per_child"] = 1
+                    with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
                         test_manager = ParallelTestManager(manager, args, temp_dir)
                         results = list(executor.map(test_manager.run_tests, test_suites, timeout=2400))
         else:


### PR DESCRIPTION
## Description

Prevent CUDA errors from cascading across unrelated test suites in the parallel test runner on multi-GPU systems.

Without process isolation, a fatal CUDA error in one test suite (e.g. an illegal memory access) corrupts the CUDA context for the entire worker process. Every subsequent test suite dispatched to that worker then fails — even completely unrelated tests — because the context is unrecoverable.

This PR sets `max_tasks_per_child=1` on the `ProcessPoolExecutor` (Python 3.11+) so each worker is replaced after completing a single test suite, but **only when multiple CUDA devices are detected** or when `--disable-process-pooling` is explicitly passed. Single-GPU systems retain process reuse for faster throughput.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

All multi-GPU tests pass on `main` today. To verify this change prevents error cascade, we temporarily reverted #2226 (which fixed the original `test_sdf_texture` CUDA errors) to reproduce the cascading failure scenario on a multi-GPU AWS EC2 instance (3247 tests).

**Without process isolation: 7 errors**
An illegal memory access in `test_sdf_texture` cascaded to 4 unrelated tests across different modules:

| Test | Module | Error |
|------|--------|-------|
| `test_uint16_vs_nanovdb_distance_cuda_1` | test_sdf_texture | CUDA error 700 (root cause) |
| `test_uint16_vs_nanovdb_gradient_cuda_0` | test_sdf_texture | Failed to allocate 12 bytes |
| `test_uint16_vs_nanovdb_gradient_cuda_1` | test_sdf_texture | Failed to allocate 12 bytes |
| `test_capsule_geometry_is_batched_across_scales` | test_viewer_geometry_batching | Failed to allocate 84 bytes |
| `test_log_state_routes_capsules_to_log_capsules` | test_viewer_geometry_batching | Failed to allocate 56 bytes |
| `test_picking_setup_device_cuda_0` | test_viewer_picking | Failed to allocate 28 bytes |
| `test_picking_setup_device_cuda_1` | test_viewer_picking | Failed to allocate 28 bytes |

The viewer geometry batching and viewer picking tests have nothing to do with SDF textures — they failed only because they were dispatched to a worker whose CUDA context was poisoned.

**With process isolation: 3 errors**
Only the actual `test_sdf_texture` failures remain — the 4 cascaded failures in unrelated modules are eliminated:

| Test | Module | Error |
|------|--------|-------|
| `test_uint16_vs_nanovdb_distance_cuda_1` | test_sdf_texture | CUDA error 700 (root cause) |
| `test_uint16_vs_nanovdb_gradient_cuda_0` | test_sdf_texture | Failed to allocate 12 bytes |
| `test_uint16_vs_nanovdb_gradient_cuda_1` | test_sdf_texture | Failed to allocate 12 bytes |

The remaining 3 errors are all within the same `test_sdf_texture` suite (the deliberately reintroduced bug from reverting #2226).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test runner now disables per-process task reuse on multi‑GPU systems to avoid cascading CUDA errors; a CLI option allows toggling this while single‑GPU throughput is unchanged.
* **Documentation**
  * Clarified CLI help to explain which backend the process‑pool option affects and when recycling is auto‑enabled.
  * Added changelog entry describing the multi‑GPU process‑reuse change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->