### PR TITLE
Close changelog and update docs links for 1.1.0 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.1.0] - 2026-04-13
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Newton was initiated by [Disney Research](https://www.disneyresearch.com/), [Goo
 - **OS:** Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
 - **GPU:** NVIDIA GPU (Maxwell or newer), driver 545 or newer (CUDA 12). No local CUDA Toolkit installation required. macOS runs on CPU.
 
-For detailed system requirements and tested configurations, see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html).
+For detailed system requirements and tested configurations, see the [installation guide](https://newton-physics.github.io/newton/1.1.0/guide/installation.html).
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ pip install "newton[examples]"
 python -m newton.examples basic_pendulum
 ```
 
-To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html).
+To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/1.1.0/guide/installation.html).
 
 ## Examples
 
@@ -796,11 +796,11 @@ python -m newton.examples basic_viewer --viewer gl --num-frames 500 --device cpu
 
 ## Contributing and Development
 
-See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/latest/guide/development.html) for instructions on how to contribute to Newton.
+See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/1.1.0/guide/development.html) for instructions on how to contribute to Newton.
 
 ## Support and Community Discussion
 
-For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/latest/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
+For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/1.1.0/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Description

Prepare the release branch for the 1.1.0 GA release:

- Rename `[Unreleased]` → `[1.1.0] - 2026-04-13` in `CHANGELOG.md`
- Update `README.md` documentation links from `/latest/` → `/1.1.0/`
- Verified all dependency pins in `pyproject.toml` use stable (non-pre-release) versions
- Regenerated `uv.lock` — no changes (already up to date, no pre-release deps)

Per the [release process](https://newton-physics.github.io/newton/latest/guide/release.html#final-ga-release).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

No code changes — changelog and documentation link updates only.