### PR TITLE
Fix eq_objtype mismatch for joint equality constraints

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -4805,7 +4805,7 @@ class SolverMuJoCo(SolverBase):
                     eq.solimp = eq_constraint_solimp[i]
 
             elif constraint_type == EqType.JOINT:
-                eq = spec.add_equality(objtype=mujoco.mjtObj.mjOBJ_JOINT)
+                eq = spec.add_equality()
                 eq.type = mujoco.mjtEq.mjEQ_JOINT
                 eq.active = eq_constraint_enabled[i]
                 j1_idx = int(eq_constraint_joint1[i])
@@ -4944,7 +4944,7 @@ class SolverMuJoCo(SolverBase):
                 )
                 continue
 
-            eq = spec.add_equality(objtype=mujoco.mjtObj.mjOBJ_JOINT)
+            eq = spec.add_equality()
             eq.type = mujoco.mjtEq.mjEQ_JOINT
             eq.active = bool(mimic_enabled[i])
             eq.name1 = j0_name  # follower (constrained joint)

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1825,9 +1825,8 @@ class TestMenagerie_FrankaEmikaPanda(TestMenagerieMJCF):
 
     robot_folder = "franka_emika_panda"
     num_steps = 20
-    dynamics_tolerance = 5e-5  # eq_ diffs cause larger qvel divergence on CI
+    dynamics_tolerance = 5e-5
     fk_enabled = True
-    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"eq_", "neq"}
     backfill_model = True
 
 
@@ -1843,11 +1842,10 @@ class TestMenagerie_FrankaFr3V2(TestMenagerieMJCF):
     """Franka FR3 v2 arm."""
 
     robot_folder = "franka_fr3_v2"
-    # Dynamics disabled: eq_ model fields differ, qpos drift 3.5e-3 (#2170)
+    # Dynamics disabled: qpos drift 3.5e-3 from body_ipos diff (#2170)
     num_steps = 0
     fk_enabled = True
     fk_tolerance = 5e-6  # float32 precision (max diff ~1.2e-6)
