### PR TITLE
Gracefully skip notebook tutorials when pandoc is not installed

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Build Sphinx documentation
         run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
+        env:
+          NEWTON_REQUIRE_PANDOC: "1"
 
       - name: Deploy to gh-pages /latest/
         run: |

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -75,6 +75,8 @@ jobs:
       - name: Build Sphinx documentation
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'
         run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
+        env:
+          NEWTON_REQUIRE_PANDOC: "1"
 
       - name: Deploy to gh-pages
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,6 +61,8 @@ jobs:
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e  # v1.1.1
       - name: Build Sphinx documentation
         run: uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
+        env:
+          NEWTON_REQUIRE_PANDOC: "1"
       - name: Verify API docs are up-to-date
         run: |
           git diff --exit-code docs/api/ || {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,8 +105,27 @@ exclude_patterns = [
     "sphinx-env",
     "**/site-packages/**",
     "**/lib/**",
-    "tutorials/**/*.ipynb",
 ]
+
+# nbsphinx requires pandoc to convert Jupyter notebooks.  When pandoc is not
+# installed we exclude the notebook tutorials so the rest of the docs can still
+# be built locally without a hard error.  CI workflows install pandoc explicitly
+# so published docs always include the tutorials.
+#
+# Set NEWTON_REQUIRE_PANDOC=1 to turn the missing-pandoc warning into an error
+# (used in CI to guarantee tutorials are never silently skipped).
+if shutil.which("pandoc") is None:
+    if os.environ.get("NEWTON_REQUIRE_PANDOC", "") == "1":
+        raise RuntimeError(
+            "pandoc is required but not found. Install pandoc "
+            "(https://pandoc.org/installing.html) or unset NEWTON_REQUIRE_PANDOC."
+        )
+    exclude_patterns.append("tutorials/**")
+    print(
+        "WARNING: pandoc not found - Jupyter notebook tutorials will be "
+        "skipped.  Install pandoc (https://pandoc.org/installing.html) to "
+        "build the complete documentation."
+    )
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
## Description

Allow building the documentation without pandoc installed. When pandoc is
missing, the Jupyter notebook tutorials are excluded from the build with a
clear warning instead of failing with a `PandocMissing` error.

CI workflows set `NEWTON_REQUIRE_PANDOC=1` to guarantee that a missing pandoc
still produces a hard error in CI, so tutorials are never silently skipped in
published documentation.

**Behavior matrix:**

| Environment | pandoc installed | Result |
|---|---|---|
| Local dev | ✅ | Full build including tutorials |
| Local dev | ❌ | Tutorials skipped with warning, rest of docs build fine |
| CI | ✅ | Full build including tutorials |
| CI | ❌ | Hard error (`RuntimeError`) — build fails immediately |

Also removes the stale `tutorials/**/*.ipynb` exclude pattern that was not
actually preventing nbsphinx from processing notebooks included via toctree
directives.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

**Without pandoc (local graceful skip):**

```bash
# Temporarily hide pandoc
sudo mv /usr/bin/pandoc /usr/bin/pandoc.bak

# Build docs — should succeed with a warning
python -m sphinx -b html docs docs/_build/html --keep-going 2>&1 | grep pandoc
# Expected: WARNING: pandoc not found – Jupyter notebook tutorials will be skipped.

sudo mv /usr/bin/pandoc.bak /usr/bin/pandoc
```

**Without pandoc (CI hard error):**

```bash
sudo mv /usr/bin/pandoc /usr/bin/pandoc.bak

NEWTON_REQUIRE_PANDOC=1 python -m sphinx -b html docs docs/_build/html 2>&1
# Expected: RuntimeError: pandoc is required but not found.

sudo mv /usr/bin/pandoc.bak /usr/bin/pandoc
```

**With pandoc (normal build):**

```bash
python -m sphinx -b html docs docs/_build/html --keep-going
# Expected: Full build with tutorials, no pandoc warnings
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation builds now require pandoc availability. When pandoc is missing and explicitly required, the build will fail; otherwise notebook tutorials are skipped with a warning. When pandoc is present, notebook tutorials are included in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->