### PR TITLE
Example IK Custom: Tune avoidance objective parameters

### DIFF
--- a/newton/examples/ik/example_ik_custom.py
+++ b/newton/examples/ik/example_ik_custom.py
@@ -54,7 +54,7 @@ def _collision_residuals(
     # Softplus of penetration depth to keep it smooth
     dist = wp.length(ee_pos - c)
     delta = (link_radius + r_obs) - dist
-    margin = 0.15
+    margin = 0.12
     pen = wp.log(1.0 + wp.exp(delta / margin)) * margin
 
     residuals[row_idx, start_idx] = weight * pen
@@ -179,8 +179,8 @@ class Example:
         self.links_to_check_collision = [
             ("fr3_link5", 7, 0.06),  # (name, index, radius)
             ("fr3_link7", 9, 0.06),
-            ("fr3_hand_tcp", 10, 0.05),
-            ("fr3_link3", 5, 0.08),  # elbow block: frequent contact risk during reach-backs and around-table moves
+            ("fr3_hand_tcp", 10, 0.10),
+            ("fr3_link3", 5, 0.10),  # elbow block: frequent contact risk during reach-backs and around-table moves
             ("fr3_link4", 6, 0.07),  # proximal forearm: fills gap between elbow and your existing link5 sphere
             ("fr3_link6", 8, 0.06),  # wrist housing: catches close passes near fixtures when orienting the tool
             # Optional but helpful if space is tight around the shoulder/torso:
@@ -227,7 +227,7 @@ class Example:
                     link_radius=link_radius,
                     obstacle_centers=self.obstacle_centers,
                     obstacle_radii=self.obstacle_radii,
-                    weight=50.0,
+                    weight=3.0,
                 )
             )
 


### PR DESCRIPTION
## Description

Tune the parameters for the avoidance objective to reduce the margin and make the object avoidance behavior more interesting.

- Increase the radii of two robot links to better capture the geometry
- Decrease the softplus margin and the avoidance objective weight

resolves #2364 

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Bug fix

See #2364

[Screencast_Example_IK.webm](https://github.com/user-attachments/assets/fb929b44-2fd4-4a8d-8bff-1b1113fe70f9)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted collision detection parameters in the inverse kinematics example, including penetration penalty smoothing and collision sphere configuration.
  * Modified collision objective weighting in the optimization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->