### PR TITLE
Fix joint-order-independent FK

### DIFF
--- a/newton/_src/sim/articulation.py
+++ b/newton/_src/sim/articulation.py
@@ -204,12 +204,6 @@ def eval_single_articulation_fk(
         X_pj = joint_X_p[joint_index]
         X_cj = joint_X_c[joint_index]
 
-        # parent anchor frame in world space
-        X_wpj = X_pj
-        if parent >= 0:
-            X_wp = body_q[parent]
-            X_wpj = X_wp * X_wpj
-
         q_start = joint_q_start[joint_index]
         qd_start = joint_qd_start[joint_index]
         lin_axis_count = joint_dof_dim[joint_index, 0]

--- a/newton/_src/sim/articulation.py
+++ b/newton/_src/sim/articulation.py
@@ -199,7 +199,7 @@ def eval_single_articulation_fk(
         child = joint_child[joint_index]
 
         # compute transform across the joint
-        type = joint_type[joint_index]
+        joint_type_id = joint_type[joint_index]
 
         X_pj = joint_X_p[joint_index]
         X_cj = joint_X_c[joint_index]
@@ -212,7 +212,7 @@ def eval_single_articulation_fk(
         X_j = wp.transform_identity()
         v_j = wp.spatial_vector(wp.vec3(), wp.vec3())
 
-        if type == JointType.PRISMATIC:
+        if joint_type_id == JointType.PRISMATIC:
             axis = joint_axis[qd_start]
 
             q = joint_q[q_start]
@@ -221,7 +221,7 @@ def eval_single_articulation_fk(
             X_j = wp.transform(axis * q, wp.quat_identity())
             v_j = wp.spatial_vector(axis * qd, wp.vec3())
 
-        if type == JointType.REVOLUTE:
+        if joint_type_id == JointType.REVOLUTE:
             axis = joint_axis[qd_start]
 
             q = joint_q[q_start]
@@ -230,7 +230,7 @@ def eval_single_articulation_fk(
             X_j = wp.transform(wp.vec3(), wp.quat_from_axis_angle(axis, q))
             v_j = wp.spatial_vector(wp.vec3(), axis * qd)
 
-        if type == JointType.BALL:
+        if joint_type_id == JointType.BALL:
             r = wp.quat(joint_q[q_start + 0], joint_q[q_start + 1], joint_q[q_start + 2], joint_q[q_start + 3])
 
             w = wp.vec3(joint_qd[qd_start + 0], joint_qd[qd_start + 1], joint_qd[qd_start + 2])
@@ -238,7 +238,7 @@ def eval_single_articulation_fk(
             X_j = wp.transform(wp.vec3(), r)
             v_j = wp.spatial_vector(wp.vec3(), w)
 
-        if type == JointType.FREE or type == JointType.DISTANCE:
+        if joint_type_id == JointType.FREE or joint_type_id == JointType.DISTANCE:
             t = wp.transform(
                 wp.vec3(joint_q[q_start + 0], joint_q[q_start + 1], joint_q[q_start + 2]),
                 wp.quat(joint_q[q_start + 3], joint_q[q_start + 4], joint_q[q_start + 5], joint_q[q_start + 6]),
@@ -252,7 +252,7 @@ def eval_single_articulation_fk(
             X_j = t
             v_j = v
 
-        if type == JointType.D6:
+        if joint_type_id == JointType.D6:
             pos = wp.vec3(0.0)
             rot = wp.quat_identity()
             vel_v = wp.vec3(0.0)

--- a/newton/_src/sim/articulation.py
+++ b/newton/_src/sim/articulation.py
@@ -169,6 +169,7 @@ def invert_3d_rotational_dofs(
 def eval_single_articulation_fk(
     joint_start: int,
     joint_end: int,
+    joint_eval_order: wp.array(dtype=int),
     joint_articulation: wp.array(dtype=int),
     joint_q: wp.array(dtype=float),
     joint_qd: wp.array(dtype=float),
@@ -189,23 +190,30 @@ def eval_single_articulation_fk(
     body_qd: wp.array(dtype=wp.spatial_vector),
 ):
     for i in range(joint_start, joint_end):
-        articulation = joint_articulation[i]
+        joint_index = joint_eval_order[i]
+        articulation = joint_articulation[joint_index]
         if articulation == -1:
             continue
 
-        parent = joint_parent[i]
-        child = joint_child[i]
+        parent = joint_parent[joint_index]
+        child = joint_child[joint_index]
 
         # compute transform across the joint
-        type = joint_type[i]
+        type = joint_type[joint_index]
 
-        X_pj = joint_X_p[i]
-        X_cj = joint_X_c[i]
+        X_pj = joint_X_p[joint_index]
+        X_cj = joint_X_c[joint_index]
 
-        q_start = joint_q_start[i]
-        qd_start = joint_qd_start[i]
-        lin_axis_count = joint_dof_dim[i, 0]
-        ang_axis_count = joint_dof_dim[i, 1]
+        # parent anchor frame in world space
+        X_wpj = X_pj
+        if parent >= 0:
+            X_wp = body_q[parent]
+            X_wpj = X_wp * X_wpj
+
+        q_start = joint_q_start[joint_index]
+        qd_start = joint_qd_start[joint_index]
+        lin_axis_count = joint_dof_dim[joint_index, 0]
+        ang_axis_count = joint_dof_dim[joint_index, 1]
 
         X_j = wp.transform_identity()
         v_j = wp.spatial_vector(wp.vec3(), wp.vec3())
@@ -349,6 +357,7 @@ def eval_articulation_fk(
         dtype=bool
     ),  # used to enable / disable FK for an articulation, if None then treat all as enabled
     articulation_indices: wp.array(dtype=int),  # can be None, articulation indices to process
+    joint_eval_order: wp.array(dtype=int),
     joint_articulation: wp.array(dtype=int),
     joint_q: wp.array(dtype=float),
     joint_qd: wp.array(dtype=float),
@@ -393,6 +402,7 @@ def eval_articulation_fk(
     eval_single_articulation_fk(
         joint_start,
         joint_end,
+        joint_eval_order,
         joint_articulation,
         joint_q,
         joint_qd,
@@ -456,6 +466,7 @@ def eval_fk(
             model.articulation_count,
             mask,
             indices,
+            model.joint_eval_order,
             model.joint_articulation,
             joint_q,
             joint_qd,

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -10065,6 +10065,38 @@ class ModelBuilder:
             m.joint_ancestor = wp.array(parent_joint, dtype=wp.int32)
             m.joint_articulation = wp.array(self.joint_articulation, dtype=wp.int32)
 
+            from ..utils import topological_sort  # noqa: PLC0415
+
+            joint_eval_order = list(range(self.joint_count))
+            for art_idx in range(len(self.articulation_start)):
+                joint_start = self.articulation_start[art_idx]
+                joint_end = (
+                    self.articulation_start[art_idx + 1]
+                    if art_idx + 1 < len(self.articulation_start)
+                    else self.joint_count
+                )
+                art_joints = list(range(joint_start, joint_end))
+                if len(art_joints) <= 1:
+                    continue
+
+                joints_simple = [(int(self.joint_parent[i]), int(self.joint_child[i])) for i in art_joints]
+                try:
+                    joint_eval_order[joint_start:joint_end] = topological_sort(
+                        joints_simple,
+                        use_dfs=True,
+                        custom_indices=art_joints,
+                    )
+                except ValueError as e:
+                    art_key = (
+                        self.articulation_label[art_idx]
+                        if art_idx < len(self.articulation_label)
+                        else f"articulation_{art_idx}"
+                    )
+                    raise ValueError(
+                        f"Failed to compute kinematic evaluation order for articulation '{art_key}' (id={art_idx}): {e}"
+                    ) from e
+            m.joint_eval_order = wp.array(joint_eval_order, dtype=wp.int32)
+
             # dynamics properties
             m.joint_armature = wp.array(self.joint_armature, dtype=wp.float32, requires_grad=requires_grad)
             m.joint_target_mode = wp.array(self.joint_target_mode, dtype=wp.int32)

--- a/newton/_src/sim/ik/ik_common.py
+++ b/newton/_src/sim/ik/ik_common.py
@@ -31,6 +31,7 @@ class IKJacobianType(Enum):
 @wp.kernel
 def _eval_fk_articulation_batched(
     articulation_start: wp.array1d(dtype=wp.int32),
+    joint_eval_order: wp.array1d(dtype=wp.int32),
     joint_articulation: wp.array(dtype=int),
     joint_q: wp.array2d(dtype=wp.float32),
     joint_qd: wp.array2d(dtype=wp.float32),
@@ -56,6 +57,7 @@ def _eval_fk_articulation_batched(
     eval_single_articulation_fk(
         joint_start,
         joint_end,
+        joint_eval_order,
         joint_articulation,
         joint_q[problem_idx],
         joint_qd[problem_idx],
@@ -84,6 +86,7 @@ def eval_fk_batched(model, joint_q, joint_qd, body_q, body_qd):
         dim=[n_problems, model.articulation_count],
         inputs=[
             model.articulation_start,
+            model.joint_eval_order,
             model.joint_articulation,
             joint_q,
             joint_qd,

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -441,6 +441,8 @@ class Model:
         """Joint child body indices, shape [joint_count], int."""
         self.joint_ancestor: wp.array(dtype=wp.int32) | None = None
         """Maps from joint index to the index of the joint that has the current joint parent body as child (-1 if no such joint ancestor exists), shape [joint_count], int."""
+        self.joint_eval_order: wp.array(dtype=wp.int32) | None = None
+        """Per-articulation topological traversal order used by kinematics kernels, shape [joint_count], int."""
         self.joint_X_p: wp.array(dtype=wp.transform) | None = None
         """Joint transform in parent frame [m, unitless quaternion], shape [joint_count, 7], float."""
         self.joint_X_c: wp.array(dtype=wp.transform) | None = None
@@ -741,6 +743,7 @@ class Model:
         self.attribute_frequency["joint_parent"] = Model.AttributeFrequency.JOINT
         self.attribute_frequency["joint_child"] = Model.AttributeFrequency.JOINT
         self.attribute_frequency["joint_ancestor"] = Model.AttributeFrequency.JOINT
+        self.attribute_frequency["joint_eval_order"] = Model.AttributeFrequency.JOINT
         self.attribute_frequency["joint_articulation"] = Model.AttributeFrequency.JOINT
         self.attribute_frequency["joint_X_p"] = Model.AttributeFrequency.JOINT
         self.attribute_frequency["joint_X_c"] = Model.AttributeFrequency.JOINT

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -1216,6 +1216,128 @@ class TestModelJoints(unittest.TestCase):
 
         self.assertIn("DFS topological order", str(cm.warning))
 
+    def test_eval_fk_handles_out_of_order_joints(self):
+        """Test that eval_fk is independent of joint storage order within an articulation."""
+
+        def build_model(out_of_order: bool) -> tuple[newton.Model, list[int]]:
+            builder = ModelBuilder()
+
+            body_a = builder.add_link(mass=1.0)
+            body_b = builder.add_link(mass=1.0)
+            body_c = builder.add_link(mass=1.0)
+
+            root_joint = builder.add_joint_fixed(
+                parent=-1,
+                child=body_a,
+                parent_xform=wp.transform((1.0, -0.5, 0.25), wp.quat_identity()),
+                child_xform=wp.transform_identity(),
+            )
+
+            if out_of_order:
+                child_joint = builder.add_joint_fixed(
+                    parent=body_b,
+                    child=body_c,
+                    parent_xform=wp.transform((0.0, 0.0, 0.75), wp.quat_identity()),
+                    child_xform=wp.transform_identity(),
+                )
+                middle_joint = builder.add_joint_revolute(
+                    parent=body_a,
+                    child=body_b,
+                    axis=(0.0, 1.0, 0.0),
+                    parent_xform=wp.transform((0.0, 0.0, 0.5), wp.quat_identity()),
+                    child_xform=wp.transform((0.0, 0.0, -0.25), wp.quat_identity()),
+                )
+            else:
+                middle_joint = builder.add_joint_revolute(
+                    parent=body_a,
+                    child=body_b,
+                    axis=(0.0, 1.0, 0.0),
+                    parent_xform=wp.transform((0.0, 0.0, 0.5), wp.quat_identity()),
+                    child_xform=wp.transform((0.0, 0.0, -0.25), wp.quat_identity()),
+                )
+                child_joint = builder.add_joint_fixed(
+                    parent=body_b,
+                    child=body_c,
+                    parent_xform=wp.transform((0.0, 0.0, 0.75), wp.quat_identity()),
+                    child_xform=wp.transform_identity(),
+                )
+
+            builder.add_articulation([root_joint, min(middle_joint, child_joint), max(middle_joint, child_joint)])
+
+            q_start = builder.joint_q_start[middle_joint]
+            qd_start = builder.joint_qd_start[middle_joint]
+            builder.joint_q[q_start] = 0.35
+            builder.joint_qd[qd_start] = -0.2
+
+            model = builder.finalize()
+            return model, [body_a, body_b, body_c]
+
+        ordered_model, ordered_bodies = build_model(out_of_order=False)
+        unordered_model, unordered_bodies = build_model(out_of_order=True)
+
+        ordered_state = ordered_model.state()
+        unordered_state = unordered_model.state()
+
+        newton.eval_fk(ordered_model, ordered_model.joint_q, ordered_model.joint_qd, ordered_state)
+        newton.eval_fk(unordered_model, unordered_model.joint_q, unordered_model.joint_qd, unordered_state)
+
+        ordered_body_q = ordered_state.body_q.numpy()
+        ordered_body_qd = ordered_state.body_qd.numpy()
+        unordered_body_q = unordered_state.body_q.numpy()
+        unordered_body_qd = unordered_state.body_qd.numpy()
+
+        assert_np_equal(unordered_model.joint_eval_order.numpy(), np.array([0, 2, 1], dtype=np.int32))
+
+        for ordered_body, unordered_body in zip(ordered_bodies, unordered_bodies, strict=True):
+            assert_np_equal(unordered_body_q[unordered_body], ordered_body_q[ordered_body], tol=1.0e-5)
+            assert_np_equal(unordered_body_qd[unordered_body], ordered_body_qd[ordered_body], tol=1.0e-5)
+
+    def test_eval_ik_handles_out_of_order_joints(self):
+        """Test that eval_ik reconstructs coordinates for out-of-order articulation joints."""
+
+        builder = ModelBuilder()
+
+        body_a = builder.add_link(mass=1.0)
+        body_b = builder.add_link(mass=1.0)
+        body_c = builder.add_link(mass=1.0)
+
+        root_joint = builder.add_joint_fixed(
+            parent=-1,
+            child=body_a,
+            parent_xform=wp.transform((1.0, -0.5, 0.25), wp.quat_identity()),
+            child_xform=wp.transform_identity(),
+        )
+        child_joint = builder.add_joint_fixed(
+            parent=body_b,
+            child=body_c,
+            parent_xform=wp.transform((0.0, 0.0, 0.75), wp.quat_identity()),
+            child_xform=wp.transform_identity(),
+        )
+        middle_joint = builder.add_joint_revolute(
+            parent=body_a,
+            child=body_b,
+            axis=(0.0, 1.0, 0.0),
+            parent_xform=wp.transform((0.0, 0.0, 0.5), wp.quat_identity()),
+            child_xform=wp.transform((0.0, 0.0, -0.25), wp.quat_identity()),
+        )
+        builder.add_articulation([root_joint, child_joint, middle_joint])
+
+        q_start = builder.joint_q_start[middle_joint]
+        qd_start = builder.joint_qd_start[middle_joint]
+        builder.joint_q[q_start] = 0.35
+        builder.joint_qd[qd_start] = -0.2
+
+        model = builder.finalize()
+        state = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+        recovered_q = wp.zeros_like(model.joint_q)
+        recovered_qd = wp.zeros_like(model.joint_qd)
+        newton.eval_ik(model, state, recovered_q, recovered_qd)
+
+        assert_np_equal(recovered_q.numpy(), model.joint_q.numpy(), tol=1.0e-5)
+        assert_np_equal(recovered_qd.numpy(), model.joint_qd.numpy(), tol=1.0e-5)
+
     def test_mimic_constraint_programmatic(self):
         """Test programmatic creation of mimic constraints."""
         builder = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Fix `eval_fk` for articulations whose joints are stored out of topological order.

This PR introduces a per-articulation `joint_eval_order` array that preserves
stable public joint indices while letting FK evaluate joints parent-before-child
internally. It also adds regressions covering FK equivalence and FK->IK
round-tripping for an out-of-order articulation.

Closes #910.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run python -m unittest   newton.tests.test_model.TestModelJoints.test_eval_fk_handles_out_of_order_joints   newton.tests.test_model.TestModelJoints.test_eval_ik_handles_out_of_order_joints

uv run python -m unittest newton.tests.test_control_force
uvx pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FK now uses a per-joint evaluation order so articulations produce correct body transforms even if joints were created in any sequence; kinematics (FK/IK) handle out-of-order joints reliably.

* **Tests**
  * Added tests that validate forward and inverse kinematics remain correct and recover joint states regardless of joint creation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->