### PR TITLE
Skip test_contact_forces_on_incline unconditionally

### DIFF
--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 import tempfile
 import time
 import unittest
@@ -4373,7 +4372,7 @@ class TestMuJoCoContactForce(unittest.TestCase):
         model.request_contact_attributes("force")
         return model, ramp_shape
 
-    @unittest.skipIf(sys.platform == "darwin", "Flaky on macOS, see GH-2239")
+    @unittest.skip("Flaky on CI, see GH-2239")
     def test_contact_forces_on_incline(self):
         """Contact force on an incline must balance gravity (tests rotated contact frame)."""
         incline_angle = 0.25  # rad (~14°); mu=1.0 > tan(0.25)≈0.26 → static


### PR DESCRIPTION
## Description

Follow-up to 8402740 (#2241), which skipped `test_contact_forces_on_incline` only on macOS. The same flaky failure (`force=0.0` instead of expected `78.48`) also occurs on `ubuntu-latest` (Linux x86-64), indicating the non-determinism is platform-independent.

This PR changes the skip from `@unittest.skipIf(sys.platform == "darwin", ...)` to `@unittest.skip(...)` so the test is skipped on all platforms until the root cause tracked in #2239 is resolved.

Also removes the now-unused `import sys`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_contact_forces_on_incline
```

Verify the test is reported as skipped (not run, not failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified a contact force test to be skipped on all platforms instead of only macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->