### PR TITLE
Reduce jitter when using SDF contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 
 ### Fixed
 
+- Fix GL viewer crash when enabling "Gap + Margin" for soft-body-only states with no rigid body transforms
 - Fix inertia validation spuriously inflating small but physically valid eigenvalues for lightweight components (< ~50 g) by using a relative threshold instead of an absolute 1e-6 cutoff
 - Restore keyboard camera movement while hovering gizmos so keyboard controls remain active when the pointer is over gizmos
 - Resolve USD asset references recursively in `resolve_usd_from_url` so nested stages are fully downloaded
@@ -123,6 +124,7 @@
 - Fix heightfield bounding-sphere radius underestimating Z extent for asymmetric height ranges (e.g. `min_z=0, max_z=10`)
 - Fix VBD self-contact barrier C2 discontinuity at `d = tau` caused by a factor-of-two error in the log-barrier coefficient
 - Fix fast inertia validation treating near-symmetric tensors within `np.allclose()` default tolerances as corrections, aligning CPU and GPU validation warnings
+- Fix URDF joint dynamics friction import so specified friction values are preserved during simulation
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -1666,6 +1666,22 @@ class Gaussian:
             print(gaussian.count, gaussian.sh_degree)
     """
 
+    class SortingMode(enum.IntEnum):
+        """Sorting strategy for ordering Gaussian splat hits along a ray.
+
+        Controls how per-ray Gaussian intersections are depth-sorted before
+        front-to-back alpha compositing.
+        """
+
+        RAY_HIT_DISTANCE = 0
+        """Sort by closest-approach distance in the Gaussian's canonical space."""
+
+        CAMERA_DISTANCE = 1
+        """Sort by projection of the Gaussian center onto the ray direction."""
+
+        Z_DEPTH = 2
+        """Sort by camera-forward depth of the Gaussian center."""
+
     @wp.struct
     class Data:
         num_points: wp.int32
@@ -1675,6 +1691,7 @@ class Gaussian:
         sh_coeffs: wp.array2d[wp.float32]
         bvh_id: wp.uint64
         min_response: wp.float32
+        sorting_mode: wp.int32
 
     def __init__(
         self,
@@ -1685,6 +1702,7 @@ class Gaussian:
         sh_coeffs: np.ndarray | None = None,
         sh_degree: int | None = None,
         min_response: float = 0.1,
+        sorting_mode: SortingMode = SortingMode.RAY_HIT_DISTANCE,
     ):
         """Construct a Gaussian splat asset from arrays.
 
@@ -1701,6 +1719,9 @@ class Gaussian:
                 (``C = 3`` -> degree 0, ``C = 12`` -> degree 1, etc.).
             sh_degree: Spherical harmonic degree.
             min_response: Minimum response required for alpha testing.
+            sorting_mode: Sorting strategy for depth-ordering Gaussian
+                intersections along each ray before alpha compositing
+                (default: :attr:`SortingMode.RAY_HIT_DISTANCE`).
         """
 
         self._positions = np.ascontiguousarray(np.asarray(positions, dtype=np.float32).reshape(-1, 3))
@@ -1734,6 +1755,8 @@ class Gaussian:
         if not np.isfinite(min_response) or not (0.0 < min_response < 1.0):
             raise ValueError("min_response must be finite and in (0, 1)")
         self._min_response = float(min_response)
+
+        self._sorting_mode = sorting_mode
 
         self._cached_hash = None
         self._positions.setflags(write=False)
@@ -1795,6 +1818,11 @@ class Gaussian:
         """Min response, float."""
         return self._min_response
 
+    @property
+    def sorting_mode(self) -> SortingMode:
+        """Sorting mode, Gaussian.SortingMode."""
+        return self._sorting_mode
+
     def _find_sh_degree(self) -> int:
         """Spherical harmonics degree (0-3), inferred from *sh_coeffs* shape."""
         c = self._sh_coeffs.shape[1]
@@ -1828,6 +1856,7 @@ class Gaussian:
             self.warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
             self.warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
             self.warp_data.min_response = self.min_response
+            self.warp_data.sorting_mode = self.sorting_mode
             self.warp_data.num_points = self.warp_data.transforms.shape[0]
 
             lowers = wp.zeros(self.count, dtype=wp.vec3f)
@@ -2049,6 +2078,7 @@ class Gaussian:
                     self._opacities.data.tobytes(),
                     self._sh_coeffs.data.tobytes(),
                     float(self._min_response),
+                    int(self._sorting_mode),
                 )
             )
         return self._cached_hash
@@ -2064,4 +2094,5 @@ class Gaussian:
             and np.array_equal(self._opacities, other._opacities)
             and np.array_equal(self._sh_coeffs, other._sh_coeffs)
             and self._min_response == other._min_response
