### PR TITLE
Remove long-form Apache header from example_mpm_viscous.py

### DIFF
--- a/newton/examples/mpm/example_mpm_viscous.py
+++ b/newton/examples/mpm/example_mpm_viscous.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 """Viscous fluid flowing through a funnel using MPM.
 


### PR DESCRIPTION
## Description

Remove the redundant long-form Apache 2.0 license header from
`newton/examples/mpm/example_mpm_viscous.py`. The two-line SPDX short-form
header is sufficient and consistent with every other file in the repository.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined file header formatting in example files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->