### PR TITLE
Expose xpbd contact force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `SolverXPBD.update_contacts()` to populate `contacts.force` with per-contact linear forces derived from XPBD constraint impulses
+- Add `SolverXPBD.update_contacts()` to populate `contacts.force` with per-contact spatial forces (linear force and torque) derived from XPBD constraint impulses
 - Add repeatable `--warp-config KEY=VALUE` CLI option for overriding `warp.config` attributes when running examples
 - Add 3D texture-based SDF, replacing NanoVDB volumes in the mesh-mesh collision pipeline for improved performance and CPU compatibility.
 - Parse URDF joint `limit effort="..."` values and propagate them to imported revolute and prismatic joint `effort_limit` settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add `SolverXPBD.update_contacts()` to populate `contacts.force` with per-contact linear forces derived from XPBD constraint impulses
 - Add repeatable `--warp-config KEY=VALUE` CLI option for overriding `warp.config` attributes when running examples
 - Add 3D texture-based SDF, replacing NanoVDB volumes in the mesh-mesh collision pipeline for improved performance and CPU compatibility.
 - Parse URDF joint `limit effort="..."` values and propagate them to imported revolute and prismatic joint `effort_limit` settings

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1282,7 +1282,15 @@ and is consumed by the solver :meth:`~solvers.SolverBase.step` method for contac
    * - Attribute
      - Description
    * - :attr:`~Contacts.force`
-     - Contact spatial forces (used by :class:`~sensors.SensorContact`)
+     - Contact spatial forces (used by :class:`~sensors.SensorContact`).
+       Populated by :meth:`~solvers.SolverBase.update_contacts`.
+
+.. note::
+
+   :class:`~solvers.SolverXPBD` with ``rigid_contact_con_weighting`` enabled
+   (the default) does not conserve momentum at contacts.  The per-contact
+   forces written by :meth:`~solvers.SolverXPBD.update_contacts` are
+   approximate -- see that method's documentation for details.
 
 Example usage:
 

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2078,6 +2078,7 @@ def solve_body_contact_positions(
     # outputs
     deltas: wp.array[wp.spatial_vector],
     contact_inv_weight: wp.array[float],
+    contact_impulse: wp.array[wp.spatial_vector],
 ):
     tid = wp.tid()
 
