### PR TITLE
Fix VSync having no effect in ViewerGL on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Fix `eq_solimp` not being written to the MuJoCo spec for equality constraints, causing it to be absent from XML saved via `save_to_mjcf`
 - Fix WELD equality constraint quaternion written in xyzw format instead of MuJoCo's wxyz format in the spec, causing incorrect orientation in XML saved via `save_to_mjcf`
 - Fix `update_contacts` not populating `rigid_contact_point0`/`rigid_contact_point1` when using `use_mujoco_contacts=True`
+- Fix VSync toggle having no effect in `ViewerGL` on Windows 8+ due to a pyglet bug where `DwmFlush()` is never called when `_always_dwm` is True
 - Fix loop joint coordinate mapping in the MuJoCo solver so joints after a loop joint read/write at correct qpos/qvel offsets
 - Fix viewer crash when contact buffer overflows by clamping contact count to buffer size
 - Decompose loop joint constraints by DOF type (WELD for fixed, CONNECT-pair for revolute, single CONNECT for ball) instead of always emitting 2x CONNECT

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -975,6 +975,17 @@ class RendererGL:
 
         self._set_icon()
 
+        # Pyglet on Windows 8+ (where _always_dwm=True) disables the GL
+        # swap interval to avoid double-syncing with DWM, but then also
+        # skips calling DwmFlush() in flip() due to a condition bug.
+        # We call DwmFlush() ourselves in present() to work around this.
+        self._dwm_flush = None
+        if sys.platform == "win32" and getattr(self.window, "_always_dwm", False):
+            try:
+                self._dwm_flush = ctypes.windll.dwmapi.DwmFlush
+            except (AttributeError, OSError):
+                pass
+
         if headless is None:
             self.headless = pyglet.options.get("headless", False)
         else:
@@ -1230,8 +1241,9 @@ class RendererGL:
 
     def present(self):
         if not self.headless:
+            if self._dwm_flush is not None and self.window._interval:
+                self._dwm_flush()
             self.window.flip()
-        #    self.app.event_loop._redraw_windows(1.0 / 60.0)
 
     def resize(self, width, height):
         self._screen_width, self._screen_height = self.window.get_framebuffer_size()


### PR DESCRIPTION
## Description

Fix VSync toggle having no effect in `ViewerGL` on Windows 8+.

Pyglet on Windows 8+ sets `_always_dwm=True`, which causes `set_vsync()` to disable the GL swap interval (to avoid double-syncing with DWM), but then `flip()` skips calling `DwmFlush()` due to a condition bug (it checks `not _always_dwm`). The result is that vsync is completely non-functional in windowed mode on modern Windows -- the property reports `True` but nothing actually synchronizes to the display refresh.

This works around the pyglet bug by calling `DwmFlush()` ourselves in `RendererGL.present()` when the broken condition is detected and vsync is requested.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Manually verified on Windows 10 (build 26200) with an NVIDIA RTX 3080:
1. Launch any example with `ViewerGL`
2. Toggle the VSync checkbox in Rendering Options
3. Confirm FPS drops to monitor refresh rate (~60 Hz) when enabled and runs uncapped when disabled

Also verified the workaround is safely a no-op on non-Windows platforms (`_dwm_flush` stays `None`).

## Bug fix

**Steps to reproduce:**

1. Run any Newton example with `ViewerGL` on Windows 8+ in windowed mode
2. Enable VSync via the checkbox in Rendering Options
3. Observe that the frame rate is unchanged (still uncapped)

**Minimal reproduction:**

```python
import pyglet
w = pyglet.window.Window(visible=False, vsync=True)
print(w._always_dwm)   # True on Windows 8+
print(w._interval)      # True -- thinks vsync is on
# But GL swap interval was set to 0 and DwmFlush() is never called
w.close()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed VSync toggle functionality on Windows 8 and later operating systems. The VSync setting now properly takes effect in the 3D viewer when toggled on or off, ensuring correct display synchronization, improved frame timing control, and consistent visual performance across all supported Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->