### PR TITLE
Render arrows for contacts in OpenGL viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Replace per-shape `Model.shape_heightfield_data` / `Model.heightfield_elevation_data` with compact `Model.shape_heightfield_index` / `Model.heightfield_data` / `Model.heightfield_elevations`, matching the SDF indirection pattern
 - Standardize `rigid_contact_normal` to point from shape 0 toward shape 1 (A-to-B), matching the documented convention. Consumers that previously negated the normal on read (XPBD, VBD, MuJoCo, Kamino) no longer need to.
 - Replace `Model.sdf_data` / `sdf_volume` / `sdf_coarse_volume` with texture-based equivalents (`texture_sdf_data`, `texture_sdf_coarse_textures`, `texture_sdf_subgrid_textures`)
+- Render all GL viewer lines (joints, contacts, wireframes) as geometry-shader quads instead of ``GL_LINES`` for uniform width across zoom levels and non-square viewports
 - Render inertia boxes as wireframe lines instead of solid boxes in the GL viewer to avoid occluding objects
 - Make contact reduction normal binning configurable (polyhedron, scan directions, voxel budget) via constants in ``contact_reduction.py``
 - Upgrade GL viewer lighting from Blinn-Phong to Cook-Torrance PBR with GGX distribution, Schlick-GGX geometry, Fresnel-weighted ambient, and ACES filmic tone mapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Add RJ45 plug-socket insertion example with SDF contacts, latch joint, and interactive gizmo
 - Add `TRIANGLE_PRISM` support-function type for heightfield triangles, extruding 1 m along the heightfield's local -Z so GJK/MPR naturally resolves shapes on the back side
 - Add `ViewerGL.log_scalar()` for live scalar time-series plots in the viewer
