### PR TITLE
Remove redundant wp.synchronize() calls before .numpy()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,16 +22,24 @@ Run `uvx pre-commit run -a` to lint/format before committing. Use `uv` for all c
 # Examples
 uv sync --extra examples
 uv run -m newton.examples basic_pendulum
+```
 
-# Tests
+## Tests
 
 Always use `unittest`, not pytest.
 
+```bash
 uv run --extra dev -m newton.tests
 uv run --extra dev -m newton.tests -k test_viewer_log_shapes           # specific test
 uv run --extra dev -m newton.tests -k test_basic.example_basic_shapes  # example test
 uv run --extra dev --extra torch-cu12 -m newton.tests                  # with PyTorch
+```
 
+### Testing guidelines
+
+- Never call `wp.synchronize()` or `wp.synchronize_device()` right before `.numpy()` on a Warp array. This is redundant as `.numpy()` performs a synchronous device-to-host copy that completes all outstanding work.
+
+```bash
 # Benchmarks
 uvx --with virtualenv asv run --launch-method spawn main^!
 ```

--- a/newton/tests/test_broad_phase.py
+++ b/newton/tests/test_broad_phase.py
@@ -217,8 +217,6 @@ class TestBroadPhase(unittest.TestCase):
             candidate_pair_count,
         )
 
-        wp.synchronize()
-
         pairs_wp = candidate_pair.numpy()
         candidate_pair_count = candidate_pair_count.numpy()[0]
 
@@ -738,8 +736,6 @@ class TestBroadPhase(unittest.TestCase):
             candidate_pair_count,
         )
 
-        wp.synchronize()
-
         pairs_wp = candidate_pair.numpy()
         candidate_pair_count = candidate_pair_count.numpy()[0]
 
@@ -856,8 +852,6 @@ class TestBroadPhase(unittest.TestCase):
             candidate_pair,
             candidate_pair_count,
         )
-
-        wp.synchronize()
 
         pairs_wp = candidate_pair.numpy()
         candidate_pair_count = candidate_pair_count.numpy()[0]
@@ -1004,8 +998,6 @@ class TestBroadPhase(unittest.TestCase):
             candidate_pair,
             candidate_pair_count,
         )
-
-        wp.synchronize()
 
         pairs_wp = candidate_pair.numpy()
         num_candidate_pair_val = candidate_pair_count.numpy()[0]
@@ -2098,7 +2090,6 @@ class TestBroadPhase(unittest.TestCase):
             pairs_nxn,
             pair_count_nxn,
         )
-        wp.synchronize()
 
         pairs_np = pairs_nxn.numpy()
         count_nxn = pair_count_nxn.numpy()[0]
@@ -2125,7 +2116,6 @@ class TestBroadPhase(unittest.TestCase):
             pairs_sap,
             pair_count_sap,
         )
-        wp.synchronize()
 
         pairs_np = pairs_sap.numpy()
         count_sap = pair_count_sap.numpy()[0]

--- a/newton/tests/test_collision_cloth.py
+++ b/newton/tests/test_collision_cloth.py
@@ -818,12 +818,10 @@ def test_avbd_particle_ground_penalty_grows(test, device):
     dt = 1.0 / 60.0
     control = model.control()
     vbd._initialize_rigid_bodies(state_in, control, contacts, dt, update_rigid_history=True)
-    wp.synchronize_device(device)
 
     k_before = float(vbd.body_particle_contact_penalty_k.numpy()[0])
 
     vbd._solve_rigid_body_iteration(state_in, state_out, control, contacts, dt)
-    wp.synchronize_device(device)
 
     k_after = float(vbd.body_particle_contact_penalty_k.numpy()[0])
     test.assertGreater(k_after, k_before)

--- a/newton/tests/test_collision_primitives.py
+++ b/newton/tests/test_collision_primitives.py
@@ -458,7 +458,6 @@ class TestCollisionPrimitives(unittest.TestCase):
             dim=len(test_cases),
             inputs=[plane_normals, plane_positions, sphere_positions, sphere_radii, distances, contact_positions],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         positions_np = contact_positions.numpy()
@@ -538,7 +537,6 @@ class TestCollisionPrimitives(unittest.TestCase):
             dim=len(test_cases),
             inputs=[pos1, radius1, pos2, radius2, distances, contact_positions, contact_normals],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -639,7 +637,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -824,7 +821,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -940,7 +936,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1083,7 +1078,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1193,7 +1187,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1308,7 +1301,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_frames,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         frames_np = contact_frames.numpy()
@@ -1393,7 +1385,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1490,7 +1481,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1577,7 +1567,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1715,7 +1704,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -1820,7 +1808,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()
@@ -2088,7 +2075,6 @@ class TestCollisionPrimitives(unittest.TestCase):
                 contact_normals,
             ],
         )
-        wp.synchronize()
 
         distances_np = distances.numpy()
         normals_np = contact_normals.numpy()

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -303,7 +303,6 @@ def test_buffer_fraction_no_crash(test, device):
 
     contacts_reduced = pipeline_reduced.contacts()
     pipeline_reduced.collide(state, contacts_reduced)
-    wp.synchronize()
     reduced_count = int(contacts_reduced.rigid_contact_count.numpy()[0])
     test.assertGreater(reduced_count, 0, "Expected non-zero contacts with reduced buffer_fraction")
 
@@ -317,7 +316,6 @@ def test_buffer_fraction_no_crash(test, device):
     )
     contacts_full = pipeline_full.contacts()
     pipeline_full.collide(state, contacts_full)
-    wp.synchronize()
     full_count = int(contacts_full.rigid_contact_count.numpy()[0])
 
     tolerance = max(2, int(0.05 * reduced_count))
@@ -381,7 +379,6 @@ def test_reduce_contacts_with_pre_prune_disabled_no_crash(test, device):
     newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
     contacts = pipeline.contacts()
     pipeline.collide(state_0, contacts)
-    wp.synchronize()
 
     rigid_count = int(contacts.rigid_contact_count.numpy()[0])
     test.assertGreater(rigid_count, 0, "Expected non-zero contacts with pre_prune_contacts=False")

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1208,7 +1208,6 @@ def compare_contacts_sorted(
     Returns:
         (matches, message) - True if contacts match within tolerance, with diagnostic message.
     """
-    wp.synchronize()
 
     nacon_newton = int(newton_data.nacon.numpy()[0])
     nacon_native = int(native_data.nacon.numpy()[0])
@@ -1306,7 +1305,6 @@ def compare_constraints_sorted(
     Returns:
         (matches, message) - True if constraint rows match modulo ordering.
     """
-    wp.synchronize()
 
     nefc_newton = newton_data.nefc.numpy()
     nefc_native = native_data.nefc.numpy()
@@ -1435,7 +1433,6 @@ def compare_mjdata_field(
         return
 
     # Sync and copy to numpy
-    wp.synchronize()
     newton_np = newton_arr.numpy()
     native_np = native_arr.numpy()
 

--- a/newton/tests/test_narrow_phase.py
+++ b/newton/tests/test_narrow_phase.py
@@ -1331,7 +1331,6 @@ class TestNarrowPhase(unittest.TestCase):
             contact_count=contact_count,
             contact_tangent=contact_tangent,
         )
-        wp.synchronize()
         self.assertEqual(contact_count.numpy()[0], 0, "Sphere A outside margin should have no contact")
 
         # Test 2: Sphere A at z=0.15 (inside margin) - contact!
@@ -1366,7 +1365,6 @@ class TestNarrowPhase(unittest.TestCase):
             contact_count=contact_count,
             contact_tangent=contact_tangent,
         )
-        wp.synchronize()
         self.assertGreater(contact_count.numpy()[0], 0, "Sphere A inside margin should have contact")
 
         # Test 3: Sphere B at z=0.23 (inside its larger margin 0.07) - contact!
@@ -1402,7 +1400,6 @@ class TestNarrowPhase(unittest.TestCase):
             contact_count=contact_count,
             contact_tangent=contact_tangent,
         )
-        wp.synchronize()
         self.assertGreater(contact_count.numpy()[0], 0, "Sphere B with larger margin should have contact")
 
     def _assert_mesh_mesh_scaled_separated_positive_penetration(self, narrow_phase: NarrowPhase):
@@ -1481,7 +1478,6 @@ class TestNarrowPhase(unittest.TestCase):
                 contact_count=contact_count,
                 contact_tangent=contact_tangent,
             )
-            wp.synchronize()
 
             count = int(contact_count.numpy()[0])
             penetrations = contact_penetration.numpy()[:count]

--- a/newton/tests/test_sdf_compute.py
+++ b/newton/tests/test_sdf_compute.py
@@ -225,7 +225,6 @@ def sample_sdf_at_points(volume, points_np: np.ndarray) -> np.ndarray:
         dim=n_points,
         inputs=[volume.id, points, values],
     )
-    wp.synchronize()
 
     return values.numpy()
 
@@ -242,7 +241,6 @@ def sample_sdf_with_gradient(volume, points_np: np.ndarray) -> tuple[np.ndarray,
         dim=n_points,
         inputs=[volume.id, points, values, gradients],
     )
-    wp.synchronize()
 
     return values.numpy(), gradients.numpy()
 
@@ -799,7 +797,6 @@ def sample_extrapolated_at_points(sdf_data: SDFData, points_np: np.ndarray) -> n
         dim=n_points,
         inputs=[sdf_data, points, values],
     )
-    wp.synchronize()
 
     return values.numpy()
 
@@ -816,7 +813,6 @@ def sample_extrapolated_with_gradient(sdf_data: SDFData, points_np: np.ndarray) 
         dim=n_points,
         inputs=[sdf_data, points, values, gradients],
     )
-    wp.synchronize()
 
     return values.numpy(), gradients.numpy()
 

--- a/newton/tests/test_sdf_texture.py
+++ b/newton/tests/test_sdf_texture.py
@@ -360,7 +360,6 @@ def _compare_texture_vs_nanovdb(test, tex_sdf, nanovdb_data, query_points, narro
     wp.launch(
         _sample_nanovdb_grad_kernel, dim=n, inputs=[nanovdb_data, query_points, nano_vals, nano_grads], device=device
     )
-    wp.synchronize()
 
     tv = tex_vals.numpy()
     nv = nano_vals.numpy()
@@ -470,7 +469,6 @@ def test_texture_sdf_extrapolation(test, device):
     results = wp.zeros(4, dtype=float, device=device)
 
     wp.launch(_sample_texture_sdf_kernel, dim=4, inputs=[tex_sdf, query_points, results], device=device)
-    wp.synchronize()
 
     vals = results.numpy()
     # Points far outside should have positive distance
@@ -528,7 +526,6 @@ def test_texture_sdf_array_indexing(test, device):
         inputs=[sdf_array, 1, query, results1],
         device=device,
     )
-    wp.synchronize()
 
     val0 = float(results0.numpy()[0])
     val1 = float(results1.numpy()[0])
@@ -554,7 +551,6 @@ def test_texture_sdf_multi_resolution(test, device):
     ref_data = mesh_copy.sdf.to_kernel_data()
     ref_results = wp.zeros(500, dtype=float, device=device)
     wp.launch(_sample_nanovdb_value_kernel, dim=500, inputs=[ref_data, query_points, ref_results], device=device)
-    wp.synchronize()
     ref_np = ref_results.numpy()
 
     prev_mean_err = float("inf")
@@ -573,7 +569,6 @@ def test_texture_sdf_multi_resolution(test, device):
         )
         tex_results = wp.zeros(500, dtype=float, device=device)
         wp.launch(_sample_texture_sdf_kernel, dim=500, inputs=[tex_sdf, query_points, tex_results], device=device)
-        wp.synchronize()
 
         tex_np = tex_results.numpy()
         valid = (np.abs(tex_np) < 1e5) & (np.abs(ref_np) < 1e5)
@@ -659,7 +654,6 @@ def test_texture_sdf_quantization_uint16(test, device):
 
     wp.launch(_sample_texture_sdf_kernel, dim=500, inputs=[tex_sdf_f32, query_points, results_f32], device=device)
     wp.launch(_sample_texture_sdf_kernel, dim=500, inputs=[tex_sdf_u16, query_points, results_u16], device=device)
-    wp.synchronize()
 
     f32_np = results_f32.numpy()
     u16_np = results_u16.numpy()
@@ -706,7 +700,6 @@ def test_texture_sdf_quantization_uint8(test, device):
 
     wp.launch(_sample_texture_sdf_kernel, dim=500, inputs=[tex_sdf_f32, query_points, results_f32], device=device)
     wp.launch(_sample_texture_sdf_kernel, dim=500, inputs=[tex_sdf_u8, query_points, results_u8], device=device)
-    wp.synchronize()
 
     f32_np = results_f32.numpy()
     u8_np = results_u8.numpy()
@@ -858,7 +851,6 @@ def test_texture_sdf_from_volume(test, device):
     query = wp.array([wp.vec3(0.0, 0.0, 0.0)], dtype=wp.vec3, device=device)
     result = wp.zeros(1, dtype=float, device=device)
     wp.launch(_sample_texture_sdf_kernel, dim=1, inputs=[tex_sdf, query, result], device=device)
-    wp.synchronize()
     val = float(result.numpy()[0])
     test.assertLess(val, 0.0, f"Origin should be inside box, got {val:.4f}")
 
@@ -866,7 +858,6 @@ def test_texture_sdf_from_volume(test, device):
     query_out = wp.array([wp.vec3(2.0, 0.0, 0.0)], dtype=wp.vec3, device=device)
     result_out = wp.zeros(1, dtype=float, device=device)
     wp.launch(_sample_texture_sdf_kernel, dim=1, inputs=[tex_sdf, query_out, result_out], device=device)
-    wp.synchronize()
     val_out = float(result_out.numpy()[0])
     test.assertGreater(val_out, 0.0, f"Far point should be outside box, got {val_out:.4f}")
 
@@ -1010,7 +1001,6 @@ def test_uint16_vs_float32_texture_accuracy(test, device):
     wp.launch(
         _sample_texture_sdf_grad_kernel, dim=n, inputs=[tex_u16, query_points, results_u16, grads_u16], device=device
     )
-    wp.synchronize()
 
     f32_np = results_f32.numpy()
     u16_np = results_u16.numpy()
@@ -1079,7 +1069,6 @@ def test_texture_sdf_vs_ground_truth_distance(test, device):
     bvh_results = wp.zeros(n, dtype=float, device=device)
     wp.launch(_sample_texture_sdf_kernel, dim=n, inputs=[tex_sdf, query_points, tex_results], device=device)
     wp.launch(_bvh_ground_truth_kernel, dim=n, inputs=[wp_mesh.id, query_points, bvh_results], device=device)
-    wp.synchronize()
 
     tex_np = tex_results.numpy()
     bvh_np = bvh_results.numpy()
@@ -1133,7 +1122,6 @@ def test_texture_sdf_vs_ground_truth_gradient(test, device):
     wp.launch(
         _bvh_ground_truth_grad_kernel, dim=n, inputs=[wp_mesh.id, query_points, bvh_vals, bvh_grads], device=device
     )
-    wp.synchronize()
 
     bv = bvh_vals.numpy()
     tg = tex_grads.numpy()

--- a/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
+++ b/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
@@ -117,7 +117,6 @@ def test_sensor_tiled_camera_multiworld_particles_consistent(test: unittest.Test
 
     depth_image = sensor.create_depth_image_output(width, height, camera_count=1)
     sensor.update(state, camera_transforms, camera_rays, depth_image=depth_image)
-    wp.synchronize()
 
     depth_np = depth_image.numpy()  # (num_worlds, num_cameras, H, W)
 

--- a/newton/tests/test_viewer_picking.py
+++ b/newton/tests/test_viewer_picking.py
@@ -196,7 +196,6 @@ class TestPickingSetup(unittest.TestCase):
         picking.update(wp.vec3(0.5, 0.0, -2.0), wp.vec3(0.0, 0.0, 1.0))
         state.body_f.zero_()
         picking._apply_picking_force(state)
-        wp.synchronize()
 
         forces = state.body_f.numpy()
         self.assertEqual(forces.shape[0], model.body_count)


### PR DESCRIPTION
## Description

Remove 50 redundant `wp.synchronize()` / `wp.synchronize_device()` calls that
appear immediately before `.numpy()` on Warp arrays across 10 test files.

`.numpy()` performs a synchronous device-to-host copy on the CUDA default stream
that completes all outstanding work, making a preceding synchronize call entirely
wasteful.

Also adds a testing guideline to `AGENTS.md` to prevent this pattern from being
reintroduced, and fixes pre-existing formatting issues in the tests/benchmarks
section.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Ran the affected test files locally on an L40 GPU:

```
test_collision_primitives  14 tests  OK
test_sdf_compute           33 tests  OK
test_narrow_phase          35 tests  OK
test_broad_phase           14 tests  OK
test_sdf_texture           21 tests  OK
test_hydroelastic          16 tests  OK (2 skipped)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidelines with new constraints for proper test execution.

* **Tests**
  * Optimized test execution patterns across the test suite for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->