### PR TITLE
Attempt to improve MPR contact quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - Fix `cloth_franka` example Jacobian broken by COM-referenced `body_qd` convention change; adjust robot base height, gripper orientations, and grasp targets for improved reachability (a follow-up PR will migrate the example to `newton.ik`)
 - Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
 - Fix `SensorRaycast` ignoring `PLANE` geometry
+- Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -33,6 +33,11 @@ import warp as wp
 
 from .types import GeoType
 
+# Relative deadband factor for box support-map sign decisions.
+# Near-zero direction components (e.g. from quaternion rotation noise ~1e-14)
+# are treated as non-negative, biasing toward the +1 vertex.
+BOX_SUPPORT_DEADBAND = 1.0e-10
+
 
 # Is not allowed to share values with GeoType
 class GeoTypeEx(enum.IntEnum):
@@ -174,7 +179,7 @@ def support_map(geom: GenericShapeData, direction: wp.vec3, data_provider: Suppo
         # the non-primary components are zero; any vertex on that face
         # is an equally valid support point, so biasing toward +1 is
         # correct and keeps MPR's initial portal construction stable.
-        threshold = 1.0e-10 * wp.length(direction)
+        threshold = BOX_SUPPORT_DEADBAND * wp.length(direction)
         sx = 1.0 if direction[0] >= -threshold else -1.0
         sy = 1.0 if direction[1] >= -threshold else -1.0
         sz = 1.0 if direction[2] >= -threshold else -1.0
@@ -324,7 +329,7 @@ def support_map_lean(geom: GenericShapeData, direction: wp.vec3, data_provider: 
         result = wp.cw_mul(mesh.points[best_idx], geom.scale)
 
     elif geom.shape_type == GeoType.BOX:
-        threshold = 1.0e-10 * wp.length(direction)
+        threshold = BOX_SUPPORT_DEADBAND * wp.length(direction)
         sx = 1.0 if direction[0] >= -threshold else -1.0
         sy = 1.0 if direction[1] >= -threshold else -1.0
         sz = 1.0 if direction[2] >= -threshold else -1.0

--- a/newton/_src/geometry/support_function.py
+++ b/newton/_src/geometry/support_function.py
@@ -168,9 +168,16 @@ def support_map(geom: GenericShapeData, direction: wp.vec3, data_provider: Suppo
             if direction[2] < 0.0:
                 result = result + wp.vec3(0.0, 0.0, -1.0)
     elif geom.shape_type == GeoType.BOX:
-        sx = 1.0 if direction[0] >= 0.0 else -1.0
-        sy = 1.0 if direction[1] >= 0.0 else -1.0
-        sz = 1.0 if direction[2] >= 0.0 else -1.0
+        # Use a relative deadband so near-zero direction components
+        # (from quaternion rotation noise ~1e-14) cannot flip the sign
+        # and select a different box vertex.  For face-aligned queries
+        # the non-primary components are zero; any vertex on that face
+        # is an equally valid support point, so biasing toward +1 is
+        # correct and keeps MPR's initial portal construction stable.
+        threshold = 1.0e-10 * wp.length(direction)
+        sx = 1.0 if direction[0] >= -threshold else -1.0
+        sy = 1.0 if direction[1] >= -threshold else -1.0
+        sz = 1.0 if direction[2] >= -threshold else -1.0
 
         result = wp.vec3(sx * geom.scale[0], sy * geom.scale[1], sz * geom.scale[2])
 
@@ -317,9 +324,10 @@ def support_map_lean(geom: GenericShapeData, direction: wp.vec3, data_provider: 
         result = wp.cw_mul(mesh.points[best_idx], geom.scale)
 
     elif geom.shape_type == GeoType.BOX:
-        sx = 1.0 if direction[0] >= 0.0 else -1.0
-        sy = 1.0 if direction[1] >= 0.0 else -1.0
-        sz = 1.0 if direction[2] >= 0.0 else -1.0
+        threshold = 1.0e-10 * wp.length(direction)
+        sx = 1.0 if direction[0] >= -threshold else -1.0
+        sy = 1.0 if direction[1] >= -threshold else -1.0
+        sz = 1.0 if direction[2] >= -threshold else -1.0
         result = wp.vec3(sx * geom.scale[0], sy * geom.scale[1], sz * geom.scale[2])
 
     elif geom.shape_type == GeoType.SPHERE:

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -717,6 +717,71 @@ for bp_name in ("explicit", "nxn", "sap"):
     )
 
 
+def test_box_box_quaternion_perturbation(test, device, broad_phase: str):
+    """Verify box-box contacts are correct under tiny quaternion perturbation.
+
+    Two identical cubes are placed face-to-face with a non-trivial base
+    rotation (30 deg around X) and a tiny quaternion perturbation (~1e-14)
+    in the second box only. Without the support-map deadband fix this
+    produces 1 invalid contact instead of 4 face-corner contacts, with an
+    out-of-bounds body-frame point and a wrong world-frame normal.
+
+    Regression test for issue #2024 / #2430.
+    """
+    with wp.ScopedDevice(device):
+        half = 0.495
+        q_clean = wp.quat(0.2588233343021173, 0.0, 0.0, 0.9659246769912934)
+        q_noisy = wp.quat(0.2588233343021173, -2.27e-14, 9.25e-15, 0.9659246769912934)
+
+        y, z = 6.680443286895752, 4.4285125732421875
+
+        builder = newton.ModelBuilder()
+        b0 = builder.add_body(xform=wp.transform(p=wp.vec3(half, y, z), q=q_clean))
+        builder.add_shape_box(body=b0, hx=half, hy=half, hz=half)
+
+        b1 = builder.add_body(xform=wp.transform(p=wp.vec3(-half, y, z), q=q_noisy))
+        builder.add_shape_box(body=b1, hx=half, hy=half, hz=half)
+
+        model = builder.finalize(device=device)
+        state = model.state()
+
+        pipeline = newton.CollisionPipeline(model, broad_phase=broad_phase)
+        contacts = pipeline.contacts()
+        pipeline.collide(state, contacts)
+
+        cc = int(contacts.rigid_contact_count.numpy()[0])
+        points0 = contacts.rigid_contact_point0.numpy()[:cc]
+        normals = contacts.rigid_contact_normal.numpy()[:cc]
+
+        test.assertEqual(cc, 4, f"Expected 4 face-corner contacts, got {cc}")
+
+        for i in range(cc):
+            pt = points0[i]
+            n = normals[i]
+            for j in range(3):
+                test.assertLessEqual(
+                    abs(pt[j]),
+                    half * 1.01,
+                    f"Contact {i} body-frame point[{j}] = {pt[j]:.4f} outside half-extent {half}",
+                )
+            test.assertAlmostEqual(
+                abs(n[0]),
+                1.0,
+                places=2,
+                msg=f"Contact {i} normal = [{n[0]:.4f}, {n[1]:.4f}, {n[2]:.4f}], expected [+-1, 0, 0]",
+            )
+
+
+for bp_name in ("explicit", "nxn", "sap"):
+    add_function_test(
+        TestRigidContactNormal,
+        f"test_box_box_quaternion_perturbation_{bp_name}",
+        test_box_box_quaternion_perturbation,
+        devices=devices,
+        broad_phase=bp_name,
+    )
+
+
 # ============================================================================
 # Particle-Shape (Soft) Contact Tests
 # ============================================================================


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Should address https://github.com/newton-physics/newton/issues/2024

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of box collision/contact detection so tiny rotation noise no longer causes spurious sign flips or invalid contacts for face-touching boxes.

* **Tests**
  * Added a regression test validating correct contacts under very small quaternion perturbations across broad-phase modes.

* **Changelog**
  * Documented the fix for rotation-noise-induced contact failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->