+- Add `ViewerBase.log_arrows()` for arrow rendering (wide line + arrowhead) in the GL viewer with a dedicated geometry shader
 
 ### Changed
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -15,8 +15,8 @@ from ...utils.mesh import compute_vertex_normals
 from ...utils.texture import normalize_texture
 from .shaders import (
     FrameShader,
+    ShaderArrow,
     ShaderLine,
-    ShaderLineWireframe,
     ShaderShape,
     ShaderSky,
     ShadowShader,
@@ -972,6 +972,9 @@ class RendererGL:
         self.draw_shadows = True
         self.draw_wireframe = False
         self.wireframe_line_width = 1.5  # pixels
+        self.line_width = 1.5  # pixels, for all log_lines batches
+        self.arrow_line_width = 2.0  # pixels, line body of arrows
+        self.arrow_head_size = 8.0  # pixels, arrowhead triangle size
 
         self.background_color = (68.0 / 255.0, 161.0 / 255.0, 255.0 / 255.0)
 
@@ -1138,8 +1141,8 @@ class RendererGL:
         self._shape_shader = ShaderShape(gl)
         self._frame_shader = FrameShader(gl)
         self._sky_shader = ShaderSky(gl)
-        self._line_shader = ShaderLine(gl)
-        self._wireframe_shader = ShaderLineWireframe(gl)
+        self._wireframe_shader = ShaderLine(gl)
+        self._arrow_shader = ShaderArrow(gl)
 
         if not headless:
             self._setup_window_callbacks()
@@ -1201,7 +1204,7 @@ class RendererGL:
                 # This is a non-fatal error that can be safely ignored
                 pass
 
-    def render(self, camera, objects, lines=None, wireframe_shapes=None):
+    def render(self, camera, objects, lines=None, wireframe_shapes=None, arrows=None):
         gl = RendererGL.gl
         self._make_current()
 
@@ -1264,6 +1267,9 @@ class RendererGL:
         # Render lines after main scene but before MSAA resolve
         if lines:
             self._render_lines(lines)
+
+        if arrows:
+            self._render_arrows(arrows)
 
         if wireframe_shapes:
             self._render_wireframe_shapes(wireframe_shapes)
@@ -1838,15 +1844,54 @@ class RendererGL:
         check_gl_error()
 
     def _render_lines(self, lines):
-        """Render all line objects using the line shader."""
-        # Set up line shader once for all line objects
-        self._line_shader.update(self._view_matrix, self._projection_matrix)
+        """Render all line objects using the geometry-shader wide-line pipeline."""
+        gl = RendererGL.gl
+        inv_asp = float(self._screen_height) / float(max(self._screen_width, 1))
+        clip_width = self.line_width * 2.0 / max(self._screen_height, 1)
 
-        with self._line_shader:
+        gl.glEnable(gl.GL_DEPTH_TEST)
+        gl.glDisable(gl.GL_CULL_FACE)
+        gl.glEnable(gl.GL_BLEND)
+        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+
+        identity = np.eye(4, dtype=np.float32)
+        with self._wireframe_shader:
+            self._wireframe_shader.update_frame(
+                self._view_matrix, self._projection_matrix, inv_asp,
+                line_width=clip_width, alpha=1.0,
+            )
+            self._wireframe_shader.set_world(identity)
             for line_obj in lines.values():
                 if hasattr(line_obj, "render"):
                     line_obj.render()
 
+        gl.glDisable(gl.GL_BLEND)
+        check_gl_error()
+
+    def _render_arrows(self, arrows):
+        """Render arrow batches (wide line + arrowhead triangle per segment)."""
+        gl = RendererGL.gl
+        inv_asp = float(self._screen_height) / float(max(self._screen_width, 1))
+        clip_width = self.arrow_line_width * 2.0 / max(self._screen_height, 1)
+        clip_arrow = self.arrow_head_size * 2.0 / max(self._screen_height, 1)
+
+        gl.glEnable(gl.GL_DEPTH_TEST)
+        gl.glDisable(gl.GL_CULL_FACE)
+        gl.glEnable(gl.GL_BLEND)
+        gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
+
+        identity = np.eye(4, dtype=np.float32)
+        with self._arrow_shader:
+            self._arrow_shader.update_frame(
+                self._view_matrix, self._projection_matrix, inv_asp,
+                line_width=clip_width, arrow_size=clip_arrow, alpha=1.0,
+            )
+            self._arrow_shader.set_world(identity)
+            for arrow_obj in arrows.values():
+                if hasattr(arrow_obj, "render"):
+                    arrow_obj.render()
+
+        gl.glDisable(gl.GL_BLEND)
         check_gl_error()
 
     def _render_wireframe_shapes(self, wireframe_shapes):

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1857,8 +1857,11 @@ class RendererGL:
         identity = np.eye(4, dtype=np.float32)
         with self._wireframe_shader:
             self._wireframe_shader.update_frame(
-                self._view_matrix, self._projection_matrix, inv_asp,
-                line_width=clip_width, alpha=1.0,
+                self._view_matrix,
+                self._projection_matrix,
+                inv_asp,
+                line_width=clip_width,
+                alpha=1.0,
             )
             self._wireframe_shader.set_world(identity)
             for line_obj in lines.values():
@@ -1883,8 +1886,12 @@ class RendererGL:
         identity = np.eye(4, dtype=np.float32)
         with self._arrow_shader:
             self._arrow_shader.update_frame(
-                self._view_matrix, self._projection_matrix, inv_asp,
-                line_width=clip_width, arrow_size=clip_arrow, alpha=1.0,
+                self._view_matrix,
+                self._projection_matrix,
+                inv_asp,
+                line_width=clip_width,
+                arrow_size=clip_arrow,
+                alpha=1.0,
             )
             self._arrow_shader.set_world(identity)
             for arrow_obj in arrows.values():

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1846,7 +1846,7 @@ class RendererGL:
         """Render all line objects using the geometry-shader wide-line pipeline."""
         gl = RendererGL.gl
         inv_asp = float(self._screen_height) / float(max(self._screen_width, 1))
-        clip_width = self.line_width * 2.0 / max(self._screen_height, 1)
+        clip_width = max(0.0, self.line_width) * 2.0 / max(self._screen_height, 1)
 
         gl.glEnable(gl.GL_DEPTH_TEST)
         gl.glDisable(gl.GL_CULL_FACE)
@@ -1874,8 +1874,9 @@ class RendererGL:
         """Render arrow batches (wide line + arrowhead triangle per segment)."""
         gl = RendererGL.gl
         inv_asp = float(self._screen_height) / float(max(self._screen_width, 1))
-        clip_width = (2.0 * self.arrow_scale) * 2.0 / max(self._screen_height, 1)
-        clip_arrow = (8.0 * self.arrow_scale) * 2.0 / max(self._screen_height, 1)
+        scale = max(0.0, self.arrow_scale)
+        clip_width = (2.0 * scale) * 2.0 / max(self._screen_height, 1)
+        clip_arrow = (8.0 * scale) * 2.0 / max(self._screen_height, 1)
 
         gl.glEnable(gl.GL_DEPTH_TEST)
         gl.glDisable(gl.GL_CULL_FACE)

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -973,8 +973,7 @@ class RendererGL:
         self.draw_wireframe = False
         self.wireframe_line_width = 1.5  # pixels
         self.line_width = 1.5  # pixels, for all log_lines batches
-        self.arrow_line_width = 2.0  # pixels, line body of arrows
-        self.arrow_head_size = 8.0  # pixels, arrowhead triangle size
+        self.arrow_scale = 1.0  # uniform scale for arrow line width and head size
 
         self.background_color = (68.0 / 255.0, 161.0 / 255.0, 255.0 / 255.0)
 
@@ -1875,8 +1874,8 @@ class RendererGL:
         """Render arrow batches (wide line + arrowhead triangle per segment)."""
         gl = RendererGL.gl
         inv_asp = float(self._screen_height) / float(max(self._screen_width, 1))
-        clip_width = self.arrow_line_width * 2.0 / max(self._screen_height, 1)
-        clip_arrow = self.arrow_head_size * 2.0 / max(self._screen_height, 1)
+        clip_width = (2.0 * self.arrow_scale) * 2.0 / max(self._screen_height, 1)
+        clip_arrow = (8.0 * self.arrow_scale) * 2.0 / max(self._screen_height, 1)
 
         gl.glEnable(gl.GL_DEPTH_TEST)
         gl.glDisable(gl.GL_CULL_FACE)

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -737,9 +737,12 @@ void main()
     float s_depth = s.z / s.w;
     float e_depth = e.z / e.w;
 
-    vec2 dir = e_ndc - s_ndc;
-    vec2 right = normalize(vec2(dir.y, -dir.x));
-    right.x = right.x * inv_asp_ratio;
+    // Compute perpendicular in screen (aspect-corrected) space so line
+    // width is uniform on non-square viewports.
+    vec2 dir_ndc = e_ndc - s_ndc;
+    vec2 dir_scr = vec2(dir_ndc.x / inv_asp_ratio, dir_ndc.y);
+    vec2 right_scr = normalize(vec2(dir_scr.y, -dir_scr.x));
+    vec2 right = vec2(right_scr.x * inv_asp_ratio, right_scr.y);
 
     vec3 color = 0.5 * (vertexColor[0] + vertexColor[1]);
     vec2 xy = 0.5 * line_width * right;
@@ -841,8 +844,11 @@ void main()
     float s_depth = s.z / s.w;
     float e_depth = e.z / e.w;
 
-    vec2 dir = e_ndc - s_ndc;
-    float len = length(dir);
+    // Work in screen space (aspect-corrected) so arrows look correct on
+    // non-square viewports.  screen_x = ndc_x / inv_asp_ratio.
+    vec2 dir_ndc = e_ndc - s_ndc;
+    vec2 dir_scr = vec2(dir_ndc.x / inv_asp_ratio, dir_ndc.y);
+    float len = length(dir_scr);
 
     vec3 color = 0.5 * (vertexColor[0] + vertexColor[1]);
 
@@ -858,9 +864,11 @@ void main()
         return;
     }
 
