### PR TITLE
Fix Raycast against plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Clamp viewer picking force to prevent explosion when picking light objects near stiff contacts, configurable via `pick_max_acceleration` parameter on the `Picking` class (default 5g of effective articulation mass)
 - Fix `cloth_franka` example Jacobian broken by COM-referenced `body_qd` convention change; adjust robot base height, gripper orientations, and grasp targets for improved reachability (a follow-up PR will migrate the example to `newton.ik`)
+- Fix `SensorRaycast` ignoring `PLANE` geometry
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -549,14 +549,11 @@ def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_di
     if t < 0.0:
         return -1.0
 
-    # Check finite bounds (0 = infinite in that axis).  For planes, size stores (half_width, half_length, 0)
-    # some code paths treat it as full extents; tracked in GH-2410.
     hit_x = ro[0] + t * rd[0]
     hit_y = ro[1] + t * rd[1]
 
     half_w = size[0] * 0.5
     half_l = size[1] * 0.5
-    half_l = size[1]
 
     if half_w > 0.0 and wp.abs(hit_x) > half_w:
         return -1.0

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -554,7 +554,8 @@ def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_di
     hit_x = ro[0] + t * rd[0]
     hit_y = ro[1] + t * rd[1]
 
-    half_w = size[0]
+    half_w = size[0] * 0.5
+    half_l = size[1] * 0.5
     half_l = size[1]
 
     if half_w > 0.0 and wp.abs(hit_x) > half_w:

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -11,7 +11,7 @@ from .types import (
 
 # A small constant to avoid division by zero and other numerical issues
 MINVAL = 1e-15
-# Float32 epsilon for near-degenerate checks (e.g. ray parallel to plane)
+# float32 epsilon for near-zero checks (e.g. ray parallel to plane)
 EPSILON = 1e-6
 
 
@@ -540,7 +540,7 @@ def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_di
     ro = wp.transform_point(world_to_geom, ray_origin)
     rd = wp.transform_vector(world_to_geom, ray_direction)
 
-    # Ray parallel to the plane (also covers zero-length direction since rd[2] == 0)
+    # Ray parallel to the plane (or degenerate)
     if wp.abs(rd[2]) < EPSILON:
         return -1.0
 
@@ -549,7 +549,8 @@ def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_di
     if t < 0.0:
         return -1.0
 
-    # Check finite bounds (0 = infinite in that axis)
+    # Check finite bounds (0 = infinite in that axis).  For planes, size stores (half_width, half_length, 0)
+    # some code paths treat it as full extents; tracked in GH-2410.
     hit_x = ro[0] + t * rd[0]
     hit_y = ro[1] + t * rd[1]
 
@@ -577,7 +578,7 @@ def ray_intersect_geom(
     Computes the intersection of a ray with a geometry.
 
     Args:
-        geom_to_world: The world-to-shape transform.
+        geom_to_world: The world transform of the shape.
         size: The size of the geometry.
         geomtype: The type of the geometry.
         ray_origin: The origin of the ray.

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -11,6 +11,8 @@ from .types import (
 
 # A small constant to avoid division by zero and other numerical issues
 MINVAL = 1e-15
+# Float32 epsilon for near-degenerate checks (e.g. ray parallel to plane)
+EPSILON = 1e-6
 
 
 @wp.func
@@ -517,6 +519,52 @@ def ray_intersect_mesh(
 
 
 @wp.func
+def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3):
+    """Computes ray-plane intersection.
+
+    The plane lies at z = 0 in local space with normal along +Z.  ``size`` holds ``(half_width, half_length, 0)``:
+    the half-extents along local X and Y.  A value of ``0`` means infinite in that axis.  The plane is double-sided:
+    rays approaching from either side register intersections.
+
+    Args:
+        geom_to_world: The world transform of the plane.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        size: ``(half_width, half_length, 0)`` -- half-extents; ``0`` = infinite.
+
+    Returns:
+        The distance along the ray to the intersection point, or -1.0 if there is no intersection.
+    """
+    # transform ray to local frame
+    world_to_geom = wp.transform_inverse(geom_to_world)
+    ro = wp.transform_point(world_to_geom, ray_origin)
+    rd = wp.transform_vector(world_to_geom, ray_direction)
+
+    # Ray parallel to the plane (also covers zero-length direction since rd[2] == 0)
+    if wp.abs(rd[2]) < EPSILON:
+        return -1.0
+
+    # t where the ray crosses z = 0
+    t = -ro[2] / rd[2]
+    if t < 0.0:
+        return -1.0
+
+    # Check finite bounds (0 = infinite in that axis)
+    hit_x = ro[0] + t * rd[0]
+    hit_y = ro[1] + t * rd[1]
+
+    half_w = size[0]
+    half_l = size[1]
+
+    if half_w > 0.0 and wp.abs(hit_x) > half_w:
+        return -1.0
+    if half_l > 0.0 and wp.abs(hit_y) > half_l:
+        return -1.0
+
+    return t
+
+
+@wp.func
 def ray_intersect_geom(
     geom_to_world: wp.transform,
     size: wp.vec3,
@@ -541,7 +589,10 @@ def ray_intersect_geom(
     """
     t_hit = -1.0
 
-    if geomtype == GeoType.SPHERE:
+    if geomtype == GeoType.PLANE:
+        t_hit = ray_intersect_plane(geom_to_world, ray_origin, ray_direction, size)
+
+    elif geomtype == GeoType.SPHERE:
         r = size[0]
         t_hit = ray_intersect_sphere(geom_to_world, ray_origin, ray_direction, r)
 

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -11,8 +11,8 @@ from .types import (
 
 # A small constant to avoid division by zero and other numerical issues
 MINVAL = 1e-15
-# float32 epsilon for near-zero checks (e.g. ray parallel to plane)
-EPSILON = 1e-6
+# Tolerance for near-parallel ray rejection (e.g. ray vs plane)
+PARALLEL_TOL = 1e-6
 
 
 @wp.func
@@ -522,15 +522,15 @@ def ray_intersect_mesh(
 def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3):
     """Computes ray-plane intersection.
 
-    The plane lies at z = 0 in local space with normal along +Z.  ``size`` holds ``(half_width, half_length, 0)``:
-    the half-extents along local X and Y.  A value of ``0`` means infinite in that axis.  The plane is double-sided:
+    The plane lies at z = 0 in local space with normal along +Z.  ``size`` holds ``(width, length, 0)``:
+    the full extents along local X and Y.  A value of ``0`` means infinite in that axis.  The plane is double-sided:
     rays approaching from either side register intersections.
 
     Args:
         geom_to_world: The world transform of the plane.
         ray_origin: The origin of the ray in world space.
         ray_direction: The direction of the ray in world space.
-        size: ``(half_width, half_length, 0)`` -- half-extents; ``0`` = infinite.
+        size: ``(width, length, 0)`` -- full extents; ``0`` = infinite.
 
     Returns:
         The distance along the ray to the intersection point, or -1.0 if there is no intersection.
@@ -541,7 +541,7 @@ def ray_intersect_plane(geom_to_world: wp.transform, ray_origin: wp.vec3, ray_di
     rd = wp.transform_vector(world_to_geom, ray_direction)
 
     # Ray parallel to the plane (or degenerate)
-    if wp.abs(rd[2]) < EPSILON:
+    if wp.abs(rd[2]) < PARALLEL_TOL:
         return -1.0
 
     # t where the ray crosses z = 0

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -13,8 +13,10 @@ from newton._src.geometry.raycast import (
     ray_intersect_capsule,
     ray_intersect_cone,
     ray_intersect_cylinder,
+    ray_intersect_ellipsoid,
     ray_intersect_geom,
     ray_intersect_mesh,
+    ray_intersect_plane,
     ray_intersect_sphere,
 )
 from newton.tests.unittest_utils import add_function_test, get_test_devices
@@ -89,6 +91,30 @@ def kernel_test_cone(
 
 
 @wp.kernel
+def kernel_test_ellipsoid(
+    out_t: wp.array[float],
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    semi_axes: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_ellipsoid(geom_to_world, ray_origin, ray_direction, semi_axes)
+
+
+@wp.kernel
+def kernel_test_plane(
+    out_t: wp.array[float],
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    size: wp.vec3,
+):
+    tid = wp.tid()
+    out_t[tid] = ray_intersect_plane(geom_to_world, ray_origin, ray_direction, size)
+
+
+@wp.kernel
 def kernel_test_geom(
     out_t: wp.array[float],
     geom_to_world: wp.transform,
@@ -121,21 +147,21 @@ def test_ray_intersect_sphere(test: TestRaycast, device: str):
     geom_to_world = wp.transform_identity()
     r = 1.0
 
-    # Case 1: Ray hits sphere
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("hit"):
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Case 2: Ray misses sphere
-    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
-    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+        wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
-    # Case 3: Ray starts inside
-    ray_origin = wp.vec3(0.0, 0.0, 0.0)
-    wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("inside"):
+        ray_origin = wp.vec3(0.0, 0.0, 0.0)
+        wp.launch(kernel_test_sphere, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
 
 def test_ray_intersect_box(test: TestRaycast, device: str):
@@ -143,30 +169,29 @@ def test_ray_intersect_box(test: TestRaycast, device: str):
     geom_to_world = wp.transform_identity()
     size = wp.vec3(1.0, 1.0, 1.0)
 
-    # Case 1: Ray hits box
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("hit"):
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Case 2: Ray misses box
-    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
-    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+        wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
-    # Case 3: Ray starts inside
-    ray_origin = wp.vec3(0.0, 0.0, 0.0)
-    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("inside"):
+        ray_origin = wp.vec3(0.0, 0.0, 0.0)
+        wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Case 4: Rotated box
-    # Rotate 45 degrees around Z axis
-    rot = wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.785398)  # pi/4
-    geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 0.0), rot)
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.41421, delta=1e-5)
+    with test.subTest("rotated"):
+        rot = wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.785398)  # pi/4
+        geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 0.0), rot)
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(kernel_test_box, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device)
+        test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.41421, delta=1e-5)
 
 
 def test_ray_intersect_capsule(test: TestRaycast, device: str):
@@ -175,23 +200,29 @@ def test_ray_intersect_capsule(test: TestRaycast, device: str):
     r = 0.5
     h = 1.0
 
-    # Case 1: Hit cylinder part
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+    with test.subTest("hit_cylinder"):
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
 
-    # Case 2: Hit top cap
-    ray_origin = wp.vec3(0.0, 0.0, -2.0)
-    ray_direction = wp.vec3(0.0, 0.0, 1.0)
-    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.0 - 0.5, delta=1e-5)
+    with test.subTest("hit_cap"):
+        ray_origin = wp.vec3(0.0, 0.0, -2.0)
+        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        wp.launch(
+            kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 2.0 - 1.0 - 0.5, delta=1e-5)
 
-    # Case 3: Miss
-    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_capsule, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
 
 def test_ray_intersect_cylinder(test: TestRaycast, device: str):
@@ -200,29 +231,29 @@ def test_ray_intersect_cylinder(test: TestRaycast, device: str):
     r = 0.5
     h = 1.0
 
-    # Case 1: Hit cylinder body
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(
-        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+    with test.subTest("hit_body"):
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
 
-    # Case 2: Hit top cap
-    ray_origin = wp.vec3(0.0, 0.0, -2.0)
-    ray_direction = wp.vec3(0.0, 0.0, 1.0)
-    wp.launch(
-        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("hit_cap"):
+        ray_origin = wp.vec3(0.0, 0.0, -2.0)
+        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        wp.launch(
+            kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Case 3: Miss
-    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(
-        kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_cylinder, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
 
 def test_ray_intersect_cone(test: TestRaycast, device: str):
@@ -231,29 +262,157 @@ def test_ray_intersect_cone(test: TestRaycast, device: str):
     r = 1.0  # base radius
     h = 1.0  # half height (so total height is 2.0)
 
-    # Case 1: Hit cone body from the side
-    ray_origin = wp.vec3(-2.0, 0.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-3)
+    with test.subTest("hit_body"):
+        ray_origin = wp.vec3(-2.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-3)
 
-    # Case 2: Hit cone base from below
-    ray_origin = wp.vec3(0.0, 0.0, -2.0)
-    ray_direction = wp.vec3(0.0, 0.0, 1.0)
-    wp.launch(kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-3)  # hits base at z=-1
+    with test.subTest("hit_base"):
+        ray_origin = wp.vec3(0.0, 0.0, -2.0)
+        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        wp.launch(
+            kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-3)  # hits base at z=-1
 
-    # Case 3: Miss cone completely
-    ray_origin = wp.vec3(-2.0, 2.0, 0.0)
-    ray_direction = wp.vec3(1.0, 0.0, 0.0)
-    wp.launch(kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-2.0, 2.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
-    # Case 4: Ray from above hitting the tip area
-    ray_origin = wp.vec3(0.0, 0.0, 2.0)
-    ray_direction = wp.vec3(0.0, 0.0, -1.0)
-    wp.launch(kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device)
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-3)  # hits tip at z=1
+    with test.subTest("hit_tip"):
+        ray_origin = wp.vec3(0.0, 0.0, 2.0)
+        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_cone, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, r, h], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-3)  # hits tip at z=1
+
+
+def test_ray_intersect_ellipsoid(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    semi_axes = wp.vec3(1.0, 0.5, 0.5)  # non-uniform to exercise ellipsoid-specific logic
+
+    with test.subTest("hit"):
+        ray_origin = wp.vec3(-3.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_ellipsoid,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, semi_axes],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 2.0, delta=1e-5)
+
+    with test.subTest("miss"):
+        ray_origin = wp.vec3(-3.0, 1.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_ellipsoid,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, semi_axes],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    with test.subTest("inside"):
+        ray_origin = wp.vec3(0.0, 0.0, 0.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_ellipsoid,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, semi_axes],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+
+
+def test_ray_intersect_plane(test: TestRaycast, device: str):
+    out_t = wp.zeros(1, dtype=float, device=device)
+    geom_to_world = wp.transform_identity()
+    size = wp.vec3(0.0, 0.0, 0.0)
+
+    with test.subTest("hit_from_above"):
+        ray_origin = wp.vec3(0.0, 0.0, 5.0)
+        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+
+    with test.subTest("parallel_miss"):
+        ray_origin = wp.vec3(0.0, 0.0, 2.0)
+        ray_direction = wp.vec3(1.0, 0.0, 0.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    with test.subTest("backward_miss"):
+        ray_origin = wp.vec3(0.0, 0.0, 5.0)
+        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    with test.subTest("translated_plane"):
+        geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 3.0), wp.quat_identity())
+        ray_origin = wp.vec3(0.0, 0.0, 8.0)
+        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+
+    with test.subTest("finite_hit"):
+        size_finite = wp.vec3(4.0, 4.0, 0.0)
+        ray_origin = wp.vec3(3.0, 0.0, 3.0)
+        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_plane,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, size_finite],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 3.0, delta=1e-5)
+
+    with test.subTest("finite_miss"):
+        size_finite = wp.vec3(4.0, 4.0, 0.0)
+        ray_origin = wp.vec3(5.0, 0.0, 3.0)
+        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_plane,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, size_finite],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    with test.subTest("hit_from_below"):
+        ray_origin = wp.vec3(0.0, 0.0, -5.0)
+        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+
+    with test.subTest("rotated_plane"):
+        q_rot = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 3.14159265 / 2.0)
+        geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 0.0), q_rot)
+        ray_origin = wp.vec3(0.0, -5.0, 0.0)
+        ray_direction = wp.vec3(0.0, 1.0, 0.0)
+        wp.launch(
+            kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
 
 
 def test_geom_ray_intersect(test: TestRaycast, device: str):
@@ -262,6 +421,18 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     ray_origin = wp.vec3(-2.0, 0.0, 0.0)
     ray_direction = wp.vec3(1.0, 0.0, 0.0)
     mesh_id = wp.uint64(0)  # No mesh for primitive shapes
+
+    # Plane (infinite ground plane at z=0, ray from above)
+    size = wp.vec3(0.0, 0.0, 0.0)
+    ray_origin_plane = wp.vec3(0.0, 0.0, 5.0)
+    ray_direction_plane = wp.vec3(0.0, 0.0, -1.0)
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GeoType.PLANE, ray_origin_plane, ray_direction_plane, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
 
     # Sphere
     size = wp.vec3(1.0, 0.0, 0.0)  # r
@@ -312,6 +483,16 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
         device=device,
     )
     test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-3)
