### PR TITLE
 Title: Add studio shading style and edge overlay to GL viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 
 - Add `SolverXPBD.update_contacts()` to populate `contacts.force` with per-contact spatial forces (linear force and torque) derived from XPBD constraint impulses
+- Add `shading_style` parameter to `ViewerGL` for selecting ``"classic"`` or ``"studio"`` rendering styles at construction or runtime
+- Add studio shading style with 3-point lighting, shadow mapping, rim highlights, and neutral matte ground plane
+- Add edge overlay toggle (`renderer.draw_edges`) for wireframe visualization on top of solid geometry
+- Add registry-based shading system (`ShadingStyleConfig` / `STYLE_REGISTRY`) for extensible style registration
 - Add repeatable `--warp-config KEY=VALUE` CLI option for overriding `warp.config` attributes when running examples
 - Add 3D texture-based SDF, replacing NanoVDB volumes in the mesh-mesh collision pipeline for improved performance and CPU compatibility.
 - Parse URDF joint `limit effort="..."` values and propagate them to imported revolute and prismatic joint `effort_limit` settings

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -89,11 +89,11 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
-        sky_upper=(0.98, 0.98, 1.0),
-        sky_lower=(0.55, 0.55, 0.60),
+        sky_upper=(0.68, 0.68, 0.72),
+        sky_lower=(0.32, 0.32, 0.36),
         draw_sun=False,
         overrides={
-            "fog_color": (0.93, 0.93, 0.95),
+            "fog_color": (0.55, 0.55, 0.58),
             "sky_color": (0.72, 0.82, 0.98),
             "ground_color": (0.50, 0.45, 0.38),
             "light_color": (0.92, 0.90, 0.86),

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -301,7 +301,7 @@ class MeshGL:
         # albedo
         gl.glVertexAttrib3f(7, 0.7, 0.5, 0.3)
         # material = (roughness, metallic, checker, texture_enable)
-        gl.glVertexAttrib4f(8, 0.85, 0.0, 0.0, 0.0)
+        gl.glVertexAttrib4f(8, 0.5, 0.0, 0.0, 0.0)
 
         gl.glBindVertexArray(0)
 
@@ -1927,11 +1927,11 @@ class RendererGL:
         gl = RendererGL.gl
         style = self._active_style
 
-        if self.draw_wireframe:
-            gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
-
         if self.draw_sky and style.draw_sky:
             self._draw_sky()
+
+        if self.draw_wireframe:
+            gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
 
         shader = self._style_shaders[style.name]
         shader.update(**self._build_shader_kwargs())

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -75,15 +75,13 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
     "studio": ShadingStyleConfig(
         name="studio",
         shader_class=ShaderShapeStudio,
-        draw_sky=False,
+        draw_sky=True,
         # ~45° elevation so the floor gets moderate (not maximum) direct light.
         sun_directions={
             0: np.array([1.0, 0.6, 0.8], dtype=np.float32),  # X-up
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
-        gradient_top=(0.96, 0.96, 0.97),
-        gradient_bottom=(0.85, 0.85, 0.87),
         overrides={
             "fog_color": (0.93, 0.93, 0.95),
             "sky_color": (0.72, 0.82, 0.98),
@@ -92,6 +90,10 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             "env_texture": None,
             "env_intensity": 0.0,
             "spotlight_enabled": False,
+            # Sky dome overrides — subtle near-white gradient, no sun flare.
+            "sky_upper": (0.96, 0.96, 0.97),
+            "sky_lower": (0.85, 0.85, 0.87),
+            "sky_sun_direction": (0.0, 0.0, 0.0),
         },
     ),
 }
@@ -2107,14 +2109,15 @@ class RendererGL:
 
         self._make_current()
 
+        overrides = self._active_style.overrides
         self._sky_shader.update(
             view_matrix=self._view_matrix,
             projection_matrix=self._projection_matrix,
             camera_pos=self.camera.pos,
             camera_far=self.camera.far,
-            sky_upper=self.sky_upper,
-            sky_lower=self.sky_lower,
-            sun_direction=self._sun_direction,
+            sky_upper=overrides.get("sky_upper", self.sky_upper),
+            sky_lower=overrides.get("sky_lower", self.sky_lower),
+            sun_direction=overrides.get("sky_sun_direction", self._sun_direction),
             up_axis=self.camera.up_axis,
         )
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -89,8 +89,8 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
-        sky_upper=(0.96, 0.96, 0.98),
-        sky_lower=(0.62, 0.62, 0.66),
+        sky_upper=(0.98, 0.98, 1.0),
+        sky_lower=(0.55, 0.55, 0.60),
         draw_sun=False,
         overrides={
             "fog_color": (0.93, 0.93, 0.95),

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1,10 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import ctypes
 import io
 import os
 import sys
+from dataclasses import dataclass, field
 
 import numpy as np
 import warp as wp
@@ -16,11 +29,82 @@ from ...utils.texture import normalize_texture
 from .shaders import (
     FrameShader,
     ShaderArrow,
+    ShaderEdge,
     ShaderLine,
     ShaderShape,
+    ShaderShapeStudio,
     ShaderSky,
     ShadowShader,
 )
+
+# ---------------------------------------------------------------------------
+# Shading style registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ShadingStyleConfig:
+    """Immutable descriptor for a named shading style.
+
+    Args:
+        name: Style identifier used in the registry.
+        shader_class: ShaderShape subclass to instantiate for this style.
+        draw_sky: Whether to render the sky sphere background.
+        sun_directions: Per-up-axis key-light direction (un-normalized).
+            Keys: 0=X-up, 1=Y-up, 2=Z-up.
+        overrides: Shader parameter overrides applied on top of live renderer
+            state. Keys absent here fall back to the renderer's own values,
+            so a style only needs to declare what it changes.
+    """
+
+    name: str
+    shader_class: type[ShaderShape]
+    draw_sky: bool
+    sun_directions: dict
+    overrides: dict = field(default_factory=dict)
+
+
+#: Global registry mapping style name -> config.
+#: Register new styles here; no other code needs to change.
+STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
+    "classic": ShadingStyleConfig(
+        name="classic",
+        shader_class=ShaderShape,
+        draw_sky=True,
+        sun_directions={
+            0: np.array((0.8, 0.2, -0.3), dtype=np.float32),  # X-up
+            1: np.array((0.2, 0.8, -0.3), dtype=np.float32),  # Y-up
+            2: np.array((0.2, -0.3, 0.8), dtype=np.float32),  # Z-up
+        },
+        # No overrides — classic defers entirely to live renderer state.
+    ),
+    "studio": ShadingStyleConfig(
+        name="studio",
+        shader_class=ShaderShapeStudio,
+        draw_sky=False,
+        # ~45° elevation so the floor gets moderate (not maximum) direct light.
+        sun_directions={
+            0: np.array([1.0, 0.6, 0.8], dtype=np.float32),  # X-up
+            1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
+            2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
+        },
+        overrides={
+            "fog_color": (0.93, 0.93, 0.95),
+            "sky_color": (0.72, 0.82, 0.98),
+            "ground_color": (0.50, 0.45, 0.38),
+            "light_color": (0.92, 0.90, 0.86),
+            "env_texture": None,
+            "env_intensity": 0.0,
+            "spotlight_enabled": False,
+        },
+    ),
+}
+
+
+def _normalized_sun(sun_dirs: dict, up_axis: int) -> np.ndarray:
+    d = sun_dirs.get(up_axis, sun_dirs[2])
+    return d / np.linalg.norm(d)
+
 
 ENABLE_CUDA_INTEROP = False
 ENABLE_GL_CHECKS = False
@@ -229,7 +313,7 @@ class MeshGL:
         # albedo
         gl.glVertexAttrib3f(7, 0.7, 0.5, 0.3)
         # material = (roughness, metallic, checker, texture_enable)
-        gl.glVertexAttrib4f(8, 0.5, 0.0, 0.0, 0.0)
+        gl.glVertexAttrib4f(8, 0.85, 0.0, 0.0, 0.0)
 
         gl.glBindVertexArray(0)
 
@@ -837,7 +921,7 @@ class MeshInstancerGL:
         self._update_vbo(self.world_xforms, colors, materials)
 
     # helper to update instance transforms from points
-    def update_from_points(self, points, widths, colors):
+    def update_from_points(self, points, widths, colors, materials=None):
         if points is None:
             active = 0
         else:
@@ -863,7 +947,7 @@ class MeshInstancerGL:
                 record_tape=False,
             )
 
-        self._update_vbo(self.world_xforms, colors, None)
+        self._update_vbo(self.world_xforms, colors, materials)
 
     # upload to vbo
     def _update_vbo(self, xforms, colors, materials):
@@ -966,7 +1050,19 @@ class RendererGL:
             cls._fallback_texture = tex
         return cls._fallback_texture
 
-    def __init__(self, title="Newton", screen_width=1920, screen_height=1080, vsync=True, headless=None, device=None):
+    def __init__(
+        self,
+        title="Newton",
+        screen_width=1920,
+        screen_height=1080,
+        vsync=True,
+        headless=None,
+        device=None,
+        shading_style: str = "classic",
+    ):
+        if shading_style not in STYLE_REGISTRY:
+            raise ValueError(f"Unknown shading_style {shading_style!r}. Available: {list(STYLE_REGISTRY)}")
+        self._active_style: ShadingStyleConfig = STYLE_REGISTRY[shading_style]
         self.draw_sky = True
         self.draw_fps = True
         self.draw_shadows = True
