### PR TITLE
[SensorTiledCamera] Added support for Gaussian Sorting Modes

### DIFF
--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -1589,6 +1589,22 @@ class Gaussian:
             print(gaussian.count, gaussian.sh_degree)
     """
 
+    class SortingMode(enum.IntEnum):
+        """Sorting strategy for ordering Gaussian splat hits along a ray.
+
+        Controls how per-ray Gaussian intersections are depth-sorted before
+        front-to-back alpha compositing.
+        """
+
+        DEFAULT = 0
+        """Sort by closest-approach distance in the Gaussian's canonical space."""
+
+        CAMERA_DISTANCE = 1
+        """Sort by projection of the Gaussian center onto the ray direction."""
+
+        Z_DEPTH = 2
+        """Sort by camera-forward depth of the Gaussian center."""
+
     @wp.struct
     class Data:
         num_points: wp.int32
@@ -1598,6 +1614,7 @@ class Gaussian:
         sh_coeffs: wp.array(dtype=wp.float32, ndim=2)
         bvh_id: wp.uint64
         min_response: wp.float32
+        sorting_mode: wp.int32
 
     def __init__(
         self,
@@ -1608,6 +1625,7 @@ class Gaussian:
         sh_coeffs: np.ndarray | None = None,
         sh_degree: int | None = None,
         min_response: float = 0.1,
+        sorting_mode: SortingMode = SortingMode.DEFAULT,
     ):
         """Construct a Gaussian splat asset from arrays.
 
@@ -1624,6 +1642,9 @@ class Gaussian:
                 (``C = 3`` -> degree 0, ``C = 12`` -> degree 1, etc.).
             sh_degree: Spherical harmonic degree.
             min_response: Minimum response required for alpha testing.
+            sorting_mode: Sorting strategy for depth-ordering Gaussian
+                intersections along each ray before alpha compositing
+                (default: :attr:`SortingMode.DEFAULT`).
         """
 
         self._positions = np.ascontiguousarray(np.asarray(positions, dtype=np.float32).reshape(-1, 3))
@@ -1657,6 +1678,8 @@ class Gaussian:
         if not np.isfinite(min_response) or not (0.0 < min_response < 1.0):
             raise ValueError("min_response must be finite and in (0, 1)")
         self._min_response = float(min_response)
+
+        self._sorting_mode = sorting_mode
 
         self._cached_hash = None
         self._positions.setflags(write=False)
@@ -1718,6 +1741,11 @@ class Gaussian:
         """Min response, float."""
         return self._min_response
 
+    @property
+    def sorting_mode(self) -> SortingMode:
+        """Sorting mode, Gaussian.SortingMode."""
+        return self._sorting_mode
+
     def _find_sh_degree(self) -> int:
         """Spherical harmonics degree (0-3), inferred from *sh_coeffs* shape."""
         c = self._sh_coeffs.shape[1]
@@ -1751,6 +1779,7 @@ class Gaussian:
             self.warp_data.opacities = wp.array(self._opacities, dtype=wp.float32)
             self.warp_data.sh_coeffs = wp.array(self._sh_coeffs, dtype=wp.float32)
             self.warp_data.min_response = self.min_response
+            self.warp_data.sorting_mode = self.sorting_mode
             self.warp_data.num_points = self.warp_data.transforms.shape[0]
 
             lowers = wp.zeros(self.count, dtype=wp.vec3f)

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -1596,7 +1596,7 @@ class Gaussian:
         front-to-back alpha compositing.
         """
 
-        DEFAULT = 0
+        RAY_HIT_DISTANCE = 0
         """Sort by closest-approach distance in the Gaussian's canonical space."""
 
         CAMERA_DISTANCE = 1
@@ -1625,7 +1625,7 @@ class Gaussian:
         sh_coeffs: np.ndarray | None = None,
         sh_degree: int | None = None,
         min_response: float = 0.1,
