### PR TITLE
Fix multi-world joint indexing in warp-to-mj coord conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,10 @@
 - Fix `cloth_franka` example Jacobian broken by COM-referenced `body_qd` convention change; adjust robot base height, gripper orientations, and grasp targets for improved reachability (a follow-up PR will migrate the example to `newton.ik`)
 - Fix joint-synthesized CONNECT constraint anchors not updating when `dof_ref` or `joint_X_p` changes at runtime via `notify_model_changed()`
 - Fix WELD constraint data corruption when a model contains both FIXED and revolute/ball loop joints, caused by CONNECT anchor kernels overwriting WELD `eq_data`
+- Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
+- Fix `SensorRaycast` ignoring `PLANE` geometry
+- Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
+- Fix multi-world coordinate conversion using the wrong body center of mass for replicated worlds
 
 ## [1.0.0] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fix MJCF importer creating finite planes from MuJoCo visual half-sizes instead of infinite planes
 - Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
 - Fix degenerate zero-area triangles in SDF marching-cubes isosurface extraction by clamping edge interpolation away from cube corners and guarding against near-zero cross products
+- Fix multi-world coordinate conversion using the wrong body center of mass for replicated worlds
 
 ## [1.1.0] - 2026-04-13
 
@@ -189,10 +190,6 @@
 - Fix `cloth_franka` example Jacobian broken by COM-referenced `body_qd` convention change; adjust robot base height, gripper orientations, and grasp targets for improved reachability (a follow-up PR will migrate the example to `newton.ik`)
 - Fix joint-synthesized CONNECT constraint anchors not updating when `dof_ref` or `joint_X_p` changes at runtime via `notify_model_changed()`
 - Fix WELD constraint data corruption when a model contains both FIXED and revolute/ball loop joints, caused by CONNECT anchor kernels overwriting WELD `eq_data`
-- Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
-- Fix `SensorRaycast` ignoring `PLANE` geometry
-- Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
-- Fix multi-world coordinate conversion using the wrong body center of mass for replicated worlds
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -644,17 +644,19 @@ def convert_warp_coords_to_mj_kernel(
 ):
     worldid, jntid = wp.tid()
 
+    joint_id = joints_per_world * worldid + jntid
+
     # Skip loop joints — they have no MuJoCo qpos/qvel entries
     q_i = mj_q_start[jntid]
     if q_i < 0:
         return
 
     qd_i = mj_qd_start[jntid]
-    type = joint_type[jntid]
-    wq_i = joint_q_start[joints_per_world * worldid + jntid]
-    wqd_i = joint_qd_start[joints_per_world * worldid + jntid]
+    jtype = joint_type[joint_id]
+    wq_i = joint_q_start[joint_id]
+    wqd_i = joint_qd_start[joint_id]
 
-    if type == JointType.FREE:
+    if jtype == JointType.FREE:
         # convert position components
         for i in range(3):
             qpos[worldid, q_i + i] = joint_q[wq_i + i]
