### PR TITLE
[SensorTiledCamera] Added support for model.shape_color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Deprecate `SensorTiledCamera.RenderContext`; use `SensorTiledCamera.RenderConfig` for config types and `SensorTiledCamera.render_config` / `SensorTiledCamera.utils` for runtime access.
 - Deprecate `SensorTiledCamera.Config`; prefer `SensorTiledCamera.RenderConfig` and `SensorTiledCamera.utils`.
 - Deprecate `Viewer.update_shape_colors()` in favor of writing directly to `Model.shape_color`
+- Deprecate `SensorTiledCamera.utils.assign_random_colors_per_world()` and `assign_random_colors_per_shape()` in favor of per-shape colors via `ModelBuilder.add_shape_*(color=...)`
 
 ### Removed
 

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -70,7 +70,6 @@ class SensorTiledCameraBenchmark:
 
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
         self.tiled_camera_sensor.utils.create_default_light(enable_shadows=False)
-        self.tiled_camera_sensor.utils.assign_random_colors_per_shape()
         self.tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
 
         self.camera_rays = self.tiled_camera_sensor.utils.compute_pinhole_camera_rays(

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -93,10 +93,10 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         """.. deprecated:: Use ``render_config.enable_ambient_lighting`` instead."""
 
         colors_per_world: bool = False
-        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead."""
+        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
 
         colors_per_shape: bool = False
-        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead."""
+        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
 
         backface_culling: bool = True
         """.. deprecated:: Use ``render_config.enable_backface_culling`` instead."""
@@ -329,13 +329,13 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         """Assign each world a random color, applied to all its shapes.
 
         .. deprecated::
-            Use ``SensorTiledCamera.utils.assign_random_colors_per_world`` instead.
+            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:
             seed: Random seed.
         """
         warnings.warn(
-            "Deprecated: SensorTiledCamera.assign_random_colors_per_world is deprecated, use SensorTiledCamera.utils.assign_random_colors_per_world instead.",
+            "``SensorTiledCamera.assign_random_colors_per_world`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -345,13 +345,13 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         """Assign a random color to each shape.
 
         .. deprecated::
-            Use ``SensorTiledCamera.utils.assign_random_colors_per_shape`` instead.
+            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:
             seed: Random seed.
         """
         warnings.warn(
-            "Deprecated: SensorTiledCamera.assign_random_colors_per_shape is deprecated, use SensorTiledCamera.utils.assign_random_colors_per_shape instead.",
+            "``SensorTiledCamera.assign_random_colors_per_shape`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -93,10 +93,10 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         """.. deprecated:: Use ``render_config.enable_ambient_lighting`` instead."""
 
         colors_per_world: bool = False
-        """.. deprecated:: Use ``SensorTiledCamera.utils.assign_random_colors_per_world()`` instead."""
+        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead."""
 
         colors_per_shape: bool = False
-        """.. deprecated:: Use ``SensorTiledCamera.utils.assign_random_colors_per_shape()`` instead."""
+        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead."""
 
         backface_culling: bool = True
         """.. deprecated:: Use ``render_config.enable_backface_culling`` instead."""

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -44,7 +44,7 @@ def create_kernel(
         shape_enabled: wp.array(dtype=wp.uint32),
         shape_types: wp.array(dtype=wp.int32),
         shape_sizes: wp.array(dtype=wp.vec3f),
-        shape_colors: wp.array(dtype=wp.vec4f),
+        shape_colors: wp.array(dtype=wp.vec3f),
         shape_transforms: wp.array(dtype=wp.transformf),
         shape_source_ptr: wp.array(dtype=wp.uint64),
         shape_texture_ids: wp.array(dtype=wp.int32),
@@ -168,11 +168,9 @@ def create_kernel(
         if not is_gaussian:
             hit_point = ray_origin_world + ray_dir_world * closest_hit.distance
 
-            color = wp.vec4f(1.0)
+            albedo_color = wp.vec3f(1.0)
             if closest_hit.shape_index < raytrace.MAX_SHAPE_ID:
-                color = shape_colors[closest_hit.shape_index]
-
-            albedo_color = wp.vec3f(color[0], color[1], color[2])
+                albedo_color = shape_colors[closest_hit.shape_index]
 
             if wp.static(config.enable_textures) and closest_hit.shape_index < raytrace.MAX_SHAPE_ID:
                 texture_index = shape_texture_ids[closest_hit.shape_index]

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
 
 import numpy as np
 import warp as wp
@@ -177,7 +176,7 @@ class RenderContext:
         self.shape_types: wp.array(dtype=wp.int32) = None
         self.shape_sizes: wp.array(dtype=wp.vec3f) = None
         self.shape_transforms: wp.array(dtype=wp.transformf) = None
-        self.shape_colors: wp.array(dtype=wp.vec4f) = None
+        self.shape_colors: wp.array(dtype=wp.vec3f) = None
         self.shape_world_index: wp.array(dtype=wp.int32) = None
         self.shape_source_ptr: wp.array(dtype=wp.uint64) = None
         self.shape_bounds: wp.array2d(dtype=wp.vec3f) = None
@@ -234,13 +233,11 @@ class RenderContext:
         self.shape_sizes = wp.empty(model.shape_count, dtype=wp.vec3f, device=self.device)
         self.shape_transforms = wp.empty(model.shape_count, dtype=wp.transformf, device=self.device)
 
+        self.shape_colors = model.shape_color
         self.shape_world_index = model.shape_world
         self.gaussians_data = model.gaussians_data
 
         self.__load_texture_and_mesh_data(model, load_textures)
-
-        colors = [(*self.__get_shape_color(i, shape), 1.0) for i, shape in enumerate(model.shape_source)]
-        self.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.device)
 
         num_enabled_shapes = wp.zeros(1, dtype=wp.int32, device=self.device)
         wp.launch(
@@ -675,36 +672,6 @@ class RenderContext:
             ],
             device=self.device,
         )
-
-    def __get_shape_color(self, index: int, shape: Any):
-        """Return the RGB color tuple for a shape.
-
-        Uses the shape's own ``color`` attribute when available,
-        otherwise cycles through a predefined color palette.
-
-        Args:
-            index: Shape index used to cycle the palette.
-            shape: Shape source object, optionally carrying a ``color``
-                attribute.
-
-        Returns:
-            RGB color as a 3-tuple of floats in ``[0, 1]``.
-        """
-        SHAPE_COLOR_MAP = [
-            (68 / 255.0, 119 / 255.0, 170 / 255.0),  # blue
-            (102 / 255.0, 204 / 255.0, 238 / 255.0),  # cyan
-            (34 / 255.0, 136 / 255.0, 51 / 255.0),  # green
-            (204 / 255.0, 187 / 255.0, 68 / 255.0),  # yellow
-            (238 / 255.0, 102 / 255.0, 119 / 255.0),  # red
-            (170 / 255.0, 51 / 255.0, 119 / 255.0),  # magenta
-            (187 / 255.0, 187 / 255.0, 187 / 255.0),  # grey
-            (238 / 255.0, 153 / 255.0, 51 / 255.0),  # orange
-            (0 / 255.0, 153 / 255.0, 136 / 255.0),  # teal
-        ]
-
-        if color := getattr(shape, "color", None):
-            return color
-        return SHAPE_COLOR_MAP[index % len(SHAPE_COLOR_MAP)]
 
     def __load_texture_and_mesh_data(self, model: Model, load_textures: bool):
         """Load mesh UV/normal data and textures from *model*.

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -416,7 +416,7 @@ class Utils:
             seed: Random seed.
         """
         warnings.warn(
-            "``SensorTiledCamera.utils.assign_random_colors_per_world`` is deprecated, Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead.",
+            "``SensorTiledCamera.utils.assign_random_colors_per_world`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -440,7 +440,7 @@ class Utils:
             seed: Random seed.
         """
         warnings.warn(
-            "``SensorTiledCamera.utils.assign_random_colors_per_shape`` is deprecated, Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead.",
+            "``SensorTiledCamera.utils.assign_random_colors_per_shape`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -408,28 +409,44 @@ class Utils:
     def assign_random_colors_per_world(self, seed: int = 100):
         """Assign each world a random color, applied to all its shapes.
 
+        .. deprecated::
+            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
+
         Args:
             seed: Random seed.
         """
+        warnings.warn(
+            "``SensorTiledCamera.utils.assign_random_colors_per_world`` is deprecated, Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
         if not self.__render_context.shape_count_total:
             return
-        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 4)) * 0.5 + 0.5
-        colors[:, -1] = 1.0
+        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 3)) * 0.5 + 0.5
         self.__render_context.shape_colors = wp.array(
             colors[self.__render_context.shape_world_index.numpy() % len(colors)],
-            dtype=wp.vec4f,
+            dtype=wp.vec3f,
             device=self.__render_context.device,
         )
 
     def assign_random_colors_per_shape(self, seed: int = 100):
         """Assign a random color to each shape.
 
+        .. deprecated::
+            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
+
         Args:
             seed: Random seed.
         """