-        sorting_mode: SortingMode = SortingMode.DEFAULT,
+        sorting_mode: SortingMode = SortingMode.RAY_HIT_DISTANCE,
     ):
         """Construct a Gaussian splat asset from arrays.
 
@@ -1644,7 +1644,7 @@ class Gaussian:
             min_response: Minimum response required for alpha testing.
             sorting_mode: Sorting strategy for depth-ordering Gaussian
                 intersections along each ray before alpha compositing
-                (default: :attr:`SortingMode.DEFAULT`).
+                (default: :attr:`SortingMode.RAY_HIT_DISTANCE`).
         """
 
         self._positions = np.ascontiguousarray(np.asarray(positions, dtype=np.float32).reshape(-1, 3))
@@ -2001,6 +2001,7 @@ class Gaussian:
                     self._opacities.data.tobytes(),
                     self._sh_coeffs.data.tobytes(),
                     float(self._min_response),
+                    int(self._sorting_mode),
                 )
             )
         return self._cached_hash
@@ -2016,4 +2017,5 @@ class Gaussian:
             and np.array_equal(self._opacities, other._opacities)
             and np.array_equal(self._sh_coeffs, other._sh_coeffs)
             and self._min_response == other._min_response
+            and self._sorting_mode == other._sorting_mode
         )

--- a/newton/_src/sensors/warp_raytrace/gaussians.py
+++ b/newton/_src/sensors/warp_raytrace/gaussians.py
@@ -46,9 +46,34 @@ def compute_gaussian_bvh_bounds(
 
 
 @wp.func
-def canonical_ray_hit_distance(ray_origin: wp.vec3f, ray_direction: wp.vec3f) -> wp.float32:
+def sorting_mode_ray_hit_distance(ray_origin: wp.vec3f, ray_direction: wp.vec3f) -> wp.float32:
     numerator = -wp.dot(ray_origin, ray_direction)
     return safe_div(numerator, wp.dot(ray_direction, ray_direction))
+
+
+@wp.func
+def sorting_mode_camera_distance(
+    gaussian_center: wp.vec3f,
+    ray_origin: wp.vec3f,
+    ray_direction: wp.vec3f,
+) -> wp.float32:
+    """Parametric *t* where the Gaussian center projects onto the ray."""
+    to_center = gaussian_center - ray_origin
+    return safe_div(wp.dot(to_center, ray_direction), wp.dot(ray_direction, ray_direction))
+
+
+@wp.func
+def sorting_mode_z_depth(
+    gaussian_center_world: wp.vec3f,
+    camera_forward: wp.vec3f,
+    ray_origin_world: wp.vec3f,
+    ray_direction_world: wp.vec3f,
+) -> wp.float32:
+    """Parametric *t* at which the ray reaches the Gaussian center's depth plane."""
+    return safe_div(
+        wp.dot(camera_forward, gaussian_center_world - ray_origin_world),
+        wp.dot(camera_forward, ray_direction_world),
+    )
 
 
 @wp.func
@@ -68,15 +93,28 @@ def ray_gsplat_hit_response(
     scale: wp.vec3f,
     opacity: wp.float32,
     min_response: wp.float32,
+    sorting_mode: wp.int32,
     ray_origin_world: wp.vec3f,
     ray_direction_world: wp.vec3f,
+    camera_forward: wp.vec3f,
     max_distance: wp.float32,
 ) -> tuple[wp.float32, wp.float32]:
     ray_origin_local, ray_direction_local = map_ray_to_local_scaled(
         transform, scale, ray_origin_world, ray_direction_world
     )
 
-    hit_distance = canonical_ray_hit_distance(ray_origin_local, ray_direction_local)
+    hit_distance = 0.0
+    if sorting_mode == wp.static(Gaussian.SortingMode.CAMERA_DISTANCE):
+        gaussian_center = wp.transform_get_translation(transform)
+        hit_distance = sorting_mode_camera_distance(gaussian_center, ray_origin_local, ray_direction_local)
+    elif sorting_mode == wp.static(Gaussian.SortingMode.Z_DEPTH):
+        gaussian_center = wp.transform_get_translation(transform)
+        gaussian_center_world = wp.transform_point(transform, wp.cw_mul(gaussian_center, scale))
+        hit_distance = sorting_mode_z_depth(
+            gaussian_center_world, camera_forward, ray_origin_world, ray_direction_world
+        )
+    else:
+        hit_distance = sorting_mode_ray_hit_distance(ray_origin_local, ray_direction_local)
 
     if hit_distance > 0.0 and hit_distance < max_distance:
         max_response = canonical_ray_max_kernel_response(ray_origin_local, wp.normalize(ray_direction_local))
@@ -94,6 +132,7 @@ def create_shade_function(config: RenderContext.Config, state: RenderContext.Sta
         scale: wp.vec3f,
         ray_origin: wp.vec3f,
         ray_direction: wp.vec3f,
+        camera_forward: wp.vec3f,
         gaussian_data: Gaussian.Data,
         max_distance: wp.float32,
     ) -> tuple[GeomHit, wp.vec3f]:
@@ -129,8 +168,10 @@ def create_shade_function(config: RenderContext.Config, state: RenderContext.Sta
                     gaussian_data.scales[hit_index],
                     gaussian_data.opacities[hit_index],
                     gaussian_data.min_response,
+                    gaussian_data.sorting_mode,
                     ray_origin_local,
                     ray_direction_local,
+                    camera_forward,
                     hit_distances[-1],
                 )
 

--- a/newton/_src/sensors/warp_raytrace/raytrace.py
+++ b/newton/_src/sensors/warp_raytrace/raytrace.py
@@ -61,6 +61,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
         gaussians_data: wp.array(dtype=Gaussian.Data),
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         if bvh_shapes_size:
             for i in range(wp.static(2 if config.enable_global_world else 1)):
@@ -187,6 +188,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
                             shape_sizes[si],
                             ray_origin_world,
                             ray_dir_world,
+                            camera_forward,
                             gaussians_data[gaussian_id],
                             closest_hit.distance,
                         )