+
+    # Ellipsoid
+    size = wp.vec3(1.0, 0.5, 0.5)  # semi-axes (rx, ry, rz)
+    wp.launch(
+        kernel_test_geom,
+        dim=1,
+        inputs=[out_t, geom_to_world, size, GeoType.ELLIPSOID, ray_origin, ray_direction, mesh_id],
+        device=device,
+    )
+    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
 
 def test_ray_intersect_mesh(test: TestRaycast, device: str):
@@ -470,11 +651,13 @@ def test_convex_hull_ray_intersect_via_geom(test: TestRaycast, device: str):
 
 
 devices = get_test_devices()
+add_function_test(TestRaycast, "test_ray_intersect_plane", test_ray_intersect_plane, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_sphere", test_ray_intersect_sphere, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_box", test_ray_intersect_box, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_capsule", test_ray_intersect_capsule, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_cylinder", test_ray_intersect_cylinder, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_cone", test_ray_intersect_cone, devices=devices)
+add_function_test(TestRaycast, "test_ray_intersect_ellipsoid", test_ray_intersect_ellipsoid, devices=devices)
 add_function_test(TestRaycast, "test_geom_ray_intersect", test_geom_ray_intersect, devices=devices)
 add_function_test(TestRaycast, "test_ray_intersect_mesh", test_ray_intersect_mesh, devices=devices)
 add_function_test(TestRaycast, "test_mesh_ray_intersect_via_geom", test_mesh_ray_intersect_via_geom, devices=devices)

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -340,12 +340,12 @@ def test_ray_intersect_plane(test: TestRaycast, device: str):
     size = wp.vec3(0.0, 0.0, 0.0)
 
     with test.subTest("hit_from_above"):
-        ray_origin = wp.vec3(0.0, 0.0, 5.0)
-        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        ray_origin = wp.vec3(0.0, 0.0, 4.0)
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple
         wp.launch(
             kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
         )
-        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
     with test.subTest("parallel_miss"):
         ray_origin = wp.vec3(0.0, 0.0, 2.0)
@@ -365,29 +365,44 @@ def test_ray_intersect_plane(test: TestRaycast, device: str):
 
     with test.subTest("translated_plane"):
         geom_to_world = wp.transform(wp.vec3(0.0, 0.0, 3.0), wp.quat_identity())
-        ray_origin = wp.vec3(0.0, 0.0, 8.0)
-        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        ray_origin = wp.vec3(0.0, 0.0, 7.0)
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, local z-offset = 4
         wp.launch(
             kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
         )
-        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
     with test.subTest("finite_hit"):
+        geom_to_world = wp.transform_identity()
         size_finite = wp.vec3(4.0, 4.0, 0.0)
-        ray_origin = wp.vec3(3.0, 0.0, 3.0)
-        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+        ray_origin = wp.vec3(0.0, 0.0, 4.0)
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, hits at (3, 0, 0)
         wp.launch(
             kernel_test_plane,
             dim=1,
             inputs=[out_t, geom_to_world, ray_origin, ray_direction, size_finite],
             device=device,
         )
-        test.assertAlmostEqual(out_t.numpy()[0], 3.0, delta=1e-5)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    with test.subTest("finite_miss"):
-        size_finite = wp.vec3(4.0, 4.0, 0.0)
-        ray_origin = wp.vec3(5.0, 0.0, 3.0)
-        ray_direction = wp.vec3(0.0, 0.0, -1.0)
+    with test.subTest("finite_miss_x"):
+        geom_to_world = wp.transform_identity()
+        size_finite = wp.vec3(2.0, 2.0, 0.0)
+        ray_origin = wp.vec3(0.0, 0.0, 4.0)
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, hits at (3, 0, 0) -- |3| > 2
+        wp.launch(
+            kernel_test_plane,
+            dim=1,
+            inputs=[out_t, geom_to_world, ray_origin, ray_direction, size_finite],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
+
+    with test.subTest("finite_miss_y"):
+        geom_to_world = wp.transform_identity()
+        size_finite = wp.vec3(10.0, 2.0, 0.0)
+        ray_origin = wp.vec3(0.0, 0.0, 4.0)
+        ray_direction = wp.vec3(0.0, 3.0, -4.0)  # 3-4-5 triple, hits at (0, 3, 0) -- |3| > 2
         wp.launch(
             kernel_test_plane,
             dim=1,
@@ -397,12 +412,13 @@ def test_ray_intersect_plane(test: TestRaycast, device: str):
         test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
     with test.subTest("hit_from_below"):
-        ray_origin = wp.vec3(0.0, 0.0, -5.0)
-        ray_direction = wp.vec3(0.0, 0.0, 1.0)
+        geom_to_world = wp.transform_identity()
+        ray_origin = wp.vec3(0.0, 0.0, -4.0)
+        ray_direction = wp.vec3(0.0, 3.0, 4.0)  # 3-4-5 triple
         wp.launch(
             kernel_test_plane, dim=1, inputs=[out_t, geom_to_world, ray_origin, ray_direction, size], device=device
         )
-        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
     with test.subTest("rotated_plane"):
         q_rot = wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 3.14159265 / 2.0)
@@ -422,77 +438,77 @@ def test_geom_ray_intersect(test: TestRaycast, device: str):
     ray_direction = wp.vec3(1.0, 0.0, 0.0)
     mesh_id = wp.uint64(0)  # No mesh for primitive shapes
 
-    # Plane (infinite ground plane at z=0, ray from above)
-    size = wp.vec3(0.0, 0.0, 0.0)
-    ray_origin_plane = wp.vec3(0.0, 0.0, 5.0)
-    ray_direction_plane = wp.vec3(0.0, 0.0, -1.0)
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.PLANE, ray_origin_plane, ray_direction_plane, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
+    with test.subTest("plane"):
+        size = wp.vec3(0.0, 0.0, 0.0)
+        ray_origin_plane = wp.vec3(0.0, 0.0, 5.0)
+        ray_direction_plane = wp.vec3(0.0, 0.0, -1.0)
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.PLANE, ray_origin_plane, ray_direction_plane, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 5.0, delta=1e-5)
 
-    # Sphere
-    size = wp.vec3(1.0, 0.0, 0.0)  # r
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.SPHERE, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("sphere"):
+        size = wp.vec3(1.0, 0.0, 0.0)  # r
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.SPHERE, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Box
-    size = wp.vec3(1.0, 1.0, 1.0)  # half-extents
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.BOX, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("box"):
+        size = wp.vec3(1.0, 1.0, 1.0)  # half-extents
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.BOX, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    # Capsule
-    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.CAPSULE, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+    with test.subTest("capsule"):
+        size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.CAPSULE, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
 
-    # Cylinder
-    size = wp.vec3(0.5, 1.0, 0.0)  # r, h
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.CYLINDER, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
+    with test.subTest("cylinder"):
+        size = wp.vec3(0.5, 1.0, 0.0)  # r, h
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.CYLINDER, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-5)
 
