### PR TITLE
Add USD intersphinx mapping and Sphinx nitpicky mode toggle

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,12 @@ except Exception as e:
 
 release = project_version
 
+# -- Nitpicky mode -----------------------------------------------------------
+# Set nitpicky = True to warn about all broken cross-references (e.g. missing
+# intersphinx targets, typos in :class:/:func:/:attr: roles, etc.).  Useful for
+# auditing docs but noisy during regular development.
+nitpicky = False
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
@@ -114,7 +120,21 @@ intersphinx_mapping = {
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytorch": ("https://docs.pytorch.org/docs/stable", None),
     "warp": ("https://nvidia.github.io/warp", None),
+    "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }
+
+# Map short USD type names (from ``from pxr import Usd``) to their fully-qualified
+# ``pxr.*`` paths so intersphinx can resolve them against the USD inventory.
+# Note: this only affects annotations processed by autodoc, not autosummary stubs.
+autodoc_type_aliases = {
+    "Usd.Prim": "pxr.Usd.Prim",
+    "Usd.Stage": "pxr.Usd.Stage",
+    "UsdGeom.XformCache": "pxr.UsdGeom.XformCache",
+    "UsdGeom.Mesh": "pxr.UsdGeom.Mesh",
+    "UsdShade.Material": "pxr.UsdShade.Material",
+    "UsdShade.Shader": "pxr.UsdShade.Shader",
+}
+
 
 source_suffix = {
     ".rst": "restructuredtext",


### PR DESCRIPTION
## Description

Add intersphinx support for USD (`pxr`) API documentation and prepare Sphinx
for cross-reference auditing via nitpicky mode.

**Changes:**

1. **USD intersphinx mapping** — adds `"usd"` entry pointing to the
   [Omniverse USD Python API docs](https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest/pxr.html),
   enabling Sphinx to resolve and hyperlink references to `pxr.Usd.Prim`,
   `pxr.Usd.Stage`, `pxr.UsdGeom.XformCache`, and other USD types.

2. **`autodoc_type_aliases`** — maps bare USD type names used in Newton source
   code (e.g. `Usd.Prim` from `from pxr import Usd`) to their fully-qualified
   `pxr.Usd.Prim` paths so autodoc can resolve them against the new intersphinx
   inventory.

3. **Nitpicky mode toggle** — adds `nitpicky = False` with a comment explaining
   how to enable it (`nitpicky = True`) for auditing all broken cross-references.
   Off by default to avoid noise during regular development.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Build the docs with nitpicky mode enabled and verify USD types resolve:

```bash
# Enable nitpicky mode temporarily
sed -i "s/nitpicky = False/nitpicky = True/" docs/conf.py

# Build and check for USD-related warnings
python -m sphinx -b html docs docs/_build/html --keep-going 2>&1 | grep -i "pxr\.\|Usd\."

# Should see zero warnings for pxr.Usd.Prim, pxr.Usd.Stage, pxr.UsdGeom.XformCache
# (bare Usd.Prim warnings from orphan autosummary stubs are a separate issue)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced cross-reference resolution in documentation for external APIs, improving developer navigation.
  * Improved type annotation documentation for USD library types through enhanced autodoc configuration.
  * Refined documentation build settings to optimize warning handling and focus on critical issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->