@@ -2284,6 +2285,37 @@ def solve_body_contact_positions(
         wp.atomic_add(deltas, body_a, wp.spatial_vector(lin_delta_a, ang_delta_a))
     if body_b >= 0:
         wp.atomic_add(deltas, body_b, wp.spatial_vector(lin_delta_b, ang_delta_b))
+
+    if contact_impulse:
+        # Accumulate per-contact impulse as spatial wrench on body0 at its COM (world frame).
+        # lin_delta_a already contains the full linear impulse contribution (normal + friction +
+        # torsion + rolling) from this iteration.  Torque at body0 COM = r_a × force.
+        r_a_com = bx_a - wp.transform_point(X_wb_a, com_a)
+        torque_on_a = wp.cross(r_a_com, lin_delta_a)
+        wp.atomic_add(contact_impulse, tid, wp.spatial_vector(lin_delta_a, torque_on_a))
+
+
+@wp.kernel
+def convert_contact_impulse_to_force(
+    contact_count: wp.array[int],
+    contact_impulse: wp.array[wp.spatial_vector],
+    dt: float,
+    # output
+    contact_force: wp.array[wp.spatial_vector],
+):
+    """Convert accumulated per-contact impulse to force in ``contacts.force`` format.
+
+    The XPBD lambda convention used in this solver already absorbs one power
+    of ``dt`` (see ``compute_contact_constraint_delta``), so dividing the
+    accumulated impulse by the substep ``dt`` yields force [N].
+    """
+    tid = wp.tid()
+    count = contact_count[0]
+    if tid >= count:
+        contact_force[tid] = wp.spatial_vector()
+        return
+
+    contact_force[tid] = contact_impulse[tid] * (1.0 / dt)
 
 
 @wp.kernel

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2291,6 +2291,57 @@ def solve_body_contact_positions(
 
 
 @wp.kernel
+def accumulate_weighted_contact_impulse(
+    contact_count: wp.array[int],
+    contact_impulse_iter: wp.array[wp.spatial_vector],
+    contact_shape0: wp.array[int],
+    contact_shape1: wp.array[int],
+    shape_body: wp.array[int],
+    constraint_inv_weight: wp.array[float],
+    # output (accumulated across iterations)
+    contact_impulse: wp.array[wp.spatial_vector],
+):
+    """Scale per-contact impulse from one iteration by 1/N and accumulate.
+
+    ``constraint_inv_weight[body]`` holds the number of active contacts on
+    each body for the current iteration.  Dividing the raw impulse by that
+    count mirrors the 1/N scaling that ``apply_body_deltas`` applies, so the
+    accumulated impulse reflects the actual correction applied to the body.
+
+    Both bodies are checked; the larger contact count is used so that the
+    reported force is correct regardless of which body is dynamic.
+    """
+    tid = wp.tid()
+    count = contact_count[0]
+    if tid >= count:
+        return
+
+    impulse = contact_impulse_iter[tid]
+
+    weight = 1.0
+    if constraint_inv_weight:
+        inv_w = 0.0
+        shape_a = contact_shape0[tid]
+        if shape_a >= 0:
+            body_a = shape_body[shape_a]
+            if body_a >= 0:
+                inv_w = wp.max(inv_w, constraint_inv_weight[body_a])
+        shape_b = contact_shape1[tid]
+        if shape_b >= 0:
+            body_b = shape_body[shape_b]
+            if body_b >= 0:
+                inv_w = wp.max(inv_w, constraint_inv_weight[body_b])
+        if inv_w > 0.0:
+            weight = 1.0 / inv_w
+
+    scaled = wp.spatial_vector(
+        wp.spatial_top(impulse) * weight,
+        wp.spatial_bottom(impulse) * weight,
+    )
+    wp.atomic_add(contact_impulse, tid, scaled)
+
+
+@wp.kernel
 def convert_contact_impulse_to_force(
     contact_count: wp.array[int],
     contact_impulse: wp.array[wp.spatial_vector],
@@ -2305,6 +2356,10 @@ def convert_contact_impulse_to_force(
     accumulated impulse by the substep ``dt`` yields force [N] and torque [N·m].
     The linear component includes normal and friction forces; the angular
     component includes torsional and rolling friction torques.
+
+    The impulse is expected to already include the 1/N contact-weighting
+    correction (applied by ``accumulate_weighted_contact_impulse`` each
+    iteration).
     """
     tid = wp.tid()
     count = contact_count[0]

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2078,7 +2078,7 @@ def solve_body_contact_positions(
     # outputs
     deltas: wp.array[wp.spatial_vector],
     contact_inv_weight: wp.array[float],
-    contact_impulse: wp.array[wp.vec3],
+    contact_impulse: wp.array[wp.spatial_vector],
 ):
     tid = wp.tid()
 
@@ -2287,24 +2287,24 @@ def solve_body_contact_positions(
         wp.atomic_add(deltas, body_b, wp.spatial_vector(lin_delta_b, ang_delta_b))
 
     if contact_impulse:
-        contact_impulse[tid] = contact_impulse[tid] + lin_delta_a
+        wp.atomic_add(contact_impulse, tid, wp.spatial_vector(lin_delta_a, ang_delta_a))
 
 
 @wp.kernel
 def convert_contact_impulse_to_force(
     contact_count: wp.array[int],
-    contact_impulse: wp.array[wp.vec3],
+    contact_impulse: wp.array[wp.spatial_vector],
     dt: float,
     # output
     contact_force: wp.array[wp.spatial_vector],
 ):
-    """Convert accumulated per-contact linear impulse to ``contacts.force`` spatial vectors.
+    """Convert accumulated per-contact spatial impulse to ``contacts.force`` spatial vectors.
 
     The XPBD lambda convention used in this solver already absorbs one power
     of ``dt`` (see ``compute_contact_constraint_delta``), so dividing the
-    accumulated impulse by the substep ``dt`` yields force [N].  The torque
-    component is left zero; downstream consumers such as :class:`SensorContact`
-    compute moments from the contact point and force direction themselves.
+    accumulated impulse by the substep ``dt`` yields force [N] and torque [N·m].
+    The linear component includes normal and friction forces; the angular
+    component includes torsional and rolling friction torques.
     """
     tid = wp.tid()
     count = contact_count[0]
@@ -2312,8 +2312,11 @@ def convert_contact_impulse_to_force(
         contact_force[tid] = wp.spatial_vector()
         return
 
-    f = contact_impulse[tid] * (1.0 / dt)
-    contact_force[tid] = wp.spatial_vector(f, wp.vec3(0.0))
+    inv_dt = 1.0 / dt
+    impulse = contact_impulse[tid]
+    f = wp.spatial_top(impulse) * inv_dt
+    tau = wp.spatial_bottom(impulse) * inv_dt
+    contact_force[tid] = wp.spatial_vector(f, tau)
 
 
 @wp.kernel

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2304,12 +2304,16 @@ def accumulate_weighted_contact_impulse(
     """Scale per-contact impulse from one iteration by 1/N and accumulate.
 
     ``constraint_inv_weight[body]`` holds the number of active contacts on
-    each body for the current iteration.  Dividing the raw impulse by that
-    count mirrors the 1/N scaling that ``apply_body_deltas`` applies, so the
-    accumulated impulse reflects the actual correction applied to the body.
+    each body for the current iteration.  ``apply_body_deltas`` divides the
+    positional correction by that count, so the raw impulse stored per contact
+    is N times too large relative to what was actually applied.
 
-    Both bodies are checked; the larger contact count is used so that the
-    reported force is correct regardless of which body is dynamic.
+    When only one body is dynamic (the other is kinematic / ground), the
+    weight is simply ``1/N_dynamic``.  When both bodies are dynamic the
+    solver applies ``1/N_a`` to body A and ``1/N_b`` to body B, so there is
+    no single exact scalar.  We use the harmonic mean ``2/(N_a + N_b)`` which
+    is symmetric with respect to body ordering and reduces to ``1/N`` when
+    both counts are equal.
     """
     tid = wp.tid()
     count = contact_count[0]
@@ -2320,19 +2324,26 @@ def accumulate_weighted_contact_impulse(
 
     weight = 1.0
     if constraint_inv_weight:
-        inv_w = 0.0
+        n_a = 0.0
+        n_b = 0.0
         shape_a = contact_shape0[tid]
         if shape_a >= 0:
             body_a = shape_body[shape_a]
             if body_a >= 0:
-                inv_w = wp.max(inv_w, constraint_inv_weight[body_a])
+                n_a = constraint_inv_weight[body_a]
         shape_b = contact_shape1[tid]
         if shape_b >= 0:
             body_b = shape_body[shape_b]
             if body_b >= 0:
-                inv_w = wp.max(inv_w, constraint_inv_weight[body_b])
-        if inv_w > 0.0:
-            weight = 1.0 / inv_w
+                n_b = constraint_inv_weight[body_b]
+        n_sum = n_a + n_b
+        if n_sum > 0.0:
+            if n_a == 0.0:
+                weight = 1.0 / n_b
+            elif n_b == 0.0:
+                weight = 1.0 / n_a
+            else:
+                weight = 2.0 / n_sum
 
     scaled = wp.spatial_vector(
         wp.spatial_top(impulse) * weight,

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2078,7 +2078,7 @@ def solve_body_contact_positions(
     # outputs
     deltas: wp.array[wp.spatial_vector],
     contact_inv_weight: wp.array[float],
-    contact_impulse: wp.array[wp.spatial_vector],
+    contact_impulse: wp.array[wp.vec3],
 ):
     tid = wp.tid()
 
@@ -2287,27 +2287,24 @@ def solve_body_contact_positions(
         wp.atomic_add(deltas, body_b, wp.spatial_vector(lin_delta_b, ang_delta_b))
 
     if contact_impulse:
-        # Accumulate per-contact impulse as spatial wrench on body0 at its COM (world frame).
-        # lin_delta_a already contains the full linear impulse contribution (normal + friction +
-        # torsion + rolling) from this iteration.  Torque at body0 COM = r_a × force.
-        r_a_com = bx_a - wp.transform_point(X_wb_a, com_a)
-        torque_on_a = wp.cross(r_a_com, lin_delta_a)
-        wp.atomic_add(contact_impulse, tid, wp.spatial_vector(lin_delta_a, torque_on_a))
+        contact_impulse[tid] = contact_impulse[tid] + lin_delta_a
 
 
 @wp.kernel
 def convert_contact_impulse_to_force(
     contact_count: wp.array[int],
-    contact_impulse: wp.array[wp.spatial_vector],
+    contact_impulse: wp.array[wp.vec3],
     dt: float,
     # output
     contact_force: wp.array[wp.spatial_vector],
 ):
-    """Convert accumulated per-contact impulse to force in ``contacts.force`` format.
+    """Convert accumulated per-contact linear impulse to ``contacts.force`` spatial vectors.
 
     The XPBD lambda convention used in this solver already absorbs one power
     of ``dt`` (see ``compute_contact_constraint_delta``), so dividing the
-    accumulated impulse by the substep ``dt`` yields force [N].
+    accumulated impulse by the substep ``dt`` yields force [N].  The torque
+    component is left zero; downstream consumers such as :class:`SensorContact`
+    compute moments from the contact point and force direction themselves.
     """
     tid = wp.tid()
     count = contact_count[0]
@@ -2315,7 +2312,8 @@ def convert_contact_impulse_to_force(
         contact_force[tid] = wp.spatial_vector()
         return
 
-    contact_force[tid] = contact_impulse[tid] * (1.0 / dt)
+    f = contact_impulse[tid] * (1.0 / dt)
+    contact_force[tid] = wp.spatial_vector(f, wp.vec3(0.0))
 
 
 @wp.kernel

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -258,7 +258,7 @@ class SolverXPBD(SolverBase):
             rigid_contact_inv_weight_init = None
 
             if contacts.force is not None:
-                contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
+                contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
 
         if control is None:
             control = model.control(clone_variables=False)
@@ -575,6 +575,7 @@ class SolverXPBD(SolverBase):
                         body_q, body_qd = self._apply_body_deltas(model, state_in, state_out, body_deltas, dt)
 
             self._contact_impulse = contact_impulse
+            self._contact_impulse_capacity = contacts.rigid_contact_max if contacts is not None else 0
             self._last_dt = dt
 
             if model.particle_count:
@@ -690,17 +691,20 @@ class SolverXPBD(SolverBase):
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
         """Populate ``contacts.force`` from XPBD contact impulses accumulated during the last :meth:`step`.
 
-        Only the linear force component is written; the torque component is
-        zero.  Downstream consumers such as :class:`SensorContact` compute
-        moments from the contact point and force direction themselves.
+        Both force [N] and torque [N·m] components are written.  The torque
+        includes torsional and rolling friction contributions that cannot be
+        reconstructed from the linear force alone.
 
         Args:
             contacts: :class:`Contacts` object whose :attr:`~Contacts.force` buffer will be written.
-                Must have been created with ``"force"`` in its requested attributes.
+                Must have been created with ``"force"`` in its requested attributes and must
+                match the :class:`Contacts` instance (same ``rigid_contact_max``) passed to
+                the preceding :meth:`step`.
             state: Unused (accepted for API compatibility with :class:`SolverBase`).
 
         Raises:
-            ValueError: If ``contacts.force`` is ``None`` (not requested) or if no step has been run yet.
+            ValueError: If ``contacts.force`` is ``None`` (not requested), if no step has been run yet,
+                or if the contacts capacity does not match the one used in the last :meth:`step`.
         """
         if contacts.force is None:
             raise ValueError(
@@ -709,6 +713,12 @@ class SolverXPBD(SolverBase):
             )
         if not hasattr(self, "_contact_impulse") or self._contact_impulse is None:
             raise ValueError("No contact impulse data available. Call step() before update_contacts().")
+        if contacts.rigid_contact_max != self._contact_impulse_capacity:
+            raise ValueError(
+                f"Contacts capacity mismatch: update_contacts() received rigid_contact_max="
+                f"{contacts.rigid_contact_max}, but step() used {self._contact_impulse_capacity}. "
+                f"Pass the same Contacts instance to both step() and update_contacts()."
+            )
 
         wp.launch(
             kernel=convert_contact_impulse_to_force,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -258,7 +258,7 @@ class SolverXPBD(SolverBase):
             rigid_contact_inv_weight_init = None
 
             if contacts.force is not None:
-                contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
+                contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
 
         if control is None:
             control = model.control(clone_variables=False)
@@ -574,9 +574,7 @@ class SolverXPBD(SolverBase):
 
                         body_q, body_qd = self._apply_body_deltas(model, state_in, state_out, body_deltas, dt)
 
-            # Stash per-contact impulse and weighting state for update_contacts().
             self._contact_impulse = contact_impulse
-            self._contact_inv_weight = rigid_contact_inv_weight
             self._last_dt = dt
 
             if model.particle_count:
@@ -692,8 +690,9 @@ class SolverXPBD(SolverBase):
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
         """Populate ``contacts.force`` from XPBD contact impulses accumulated during the last :meth:`step`.
 
-        Each entry in ``contacts.force`` is a spatial wrench (force [N] and torque [N·m])
-        exerted on body0 by body1, referenced to the center of mass of body0 in world frame.
+        Only the linear force component is written; the torque component is
+        zero.  Downstream consumers such as :class:`SensorContact` compute
+        moments from the contact point and force direction themselves.
 
         Args:
             contacts: :class:`Contacts` object whose :attr:`~Contacts.force` buffer will be written.

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -15,6 +15,7 @@ from .kernels import (
     apply_particle_shape_restitution,
     apply_rigid_restitution,
     bending_constraint,
+    convert_contact_impulse_to_force,
     copy_kinematic_body_state_kernel,
     solve_body_contact_positions,
     solve_body_joints,
@@ -249,10 +250,15 @@ class SolverXPBD(SolverBase):
 
         rigid_contact_inv_weight = None
 
+        contact_impulse = None
+
         if contacts:
             if self.rigid_contact_con_weighting:
                 rigid_contact_inv_weight = wp.zeros(model.body_count, dtype=float, device=model.device)
             rigid_contact_inv_weight_init = None
+
+            if contacts.force is not None:
+                contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
 
         if control is None:
             control = model.control(clone_variables=False)
@@ -501,6 +507,7 @@ class SolverXPBD(SolverBase):
                             outputs=[
                                 body_deltas,
                                 rigid_contact_inv_weight,
+                                contact_impulse,
                             ],
                             device=model.device,
                         )
@@ -566,6 +573,11 @@ class SolverXPBD(SolverBase):
                         )
 
                         body_q, body_qd = self._apply_body_deltas(model, state_in, state_out, body_deltas, dt)
+
+            # Stash per-contact impulse and weighting state for update_contacts().
+            self._contact_impulse = contact_impulse
+            self._contact_inv_weight = rigid_contact_inv_weight
+            self._last_dt = dt
 
             if model.particle_count:
                 if particle_q.ptr != state_out.particle_q.ptr:
@@ -675,3 +687,38 @@ class SolverXPBD(SolverBase):
 
             if model.body_count:
                 self.copy_kinematic_body_state(model, state_in, state_out)
+
+    @override
+    def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
+        """Populate ``contacts.force`` from XPBD contact impulses accumulated during the last :meth:`step`.
+
+        Each entry in ``contacts.force`` is a spatial wrench (force [N] and torque [N·m])
+        exerted on body0 by body1, referenced to the center of mass of body0 in world frame.
+
+        Args:
+            contacts: :class:`Contacts` object whose :attr:`~Contacts.force` buffer will be written.
+                Must have been created with ``"force"`` in its requested attributes.
+            state: Unused (accepted for API compatibility with :class:`SolverBase`).
+
+        Raises:
+            ValueError: If ``contacts.force`` is ``None`` (not requested) or if no step has been run yet.
+        """
+        if contacts.force is None:
+            raise ValueError(
+                "contacts.force is not allocated. Call model.request_contact_attributes('force') "
+                "before creating the Contacts object."
+            )
+        if not hasattr(self, "_contact_impulse") or self._contact_impulse is None:
+            raise ValueError("No contact impulse data available. Call step() before update_contacts().")
+
+        wp.launch(
+            kernel=convert_contact_impulse_to_force,
+            dim=contacts.rigid_contact_max,
+            inputs=[
+                contacts.rigid_contact_count,
+                self._contact_impulse,
+                self._last_dt,
+            ],
+            outputs=[contacts.force],
+            device=self.model.device,
+        )

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -8,6 +8,7 @@ from ...sim import Contacts, Control, Model, State
 from ..flags import SolverNotifyFlags
 from ..solver import SolverBase
 from .kernels import (
+    accumulate_weighted_contact_impulse,
     apply_body_delta_velocities,
     apply_body_deltas,
     apply_joint_forces,
@@ -251,6 +252,7 @@ class SolverXPBD(SolverBase):
         rigid_contact_inv_weight = None
 
         contact_impulse = None
+        contact_impulse_iter = None
 
         if contacts:
             if self.rigid_contact_con_weighting:
@@ -259,6 +261,7 @@ class SolverXPBD(SolverBase):
 
             if contacts.force is not None:
                 contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
+                contact_impulse_iter = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
 
         if control is None:
             control = model.control(clone_variables=False)
@@ -477,6 +480,9 @@ class SolverXPBD(SolverBase):
                         if self.rigid_contact_con_weighting:
                             rigid_contact_inv_weight.zero_()
 
+                        if contact_impulse_iter is not None:
+                            contact_impulse_iter.zero_()
+
                         wp.launch(
                             kernel=solve_body_contact_positions,
                             dim=contacts.rigid_contact_max,
@@ -507,10 +513,26 @@ class SolverXPBD(SolverBase):
                             outputs=[
                                 body_deltas,
                                 rigid_contact_inv_weight,
-                                contact_impulse,
+                                contact_impulse_iter,
                             ],
                             device=model.device,
                         )
+
+                        if contact_impulse_iter is not None:
+                            wp.launch(
+                                kernel=accumulate_weighted_contact_impulse,
+                                dim=contacts.rigid_contact_max,
+                                inputs=[
+                                    contacts.rigid_contact_count,
+                                    contact_impulse_iter,
+                                    contacts.rigid_contact_shape0,
+                                    contacts.rigid_contact_shape1,
+                                    model.shape_body,
+                                    rigid_contact_inv_weight,
+                                ],
+                                outputs=[contact_impulse],
+                                device=model.device,
+                            )
 
                         # if model.rigid_contact_count.numpy()[0] > 0:
                         #     print("rigid_contact_count:", model.rigid_contact_count.numpy().flatten())
@@ -719,6 +741,8 @@ class SolverXPBD(SolverBase):
                 f"{contacts.rigid_contact_max}, but step() used {self._contact_impulse_capacity}. "
                 f"Pass the same Contacts instance to both step() and update_contacts()."
             )
+
+        contacts.force.zero_()
 
         wp.launch(
             kernel=convert_contact_impulse_to_force,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -39,6 +39,16 @@ class SolverXPBD(SolverBase):
     After constructing :class:`Model`, :class:`State`, and :class:`Control` (optional) objects, this time-integrator
     may be used to advance the simulation state forward in time.
 
+    Limitations:
+        **Momentum conservation** -- When ``rigid_contact_con_weighting`` is
+        enabled (the default), each body's positional correction is divided by
+        its number of active contacts.  This improves convergence for stacking
+        scenarios but means the solver does not conserve momentum at contacts.
+        Reported per-contact forces (see :meth:`update_contacts`) are
+        approximate: for contacts between two dynamic bodies the force is
+        computed using the harmonic mean of the two bodies' contact counts,
+        which is symmetric but not exact.
+
     Joint limitations:
         - Supported joint types: PRISMATIC, REVOLUTE, BALL, FIXED, FREE, DISTANCE, D6.
           CABLE joints are not supported.
@@ -261,7 +271,9 @@ class SolverXPBD(SolverBase):
 
             if contacts.force is not None:
                 contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
-                contact_impulse_iter = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
+                contact_impulse_iter = wp.zeros(
+                    contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device
+                )
 
         if control is None:
             control = model.control(clone_variables=False)
@@ -716,6 +728,16 @@ class SolverXPBD(SolverBase):
         Both force [N] and torque [N·m] components are written.  The torque
         includes torsional and rolling friction contributions that cannot be
         reconstructed from the linear force alone.
+
+        When ``rigid_contact_con_weighting`` is enabled, the raw per-contact
+        impulse is scaled to reflect the ``1/N`` correction that
+        ``apply_body_deltas`` applies.  For contacts between a dynamic and a
+        kinematic body, ``N`` is the dynamic body's contact count.  For
+        contacts between two dynamic bodies, the harmonic mean
+        ``2/(N_a + N_b)`` is used so that the reported force is symmetric with
+        respect to body ordering.  This is an approximation -- the solver
+        applies ``1/N_a`` and ``1/N_b`` independently to each side, so no
+        single scalar can exactly represent both.
 
         Args:
             contacts: :class:`Contacts` object whose :attr:`~Contacts.force` buffer will be written.

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -530,9 +530,9 @@ def test_xpbd_contact_force_heavy_sphere_on_plane(test, device):
 def test_xpbd_contact_force_box_on_plane(test, device):
     """A box on a ground plane has multiple contact points; total force must equal mg, not N*mg.
 
-    This specifically tests the fix for the N× contact force inflation bug when
+    This specifically tests the fix for the N*contact force inflation bug when
     ``rigid_contact_con_weighting`` is enabled (the default).  A box generates 4
-    bottom-face contacts, so without the fix the summed force would be ~4× the
+    bottom-face contacts, so without the fix the summed force would be ~4x the
     true weight.
     """
     hx, hy, hz = 0.5, 0.5, 0.5
@@ -586,11 +586,117 @@ def test_xpbd_contact_force_box_on_plane(test, device):
     avg_force = force_acc / avg_steps
     expected_fz = mass * gravity
     np.testing.assert_allclose(
-        avg_force[2], -expected_fz, rtol=0.10,
+        avg_force[2],
+        -expected_fz,
+        rtol=0.10,
         err_msg="Total vertical contact force over multiple contacts should match -mg, not N*mg",
     )
     np.testing.assert_allclose(avg_force[0], 0.0, atol=1.0, err_msg="Horizontal X force should be ~0")
     np.testing.assert_allclose(avg_force[1], 0.0, atol=1.0, err_msg="Horizontal Y force should be ~0")
+
+
+def test_xpbd_contact_force_mini_pyramid(test, device):
+    """Two-layer pyramid: ground reaction forces must reflect stacked weight.
+
+    Layout (Z-up):
+        - Ground plane at z=0 (shape 0, body -1)
+        - Two bottom cubes (bodies 0, 1) side-by-side on the ground
+        - One top cube (body 2) centered on top of both
+
+    All cubes have the same mass m.  At steady state the ground pushes up on
+    each bottom cube with 1.5*mg (own weight + half the top cube).
+
+    Only ground-contact forces are checked here.  Inter-body forces between
+    dynamic bodies are under-reported by the per-body contact weighting
+    scheme (``rigid_contact_con_weighting``) because a body's weight mixes
+    contacts from different pairs.
+    """
+    h = 0.5
+    density = 1000.0
+    volume = (2.0 * h) ** 3
+    mass = density * volume
+    gravity = 9.81
+    mg = mass * gravity
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.density = density
+    builder.add_ground_plane()
+
+    b0 = builder.add_body(xform=wp.transform(wp.vec3(-h, 0.0, h), wp.quat_identity()))
+    builder.add_shape_box(body=b0, hx=h, hy=h, hz=h)
+    b1 = builder.add_body(xform=wp.transform(wp.vec3(h, 0.0, h), wp.quat_identity()))
+    builder.add_shape_box(body=b1, hx=h, hy=h, hz=h)
+    b2 = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 3.0 * h), wp.quat_identity()))
+    builder.add_shape_box(body=b2, hx=h, hy=h, hz=h)
+
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = newton.solvers.SolverXPBD(model, iterations=32, rigid_contact_con_weighting=True)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+    dt = 1.0 / 60.0
+    num_substeps = 8
+    sub_dt = dt / num_substeps
+    settle_steps = 200
+    avg_steps = 60
+
+    for _ in range(settle_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+
+    shape_body_np = model.shape_body.numpy()
+    ground_shape = 0
+
+    ground_fz_on_b0 = 0.0
+    ground_fz_on_b1 = 0.0
+
+    for _ in range(avg_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+        solver.update_contacts(contacts, state_in)
+
+        nc = int(contacts.rigid_contact_count.numpy()[0])
+        if nc == 0:
+            continue
+        forces = contacts.force.numpy()[:nc, :3]
+        s0 = contacts.rigid_contact_shape0.numpy()[:nc]
+        s1 = contacts.rigid_contact_shape1.numpy()[:nc]
+        for ci in range(nc):
+            if s0[ci] != ground_shape:
+                continue
+            fz = forces[ci, 2]
+            body_b = shape_body_np[s1[ci]] if s1[ci] >= 0 else -1
+            if body_b == b0:
+                ground_fz_on_b0 += -fz
+            elif body_b == b1:
+                ground_fz_on_b1 += -fz
+
+    ground_fz_on_b0 /= avg_steps
+    ground_fz_on_b1 /= avg_steps
+
+    np.testing.assert_allclose(
+        ground_fz_on_b0,
+        1.5 * mg,
+        rtol=0.15,
+        err_msg=f"Ground reaction on bottom cube 0 should be ~1.5*mg={1.5 * mg:.0f}, got {ground_fz_on_b0:.0f}",
+    )
+    np.testing.assert_allclose(
+        ground_fz_on_b1,
+        1.5 * mg,
+        rtol=0.15,
+        err_msg=f"Ground reaction on bottom cube 1 should be ~1.5*mg={1.5 * mg:.0f}, got {ground_fz_on_b1:.0f}",
+    )
 
 
 def test_xpbd_contact_force_zero_when_no_contact(test, device):
@@ -756,6 +862,14 @@ add_function_test(
     TestSolverXPBD,
     "test_xpbd_contact_force_box_on_plane",
     test_xpbd_contact_force_box_on_plane,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_mini_pyramid",
+    test_xpbd_contact_force_mini_pyramid,
     devices=devices,
     check_output=False,
 )

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -466,10 +466,8 @@ def test_articulation_contact_drift(test, device):
     )
 
 
-def test_xpbd_contact_force_sphere_on_plane(test, device):
+def _test_xpbd_contact_force_sphere_on_plane(test, device, radius, density):
     """A sphere resting on a ground plane must report contact force equal to its weight."""
-    radius = 0.25
-    density = 1000.0
     mass = density * (4.0 / 3.0) * np.pi * radius**3
     gravity = 9.81
 
@@ -519,24 +517,39 @@ def test_xpbd_contact_force_sphere_on_plane(test, device):
     np.testing.assert_allclose(avg_force[2], -expected_fz, rtol=0.05, err_msg="Vertical contact force should match -mg")
     np.testing.assert_allclose(avg_force[0], 0.0, atol=0.5, err_msg="Horizontal X force should be ~0")
     np.testing.assert_allclose(avg_force[1], 0.0, atol=0.5, err_msg="Horizontal Y force should be ~0")
+
+
+def test_xpbd_contact_force_sphere_on_plane(test, device):
+    _test_xpbd_contact_force_sphere_on_plane(test, device, radius=0.25, density=1000.0)
 
 
 def test_xpbd_contact_force_heavy_sphere_on_plane(test, device):
-    """A heavier sphere on a ground plane -- force must still match mg (single contact)."""
-    radius = 0.5
-    density = 2000.0
-    mass = density * (4.0 / 3.0) * np.pi * radius**3
+    _test_xpbd_contact_force_sphere_on_plane(test, device, radius=0.5, density=2000.0)
+
+
+def test_xpbd_contact_force_box_on_plane(test, device):
+    """A box on a ground plane has multiple contact points; total force must equal mg, not N*mg.
+
+    This specifically tests the fix for the N× contact force inflation bug when
+    ``rigid_contact_con_weighting`` is enabled (the default).  A box generates 4
+    bottom-face contacts, so without the fix the summed force would be ~4× the
+    true weight.
+    """
+    hx, hy, hz = 0.5, 0.5, 0.5
+    density = 1000.0
+    volume = (2.0 * hx) * (2.0 * hy) * (2.0 * hz)
+    mass = density * volume
     gravity = 9.81
 
     builder = newton.ModelBuilder()
     builder.default_shape_cfg.density = density
     builder.add_ground_plane()
-    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius), wp.quat_identity()))
-    builder.add_shape_sphere(body=body, radius=radius)
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, hz), wp.quat_identity()))
+    builder.add_shape_box(body=body, hx=hx, hy=hy, hz=hz)
     model = builder.finalize(device=device)
     model.request_contact_attributes("force")
 
-    solver = newton.solvers.SolverXPBD(model, iterations=32)
+    solver = newton.solvers.SolverXPBD(model, iterations=32, rigid_contact_con_weighting=True)
     state_in = model.state()
     state_out = model.state()
     control = model.control()
@@ -565,15 +578,19 @@ def test_xpbd_contact_force_heavy_sphere_on_plane(test, device):
             state_in, state_out = state_out, state_in
         solver.update_contacts(contacts, state_in)
         ncontacts = int(contacts.rigid_contact_count.numpy()[0])
+        test.assertGreater(ncontacts, 1, "Box should generate multiple contact points")
         if ncontacts > 0:
             f = contacts.force.numpy()[:ncontacts, :3]
             force_acc += np.sum(f, axis=0)
 
     avg_force = force_acc / avg_steps
     expected_fz = mass * gravity
-    np.testing.assert_allclose(avg_force[2], -expected_fz, rtol=0.05, err_msg="Vertical contact force should match -mg")
-    np.testing.assert_allclose(avg_force[0], 0.0, atol=0.5, err_msg="Horizontal X force should be ~0")
-    np.testing.assert_allclose(avg_force[1], 0.0, atol=0.5, err_msg="Horizontal Y force should be ~0")
+    np.testing.assert_allclose(
+        avg_force[2], -expected_fz, rtol=0.10,
+        err_msg="Total vertical contact force over multiple contacts should match -mg, not N*mg",
+    )
+    np.testing.assert_allclose(avg_force[0], 0.0, atol=1.0, err_msg="Horizontal X force should be ~0")
+    np.testing.assert_allclose(avg_force[1], 0.0, atol=1.0, err_msg="Horizontal Y force should be ~0")
 
 
 def test_xpbd_contact_force_zero_when_no_contact(test, device):
@@ -731,6 +748,14 @@ add_function_test(
     TestSolverXPBD,
     "test_xpbd_contact_force_heavy_sphere_on_plane",
     test_xpbd_contact_force_heavy_sphere_on_plane,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_box_on_plane",
+    test_xpbd_contact_force_box_on_plane,
     devices=devices,
     check_output=False,
 )

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -466,6 +466,168 @@ def test_articulation_contact_drift(test, device):
     )
 
 
