### PR TITLE
Document PyTorch compatibility for CUDA 12.4–12.5

### DIFF
--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -187,6 +187,16 @@ not installed. In order to run these tests, include the ``torch-cu12`` or
             # run tests
             python -m newton.tests
 
+.. note::
+
+    The ``torch-cu12`` extra requires PyTorch built against CUDA 12.8. If your
+    driver only supports CUDA 12.4 or 12.5 (check with ``nvidia-smi``), install
+    PyTorch 2.6.0 manually instead of using the ``torch-cu12`` extra:
+
+    .. code-block:: console
+
+        pip install torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
+
 Specific Newton examples can be tested in isolation via the ``-k`` argument:
 
 .. tab-set::

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -159,6 +159,8 @@ with other packages:
     ``examples`` extra). If you encounter installation errors, we recommend upgrading to a later
     Python version, or follow the :doc:`development` guide to install Newton using ``uv``.
 
+.. _running-examples:
+
 Running Examples
 ^^^^^^^^^^^^^^^^
 
@@ -177,6 +179,17 @@ to check the supported CUDA version (shown in the top-right corner of the output
 
     pip install newton[torch-cu12] --extra-index-url https://download.pytorch.org/whl/cu128
     python -m newton.examples robot_anymal_c_walk
+
+.. note::
+
+    The ``torch-cu12`` extra installs PyTorch built against CUDA 12.8. If your
+    driver only supports CUDA 12.4 or 12.5 (check with ``nvidia-smi``), you
+    need to install PyTorch 2.6.0 manually instead:
+
+    .. code-block:: console
+
+        pip install "newton[examples]"
+        pip install torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
 
 See a list of all available examples:
 
@@ -263,7 +276,7 @@ Additional optional dependency sets are defined in ``pyproject.toml``:
    * - ``examples``
      - Dependencies for running examples, including visualization (includes ``sim`` + ``importers``)
    * - ``torch-cu12``
-     - PyTorch (CUDA 12) for running RL policy examples (includes ``examples``)
+     - PyTorch (CUDA 12.8+) for running RL policy examples (includes ``examples``); see :ref:`note above <running-examples>` for CUDA 12.4–12.5
    * - ``torch-cu13``
      - PyTorch (CUDA 13) for running RL policy examples (includes ``examples``)
    * - ``notebook``


### PR DESCRIPTION
## Description

The `torch-cu12` extra installs PyTorch built against CUDA 12.8, which is
incompatible with drivers that only support CUDA 12.4 or 12.5. This adds
notes in the installation and development guides explaining how to manually
install `torch==2.6.0` with `cu124` wheels as a workaround.

Closes #2365

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Documentation-only change. Verified RST syntax by running `uvx pre-commit run -a` (all checks pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CUDA 12.8 requirement for the `torch-cu12` extra and added alternative installation guidance for CUDA 12.4/12.5 support.
  * Improved documentation structure with better navigation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->