### PR TITLE
Fix URDF inertial parameter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fix `ModelBuilder.approximate_meshes()` to handle the duplication of per-shape custom attributes that results from convex decomposition
 - Fix `get_tetmesh()` winding order for left-handed USD meshes
 - Fix contact force conversion in `SolverMuJoCo` to include friction (tangential) components
+- Fix URDF inertial parameters parsing in parse_urdf so inertia tensor is correctly calculated as R@I@R.T
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -650,7 +650,7 @@ def parse_urdf(
                 I_m[2, 0] = I_m[0, 2]
                 I_m[2, 1] = I_m[1, 2]
                 rot = wp.quat_to_matrix(inertial_frame.q)
-                I_m = rot @ wp.mat33(I_m)
+                I_m = rot @ wp.mat33(I_m) @ wp.transpose(rot)
                 builder.body_inertia[link] = I_m
                 if any(x for x in I_m):
                     builder.body_inv_inertia[link] = wp.inverse(I_m)

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -67,7 +67,7 @@ INERTIAL_URDF = """
 <robot name="inertial_test">
     <link name="base_link">
         <inertial>
-            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <origin xyz="0 0 0" rpy="3 4 5"/>
             <mass value="1.0"/>
             <inertia ixx="1.0" ixy="0.0" ixz="0.0"
                      iyy="1.0" iyz="0.0"
@@ -266,7 +266,9 @@ class TestImportUrdfBasic(unittest.TestCase):
 
         # Check inertial parameters
         assert_np_equal(builder.body_mass[0], np.array([1.0]))
-        assert_np_equal(builder.body_inertia[0], np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]))
+        assert_np_equal(
+            np.array(builder.body_inertia[0]), np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]), 1e-6
+        )
         assert_np_equal(builder.body_com[0], np.array([0.0, 0.0, 0.0]))
 
     def test_cylinder_shapes_preserved(self):


### PR DESCRIPTION
## Description

This PR fixes the URDF importer to parse the inertial properties correctly. 

The current calculation is I_m = rot@I_m. This ommits the right-side transpose and is clearly incorrect.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Modified test in`newton.tests.test_import_urdf.TestImportUrdfBasic.test_inertial_params_urdf` to verify that inertial tensor is imported and processed correctly.

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton
from newton.tests.unittest_utils import assert_np_equal
import warp as wp
import numpy as np

urdf_content = """
<robot name="inertial_test">
    <link name="base_link">
        <inertial>
            <origin xyz="0 0 0" rpy="3 4 5"/>
            <mass value="1.0"/>
            <inertia ixx="1.0" ixy="0.0" ixz="0.0"
                     iyy="1.0" iyz="0.0"
                     izz="1.0"/>
        </inertial>
        <visual>
            <geometry>
                <capsule radius="0.5" length="1.0"/>
            </geometry>
            <origin xyz="1.0 2.0 3.0" rpy="1.5707963 0 0"/>
        </visual>
    </link>
</robot>
"""

builder = newton.ModelBuilder()
builder.validate_inertia_detailed = True
builder.add_urdf(
    urdf_content,
    xform=wp.transform(wp.vec3(0.0, 0.0, 0.8), wp.quat_identity()),
    floating=True,
)
model = builder.finalize()
assert_np_equal(builder.body_inertia[0], np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]))
```
Output:
```
AssertionError: 
Arrays are not equal

Mismatched elements: 9 / 9 (100%)
First 5 mismatches are at indices:
 [0]: -0.1854141354560852 (ACTUAL), 1.0 (DESIRED)
 [1]: -0.9796227216720581 (ACTUAL), 0.0 (DESIRED)
 [2]: 0.07720446586608887 (ACTUAL), 0.0 (DESIRED)
 [3]: 0.6267945766448975 (ACTUAL), 0.0 (DESIRED)
 [4]: -0.17841051518917084 (ACTUAL), 1.0 (DESIRED)
Max absolute difference among violations: 1.18541414
Max relative difference among violations: 1.18541414
 ACTUAL: array([-0.185414, -0.979623,  0.077204,  0.626795, -0.178411, -0.758484,
        0.756802, -0.092242,  0.647102], dtype=float32)
 DESIRED: array([1., 0., 0., 0., 1., 0., 0., 0., 1.])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inertial tensor transformation when importing URDF files to correctly apply rotation transforms, ensuring accurate physics behavior for models with rotated inertial frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->