+def test_xpbd_contact_force_sphere_on_plane(test, device):
+    """A sphere resting on a ground plane must report contact force equal to its weight."""
+    radius = 0.25
+    density = 1000.0
+    mass = density * (4.0 / 3.0) * np.pi * radius**3
+    gravity = 9.81
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.density = density
+    builder.add_ground_plane()
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius), wp.quat_identity()))
+    builder.add_shape_sphere(body=body, radius=radius)
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = newton.solvers.SolverXPBD(model, iterations=32)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+    dt = 1.0 / 60.0
+    num_substeps = 8
+    sub_dt = dt / num_substeps
+    settle_steps = 120
+    avg_steps = 60
+
+    for _ in range(settle_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+
+    force_acc = np.zeros(3)
+    for _ in range(avg_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+        solver.update_contacts(contacts, state_in)
+        ncontacts = int(contacts.rigid_contact_count.numpy()[0])
+        if ncontacts > 0:
+            f = contacts.force.numpy()[:ncontacts, :3]
+            force_acc += np.sum(f, axis=0)
+
+    avg_force = force_acc / avg_steps
+    expected_fz = mass * gravity
+    np.testing.assert_allclose(avg_force[2], -expected_fz, rtol=0.05, err_msg="Vertical contact force should match -mg")
+    np.testing.assert_allclose(avg_force[0], 0.0, atol=0.5, err_msg="Horizontal X force should be ~0")
+    np.testing.assert_allclose(avg_force[1], 0.0, atol=0.5, err_msg="Horizontal Y force should be ~0")
+
+
+def test_xpbd_contact_force_heavy_sphere_on_plane(test, device):
+    """A heavier sphere on a ground plane -- force must still match mg (single contact)."""
+    radius = 0.5
+    density = 2000.0
+    mass = density * (4.0 / 3.0) * np.pi * radius**3
+    gravity = 9.81
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.density = density
+    builder.add_ground_plane()
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius), wp.quat_identity()))
+    builder.add_shape_sphere(body=body, radius=radius)
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = newton.solvers.SolverXPBD(model, iterations=32)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+    dt = 1.0 / 60.0
+    num_substeps = 8
+    sub_dt = dt / num_substeps
+    settle_steps = 120
+    avg_steps = 60
+
+    for _ in range(settle_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+
+    force_acc = np.zeros(3)
+    for _ in range(avg_steps):
+        for _ in range(num_substeps):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sub_dt)
+            state_in, state_out = state_out, state_in
+        solver.update_contacts(contacts, state_in)
+        ncontacts = int(contacts.rigid_contact_count.numpy()[0])
+        if ncontacts > 0:
+            f = contacts.force.numpy()[:ncontacts, :3]
+            force_acc += np.sum(f, axis=0)
+
+    avg_force = force_acc / avg_steps
+    expected_fz = mass * gravity
+    np.testing.assert_allclose(avg_force[2], -expected_fz, rtol=0.05, err_msg="Vertical contact force should match -mg")
+    np.testing.assert_allclose(avg_force[0], 0.0, atol=0.5, err_msg="Horizontal X force should be ~0")
+    np.testing.assert_allclose(avg_force[1], 0.0, atol=0.5, err_msg="Horizontal Y force should be ~0")
+
+
+def test_xpbd_contact_force_zero_when_no_contact(test, device):
+    """A sphere in free-fall (no ground) should produce zero contact force."""
+    radius = 0.25
+
+    builder = newton.ModelBuilder()
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 5.0), wp.quat_identity()))
+    builder.add_shape_sphere(body=body, radius=radius)
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+    dt = 1.0 / 60.0
+    state_in.clear_forces()
+    model.collide(state_in, contacts)
+    solver.step(state_in, state_out, control, contacts, dt)
+    solver.update_contacts(contacts, state_out)
+
+    ncontacts = int(contacts.rigid_contact_count.numpy()[0])
+    if ncontacts > 0:
+        forces = contacts.force.numpy()[:ncontacts]
+        np.testing.assert_allclose(forces, 0.0, atol=1e-6, err_msg="No contact force expected in free-fall")
+
+
+def test_xpbd_update_contacts_requires_force_attribute(test, device):
+    """update_contacts should raise ValueError when contacts.force is not allocated."""
+    builder = newton.ModelBuilder()
+    builder.add_ground_plane()
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.25), wp.quat_identity()))
+    builder.add_shape_sphere(body=body, radius=0.25)
+    model = builder.finalize(device=device)
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+
+    state_in.clear_forces()
+    model.collide(state_in, contacts)
+    solver.step(state_in, state_out, control, contacts, 1.0 / 60.0)
+
+    test.assertIsNone(contacts.force)
+    with test.assertRaises(ValueError):
+        solver.update_contacts(contacts)
+
+
 devices = get_test_devices(mode="basic")
 
 
