### PR TITLE
Material color extraction

### DIFF
--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1612,6 +1612,7 @@ def _extract_shader_properties(shader: UsdShade.Shader | None, prim: Usd.Prim) -
             shader,
             (
                 "diffuse_color_constant",
+                "diffuse_tint",
                 "diffuse_color",
                 "diffuseColor",
                 "base_color",
@@ -1834,6 +1835,18 @@ def resolve_material_properties_for_prim(prim: Usd.Prim) -> dict[str, Any]:
                     fallback_props = subset_props
             if fallback_props is not None:
                 return fallback_props
+
+    # Last resort: check displayColor primvar even when no material is bound.
+    # This covers collision-only prims whose colour is set via displayColor
+    # rather than through a material binding (e.g. ground planes).
+    if UsdGeom is not None:
+        display_color = UsdGeom.PrimvarsAPI(prim).GetPrimvar("displayColor")
+        if display_color:
+            color = _coerce_color(display_color.Get())
+            if color is not None:
+                props = _empty_material_properties()
+                props["color"] = color
+                return props
 
     return _empty_material_properties()
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -524,6 +524,18 @@ def parse_usd(
             return
 
         if path_name not in path_shape_map:
+            # Resolve material color for primitive (non-mesh) visual shapes.
+            # Walk up to the parent if the prim itself has no material bound,
+            # since USD materials are often authored on a parent Xform.
+            _prim_color = None
+            if type_name != "mesh":
+                _prim_mat_props = _get_material_props_cached(prim)
+                _prim_color = _prim_mat_props.get("color")
+                if _prim_color is None:
+                    parent = prim.GetParent()
+                    if parent and parent.IsValid():
+                        _prim_color = _get_material_props_cached(parent).get("color")
+
             if type_name == "cube":
                 size = usd.get_float(prim, "size", 2.0)
                 side_lengths = scale * size
@@ -535,6 +547,7 @@ def parse_usd(
                     hz=side_lengths[2] / 2,
                     cfg=visual_shape_cfg,
                     as_site=is_site,
+                    color=_prim_color,
                     label=path_name,
                 )
             elif type_name == "sphere":
@@ -547,6 +560,7 @@ def parse_usd(
                     radius,
                     cfg=visual_shape_cfg,
                     as_site=is_site,
+                    color=_prim_color,
                     label=path_name,
                 )
             elif type_name == "plane":
@@ -562,6 +576,7 @@ def parse_usd(
                     width=width,
                     length=length,
                     cfg=visual_shape_cfg,
+                    color=_prim_color,
                     label=path_name,
                 )
             elif type_name == "capsule":
@@ -577,6 +592,7 @@ def parse_usd(
                     half_height,
                     cfg=visual_shape_cfg,
                     as_site=is_site,
+                    color=_prim_color,
                     label=path_name,
                 )
             elif type_name == "cylinder":
@@ -592,6 +608,7 @@ def parse_usd(
                     half_height,
                     cfg=visual_shape_cfg,
                     as_site=is_site,
+                    color=_prim_color,
                     label=path_name,
                 )
             elif type_name == "cone":
@@ -2151,9 +2168,22 @@ def parse_usd(
                 if shape_kd is None:
                     shape_kd = builder.default_shape_cfg.kd
 
+                # Resolve material color for visible collision shapes so they
+                # render with the correct colour instead of the palette fallback.
+                # Walk up to the parent if the prim itself has no material.
+                _collider_color = None
+                if collider_is_visible:
+                    _coll_mat = _get_material_props_cached(prim)
+                    _collider_color = _coll_mat.get("color")
+                    if _collider_color is None:
+                        _coll_parent = prim.GetParent()
+                        if _coll_parent and _coll_parent.IsValid():
+                            _collider_color = _get_material_props_cached(_coll_parent).get("color")
+
                 shape_params = {
                     "body": body_id,
                     "xform": shape_xform,
+                    "color": _collider_color,
                     "cfg": ModelBuilder.ShapeConfig(
                         ke=shape_ke,
                         kd=shape_kd,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -431,11 +431,14 @@ def parse_usd(
             mesh.texture = texture
         if mesh.texture is not None and mesh.uvs is None:
             warnings.warn(
-                f"Warning: mesh {path_name} has a texture but no UVs; texture will be ignored.",
+                f"Mesh {path_name} has a texture but no UVs; texture will use projected UVs.",
                 stacklevel=2,
             )
-            mesh.texture = None
-        if material_props.get("color") is not None and mesh.texture is None:
+        if mesh.texture is not None:
+            # Texture provides albedo; use white so it renders at full brightness.
+            # (diffuse_color_constant is the untextured fallback, not a multiplier.)
+            mesh.color = (1.0, 1.0, 1.0)
+        elif material_props.get("color") is not None:
             mesh.color = material_props["color"]
         if material_props.get("roughness") is not None:
             mesh.roughness = material_props["roughness"]

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -461,6 +461,42 @@ def parse_usd(
             prim_world_mat = incoming_mat @ prim_world_mat
         return prim_world_mat
 
+    def _cube_to_textured_mesh(hx: float, hy: float, hz: float, material_props: dict) -> Mesh:
+        """Convert a cube primitive to a Mesh with box-mapped UVs for texture rendering.
+
+        Creates 24 vertices (4 per face) with independent UVs so each face
+        maps the full texture via simple box projection.
+        """
+        # 6 faces, 4 verts each, 2 tris each — winding is CCW when viewed from outside
+        verts = np.array([
+            # +X face
+            [hx, -hy, -hz], [hx, hy, -hz], [hx, hy, hz], [hx, -hy, hz],
+            # -X face
+            [-hx, hy, -hz], [-hx, -hy, -hz], [-hx, -hy, hz], [-hx, hy, hz],
+            # +Y face
+            [hx, hy, -hz], [-hx, hy, -hz], [-hx, hy, hz], [hx, hy, hz],
+            # -Y face
+            [-hx, -hy, -hz], [hx, -hy, -hz], [hx, -hy, hz], [-hx, -hy, hz],
+            # +Z face
+            [-hx, -hy, hz], [hx, -hy, hz], [hx, hy, hz], [-hx, hy, hz],
+            # -Z face
+            [-hx, hy, -hz], [hx, hy, -hz], [hx, -hy, -hz], [-hx, -hy, -hz],
+        ], dtype=np.float32)
+        uvs = np.tile(np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=np.float32), (6, 1))
+        tris = np.array([[i * 4 + j for j in t] for i in range(6) for t in [[0, 1, 2], [0, 2, 3]]], dtype=np.int32)
+        mesh = Mesh(verts, tris, uvs=uvs, compute_inertia=False)
+        mesh.texture = material_props.get("texture")
+        # When a texture is present, the texture provides the albedo and the
+        # shape color acts as a multiplier.  Use white so the texture renders
+        # at full brightness (OmniPBR's diffuse_color_constant is the
+        # untextured fallback and would darken the image if used here).
+        mesh.color = (1.0, 1.0, 1.0)
+        if material_props.get("roughness") is not None:
+            mesh.roughness = material_props["roughness"]
+        if material_props.get("metallic") is not None:
+            mesh.metallic = material_props["metallic"]
+        return mesh
+
     def _load_visual_shapes_impl(
         parent_body_id: int,
         prim: Usd.Prim,
@@ -524,32 +560,47 @@ def parse_usd(
             return
 
         if path_name not in path_shape_map:
-            # Resolve material color for primitive (non-mesh) visual shapes.
+            # Resolve material properties for primitive (non-mesh) visual shapes.
             # Walk up to the parent if the prim itself has no material bound,
             # since USD materials are often authored on a parent Xform.
-            _prim_color = None
+            _prim_mat_props = {}
             if type_name != "mesh":
                 _prim_mat_props = _get_material_props_cached(prim)
-                _prim_color = _prim_mat_props.get("color")
-                if _prim_color is None:
+                if _prim_mat_props.get("color") is None and _prim_mat_props.get("texture") is None:
                     parent = prim.GetParent()
                     if parent and parent.IsValid():
-                        _prim_color = _get_material_props_cached(parent).get("color")
+                        _par_props = _get_material_props_cached(parent)
+                        if _par_props.get("color") is not None or _par_props.get("texture") is not None:
+                            _prim_mat_props = _par_props
+                _prim_color = _prim_mat_props.get("color")
 
             if type_name == "cube":
                 size = usd.get_float(prim, "size", 2.0)
                 side_lengths = scale * size
-                shape_id = builder.add_shape_box(
-                    parent_body_id,
-                    xform,
-                    hx=side_lengths[0] / 2,
-                    hy=side_lengths[1] / 2,
-                    hz=side_lengths[2] / 2,
-                    cfg=visual_shape_cfg,
-                    as_site=is_site,
-                    color=_prim_color,
-                    label=path_name,
-                )
+                hx, hy, hz = side_lengths[0] / 2, side_lengths[1] / 2, side_lengths[2] / 2
+                # If the material has a texture, convert the cube to a mesh
+                # with UVs so Newton's texture pipeline can render it.
+                if _prim_mat_props.get("texture") is not None:
+                    mesh = _cube_to_textured_mesh(hx, hy, hz, _prim_mat_props)
+                    shape_id = builder.add_shape_mesh(
+                        parent_body_id,
+                        xform,
+                        mesh=mesh,
+                        cfg=visual_shape_cfg,
+                        label=path_name,
+                    )
+                else:
+                    shape_id = builder.add_shape_box(
+                        parent_body_id,
+                        xform,
+                        hx=hx,
+                        hy=hy,
+                        hz=hz,
+                        cfg=visual_shape_cfg,
+                        as_site=is_site,
+                        color=_prim_color,
+                        label=path_name,
+                    )
             elif type_name == "sphere":
                 if not (scale[0] == scale[1] == scale[2]):
                     print("Warning: Non-uniform scaling of spheres is not supported.")


### PR DESCRIPTION
## Description                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  Fix material color extraction from USD so that OmniPBR/MDL materials, primitive shapes, and collision shapes render with correct colors instead of falling back to the shape palette.                          
                                                                                                                                                                                                                 
  Four gaps addressed:                                                                                                                                                                                           
  1. OmniPBR MDL shaders use `diffuse_tint` for their base color, but `_extract_shader_properties` didn't include it in the fallback name list.                                                                  
  2. Prims without material bindings (e.g. collision-only ground planes) never reached the `displayColor` primvar fallback.                                                                                      
  3. Visual primitive shapes (box, sphere, plane, etc.) and collision shapes never extracted material colors — they always got palette colors.                                                                   
  4. Textured cube primitives couldn't render textures because box shapes lack UVs. Cubes with textured materials are now auto-converted to meshes with per-face UVs.                                            
                                                                                                                                                                                                                 
  ## Checklist                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - [ ] New or existing tests cover these changes                                                                                                                                                                
  - [ ] The documentation is up to date with these changes                                                                                                                                                       
  - [x] `CHANGELOG.md` has been updated (if user-facing change)                                                                                                                                                  
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  Verified end-to-end with a dextrah Kuka-Allegro manipulation scene (64 envs, Newton Warp renderer) containing:                                                                                                 
  - Robot meshes with OmniPBR materials (`arm_gray`, `arm_orange`, `allegro_black`) — now render with correct material colors instead of palette rainbow                                                         
  - Table (cube primitive with OmniPBR texture) — now renders with walnut plank texture via cube-to-mesh conversion                                                                                              
  - Ground plane (collision-only, no material binding) — now picks up `displayColor` instead of palette blue                                                                                                     
  - Grasp objects with UsdPreviewSurface materials — continue to render correctly                                                                                                                                
                                                                                                                                                                                                                 
  ## Bug fix                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  **Steps to reproduce:**                                                                                                                                                                                        
                                                                                                                                                                                                                 
  1. Load a USD scene with OmniPBR materials (e.g. a robot URDF imported through Isaac Sim)                                                                                                                      
  2. Build a Newton model via `ModelBuilder.add_usd(stage)`                                                                                                                                                      
  3. Render with `SensorTiledCamera` with `enable_textures=True`                                                                                                                                                 
  4. Observe: robot meshes show cycling palette colors (blue, cyan, green, yellow...) instead of their material colors. Primitive shapes (table box, ground plane) also show palette colors. Textured cubes      
  render without textures.                                                                                                                                                                                       
                                                                                                                                                                                                                 
  **Minimal reproduction:**                                                                                                                                                                                      
                                                                                                                                                                                                                 
  ```python                                                                                                                                                                                                      
  import newton                                                                                                                                                                                                  
  from newton import ModelBuilder

  builder = ModelBuilder()
  # Load any USD scene with OmniPBR materials (e.g. robot + table)
  builder.add_usd("scene_with_omnipbr_materials.usd", load_visual_shapes=True)
  model = builder.finalize(device="cuda:0")

  sensor = newton.sensors.SensorTiledCamera(model)
  sensor.render_config.enable_textures = True

  # Inspect shape colors — without fix, OmniPBR shapes get palette colors
  colors = model.shape_color.numpy()
  # colors[i] will be palette values like (0.267, 0.467, 0.667) instead of
  # the material's diffuse_tint (e.g. (0.7, 0.7, 0.7) for grey arm)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Objects without bound materials can now extract color from display properties.
  * Cube primitives now support textured mesh rendering.
  * Visual and collision shapes properly display resolved material colors.

* **Bug Fixes**
  * Textured objects no longer discard textures when UV data is missing; projected UVs are applied instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->