@@ -974,6 +1070,8 @@ class RendererGL:
         self.wireframe_line_width = 1.5  # pixels
         self.line_width = 1.5  # pixels, for all log_lines batches
         self.arrow_scale = 1.0  # uniform scale for arrow line width and head size
+        self.draw_edges = False
+        self._edge_color = (0.05, 0.05, 0.05, 1.0)  # RGBA dark near-black
 
         self.background_color = (68.0 / 255.0, 161.0 / 255.0, 255.0 / 255.0)
 
@@ -987,13 +1085,6 @@ class RendererGL:
         self.spotlight_enabled = True
         self._shadow_extents = 10.0
         self._exposure = 1.6
-
-        # Hemispherical ambient light colors, interpolated by dot(N, up).
-        # Decoupled from the sky background so the visible sky can be a
-        # saturated blue while the ambient fill stays neutral — a stand-in
-        # for a proper irradiance map that we don't precompute yet.
-        self.ambient_sky = (0.8, 0.8, 0.85)
-        self.ambient_ground = (0.3, 0.3, 0.35)
 
         # On Wayland, PyOpenGL defaults to EGL which cannot see the GLX context
         # that pyglet creates via XWayland. Force GLX so both libraries agree.
@@ -1103,6 +1194,7 @@ class RendererGL:
         self._shadow_shader = None
         self._shadow_width = 4096
         self._shadow_height = 4096
+        self._light_space_matrix = np.eye(4, dtype=np.float32)
 
         self._frame_texture = None
         self._frame_depth_texture = None
@@ -1137,7 +1229,10 @@ class RendererGL:
         self._setup_frame_mesh()
 
         self._shadow_shader = ShadowShader(gl)
-        self._shape_shader = ShaderShape(gl)
+        self._style_shaders: dict[str, ShaderShape] = {
+            name: cfg.shader_class(gl) for name, cfg in STYLE_REGISTRY.items()
+        }
+        self._edge_shader = ShaderEdge(gl)
         self._frame_shader = FrameShader(gl)
         self._sky_shader = ShaderSky(gl)
         self._wireframe_shader = ShaderLine(gl)
@@ -1186,6 +1281,16 @@ class RendererGL:
     def exposure(self, value: float):
         self._exposure = max(float(value), 0.0)
 
+    @property
+    def shading_style(self) -> str:
+        return self._active_style.name
+
+    @shading_style.setter
+    def shading_style(self, value: str):
+        if value not in STYLE_REGISTRY:
+            raise ValueError(f"Unknown shading_style {value!r}. Available: {list(STYLE_REGISTRY)}")
+        self._active_style = STYLE_REGISTRY[value]
+
     def update(self):
         self._make_current()
 
@@ -1207,22 +1312,17 @@ class RendererGL:
         gl = RendererGL.gl
         self._make_current()
 
-        gl.glClearColor(*self.sky_upper, 1)
+        style = self._active_style
+        bg = style.overrides.get("fog_color", self.sky_upper)
+        gl.glClearColor(*bg, 1)
         gl.glEnable(gl.GL_DEPTH_TEST)
         gl.glDepthMask(True)
         gl.glDepthRange(0.0, 1.0)
 
         self.camera = camera
 
-        # Lazy-init sun direction based on camera up axis
-        if self._sun_direction is None:
-            _sun_dirs = {
-                0: np.array((0.8, 0.2, -0.3)),  # X-up
-                1: np.array((0.2, 0.8, -0.3)),  # Y-up
-                2: np.array((0.2, -0.3, 0.8)),  # Z-up
-            }
-            d = _sun_dirs.get(camera.up_axis, _sun_dirs[2])
-            self._sun_direction = d / np.linalg.norm(d)
+        # Set sun direction for this frame from the active style's key-light table.
+        self._sun_direction = _normalized_sun(style.sun_directions, camera.up_axis)
 
         # Store matrices for other methods
         self._view_matrix = self.camera.get_view_matrix()
@@ -1257,7 +1357,7 @@ class RendererGL:
         gl.glBindFramebuffer(gl.GL_DRAW_FRAMEBUFFER, target_fbo)
         gl.glDrawBuffer(gl.GL_COLOR_ATTACHMENT0)
 
-        gl.glClearColor(*self.sky_upper, 1)
+        gl.glClearColor(*bg, 1)
         gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
         gl.glBindVertexArray(0)
 
@@ -1803,42 +1903,73 @@ class RendererGL:
 
         check_gl_error()
 
+    def _build_shader_kwargs(self) -> dict:
+        """Merge active style overrides onto live renderer defaults for shader.update().
+
+        Renderer defaults are built first; style overrides are applied on top via
+        dict.update(), so a style only needs to declare the keys it changes.
+        dict.update() is safe for all values including black (0,0,0) and 0.0.
+        """
+        kwargs = {
+            "view_matrix": self._view_matrix,
+            "projection_matrix": self._projection_matrix,
+            "view_pos": self.camera.pos,
+            "up_axis": self.camera.up_axis,
+            "sun_direction": tuple(self._sun_direction),
+            "fog_color": self.sky_lower,
+            "sky_color": self.sky_upper,
+            "ground_color": self.sky_lower,
+            "light_color": self._light_color,
+            "enable_shadows": self.draw_shadows,
+            "shadow_texture": self._shadow_texture,
+            "light_space_matrix": self._light_space_matrix,
+            "env_texture": self._env_texture,
+            "env_intensity": self._env_intensity,
+            "shadow_radius": self.shadow_radius,
+            "shadow_extents": self.shadow_extents,
+            "diffuse_scale": self.diffuse_scale,
+            "specular_scale": self.specular_scale,
+            "spotlight_enabled": self.spotlight_enabled,
+        }
+        kwargs.update(self._active_style.overrides)
+        return kwargs
+
     def _render_scene(self, objects):
         gl = RendererGL.gl
-
-        if self.draw_sky:
-            self._draw_sky()
+        style = self._active_style
 
         if self.draw_wireframe:
             gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
 
-        self._shape_shader.update(
-            view_matrix=self._view_matrix,
-            projection_matrix=self._projection_matrix,
-            view_pos=self.camera.pos,
-            fog_color=self.sky_lower,
-            up_axis=self.camera.up_axis,
-            sun_direction=self._sun_direction,
-            enable_shadows=self.draw_shadows,
-            shadow_texture=self._shadow_texture,
-            light_space_matrix=self._light_space_matrix,
-            light_color=self._light_color,
-            sky_color=self.ambient_sky,
-            ground_color=self.ambient_ground,
-            env_texture=self._env_texture,
-            env_intensity=self._env_intensity,
-            shadow_radius=self.shadow_radius,
-            diffuse_scale=self.diffuse_scale,
-            specular_scale=self.specular_scale,
-            spotlight_enabled=self.spotlight_enabled,
-            shadow_extents=self.shadow_extents,
-            exposure=self.exposure,
-        )
+        if style.draw_sky:
+            self._draw_sky()
 
-        with self._shape_shader:
+        shader = self._style_shaders[style.name]
+        shader.update(**self._build_shader_kwargs())
+        with shader:
             self._draw_objects(objects)
 
         gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_FILL)
+
+        # Edge overlay pass — draw the same geometry a second time as lines.
+        # GL_LEQUAL lets edges pass the depth test against their own solid surface
+        # (same geometry → same interpolated depths) while correctly hiding edges of
+        # objects that are occluded (their depth > buffer value from the solid pass).
+        # No polygon offset is needed or wanted: factor-based offsets shift depths on
+        # steep surfaces enough to let occluded edges bleed through other objects.
+        if self.draw_edges:
+            self._edge_shader.update(
+                view_matrix=self._view_matrix,
+                projection_matrix=self._projection_matrix,
+                edge_color=self._edge_color,
+                light_space_matrix=self._light_space_matrix,
+            )
+            gl.glDepthFunc(gl.GL_LEQUAL)
+            gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
+            with self._edge_shader:
+                self._draw_objects(objects)
+            gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_FILL)
+            gl.glDepthFunc(gl.GL_LESS)
 
         check_gl_error()
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -41,6 +41,10 @@ class ShadingStyleConfig:
         draw_sky: Whether to render the sky sphere background.
         sun_directions: Per-up-axis key-light direction (un-normalized).
             Keys: 0=X-up, 1=Y-up, 2=Z-up.
+        sky_upper: Override for the sky dome upper (zenith) color, or ``None``
+            to use the renderer's ``sky_upper`` attribute (default).
+        sky_lower: Override for the sky dome lower (horizon) color.
+        draw_sun: Whether the sky dome renders a sun flare (default ``True``).
         gradient_top: Top color for a screen-space gradient background, or
             ``None`` to skip the gradient pass (default).
         gradient_bottom: Bottom color for the gradient background.
@@ -53,6 +57,9 @@ class ShadingStyleConfig:
     shader_class: type[ShaderShape]
     draw_sky: bool
     sun_directions: dict
+    sky_upper: tuple[float, float, float] | None = None
+    sky_lower: tuple[float, float, float] | None = None
+    draw_sun: bool = True
     gradient_top: tuple[float, float, float] | None = None
     gradient_bottom: tuple[float, float, float] | None = None
     overrides: dict = field(default_factory=dict)
@@ -82,6 +89,9 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
+        sky_upper=(0.96, 0.96, 0.97),
+        sky_lower=(0.85, 0.85, 0.87),
+        draw_sun=False,
         overrides={
             "fog_color": (0.93, 0.93, 0.95),
             "sky_color": (0.72, 0.82, 0.98),
@@ -90,10 +100,6 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             "env_texture": None,
             "env_intensity": 0.0,
             "spotlight_enabled": False,
-            # Sky dome overrides — subtle near-white gradient, no sun flare.
-            "sky_upper": (0.96, 0.96, 0.97),
-            "sky_lower": (0.85, 0.85, 0.87),
-            "sky_sun_direction": (0.0, 0.0, 0.0),
         },
     ),
 }
