### PR TITLE
Fix FAQ formatting and update warp.sim deprecation status

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,7 +7,7 @@ Frequently Asked Questions (FAQ)
 This FAQ addresses general questions about Newton. For technical questions and answers, please refer to `GitHub Discussions <https://github.com/newton-physics/newton/discussions>`_.
 
 What is Newton?
-----------------
+---------------
 
 Newton is an open-source, GPU-accelerated, extensible, and differentiable physics engine for robotics built on `NVIDIA Warp <https://github.com/NVIDIA/warp>`_, initially focused on high-performance robot learning and `MuJoCo Warp <https://github.com/google-deepmind/mujoco_warp>`_ integration.
 
@@ -18,14 +18,14 @@ Newton is a `Linux Foundation <https://www.linuxfoundation.org/>`_ project initi
 What is the difference between Warp and Newton?
 -----------------------------------------------
 
-`Warp <https://github.com/NVIDIA/warp>`_ is a Python framework for writing high‑performance, differentiable GPU kernels for physics simulation and spatial computing. Newton is a full physics engine built on Warp that adds high‑level simulation APIs, interchangeable solvers, and asset I/O for robotics.
+`Warp <https://github.com/NVIDIA/warp>`_ is a Python framework for writing high-performance, differentiable GPU kernels for physics simulation and spatial computing. Newton is a full physics engine built on Warp that adds high-level simulation APIs, interchangeable solvers, and asset I/O for robotics.
 
-What is the difference between Warp.sim and Newton?
----------------------------------------------------
+What is the difference between ``warp.sim`` and Newton?
+-------------------------------------------------------
 
-Warp.sim is the predecessor to Newton, developed by NVIDIA as a module in Warp, and will be deprecated as of Warp 1.10. See the `announcement <https://github.com/NVIDIA/warp/discussions/735>`_ and :doc:`migration` to Newton.
+``warp.sim`` was the predecessor to Newton, developed by NVIDIA as a module in Warp. It was deprecated in Warp 1.8 and removed in Warp 1.10. See the :doc:`migration` to Newton.
 
-Does Newton support coupling of solvers for multiphysics or co‑simulation?
+Does Newton support coupling of solvers for multiphysics or co-simulation?
 --------------------------------------------------------------------------
 
 Yes, Newton is explicitly designed to be extensible with multiple solver implementations for rich multiphysics scenarios. Newton provides APIs for users to implement coupling between solvers, and we have successfully demonstrated one-way coupling in examples such as cloth manipulation by a robotic arm and a quadruped walking through non-rigid terrain. Two-way coupling and implicit coupling between select solvers are on the Newton roadmap.
@@ -45,7 +45,7 @@ Yes, an experimental Newton integration is available in Isaac Lab and under acti
 Newton integration with Isaac Sim as a physics backend is under development.
 
 Is Newton a standalone framework?
------------------------------------------
+---------------------------------
 
 Yes, Newton and its modern Python API can be used as a standalone simulation framework. See the :doc:`api/newton` or the `Quickstart Guide <https://github.com/newton-physics/newton?tab=readme-ov-file#quickstart>`_ for more information.
 
@@ -54,7 +54,7 @@ Does Newton provide visualization capabilities?
 
 Newton provides basic visualization for debugging purposes. Read more in the :doc:`guide/visualization` Guide.
 
-For rich real‑time graphics, users commonly pair Newton with Isaac Lab, which provides advanced rendering. Users can also export simulation outputs to a time-sampled USD that can be visualized, for example, in `NVIDIA Omniverse <https://www.nvidia.com/en-us/omniverse/>`_ or `Isaac Sim <https://developer.nvidia.com/isaac/sim>`_.
+For rich real-time graphics, users commonly pair Newton with Isaac Lab, which provides advanced rendering. Users can also export simulation outputs to a time-sampled USD that can be visualized, for example, in `NVIDIA Omniverse <https://www.nvidia.com/en-us/omniverse/>`_ or `Isaac Sim <https://developer.nvidia.com/isaac/sim>`_.
 
 How can I contribute to Newton?
 -------------------------------
@@ -69,14 +69,14 @@ Yes, Newton is designed to be highly extensible, supporting custom solvers, inte
 What is PhysX?
 --------------
 
-`PhysX <https://github.com/NVIDIAGameWorks/PhysX>`_ is an open-source, multi-physics SDK that provides scalable simulation across CPUs and GPUs, widely used for industrial digital-twin simulation in Omniverse, and robotics simulation in IsaacSim and IsaacLab.
+`PhysX <https://github.com/NVIDIAGameWorks/PhysX>`_ is an open-source, multi-physics SDK that provides scalable simulation across CPUs and GPUs, widely used for industrial digital-twin simulation in Omniverse, and robotics simulation in Isaac Sim and Isaac Lab.
 
 It features a unified simulation framework for reduced-coordinate articulations and rigid bodies, deformable bodies and cloth (FEM), fluids/particles (PBD), vehicle dynamics, and character controllers.
 
 Will Newton replace PhysX?
 --------------------------
 
-No, the two engines serve different primary goals: Newton targets robot learning and extensible multiphysics with differentiability, while PhysX focuses on industrial digital-twin simulation as a mature, multi-platform real‑time physics SDK that is actively maintained and updated.
+No, the two engines serve different primary goals: Newton targets robot learning and extensible multiphysics with differentiability, while PhysX focuses on industrial digital-twin simulation as a mature, multi-platform real-time physics SDK that is actively maintained and updated.
 
 Isaac Lab's experimental Newton integration does not support PhysX, but Isaac Lab plans to continue supporting PhysX as a simulation backend.
 


### PR DESCRIPTION
## Description

Fix several formatting and content issues in `docs/faq.rst`:

- Replace non-breaking hyphens (U+2011) with standard hyphens
- Fix RST heading underline lengths to match title lengths
- Use inline code (`` ``warp.sim`` ``) instead of plain text "Warp.sim"
- Update deprecation language: `warp.sim` was deprecated in Warp 1.8 and removed in Warp 1.10 (not "will be deprecated")
- Remove outdated link to the deprecation announcement
- Fix "IsaacSim"/"IsaacLab" → "Isaac Sim"/"Isaac Lab" for consistency

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Documentation-only change. Verified RST renders correctly by inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ with improved formatting and section structure
  * Corrected product naming conventions to Isaac Sim / Isaac Lab
  * Updated Warp.sim deprecation information (deprecated in 1.8, removed in 1.10)
  * Normalized hyphenation and formatting conventions throughout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->