### PR TITLE
Update release process docs

### DIFF
--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -98,9 +98,10 @@ Code freeze and release branch creation
    * - ☐
      - On **release-X.Y**: update dependencies in ``pyproject.toml`` from dev
        to RC versions where applicable and remove the NVIDIA package index
-       (``[[tool.uv.index]]`` entry for ``nvidia``) so the release wheel
-       installs purely from PyPI, then regenerate ``uv.lock`` (``uv lock``)
-       and commit.
+       (``[[tool.uv.index]]`` entry for ``nvidia`` **and** the
+       ``warp-lang`` entry in ``[tool.uv.sources]`` that references it) so
+       the release wheel installs purely from PyPI, then regenerate
+       ``uv.lock`` (``uv lock``) and commit.
    * - ☐
      - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
        (build wheel → PyPI publish with manual approval).

--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -108,9 +108,18 @@ Code freeze and release branch creation
      - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
        (build wheel → PyPI publish with manual approval).
    * - ☐
-     - Manually trigger the **minspec** and **multi-GPU** CI workflows on the
-       ``release-X.Y`` branch (these do not run automatically on new
-       branches).  Verify they pass before announcing the RC.
+     - Manually trigger the **minimum-dependency** and **multi-GPU** CI
+       workflows on the ``release-X.Y`` branch (the nightly orchestrator
+       only runs on ``main``).  Verify both pass before announcing the RC.
+
+       .. code-block:: bash
+
+          # Minimum-dependency tests (lowest compatible PyPI versions)
+          gh workflow run minimum_deps_tests.yml --ref release-X.Y
+
+          # Multi-GPU tests (g7e.12xlarge = 4× L40S GPUs)
+          gh workflow run aws_gpu_tests.yml --ref release-X.Y \
+              -f instance-type=g7e.12xlarge
    * - ☐
      - RC1 published to PyPI (approve in GitHub environment).
 

--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -75,7 +75,7 @@ Pre-release planning
        - Verify deprecated symbols carry proper deprecation warnings and
          migration guidance (see :ref:`deprecation-timeline`).
        - Confirm new public API has complete docstrings and is included in
-         Sphinx docs (run ``docs/generate_api.py``).
+         Sphinx docs (run ``uv run docs/generate_api.py``).
    * - ☐
      - Communicate the timeline to the community.
 
@@ -91,17 +91,26 @@ Code freeze and release branch creation
      - Create ``release-X.Y`` branch from ``main`` and push it.
    * - ☐
      - On **main**: bump the version in ``pyproject.toml`` to ``X.(Y+1).0.dev0`` and run
-       ``docs/generate_api.py``.
+       ``uv run docs/generate_api.py``.
    * - ☐
      - On **release-X.Y**: bump the version in ``pyproject.toml`` to ``X.Y.ZrcN`` and
-       run ``docs/generate_api.py``.
+       run ``uv run docs/generate_api.py``.
    * - ☐
      - On **release-X.Y**: update dependencies in ``pyproject.toml`` from dev
        to RC versions where applicable, then regenerate ``uv.lock``
        (``uv lock``) and commit it.
    * - ☐
+     - On **release-X.Y**: remove the NVIDIA package index
+       (``[[tool.uv.index]]`` entry for ``nvidia``) from ``pyproject.toml``
+       so the release wheel installs purely from PyPI, then regenerate
+       ``uv.lock`` (``uv lock``) and commit.
+   * - ☐
      - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
        (build wheel → PyPI publish with manual approval).
+   * - ☐
+     - Manually trigger the **minspec** and **multi-GPU** CI workflows on the
+       ``release-X.Y`` branch (these do not run automatically on new
+       branches).  Verify they pass before announcing the RC.
    * - ☐
      - RC1 published to PyPI (approve in GitHub environment).
 
@@ -115,7 +124,7 @@ branch and open a pull request targeting ``release-X.Y`` — never push
 directly to the release branch.
 
 For each new RC (``rc2``, ``rc3``, …) bump the version in
-``pyproject.toml`` and run ``docs/generate_api.py``, then tag and push.
+``pyproject.toml`` and run ``uv run docs/generate_api.py``, then tag and push.
 Resolve any cherry-pick conflicts or missing dependent cherry-picks that
 cause CI failures before tagging.
 
@@ -194,7 +203,7 @@ otherwise.
        dependencies remain in the lock file.
    * - ☐
      - Bump the version in ``pyproject.toml`` to ``X.Y.Z`` (remove the RC suffix) and
-       run ``docs/generate_api.py``.
+       run ``uv run docs/generate_api.py``.
    * - ☐
      - Commit and push tag ``vX.Y.Z``.  Automated workflows trigger:
 

--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -97,13 +97,10 @@ Code freeze and release branch creation
        run ``uv run docs/generate_api.py``.
    * - ☐
      - On **release-X.Y**: update dependencies in ``pyproject.toml`` from dev
-       to RC versions where applicable, then regenerate ``uv.lock``
-       (``uv lock``) and commit it.
-   * - ☐
-     - On **release-X.Y**: remove the NVIDIA package index
-       (``[[tool.uv.index]]`` entry for ``nvidia``) from ``pyproject.toml``
-       so the release wheel installs purely from PyPI, then regenerate
-       ``uv.lock`` (``uv lock``) and commit.
+       to RC versions where applicable and remove the NVIDIA package index
+       (``[[tool.uv.index]]`` entry for ``nvidia``) so the release wheel
+       installs purely from PyPI, then regenerate ``uv.lock`` (``uv lock``)
+       and commit.
    * - ☐
      - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
        (build wheel → PyPI publish with manual approval).


### PR DESCRIPTION
## Description

Three improvements to the release process checklist based on lessons from the 1.1.0 release:

- Add `uv run` prefix to all `docs/generate_api.py` invocations so the uv-managed Python version is used consistently
- Add checklist entry for removing the NVIDIA package index (`[[tool.uv.index]]` for `nvidia`) from `pyproject.toml` on the release branch, so the wheel installs purely from PyPI
- Add checklist entry for manually triggering the minspec and multi-GPU CI workflows on the release branch (they don't run automatically on new branches)

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Documentation-only change. Verified by reviewing the rendered RST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized API docs generation to run via the centralized docs tool/command across pre-release, RC, and final release steps.
  * Updated release-branch flow to remove the vendor-specific package index entry and regenerate the dependency lockfile before proceeding.
  * Added manual CI verification for release candidates: require minimum-deps and multi-GPU AWS test workflows to pass before announcing an RC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->