### PR TITLE
Fix selection_cartpole explosion by adding joint armature

### DIFF
--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -57,6 +57,7 @@ class Example:
         verbose = True
 
         world = newton.ModelBuilder()
+        world.default_joint_cfg.armature = 0.1
         world.add_usd(
             newton.examples.get_asset("cartpole.usda"),
             collapse_fixed_joints=COLLAPSE_FIXED_JOINTS,


### PR DESCRIPTION
## Description

The `selection_cartpole` example explodes (velocities go to NaN) after ~25 seconds of simulation. The root cause is the missing joint armature — without it the joint-space inertia matrix becomes ill-conditioned and the aggressive ±20 N bang-bang control excites instability modes that grow unboundedly.

Adding `default_joint_cfg.armature = 0.1` (matching what `robot_cartpole` already uses) regularizes the mass matrix and keeps the simulation stable indefinitely.

Closes #2357

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_selection.example_selection_cartpole
```

Also verified with a standalone script running 5000 frames (~83 s sim time):
- **Before fix:** NaN at frame 1500 (25 s)
- **After fix:** Stable through all 5000 frames

## Bug fix

**Steps to reproduce:**

1. `python -m newton.examples selection_cartpole --world-count 8`
2. Wait ~25 seconds
3. Observe bodies flying apart (NaN velocities)

**Minimal reproduction:**

```python
import newton

world = newton.ModelBuilder()
# No armature set (default 0.0)
world.add_usd(
    newton.examples.get_asset("cartpole.usda"),
    collapse_fixed_joints=False,
    enable_self_collisions=False,
)
scene = newton.ModelBuilder()
scene.replicate(world, world_count=8)
model = scene.finalize()
solver = newton.solvers.SolverMuJoCo(model, disable_contacts=True)
# Simulation explodes after ~1500 frames with bang-bang control
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved physics simulation accuracy in the cartpole example by updating default joint configuration parameters. This adjustment enhances simulation realism and improves model behavior initialization for users running physics-based examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->