### PR TITLE
Align inertia symmetry tolerances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - Fix Poisson surface reconstruction segfault under parallel test execution by defaulting to single-threaded Open3D Poisson (`n_threads=1`)
 - Fix overly conservative broadphase AABB for mesh shapes by using the pre-computed local AABB with a rotated-box transform instead of a bounding-sphere fallback, eliminating false contacts between distant meshes
 - Fix heightfield bounding-sphere radius underestimating Z extent for asymmetric height ranges (e.g. `min_z=0, max_z=10`)
+- Fix fast inertia validation treating near-symmetric tensors within `np.allclose()` default tolerances as corrections, aligning CPU and GPU validation warnings
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/inertia.py
+++ b/newton/_src/geometry/inertia.py
@@ -33,6 +33,11 @@ _INERTIA_ABS_FLOOR = 1.0e-10
 # becomes [1e-6, 1e-6, 1e-6]).
 _INERTIA_ABS_ADJUSTMENT = 1.0e-6
 
+# Match numpy's default np.allclose() tolerances when deciding whether a
+# nearly-symmetric tensor should be treated as unchanged.
+_INERTIA_SYMMETRY_RTOL = 1.0e-5
+_INERTIA_SYMMETRY_ATOL = 1.0e-8
+
 
 def compute_inertia_sphere(density: float, radius: float) -> tuple[float, wp.vec3, wp.mat33]:
     """Helper to compute mass and inertia of a solid sphere
@@ -671,7 +676,12 @@ def verify_and_correct_inertia(
 
     # Unconditionally symmetrize inertia matrix (idempotent for symmetric tensors)
     symmetrized = (inertia_array + inertia_array.T) / 2
-    if not np.allclose(inertia_array, symmetrized):
+    if not np.allclose(
+        inertia_array,
+        symmetrized,
+        rtol=_INERTIA_SYMMETRY_RTOL,
+        atol=_INERTIA_SYMMETRY_ATOL,
+    ):
         warnings.warn(f"Inertia matrix{body_id} is not symmetric, making it symmetric", stacklevel=2)
         was_corrected = True
     corrected_inertia = symmetrized
@@ -813,6 +823,7 @@ def validate_and_correct_inertia_kernel(
 
     mass = body_mass[tid]
     inertia = body_inertia[tid]
+    original_inertia = inertia
     was_corrected = False
 
     # Detect NaN/Inf in mass or any inertia coefficient and zero out
@@ -848,18 +859,32 @@ def validate_and_correct_inertia_kernel(
         inertia = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     else:
         # Symmetrize inertia matrix: (I + I^T) / 2
+        sym01 = (inertia[0, 1] + inertia[1, 0]) * 0.5
+        sym02 = (inertia[0, 2] + inertia[2, 0]) * 0.5
+        sym12 = (inertia[1, 2] + inertia[2, 1]) * 0.5
         sym = wp.mat33(
             inertia[0, 0],
-            (inertia[0, 1] + inertia[1, 0]) * 0.5,
-            (inertia[0, 2] + inertia[2, 0]) * 0.5,
-            (inertia[0, 1] + inertia[1, 0]) * 0.5,
+            sym01,
+            sym02,
+            sym01,
             inertia[1, 1],
-            (inertia[1, 2] + inertia[2, 1]) * 0.5,
-            (inertia[0, 2] + inertia[2, 0]) * 0.5,
-            (inertia[1, 2] + inertia[2, 1]) * 0.5,
+            sym12,
+            sym02,
+            sym12,
             inertia[2, 2],
         )
-        if wp.ddot(inertia - sym, inertia - sym) > 0.0:
+
+        tol01 = _INERTIA_SYMMETRY_ATOL + _INERTIA_SYMMETRY_RTOL * wp.abs(sym01)
+        tol02 = _INERTIA_SYMMETRY_ATOL + _INERTIA_SYMMETRY_RTOL * wp.abs(sym02)
+        tol12 = _INERTIA_SYMMETRY_ATOL + _INERTIA_SYMMETRY_RTOL * wp.abs(sym12)
+        if (
+            wp.abs(inertia[0, 1] - sym01) > tol01
+            or wp.abs(inertia[1, 0] - sym01) > tol01
+            or wp.abs(inertia[0, 2] - sym02) > tol02
+            or wp.abs(inertia[2, 0] - sym02) > tol02
+            or wp.abs(inertia[1, 2] - sym12) > tol12
+            or wp.abs(inertia[2, 1] - sym12) > tol12
+        ):
             was_corrected = True
         inertia = sym
 
@@ -905,9 +930,11 @@ def validate_and_correct_inertia_kernel(
             inertia = inertia + wp.mat33(adjustment, 0.0, 0.0, 0.0, adjustment, 0.0, 0.0, 0.0, adjustment)
             was_corrected = True
 
+    output_inertia = inertia if was_corrected else original_inertia
+
     # Write back corrected values
     body_mass[tid] = mass
-    body_inertia[tid] = inertia
+    body_inertia[tid] = output_inertia
 
     # Update inverse mass
     if mass > 0.0:
@@ -917,7 +944,7 @@ def validate_and_correct_inertia_kernel(
 
     # Update inverse inertia
     if mass > 0.0:
-        body_inv_inertia[tid] = wp.inverse(inertia)
+        body_inv_inertia[tid] = wp.inverse(output_inertia)
     else:
         body_inv_inertia[tid] = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 

--- a/newton/tests/test_inertia_validation.py
+++ b/newton/tests/test_inertia_validation.py
@@ -406,6 +406,38 @@ class TestInertiaValidationParity(unittest.TestCase):
         inertia = results["detailed"]["model_inertia"]
         np.testing.assert_allclose(inertia, inertia.T, atol=1e-6)
 
+    def test_parity_near_symmetric_inertia_within_allclose_tolerance(self):
+        """Tiny asymmetry within np.allclose defaults should pass unchanged in both paths."""
+        inertia = np.array(
+            [
+                [1.0152890e-02, 0.0, 0.0],
+                [0.0, 1.0201062e-02, 2.8712206e-12],
+                [0.0, 2.8712208e-12, 1.0152890e-02],
+            ],
+            dtype=np.float32,
+        )
+        results = {}
+
+        for detailed in [True, False]:
+            builder = ModelBuilder()
+            builder.validate_inertia_detailed = detailed
+            idx = builder.add_body(mass=1.0, inertia=wp.mat33(inertia), label="near_symmetric")
+
+            with warnings.catch_warnings(record=True) as w:
+                model = builder.finalize()
+
+            self.assertEqual(len(w), 0, f"Unexpected warnings: {[str(x.message) for x in w]}")
+            mode = "detailed" if detailed else "fast"
+            results[mode] = {
+                "model_mass": float(model.body_mass.numpy()[idx]),
+                "model_inertia": np.array(model.body_inertia.numpy()[idx]),
+            }
+
+        np.testing.assert_allclose(
+            results["detailed"]["model_inertia"], results["fast"]["model_inertia"], rtol=0.0, atol=0.0
+        )
+        np.testing.assert_allclose(results["fast"]["model_inertia"], inertia, rtol=0.0, atol=0.0)
+
     def test_parity_exact_triangle_boundary(self):
         """Exact triangle equality diag(1,1,2) should be a no-op in both paths."""
         results = self._finalize_both_paths(mass=1.0, inertia=np.diag([1.0, 1.0, 2.0]))


### PR DESCRIPTION
## Description

- Align the fast inertia validation symmetry check with the detailed path by using the default `np.allclose()` tolerances (`rtol=1e-5`, `atol=1e-8`).
- Preserve the original tensor in the fast path when the matrix is already within that tolerance instead of counting it as a correction.
- Add a regression test and changelog entry for the misleading warning seen from `newton/examples/basic/example_basic_urdf.py`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv run --extra dev -m unittest newton.tests.test_inertia_validation`
- Reproduced the `newton/examples/basic/example_basic_urdf.py` finalize path before the fix and observed `UserWarning: Inertia validation corrected 400 bodies. Set validate_inertia_detailed=True for detailed per-body warnings.`
- Re-ran the same finalize path after this change and verified that it emits no warnings.

## Bug fix

**Steps to reproduce:**

1. Run `python -m newton.examples.basic.example_basic_urdf`.
2. Observe `scene.finalize()` warn with `UserWarning: Inertia validation corrected 400 bodies. Set validate_inertia_detailed=True for detailed per-body warnings.`
3. Note that the example already uses `ignore_inertial_definitions=True` in `newton/examples/basic/example_basic_urdf.py`, so the warning is misleading: it is caused by tiny off-diagonal asymmetry in four `*_HAA` link inertia tensors, multiplied across the default `world_count=100`.

**Minimal reproduction:**

```python
import warnings
import numpy as np
import warp as wp

import newton
import newton.examples

quadruped = newton.ModelBuilder()
quadruped.default_joint_cfg.armature = 0.01
quadruped.default_joint_cfg.target_ke = 2000.0
quadruped.default_joint_cfg.target_kd = 1.0
quadruped.default_shape_cfg.mu = 1.0
quadruped.add_urdf(
    newton.examples.get_asset("quadruped.urdf"),
    xform=wp.transform(wp.vec3(0.0, 0.0, 0.7), wp.quat_identity()),
    floating=True,
    enable_self_collisions=False,
    ignore_inertial_definitions=True,
)
for body in range(quadruped.body_count):
    inertia = np.asarray(quadruped.body_inertia[body], dtype=np.float32).reshape(3, 3)
    inertia += np.eye(3, dtype=np.float32) * 0.01
    quadruped.body_inertia[body] = wp.mat33(inertia)

scene = newton.ModelBuilder()
scene.replicate(quadruped, 100)
scene.add_ground_plane(cfg=quadruped.default_shape_cfg)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    scene.finalize()

print([str(msg.message) for msg in w])
# Before: ['Inertia validation corrected 400 bodies. Set validate_inertia_detailed=True for detailed per-body warnings.']
# After: []
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed inertia validation inconsistency for nearly symmetric tensors across compute backends. CPU and GPU implementations now use identical numerical tolerance thresholds during validation, ensuring consistent warnings and predictable behavior when encountering edge cases with nearly symmetric inertia matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->