### PR TITLE
Fix duplicate Reset button in brick stacking example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@
 - Fix VBD self-contact barrier C2 discontinuity at `d = tau` caused by a factor-of-two error in the log-barrier coefficient
 - Fix fast inertia validation treating near-symmetric tensors within `np.allclose()` default tolerances as corrections, aligning CPU and GPU validation warnings
 - Fix URDF joint dynamics friction import so specified friction values are preserved during simulation
+- Fix duplicate Reset button in brick stacking example when using the example browser
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/examples/contacts/example_brick_stacking.py
+++ b/newton/examples/contacts/example_brick_stacking.py
@@ -923,10 +923,6 @@ class Example:
         if errors:
             raise ValueError("Brick stacking verification failed:\n  " + "\n  ".join(errors))
 
-    def gui(self, ui):
-        if ui.button("Reset"):
-            self.reset()
-
 
 if __name__ == "__main__":
     parser = newton.examples.create_parser()


### PR DESCRIPTION
## Description

Remove the duplicate Reset button from the brick stacking example's `gui()` method. The `_ExampleBrowser` already provides a universal Reset button in the Examples panel, so having a second one in Example Options was redundant and confusing.

Closes #2345

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Run the brick stacking example, expand the Examples dropdown, and verify only one Reset button is visible:
```
uv sync --extra examples
uv run -m newton.examples brick_stacking
```

## Bug fix

**Steps to reproduce:**

1. Run any example with `uv run -m newton.examples brick_stacking`
2. Expand the "Examples" collapsing header in the left panel
3. Observe two "Reset" buttons — one under "Examples" and one under "Example Options"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate "Reset" button that appeared in the brick stacking example when accessed through the example browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->