### PR TITLE
Fix flaky panda hydro test grip sequence

### DIFF
--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -215,7 +215,7 @@ class Example:
                 body=self.object_body_local, radius=radius, half_height=length / 2, cfg=shape_cfg_primitives
             )
             self.grasping_offset = [-0.03, 0.0, 0.13]
-            self.place_offset = -0.02
+            self.place_offset = 0.01
 
         elif self.scene == SceneType.CUBE:
             size = 0.04
@@ -431,7 +431,21 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # NOTE: in-cup placement check removed due to flaky failures (see #1345)
+        # Verify that the object ended up in the cup
+        if self.put_in_cup:
+            body_q = self.state_0.body_q.numpy()
+            cup_x, cup_y, cup_z = self.cup_pos
+            tolerance_xy = 0.05
+            min_z = cup_z - 0.05
+
+            for world_idx in range(self.world_count):
+                object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
+                x, y, z = body_q[object_body_idx][:3]
+                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
+                    f"World {world_idx}: Object is not in the cup. "
+                    f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
+                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
+                )
 
     def setup_ik(self):
         self.ee_index = 10
@@ -485,17 +499,17 @@ class Example:
         ]
 
         if self.put_in_cup:
-            loose_pos = 0.71
+            loose_pos = 0.69
             wps = []
             cup_pos_higher = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest])
             cup_pos_lower = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest - 0.1])
             wps.extend(
                 [
                     [cup_pos_higher, 2.0, grasp_pos, rot_hand],
-                    [cup_pos_higher, 2.0, loose_pos, rot_hand],
-                    [cup_pos_higher, 1.0, loose_pos, rot_hand],
-                    [cup_pos_lower, 1.0, loose_pos, rot_hand],
-                    [cup_pos_lower, 1.0, 0.0, rot_hand],
+                    [cup_pos_higher, 0.25, loose_pos, rot_hand],
+                    [cup_pos_higher, 1.0, grasp_pos, rot_hand],
+                    [cup_pos_lower, 1.0, grasp_pos, rot_hand],
+                    [cup_pos_lower, 1.0, no_grasp_pos, rot_hand],
                 ]
             )
             self.waypoints.extend(wps)


### PR DESCRIPTION
## Description

Fix flaky `test_robot.example_robot_panda_hydro_cuda_0` by adjusting the gripper waypoint sequence during cup placement.

Closes #1337
Closes #1345

**Root cause:** The old sequence held the pen with a loose grip (`0.71`) for 4 seconds while transporting and lowering it into the cup. Non-deterministic hydroelastic contact forces occasionally caused the pen to slip sideways out of the gripper, missing the cup entirely (Y deviation ~10cm vs 5cm tolerance).

**Fix:** Briefly loosen the grip (`0.69` for `0.25s`) to nudge the pen, then re-grip firmly before lowering into the cup and releasing. Also adjust `place_offset` from `-0.02` to `0.01` for better cup alignment.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A, internal test fix

## Test plan

```
uv run --extra dev -m newton.tests -k test_robot.example_robot_panda_hydro
```

Ran 20 consecutive times with 0 failures (previously ~1 in 8 runs failed).

## Bug fix

**Steps to reproduce:**

Run the test repeatedly — it fails roughly 12.5% of the time:
```
for i in $(seq 1 8); do uv run --extra dev -m newton.tests -k test_robot.example_robot_panda_hydro; done
```

The failure is always in the cup placement assertion: the pen's final Y position deviates ~10cm from the cup center (tolerance is 5cm). The pen slips out of the loosened gripper during transport due to non-deterministic hydroelastic contact ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object placement accuracy for pen placement operations.
  * Enhanced verification that objects are correctly placed in cups with runtime position checks.

* **Improvements**
  * Refined gripper control sequences and waypoint timing for more precise cup manipulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->