-        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 4)) * 0.5 + 0.5
-        colors[:, -1] = 1.0
-        self.__render_context.shape_colors = wp.array(colors, dtype=wp.vec4f, device=self.__render_context.device)
+        warnings.warn(
+            "``SensorTiledCamera.utils.assign_random_colors_per_shape`` is deprecated, Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``) instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 3)) * 0.5 + 0.5
+        self.__render_context.shape_colors = wp.array(colors, dtype=wp.vec3f, device=self.__render_context.device)
 
     def create_default_light(self, enable_shadows: bool = True, direction: wp.vec3f | None = None):
         """Create a default directional light oriented at ``(-1, 1, -1)``.

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -127,11 +127,14 @@ class Example:
                     builder.add_body(xform=wp.transform(p=wp.vec3(0.0, -4.0, 0.5), q=wp.quat_identity())),
                     radius=0.4,
                     half_height=0.5,
+                    color=(0.27, 0.47, 0.67),
                 )
                 semantic_colors.append(SEMANTIC_COLOR_CYLINDER)
             if rng.random() < 0.5:
                 builder.add_shape_sphere(
-                    builder.add_body(xform=wp.transform(p=wp.vec3(-2.0, -2.0, 0.5), q=wp.quat_identity())), radius=0.5
+                    builder.add_body(xform=wp.transform(p=wp.vec3(-2.0, -2.0, 0.5), q=wp.quat_identity())),
+                    radius=0.5,
+                    color=(0.40, 0.80, 0.93),
                 )
                 semantic_colors.append(SEMANTIC_COLOR_SPHERE)
             if rng.random() < 0.5:
@@ -139,6 +142,7 @@ class Example:
                     builder.add_body(xform=wp.transform(p=wp.vec3(-4.0, 0.0, 0.75), q=wp.quat_identity())),
                     radius=0.25,
                     half_height=0.5,
+                    color=(0.13, 0.53, 0.20),
                 )
                 semantic_colors.append(SEMANTIC_COLOR_CAPSULE)
             if rng.random() < 0.5:
@@ -147,6 +151,7 @@ class Example:
                     hx=0.5,
                     hy=0.35,
                     hz=0.5,
+                    color=(0.80, 0.73, 0.27),
                 )
                 semantic_colors.append(SEMANTIC_COLOR_BOX)
             if rng.random() < 0.5:
@@ -154,6 +159,7 @@ class Example:
                     builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 4.0, 0.0), q=wp.quat(0.5, 0.5, 0.5, 0.5))),
                     mesh=bunny_mesh,
                     scale=(0.5, 0.5, 0.5),
+                    color=(0.93, 0.40, 0.47),
                 )
                 semantic_colors.append(SEMANTIC_COLOR_MESH)
 
@@ -168,7 +174,7 @@ class Example:
             semantic_colors.extend([SEMANTIC_COLOR_ROBOT] * robot_builder.shape_count)
             builder.end_world()
 
-        builder.add_ground_plane()
+        builder.add_ground_plane(color=(0.6, 0.6, 0.6))
         semantic_colors.append(SEMANTIC_COLOR_GROUND_PLANE)
 
         self.model = builder.finalize()

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -19,27 +19,29 @@ class TestSensorTiledCamera(unittest.TestCase):
         builder = newton.ModelBuilder()
 
         # add ground plane
-        builder.add_ground_plane()
+        builder.add_ground_plane(color=(0.91749084, 0.798277, 0.64443165))
 
         # SPHERE
         sphere_pos = wp.vec3(0.0, -2.0, 0.5)
         body_sphere = builder.add_body(xform=wp.transform(p=sphere_pos, q=wp.quat_identity()), label="sphere")
-        builder.add_shape_sphere(body_sphere, radius=0.5)
+        builder.add_shape_sphere(body_sphere, radius=0.5, color=(0.5214758, 0.9868272, 0.79823583))
 
         # CAPSULE
         capsule_pos = wp.vec3(0.0, 0.0, 0.75)
         body_capsule = builder.add_body(xform=wp.transform(p=capsule_pos, q=wp.quat_identity()), label="capsule")
-        builder.add_shape_capsule(body_capsule, radius=0.25, half_height=0.5)
+        builder.add_shape_capsule(body_capsule, radius=0.25, half_height=0.5, color=(0.8951316, 0.9551697, 0.8440772))
 
         # CYLINDER
         cylinder_pos = wp.vec3(0.0, -4.0, 0.5)
         body_cylinder = builder.add_body(xform=wp.transform(p=cylinder_pos, q=wp.quat_identity()), label="cylinder")
-        builder.add_shape_cylinder(body_cylinder, radius=0.4, half_height=0.5)
+        builder.add_shape_cylinder(
+            body_cylinder, radius=0.4, half_height=0.5, color=(0.59499574, 0.99073946, 0.64237005)
+        )
 
         # BOX
         box_pos = wp.vec3(0.0, 2.0, 0.5)
         body_box = builder.add_body(xform=wp.transform(p=box_pos, q=wp.quat_identity()), label="box")
-        builder.add_shape_box(body_box, hx=0.5, hy=0.35, hz=0.5)
+        builder.add_shape_box(body_box, hx=0.5, hy=0.35, hz=0.5, color=(0.8146366, 0.7905182, 0.79995614))
 
         # MESH (bunny)
         bunny_filename = os.path.join(os.path.dirname(__file__), "..", "examples", "assets", "bunny.usd")
@@ -54,7 +56,7 @@ class TestSensorTiledCamera(unittest.TestCase):
 
         mesh_pos = wp.vec3(0.0, 4.0, 0.0)
         body_mesh = builder.add_body(xform=wp.transform(p=mesh_pos, q=wp.quat(0.5, 0.5, 0.5, 0.5)), label="mesh")
-        builder.add_shape_mesh(body_mesh, mesh=demo_mesh)
+        builder.add_shape_mesh(body_mesh, mesh=demo_mesh, color=(0.7676241, 0.99788857, 0.75097305))
 
         return builder.finalize()
 
@@ -98,7 +100,6 @@ class TestSensorTiledCamera(unittest.TestCase):
 
         tiled_camera_sensor = SensorTiledCamera(model=model)
         tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
-        tiled_camera_sensor.utils.assign_random_colors_per_shape()
         tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
 
         camera_rays = tiled_camera_sensor.utils.compute_pinhole_camera_rays(width, height, math.radians(45.0))


### PR DESCRIPTION
## Description
Use `model.shape_color` directly in `SensorTiledCamera` instead of maintaining a separate color pipeline. This removes the internal `__get_shape_color` method and its hardcoded 9-color palette, replacing it with the colors already stored on the model via `builder.add_shape_*(..., color=(...))`.
Key changes:
- **Simplify color pipeline**: `RenderContext` now reads `model.shape_color` directly instead of iterating over shape sources and falling back to a palette. The ~30-line `__get_shape_color` helper and `SHAPE_COLOR_MAP` are removed.
- **Narrow color dtype from `vec4f` to `vec3f`**: The alpha channel was always hardcoded to `1.0` and never used in shading; removing it simplifies the render kernel and saves a float per shape.
- **Deprecate `assign_random_colors_per_shape` / `assign_random_colors_per_world`**: Both methods now emit `DeprecationWarning` directing users to set colors via the builder API. They still function for backwards compatibility.
- **Update example, tests, and benchmark**: Shapes now specify explicit `color=` arguments, and calls to the deprecated helpers are removed where they were the only color source.
## Checklist
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)
## Test plan
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera

Verify the example still renders correctly:
uv run -m newton.examples sensor_tiled_camera

## New feature / API change
Shape colors are now set at build time via the existing `color` parameter on shape builder methods, and the tiled camera sensor picks them up automatically:
```python
import newton
builder = newton.ModelBuilder()
body = builder.add_body(xform=wp.transform_identity())
builder.add_shape_sphere(body, radius=0.5, color=(0.4, 0.8, 0.9))
builder.add_ground_plane(color=(0.6, 0.6, 0.6))
model = builder.finalize()
sensor = newton.SensorTiledCamera(model=model)
# Colors are applied automatically — no need to call
# sensor.utils.assign_random_colors_per_shape()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Marked `SensorTiledCamera.utils.assign_random_colors_per_world()` and `assign_random_colors_per_shape()` as deprecated with updated guidance.

* **Documentation**
  * Updated deprecation warnings and guidance text directing users to alternative color assignment approaches.

* **Examples & Tests**
  * Updated example code and test cases to demonstrate explicit per-shape color specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->