@@ -2109,15 +2115,16 @@ class RendererGL:
 
         self._make_current()
 
-        overrides = self._active_style.overrides
+        style = self._active_style
+        sun_dir = self._sun_direction if style.draw_sun else (0.0, 0.0, 0.0)
         self._sky_shader.update(
             view_matrix=self._view_matrix,
             projection_matrix=self._projection_matrix,
             camera_pos=self.camera.pos,
             camera_far=self.camera.far,
-            sky_upper=overrides.get("sky_upper", self.sky_upper),
-            sky_lower=overrides.get("sky_lower", self.sky_lower),
-            sun_direction=overrides.get("sky_sun_direction", self._sun_direction),
+            sky_upper=style.sky_upper or self.sky_upper,
+            sky_lower=style.sky_lower or self.sky_lower,
+            sun_direction=sun_dir,
             up_axis=self.camera.up_axis,
         )
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1066,6 +1066,11 @@ class RendererGL:
         self.sky_upper = self.background_color
         self.sky_lower = (40.0 / 255.0, 44.0 / 255.0, 55.0 / 255.0)
 
+        # Hemisphere ambient colors — decoupled from the visible sky so the
+        # sky dome can be a saturated blue while the ambient fill stays neutral.
+        self.ambient_sky = (0.8, 0.8, 0.85)
+        self.ambient_ground = (0.3, 0.3, 0.35)
+
         # Lighting settings
         self._shadow_radius = 3.0
         self._diffuse_scale = 1.0
@@ -1905,8 +1910,8 @@ class RendererGL:
             "up_axis": self.camera.up_axis,
             "sun_direction": tuple(self._sun_direction),
             "fog_color": self.sky_lower,
-            "sky_color": self.sky_upper,
-            "ground_color": self.sky_lower,
+            "sky_color": self.ambient_sky,
+            "ground_color": self.ambient_ground,
             "light_color": self._light_color,
             "enable_shadows": self.draw_shadows,
             "shadow_texture": self._shadow_texture,

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -89,8 +89,8 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
-        sky_upper=(0.96, 0.96, 0.97),
-        sky_lower=(0.85, 0.85, 0.87),
+        sky_upper=(0.96, 0.96, 0.98),
+        sky_lower=(0.62, 0.62, 0.66),
         draw_sun=False,
         overrides={
             "fog_color": (0.93, 0.93, 0.95),

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -18,6 +18,7 @@ from .shaders import (
     FrameShader,
     ShaderArrow,
     ShaderEdge,
+    ShaderGradientBg,
     ShaderLine,
     ShaderShape,
     ShaderShapeStudio,
@@ -40,6 +41,9 @@ class ShadingStyleConfig:
         draw_sky: Whether to render the sky sphere background.
         sun_directions: Per-up-axis key-light direction (un-normalized).
             Keys: 0=X-up, 1=Y-up, 2=Z-up.
+        gradient_top: Top color for a screen-space gradient background, or
+            ``None`` to skip the gradient pass (default).
+        gradient_bottom: Bottom color for the gradient background.
         overrides: Shader parameter overrides applied on top of live renderer
             state. Keys absent here fall back to the renderer's own values,
             so a style only needs to declare what it changes.
@@ -49,6 +53,8 @@ class ShadingStyleConfig:
     shader_class: type[ShaderShape]
     draw_sky: bool
     sun_directions: dict
+    gradient_top: tuple[float, float, float] | None = None
+    gradient_bottom: tuple[float, float, float] | None = None
     overrides: dict = field(default_factory=dict)
 
 
@@ -76,6 +82,8 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
             1: np.array([0.6, 1.0, 0.8], dtype=np.float32),  # Y-up
             2: np.array([0.8, 0.6, 1.0], dtype=np.float32),  # Z-up
         },
+        gradient_top=(0.96, 0.96, 0.97),
+        gradient_bottom=(0.85, 0.85, 0.87),
         overrides={
             "fog_color": (0.93, 0.93, 0.95),
             "sky_color": (0.72, 0.82, 0.98),
@@ -1220,6 +1228,7 @@ class RendererGL:
         self._setup_frame_buffer()
         self._setup_sky_mesh()
         self._setup_frame_mesh()
+        self._setup_gradient_bg_mesh()
 
         self._shadow_shader = ShadowShader(gl)
         self._style_shaders: dict[str, ShaderShape] = {
@@ -1228,6 +1237,7 @@ class RendererGL:
         self._edge_shader = ShaderEdge(gl)
         self._frame_shader = FrameShader(gl)
         self._sky_shader = ShaderSky(gl)
+        self._gradient_bg_shader = ShaderGradientBg(gl)
         self._wireframe_shader = ShaderLine(gl)
         self._arrow_shader = ShaderArrow(gl)
 
@@ -1830,6 +1840,39 @@ class RendererGL:
 
         check_gl_error()
 
+    def _setup_gradient_bg_mesh(self):
+        gl = RendererGL.gl
+
+        # fmt: off
+        verts = np.array([
+            -1.0, -1.0,
+             1.0, -1.0,
+             1.0,  1.0,
+            -1.0,  1.0,
+        ], dtype=np.float32)
+        # fmt: on
+        indices = np.array([0, 1, 2, 2, 3, 0], dtype=np.uint32)
+
+        self._grad_bg_vao = gl.GLuint()
+        gl.glGenVertexArrays(1, self._grad_bg_vao)
+        gl.glBindVertexArray(self._grad_bg_vao)
+
+        vbo = gl.GLuint()
+        gl.glGenBuffers(1, vbo)
+        gl.glBindBuffer(gl.GL_ARRAY_BUFFER, vbo)
+        gl.glBufferData(gl.GL_ARRAY_BUFFER, verts.nbytes, verts.ctypes.data, gl.GL_STATIC_DRAW)
+
+        ebo = gl.GLuint()
+        gl.glGenBuffers(1, ebo)
+        gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, ebo)
+        gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, indices.nbytes, indices.ctypes.data, gl.GL_STATIC_DRAW)
+
+        gl.glVertexAttribPointer(0, 2, gl.GL_FLOAT, gl.GL_FALSE, 2 * verts.itemsize, ctypes.c_void_p(0))
+        gl.glEnableVertexAttribArray(0)
+
+        gl.glBindVertexArray(0)
+        check_gl_error()
+
     def _setup_shadow_buffer(self):
         gl = RendererGL.gl
 
@@ -1931,6 +1974,9 @@ class RendererGL:
     def _render_scene(self, objects):
         gl = RendererGL.gl
         style = self._active_style
+
+        if style.gradient_top is not None:
+            self._draw_gradient_bg(style.gradient_top, style.gradient_bottom)
 
         if self.draw_sky and style.draw_sky:
             self._draw_sky()
@@ -2075,6 +2121,24 @@ class RendererGL:
         gl.glBindVertexArray(self._sky_vao)
         gl.glDrawElements(gl.GL_TRIANGLES, self._sky_tri_count, gl.GL_UNSIGNED_INT, None)
         gl.glBindVertexArray(0)
+
+        check_gl_error()
+
+    def _draw_gradient_bg(
+        self,
+        top_color: tuple[float, float, float],
+        bottom_color: tuple[float, float, float],
+    ):
+        gl = RendererGL.gl
+        self._make_current()
+
+        gl.glDepthMask(gl.GL_FALSE)
+        self._gradient_bg_shader.update(top_color=top_color, bottom_color=bottom_color)
+        with self._gradient_bg_shader:
+            gl.glBindVertexArray(self._grad_bg_vao)
+            gl.glDrawElements(gl.GL_TRIANGLES, 6, gl.GL_UNSIGNED_INT, None)
+            gl.glBindVertexArray(0)
+        gl.glDepthMask(gl.GL_TRUE)
 
         check_gl_error()
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import ctypes
 import io
@@ -1930,6 +1918,7 @@ class RendererGL:
             "diffuse_scale": self.diffuse_scale,
             "specular_scale": self.specular_scale,
             "spotlight_enabled": self.spotlight_enabled,
+            "exposure": self.exposure,
         }
         kwargs.update(self._active_style.overrides)
         return kwargs
@@ -1941,7 +1930,7 @@ class RendererGL:
         if self.draw_wireframe:
             gl.glPolygonMode(gl.GL_FRONT_AND_BACK, gl.GL_LINE)
 
