### PR TITLE
Add --warp-config KEY=VALUE CLI option to examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add repeatable `--warp-config KEY=VALUE` CLI option for overriding `warp.config` attributes when running examples
 - Add 3D texture-based SDF, replacing NanoVDB volumes in the mesh-mesh collision pipeline for improved performance and CPU compatibility.
 - Add `--benchmark [SECONDS]` flag to examples for headless FPS measurement with warmup
 - Interactive example browser in the GL viewer with tree-view navigation and switch/reset support

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import importlib
 import os
 import warnings
@@ -449,6 +450,13 @@ def create_parser():
         metavar="SECONDS",
         help="Run in benchmark mode: measure FPS after a warmup period. If SECONDS is given, stop after that many seconds or --num-frames, whichever comes first.",
     )
+    parser.add_argument(
+        "--warp-config",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Override a warp.config attribute (repeatable).",
+    )
 
     return parser
 
@@ -512,6 +520,38 @@ def default_args(parser=None):
     return parser.parse_known_args([])[0]
 
 
+def _apply_warp_config(parser, args):
+    """Apply ``--warp-config`` overrides to :obj:`warp.config`.
+
+    Each entry in ``args.warp_config`` must have the form ``KEY=VALUE``.  The
+    key is validated to be an existing attribute of :obj:`warp.config`.  The
+    value is parsed with :func:`ast.literal_eval`; if that fails the raw
+    string is kept.
+
+    Args:
+        parser: The argument parser, used for error reporting.
+        args: Parsed argument namespace containing ``warp_config``.
+    """
+    if not args.warp_config:
+        return
+
+    for entry in args.warp_config:
+        if "=" not in entry:
+            parser.error(f"invalid --warp-config format '{entry}': expected KEY=VALUE")
+
+        key, value_str = entry.split("=", 1)
+
+        if not hasattr(wp.config, key):
+            parser.error(f"invalid --warp-config key '{key}': not a recognized warp.config setting")
+
+        try:
+            value = ast.literal_eval(value_str)
+        except (ValueError, SyntaxError):
+            value = value_str
+
+        setattr(wp.config, key, value)
+
+
 def init(parser=None):
     """Initialize Newton example components from parsed arguments.
 
@@ -536,6 +576,9 @@ def init(parser=None):
     else:
         # When parser is provided, use parse_args() to properly handle --help
         args = parser.parse_args()
+
+    # Apply --warp-config overrides before any Warp API calls
+    _apply_warp_config(parser, args)
 
     # Suppress Warp compilation messages if requested
     if args.quiet:

--- a/newton/tests/test_warp_config_cli.py
+++ b/newton/tests/test_warp_config_cli.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``--warp-config KEY=VALUE`` CLI option."""
+
+import contextlib
+import io
+import unittest
+
+import warp as wp
+
+from newton.examples import _apply_warp_config, create_parser
+
+
+class TestWarpConfigCLI(unittest.TestCase):
+    """Tests for :func:`_apply_warp_config`."""
+
+    def setUp(self):
+        self._saved_config = {attr: getattr(wp.config, attr) for attr in dir(wp.config) if not attr.startswith("__")}
+
+    def tearDown(self):
+        for attr, value in self._saved_config.items():
+            setattr(wp.config, attr, value)
+
+    def _parse(self, *cli_args):
+        """Parse *cli_args* through :func:`create_parser` and return (parser, args)."""
+        parser = create_parser()
+        args = parser.parse_known_args(list(cli_args))[0]
+        return parser, args
+
+    def test_no_overrides(self):
+        """No --warp-config flags should be a no-op."""
+        parser, args = self._parse()
+        _apply_warp_config(parser, args)
+        self.assertEqual(wp.config.verbose, self._saved_config["verbose"])
+
+    def test_int_override(self):
+        """Integer values should be parsed via literal_eval."""
+        parser, args = self._parse("--warp-config", "max_unroll=8")
+        _apply_warp_config(parser, args)
+        self.assertEqual(wp.config.max_unroll, 8)
+
+    def test_string_fallback(self):
+        """Bare words that aren't Python literals should be kept as strings."""
+        parser, args = self._parse("--warp-config", "mode=release")
+        _apply_warp_config(parser, args)
+        self.assertEqual(wp.config.mode, "release")
+
+    def test_bool_override(self):
+        """Boolean values should be parsed correctly."""
+        parser, args = self._parse("--warp-config", "verbose=True")
+        _apply_warp_config(parser, args)
+        self.assertIs(wp.config.verbose, True)
+
+    def test_none_override(self):
+        """None values should be accepted."""
+        parser, args = self._parse("--warp-config", "cache_kernels=None")
+        _apply_warp_config(parser, args)
+        self.assertIsNone(wp.config.cache_kernels)
+
+    def test_empty_string_override(self):
+        """Empty value (KEY=) should produce an empty string."""
+        parser, args = self._parse("--warp-config", "mode=")
+        _apply_warp_config(parser, args)
+        self.assertEqual(wp.config.mode, "")
+
+    def test_repeated_overrides(self):
+        """Later overrides should win."""
+        parser, args = self._parse(
+            "--warp-config",
+            "max_unroll=4",
+            "--warp-config",
+            "max_unroll=16",
+        )
+        _apply_warp_config(parser, args)
+        self.assertEqual(wp.config.max_unroll, 16)
+
+    def test_unknown_key_errors(self):
+        """An unknown key should produce a clear error naming the bad key."""
+        parser, args = self._parse("--warp-config", "bogus_key_xyz=1")
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+            _apply_warp_config(parser, args)
+        self.assertIn(
+            "invalid --warp-config key 'bogus_key_xyz': not a recognized warp.config setting", stderr.getvalue()
+        )
+
+    def test_missing_equals_errors(self):
+        """A missing '=' should produce a clear error showing the bad entry."""
+        parser, args = self._parse("--warp-config", "no_equals")
+        stderr = io.StringIO()
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+            _apply_warp_config(parser, args)
+        self.assertIn("invalid --warp-config format 'no_equals': expected KEY=VALUE", stderr.getvalue())
+
+    def test_parser_has_warp_config_arg(self):
+        """The base parser should include --warp-config."""
+        parser = create_parser()
+        args = parser.parse_known_args(["--warp-config", "mode=release"])[0]
+        self.assertEqual(args.warp_config, ["mode=release"])
+
+    def test_default_warp_config_empty(self):
+        """Default value of --warp-config should be an empty list."""
+        parser = create_parser()
+        args = parser.parse_known_args([])[0]
+        self.assertEqual(args.warp_config, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Add a repeatable `--warp-config KEY=VALUE` CLI option to the shared example
argument parser so that `warp.config` attributes can be overridden from the
command line without editing source code.

Closes #2205

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m unittest newton.tests.test_warp_config_cli -v
```

11 unit tests covering integer, string, boolean, `None`, and empty-string
values, repeated overrides, unknown keys, and malformed entries.

Manual smoke test:

```bash
uv run -m newton.examples basic_pendulum --warp-config mode=release
uv run -m newton.examples basic_pendulum --warp-config optimization_level=2 \
    --warp-config verbose=True
```

## New feature / API change

```bash
# Override a single warp.config attribute
uv run -m newton.examples basic_pendulum --warp-config optimization_level=2

# Override multiple attributes
uv run -m newton.examples basic_pendulum \
    --warp-config optimization_level=2 \
    --warp-config cpu_compiler_flags=""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable CLI option (--warp-config KEY=VALUE) to override runtime configuration keys with basic type coercion.

* **Tests**
  * Added tests covering type parsing (numbers, booleans, None, bare words), repeated overrides, empty values, and error cases for malformed or unknown entries.

* **Documentation**
  * Changelog updated to document the new CLI override option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->