### PR TITLE
Bump warp-lang to 1.13.0 dev nightly

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U warp-lang==1.12.1 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U warp-lang==1.13.0.dev20260413 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.6.0",
     "python -m pip install -U mujoco-warp==3.6.0",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U warp-lang==1.13.0.dev20260413 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.13.0.dev20260413 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.6.0",
     "python -m pip install -U mujoco-warp==3.6.0",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ url = "https://pypi.nvidia.com/"
 explicit = true
 
 [tool.uv]
-prerelease = "allow"
 conflicts = [
     [
         { extra = "torch-cu12" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ url = "https://pypi.nvidia.com/"
 explicit = true
 
 [tool.uv]
+prerelease = "allow"
 conflicts = [
     [
         { extra = "torch-cu12" },

--- a/uv.lock
+++ b/uv.lock
@@ -18,9 +18,6 @@ conflicts = [[
     { package = "newton", extra = "torch-cu13" },
 ]]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "absl-py"
 version = "2.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,9 @@ conflicts = [[
     { package = "newton", extra = "torch-cu13" },
 ]]
 
+[options]
+prerelease-mode = "allow"
+
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -5906,17 +5909,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.1"
+version = "1.13.0.dev20260413"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98df3533a6c40a33cce961f8efa991006b30c9d286356e4cd77ea8ce86928f1d" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6bf01f10509488ba8eacaf4ec7fcf7cfbd503118b22e002ecba407b40a17424e" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:af6d680e79c1be6e46ddf80ecaa358f222804f882f4683260a7b4abd80a0981b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-win_amd64.whl", hash = "sha256:826b2f93df8e47eac0c751a8eb5a0533e2fc5434158c8896a63be53bfbd728c7" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260413-py3-none-macosx_11_0_arm64.whl", hash = "sha256:50ab8d4538c808469bb7d4aaf909e250db365cb571e4f6d5a7350aaf5d9fb6b5" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260413-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ed4c9bc8f8b0c252dc6afd1bd9b1b535ea803ca21a623ae27bbe75b3142c2e9c" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260413-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:22559b23bfe04596e855fa48672220b9f3178c10cb866fddfa4d10d3068412a7" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260413-py3-none-win_amd64.whl", hash = "sha256:ad6ef8a2b258734dbeb07f9dbbe3819b83e023f9bd658152e7e70dde04fe5337" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bump warp-lang to 1.13.0.dev20260413 for 1.2 development cycle.

- Add `prerelease = "allow"` to `[tool.uv]` in `pyproject.toml` so `uv lock` (including the pre-commit hook) resolves the warp-lang nightly correctly
- Update `uv.lock` to warp-lang 1.13.0.dev20260413
- Update `asv.conf.json` benchmark pin to warp-lang 1.13.0.dev20260413

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

CI will validate that the nightly warp-lang wheel installs and all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration to enable pre-release package version support
  * Upgraded dependency to a more recent development version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->