### PR TITLE
Skip `test_contact_forces_on_incline` on Mac OS

### DIFF
--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import sys
 import tempfile
 import time
 import unittest
@@ -4075,6 +4076,7 @@ class TestMuJoCoContactForce(unittest.TestCase):
         model.request_contact_attributes("force")
         return model, ramp_shape
 
+    @unittest.skipIf(sys.platform == "darwin", "Flaky on macOS, see GH-2239")
     def test_contact_forces_on_incline(self):
         """Contact force on an incline must balance gravity (tests rotated contact frame)."""
         incline_angle = 0.25  # rad (~14°); mu=1.0 > tan(0.25)≈0.26 → static


### PR DESCRIPTION
test_contact_forces_on_incline fails intermittently on CI (macos-latest), see https://github.com/newton-physics/newton/issues/2239.

This PR skips this test on Mac OS, it is not a desirable solution but at least the pipeline should be green again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability on macOS by addressing intermittent test failures to enhance overall test suite stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->