@@ -286,6 +288,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
         gaussians_data: wp.array(dtype=Gaussian.Data),
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         closest_hit = ClosestHit()
         closest_hit.distance = max_distance
@@ -310,6 +313,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if wp.static(config.enable_particles):
@@ -350,6 +354,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
         gaussians_data: wp.array(dtype=Gaussian.Data),
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         if bvh_shapes_size:
             for i in range(wp.static(2 if config.enable_global_world else 1)):
@@ -442,6 +447,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
                             shape_sizes[si],
                             ray_origin_world,
                             ray_dir_world,
+                            camera_forward,
                             gaussians_data[gaussian_id],
                             closest_hit.distance,
                         )
@@ -531,6 +537,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
         gaussians_data: wp.array(dtype=Gaussian.Data),
         ray_origin_world: wp.vec3f,
         ray_dir_world: wp.vec3f,
+        camera_forward: wp.vec3f,
     ) -> ClosestHit:
         closest_hit = ClosestHit()
         closest_hit.distance = max_distance
@@ -556,6 +563,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if wp.static(config.enable_particles):

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -104,6 +104,7 @@ def create_kernel(
         camera_transform = camera_transforms[camera_index, world_index]
         ray_origin_world = wp.transform_point(camera_transform, camera_rays[camera_index, py, px, 0])
         ray_dir_world = wp.transform_vector(camera_transform, camera_rays[camera_index, py, px, 1])
+        camera_forward = wp.transform_vector(camera_transform, wp.vec3f(0.0, 0.0, -1.0))
 
         closest_hit = raytrace_closest_hit(
             bvh_shapes_size,
@@ -127,6 +128,7 @@ def create_kernel(
             gaussians_data,
             ray_origin_world,
             ray_dir_world,
+            camera_forward,
         )
 
         if closest_hit.shape_index == raytrace.NO_HIT_SHAPE_ID:

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1866,6 +1866,13 @@ def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:
     if positions is None:
         raise ValueError("USD Gaussian prim is missing required 'positions' attribute")
 
+    sorting_mode = Gaussian.SortingMode.DEFAULT
+    if usd_sorting_mode := get_attribute(prim, "sortingModeHint"):
+        if usd_sorting_mode == "zDepth":
+            sorting_mode = Gaussian.SortingMode.Z_DEPTH
+        if usd_sorting_mode == "cameraDistance":
+            sorting_mode = Gaussian.SortingMode.CAMERA_DISTANCE
+
     return Gaussian(
         positions=positions,
         rotations=_get_float_array_attr("orientations"),
@@ -1874,4 +1881,5 @@ def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:
         sh_coeffs=_get_float_array_attr("radiance:sphericalHarmonicsCoefficients"),
         sh_degree=get_attribute(prim, "radiance:sphericalHarmonicsDegree"),
         min_response=min_response,
+        sorting_mode=sorting_mode,
     )

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1866,12 +1866,16 @@ def get_gaussian(prim: Usd.Prim, min_response: float = 0.1) -> Gaussian:
     if positions is None:
         raise ValueError("USD Gaussian prim is missing required 'positions' attribute")
 
-    sorting_mode = Gaussian.SortingMode.DEFAULT
+    sorting_mode = Gaussian.SortingMode.RAY_HIT_DISTANCE
     if usd_sorting_mode := get_attribute(prim, "sortingModeHint"):
         if usd_sorting_mode == "zDepth":
             sorting_mode = Gaussian.SortingMode.Z_DEPTH
-        if usd_sorting_mode == "cameraDistance":
+        elif usd_sorting_mode == "cameraDistance":
             sorting_mode = Gaussian.SortingMode.CAMERA_DISTANCE
+        elif usd_sorting_mode == "rayHitDistance":
+            sorting_mode = Gaussian.SortingMode.RAY_HIT_DISTANCE
+        else:
+            raise ValueError(f"Unsupported gaussian sorting mode: {usd_sorting_mode}")
 
     return Gaussian(
         positions=positions,


### PR DESCRIPTION
## Description

Add configurable sorting modes for Gaussian splat depth-ordering in the tiled camera sensor's ray tracer. The default sorting strategy (closest-approach distance in canonical space) can now be overridden with two alternatives — **camera distance** (projection of the Gaussian center onto the ray) and **Z depth** (camera-forward depth of the Gaussian center) — giving users control over compositing order for scenes where the default heuristic produces artifacts.

## Changes

- **`Gaussian.SortingMode` enum** (`geometry/types.py`): New nested `IntEnum` with `DEFAULT`, `CAMERA_DISTANCE`, and `Z_DEPTH`. Added as a parameter to `Gaussian.__init__`, stored in the Warp `Data` struct, and exposed via a `sorting_mode` property.
- **Sorting kernels** (`warp_raytrace/gaussians.py`): Two new Warp functions — `camera_distance_sorting` and `z_depth_sorting` — applied conditionally in the shade function based on `gaussian_data.sorting_mode`.
- **Ray pipeline plumbing** (`warp_raytrace/raytrace.py`, `render.py`): Computed `camera_forward` from the camera transform and threaded it through `create_closest_hit_function` and `create_closest_hit_depth_only_function` so the Z-depth sorting mode has access to the camera's forward vector.
- **USD ingestion** (`usd/utils.py`): Reads the `sortingModeHint` attribute from USD Gaussian prims (`"zDepth"` / `"cameraDistance"`) and maps it to the corresponding `SortingMode`.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- Verify the tiled camera sensor renders Gaussian splats correctly with each sorting mode (`DEFAULT`, `CAMERA_DISTANCE`, `Z_DEPTH`).
- Load a USD scene with the `sortingModeHint` attribute set and confirm the correct mode is parsed.
- Run existing sensor / Gaussian regression tests to confirm no regressions:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable depth-sorting strategies for Gaussian rendering: ray-hit distance, camera-distance, and z-depth.
  * Sorting mode can be specified when loading USD assets and is applied end-to-end during rendering (camera-facing depth is now propagated into raytracing/shading).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->