### PR TITLE
Fix ViewerViser terrain mesh popping artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 - Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
 - Fix `SensorRaycast` ignoring `PLANE` geometry
 - Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
+- Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -578,7 +578,9 @@ class ViewerViser(ViewerBase):
         if batched_colors is None:
             batched_colors = np.full((num_instances, 3), 180, dtype=np.uint8)
 
-        # Create new batched mesh
+        # Create new batched mesh.
+        # LOD is disabled because viser's automatic mesh simplification creates
+        # holes in complex geometry (e.g. terrain), causing popping artifacts.
         if use_trimesh:
             handle = self._call_scene_method(
                 self._server.scene.add_batched_meshes_trimesh,
@@ -587,7 +589,7 @@ class ViewerViser(ViewerBase):
                 batched_positions=positions,
                 batched_wxyzs=quats_wxyz,
                 batched_scales=batched_scales,
-                lod="auto",
+                lod="off",
             )
         else:
             handle = self._call_scene_method(
@@ -599,7 +601,7 @@ class ViewerViser(ViewerBase):
                 batched_wxyzs=quats_wxyz,
                 batched_scales=batched_scales,
                 batched_colors=batched_colors,
-                lod="auto",
+                lod="off",
             )
 
         self._scene_handles[name] = handle


### PR DESCRIPTION
## Description

Disable viser's automatic LOD (Level of Detail) for batched meshes. The mesh simplification creates holes in complex geometry (e.g. terrain), causing chunks to pop in and out when orbiting the camera.

Closes #1951

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Manual testing with a terrain mesh in ViewerViser:
```
uv pip install viser
uv run -m newton.examples basic_heightfield --viewer viser
```
Orbit the camera around the terrain and verify no geometry popping occurs.

## Bug fix

**Steps to reproduce:**
1. Create a terrain mesh (heightfield or trimesh-based grid terrain)
2. Render in ViewerViser
3. Orbit the camera at a low angle
4. Observe chunks of the terrain popping in and out

**Minimal reproduction:**

```python
import time
import numpy as np
import trimesh
import warp as wp
import newton

wp.init()

meshes = []
for row in range(4):
    for col in range(4):
        for k in range(5):
            box = trimesh.creation.box(
                (8.0 - 2*k*0.3, 8.0 - 2*k*0.3, (k+2)*0.15),
                trimesh.transformations.translation_matrix([
                    col*8.0 + 4.0, row*8.0 + 4.0, k*0.15/2
                ]),
            )
            meshes.append(box)

combined = trimesh.util.concatenate(meshes)
vertices = np.array(combined.vertices, dtype=np.float32)
indices = np.array(combined.faces, dtype=np.int32).flatten()

builder = newton.ModelBuilder()
mesh = newton.Mesh(vertices=vertices, indices=indices)
builder.add_shape_mesh(body=-1, mesh=mesh)
model = builder.finalize()

viewer = newton.viewer.ViewerViser()
viewer.set_model(model)
state = model.state()

for i in range(10000):
    viewer.begin_frame(i / 60.0)
    viewer.log_state(state)
    viewer.end_frame()
    time.sleep(1.0 / 60.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved viewer mesh "popping" artifacts by disabling automatic LOD simplification in affected mesh batching, preventing holes and visual distortions with complex geometry.

* **Documentation**
  * Updated changelog to document the mesh popping fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->