### PR TITLE
ci: prevent gh-pages history bloat by using orphan commits

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -56,15 +56,12 @@ jobs:
           mv docs/_build/html /tmp/docs-latest
           cp docs/_static/gh-pages-404.html /tmp/gh-pages-404.html
 
-          # Switch to gh-pages branch (check existence first to avoid masking other fetch errors)
-          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
-            git fetch origin gh-pages:gh-pages
-            git checkout gh-pages
-          else
-            echo "Creating new gh-pages branch"
-            git checkout --orphan gh-pages
-            git rm -rf . || true
-          fi
+          # Always create a fresh orphan gh-pages branch to prevent history bloat.
+          # Each deploy carries the full Sphinx build (~11 MB environment.pickle),
+          # and accumulating these as normal commits inflates clone size (~418 MB
+          # over 433 deploys). An orphan branch keeps only the latest build.
+          git checkout --orphan gh-pages
+          git rm -rf . || true
 
           # Remove old /latest/ and replace with new build
           rm -rf latest
@@ -88,4 +85,4 @@ jobs:
           # like .venv/ that persist after switching branches)
           git add latest 404.html .nojekyll
           git diff --cached --quiet || git commit -m "Update dev docs from main@${GITHUB_SHA::8}"
-          git push origin gh-pages
+          git push --force origin gh-pages

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -92,15 +92,17 @@ jobs:
           mv docs/_build/html /tmp/docs-release
           cp docs/_static/gh-pages-404.html /tmp/gh-pages-404.html
 
-          # Switch to gh-pages branch (check existence first to avoid masking other fetch errors)
+          # Fetch existing gh-pages content but deploy as orphan commit to prevent
+          # history bloat. Each deploy carries large binary files (environment.pickle
+          # ~11 MB), and accumulating normal commits inflates clone size (~418 MB
+          # over 433 deploys). Orphan commits keep only the latest snapshot.
           if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
-            git fetch origin gh-pages:gh-pages
-            git checkout gh-pages
-          else
-            echo "Creating new gh-pages branch"
-            git checkout --orphan gh-pages
-            git rm -rf . || true
+            git fetch origin gh-pages
+            # Save existing versioned content before creating orphan branch
+            git checkout origin/gh-pages -- . 2>/dev/null || true
           fi
+          # Create orphan branch (no parent commit = no history accumulation)
+          git checkout --orphan gh-pages
 
           # Deploy version directory (remove old if rebuilding)
           rm -rf "$VERSION"
@@ -150,4 +152,4 @@ jobs:
           # like .venv/ that persist after switching branches)
           git add "$VERSION" stable switcher.json index.html 404.html .nojekyll
           git diff --cached --quiet || git commit -m "Release v$VERSION documentation"
-          git push origin gh-pages
+          git push --force origin gh-pages


### PR DESCRIPTION
## Summary
- Changed both `docs-dev.yml` and `docs-release.yml` to always create an orphan `gh-pages` branch instead of appending commits
- Force-push ensures only the latest snapshot is stored, preventing history accumulation
- For release deploys, existing versioned directories are preserved by checking them out before creating the orphan branch

### Problem
Over 433 deploys, the `gh-pages` branch accumulated ~418 MB of near-duplicate binary content (`environment.pickle` ~11 MB per deploy, `searchindex.js`, `.viser` files, etc.) that git cannot delta-compress well. Every `git clone` downloads all of this.

### Solution
Use orphan commits + `git push --force` so the `gh-pages` branch always has exactly one commit with the current docs. This drops clone size from ~418 MB to ~11 MB for the docs portion.

Fixes #2352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflows to improve reliability and consistency in documentation publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->