### PR TITLE
Cancel in-progress workflows when a PR is closed

### DIFF
--- a/.github/workflows/pr_closed.yml
+++ b/.github/workflows/pr_closed.yml
@@ -1,7 +1,7 @@
 name: Cancel workflows on PR close
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:
@@ -22,9 +22,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           CURRENT_RUN: ${{ github.run_id }}
         run: |
-          echo "PR #${{ github.event.pull_request.number }} closed, cancelling workflows for branch: $HEAD_BRANCH"
+          echo "PR #$PR_NUMBER closed, cancelling workflows for branch: $HEAD_BRANCH"
 
           # Cancel all in-progress and queued runs on this PR's head branch (except this one)
           for status in in_progress queued; do


### PR DESCRIPTION
## Summary

When a pull request is closed (merged or not), any in-progress or queued workflow runs for that PR's branch are automatically cancelled. This avoids wasting CI resources on PRs that are no longer active.

## How it works

A new `pr_closed.yml` workflow triggers on `pull_request: [closed]` and uses the `gh` CLI to list and cancel all in-progress/queued runs on the PR's head branch, excluding its own run.

## Safety

- AWS EC2-based workflows (`aws_gpu_tests.yml`, `aws_gpu_benchmarks.yml`) handle cancellation gracefully because their `stop-runner` jobs use `if: always()`, ensuring EC2 instances are always terminated.
- The workflow skips its own run ID to avoid self-cancellation.

## Testing

Tested on fork (shi-eric/newton):
- Opened a PR, waited for workflows to start, then closed it
- Cancel workflow ran successfully and cancelled the in-progress `Pull Request` workflow
- Cancel workflow did not cancel itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically cancel in-progress and queued CI workflows when a pull request is closed, reducing wasted runs and improving resource usage.
  * Adds a runner hardening step with an audit-focused egress policy to improve workflow execution security and make cancellations more robust even if individual cancellation attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->