@@ -683,7 +685,7 @@ def convert_warp_coords_to_mj_kernel(
         w_world = wp.vec3(joint_qd[wqd_i + 3], joint_qd[wqd_i + 4], joint_qd[wqd_i + 5])
 
         # Get CoM offset in world frame
-        child = joint_child[jntid]
+        child = joint_child[joint_id]
         com_local = body_com[child]
         com_world = wp.quat_rotate(rot, com_local)
 
@@ -702,7 +704,7 @@ def convert_warp_coords_to_mj_kernel(
         qvel[worldid, qd_i + 4] = w_body[1]
         qvel[worldid, qd_i + 5] = w_body[2]
 
-    elif type == JointType.BALL:
+    elif jtype == JointType.BALL:
         # change quaternion order from xyzw to wxyz
         ball_q = wp.quat(joint_q[wq_i], joint_q[wq_i + 1], joint_q[wq_i + 2], joint_q[wq_i + 3])
         ball_q_wxyz = quat_xyzw_to_wxyz(ball_q)
@@ -714,7 +716,7 @@ def convert_warp_coords_to_mj_kernel(
             # convert velocity components
             qvel[worldid, qd_i + i] = joint_qd[wqd_i + i]
     else:
-        axis_count = joint_dof_dim[jntid, 0] + joint_dof_dim[jntid, 1]
+        axis_count = joint_dof_dim[joint_id, 0] + joint_dof_dim[joint_id, 1]
         for i in range(axis_count):
             ref = float(0.0)
             if dof_ref:

--- a/newton/tests/test_multiworld_body_properties.py
+++ b/newton/tests/test_multiworld_body_properties.py
@@ -150,10 +150,10 @@ class TestMultiworldBodyProperties(unittest.TestCase):
     pass
 
 
-# The buggy code path is warp-to-mj coordinate conversion, which only
-# runs on CUDA (SolverMuJoCo with use_mujoco_cpu=False). Skip CPU devices
-# so CPU-only CI runners don't fail.
-devices = [d for d in get_test_devices() if d.is_cuda]
+# The buggy code path (convert_warp_coords_to_mj_kernel) runs on any
+# device when SolverMuJoCo is used with use_mujoco_cpu=False (default),
+# so this test must run on all available devices.
+devices = get_test_devices()
 for device in devices:
     add_function_test(
         TestMultiworldBodyProperties,

--- a/newton/tests/test_multiworld_body_properties.py
+++ b/newton/tests/test_multiworld_body_properties.py
@@ -15,57 +15,36 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.solvers import SolverMuJoCo, SolverNotifyFlags
+from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 
-def _build_articulated_model(device, num_worlds: int = 2):
-    """Build a 2-link articulated model (free joint + revolute).
-
-    Using multiple joints/bodies is essential because the indexing
-    bug only manifests when joint_child maps to different bodies
-    across the flat array -- a single-body model has identical
-    indices for all worlds.
+def _build_model_with_per_world_com(device, world_base_coms):
+    """Build a multi-world model where each world has a free-floating
+    body with its own base CoM.
     """
-    template = newton.ModelBuilder()
+    scene = newton.ModelBuilder()
 
-    # Base link (free floating)
-    base = template.add_link(
-        mass=5.0,
-        com=wp.vec3(0.02, 0.05, -0.03),
-        inertia=wp.mat33(np.eye(3) * 0.1),
-    )
-    template.add_shape_sphere(base, radius=0.1)
-    j_free = template.add_joint_free(parent=-1, child=base)
+    for base_com in world_base_coms:
+        template = newton.ModelBuilder()
+        base = template.add_link(
+            mass=5.0,
+            com=base_com,
+            inertia=wp.mat33(np.eye(3) * 0.1),
+        )
+        j_free = template.add_joint_free(parent=-1, child=base)
+        template.add_articulation([j_free])
 
-    # Child link attached via revolute joint
-    child = template.add_link(
-        mass=1.0,
-        com=wp.vec3(-0.05, 0.03, 0.01),
-        inertia=wp.mat33(np.eye(3) * 0.01),
-    )
-    template.add_shape_sphere(child, radius=0.05)
-    j_rev = template.add_joint_revolute(
-        parent=base,
-        child=child,
-        axis=newton.Axis.Y,
-        parent_xform=wp.transform(wp.vec3(0.0, 0.0, -0.3), wp.quat_identity()),
-    )
-    template.add_articulation([j_free, j_rev])
+        scene.begin_world()
+        scene.add_builder(template)
+        scene.end_world()
 
-    if num_worlds == 1:
-        model = template.finalize(device=device)
-    else:
-        builder = newton.ModelBuilder()
-        builder.replicate(template, world_count=num_worlds)
-        model = builder.finalize(device=device)
-    return model
+    return scene.finalize(device=device)
 
 
 def _run_sim(model, num_steps: int = 100, sim_dt: float = 1e-3):
     """Step simulation and return final joint_q as numpy array."""
     solver = SolverMuJoCo(model)
-    solver.notify_model_changed(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
 
     state_0 = model.state()
     state_1 = model.state()
@@ -76,11 +55,9 @@ def _run_sim(model, num_steps: int = 100, sim_dt: float = 1e-3):
     # convert_warp_coords_to_mj_kernel affects the velocity
     # conversion v_origin = v_com - w x com. With w=0 the cross
     # product vanishes and the wrong com is harmless.
-    q_total = model.joint_coord_count
-    qd_total = model.joint_dof_count
     nw = model.world_count
-    q_per_world = q_total // nw
-    qd_per_world = qd_total // nw
+    q_per_world = model.joint_coord_count // nw
+    qd_per_world = model.joint_dof_count // nw
     joint_q = state_0.joint_q.numpy().reshape(nw, q_per_world)
     joint_q[:, 2] = 1.0  # z = 1m for all worlds
     state_0.joint_q.assign(joint_q.flatten())
@@ -105,25 +82,17 @@ def _run_sim(model, num_steps: int = 100, sim_dt: float = 1e-3):
 def test_perworld_com_produces_consistent_physics(test, device):
     """Multi-world with different per-world base CoM should match
     independent single-world runs with the same CoM."""
-    com_a = np.array([0.0, 0.0, 0.0], dtype=np.float32)
-    com_b = np.array([0.05, 0.0, -0.02], dtype=np.float32)
+    com_a = wp.vec3(0.0, 0.0, 0.0)
+    com_b = wp.vec3(0.05, 0.0, -0.02)
 
     # --- Reference: single-world runs ---
     ref_q = {}
     for com_val, label in [(com_a, "A"), (com_b, "B")]:
-        model = _build_articulated_model(device, num_worlds=1)
-        body_com = model.body_com.numpy().reshape(-1, 3)
-        body_com[0] = com_val  # base body
-        model.body_com.assign(body_com.flatten())
+        model = _build_model_with_per_world_com(device, [com_val])
         ref_q[label] = _run_sim(model)
 
     # --- Multi-world run ---
-    model = _build_articulated_model(device, num_worlds=2)
-    bodies_per_world = model.body_count // model.world_count
-    body_com = model.body_com.numpy().reshape(model.world_count, bodies_per_world, 3)
-    body_com[0, 0] = com_a
-    body_com[1, 0] = com_b
-    model.body_com.assign(body_com.reshape(-1, 3))
+    model = _build_model_with_per_world_com(device, [com_a, com_b])
     multi_q = _run_sim(model)
 
     q_per_world = model.joint_coord_count // model.world_count
@@ -150,9 +119,6 @@ class TestMultiworldBodyProperties(unittest.TestCase):
     pass
 
 
-# The buggy code path (convert_warp_coords_to_mj_kernel) runs on any
-# device when SolverMuJoCo is used with use_mujoco_cpu=False (default),
-# so this test must run on all available devices.
 devices = get_test_devices()
 for device in devices:
     add_function_test(

--- a/newton/tests/test_multiworld_body_properties.py
+++ b/newton/tests/test_multiworld_body_properties.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test that per-world body property changes produce correct physics.
+
+Regression test for a bug in convert_warp_coords_to_mj_kernel where
+joint_type and joint_child were indexed with the per-world joint index
+instead of the global index, causing incorrect CoM references for
+worlds with worldid > 0.
+"""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.solvers import SolverMuJoCo, SolverNotifyFlags
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+
+def _build_articulated_model(device, num_worlds: int = 2):
+    """Build a 2-link articulated model (free joint + revolute).
+
+    Using multiple joints/bodies is essential because the indexing
+    bug only manifests when joint_child maps to different bodies
+    across the flat array -- a single-body model has identical
+    indices for all worlds.
+    """
+    template = newton.ModelBuilder()
+
+    # Base link (free floating)
+    base = template.add_link(
+        mass=5.0,
+        com=wp.vec3(0.02, 0.05, -0.03),
+        inertia=wp.mat33(np.eye(3) * 0.1),
+    )
+    template.add_shape_sphere(base, radius=0.1)
+    j_free = template.add_joint_free(parent=-1, child=base)
+
+    # Child link attached via revolute joint
+    child = template.add_link(
+        mass=1.0,
+        com=wp.vec3(-0.05, 0.03, 0.01),
+        inertia=wp.mat33(np.eye(3) * 0.01),
+    )
+    template.add_shape_sphere(child, radius=0.05)
+    j_rev = template.add_joint_revolute(
+        parent=base,
+        child=child,
+        axis=newton.Axis.Y,
+        parent_xform=wp.transform(wp.vec3(0.0, 0.0, -0.3), wp.quat_identity()),
+    )
+    template.add_articulation([j_free, j_rev])
+
+    if num_worlds == 1:
+        model = template.finalize(device=device)
+    else:
+        builder = newton.ModelBuilder()
+        builder.replicate(template, world_count=num_worlds)
+        model = builder.finalize(device=device)
+    return model
+
+
+def _run_sim(model, num_steps: int = 100, sim_dt: float = 1e-3):
+    """Step simulation and return final joint_q as numpy array."""
+    solver = SolverMuJoCo(model)
+    solver.notify_model_changed(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
+
+    state_0 = model.state()
+    state_1 = model.state()
+    control = model.control()
+
+    # Set initial height and angular velocity for all worlds.
+    # Non-zero angular velocity is critical: the bug in
+    # convert_warp_coords_to_mj_kernel affects the velocity
+    # conversion v_origin = v_com - w x com. With w=0 the cross
+    # product vanishes and the wrong com is harmless.
+    q_total = model.joint_coord_count
+    qd_total = model.joint_dof_count
+    nw = model.world_count
+    q_per_world = q_total // nw
+    qd_per_world = qd_total // nw
+    joint_q = state_0.joint_q.numpy().reshape(nw, q_per_world)
+    joint_q[:, 2] = 1.0  # z = 1m for all worlds
+    state_0.joint_q.assign(joint_q.flatten())
+    state_1.joint_q.assign(joint_q.flatten())
+    # Set initial angular velocity (world frame) on the free joint
+    joint_qd = state_0.joint_qd.numpy().reshape(nw, qd_per_world)
+    joint_qd[:, 3] = 1.0  # wx = 1 rad/s
+    joint_qd[:, 4] = 0.5  # wy = 0.5 rad/s
+    state_0.joint_qd.assign(joint_qd.flatten())
+    state_1.joint_qd.assign(joint_qd.flatten())
+    newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+    newton.eval_fk(model, state_1.joint_q, state_1.joint_qd, state_1)
+
+    for _ in range(num_steps):
+        state_0.clear_forces()
+        solver.step(state_0, state_1, control, None, sim_dt)
+        state_0, state_1 = state_1, state_0
+
+    return state_0.joint_q.numpy()
+
+
+def test_perworld_com_produces_consistent_physics(test, device):
+    """Multi-world with different per-world base CoM should match
+    independent single-world runs with the same CoM."""
+    com_a = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    com_b = np.array([0.05, 0.0, -0.02], dtype=np.float32)
+
+    # --- Reference: single-world runs ---
+    ref_q = {}
+    for com_val, label in [(com_a, "A"), (com_b, "B")]:
+        model = _build_articulated_model(device, num_worlds=1)
+        body_com = model.body_com.numpy().reshape(-1, 3)
+        body_com[0] = com_val  # base body
+        model.body_com.assign(body_com.flatten())
+        ref_q[label] = _run_sim(model)
+
+    # --- Multi-world run ---
+    model = _build_articulated_model(device, num_worlds=2)
+    bodies_per_world = model.body_count // model.world_count
+    body_com = model.body_com.numpy().reshape(model.world_count, bodies_per_world, 3)
+    body_com[0, 0] = com_a
+    body_com[1, 0] = com_b
+    model.body_com.assign(body_com.reshape(-1, 3))
+    multi_q = _run_sim(model)
+
+    q_per_world = model.joint_coord_count // model.world_count
+    multi_q = multi_q.reshape(model.world_count, q_per_world)
+
+    np.testing.assert_allclose(
+        multi_q[0],
+        ref_q["A"],
+        atol=1e-4,
+        err_msg="World 0 (com_A) diverges from single-world reference",
+    )
+    np.testing.assert_allclose(
+        multi_q[1],
+        ref_q["B"],
+        atol=1e-4,
+        err_msg="World 1 (com_B) diverges from single-world reference",
+    )
+
+
+class TestMultiworldBodyProperties(unittest.TestCase):
+    """Verify that multi-world simulations with per-world body mass/CoM
+    produce physically consistent results across all worlds."""
+
+    pass
+
+
+# The buggy code path is warp-to-mj coordinate conversion, which only
+# runs on CUDA (SolverMuJoCo with use_mujoco_cpu=False). Skip CPU devices
+# so CPU-only CI runners don't fail.
+devices = [d for d in get_test_devices() if d.is_cuda]
+for device in devices:
+    add_function_test(
+        TestMultiworldBodyProperties,
+        f"test_perworld_com_produces_consistent_physics_{device}",
+        test_perworld_com_produces_consistent_physics,
+        devices=[device],
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


## Description
convert_warp_coords_to_mj_kernel used per-world joint index for joint_type and joint_child instead of the global index. This caused wrong body CoM lookups for worldid > 0. The sibling kernel convert_mj_coords_to_warp_kernel already uses the global index.

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
       uv run --extra dev -m newton.tests -k test_multiworld_body_properties
     ``` -->
  - Without fix: `test_perworld_com_produces_consistent_physics` FAILS
  - With fix: both tests PASS
 
## Bug fix

**Steps to reproduce:**

1. Create a multi-world model with an articulated body (free + revolute joint)
2. Set different `body_com` per world via `model.body_com` + `notify_model_changed(BODY_INERTIAL_PROPERTIES)`
3. Set non-zero initial angular velocity
4. Step physics and compare world 1 result against a single-world reference with the same parameters
5. World 1 diverges because `convert_warp_coords_to_mj_kernel` reads world 0's `joint_child`

**Minimal reproduction:**
See `newton/tests/test_multiworld_body_properties.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed joint indexing across multiple simulation worlds, resolving incorrect center-of-mass and joint handling when running concurrent worlds.

* **Tests**
  * Added regression tests that verify per-world body mass/center-of-mass produce simulation results consistent with equivalent single-world runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->