-    # Cone
-    size = wp.vec3(1.0, 1.0, 0.0)  # r, h
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.CONE, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-3)
+    with test.subTest("cone"):
+        size = wp.vec3(1.0, 1.0, 0.0)  # r, h
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.CONE, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.5, delta=1e-3)
 
-    # Ellipsoid
-    size = wp.vec3(1.0, 0.5, 0.5)  # semi-axes (rx, ry, rz)
-    wp.launch(
-        kernel_test_geom,
-        dim=1,
-        inputs=[out_t, geom_to_world, size, GeoType.ELLIPSOID, ray_origin, ray_direction, mesh_id],
-        device=device,
-    )
-    test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+    with test.subTest("ellipsoid"):
+        size = wp.vec3(1.0, 0.5, 0.5)  # semi-axes (rx, ry, rz)
+        wp.launch(
+            kernel_test_geom,
+            dim=1,
+            inputs=[out_t, geom_to_world, size, GeoType.ELLIPSOID, ray_origin, ray_direction, mesh_id],
+            device=device,
+        )
+        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
 
 def test_ray_intersect_mesh(test: TestRaycast, device: str):

--- a/newton/tests/test_raycast.py
+++ b/newton/tests/test_raycast.py
@@ -372,24 +372,24 @@ def test_ray_intersect_plane(test: TestRaycast, device: str):
         )
         test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
 
