### PR TITLE
Minor benchmark doc improvement

### DIFF
--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -736,7 +736,7 @@ benchmark code from the ``asv/benchmarks`` directory against the code state of t
 the benchmark definitions themselves are not checked out from different branches—only the code being
 benchmarked is.
 
-Benchmarks can also be run against a range of commits using the ``commit1...commit2`` or ``commit1..commit2`` syntax.
+Benchmarks can also be run against a range of commits using the ``commit1..commit2`` syntax.
 This is useful for comparing performance across several recent changes:
 
 .. tab-set::
@@ -756,7 +756,7 @@ This is useful for comparing performance across several recent changes:
 
             asv run --launch-method spawn HEAD~4..HEAD
 
-Note that the older commit has to come first when using the ``commit1..commit2`` syntax.
+Note that the older commit has to come first.
 Commit hashes can be used instead of relative references:
 
 .. tab-set::


### PR DESCRIPTION
## Description
Minor clarification in the benchmark doc about ".." syntax and remove mention of the "..." syntax.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmark commit-range syntax: updated guidance to prefer the two-dot form (commit1..commit2) and added a note that the older commit must appear first when using that form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->