### PR TITLE
ci: skip push-triggered CI in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   minimal-import-test:
+    if: github.event_name != 'push' || github.repository == 'newton-physics/newton'
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary

When syncing a fork's `main` or `release-*` branch with upstream, the `push` event triggers CI unnecessarily — wasting the fork owner's Actions minutes on commits that upstream has already tested.

## Changes

Added an `if` condition to the root job (`minimal-import-test`) in `ci.yml`:

```yaml
if: github.event_name != 'push' || github.repository == 'newton-physics/newton'
```

Since `dependency-install-test` and `newton-unittests` depend on `minimal-import-test` via `needs`, the entire workflow is skipped when a fork receives a push event.

**What still works in forks:**
- `workflow_dispatch` (manual triggers)
- `workflow_call` (called by other workflows)

**What gets skipped:**
- `push` events to `main`, `release-*`, or `v*` tags in forks

This is consistent with the existing guard in `push_aws_gpu.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD workflow execution conditions for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->