### PR TITLE
Auto-discover bundled pandoc in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,14 +116,49 @@ exclude_patterns = [
     "**/lib/**",
 ]
 
+
+def _ensure_pandoc_on_path() -> str | None:
+    """Return a usable pandoc executable path, preferring the bundled docs dependency."""
+
+    pandoc_path = shutil.which("pandoc")
+    if pandoc_path is not None:
+        return pandoc_path
+
+    try:
+        import pypandoc  # noqa: PLC0415
+    except ImportError:
+        return None
+
+    try:
+        bundled_path = Path(pypandoc.get_pandoc_path())
+    except OSError:
+        return None
+
+    search_dir = bundled_path.parent
+    if not search_dir.is_dir():
+        return None
+
+    resolved_path = shutil.which("pandoc", path=str(search_dir))
+    if resolved_path is None:
+        return None
+
+    existing_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = str(Path(resolved_path).parent) + os.pathsep + existing_path
+    os.environ.setdefault("PYPANDOC_PANDOC", resolved_path)
+    return resolved_path
+
+
 # nbsphinx requires pandoc to convert Jupyter notebooks.  When pandoc is not
 # installed we exclude the notebook tutorials so the rest of the docs can still
 # be built locally without a hard error.  CI workflows install pandoc explicitly
-# so published docs always include the tutorials.
+# so published docs always include the tutorials.  Prefer the bundled
+# ``pypandoc_binary`` executable when available so local docs builds work out of
+# the box in the docs environment.
 #
 # Set NEWTON_REQUIRE_PANDOC=1 to turn the missing-pandoc warning into an error
 # (used in CI to guarantee tutorials are never silently skipped).
-if shutil.which("pandoc") is None:
+pandoc_path = _ensure_pandoc_on_path()
+if pandoc_path is None:
     if os.environ.get("NEWTON_REQUIRE_PANDOC", "") == "1":
         raise RuntimeError(
             "pandoc is required but not found. Install pandoc "

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,32 +120,25 @@ exclude_patterns = [
 def _ensure_pandoc_on_path() -> str | None:
     """Return a usable pandoc executable path, preferring the bundled docs dependency."""
 
-    pandoc_path = shutil.which("pandoc")
-    if pandoc_path is not None:
-        return pandoc_path
-
+    # Try the bundled pypandoc_binary first so local docs builds work out of
+    # the box even when a stale or incompatible system pandoc is on PATH.
     try:
         import pypandoc  # noqa: PLC0415
-    except ImportError:
-        return None
 
-    try:
         bundled_path = Path(pypandoc.get_pandoc_path())
-    except OSError:
-        return None
+        search_dir = bundled_path.parent
+        if search_dir.is_dir():
+            resolved_path = shutil.which("pandoc", path=str(search_dir))
+            if resolved_path is not None:
+                existing_path = os.environ.get("PATH", "")
+                os.environ["PATH"] = str(Path(resolved_path).parent) + os.pathsep + existing_path
+                os.environ.setdefault("PYPANDOC_PANDOC", resolved_path)
+                return resolved_path
+    except (ImportError, OSError):
+        pass
 
-    search_dir = bundled_path.parent
-    if not search_dir.is_dir():
-        return None
-
-    resolved_path = shutil.which("pandoc", path=str(search_dir))
-    if resolved_path is None:
-        return None
-
-    existing_path = os.environ.get("PATH", "")
-    os.environ["PATH"] = str(Path(resolved_path).parent) + os.pathsep + existing_path
-    os.environ.setdefault("PYPANDOC_PANDOC", resolved_path)
-    return resolved_path
+    # Fall back to whatever pandoc is already on PATH.
+    return shutil.which("pandoc")
 
 
 # nbsphinx requires pandoc to convert Jupyter notebooks.  When pandoc is not

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -400,8 +400,9 @@ The built documentation will be available in ``docs/_build/html``.
 .. note::
 
     The documentation build requires `pandoc <https://pandoc.org/>`_ for converting Jupyter notebooks.
-    While ``pypandoc_binary`` is included in the ``[docs]`` dependencies, some systems may require
-    pandoc to be installed separately:
+    The ``[docs]`` dependencies include ``pypandoc_binary``, and ``docs/conf.py`` will
+    automatically use that bundled executable when it is available. If your environment
+    still cannot locate pandoc, install it separately:
 
     - **Ubuntu/Debian:** ``sudo apt-get install pandoc``
     - **macOS:** ``brew install pandoc``


### PR DESCRIPTION
## Description

Auto-discover the `pandoc` executable bundled by `pypandoc_binary` during Sphinx builds so notebook tutorials build without manual `PATH` configuration.

Update the development guide to document the new fallback behavior and add a changelog entry for the user-facing docs build fix.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```powershell
$env:NEWTON_REQUIRE_PANDOC='1'
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Use the docs environment where `pypandoc_binary` is installed but `pandoc` is not on `PATH`.
2. Run the Sphinx HTML build with `NEWTON_REQUIRE_PANDOC=1`.
3. Observe `docs/conf.py` raise before notebook conversion because it only checks `shutil.which("pandoc")`.

**Minimal reproduction:**

```powershell
$env:NEWTON_REQUIRE_PANDOC='1'
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

## New feature / API change

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sphinx documentation builds now auto-discover the bundled pandoc executable, removing the need for manual PATH configuration when building notebook tutorials.

* **Documentation**
  * Updated development guide with clearer guidance on documentation builds and how the bundled pandoc is preferred when available.

* **Chores**
  * Added an unreleased changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->