-        if style.draw_sky:
+        if self.draw_sky and style.draw_sky:
             self._draw_sky()
 
         shader = self._style_shaders[style.name]

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -95,7 +95,7 @@ STYLE_REGISTRY: dict[str, ShadingStyleConfig] = {
         overrides={
             "fog_color": (0.55, 0.55, 0.58),
             "sky_color": (0.72, 0.82, 0.98),
-            "ground_color": (0.50, 0.45, 0.38),
+            "ground_color": (0.30, 0.28, 0.25),
             "light_color": (0.92, 0.90, 0.86),
             "env_texture": None,
             "env_intensity": 0.0,

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import ctypes
 

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -884,6 +884,13 @@ void main()
         albedo = mix(albedo, albedo2, cb);
     }
 
+    // Specular color: dielectrics ~0.04, metals use albedo.
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+
+    // Metals: lift albedo toward brighter, less saturated version (no full IBL).
+    float luma = dot(albedo, vec3(0.2126, 0.7152, 0.0722));
+    albedo = mix(albedo, vec3(luma * 1.4), metallic * 0.45);
+
     vec3 N = normalize(Normal);
     if (!gl_FrontFacing)
         N = -N;
@@ -896,53 +903,70 @@ void main()
     if (up_axis == 0) up = vec3(1.0, 0.0, 0.0);
     if (up_axis == 2) up = vec3(0.0, 0.0, 1.0);
 
-    // Soft hemisphere ambient — reduced so the directional key light has contrast.
-    // A fully-bright hemisphere washes out all directional shading.
+    // Cook-Torrance PBR
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotV = max(dot(N, V), 0.001);
+    float HdotV = max(dot(H, V), 0.0);
+
+    // GGX/Trowbridge-Reitz normal distribution
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float denom = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    float D = a2 / (PI * denom * denom);
+
+    // Schlick-GGX geometry (Smith method)
+    float k = (roughness + 1.0) * (roughness + 1.0) / 8.0;
+    float G1_V = NdotV / (NdotV * (1.0 - k) + k);
+    float G1_L = NdotL / (NdotL * (1.0 - k) + k);
+    float G = G1_V * G1_L;
+
+    // Schlick Fresnel, dampened by roughness
+    vec3 F_max = mix(F0, vec3(1.0), 1.0 - roughness);
+    vec3 F = F0 + (F_max - F0) * pow(1.0 - HdotV, 5.0);
+
+    // Cook-Torrance specular BRDF
+    vec3 spec = (D * G * F) / (4.0 * NdotV * NdotL + 0.0001);
+
+    // Diffuse uses remaining energy not reflected
+    vec3 kD = (1.0 - F) * (1.0 - metallic);
+
+    // Soft hemisphere ambient
     float sky_fac = dot(N, up) * 0.5 + 0.5;
     vec3 ambient = mix(ground_color, sky_color, sky_fac) * albedo * 0.35;
 
-    // Key directional light (primary source of contrast / shape definition)
-    float NdotL = max(dot(N, L), 0.0);
-    vec3 diffuse = albedo * light_color * NdotL * 1.10 * diffuse_scale;
+    // Key directional light (higher multiplier compensates for PI-normalised BRDF)
+    vec3 diffuse = kD * albedo / PI * light_color * NdotL * 4.0 * diffuse_scale;
 
-    // Fill light: perpendicular to key in the horizontal plane, slightly elevated.
-    // This softly illuminates faces that are in shadow of the key without
-    // collapsing them to pure black, while still preserving contrast.
+    // Fill light: perpendicular to key, slightly elevated
     vec3 fill_dir = normalize(cross(up, L) + up * 0.20);
-    float NdotFill = max(dot(N, fill_dir), 0.0) * 0.28;
-    diffuse += albedo * light_color * NdotFill;
+    float NdotFill = max(dot(N, fill_dir), 0.0);
+    vec3 H_fill = normalize(V + fill_dir);
+    float NdotH_fill = max(dot(N, H_fill), 0.0);
+    float denom_fill = NdotH_fill * NdotH_fill * (a2 - 1.0) + 1.0;
+    float D_fill = a2 / (PI * denom_fill * denom_fill);
+    float G1_fill = NdotFill / (NdotFill * (1.0 - k) + k);
+    float G_fill = G1_V * G1_fill;
+    float HdotV_fill = max(dot(H_fill, V), 0.0);
+    vec3 F_fill = F0 + (F_max - F0) * pow(1.0 - HdotV_fill, 5.0);
+    vec3 spec_fill = (D_fill * G_fill * F_fill) / (4.0 * NdotV * NdotFill + 0.0001);
+    vec3 kD_fill = (1.0 - F_fill) * (1.0 - metallic);
+    diffuse += kD_fill * albedo / PI * light_color * NdotFill * 1.2;
 
-    // Soft back fill (opposite key) to prevent pitch-black rear faces
+    // Soft back fill (opposite key)
     float NdotBack = max(dot(N, -L), 0.0) * 0.10;
-    diffuse += albedo * light_color * NdotBack;
-
-    diffuse *= (1.0 - metallic);
-
-    // Specular — studio style.
-    // Physical dielectric reflectance F0=0.04 combined with energy-conserving
-    // normFactor produces ~1% brightness at typical angles, which is invisible.
-    // Instead use a boosted reflectance (0.30 for dielectrics, albedo for metals)
-    // without normFactor so the highlight is clearly visible at moderate roughness.
-    float gloss     = clamp(1.0 - roughness, 0.0, 1.0);
-    float shininess = 4.0 + pow(gloss, 2.0) * 60.0;  // range [4, 64]: soft but defined
-    float NdotH = max(dot(N, H), 0.0);
-    float spec_reflectance = mix(0.30, 1.0, metallic);
-    vec3  spec_color = mix(vec3(spec_reflectance), albedo, metallic);
-    vec3  spec = spec_color * light_color * pow(NdotH, shininess) * NdotL * specular_scale;
+    diffuse += kD * albedo / PI * light_color * NdotBack;
 
     // Studio-style rim highlight
     float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.07;
     vec3 rim_color = sky_color * rim;
 
-    // Camera-space catch light — places a soft highlight on surfaces facing the viewer.
-    // This is the characteristic studio catch-light "sphere pop": regardless of world-space light
-    // direction, spheres and curved surfaces always show a visible bright region near their
-    // silhouette-facing centre, giving them instant 3D depth.
+    // Camera-space catch light for 3D depth
     float NdotV_clamp = max(dot(N, V), 0.0);
     vec3 catch_light = albedo * light_color * 0.18 * pow(NdotV_clamp, 3.0);
 
     float shadow = (enable_shadows != 0) ? ShadowCalculation() : 0.0;
-    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec) + rim_color + catch_light;
+    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec * specular_scale + spec_fill * 0.28 * specular_scale) + rim_color + catch_light;
 
     // Apply exposure for brightness control (no ACES — studio uses lower
     // light multipliers that stay in a moderate range where filmic rolloff

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -282,37 +282,57 @@ void main()
         albedo = mix(albedo, albedo2, cb);
     }
 
+    // Specular color: dielectrics ~0.04, metals use albedo.
+    // Computed before desaturation so F0 reflects true material reflectance.
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+
+    // Metals appear paler/desaturated because their look is dominated by
+    // bright specular reflections.  Without full IBL we approximate this by
+    // lifting the albedo toward a brighter, less saturated version.
+    float luma = dot(albedo, vec3(0.2126, 0.7152, 0.0722));
+    albedo = mix(albedo, vec3(luma * 1.4), metallic * 0.45);
+
     // surface vectors
     vec3 N = normalize(Normal);
-    // Flip normal for backfacing triangles
-    if (!gl_FrontFacing) {
-        N = -N;
-    }
     vec3 V = normalize(view_pos - FragPos);
+    // Flip normal for backfacing triangles
+    if (!gl_FrontFacing) N = -N;
     vec3 L = normalize(sun_direction);
     vec3 H = normalize(V + L);
 
-    // Blinn-Phong terms
+    // Cook-Torrance PBR
     float NdotL = max(dot(N, L), 0.0);
     float NdotH = max(dot(N, H), 0.0);
-    float NdotV = max(dot(N, V), 0.0);
+    float NdotV = max(dot(N, V), 0.001);
+    float HdotV = max(dot(H, V), 0.0);
 
-    // Derive Blinn-Phong exponent from perceptual roughness.
-    // roughness 0 → perfectly smooth, 1 → very rough
-    float gloss = clamp(1.0 - roughness, 0.0, 1.0);
-    // Map gloss to exponent range ~[2, 1024]
-    float shininess = 1.0 + pow(gloss, 4.0) * 1023.0;
+    // GGX/Trowbridge-Reitz normal distribution
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float denom = NdotH * NdotH * (a2 - 1.0) + 1.0;
+    float D = a2 / (PI * denom * denom);
 
-    // energy-preserving normalization for Blinn-Phong
-    float normFactor = (shininess + 2.0) / (8.0 * PI);
+    // Schlick-GGX geometry function (Smith method for both view and light)
+    float k = (roughness + 1.0) * (roughness + 1.0) / 8.0;
+    float G1_V = NdotV / (NdotV * (1.0 - k) + k);
+    float G1_L = NdotL / (NdotL * (1.0 - k) + k);
+    float G = G1_V * G1_L;
 
-    vec3 diffuse  = albedo * light_color * NdotL * 3.0 * diffuse_scale;
+    // Schlick Fresnel, dampened by roughness to reduce edge aliasing
+    vec3 F_max = mix(F0, vec3(1.0), 1.0 - roughness);
+    vec3 F = F0 + (F_max - F0) * pow(1.0 - HdotV, 5.0);
 
-    // Specular color: dielectrics ~0.04, metals use albedo
-    vec3 F0 = mix(vec3(0.04), albedo, metallic);
-    vec3 spec = F0 * light_color * normFactor * pow(NdotH, shininess) * NdotL * specular_scale;
+    // Cook-Torrance specular BRDF
+    vec3 spec = (D * G * F) / (4.0 * NdotV * NdotL + 0.0001);
 
-    // simple hemispherical ambient term
+    // Diffuse uses remaining energy not reflected
+    vec3 kD = (1.0 - F) * (1.0 - metallic);
+    vec3 diffuse = kD * albedo / PI;
+
+    // Direct lighting
+    vec3 Lo = (diffuse * diffuse_scale + spec * specular_scale) * light_color * NdotL * 3.0;
+
+    // Hemispherical ambient (kept subtle for depth)
     vec3 up = vec3(0.0, 1.0, 0.0);
     if (up_axis == 0) up = vec3(1.0, 0.0, 0.0);
     if (up_axis == 2) up = vec3(0.0, 0.0, 1.0);
