### PR TITLE
Fix material combination inconsistencies

### DIFF
--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -27,9 +27,15 @@ vec11 = wp.types.vector(length=11, dtype=wp.float32)
 
 # Constants
 MJ_MINVAL = 2.220446049250313e-16
+MJ_MINMU = 1e-5
 
 
 # Utility functions
+@wp.func
+def safe_div(x: float, y: float) -> float:
+    return x / wp.where(y != 0.0, y, MJ_MINVAL)
+
+
 @wp.func
 def orthogonals(a: wp.vec3):
     y = wp.vec3(0.0, 1.0, 0.0)
@@ -144,7 +150,7 @@ def contact_params(
     else:
         solmix1 = geom_solmix[worldid, g1]
         solmix2 = geom_solmix[worldid, g2]
-        mix = solmix1 / (solmix1 + solmix2)
+        mix = safe_div(solmix1, solmix1 + solmix2)
         mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
         mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
         mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
@@ -152,11 +158,11 @@ def contact_params(
         resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
 
     friction = vec5(
-        resolved_friction[0],
-        resolved_friction[0],
-        resolved_friction[1],
-        resolved_friction[2],
-        resolved_friction[2],
+        wp.max(MJ_MINMU, resolved_friction[0]),
+        wp.max(MJ_MINMU, resolved_friction[0]),
+        wp.max(MJ_MINMU, resolved_friction[1]),
+        wp.max(MJ_MINMU, resolved_friction[2]),
+        wp.max(MJ_MINMU, resolved_friction[2]),
     )
 
     # Sum margins for consistency with thickness summing

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -122,7 +122,7 @@ def contact_params(
     geoms: wp.vec2i,
     worldid: int,
 ):
-    # See function contact_params in mujoco_warp, file collision_primitive.py
+    # See function contact_params in mujoco_warp, file collision_core.py
 
     g1 = geoms[0]
     g2 = geoms[1]
@@ -130,31 +130,38 @@ def contact_params(
     p1 = geom_priority[g1]
     p2 = geom_priority[g2]
 
-    solmix1 = geom_solmix[worldid, g1]
-    solmix2 = geom_solmix[worldid, g2]
+    condim1 = geom_condim[g1]
+    condim2 = geom_condim[g2]
 
-    mix = solmix1 / (solmix1 + solmix2)
-    mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
-    mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
-    mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
-    mix = wp.where(p1 == p2, mix, wp.where(p1 > p2, 1.0, 0.0))
+    if p1 > p2:
+        mix = 1.0
+        condim = condim1
+        resolved_friction = geom_friction[worldid, g1]
+    elif p2 > p1:
+        mix = 0.0
+        condim = condim2
+        resolved_friction = geom_friction[worldid, g2]
+    else:
+        solmix1 = geom_solmix[worldid, g1]
+        solmix2 = geom_solmix[worldid, g2]
+        mix = solmix1 / (solmix1 + solmix2)
+        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
+        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
+        mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
+        condim = wp.max(condim1, condim2)
+        resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
+
+    friction = vec5(
+        resolved_friction[0],
+        resolved_friction[0],
+        resolved_friction[1],
+        resolved_friction[2],
+        resolved_friction[2],
+    )
 
     # Sum margins for consistency with thickness summing
     margin = geom_margin[worldid, g1] + geom_margin[worldid, g2]
     gap = geom_gap[worldid, g1] + geom_gap[worldid, g2]
-
-    condim1 = geom_condim[g1]
-    condim2 = geom_condim[g2]
-    condim = wp.where(p1 == p2, wp.max(condim1, condim2), wp.where(p1 > p2, condim1, condim2))
-
-    max_geom_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
-    friction = vec5(
-        max_geom_friction[0],
-        max_geom_friction[0],
-        max_geom_friction[1],
-        max_geom_friction[2],
-        max_geom_friction[2],
-    )
 
     if geom_solref[worldid, g1].x > 0.0 and geom_solref[worldid, g2].x > 0.0:
         solref = mix * geom_solref[worldid, g1] + (1.0 - mix) * geom_solref[worldid, g2]

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4026,36 +4026,37 @@ class TestFrictionPriority(unittest.TestCase):
         self.assertGreater(nacon, 0, "No contacts generated")
         return solver.mjw_data.contact.friction.numpy()[:nacon]
 
-    def test_higher_priority_friction_used(self):
-        """Contact friction should come from the higher-priority geom."""
-        hi_mu = 0.3
-        lo_mu = 0.9
-        model = self._build_model(priority_a=5, friction_a=hi_mu, priority_b=0, friction_b=lo_mu)
-        friction = self._get_contact_friction(model)
-
-        for i in range(len(friction)):
-            self.assertAlmostEqual(
-                float(friction[i, 0]),
-                hi_mu,
-                places=5,
-                msg=f"Contact {i}: slide friction should be {hi_mu} (high-priority geom), got {friction[i, 0]}",
-            )
-
-    def test_equal_priority_uses_max(self):
-        """When priorities are equal, contact friction should be the element-wise max."""
-        mu_a = 0.2
-        mu_b = 0.8
-        model = self._build_model(priority_a=0, friction_a=mu_a, priority_b=0, friction_b=mu_b)
-        friction = self._get_contact_friction(model)
-
-        expected = max(mu_a, mu_b)
+    def _assert_slide_friction(self, friction, expected, label):
         for i in range(len(friction)):
             self.assertAlmostEqual(
                 float(friction[i, 0]),
                 expected,
                 places=5,
-                msg=f"Contact {i}: slide friction should be max({mu_a}, {mu_b})={expected}, got {friction[i, 0]}",
+                msg=f"{label}: contact {i} slide friction should be {expected}, got {friction[i, 0]}",
             )
+
+    def test_higher_priority_friction_used(self):
+        """Contact friction should come from the higher-priority geom, regardless of operand order."""
+        hi_mu = 0.3
+        lo_mu = 0.9
+
+        model_a = self._build_model(priority_a=5, friction_a=hi_mu, priority_b=0, friction_b=lo_mu)
+        self._assert_slide_friction(self._get_contact_friction(model_a), hi_mu, "high-priority on body A")
+
+        model_b = self._build_model(priority_a=0, friction_a=lo_mu, priority_b=5, friction_b=hi_mu)
+        self._assert_slide_friction(self._get_contact_friction(model_b), hi_mu, "high-priority on body B")
+
+    def test_equal_priority_uses_max(self):
+        """When priorities are equal, contact friction should be the element-wise max, regardless of operand order."""
+        mu_lo = 0.2
+        mu_hi = 0.8
+        expected = mu_hi
+
+        model_a = self._build_model(priority_a=0, friction_a=mu_hi, priority_b=0, friction_b=mu_lo)
+        self._assert_slide_friction(self._get_contact_friction(model_a), expected, "larger mu on body A")
+
+        model_b = self._build_model(priority_a=0, friction_a=mu_lo, priority_b=0, friction_b=mu_hi)
+        self._assert_slide_friction(self._get_contact_friction(model_b), expected, "larger mu on body B")
 
 
 class TestImmovableContactFiltering(unittest.TestCase):

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -3971,6 +3971,93 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
         self.assertEqual(n_stale, 0, f"{n_stale}/{inactive.sum()} inactive contacts have stale efc_address")
 
 
+class TestFrictionPriority(unittest.TestCase):
+    """Verify that contact friction respects geom priority.
+
+    When two geoms have different priorities, the higher-priority geom's
+    friction should be used directly (not the element-wise max).
+    """
+
+    def _build_model(self, priority_a, friction_a, priority_b, friction_b):
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+
+        cfg_a = newton.ModelBuilder.ShapeConfig(ke=1e4, kd=1000.0, mu=friction_a)
+        cfg_b = newton.ModelBuilder.ShapeConfig(ke=1e4, kd=1000.0, mu=friction_b)
+
+        body_a = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.3), wp.quat_identity()))
+        builder.add_shape_box(
+            body=body_a,
+            hx=0.2,
+            hy=0.2,
+            hz=0.1,
+            cfg=cfg_a,
+            custom_attributes={"mujoco:geom_priority": priority_a},
+        )
+
+        body_b = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.1), wp.quat_identity()))
+        builder.add_shape_box(
+            body=body_b,
+            hx=0.5,
+            hy=0.5,
+            hz=0.1,
+            cfg=cfg_b,
+            custom_attributes={"mujoco:geom_priority": priority_b},
+        )
+
+        model = builder.finalize()
+        return model
+
+    def _get_contact_friction(self, model):
+        try:
+            solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=200, nconmax=200)
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed: {e}")
+
+        contacts = model.contacts()
+        state_in = model.state()
+        state_out = model.state()
+        control = model.control()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+        model.collide(state_in, contacts)
+        solver.step(state_in, state_out, control, contacts, 0.002)
+
+        nacon = solver.mjw_data.nacon.numpy()[0]
+        self.assertGreater(nacon, 0, "No contacts generated")
+        return solver.mjw_data.contact.friction.numpy()[:nacon]
+
+    def test_higher_priority_friction_used(self):
+        """Contact friction should come from the higher-priority geom."""
+        hi_mu = 0.3
+        lo_mu = 0.9
+        model = self._build_model(priority_a=5, friction_a=hi_mu, priority_b=0, friction_b=lo_mu)
+        friction = self._get_contact_friction(model)
+
+        for i in range(len(friction)):
+            self.assertAlmostEqual(
+                float(friction[i, 0]),
+                hi_mu,
+                places=5,
+                msg=f"Contact {i}: slide friction should be {hi_mu} (high-priority geom), got {friction[i, 0]}",
+            )
+
+    def test_equal_priority_uses_max(self):
+        """When priorities are equal, contact friction should be the element-wise max."""
+        mu_a = 0.2
+        mu_b = 0.8
+        model = self._build_model(priority_a=0, friction_a=mu_a, priority_b=0, friction_b=mu_b)
+        friction = self._get_contact_friction(model)
+
+        expected = max(mu_a, mu_b)
+        for i in range(len(friction)):
+            self.assertAlmostEqual(
+                float(friction[i, 0]),
+                expected,
+                places=5,
+                msg=f"Contact {i}: slide friction should be max({mu_a}, {mu_b})={expected}, got {friction[i, 0]}",
+            )
+
+
 class TestImmovableContactFiltering(unittest.TestCase):
     """Verify that contacts between two immovable bodies are filtered out.
 


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
MjWarp currently uses a different material combination logic. This MR applies the same logic into the Newton-to-MjWarp contact converter. See https://github.com/newton-physics/newton/issues/2422 and https://github.com/newton-physics/newton/discussions/2377


## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contact friction and parameter resolution in the MuJoCo solver now respect geometry priority ordering, correctly selecting higher-priority geometry values and applying component-wise clamping and stable mixing behavior for equal priorities.
* **Tests**
  * Added tests validating friction selection when priorities differ and element-wise mixing when priorities are equal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->