-    with test.subTest("finite_hit"):
+    with test.subTest("finite_miss_half_extent"):
         geom_to_world = wp.transform_identity()
-        size_finite = wp.vec3(4.0, 4.0, 0.0)
+        size_finite = wp.vec3(4.0, 4.0, 0.0)  # full width 4, half-extent 2
         ray_origin = wp.vec3(0.0, 0.0, 4.0)
-        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, hits at (3, 0, 0)
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, crosses plane at (3, 0, 0) -- |3| > 2
         wp.launch(
             kernel_test_plane,
             dim=1,
             inputs=[out_t, geom_to_world, ray_origin, ray_direction, size_finite],
             device=device,
         )
-        test.assertAlmostEqual(out_t.numpy()[0], 1.0, delta=1e-5)
+        test.assertAlmostEqual(out_t.numpy()[0], -1.0, delta=1e-5)
 
     with test.subTest("finite_miss_x"):
         geom_to_world = wp.transform_identity()
-        size_finite = wp.vec3(2.0, 2.0, 0.0)
+        size_finite = wp.vec3(2.0, 2.0, 0.0)  # full width 2, half-extent 1
         ray_origin = wp.vec3(0.0, 0.0, 4.0)
-        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, hits at (3, 0, 0) -- |3| > 2
+        ray_direction = wp.vec3(3.0, 0.0, -4.0)  # 3-4-5 triple, hits at (3, 0, 0) -- |3| > 1
         wp.launch(
             kernel_test_plane,
             dim=1,
@@ -402,7 +402,7 @@ def test_ray_intersect_plane(test: TestRaycast, device: str):
         geom_to_world = wp.transform_identity()
         size_finite = wp.vec3(10.0, 2.0, 0.0)
         ray_origin = wp.vec3(0.0, 0.0, 4.0)
-        ray_direction = wp.vec3(0.0, 3.0, -4.0)  # 3-4-5 triple, hits at (0, 3, 0) -- |3| > 2
+        ray_direction = wp.vec3(0.0, 3.0, -4.0)  # 3-4-5 triple, hits at (0, 3, 0) -- |3| > half 2 = 1
         wp.launch(
             kernel_test_plane,
             dim=1,

--- a/newton/tests/test_sensor_raycast.py
+++ b/newton/tests/test_sensor_raycast.py
@@ -403,7 +403,7 @@ def test_sensor_raycast_ground_plane(test: unittest.TestCase, device: str):
 
     state = model.state()
 
-    # Camera at z=5 looking straight down — should see ground at z=0
+    # Camera at z=5 looking straight down -- should see ground at z=0
     sensor = SensorRaycast(
         model=model,
         camera_position=(0.0, 0.0, 5.0),

--- a/newton/tests/test_sensor_raycast.py
+++ b/newton/tests/test_sensor_raycast.py
@@ -393,6 +393,69 @@ def test_sensor_raycast_single_pixel_hit(test: unittest.TestCase, device):
     test.assertTrue(np.all(depth_image[no_hit_mask] < 0.0), "Non-target pixels should report no hit (-1).")
 
 
+def test_sensor_raycast_ground_plane(test: unittest.TestCase, device: str):
+    """Test that SensorRaycast detects the ground plane."""
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+    builder.add_ground_plane()
+
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+
+    state = model.state()
+
+    # Camera at z=5 looking straight down — should see ground at z=0
+    sensor = SensorRaycast(
+        model=model,
+        camera_position=(0.0, 0.0, 5.0),
+        camera_direction=(0.0, 0.0, -1.0),
+        camera_up=(0.0, 1.0, 0.0),
+        fov_radians=0.5,
+        width=8,
+        height=8,
+        max_distance=100.0,
+    )
+
+    sensor.update(state)
+    depth = sensor.get_depth_image_numpy()
+
+    # Every pixel should hit the infinite ground plane
+    test.assertTrue(np.all(depth > 0.0), "All pixels should hit the ground plane")
+    # Center pixel should be at distance 5.0
+    test.assertAlmostEqual(float(depth[4, 4]), 5.0, delta=0.1)
+
+
+def test_sensor_raycast_ellipsoid(test: unittest.TestCase, device: str):
+    """Test that SensorRaycast detects an ellipsoid shape."""
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 5.0), wp.quat_identity()))
+    builder.add_shape_ellipsoid(body=body, rx=1.5, ry=1.0, rz=0.8)
+
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+
+    state = model.state()
+    newton.eval_fk(model, state.joint_q, state.joint_qd, state)
+
+    # Camera at origin looking +Z toward the ellipsoid
+    sensor = SensorRaycast(
+        model=model,
+        camera_position=(0.0, 0.0, 0.0),
+        camera_direction=(0.0, 0.0, 1.0),
+        camera_up=(0.0, 1.0, 0.0),
+        fov_radians=0.1,
+        width=1,
+        height=1,
+        max_distance=20.0,
+    )
+
+    sensor.update(state)
+    depth = sensor.get_depth_image_numpy()
+
+    test.assertEqual(depth.shape, (1, 1))
+    # Ray along +Z hits ellipsoid at z = 5.0 - rz = 4.2
+    test.assertAlmostEqual(float(depth[0, 0]), 4.2, delta=1e-3)
+
+
 class TestSensorRaycast(unittest.TestCase):
     pass
 
