### PR TITLE
Disable flaky in-cup placement check in panda hydro example

### DIFF
--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -431,21 +431,7 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # Verify that the object ended up in the cup
-        if self.put_in_cup:
-            body_q = self.state_0.body_q.numpy()
-            cup_x, cup_y, cup_z = self.cup_pos
-            tolerance_xy = 0.05
-            min_z = cup_z - 0.05
-
-            for world_idx in range(self.world_count):
-                object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
-                x, y, z = body_q[object_body_idx][:3]
-                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
-                    f"World {world_idx}: Object is not in the cup. "
-                    f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
-                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
-                )
+        # NOTE: in-cup placement check removed due to flaky failures (see #1345)
 
     def setup_ik(self):
         self.ee_index = 10


### PR DESCRIPTION
## Description

Remove the in-cup placement assertion from the panda hydro example's
`test_final()` — it fails intermittently due to non-deterministic object
placement. The lift-height check is kept so the test still verifies that
the robot picks up the object.

This matches the approach taken in #1328 when the check was originally
removed. Reopened #1345 and retargeted to the 1.2 milestone.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_examples.TestRobotExamples.test_robot_example_robot_panda_hydro
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unreliable placement verification from the robot manipulation example test that was causing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->