@@ -511,6 +673,38 @@ add_function_test(
     TestSolverXPBD,
     "test_articulation_contact_drift",
     test_articulation_contact_drift,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_sphere_on_plane",
+    test_xpbd_contact_force_sphere_on_plane,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_heavy_sphere_on_plane",
+    test_xpbd_contact_force_heavy_sphere_on_plane,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_zero_when_no_contact",
+    test_xpbd_contact_force_zero_when_no_contact,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_update_contacts_requires_force_attribute",
+    test_xpbd_update_contacts_requires_force_attribute,
     devices=devices,
     check_output=False,
 )

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -605,6 +605,48 @@ def test_xpbd_contact_force_zero_when_no_contact(test, device):
         np.testing.assert_allclose(forces, 0.0, atol=1e-6, err_msg="No contact force expected in free-fall")
 
 
+def test_xpbd_contact_force_zero_when_not_touching(test, device):
+    """A sphere near a ground plane with a large gap: contact pair exists but force is zero."""
+    radius = 0.25
+    gap = 1.0
+    # Place sphere so it's within the gap (contact pair generated) but not penetrating.
+    # Ground is at z=0, sphere center at z = radius + 0.5*gap (well above surface).
+    z = radius + 0.5 * gap
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.gap = gap
+    builder.add_ground_plane()
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, z), wp.quat_identity()))
+    builder.add_shape_sphere(body=body, radius=radius)
+    model = builder.finalize(device=device)
+    model.set_gravity(wp.vec3(0.0, 0.0, 0.0))
+    model.request_contact_attributes("force")
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2)
+    state_in = model.state()
+    state_out = model.state()
+    control = model.control()
+    contacts = model.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+    state_in.clear_forces()
+    model.collide(state_in, contacts)
+
+    ncontacts = int(contacts.rigid_contact_count.numpy()[0])
+    test.assertGreater(ncontacts, 0, "Gap should cause a contact pair to be generated")
+
+    solver.step(state_in, state_out, control, contacts, 1.0 / 60.0)
+    solver.update_contacts(contacts, state_out)
+
+    forces = contacts.force.numpy()[:ncontacts, :3]
+    np.testing.assert_allclose(
+        forces,
+        0.0,
+        atol=1e-6,
+        err_msg="Contact pair within gap but not touching should report zero force",
+    )
+
+
 def test_xpbd_update_contacts_requires_force_attribute(test, device):
     """update_contacts should raise ValueError when contacts.force is not allocated."""
     builder = newton.ModelBuilder()