@@ -400,6 +463,12 @@ class TestSensorRaycast(unittest.TestCase):
 # Register test for all available devices
 devices = get_test_devices()
 add_function_test(TestSensorRaycast, "test_sensor_raycast_cubemap", test_sensor_raycast_cubemap, devices=devices)
+add_function_test(
+    TestSensorRaycast,
+    "test_sensor_raycast_ground_plane",
+    test_sensor_raycast_ground_plane,
+    devices=devices,
+)
 add_function_test(
     TestSensorRaycast,
     "test_sensor_raycast_particles_hit",
@@ -440,6 +509,12 @@ add_function_test(
     TestSensorRaycast,
     "test_sensor_raycast_single_pixel_hit",
     test_sensor_raycast_single_pixel_hit,
+    devices=devices,
+)
+add_function_test(
+    TestSensorRaycast,
+    "test_sensor_raycast_ellipsoid",
+    test_sensor_raycast_ellipsoid,
     devices=devices,
 )
 


### PR DESCRIPTION
## Description

SensorRaycast silently ignored PLANE geometry because ray_intersect_geom had no `GeoType.PLANE` branch. Add `ray_intersect_plane()` and wire it into the dispatch.

Also adds unit tests for ellipsoid raycast (previously untested).

resolves #2402

Heightfields are still not covered; this is tracked in #2412.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_raycast
uv run --extra dev -m newton.tests -k test_sensor_raycast
```

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

1. Create a scene with a ground plane (builder.add_ground_plane())
2. Attach a SensorRaycast pointing at the plane
3. Call sensor.update(state) and read the depth image
4. All pixels report -1.0 (no hit) despite the plane being in view
**Minimal reproduction:**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ray-casting sensor now correctly detects intersections with plane geometry.

* **Tests**
  * Added tests validating plane geometry and ellipsoid ray intersections, including sensor depth checks.
  * Refined raycast test structure for clearer, more maintainable assertions.

* **Documentation**
  * Added changelog entry documenting the plane intersection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->