@@ -328,25 +348,16 @@ void main()
     // shadows
     float shadow = ShadowCalculation();
 
-    // spotlight attenuation
-    float spotlightAttenuation = SpotlightAttenuation();
+    float spotAttenuation = SpotlightAttenuation();
+    vec3 color = ambient + (1.0 - shadow) * spotAttenuation * Lo;
 
-    // Metals should contribute little diffuse light.
-    diffuse *= 1.0 - metallic;
-    vec3 color = ambient + (1.0 - shadow) * spotlightAttenuation * (diffuse + spec);
-
-    // Fresnel darkening: reduce brightness at glancing angles for metals
-    color *= mix(1.0, pow(NdotV, 2.0), metallic);
-
-    // environment reflection for metallic look (fade with roughness)
-    float env_lod = clamp(pow(roughness, 1.0/4.0), 0.0, 1.0) * 8.0;
+    // Environment / image-based lighting for metals
     vec3 R = reflect(-V, N);
-    vec3 env_color = sample_env_map(R, env_lod);
-    env_color = pow(env_color, vec3(2.2)); // to linear
-    float reflection_strength = clamp(metallic * pow(1.0 - roughness, 2.0), 0.0, 1.0);
-    vec3 env_tint = mix(vec3(1.0), albedo, metallic);
-    vec3 env_reflection = env_color * env_tint * env_intensity;
-    color = mix(color, env_reflection, reflection_strength);
+    float env_lod = roughness * 8.0;
+    vec3 env_color = pow(sample_env_map(R, env_lod), vec3(2.2));
+    vec3 env_F = F0 + (F_max - F0) * pow(1.0 - NdotV, 5.0);
+    vec3 env_spec = env_color * env_F * env_intensity;
+    color += env_spec * metallic;
 
     // fog
     float dist = length(FragPos - view_pos);
@@ -532,8 +543,8 @@ class ShaderShape(ShaderGL):
         up_axis: int,
         sun_direction: tuple[float, float, float],
         light_color: tuple[float, float, float] = (2.0, 2.0, 2.0),
-        ground_color: tuple[float, float, float] = (0.294, 0.333, 0.592),
-        sky_color: tuple[float, float, float] = (0.745, 0.863, 0.941),
+        ground_color: tuple[float, float, float] = (0.3, 0.3, 0.35),
+        sky_color: tuple[float, float, float] = (0.8, 0.8, 0.85),
         enable_shadows: bool = False,
         shadow_texture: int | None = None,
         light_space_matrix: np.ndarray | None = None,
@@ -706,6 +717,7 @@ uniform sampler2D shadow_map;
 uniform mat4 light_space_matrix;
 uniform float shadow_radius;
 uniform float shadow_extents;
+uniform float exposure;
 uniform int up_axis;
 
 const float PI = 3.14159265359;
@@ -873,6 +885,12 @@ void main()
 
     float shadow = ShadowCalculation();
     vec3 color = ambient + (1.0 - shadow) * (diffuse + spec) + rim_color + catch_light;
+
+    // Apply exposure for brightness control (no ACES — studio uses lower
+    // light multipliers that stay in a moderate range where filmic rolloff
+    // would just darken the image and shift hues).
+    color *= exposure;
+    color = clamp(color, 0.0, 1.0);
 
     // gamma correction (sRGB)
     color = pow(color, vec3(1.0 / 2.2));

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -868,6 +868,10 @@ void main()
     float texture_enable = Material.w;
     float checker_scale = 1.0;
 
+    // Ground plane (checker) should look matte in studio lighting
+    if (checker_enable > 0.0)
+        roughness = max(roughness, 0.85);
+
     // convert to linear space
     vec3 albedo = pow(ObjectColor, vec3(2.2));
     if (texture_enable > 0.5)

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -434,6 +434,32 @@ void main()
 }
 """
 
+gradient_bg_vertex_shader = """
+#version 330 core
+layout (location = 0) in vec2 aPos;
+
+out float vT;
+
+void main() {
+    gl_Position = vec4(aPos, 0.0, 1.0);
+    vT = aPos.y * 0.5 + 0.5;  // [-1,1] -> [0,1]
+}
+"""
+
+gradient_bg_fragment_shader = """
+#version 330 core
+out vec4 FragColor;
+
+in float vT;
+
+uniform vec3 top_color;
+uniform vec3 bottom_color;
+
+void main() {
+    FragColor = vec4(mix(bottom_color, top_color, vT), 1.0);
+}
+"""
+
 frame_vertex_shader = """
 #version 330 core
 layout (location = 0) in vec3 aPos;
@@ -649,6 +675,33 @@ class ShaderSky(ShaderGL):
             self._gl.glUniform3f(self.loc_sky_lower, *sky_lower)
             self._gl.glUniform3f(self.loc_sun_direction, *sun_direction)
             self._gl.glUniform1i(self.loc_up_axis, up_axis)
+
+
+class ShaderGradientBg(ShaderGL):
+    """Full-screen gradient background (two-color vertical blend)."""
+
+    def __init__(self, gl):
+        super().__init__()
+        from pyglet.graphics.shader import Shader, ShaderProgram
+
+        self._gl = gl
+        self.shader_program = ShaderProgram(
+            Shader(gradient_bg_vertex_shader, "vertex"),
+            Shader(gradient_bg_fragment_shader, "fragment"),
+        )
+
+        with self:
+            self.loc_top_color = self._get_uniform_location("top_color")
+            self.loc_bottom_color = self._get_uniform_location("bottom_color")
+
+    def update(
+        self,
+        top_color: tuple[float, float, float],
+        bottom_color: tuple[float, float, float],
+    ):
+        with self:
+            self._gl.glUniform3f(self.loc_top_color, *top_color)
+            self._gl.glUniform3f(self.loc_bottom_color, *bottom_color)
 
 
 class ShadowShader(ShaderGL):

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -533,6 +533,7 @@ class ShaderShape(ShaderGL):
             self.loc_spotlight_enabled = self._get_uniform_location("spotlight_enabled")
             self.loc_shadow_extents = self._get_uniform_location("shadow_extents")
             self.loc_exposure = self._get_uniform_location("exposure")
+            self.loc_enable_shadows = self._get_uniform_location("enable_shadows")
 
     def update(
         self,
@@ -575,6 +576,7 @@ class ShaderShape(ShaderGL):
             self._gl.glUniform1i(self.loc_spotlight_enabled, int(spotlight_enabled))
             self._gl.glUniform1f(self.loc_shadow_extents, shadow_extents)
             self._gl.glUniform1f(self.loc_exposure, exposure)
+            self._gl.glUniform1i(self.loc_enable_shadows, int(enable_shadows))
 
             # Fog and rendering options
             self._gl.glUniform3f(self.loc_fog_color, *fog_color)
@@ -718,6 +720,9 @@ uniform mat4 light_space_matrix;
 uniform float shadow_radius;
 uniform float shadow_extents;
 uniform float exposure;
+uniform float diffuse_scale;
+uniform float specular_scale;
+uniform int enable_shadows;
 uniform int up_axis;
 
 const float PI = 3.14159265359;
@@ -845,7 +850,7 @@ void main()
 
     // Key directional light (primary source of contrast / shape definition)
     float NdotL = max(dot(N, L), 0.0);
-    vec3 diffuse = albedo * light_color * NdotL * 1.10;
+    vec3 diffuse = albedo * light_color * NdotL * 1.10 * diffuse_scale;
 
     // Fill light: perpendicular to key in the horizontal plane, slightly elevated.
     // This softly illuminates faces that are in shadow of the key without
@@ -870,7 +875,7 @@ void main()
     float NdotH = max(dot(N, H), 0.0);
     float spec_reflectance = mix(0.30, 1.0, metallic);
     vec3  spec_color = mix(vec3(spec_reflectance), albedo, metallic);
-    vec3  spec = spec_color * light_color * pow(NdotH, shininess) * NdotL;
+    vec3  spec = spec_color * light_color * pow(NdotH, shininess) * NdotL * specular_scale;
 
     // Studio-style rim highlight
     float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.07;
@@ -883,7 +888,7 @@ void main()
     float NdotV_clamp = max(dot(N, V), 0.0);
     vec3 catch_light = albedo * light_color * 0.18 * pow(NdotV_clamp, 3.0);
 
-    float shadow = ShadowCalculation();
+    float shadow = (enable_shadows != 0) ? ShadowCalculation() : 0.0;
     vec3 color = ambient + (1.0 - shadow) * (diffuse + spec) + rim_color + catch_light;
 
     // Apply exposure for brightness control (no ACES — studio uses lower

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -1268,4 +1268,3 @@ class ShaderEdge(ShaderGL):
             self._gl.glUniform4f(self.loc_edge_color, *edge_color)
             lsm = light_space_matrix if light_space_matrix is not None else np.eye(4, dtype=np.float32)
             self._gl.glUniformMatrix4fv(self.loc_light_space_matrix, 1, self._gl.GL_FALSE, arr_pointer(lsm))
-

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -869,8 +869,11 @@ void main()
     float checker_scale = 1.0;
 
     // Ground plane (checker) should look matte in studio lighting
-    if (checker_enable > 0.0)
+    float ground_dampen = 1.0;
+    if (checker_enable > 0.0) {
         roughness = max(roughness, 0.85);
+        ground_dampen = 0.35;  // reduce direct light on ground
+    }
 
     // convert to linear space
     vec3 albedo = pow(ObjectColor, vec3(2.2));
@@ -970,7 +973,8 @@ void main()
     vec3 catch_light = albedo * light_color * 0.06 * pow(NdotV_clamp, 3.0);
 
     float shadow = (enable_shadows != 0) ? ShadowCalculation() : 0.0;
-    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec * specular_scale + spec_fill * 0.20 * specular_scale) + rim_color + catch_light;
+    vec3 direct = (diffuse + spec * specular_scale + spec_fill * 0.20 * specular_scale) * ground_dampen;
+    vec3 color = ambient + (1.0 - shadow) * direct + rim_color + catch_light;
 
     // Apply exposure for brightness control (no ACES — studio uses lower
     // light multipliers that stay in a moderate range where filmic rolloff

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import ctypes
 
