### PR TITLE
Attempt to minimize overlaps in brick stacking example

### DIFF
--- a/newton/examples/contacts/example_brick_stacking.py
+++ b/newton/examples/contacts/example_brick_stacking.py
@@ -708,7 +708,7 @@ class Example:
             mesh = _build_mesh_with_sdf(self.v_2x4, self.f_2x4, color=colors[i], scale=BRICK_SCALE)
             body = scene.add_body(xform=wp.transform(positions[i], rotations[i]), label=labels[i])
             shape_idx = scene.shape_count
-            #scene.add_shape_mesh(body, mesh=mesh, cfg=brick_cfg)
+            scene.add_shape_mesh(body, mesh=mesh, cfg=brick_cfg)
             if solimp_attr is not None:
                 if solimp_attr.values is None:
                     solimp_attr.values = {}


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Closes https://github.com/newton-physics/newton/issues/2339

Add invisible primitive colliders (boxes + cylinders) to each Lego brick in the
`brick_stacking` example to prevent deep SDF interlock when bricks fall onto
each other.

The detailed SDF mesh faithfully represents the brick cavity and studs, so once
a falling brick's studs enter the cavity of another brick the SDF gradient traps
it instead of pushing it out. The fix adds lightweight primitive shapes that sit
just inside the mesh surface (shrunk by a small `COLLIDER_INSET`) and act as a
penetration backstop:

- **Top-plate box** — covers the brick body from `z = STUD_HEIGHT` to
  `z = BRICK_HEIGHT`, blocking objects from entering the cavity from above.
- **Four wall boxes** — one per side wall, full brick height, preventing
  lateral cavity entry.
- **Stud cylinders** — one per stud with a slightly reduced radius
  (`STUD_RADIUS - 0.0002`), preventing deep stud-on-stud overlap while not
  engaging during normal stacking.

All helper shapes use `is_visible=False` so they are invisible in the viewer.
Contact limits are increased to accommodate the additional collision pairs.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

```
uv run --extra examples -m newton.examples brick_stacking
```

Manually verified that bricks no longer interlock when dropped from ≥ 3 cm, and
that the robot arm can still pick, stack, and release bricks normally.

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

1. Run `uv run --extra examples -m newton.examples brick_stacking`
2. Pick up a brick with the mouse and drop it from ~3 cm onto another brick
3. Observe the bricks interlock — the SDF contacts cannot push them apart once
   the studs enter the opposing cavity

**Minimal reproduction:**

```python
import newton

# Run the brick_stacking example and drop a brick onto another from ~3 cm.
# The bricks interlock and the SDF contacts fail to separate them.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to supply invisible collider configuration for board floors and bricks to control collisions more precisely.
* **Refactor**
  * Collision system reworked and contact capacity increased to handle denser, more robust stacking scenarios.
* **Bug Fixes**
  * Improved stacking stability and reduced interpenetration by combining visible meshes with tuned invisible primitive colliders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->