@@ -697,6 +739,14 @@ add_function_test(
     TestSolverXPBD,
     "test_xpbd_contact_force_zero_when_no_contact",
     test_xpbd_contact_force_zero_when_no_contact,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_xpbd_contact_force_zero_when_not_touching",
+    test_xpbd_contact_force_zero_when_not_touching,
     devices=devices,
     check_output=False,
 )


### PR DESCRIPTION
## Description

Connect XPBD to the contact force reporting API. Requested by Disney to simplify solver comparisons.

Implements `SolverXPBD.update_contacts()` so that `contacts.force` is populated after `step()`, matching the existing pattern used by `SolverMuJoCo`. Per-contact linear impulse is accumulated across XPBD iterations inside `solve_body_contact_positions` and converted to force (impulse / dt) in `update_contacts()`. Only the linear component is written; XPBD point contacts carry no intrinsic torque.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_solver_xpbd
```

New tests (all run on CPU + CUDA):
- `test_xpbd_contact_force_sphere_on_plane` — sphere resting on ground, asserts Fz ≈ -mg (5%)
- `test_xpbd_contact_force_heavy_sphere_on_plane` — heavier sphere, same assertion
- `test_xpbd_contact_force_zero_when_no_contact` — free-fall sphere, no contacts, force is zero
- `test_xpbd_contact_force_zero_when_not_touching` — large gap creates contact pair but no penetration, force is zero
- `test_xpbd_update_contacts_requires_force_attribute` — ValueError when `contacts.force` not allocated

## New feature / API change

```python
import newton

model = newton.ModelBuilder()
model.add_ground_plane()
body = model.add_body(xform=wp.transform([0, 0, 0.25], wp.quat_identity()))
model.add_shape_sphere(body=body, radius=0.25)
model = model.finalize()
model.request_contact_attributes("force")

solver = newton.solvers.SolverXPBD(model)
state_in, state_out = model.state(), model.state()
contacts = model.contacts()

model.collide(state_in, contacts)
solver.step(state_in, state_out, model.control(), contacts, 1.0 / 60.0)
solver.update_contacts(contacts, state_out)

# contacts.force now contains per-contact spatial vectors (linear force + zero torque)
print(contacts.force.numpy()[:int(contacts.rigid_contact_count.numpy()[0])])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * XPBD solver can now produce per-contact spatial forces (including torque) and populate contact force storage via a new update workflow; the update validates that force buffers are allocated.

* **Tests**
  * Added comprehensive tests covering contact-force computations and edge cases (various contact scenarios, no-contact/not-touching, and update validation).

* **Documentation**
  * Clarified Contacts.force behavior and noted XPBD per-contact forces are approximate when weighting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->