@@ -282,57 +294,37 @@ void main()
         albedo = mix(albedo, albedo2, cb);
     }
 
-    // Specular color: dielectrics ~0.04, metals use albedo.
-    // Computed before desaturation so F0 reflects true material reflectance.
-    vec3 F0 = mix(vec3(0.04), albedo, metallic);
-
-    // Metals appear paler/desaturated because their look is dominated by
-    // bright specular reflections.  Without full IBL we approximate this by
-    // lifting the albedo toward a brighter, less saturated version.
-    float luma = dot(albedo, vec3(0.2126, 0.7152, 0.0722));
-    albedo = mix(albedo, vec3(luma * 1.4), metallic * 0.45);
-
     // surface vectors
     vec3 N = normalize(Normal);
-    vec3 V = normalize(view_pos - FragPos);
     // Flip normal for backfacing triangles
-    if (!gl_FrontFacing) N = -N;
+    if (!gl_FrontFacing) {
+        N = -N;
+    }
+    vec3 V = normalize(view_pos - FragPos);
     vec3 L = normalize(sun_direction);
     vec3 H = normalize(V + L);
 
-    // Cook-Torrance PBR
+    // Blinn-Phong terms
     float NdotL = max(dot(N, L), 0.0);
     float NdotH = max(dot(N, H), 0.0);