+            and self._sorting_mode == other._sorting_mode
         )

--- a/newton/_src/sensors/warp_raytrace/gaussians.py
+++ b/newton/_src/sensors/warp_raytrace/gaussians.py
@@ -46,9 +46,34 @@ def compute_gaussian_bvh_bounds(
 
 
 @wp.func
-def canonical_ray_hit_distance(ray_origin: wp.vec3f, ray_direction: wp.vec3f) -> wp.float32:
+def sorting_mode_ray_hit_distance(ray_origin: wp.vec3f, ray_direction: wp.vec3f) -> wp.float32:
     numerator = -wp.dot(ray_origin, ray_direction)
     return safe_div(numerator, wp.dot(ray_direction, ray_direction))
+
+
+@wp.func
+def sorting_mode_camera_distance(
+    gaussian_center: wp.vec3f,
+    ray_origin: wp.vec3f,
+    ray_direction: wp.vec3f,
+) -> wp.float32:
+    """Parametric *t* where the Gaussian center projects onto the ray."""
+    to_center = gaussian_center - ray_origin
+    return safe_div(wp.dot(to_center, ray_direction), wp.dot(ray_direction, ray_direction))
+
+
+@wp.func
+def sorting_mode_z_depth(
+    gaussian_center_world: wp.vec3f,
+    camera_forward: wp.vec3f,
+    ray_origin_world: wp.vec3f,
+    ray_direction_world: wp.vec3f,
+) -> wp.float32:
+    """Parametric *t* at which the ray reaches the Gaussian center's depth plane."""
+    return safe_div(
+        wp.dot(camera_forward, gaussian_center_world - ray_origin_world),
+        wp.dot(camera_forward, ray_direction_world),
+    )
 
 
 @wp.func
@@ -68,15 +93,28 @@ def ray_gsplat_hit_response(
     scale: wp.vec3f,
     opacity: wp.float32,
     min_response: wp.float32,
+    sorting_mode: wp.int32,
     ray_origin_world: wp.vec3f,
     ray_direction_world: wp.vec3f,
+    camera_forward: wp.vec3f,
     max_distance: wp.float32,
 ) -> tuple[wp.float32, wp.float32]:
     ray_origin_local, ray_direction_local = map_ray_to_local_scaled(
         transform, scale, ray_origin_world, ray_direction_world
     )
 
-    hit_distance = canonical_ray_hit_distance(ray_origin_local, ray_direction_local)
+    hit_distance = 0.0
+    if sorting_mode == wp.static(Gaussian.SortingMode.CAMERA_DISTANCE):
+        gaussian_center = wp.transform_get_translation(transform)
+        hit_distance = sorting_mode_camera_distance(gaussian_center, ray_origin_local, ray_direction_local)
+    elif sorting_mode == wp.static(Gaussian.SortingMode.Z_DEPTH):
+        gaussian_center = wp.transform_get_translation(transform)
+        gaussian_center_world = wp.transform_point(transform, wp.cw_mul(gaussian_center, scale))
+        hit_distance = sorting_mode_z_depth(
+            gaussian_center_world, camera_forward, ray_origin_world, ray_direction_world
+        )
+    else:
+        hit_distance = sorting_mode_ray_hit_distance(ray_origin_local, ray_direction_local)
 
     if hit_distance > 0.0 and hit_distance < max_distance:
         max_response = canonical_ray_max_kernel_response(ray_origin_local, wp.normalize(ray_direction_local))
@@ -94,6 +132,7 @@ def create_shade_function(config: RenderContext.Config, state: RenderContext.Sta
         scale: wp.vec3f,
         ray_origin: wp.vec3f,
         ray_direction: wp.vec3f,
+        camera_forward: wp.vec3f,
         gaussian_data: Gaussian.Data,
         max_distance: wp.float32,
     ) -> tuple[GeomHit, wp.vec3f]:
@@ -129,8 +168,10 @@ def create_shade_function(config: RenderContext.Config, state: RenderContext.Sta
                     gaussian_data.scales[hit_index],
                     gaussian_data.opacities[hit_index],
                     gaussian_data.min_response,
+                    gaussian_data.sorting_mode,
                     ray_origin_local,
                     ray_direction_local,
+                    camera_forward,
                     hit_distances[-1],
                 )
 

--- a/newton/_src/sensors/warp_raytrace/raytrace.py
+++ b/newton/_src/sensors/warp_raytrace/raytrace.py
@@ -59,6 +59,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
         gaussians_data: wp.array[Gaussian.Data],
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         if bvh_shapes_size:
             for i in range(wp.static(2 if config.enable_global_world else 1)):
@@ -185,6 +186,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
                             shape_sizes[si],
                             ray_origin_world,
                             ray_dir_world,
+                            camera_forward,
                             gaussians_data[gaussian_id],
                             closest_hit.distance,
                         )
