### PR TITLE
Add version numbers to all `.. deprecated::` directives

### DIFF
--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -76,36 +76,36 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     class Config:
         """Sensor configuration.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :class:`RenderConfig` and ``SensorTiledCamera.utils.*`` instead.
         """
 
         checkerboard_texture: bool = False
-        """.. deprecated:: Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes()`` instead."""
+        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes()`` instead."""
 
         default_light: bool = False
-        """.. deprecated:: Use ``SensorTiledCamera.utils.create_default_light()`` instead."""
+        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.create_default_light()`` instead."""
 
         default_light_shadows: bool = False
-        """.. deprecated:: Use ``SensorTiledCamera.utils.create_default_light(enable_shadows=True)`` instead."""
+        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.create_default_light(enable_shadows=True)`` instead."""
 
         enable_ambient_lighting: bool = True
-        """.. deprecated:: Use ``render_config.enable_ambient_lighting`` instead."""
+        """.. deprecated:: 1.1 Use ``render_config.enable_ambient_lighting`` instead."""
 
         colors_per_world: bool = False
-        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
+        """.. deprecated:: 1.1 Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
 
         colors_per_shape: bool = False
-        """.. deprecated:: Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
+        """.. deprecated:: 1.1 Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
 
         backface_culling: bool = True
-        """.. deprecated:: Use ``render_config.enable_backface_culling`` instead."""
+        """.. deprecated:: 1.1 Use ``render_config.enable_backface_culling`` instead."""
 
         enable_textures: bool = False
-        """.. deprecated:: Use ``render_config.enable_textures`` instead."""
+        """.. deprecated:: 1.1 Use ``render_config.enable_textures`` instead."""
 
         enable_particles: bool = True
-        """.. deprecated:: Use ``render_config.enable_particles`` instead."""
+        """.. deprecated:: 1.1 Use ``render_config.enable_particles`` instead."""
 
     def __init__(self, model: Model, *, config: Config | RenderConfig | None = None, load_textures: bool = True):
         """Initialize the tiled camera sensor from a simulation model.
@@ -228,7 +228,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         Generates rays in camera space (origin at the camera center, direction normalized) for each pixel based on the
         vertical field of view.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.compute_pinhole_camera_rays`` instead.
 
         Args:
@@ -257,7 +257,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
 
         Arranges ``(world_count * camera_count)`` tiles in a grid. Each tile shows one camera's view of one world.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.flatten_color_image_to_rgba`` instead.
 
         Args:
@@ -282,7 +282,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
 
         Arranges ``(world_count * camera_count)`` tiles in a grid. Each tile shows one camera's view of one world.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.flatten_normal_image_to_rgba`` instead.
 
         Args:
@@ -309,7 +309,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         Encodes depth as grayscale: inverts values (closer = brighter) and normalizes to the ``[50, 255]``
         range. Background pixels (no hit) remain black.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.flatten_depth_image_to_rgba`` instead.
 
         Args:
@@ -328,7 +328,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def assign_random_colors_per_world(self, seed: int = 100):
         """Assign each world a random color, applied to all its shapes.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:
@@ -344,7 +344,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def assign_random_colors_per_shape(self, seed: int = 100):
         """Assign a random color to each shape.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:
@@ -360,7 +360,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_default_light(self, enable_shadows: bool = True):
         """Create a default directional light oriented at ``(-1, 1, -1)``.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_default_light`` instead.
 
         Args:
@@ -379,7 +379,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         Creates a gray checkerboard pattern texture and applies it to all shapes
         in the scene.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes`` instead.
 
         Args:
@@ -396,7 +396,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create a color output array for :meth:`update`.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_color_image_output`` instead.
 
         Args:
@@ -417,7 +417,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_depth_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.float32]:
         """Create a depth output array for :meth:`update`.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_depth_image_output`` instead.
 
         Args:
@@ -438,7 +438,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_shape_index_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create a shape-index output array for :meth:`update`.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_shape_index_image_output`` instead.
 
         Args:
@@ -459,7 +459,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_normal_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
         """Create a normal output array for :meth:`update`.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_normal_image_output`` instead.
 
         Args:
@@ -480,7 +480,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def create_albedo_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create an albedo output array for :meth:`update`.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use ``SensorTiledCamera.utils.create_albedo_image_output`` instead.
 
         Args:
@@ -502,7 +502,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     def render_context(self) -> RenderContext:
         """Internal Warp raytracing context used by :meth:`update` and buffer helpers.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Direct access is deprecated and will be removed. Prefer this
             class's public methods, or :attr:`render_config` for
             :class:`RenderConfig` access.

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -753,7 +753,7 @@ class RenderContext:
     def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create an output array for color rendering.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :meth:`SensorTiledCamera.utils.create_color_image_output`.
         """
         warnings.warn(
@@ -766,7 +766,7 @@ class RenderContext:
     def create_depth_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.float32]:
         """Create an output array for depth rendering.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :meth:`SensorTiledCamera.utils.create_depth_image_output`.
         """
         warnings.warn(
@@ -779,7 +779,7 @@ class RenderContext:
     def create_shape_index_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create an output array for shape-index rendering.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :meth:`SensorTiledCamera.utils.create_shape_index_image_output`.
         """
         warnings.warn(
@@ -792,7 +792,7 @@ class RenderContext:
     def create_normal_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
         """Create an output array for surface-normal rendering.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :meth:`SensorTiledCamera.utils.create_normal_image_output`.
         """
         warnings.warn(
@@ -805,7 +805,7 @@ class RenderContext:
     def create_albedo_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create an output array for albedo rendering.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use :meth:`SensorTiledCamera.utils.create_albedo_image_output`.
         """
         warnings.warn(

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -467,7 +467,7 @@ class Utils:
     def assign_random_colors_per_world(self, seed: int = 100):
         """Assign each world a random color, applied to all its shapes.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:
@@ -491,7 +491,7 @@ class Utils:
     def assign_random_colors_per_shape(self, seed: int = 100):
         """Assign a random color to each shape.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
 
         Args:

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -624,7 +624,7 @@ class SolverImplicitMPM(SolverBase):
         """Collider velocity computation mode. ``'forward'`` uses the current velocity,
         ``'backward'`` uses the previous timestep position.
 
-        .. deprecated::
+        .. deprecated:: 1.1
             Aliases ``'instantaneous'`` (= ``'forward'``) and ``'finite_difference'``
             (= ``'backward'``) are deprecated and will be removed in a future release.
         """


### PR DESCRIPTION
Closes #2306

All 32 `.. deprecated::` directives in the codebase were missing the required Sphinx version number, causing the first word of the description text to be parsed as the version string:

> **Deprecated since version Use:** RenderConfig and SensorTiledCamera.utils.\* instead.

This adds `1.1` to every occurrence (confirmed none of these deprecations existed in the 1.0 release branch). They now render as:

> **Deprecated since version 1.1:** Use RenderConfig and SensorTiledCamera.utils.\* instead.

### Files changed

| File | Count |
|---|---|
| `newton/_src/sensors/sensor_tiled_camera.py` | 24 |
| `newton/_src/sensors/warp_raytrace/render_context.py` | 5 |
| `newton/_src/sensors/warp_raytrace/utils.py` | 2 |
| `newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py` | 1 |

Docs build cleanly with `-W` (warnings as errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation version markers to explicitly indicate version 1.1 for deprecated features across sensor camera and solver components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->