-    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"eq_", "neq"}
     backfill_model = True
 
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8807,12 +8807,10 @@ class TestEqualityJointObjType(unittest.TestCase):
         </mujoco>
         """)
 
-        newton_objtype = solver.mjw_model.eq_objtype.numpy().flatten()
-        native_objtype = native_model.eq_objtype
-
+        self.assertEqual(solver.mj_model.neq, native_model.neq, "neq count mismatch")
         np.testing.assert_array_equal(
-            newton_objtype[:1],
-            native_objtype,
+            solver.mj_model.eq_objtype,
+            native_model.eq_objtype,
             err_msg="eq_objtype mismatch: Newton should match native MuJoCo for joint equality",
         )
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8765,6 +8765,58 @@ class TestEqualityWeldConstraintDefaults(unittest.TestCase):
             os.unlink(xml_path)
 
 
+class TestEqualityJointObjType(unittest.TestCase):
+    """Verify eq_objtype matches native MuJoCo for joint equality constraints.
+
+    Regression test: Newton's solver previously passed objtype=mjOBJ_JOINT to
+    spec.add_equality(), causing eq_objtype=3 in the compiled model. Native
+    MuJoCo (from XML) produces eq_objtype=0. The fix: don't pass objtype for
+    joint equality constraints, letting MuJoCo set it automatically.
+    """
+
+    def test_joint_equality_objtype_matches_native(self):
+        """eq_objtype should match between Newton and native for joint equality."""
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+
+        b1 = builder.add_link()
+        j1 = builder.add_joint_revolute(-1, b1, axis=(0, 0, 1))
+        builder.add_shape_box(body=b1, hx=0.1, hy=0.1, hz=0.1)
+        b2 = builder.add_link()
+        j2 = builder.add_joint_revolute(-1, b2, axis=(0, 0, 1))
+        builder.add_shape_box(body=b2, hx=0.1, hy=0.1, hz=0.1)
+        builder.add_articulation([j1])
+        builder.add_articulation([j2])
+        builder.add_equality_constraint_joint(j1, j2)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model)
+
+        # Native: load equivalent MJCF
+        import mujoco
+
+        native_model = mujoco.MjModel.from_xml_string("""
+        <mujoco>
+          <worldbody>
+            <body><joint name="j1" type="hinge" axis="0 0 1"/><geom type="box" size="0.1 0.1 0.1"/></body>
+            <body><joint name="j2" type="hinge" axis="0 0 1"/><geom type="box" size="0.1 0.1 0.1"/></body>
+          </worldbody>
+          <equality>
+            <joint joint1="j1" joint2="j2"/>
+          </equality>
+        </mujoco>
+        """)
+
+        newton_objtype = solver.mjw_model.eq_objtype.numpy().flatten()
+        native_objtype = native_model.eq_objtype
+
+        np.testing.assert_array_equal(
+            newton_objtype[:1],
+            native_objtype,
+            err_msg="eq_objtype mismatch: Newton should match native MuJoCo for joint equality",
+        )
+
+
 class TestUpdateContactsPointPositions(unittest.TestCase):
     """Test that update_contacts populates rigid_contact_point0/point1."""
 


### PR DESCRIPTION
## Description

Fix `eq_objtype` mismatch between Newton and native MuJoCo for joint equality constraints.

Part of #2170

### Root cause

Newton's solver passed `objtype=mujoco.mjtObj.mjOBJ_JOINT` to `spec.add_equality()`, causing `eq_objtype=3` in the compiled model. Native MuJoCo (from XML) produces `eq_objtype=0`. The spec API and XML parser set this field differently.

### Fix

Don't pass `objtype` to `spec.add_equality()` for joint equality constraints. MuJoCo sets it automatically, matching the XML behavior.

### Impact

- FrankaEmikaPanda and FrankaFr3V2 no longer need `{"eq_", "neq"}` in `model_skip_fields`
- Also fixes mimic constraint path (same issue)

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change) — N/A, internal fix

## Test plan

```
uv run python -m unittest newton.tests.test_mujoco_solver.TestEqualityJointObjType
# 1 test OK

uv run python -m unittest newton.tests.test_menagerie_mujoco.TestMenagerie_FrankaEmikaPanda.test_model_comparison
# OK (no eq_ skip needed)
```

## Bug fix

**Steps to reproduce:**

1. Create a model with joint equality constraints
2. Compare `eq_objtype` between Newton's mjwarp model and native MuJoCo
3. Newton has 3 (`mjOBJ_JOINT`), native has 0

**Minimal reproduction:**

```python
import mujoco

# Spec API (Newton's path): eq_objtype = 3
spec = mujoco.MjSpec()
b1 = spec.worldbody.add_body()
b1.add_joint(name="j1", type=mujoco.mjtJoint.mjJNT_HINGE)
b1.add_geom(size=[0.1, 0, 0])
eq = spec.add_equality(objtype=mujoco.mjtObj.mjOBJ_JOINT)
eq.type = mujoco.mjtEq.mjEQ_JOINT
eq.name1 = "j1"
m = spec.compile()
print(m.eq_objtype)  # [3]

# XML (native path): eq_objtype = 0
m2 = mujoco.MjModel.from_xml_string("""
<mujoco>
  <worldbody>
    <body><joint name="j1" type="hinge"/><geom size="0.1"/></body>
  </worldbody>
  <equality><joint joint1="j1"/></equality>
</mujoco>
""")
print(m2.eq_objtype)  # [0]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MuJoCo equality constraint generation so joint and mimic constraints match native MuJoCo behavior.

* **Tests**
  * Added a regression test to validate equality-constraint object type matches native MuJoCo.
  * Updated test configurations to tighten tolerances and reduce robot-specific model skips for broader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->