### PR TITLE
Fix finite plane scale and MJCF plane import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
 - Fix `SensorRaycast` ignoring `PLANE` geometry
 - Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
+- Fix MJCF importer creating finite planes from MuJoCo visual half-sizes instead of infinite planes
 
 ## [1.0.0] - 2026-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 - Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
 - Fix `SensorRaycast` ignoring `PLANE` geometry
 - Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
+- Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/utils.py
+++ b/newton/_src/geometry/utils.py
@@ -88,8 +88,7 @@ def compute_shape_radius(geo_type: int, scale: Vec3, src: Mesh | Heightfield | N
         return np.linalg.norm(vmax)
     elif geo_type == GeoType.PLANE:
         if scale[0] > 0.0 and scale[1] > 0.0:
-            # finite plane
-            return np.linalg.norm(scale)
+            return np.linalg.norm(scale) * 0.5
         else:
             return 1.0e6
     elif geo_type == GeoType.HFIELD:

--- a/newton/_src/sensors/warp_raytrace/ray_intersect.py
+++ b/newton/_src/sensors/warp_raytrace/ray_intersect.py
@@ -87,7 +87,7 @@ def ray_intersect_plane(
     )
 
     # accept only within rendered rectangle
-    if (size[0] <= 0.0 or wp.abs(p[0]) <= size[0]) and (size[1] <= 0.0 or wp.abs(p[1]) <= size[1]):
+    if (size[0] <= 0.0 or wp.abs(p[0]) <= size[0] * 0.5) and (size[1] <= 0.0 or wp.abs(p[1]) <= size[1] * 0.5):
         return t_hit
     return -1.0
 

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -238,7 +238,10 @@ def compute_shape_aabbs(
         # Create generic shape data
         shape_data = GenericShapeData()
         shape_data.shape_type = geo_type
-        shape_data.scale = scale
+        if geo_type == GeoType.PLANE:
+            shape_data.scale = wp.vec3(scale[0] * 0.5, scale[1] * 0.5, 0.0)
+        else:
+            shape_data.scale = scale
         shape_data.auxiliary = wp.vec3(0.0, 0.0, 0.0)
 
         # For CONVEX_MESH, pack the mesh pointer
@@ -254,7 +257,10 @@ def compute_shape_aabbs(
         aabb_upper[shape_id] = aabb_max_world + margin_vec
 
     # Narrow-phase geometry data (reuses X_ws and scale already computed above)
-    geom_data[shape_id] = wp.vec4(scale[0], scale[1], scale[2], margin)
+    geom_scale = scale
+    if geo_type == GeoType.PLANE:
+        geom_scale = wp.vec3(scale[0] * 0.5, scale[1] * 0.5, 0.0)
+    geom_data[shape_id] = wp.vec4(geom_scale[0], geom_scale[1], geom_scale[2], margin)
     geom_xform[shape_id] = X_ws
 
 

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -201,6 +201,8 @@ def compute_shape_aabbs(
     is_mesh = geo_type == GeoType.MESH
     is_hfield = geo_type == GeoType.HFIELD
 
+    geom_scale = scale
+
     if is_infinite_plane:
         # Bounding sphere fallback for infinite planes
         radius = shape_collision_radius[shape_id]
@@ -239,9 +241,8 @@ def compute_shape_aabbs(
         shape_data = GenericShapeData()
         shape_data.shape_type = geo_type
         if geo_type == GeoType.PLANE:
-            shape_data.scale = wp.vec3(scale[0] * 0.5, scale[1] * 0.5, 0.0)
-        else:
-            shape_data.scale = scale
+            geom_scale = wp.vec3(scale[0] * 0.5, scale[1] * 0.5, 0.0)
+        shape_data.scale = geom_scale
         shape_data.auxiliary = wp.vec3(0.0, 0.0, 0.0)
 
         # For CONVEX_MESH, pack the mesh pointer
@@ -257,9 +258,6 @@ def compute_shape_aabbs(
         aabb_upper[shape_id] = aabb_max_world + margin_vec
 
     # Narrow-phase geometry data (reuses X_ws and scale already computed above)
-    geom_scale = scale
-    if geo_type == GeoType.PLANE:
-        geom_scale = wp.vec3(scale[0] * 0.5, scale[1] * 0.5, 0.0)
     geom_data[shape_id] = wp.vec4(geom_scale[0], geom_scale[1], geom_scale[2], margin)
     geom_xform[shape_id] = X_ws
 

--- a/newton/_src/solvers/kamino/_src/geometry/unified.py
+++ b/newton/_src/solvers/kamino/_src/geometry/unified.py
@@ -270,7 +270,7 @@ def _compute_collision_radius(geo_type: int32, scale: vec3f) -> float32:
         radius = wp.max(wp.max(scale[0], scale[1]), scale[2])
     elif geo_type == GeoType.PLANE:
         if scale[0] > 0.0 and scale[1] > 0.0:
-            radius = wp.length(scale)
+            radius = wp.length(scale) * 0.5
         else:
             radius = float32(1.0e6)
     elif geo_type == GeoType.MESH or geo_type == GeoType.CONVEX_MESH or geo_type == GeoType.HFIELD:

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -994,10 +994,11 @@ def parse_mjcf(
             elif geom_type == "plane":
                 # Use xform directly - plane has local normal (0,0,1) and passes through origin
                 # The transform tf positions and orients the plane in world space
+                # MuJoCo planes are always infinite for collision; pass 0 extents.
                 s = builder.add_shape_plane(
                     xform=tf,
-                    width=geom_size[0],
-                    length=geom_size[1],
+                    width=0.0,
+                    length=0.0,
                     **shape_kwargs,
                 )
                 shapes.append(s)

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -7485,6 +7485,24 @@ class TestContypeConaffinityZero(unittest.TestCase):
         self.assertGreater(solver.mj_data.ncon, 0, "Explicit <pair> should generate contacts")
 
 
+class TestMjcfPlaneInfinite(unittest.TestCase):
+    """Verify MJCF plane geoms are imported as infinite planes."""
+
+    def test_plane_scale_is_zero(self):
+        """MuJoCo plane size is visual-only; imported plane should have zero extents (infinite)."""
+        mjcf = """<mujoco><worldbody>
+            <geom name="floor" type="plane" size="5 5 0.1"/>
+        </worldbody></mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+
+        scale = model.shape_scale.numpy()[0]
+        np.testing.assert_allclose(
+            scale, [0.0, 0.0, 0.0], atol=1e-7, err_msg="MJCF plane should be infinite (zero extents)"
+        )
+
+
 class TestJointFrictionloss(unittest.TestCase):
     """Verify MJCF joint frictionloss is parsed into Newton's joint_friction."""
 

--- a/newton/tests/test_mesh_aabb.py
+++ b/newton/tests/test_mesh_aabb.py
@@ -214,5 +214,20 @@ class TestHeightfieldLocalAABB(unittest.TestCase):
         np.testing.assert_allclose(hi, [4.0, 1.5, 12.0], atol=1e-5)
 
 
+class TestPlaneBoundingSphere(unittest.TestCase):
+    """Verify plane bounding-sphere radius uses half-diagonal for finite planes."""
+
+    def test_finite_plane_radius(self):
+        """Finite plane radius should be half the diagonal of the full extents."""
+        radius = compute_shape_radius(GeoType.PLANE, (4.0, 6.0, 0.0), None)
+        expected = np.linalg.norm([4.0, 6.0, 0.0]) * 0.5
+        self.assertAlmostEqual(radius, expected, places=5)
+
+    def test_infinite_plane_radius(self):
+        """Infinite plane (zero extents) should return large sentinel radius."""
+        radius = compute_shape_radius(GeoType.PLANE, (0.0, 0.0, 0.0), None)
+        self.assertEqual(radius, 1.0e6)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2, failfast=True)

--- a/newton/tests/test_sensor_raycast.py
+++ b/newton/tests/test_sensor_raycast.py
@@ -424,6 +424,48 @@ def test_sensor_raycast_ground_plane(test: unittest.TestCase, device: str):
     test.assertAlmostEqual(float(depth[4, 4]), 5.0, delta=0.1)
 
 
+def test_sensor_raycast_finite_plane_boundary(test: unittest.TestCase, device: str):
+    """Rays inside a finite plane boundary hit; rays outside miss."""
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+    # Finite plane: full extents 4x4 -> half-extents 2x2
+    builder.add_shape_plane(xform=wp.transform_identity(), width=4.0, length=4.0)
+
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+
+    state = model.state()
+
+    # Ray straight down at center (x=0) -> should hit
+    sensor_center = SensorRaycast(
+        model=model,
+        camera_position=(0.0, 0.0, 5.0),
+        camera_direction=(0.0, 0.0, -1.0),
+        camera_up=(0.0, 1.0, 0.0),
+        fov_radians=0.01,
+        width=1,
+        height=1,
+        max_distance=100.0,
+    )
+    sensor_center.update(state)
+    depth_center = sensor_center.get_depth_image_numpy()
+    test.assertAlmostEqual(float(depth_center[0, 0]), 5.0, delta=0.1, msg="Center ray should hit finite plane")
+
+    # Ray straight down at x=3 (outside half-extent 2) -> should miss
+    sensor_outside = SensorRaycast(
+        model=model,
+        camera_position=(3.0, 0.0, 5.0),
+        camera_direction=(0.0, 0.0, -1.0),
+        camera_up=(0.0, 1.0, 0.0),
+        fov_radians=0.01,
+        width=1,
+        height=1,
+        max_distance=100.0,
+    )
+    sensor_outside.update(state)
+    depth_outside = sensor_outside.get_depth_image_numpy()
+    test.assertLess(float(depth_outside[0, 0]), 0.0, msg="Ray outside finite plane boundary should miss")
+
+
 def test_sensor_raycast_ellipsoid(test: unittest.TestCase, device: str):
     """Test that SensorRaycast detects an ellipsoid shape."""
     builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
@@ -515,6 +557,12 @@ add_function_test(
     TestSensorRaycast,
     "test_sensor_raycast_ellipsoid",
     test_sensor_raycast_ellipsoid,
+    devices=devices,
+)
+add_function_test(
+    TestSensorRaycast,
+    "test_sensor_raycast_finite_plane_boundary",
+    test_sensor_raycast_finite_plane_boundary,
     devices=devices,
 )
 


### PR DESCRIPTION
## Description

Finite planes were being used inconsistently (#2410). This PR fixes the inconsistent interpretation of the scale as half-extents.

Separately, this PR fixes the parsing of planes from MJCF: MuJoCo treats all planes as infinite, thus their shape scale in Newton must be set to 0.


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_plane_scale_is_zero
uv run --extra dev -m newton.tests -k TestPlaneBoundingSphere
uv run --extra dev -m newton.tests -k test_sensor_raycast_finite_plane_boundary
```

## Bug fix

See #2410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected finite plane sizing (was 2x too large), fixing collisions, bounding-sphere calculations, and raycast/hit results.
  * Updated MJCF import so planes are represented correctly as finite or infinite.

* **Tests**
  * Added tests for plane bounding-sphere behavior, MJCF plane import handling, and raycast boundary/no-hit cases to validate fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->