-    vec2 fwd = dir / len;
-    vec2 right = vec2(fwd.y, -fwd.x);
-    right.x *= inv_asp_ratio;
+    // fwd/right in screen space, then convert offsets back to NDC (scale x by inv_asp_ratio)
+    vec2 fwd_scr = dir_scr / len;
+    vec2 right_scr = vec2(fwd_scr.y, -fwd_scr.x);
+    vec2 fwd   = vec2(fwd_scr.x * inv_asp_ratio, fwd_scr.y);
+    vec2 right = vec2(right_scr.x * inv_asp_ratio, right_scr.y);
 
     // Triangle 1+2: line body quad
     vec2 xy = 0.5 * line_width * right;
@@ -876,10 +884,7 @@ void main()
     EndPrimitive();
 
     // Triangle 3: arrowhead at endpoint
-    vec2 fwd_asp = fwd;
-    fwd_asp.x *= inv_asp_ratio;
-
-    vec2 tip    = e_ndc + fwd_asp * arrow_size;
+    vec2 tip    = e_ndc + fwd * arrow_size;
     vec2 base_l = e_ndc - right * arrow_size * 0.5;
     vec2 base_r = e_ndc + right * arrow_size * 0.5;
 

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -872,23 +872,24 @@ void main()
     vec2 fwd   = vec2(fwd_scr.x * safe_asp, fwd_scr.y);
     vec2 right = vec2(right_scr.x * safe_asp, right_scr.y);
 
-    // Triangle 1+2: line body quad
+    // Shorten the line body so it ends at the arrowhead base
     vec2 xy = 0.5 * line_width * right;
+    vec2 e_body = e_ndc - fwd * arrow_size;
 