-    float NdotV = max(dot(N, V), 0.001);
-    float HdotV = max(dot(H, V), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
 
-    // GGX/Trowbridge-Reitz normal distribution
-    float a = roughness * roughness;
-    float a2 = a * a;
-    float denom = NdotH * NdotH * (a2 - 1.0) + 1.0;
-    float D = a2 / (PI * denom * denom);
+    // Derive Blinn-Phong exponent from perceptual roughness.
+    // roughness 0 → perfectly smooth, 1 → very rough
+    float gloss = clamp(1.0 - roughness, 0.0, 1.0);
+    // Map gloss to exponent range ~[2, 1024]
+    float shininess = 1.0 + pow(gloss, 4.0) * 1023.0;
 
-    // Schlick-GGX geometry function (Smith method for both view and light)
-    float k = (roughness + 1.0) * (roughness + 1.0) / 8.0;
-    float G1_V = NdotV / (NdotV * (1.0 - k) + k);
-    float G1_L = NdotL / (NdotL * (1.0 - k) + k);
-    float G = G1_V * G1_L;
+    // energy-preserving normalization for Blinn-Phong
+    float normFactor = (shininess + 2.0) / (8.0 * PI);
 
-    // Schlick Fresnel, dampened by roughness to reduce edge aliasing
-    vec3 F_max = mix(F0, vec3(1.0), 1.0 - roughness);
-    vec3 F = F0 + (F_max - F0) * pow(1.0 - HdotV, 5.0);
+    vec3 diffuse  = albedo * light_color * NdotL * 3.0 * diffuse_scale;
 
-    // Cook-Torrance specular BRDF
-    vec3 spec = (D * G * F) / (4.0 * NdotV * NdotL + 0.0001);
+    // Specular color: dielectrics ~0.04, metals use albedo
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    vec3 spec = F0 * light_color * normFactor * pow(NdotH, shininess) * NdotL * specular_scale;
 
-    // Diffuse uses remaining energy not reflected
-    vec3 kD = (1.0 - F) * (1.0 - metallic);
-    vec3 diffuse = kD * albedo / PI;
-
-    // Direct lighting
-    vec3 Lo = (diffuse * diffuse_scale + spec * specular_scale) * light_color * NdotL * 3.0;
-
-    // Hemispherical ambient (kept subtle for depth)
+    // simple hemispherical ambient term
     vec3 up = vec3(0.0, 1.0, 0.0);
     if (up_axis == 0) up = vec3(1.0, 0.0, 0.0);
     if (up_axis == 2) up = vec3(0.0, 0.0, 1.0);
@@ -348,16 +340,25 @@ void main()
     // shadows
     float shadow = ShadowCalculation();
 
-    float spotAttenuation = SpotlightAttenuation();
-    vec3 color = ambient + (1.0 - shadow) * spotAttenuation * Lo;
+    // spotlight attenuation
+    float spotlightAttenuation = SpotlightAttenuation();
 
-    // Environment / image-based lighting for metals
+    // Metals should contribute little diffuse light.
+    diffuse *= 1.0 - metallic;
+    vec3 color = ambient + (1.0 - shadow) * spotlightAttenuation * (diffuse + spec);
+
+    // Fresnel darkening: reduce brightness at glancing angles for metals
+    color *= mix(1.0, pow(NdotV, 2.0), metallic);
+
+    // environment reflection for metallic look (fade with roughness)
+    float env_lod = clamp(pow(roughness, 1.0/4.0), 0.0, 1.0) * 8.0;
     vec3 R = reflect(-V, N);
-    float env_lod = roughness * 8.0;
-    vec3 env_color = pow(sample_env_map(R, env_lod), vec3(2.2));
-    vec3 env_F = F0 + (F_max - F0) * pow(1.0 - NdotV, 5.0);
-    vec3 env_spec = env_color * env_F * env_intensity;
-    color += env_spec * metallic;
+    vec3 env_color = sample_env_map(R, env_lod);
+    env_color = pow(env_color, vec3(2.2)); // to linear
+    float reflection_strength = clamp(metallic * pow(1.0 - roughness, 2.0), 0.0, 1.0);
+    vec3 env_tint = mix(vec3(1.0), albedo, metallic);
+    vec3 env_reflection = env_color * env_tint * env_intensity;
+    color = mix(color, env_reflection, reflection_strength);
 
     // fog
     float dist = length(FragPos - view_pos);
@@ -503,14 +504,13 @@ class ShaderGL:
 class ShaderShape(ShaderGL):
     """Shader for rendering 3D shapes with lighting and shadows."""
 
-    def __init__(self, gl):
+    def __init__(self, gl, fragment_shader: str | None = None):
         super().__init__()
         from pyglet.graphics.shader import Shader, ShaderProgram
 
         self._gl = gl
-        self.shader_program = ShaderProgram(
-            Shader(shape_vertex_shader, "vertex"), Shader(shape_fragment_shader, "fragment")
-        )
+        frag = fragment_shader if fragment_shader is not None else shape_fragment_shader
+        self.shader_program = ShaderProgram(Shader(shape_vertex_shader, "vertex"), Shader(frag, "fragment"))
 
         # Get all uniform locations
         with self:
@@ -544,8 +544,8 @@ class ShaderShape(ShaderGL):
         up_axis: int,
         sun_direction: tuple[float, float, float],
         light_color: tuple[float, float, float] = (2.0, 2.0, 2.0),
-        ground_color: tuple[float, float, float] = (0.3, 0.3, 0.35),
-        sky_color: tuple[float, float, float] = (0.8, 0.8, 0.85),
+        ground_color: tuple[float, float, float] = (0.294, 0.333, 0.592),
+        sky_color: tuple[float, float, float] = (0.745, 0.863, 0.941),
         enable_shadows: bool = False,
         shadow_texture: int | None = None,
         light_space_matrix: np.ndarray | None = None,
@@ -694,6 +694,225 @@ class FrameShader(ShaderGL):
         """Update texture uniform."""
         with self:
             self._gl.glUniform1i(self.loc_texture, texture_unit)
+
+
+shape_fragment_shader_studio = """
+#version 330 core
+out vec4 FragColor;
+
+in vec3 Normal;
+in vec3 FragPos;
+in vec3 LocalPos;
+in vec2 TexCoord;
+in vec3 ObjectColor;
+in vec4 FragPosLightSpace;
+in vec4 Material;
+
+uniform vec3 view_pos;
+uniform vec3 light_color;
+uniform vec3 sky_color;
+uniform vec3 ground_color;
+uniform vec3 sun_direction;
+uniform sampler2D albedo_map;
+uniform sampler2D shadow_map;
+uniform mat4 light_space_matrix;
+uniform float shadow_radius;
+uniform float shadow_extents;
+uniform int up_axis;
+
+const float PI = 3.14159265359;
+
+vec2 poissonDisk[16] = vec2[](
+   vec2( -0.94201624, -0.39906216 ),
+   vec2( 0.94558609, -0.76890725 ),
+   vec2( -0.094184101, -0.92938870 ),
+   vec2( 0.34495938, 0.29387760 ),
+   vec2( -0.91588581, 0.45771432 ),
+   vec2( -0.81544232, -0.87912464 ),
+   vec2( -0.38277543, 0.27676845 ),
+   vec2( 0.97484398, 0.75648379 ),
+   vec2( 0.44323325, -0.97511554 ),
+   vec2( 0.53742981, -0.47373420 ),
+   vec2( -0.26496911, -0.41893023 ),
+   vec2( 0.79197514, 0.19090188 ),
+   vec2( -0.24188840, 0.99706507 ),
+   vec2( -0.81409955, 0.91437590 ),
+   vec2( 0.19984126, 0.78641367 ),
+   vec2( 0.14383161, -0.14100790 )
+);
+
+float rand(vec2 co) {
+    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+float ShadowCalculation()
+{
+    vec3 normal = normalize(Normal);
+    if (!gl_FrontFacing) normal = -normal;
+
+    float worldTexel = (shadow_extents * 2.0) / float(4096);
+    float normalBias = 2.0 * worldTexel;
+    vec4 light_space_pos = light_space_matrix * vec4(FragPos + normal * normalBias, 1.0);
+    vec3 projCoords = light_space_pos.xyz / light_space_pos.w;
+    projCoords = projCoords * 0.5 + 0.5;
+    if (projCoords.z > 1.0) return 0.0;
+
+    float frag_depth = projCoords.z;
+    float fade = 1.0;
+    float margin = 0.15;
+    fade *= smoothstep(0.0, margin, projCoords.x);
+    fade *= smoothstep(0.0, margin, 1.0 - projCoords.x);
+    fade *= smoothstep(0.0, margin, projCoords.y);
+    fade *= smoothstep(0.0, margin, 1.0 - projCoords.y);
+
+    float NdotL_bias = max(dot(normal, normalize(sun_direction)), 0.0);
+    float depthBias = mix(0.0003, 0.00002, NdotL_bias);
+    float biased_depth = frag_depth - depthBias;
+
+    float shadow = 0.0;
+    vec2 texelSize = 1.0 / textureSize(shadow_map, 0);
+    float angle = rand(gl_FragCoord.xy) * 2.0 * PI;
+    float s = sin(angle); float c = cos(angle);
+    mat2 rot = mat2(c, -s, s, c);
+    for (int i = 0; i < 16; i++) {
+        vec2 offset = rot * poissonDisk[i];
+        float pcf_depth = texture(shadow_map, projCoords.xy + offset * shadow_radius * texelSize).r;
+        if (pcf_depth < biased_depth) shadow += 1.0;
+    }
+    return (shadow / 16.0) * fade;
+}
+
+float filterwidth(vec2 v)
+{
+    vec2 fw = max(abs(dFdx(v)), abs(dFdy(v)));
+    return max(fw.x, fw.y);
+}
+
+vec2 bump(vec2 x)
+{
+    return (floor(x / 2.0) + 2.0 * max(x / 2.0 - floor(x / 2.0) - 0.5, 0.0));
+}
+
+float checker(vec2 uv)
+{
+    float width = filterwidth(uv);
+    vec2 p0 = uv - 0.5 * width;
+    vec2 p1 = uv + 0.5 * width;
+    vec2 i = (bump(p1) - bump(p0)) / width;
+    return i.x * i.y + (1.0 - i.x) * (1.0 - i.y);
+}
+
+void main()
+{
+    float roughness = clamp(Material.x, 0.0, 1.0);
+    float metallic  = clamp(Material.y, 0.0, 1.0);
+    float checker_enable = Material.z;
+    float texture_enable = Material.w;
+    float checker_scale = 1.0;
+
+    // convert to linear space
+    vec3 albedo = pow(ObjectColor, vec3(2.2));
+    if (texture_enable > 0.5)
+    {
+        vec3 tex_color = texture(albedo_map, TexCoord).rgb;
+        albedo *= pow(tex_color, vec3(2.2));
+    }
+
+    if (checker_enable > 0.0)
+    {
+        vec2 uv = LocalPos.xy * checker_scale;
+        float cb = checker(uv);
+        vec3 albedo2 = albedo * 0.7;
+        albedo = mix(albedo, albedo2, cb);
+    }
+
+    vec3 N = normalize(Normal);
+    if (!gl_FrontFacing)
+        N = -N;
+    vec3 V = normalize(view_pos - FragPos);
+    vec3 L = normalize(sun_direction);
+    vec3 H = normalize(V + L);
+
+    // Up axis
+    vec3 up = vec3(0.0, 1.0, 0.0);
+    if (up_axis == 0) up = vec3(1.0, 0.0, 0.0);
+    if (up_axis == 2) up = vec3(0.0, 0.0, 1.0);
+
+    // Soft hemisphere ambient — reduced so the directional key light has contrast.
+    // A fully-bright hemisphere washes out all directional shading.
+    float sky_fac = dot(N, up) * 0.5 + 0.5;
+    vec3 ambient = mix(ground_color, sky_color, sky_fac) * albedo * 0.35;
+
+    // Key directional light (primary source of contrast / shape definition)
+    float NdotL = max(dot(N, L), 0.0);
+    vec3 diffuse = albedo * light_color * NdotL * 1.10;
+
+    // Fill light: perpendicular to key in the horizontal plane, slightly elevated.
+    // This softly illuminates faces that are in shadow of the key without
+    // collapsing them to pure black, while still preserving contrast.
+    vec3 fill_dir = normalize(cross(up, L) + up * 0.20);
+    float NdotFill = max(dot(N, fill_dir), 0.0) * 0.28;
+    diffuse += albedo * light_color * NdotFill;
+
+    // Soft back fill (opposite key) to prevent pitch-black rear faces
+    float NdotBack = max(dot(N, -L), 0.0) * 0.10;
+    diffuse += albedo * light_color * NdotBack;
+
+    diffuse *= (1.0 - metallic);
+
+    // Specular — studio style.
+    // Physical dielectric reflectance F0=0.04 combined with energy-conserving
+    // normFactor produces ~1% brightness at typical angles, which is invisible.
+    // Instead use a boosted reflectance (0.30 for dielectrics, albedo for metals)
+    // without normFactor so the highlight is clearly visible at moderate roughness.
+    float gloss     = clamp(1.0 - roughness, 0.0, 1.0);
+    float shininess = 4.0 + pow(gloss, 2.0) * 60.0;  // range [4, 64]: soft but defined
+    float NdotH = max(dot(N, H), 0.0);
+    float spec_reflectance = mix(0.30, 1.0, metallic);
+    vec3  spec_color = mix(vec3(spec_reflectance), albedo, metallic);
+    vec3  spec = spec_color * light_color * pow(NdotH, shininess) * NdotL;
+
+    // Studio-style rim highlight
+    float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.07;
+    vec3 rim_color = sky_color * rim;
+
+    // Camera-space catch light — places a soft highlight on surfaces facing the viewer.
+    // This is the characteristic studio catch-light "sphere pop": regardless of world-space light
+    // direction, spheres and curved surfaces always show a visible bright region near their
+    // silhouette-facing centre, giving them instant 3D depth.
+    float NdotV_clamp = max(dot(N, V), 0.0);
+    vec3 catch_light = albedo * light_color * 0.18 * pow(NdotV_clamp, 3.0);
+
+    float shadow = ShadowCalculation();
+    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec) + rim_color + catch_light;
+
+    // gamma correction (sRGB)
+    color = pow(color, vec3(1.0 / 2.2));
+    FragColor = vec4(color, 1.0);
+}
+"""
+
+
+class ShaderShapeStudio(ShaderShape):
+    """Studio-style shape shader: 3-point lighting, cast shadows, no fog or env map.
+
+    Uniforms absent from the studio fragment shader return location -1; OpenGL
+    silently ignores glUniform* calls with location -1, so update() is fully inherited.
+    """
+
+    def __init__(self, gl):
+        super().__init__(gl, fragment_shader=shape_fragment_shader_studio)
+
+
+edge_fragment_shader = """
+#version 330 core
+out vec4 FragColor;
+uniform vec4 edge_color;
+void main()
+{
+    FragColor = edge_color;
+}
+"""
 
 
 wireframe_vertex_shader = """
@@ -944,3 +1163,45 @@ class ShaderArrow(ShaderGL):
     def set_world(self, world: np.ndarray):
         """Set the per-shape world matrix uniform."""
         self._gl.glUniformMatrix4fv(self.loc_world, 1, self._gl.GL_FALSE, arr_pointer(world))
+
+
+class ShaderEdge(ShaderGL):
+    """Flat-color shader used for the edge/wireframe overlay pass.
+
+    Reuses the instanced shape vertex shader so the second geometry pass
+    is correctly positioned, then ignores all lighting and outputs a single
+    uniform ``edge_color``.
+    """
+
+    def __init__(self, gl):
+        super().__init__()
+        from pyglet.graphics.shader import Shader, ShaderProgram
+
+        self._gl = gl
+        self.shader_program = ShaderProgram(
+            Shader(shape_vertex_shader, "vertex"), Shader(edge_fragment_shader, "fragment")
+        )
+
+        with self:
+            self.loc_view = self._get_uniform_location("view")
+            self.loc_projection = self._get_uniform_location("projection")
+            self.loc_edge_color = self._get_uniform_location("edge_color")
+            # light_space_matrix is referenced in the vertex shader; set to identity
+            # so gl_Position is computed correctly even though it is not used here.
+            self.loc_light_space_matrix = self._get_uniform_location("light_space_matrix")
+
+    def update(
+        self,
+        view_matrix: np.ndarray,
+        projection_matrix: np.ndarray,
+        edge_color: tuple[float, float, float, float] = (0.05, 0.05, 0.05, 1.0),
+        light_space_matrix: np.ndarray | None = None,
+    ):
+        """Update shader uniforms for the edge pass."""
+        with self:
+            self._gl.glUniformMatrix4fv(self.loc_view, 1, self._gl.GL_FALSE, arr_pointer(view_matrix))
+            self._gl.glUniformMatrix4fv(self.loc_projection, 1, self._gl.GL_FALSE, arr_pointer(projection_matrix))
+            self._gl.glUniform4f(self.loc_edge_color, *edge_color)
+            lsm = light_space_matrix if light_space_matrix is not None else np.eye(4, dtype=np.float32)
+            self._gl.glUniformMatrix4fv(self.loc_light_space_matrix, 1, self._gl.GL_FALSE, arr_pointer(lsm))
+

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -999,9 +999,13 @@ class ShaderShapeStudio(ShaderShape):
 edge_fragment_shader = """
 #version 330 core
 out vec4 FragColor;
+in vec4 Material;
 uniform vec4 edge_color;
 void main()
 {
+    // Skip ground plane (checker-enabled surfaces)
+    if (Material.z > 0.0)
+        discard;
     FragColor = edge_color;
 }
 """

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -937,10 +937,10 @@ void main()
 
     // Soft hemisphere ambient
     float sky_fac = dot(N, up) * 0.5 + 0.5;
-    vec3 ambient = mix(ground_color, sky_color, sky_fac) * albedo * 0.35;
+    vec3 ambient = mix(ground_color, sky_color, sky_fac) * albedo * 0.25;
 
-    // Key directional light (higher multiplier compensates for PI-normalised BRDF)
-    vec3 diffuse = kD * albedo / PI * light_color * NdotL * 4.0 * diffuse_scale;
+    // Key directional light (same 3.0 multiplier as classic)
+    vec3 diffuse = kD * albedo / PI * light_color * NdotL * 3.0 * diffuse_scale;
 
     // Fill light: perpendicular to key, slightly elevated
     vec3 fill_dir = normalize(cross(up, L) + up * 0.20);
@@ -955,22 +955,22 @@ void main()
     vec3 F_fill = F0 + (F_max - F0) * pow(1.0 - HdotV_fill, 5.0);
     vec3 spec_fill = (D_fill * G_fill * F_fill) / (4.0 * NdotV * NdotFill + 0.0001);
     vec3 kD_fill = (1.0 - F_fill) * (1.0 - metallic);
-    diffuse += kD_fill * albedo / PI * light_color * NdotFill * 1.2;
+    diffuse += kD_fill * albedo / PI * light_color * NdotFill * 0.5;
 
     // Soft back fill (opposite key)
-    float NdotBack = max(dot(N, -L), 0.0) * 0.10;
+    float NdotBack = max(dot(N, -L), 0.0) * 0.08;
     diffuse += kD * albedo / PI * light_color * NdotBack;
 
     // Studio-style rim highlight
-    float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.07;
+    float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.04;
     vec3 rim_color = sky_color * rim;
 
     // Camera-space catch light for 3D depth
     float NdotV_clamp = max(dot(N, V), 0.0);
-    vec3 catch_light = albedo * light_color * 0.18 * pow(NdotV_clamp, 3.0);
+    vec3 catch_light = albedo * light_color * 0.06 * pow(NdotV_clamp, 3.0);
 
     float shadow = (enable_shadows != 0) ? ShadowCalculation() : 0.0;
-    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec * specular_scale + spec_fill * 0.28 * specular_scale) + rim_color + catch_light;
+    vec3 color = ambient + (1.0 - shadow) * (diffuse + spec * specular_scale + spec_fill * 0.20 * specular_scale) + rim_color + catch_light;
 
     // Apply exposure for brightness control (no ACES — studio uses lower
     // light multipliers that stay in a moderate range where filmic rolloff

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -21,7 +21,7 @@ from ..core.types import Axis, override
 from ..utils.render import copy_rgb_frame_uint8
 from .camera import Camera
 from .gl.gui import UI
-from .gl.opengl import LinesGL, MeshGL, MeshInstancerGL, RendererGL
+from .gl.opengl import STYLE_REGISTRY, LinesGL, MeshGL, MeshInstancerGL, RendererGL
 from .picking import Picking
 from .viewer import ViewerBase
 from .wind import Wind
@@ -194,6 +194,7 @@ class ViewerGL(ViewerBase):
         vsync: bool = False,
         headless: bool = False,
         plot_history_size: int = 250,
+        shading_style: str = "classic",
     ):
         """
         Initialize the OpenGL viewer and UI.
@@ -205,6 +206,9 @@ class ViewerGL(ViewerBase):
             headless: Run in headless mode (no window).
             plot_history_size: Maximum number of samples kept per
                 :meth:`log_scalar` signal for the live time-series plots.
+            shading_style: Visual rendering style. ``"classic"`` uses Newton's default
+                checker-floor look. ``"studio"`` uses a clean studio look with soft
+                hemisphere lighting, directional shadows, and a neutral ground plane.
         """
         if not isinstance(plot_history_size, int) or isinstance(plot_history_size, bool):
             raise TypeError("plot_history_size must be an integer")
@@ -224,7 +228,13 @@ class ViewerGL(ViewerBase):
 
         super().__init__()
 
-        self.renderer = RendererGL(vsync=vsync, screen_width=width, screen_height=height, headless=headless)
+        self.renderer = RendererGL(
+            vsync=vsync,
+            screen_width=width,
+            screen_height=height,
+            headless=headless,
+            shading_style=shading_style,
+        )
         self.renderer.set_title("Newton Viewer")
 
         fb_w, fb_h = self.renderer.window.get_framebuffer_size()
@@ -2209,6 +2219,16 @@ class ViewerGL(ViewerBase):
                     # Collision geometry toggle
                     show_collision = self.show_collision
                     changed, self.show_collision = imgui.checkbox("Show Collision", show_collision)
+
+                    # Edge overlay toggle
+                    changed, self.renderer.draw_edges = imgui.checkbox("Show Edges", self.renderer.draw_edges)
+
+                    # Shading style dropdown
+                    shading_styles = list(STYLE_REGISTRY.keys())
+                    current_style_idx = shading_styles.index(self.renderer.shading_style)
+                    changed, current_style_idx = imgui.combo("Shading", current_style_idx, shading_styles)
+                    if changed:
+                        self.renderer.shading_style = shading_styles[current_style_idx]
 
                     # Gap + margin wireframe mode
                     _sdf_margin_labels = ["Off", "Margin", "Margin + Gap"]


### PR DESCRIPTION
## Description

<img width="1300" height="520" alt="cloth_franka_comparison" src="https://github.com/user-attachments/assets/e95262c9-befe-4651-9c11-d447ff18cba0" />
<img width="2560" height="720" alt="robot_anymal_d_comparison" src="https://github.com/user-attachments/assets/4dcd03b8-7940-446e-ba86-7096e1d99be0" />
<img width="2560" height="720" alt="cloth_h1_comparison" src="https://github.com/user-attachments/assets/ec9d4af4-c2ee-40e2-b5d9-6d1b6bf64dd1" />

  Add a "studio" rendering style to the GL viewer with soft 3-point lighting, shadow mapping, rim highlights, and a neutral matte ground plane. The existing "classic"
  checker-floor style remains the default.

  Refactor the shading system into a registry-based design (ShadingStyleConfig + STYLE_REGISTRY) so new styles can be added by registering a config dict — no viewer code
  changes needed. The sidebar dropdown auto-populates from the registry.

  Also add an optional edge overlay that draws mesh wireframes on top of solid geometry.


<img width="2560" height="720" alt="cloth_rollers_edges_comparison" src="https://github.com/user-attachments/assets/f7f6efe1-6d70-4cfd-b985-fadf580aa58a" />

  Changes

  - Studio shading — hemisphere ambient + directional key light with shadow maps, fill light, rim highlights, ground plane with roughness 0.85
  - Edge overlay — `renderer.draw_edges = True` draws wireframe edges over solid shading
  - Registry-based styles — `ShadingStyleConfig` dataclass + `STYLE_REGISTRY` dict; adding a new style only requires registering a config
  - shading_style constructor param — `ViewerGL(shading_style="studio")` for headless/programmatic use
  - Sidebar UI — Shading dropdown, Show Edges checkbox (above Gap + Margin controls)

  Checklist

  - New or existing tests cover these changes
  - The documentation is up to date with these changes
  - CHANGELOG.md has been updated (if user-facing change)

  Test plan

  Tested with four examples in headless mode (Xvfb), verifying non-black frames for classic, studio, and studio+edges:

  cloth_franka   — 60 frames @ 60fps ✓
  cloth_h1       — 300 frames @ 60fps ✓
  robot_anymal_d — 250 frames @ 50fps ✓
  cloth_rollers  — 300 frames @ 60fps ✓

  Runtime style switching verified (single viewer, switching renderer.shading_style between "classic" and "studio").
```
  New feature / API change

  import newton.viewer

  # Studio shading via constructor
  viewer = newton.viewer.ViewerGL(shading_style="studio")

  # Runtime style switching
  viewer.renderer.shading_style = "classic"

  # Edge overlay
  viewer.renderer.draw_edges = True
```

See https://docs.google.com/document/d/1wdY3Xg2xEXUk8zDkclwjMyTGQ8LfyobCzB69QGh5qkg/edit?usp=sharing for designs and implementation explanation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable shading styles (classic, studio) with per-style presets and runtime switching.
  * Optional edge-overlay rendering for wireframe/edge visualization.

* **Rendering Improvements**
  * Studio shading with three-point lighting, rim highlights and shadowing; simpler, predictable diffuse/specular.
  * Per-style fog/sky/sun settings drive rendering each frame and select appropriate shaders.

* **UI/UX Improvements**
  * Shading dropdown and "Show Edges" checkbox in the viewport panel.

* **Documentation**
  * CHANGELOG updated with new shading and edge features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->