### PR TITLE
Clean up 1.1 changelog: coverage, duplicates, migration guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,9 @@
 - Switch Python build backend from `hatchling` to `uv_build`
 - Switch mesh-SDF collision from triangle-based gradient descent to edge-based Brent's method to reduce contact jitter
 - Unify heightfield and mesh collision pipeline paths; the separate `heightfield_midphase_kernel` and `shape_pairs_heightfield` buffer are removed in favor of the shared mesh midphase
-- Replace per-shape `Model.shape_heightfield_data` / `Model.heightfield_elevation_data` with compact `Model.shape_heightfield_index` / `Model.heightfield_data` / `Model.heightfield_elevations`, matching the SDF indirection pattern. If you accessed `Model.shape_heightfield_data` or `Model.heightfield_elevation_data`, use `Model.heightfield_data` indexed via `Model.shape_heightfield_index` instead.
+- Replace per-shape `Model.shape_heightfield_data` / `Model.heightfield_elevation_data` with compact `Model.shape_heightfield_index` / `Model.heightfield_data` / `Model.heightfield_elevations`, matching the SDF indirection pattern. Use `Model.heightfield_data` indexed via `Model.shape_heightfield_index` instead.
 - Standardize `rigid_contact_normal` to point from shape 0 toward shape 1 (A-to-B), matching the documented convention. Consumers that previously negated the normal on read (XPBD, VBD, MuJoCo, Kamino) no longer need to.
-- Replace `Model.sdf_data` / `sdf_volume` / `sdf_coarse_volume` with texture-based equivalents (`texture_sdf_data`, `texture_sdf_coarse_textures`, `texture_sdf_subgrid_textures`). If you accessed `Model.sdf_data`, `sdf_volume`, or `sdf_coarse_volume`, use `Model.texture_sdf_data`, `texture_sdf_coarse_textures`, and `texture_sdf_subgrid_textures` instead.
+- Replace `Model.sdf_data` / `sdf_volume` / `sdf_coarse_volume` with texture-based equivalents (`texture_sdf_data`, `texture_sdf_coarse_textures`, `texture_sdf_subgrid_textures`). Use `Model.texture_sdf_data`, `texture_sdf_coarse_textures`, and `texture_sdf_subgrid_textures` instead.
 - Render inertia boxes as wireframe lines instead of solid boxes in the GL viewer to avoid occluding objects
 - Make contact reduction normal binning configurable (polyhedron, scan directions, voxel budget) via constants in ``contact_reduction.py``
 - Upgrade GL viewer lighting from Blinn-Phong to Cook-Torrance PBR with GGX distribution, Schlick-GGX geometry, Fresnel-weighted ambient, and ACES filmic tone mapping


### PR DESCRIPTION
## Description

Audit and clean up the 1.1 changelog by cross-referencing every entry against
both `release-1.0` (v1.0.0) and `upstream/release-1.1` commit histories.

**Removed (4 entries):**
- Duplicate Added: `compute_normals`/`compute_uvs` on heightfield/terrain
- Duplicate Fixed: FK child-origin velocity for translated joints
- Already-in-1.0 Fixed: `imgui_bundle>=1.92.6` crash (#1991 — cherry-picked to release-1.0)
- Already-in-1.0 Fixed: Show prismatic joints in GL viewer (#2038 — cherry-picked to release-1.0)

**Added (9 missing entries):**
- Gaussian Splat geometry support (#1882)
- SensorTiledCamera Gaussian sorting modes (#2287)
- Automatic box/sphere/capsule shape fitting in MJCF import (#2011)
- Color and texture reading in `usd.utils.get_mesh()` (#1980)
- `ViewerBase` export from `newton.viewer` (#2187)
- `custom_attributes` on `add_shape_convex_hull()` (moved from Changed → Added)
- `plyfile` → `open3d` dependency swap (#2100)
- `mujoco ~=3.6.0` / `mujoco-warp ~=3.6.0` requirement (#2054)
- `uv_build` backend switch (#2251)
- `ArticulationView` `requires_grad` fix (#1774)

**Improved migration guidance (4 entries):**
- Heightfield data replacement
- SDF data replacement
- MPM collider velocity mode names
- `cylinder_center` → `cylinder_pos` rename

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Changelog-only change — no code modified. Verified by diffing the commit log
of `v1.0.0..upstream/release-1.1` against `release-1.0` cherry-picks to
confirm every entry belongs exclusively to the 1.1 release.