-    gl_Position = vec4(s_ndc - xy, s_depth, 1); lineColor = color; EmitVertex();
-    gl_Position = vec4(e_ndc + xy, e_depth, 1); lineColor = color; EmitVertex();
-    gl_Position = vec4(s_ndc + xy, s_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(s_ndc  - xy, s_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_body + xy, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(s_ndc  + xy, s_depth, 1); lineColor = color; EmitVertex();
     EndPrimitive();
 
-    gl_Position = vec4(s_ndc - xy, s_depth, 1); lineColor = color; EmitVertex();
-    gl_Position = vec4(e_ndc - xy, e_depth, 1); lineColor = color; EmitVertex();
-    gl_Position = vec4(e_ndc + xy, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(s_ndc  - xy, s_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_body - xy, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_body + xy, e_depth, 1); lineColor = color; EmitVertex();
     EndPrimitive();
 
-    // Triangle 3: arrowhead at endpoint
-    vec2 tip    = e_ndc + fwd * arrow_size;
-    vec2 base_l = e_ndc - right * arrow_size * 0.5;
-    vec2 base_r = e_ndc + right * arrow_size * 0.5;
+    // Triangle 3: arrowhead with tip exactly at the endpoint
+    vec2 tip    = e_ndc;
+    vec2 base_l = e_body - right * arrow_size * 0.5;
+    vec2 base_r = e_body + right * arrow_size * 0.5;
 
     gl_Position = vec4(tip,    e_depth, 1); lineColor = color; EmitVertex();
     gl_Position = vec4(base_l, e_depth, 1); lineColor = color; EmitVertex();

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -31,35 +31,6 @@ void main() { }
 """
 
 
-line_vertex_shader = """
-#version 330 core
-layout (location = 0) in vec3 aPos;
-layout (location = 1) in vec3 aColor;
-
-uniform mat4 view;
-uniform mat4 projection;
-
-out vec3 vertexColor;
-
-void main()
-{
-    vertexColor = aColor;
-    gl_Position = projection * view * vec4(aPos, 1.0);
-}
-"""
-
-line_fragment_shader = """
-#version 330 core
-in vec3 vertexColor;
-out vec4 FragColor;
-
-void main()
-{
-    FragColor = vec4(vertexColor, 1.0);
-}
-"""
-
-
 shape_vertex_shader = """
 #version 330 core
 layout (location = 0) in vec3 aPos;
@@ -723,30 +694,6 @@ class FrameShader(ShaderGL):
             self._gl.glUniform1i(self.loc_texture, texture_unit)
 
 
-class ShaderLine(ShaderGL):
-    """Simple shader for rendering lines with per-vertex colors."""
-
-    def __init__(self, gl):
-        super().__init__()
-        from pyglet.graphics.shader import Shader, ShaderProgram
-
-        self._gl = gl
-        self.shader_program = ShaderProgram(
-            Shader(line_vertex_shader, "vertex"), Shader(line_fragment_shader, "fragment")
-        )
-
-        # Get uniform locations
-        with self:
-            self.loc_view = self._get_uniform_location("view")
-            self.loc_projection = self._get_uniform_location("projection")
-
-    def update(self, view_matrix: np.ndarray, projection_matrix: np.ndarray):
-        """Update view and projection matrices for line rendering."""
-        with self:
-            self._gl.glUniformMatrix4fv(self.loc_view, 1, self._gl.GL_FALSE, arr_pointer(view_matrix))
-            self._gl.glUniformMatrix4fv(self.loc_projection, 1, self._gl.GL_FALSE, arr_pointer(projection_matrix))
-
-
 wireframe_vertex_shader = """
 #version 330 core
 layout (location = 0) in vec3 aPos;
@@ -829,7 +776,7 @@ void main()
 """
 
 
-class ShaderLineWireframe(ShaderGL):
+class ShaderLine(ShaderGL):
     """Geometry-shader-based line renderer that expands GL_LINES into screen-space quads."""
 
     def __init__(self, gl):
@@ -864,6 +811,124 @@ class ShaderLineWireframe(ShaderGL):
         self._gl.glUniformMatrix4fv(self.loc_projection, 1, self._gl.GL_FALSE, arr_pointer(projection_matrix))
         self._gl.glUniform1f(self.loc_inv_asp_ratio, float(inv_asp_ratio))
         self._gl.glUniform1f(self.loc_line_width, float(line_width))
+        self._gl.glUniform1f(self.loc_alpha, float(alpha))
+
+    def set_world(self, world: np.ndarray):
+        """Set the per-shape world matrix uniform."""
+        self._gl.glUniformMatrix4fv(self.loc_world, 1, self._gl.GL_FALSE, arr_pointer(world))
+
+
+arrow_geometry_shader = """
+#version 330 core
+layout (lines) in;
+layout (triangle_strip, max_vertices = 9) out;
+
+in vec3 vertexColor[2];
+out vec3 lineColor;
+
+uniform float inv_asp_ratio;
+uniform float line_width;
+uniform float arrow_size;
+
+void main()
+{
+    vec4 s = gl_in[0].gl_Position;
+    vec4 e = gl_in[1].gl_Position;
+    if (s.w <= 0.0 || e.w <= 0.0) return;
+
+    vec2 s_ndc = s.xy / s.w;
+    vec2 e_ndc = e.xy / e.w;
+    float s_depth = s.z / s.w;
+    float e_depth = e.z / e.w;
+
+    vec2 dir = e_ndc - s_ndc;
+    float len = length(dir);
+
+    vec3 color = 0.5 * (vertexColor[0] + vertexColor[1]);
+
+    // Degenerate case: line points into/out of screen
+    if (len < 1e-6) {
+        float r = arrow_size * 0.4;
+        vec2 up = vec2(0.0, r);
+        vec2 rt = vec2(r * inv_asp_ratio, 0.0);
+        gl_Position = vec4(e_ndc + up, e_depth, 1); lineColor = color; EmitVertex();
+        gl_Position = vec4(e_ndc - rt, e_depth, 1); lineColor = color; EmitVertex();
+        gl_Position = vec4(e_ndc + rt, e_depth, 1); lineColor = color; EmitVertex();
+        EndPrimitive();
+        return;
+    }
+
+    vec2 fwd = dir / len;
+    vec2 right = vec2(fwd.y, -fwd.x);
+    right.x *= inv_asp_ratio;
+
+    // Triangle 1+2: line body quad
+    vec2 xy = 0.5 * line_width * right;
+
+    gl_Position = vec4(s_ndc - xy, s_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_ndc + xy, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(s_ndc + xy, s_depth, 1); lineColor = color; EmitVertex();
+    EndPrimitive();
+
+    gl_Position = vec4(s_ndc - xy, s_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_ndc - xy, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(e_ndc + xy, e_depth, 1); lineColor = color; EmitVertex();
+    EndPrimitive();
+
+    // Triangle 3: arrowhead at endpoint
+    vec2 fwd_asp = fwd;
+    fwd_asp.x *= inv_asp_ratio;
+
+    vec2 tip    = e_ndc + fwd_asp * arrow_size;
+    vec2 base_l = e_ndc - right * arrow_size * 0.5;
+    vec2 base_r = e_ndc + right * arrow_size * 0.5;
+
+    gl_Position = vec4(tip,    e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(base_l, e_depth, 1); lineColor = color; EmitVertex();
+    gl_Position = vec4(base_r, e_depth, 1); lineColor = color; EmitVertex();
+    EndPrimitive();
+}
+"""
+
+
+class ShaderArrow(ShaderGL):
+    """Geometry-shader-based arrow renderer: wide line + arrowhead triangle per segment."""
+
+    def __init__(self, gl):
+        super().__init__()
+        from pyglet.graphics.shader import Shader, ShaderProgram
+
+        self._gl = gl
+        self.shader_program = ShaderProgram(
+            Shader(wireframe_vertex_shader, "vertex"),
+            Shader(arrow_geometry_shader, "geometry"),
+            Shader(wireframe_fragment_shader, "fragment"),
+        )
+
+        with self:
+            self.loc_view = self._get_uniform_location("view")
+            self.loc_projection = self._get_uniform_location("projection")
+            self.loc_world = self._get_uniform_location("world")
+            self.loc_inv_asp_ratio = self._get_uniform_location("inv_asp_ratio")
+            self.loc_line_width = self._get_uniform_location("line_width")
+            self.loc_arrow_size = self._get_uniform_location("arrow_size")
+            self.loc_alpha = self._get_uniform_location("alpha")
+
+    def update_frame(
+        self,
+        view_matrix: np.ndarray,
+        projection_matrix: np.ndarray,
+        inv_asp_ratio: float,
+        line_width: float = 0.003,
+        arrow_size: float = 0.01,
+        alpha: float = 1.0,
+    ):
+        """Set per-frame uniforms (call once before rendering all arrow batches)."""
+        self._gl.glUniformMatrix4fv(self.loc_view, 1, self._gl.GL_FALSE, arr_pointer(view_matrix))
+        self._gl.glUniformMatrix4fv(self.loc_projection, 1, self._gl.GL_FALSE, arr_pointer(projection_matrix))
+        self._gl.glUniform1f(self.loc_inv_asp_ratio, float(inv_asp_ratio))
+        self._gl.glUniform1f(self.loc_line_width, float(line_width))
+        self._gl.glUniform1f(self.loc_arrow_size, float(arrow_size))
         self._gl.glUniform1f(self.loc_alpha, float(alpha))
 
     def set_world(self, world: np.ndarray):

--- a/newton/_src/viewer/gl/shaders.py
+++ b/newton/_src/viewer/gl/shaders.py
@@ -739,10 +739,11 @@ void main()
 
     // Compute perpendicular in screen (aspect-corrected) space so line
     // width is uniform on non-square viewports.
+    float safe_asp = max(inv_asp_ratio, 1e-6);
     vec2 dir_ndc = e_ndc - s_ndc;
-    vec2 dir_scr = vec2(dir_ndc.x / inv_asp_ratio, dir_ndc.y);
+    vec2 dir_scr = vec2(dir_ndc.x / safe_asp, dir_ndc.y);
     vec2 right_scr = normalize(vec2(dir_scr.y, -dir_scr.x));
-    vec2 right = vec2(right_scr.x * inv_asp_ratio, right_scr.y);
+    vec2 right = vec2(right_scr.x * safe_asp, right_scr.y);
 
     vec3 color = 0.5 * (vertexColor[0] + vertexColor[1]);
     vec2 xy = 0.5 * line_width * right;
@@ -846,8 +847,9 @@ void main()
 
     // Work in screen space (aspect-corrected) so arrows look correct on
     // non-square viewports.  screen_x = ndc_x / inv_asp_ratio.
+    float safe_asp = max(inv_asp_ratio, 1e-6);
     vec2 dir_ndc = e_ndc - s_ndc;
-    vec2 dir_scr = vec2(dir_ndc.x / inv_asp_ratio, dir_ndc.y);
+    vec2 dir_scr = vec2(dir_ndc.x / safe_asp, dir_ndc.y);
     float len = length(dir_scr);
 
     vec3 color = 0.5 * (vertexColor[0] + vertexColor[1]);
@@ -856,7 +858,7 @@ void main()
     if (len < 1e-6) {
         float r = arrow_size * 0.4;
         vec2 up = vec2(0.0, r);
-        vec2 rt = vec2(r * inv_asp_ratio, 0.0);
+        vec2 rt = vec2(r * safe_asp, 0.0);
         gl_Position = vec4(e_ndc + up, e_depth, 1); lineColor = color; EmitVertex();
         gl_Position = vec4(e_ndc - rt, e_depth, 1); lineColor = color; EmitVertex();
         gl_Position = vec4(e_ndc + rt, e_depth, 1); lineColor = color; EmitVertex();
@@ -864,11 +866,11 @@ void main()
         return;
     }
 
-    // fwd/right in screen space, then convert offsets back to NDC (scale x by inv_asp_ratio)
+    // fwd/right in screen space, then convert offsets back to NDC (scale x by safe_asp)
     vec2 fwd_scr = dir_scr / len;
     vec2 right_scr = vec2(fwd_scr.y, -fwd_scr.x);
-    vec2 fwd   = vec2(fwd_scr.x * inv_asp_ratio, fwd_scr.y);
-    vec2 right = vec2(right_scr.x * inv_asp_ratio, right_scr.y);
+    vec2 fwd   = vec2(fwd_scr.x * safe_asp, fwd_scr.y);
+    vec2 right = vec2(right_scr.x * safe_asp, right_scr.y);
 
     // Triangle 1+2: line body quad
     vec2 xy = 0.5 * line_width * right;

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -597,8 +597,11 @@ class ViewerBase(ABC):
         self._log_com(state)
 
     def log_contacts(self, contacts: newton.Contacts, state: newton.State):
-        """
-        Creates line segments along contact normals for rendering.
+        """Render contact normals as arrows.
+
+        Each active rigid contact is drawn as an arrow from the contact point
+        along the contact normal.  When ``show_contacts`` is ``False`` the
+        arrow batch is cleared.
 
         Args:
             contacts: The contacts to render.
@@ -1083,15 +1086,21 @@ class ViewerBase(ABC):
         width: float = 0.01,
         hidden: bool = False,
     ):
-        """
-        Log line segments for rendering.
+        """Log line segments for rendering.
+
+        Lines are rendered as screen-space quads whose pixel width is
+        controlled by the renderer (e.g. ``RendererGL.line_width``).
+        The *width* parameter is currently unused and reserved for
+        future world-space width support.
 
         Args:
             name: Unique path/name for the line batch.
             starts: Optional line start points as a Warp vec3 array.
             ends: Optional line end points as a Warp vec3 array.
             colors: Per-line colors as a Warp array, or a single RGB triplet.
-            width: Line width in rendered scene units.
+            width: Reserved for future use (world-space line width).
+                Currently ignored; line width is set in screen-space pixels
+                via the renderer.
             hidden: Whether the line batch should be hidden.
         """
         pass
@@ -1108,7 +1117,7 @@ class ViewerBase(ABC):
         """Log arrow segments (line + arrowhead) for rendering.
 
         The GL viewer renders these with a dedicated arrow shader that draws
-        a wide line plus a fixed-pixel-size arrowhead triangle per segment.
+        a screen-space quad line body plus a triangular arrowhead per segment.
         Other backends fall back to :meth:`log_lines`.
 
         Args:
@@ -1116,7 +1125,9 @@ class ViewerBase(ABC):
             starts: Optional arrow start points as a Warp vec3 array.
             ends: Optional arrow end points (arrowhead tip) as a Warp vec3 array.
             colors: Per-arrow colors as a Warp array, or a single RGB triplet.
-            width: Line width in rendered scene units.
+            width: Reserved for future use (world-space line width).
+                Currently ignored; arrow size is set in screen-space pixels
+                via the renderer (e.g. ``RendererGL.arrow_scale``).
             hidden: Whether the arrow batch should be hidden.
         """
         self.log_lines(name, starts, ends, colors, width=width, hidden=hidden)
@@ -2027,7 +2038,6 @@ class ViewerBase(ABC):
             state: Current simulation state
         """
         if not self.show_joints:
-            # Pass None to hide joints - renderer will handle creating empty arrays
             self.log_lines("/model/joints", None, None, None)
             return
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -606,8 +606,7 @@ class ViewerBase(ABC):
         """
 
         if not self.show_contacts:
-            # Pass None to hide joints - renderer will handle creating empty arrays
-            self.log_lines("/contacts", None, None, None)
+            self.log_arrows("/contacts", None, None, None)
             return
 
         # Get contact count, clamped to buffer size (counter may exceed max on overflow)
@@ -647,7 +646,7 @@ class ViewerBase(ABC):
                 device=self.device,
             )
 
-        # Always call log_lines to update the renderer (handles zero contacts gracefully)
+        # Always call log_arrows to update the renderer (handles zero contacts gracefully)
         if num_contacts > 0:
             # Slice arrays to only include active contacts
             starts = self._contact_points0[:num_contacts]
@@ -657,10 +656,9 @@ class ViewerBase(ABC):
             starts = wp.array([], dtype=wp.vec3, device=self.device)
             ends = wp.array([], dtype=wp.vec3, device=self.device)
 
-        # Use green color for contact normals
         colors = (0.0, 1.0, 0.0)
 
-        self.log_lines("/contacts", starts, ends, colors)
+        self.log_arrows("/contacts", starts, ends, colors)
 
     def log_hydro_contact_surface(
         self,
@@ -1097,6 +1095,31 @@ class ViewerBase(ABC):
             hidden: Whether the line batch should be hidden.
         """
         pass
+
+    def log_arrows(
+        self,
+        name: str,
+        starts: wp.array[wp.vec3] | None,
+        ends: wp.array[wp.vec3] | None,
+        colors: (wp.array[wp.vec3] | wp.array[wp.float32] | tuple[float, float, float] | list[float] | None),
+        width: float = 0.01,
+        hidden: bool = False,
+    ):
+        """Log arrow segments (line + arrowhead) for rendering.
+
+        The GL viewer renders these with a dedicated arrow shader that draws
+        a wide line plus a fixed-pixel-size arrowhead triangle per segment.
+        Other backends fall back to :meth:`log_lines`.
+
+        Args:
+            name: Unique path/name for the arrow batch.
+            starts: Optional arrow start points as a Warp vec3 array.
+            ends: Optional arrow end points (arrowhead tip) as a Warp vec3 array.
+            colors: Per-arrow colors as a Warp array, or a single RGB triplet.
+            width: Line width in rendered scene units.
+            hidden: Whether the arrow batch should be hidden.
+        """
+        self.log_lines(name, starts, ends, colors, width=width, hidden=hidden)
 
     def log_wireframe_shape(  # noqa: B027
         self,

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -886,6 +886,8 @@ class ViewerGL(ViewerBase):
             else:
                 # Handle zero lines case
                 colors = wp.array([], dtype=wp.vec3, device=self.device)
+        elif isinstance(colors, wp.array) and colors.dtype == wp.float32:
+            colors = colors.reshape((num_lines, 3)).view(dtype=wp.vec3)
 
         assert isinstance(colors, wp.array)
         assert len(colors) == num_lines, "Number of line colors must match line begins"
@@ -946,6 +948,8 @@ class ViewerGL(ViewerBase):
                 colors.fill_(color_vec)
             else:
                 colors = wp.array([], dtype=wp.vec3, device=self.device)
+        elif isinstance(colors, wp.array) and colors.dtype == wp.float32:
+            colors = colors.reshape((num_arrows, 3)).view(dtype=wp.vec3)
 
         assert isinstance(colors, wp.array)
         assert len(colors) == num_arrows, "Number of arrow colors must match arrow begins"

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -850,15 +850,20 @@ class ViewerGL(ViewerBase):
         width: float = 0.01,
         hidden: bool = False,
     ):
-        """
-        Log line data for rendering.
+        """Log line data for rendering.
+
+        Lines are drawn as screen-space quads whose pixel width is set by
+        :pyattr:`RendererGL.line_width`.  The *width* parameter is currently
+        unused and reserved for future world-space width support.
 
         Args:
             name: Unique identifier for the line batch.
             starts: Array of line start positions (shape: [N, 3]) or None for empty.
             ends: Array of line end positions (shape: [N, 3]) or None for empty.
             colors: Array of line colors (shape: [N, 3]) or tuple/list of RGB or None for empty.
-            width: The width of the lines.
+            width: Reserved for future use (world-space line width).
+                Currently ignored; pixel width is controlled by
+                ``RendererGL.line_width``.
             hidden: Whether the lines are initially hidden.
         """
         # Handle empty logs by resetting the LinesGL object
@@ -909,14 +914,19 @@ class ViewerGL(ViewerBase):
         width: float = 0.01,
         hidden: bool = False,
     ):
-        """Log arrow data for rendering (wide line + arrowhead per segment).
+        """Log arrow data for rendering (screen-space quad line + arrowhead per segment).
+
+        Arrow size is controlled in screen-space pixels by
+        ``RendererGL.arrow_scale``.
 
         Args:
             name: Unique identifier for the arrow batch.
             starts: Array of arrow start positions (shape: [N, 3]) or None for empty.
             ends: Array of arrow end positions / arrowhead tips (shape: [N, 3]) or None for empty.
             colors: Array of arrow colors (shape: [N, 3]) or tuple/list of RGB or None for empty.
-            width: The width of the arrow lines.
+            width: Reserved for future use (world-space line width).
+                Currently ignored; pixel dimensions are controlled by
+                ``RendererGL.arrow_scale``.
             hidden: Whether the arrows are initially hidden.
         """
         if starts is None or ends is None or colors is None:
@@ -2172,11 +2182,8 @@ class ViewerGL(ViewerBase):
                     changed, self.show_contacts = imgui.checkbox("Show Contacts", show_contacts)
 
                     if self.show_contacts:
-                        _, self.renderer.arrow_line_width = imgui.slider_float(
-                            "Arrow Line Width (px)", self.renderer.arrow_line_width, 0.5, 5.0
-                        )
-                        _, self.renderer.arrow_head_size = imgui.slider_float(
-                            "Arrow Head Size (px)", self.renderer.arrow_head_size, 2.0, 20.0
+                        _, self.renderer.arrow_scale = imgui.slider_float(
+                            "Arrow Scale", self.renderer.arrow_scale, 0.25, 5.0
                         )
 
                     # Particle visualization

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -853,7 +853,7 @@ class ViewerGL(ViewerBase):
         """Log line data for rendering.
 
         Lines are drawn as screen-space quads whose pixel width is set by
-        :pyattr:`RendererGL.line_width`.  The *width* parameter is currently
+        :attr:`RendererGL.line_width`.  The *width* parameter is currently
         unused and reserved for future world-space width support.
 
         Args:

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -406,8 +406,15 @@ class ViewerGL(ViewerBase):
         and whenever the current model is discarded.
         """
         # Render object and line caches (path -> GL object)
+        for obj in getattr(self, "objects", {}).values():
+            if hasattr(obj, "destroy"):
+                obj.destroy()
         self.objects = {}
+        for obj in getattr(self, "lines", {}).values():
+            obj.destroy()
         self.lines = {}
+        for obj in getattr(self, "arrows", {}).values():
+            obj.destroy()
         self.arrows = {}
         self._destroy_all_wireframes()
         self.wireframe_shapes = {}
@@ -581,7 +588,8 @@ class ViewerGL(ViewerBase):
         current_names = {s.name for s in self._shape_instances.values()}
         stale = [k for k, v in self.objects.items() if isinstance(v, MeshInstancerGL) and k not in current_names]
         for k in stale:
-            del self.objects[k]
+            obj = self.objects.pop(k)
+            del obj
 
         shape_scale = self.model.shape_scale
         if shape_scale.device != self.device:
@@ -728,8 +736,10 @@ class ViewerGL(ViewerBase):
             resized = True
         elif transform_count > instancer.num_instances:
             new_capacity = max(transform_count, instancer.num_instances * 2)
+            old = instancer
             instancer = MeshInstancerGL(new_capacity, self.objects[mesh])
             self.objects[name] = instancer
+            del old
             resized = True
 
         needs_update = resized or not hidden
@@ -887,6 +897,7 @@ class ViewerGL(ViewerBase):
             self.lines[name] = LinesGL(max_lines, self.device, hidden=hidden)
 
         self.lines[name].update(starts, ends, colors)
+        self.lines[name].hidden = hidden
 
     @override
     def log_arrows(
@@ -938,6 +949,7 @@ class ViewerGL(ViewerBase):
             self.arrows[name] = LinesGL(max_arrows, self.device, hidden=hidden)
 
         self.arrows[name].update(starts, ends, colors)
+        self.arrows[name].hidden = hidden
 
     @override
     def log_wireframe_shape(
@@ -1032,6 +1044,7 @@ class ViewerGL(ViewerBase):
             old = self.objects[name]
             new_capacity = max(num_points, old.num_instances * 2)
             self.objects[name] = MeshInstancerGL(new_capacity, self._point_mesh)
+            del old
             object_recreated = True
 
         if radii is None:
@@ -1136,8 +1149,10 @@ class ViewerGL(ViewerBase):
             self.objects[name].cast_shadow = False
             recreated = True
         elif n > self.objects[name].num_instances:
-            self.objects[name] = MeshInstancerGL(max(n, self.objects[name].num_instances * 2), self._gaussian_mesh)
+            old = self.objects[name]
+            self.objects[name] = MeshInstancerGL(max(n, old.num_instances * 2), self._gaussian_mesh)
             self.objects[name].cast_shadow = False
+            del old
             recreated = True
 
         instancer = self.objects[name]

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -408,6 +408,7 @@ class ViewerGL(ViewerBase):
         # Render object and line caches (path -> GL object)
         self.objects = {}
         self.lines = {}
+        self.arrows = {}
         self._destroy_all_wireframes()
         self.wireframe_shapes = {}
         self._wireframe_vbo_owners: dict[int, WireframeShapeGL] = {}
@@ -886,6 +887,57 @@ class ViewerGL(ViewerBase):
             self.lines[name] = LinesGL(max_lines, self.device, hidden=hidden)
 
         self.lines[name].update(starts, ends, colors)
+
+    @override
+    def log_arrows(
+        self,
+        name: str,
+        starts: wp.array[wp.vec3] | None,
+        ends: wp.array[wp.vec3] | None,
+        colors: (wp.array[wp.vec3] | wp.array[wp.float32] | tuple[float, float, float] | list[float] | None),
+        width: float = 0.01,
+        hidden: bool = False,
+    ):
+        """Log arrow data for rendering (wide line + arrowhead per segment).
+
+        Args:
+            name: Unique identifier for the arrow batch.
+            starts: Array of arrow start positions (shape: [N, 3]) or None for empty.
+            ends: Array of arrow end positions / arrowhead tips (shape: [N, 3]) or None for empty.
+            colors: Array of arrow colors (shape: [N, 3]) or tuple/list of RGB or None for empty.
+            width: The width of the arrow lines.
+            hidden: Whether the arrows are initially hidden.
+        """
+        if starts is None or ends is None or colors is None:
+            if name in self.arrows:
+                self.arrows[name].update(None, None, None)
+            return
+
+        assert isinstance(starts, wp.array)
+        assert isinstance(ends, wp.array)
+        num_arrows = len(starts)
+        assert len(ends) == num_arrows, "Number of arrow ends must match arrow begins"
+
+        if isinstance(colors, tuple | list):
+            if num_arrows > 0:
+                color_vec = wp.vec3(*colors)
+                colors = wp.zeros(num_arrows, dtype=wp.vec3, device=self.device)
+                colors.fill_(color_vec)
+            else:
+                colors = wp.array([], dtype=wp.vec3, device=self.device)
+
+        assert isinstance(colors, wp.array)
+        assert len(colors) == num_arrows, "Number of arrow colors must match arrow begins"
+
+        if name not in self.arrows:
+            max_arrows = max(num_arrows, 1000)
+            self.arrows[name] = LinesGL(max_arrows, self.device, hidden=hidden)
+        elif num_arrows > self.arrows[name].max_lines:
+            self.arrows[name].destroy()
+            max_arrows = max(num_arrows, self.arrows[name].max_lines * 2)
+            self.arrows[name] = LinesGL(max_arrows, self.device, hidden=hidden)
+
+        self.arrows[name].update(starts, ends, colors)
 
     @override
     def log_wireframe_shape(
@@ -1383,7 +1435,7 @@ class ViewerGL(ViewerBase):
             return
 
         # Render the scene and present it
-        self.renderer.render(self.camera, self.objects, self.lines, self.wireframe_shapes)
+        self.renderer.render(self.camera, self.objects, self.lines, self.wireframe_shapes, self.arrows)
 
         # Always update FPS tracking, even if UI is hidden
         self._update_fps()
@@ -2104,6 +2156,14 @@ class ViewerGL(ViewerBase):
                     show_contacts = self.show_contacts
                     changed, self.show_contacts = imgui.checkbox("Show Contacts", show_contacts)
 
+                    if self.show_contacts:
+                        _, self.renderer.arrow_line_width = imgui.slider_float(
+                            "Arrow Line Width (px)", self.renderer.arrow_line_width, 0.5, 5.0
+                        )
+                        _, self.renderer.arrow_head_size = imgui.slider_float(
+                            "Arrow Head Size (px)", self.renderer.arrow_head_size, 2.0, 20.0
+                        )
+
                     # Particle visualization
                     show_particles = self.show_particles
                     changed, self.show_particles = imgui.checkbox("Show Particles", show_particles)
@@ -2131,7 +2191,7 @@ class ViewerGL(ViewerBase):
 
                     if self.sdf_margin_mode != self.SDFMarginMode.OFF:
                         _, self.renderer.wireframe_line_width = imgui.slider_float(
-                            "Line Width (px)", self.renderer.wireframe_line_width, 0.5, 5.0
+                            "Wireframe Width (px)", self.renderer.wireframe_line_width, 0.5, 5.0
                         )
 
                     # Visual geometry toggle


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Replaces the very thin lines that were used for contact rendering with wider, better visible arrows. Requested by Disney.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arrow visualization for contact normals (wide lines with arrowheads).
  * New logging API to emit arrows and renderer support to display them.
  * UI slider to control arrow scale.

* **Improvements**
  * More consistent wide-line and arrow appearance across viewports/aspect ratios.
  * Clarified wireframe width label in UI.
  * Improved GPU resource cleanup to avoid stale rendering caches.

* **Documentation**
  * Changelog entry documenting the new arrow logging API and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->