@@ -284,6 +286,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
         gaussians_data: wp.array[Gaussian.Data],
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         closest_hit = ClosestHit()
         closest_hit.distance = max_distance
@@ -308,6 +311,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if wp.static(config.enable_particles):
@@ -348,6 +352,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
         gaussians_data: wp.array[Gaussian.Data],
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         if bvh_shapes_size:
             for i in range(wp.static(2 if config.enable_global_world else 1)):
@@ -440,6 +445,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
                             shape_sizes[si],
                             ray_origin_world,
                             ray_dir_world,
+                            camera_forward,
                             gaussians_data[gaussian_id],
                             closest_hit.distance,
                         )
@@ -529,6 +535,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
         gaussians_data: wp.array[Gaussian.Data],
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         closest_hit = ClosestHit()
         closest_hit.distance = max_distance
@@ -554,6 +561,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if wp.static(config.enable_particles):

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -104,6 +104,7 @@ def create_kernel(
         camera_transform = camera_transforms[camera_index, world_index]
         ray_origin_world = wp.transform_point(camera_transform, camera_rays[camera_index, py, px, 0])
         ray_dir_world = wp.transform_vector(camera_transform, camera_rays[camera_index, py, px, 1])
+        camera_forward = wp.transform_vector(camera_transform, wp.vec3f(0.0, 0.0, -1.0))
 
         closest_hit = raytrace_closest_hit(
             bvh_shapes_size,
@@ -127,6 +128,7 @@ def create_kernel(
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if closest_hit.shape_index == raytrace.NO_HIT_SHAPE_ID:

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1866,6 +1866,17 @@ def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:
     if positions is None:
         raise ValueError("USD Gaussian prim is missing required 'positions' attribute")
 
+    sorting_mode = Gaussian.SortingMode.RAY_HIT_DISTANCE
+    if usd_sorting_mode := get_attribute(prim, "sortingModeHint"):
+        if usd_sorting_mode == "zDepth":
+            sorting_mode = Gaussian.SortingMode.Z_DEPTH
+        elif usd_sorting_mode == "cameraDistance":
+            sorting_mode = Gaussian.SortingMode.CAMERA_DISTANCE
+        elif usd_sorting_mode == "rayHitDistance":
+            sorting_mode = Gaussian.SortingMode.RAY_HIT_DISTANCE
+        else:
+            raise ValueError(f"Unsupported gaussian sorting mode: {usd_sorting_mode}")
+
     return Gaussian(
         positions=positions,
         rotations=_get_float_array_attr("orientations"),
@@ -1874,4 +1885,5 @@ def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:
         sh_coeffs=_get_float_array_attr("radiance:sphericalHarmonicsCoefficients"),
         sh_degree=get_attribute(prim, "radiance:sphericalHarmonicsDegree"),
         min_response=min_response,
+        sorting_mode=sorting_mode,
     )

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -218,6 +218,7 @@ def parse_urdf(
     default_joint_limit_lower = builder.default_joint_cfg.limit_lower
     default_joint_limit_upper = builder.default_joint_cfg.limit_upper
     default_joint_damping = builder.default_joint_cfg.target_kd
+    default_joint_friction = builder.default_joint_cfg.friction
 
     # load shape defaults
     default_shape_density = builder.default_shape_cfg.density
@@ -531,7 +532,7 @@ def parse_urdf(
             "type": joint.get("type"),
             "origin": parse_transform(joint),
             "damping": default_joint_damping,
-            "friction": 0.0,
+            "friction": default_joint_friction,
             "axis": wp.vec3(1.0, 0.0, 0.0),
             "limit_lower": default_joint_limit_lower,
             "limit_upper": default_joint_limit_upper,
@@ -544,7 +545,7 @@ def parse_urdf(
         el_dynamics = joint.find("dynamics")
         if el_dynamics is not None:
             joint_data["damping"] = float(el_dynamics.get("damping", default_joint_damping))
-            joint_data["friction"] = float(el_dynamics.get("friction", 0))
+            joint_data["friction"] = float(el_dynamics.get("friction", default_joint_friction))
         el_limit = joint.find("limit")
         if el_limit is not None:
             joint_data["limit_lower"] = float(el_limit.get("lower", default_joint_limit_lower))
@@ -740,6 +741,7 @@ def parse_urdf(
         lower = joint.get("limit_lower", None)
         upper = joint.get("limit_upper", None)
         joint_damping = joint["damping"]
+        joint_friction = joint["friction"]
 
         parent_xform = joint["origin"]
 
@@ -762,6 +764,7 @@ def parse_urdf(
             created_joint_idx = builder.add_joint_revolute(
                 axis=joint["axis"],
                 target_kd=joint_damping,
+                friction=joint_friction,
                 actuator_mode=actuator_mode,
                 limit_lower=lower,
                 limit_upper=upper,
@@ -771,6 +774,7 @@ def parse_urdf(
             created_joint_idx = builder.add_joint_prismatic(
                 axis=joint["axis"],
                 target_kd=joint_damping,
+                friction=joint_friction,
                 actuator_mode=actuator_mode,
                 limit_lower=lower * scale,
                 limit_upper=upper * scale,
@@ -801,6 +805,7 @@ def parse_urdf(
                         limit_lower=lower * scale,
                         limit_upper=upper * scale,
                         target_kd=joint_damping,
+                        friction=joint_friction,
                         actuator_mode=actuator_mode,
                     ),
                     ModelBuilder.JointDofConfig(
@@ -808,6 +813,7 @@ def parse_urdf(
                         limit_lower=lower * scale,
                         limit_upper=upper * scale,
                         target_kd=joint_damping,
+                        friction=joint_friction,
                         actuator_mode=actuator_mode,
                     ),
                 ],

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -1967,7 +1967,7 @@ class ViewerBase(ABC):
             return
 
         # Update world transforms for the active mode
-        body_q = state.body_q.numpy() if state is not None else None
+        body_q = state.body_q.numpy() if state is not None and state.body_q is not None else None
         offsets_np = self.world_offsets.numpy() if self.world_offsets is not None else None
 
         for s, (_vertex_data, body_idx, shape_xf, world_idx) in edge_cache.items():

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1747,5 +1747,69 @@ class TestOverrideRootXformURDF(unittest.TestCase):
         )
 
 
+FRICTION_URDF = """
+<robot name="friction_test">
+<link name="base_link"/>
+<link name="revolute_link"/>
+<link name="prismatic_link"/>
+<joint name="revolute_joint" type="revolute">
+    <parent link="base_link"/>
+    <child link="revolute_link"/>
+    <origin xyz="0 1 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <dynamics damping="1.0" friction="0.25"/>
+    <limit lower="-1.0" upper="1.0"/>
+</joint>
+<joint name="prismatic_joint" type="prismatic">
+    <parent link="revolute_link"/>
+    <child link="prismatic_link"/>
+    <origin xyz="0 0.5 0" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <dynamics damping="2.0" friction="0.75"/>
+    <limit lower="-0.5" upper="0.5"/>
+</joint>
+</robot>
+"""
+
+
+class TestUrdfJointFriction(unittest.TestCase):
+    def test_joint_friction_parsed_from_urdf(self):
+        """Joint friction values from <dynamics friction='...'> should be forwarded to the model."""
+        builder = newton.ModelBuilder()
+        parse_urdf(FRICTION_URDF, builder)
+        model = builder.finalize()
+
+        friction_values = model.joint_friction.numpy()
+
+        # Find joint indices by label
+        revolute_idx = None
+        prismatic_idx = None
+        for i, label in enumerate(builder.joint_label):
+            if "revolute_joint" in label:
+                revolute_idx = i
+            elif "prismatic_joint" in label:
+                prismatic_idx = i
+
+        self.assertIsNotNone(revolute_idx, "revolute_joint not found")
+        self.assertIsNotNone(prismatic_idx, "prismatic_joint not found")
+
+        # Each of these joints has 1 DOF, so joint_qd_start gives us the DOF index
+        rev_dof = builder.joint_qd_start[revolute_idx]
+        pri_dof = builder.joint_qd_start[prismatic_idx]
+
+        self.assertAlmostEqual(float(friction_values[rev_dof]), 0.25, places=5)
+        self.assertAlmostEqual(float(friction_values[pri_dof]), 0.75, places=5)
+
+    def test_joint_friction_defaults_to_zero(self):
+        """Joints without <dynamics friction='...'> should default to 0.0 friction."""
+        builder = newton.ModelBuilder()
+        parse_urdf(JOINT_URDF, builder)
+        model = builder.finalize()
+
+        friction_values = model.joint_friction.numpy()
+        for val in friction_values:
+            self.assertAlmostEqual(float(val), 0.0, places=5)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Replace triangle gradient descent with edge-based Brent's method for SDF collision. This strongly reduces the jitter artefacts reported here https://github.com/newton-physics/newton/issues/2197

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now include mesh-edge metadata and the collision pipeline accepts mesh-edge inputs for edge-aware collision handling.

* **Refactor**
  * Narrow-phase processing converted from triangle-based to edge-based for mesh–SDF and mesh–mesh workflows.

* **Performance**
  * Reduced per-candidate staging and an edge-focused optimization path for more stable, faster contact resolution.

* **Tests**
  * Collision tests increased SDF resolution and updated to exercise the new edge-based narrow phase.

* **Changelog**
  * Documented edge-based collision change and reduced contact jitter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->