### PR TITLE
Fix flaky panda hydro test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations
 - Fix USD import of multi-DOF joints from MuJoCo-converted assets where multiple revolute joints between the same two bodies caused false cycle detection; merge them into D6 joints with correct DOF label mapping for MjcActuator target resolution
 - Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
+- Improve `robot_panda_hydro` example to solve flakiness in the CI.
 
 ## [1.1.0] - 2026-04-13
 

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -431,7 +431,21 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # NOTE: in-cup placement check removed due to flaky failures (see #1345)
+        # Verify that the object ended up in the cup
+        if self.put_in_cup:
+            body_q = self.state_0.body_q.numpy()
+            cup_x, cup_y, cup_z = self.cup_pos
+            tolerance_xy = 0.05
+            min_z = cup_z - 0.05
+
+            for world_idx in range(self.world_count):
+                object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
+                x, y, z = body_q[object_body_idx][:3]
+                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
+                    f"World {world_idx}: Object is not in the cup. "
+                    f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
+                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
+                )
 
     def setup_ik(self):
         self.ee_index = 10
@@ -485,10 +499,10 @@ class Example:
         ]
 
         if self.put_in_cup:
-            loose_pos = 0.71
+            loose_pos = 0.72
             wps = []
             cup_pos_higher = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest])
-            cup_pos_lower = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest - 0.1])
+            cup_pos_lower = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest - 0.15])
             wps.extend(
                 [
                     [cup_pos_higher, 2.0, grasp_pos, rot_hand],

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -250,6 +250,7 @@ class Example:
             )
             cup_body = builder.add_body(label="cup", xform=cup_xform)
             builder.add_shape_mesh(body=cup_body, mesh=cup_mesh, cfg=shape_cfg_meshes)
+            self.cup_rim_z = self.cup_pos[2] + float(cup_mesh.vertices[:, 2].max())
 
         # build model for IK
         self.model_single = copy.deepcopy(builder).finalize()
@@ -431,20 +432,21 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # Verify that the object ended up in the cup
+        # Verify that the object ended up inside the cup
         if self.put_in_cup:
             body_q = self.state_0.body_q.numpy()
             cup_x, cup_y, cup_z = self.cup_pos
-            tolerance_xy = 0.05
-            min_z = cup_z - 0.05
+            tolerance_xy = 0.03  # cup inner radius is ~0.024m
+            max_z = self.cup_rim_z  # pen COM must be below the cup rim
 
             for world_idx in range(self.world_count):
                 object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
                 x, y, z = body_q[object_body_idx][:3]
-                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
+                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z < max_z, (
                     f"World {world_idx}: Object is not in the cup. "
                     f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
-                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
+                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f}), "
+                    f"cup rim z={max_z:.3f}"
                 )
 
     def setup_ik(self):
@@ -499,7 +501,7 @@ class Example:
         ]
 
         if self.put_in_cup:
-            loose_pos = 0.72
+            loose_pos = 0.715
             wps = []
             cup_pos_higher = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest])
             cup_pos_lower = wp.vec3([self.cup_pos[0] + self.place_offset, self.cup_pos[1], self.z_rest - 0.15])


### PR DESCRIPTION
## Description
This will close #1337.
Put back the example as a UT
- Slightly change the loose_pos to be sure the pen is not dropped.
- Pen goes now lower to be sure it goes into the cup instead of just trusting the release.
- Make passing conditions more strict to have no false positive.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Tested the example by running it 200 times without any failure, before my change I got a ~2-5% failure rate.
Also looks fine visually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cup placement accuracy by computing the rim height from the cup geometry for more reliable z-threshold checks.
  * Added test assertions to validate objects are correctly placed inside the cup, with clearer diagnostic output on failures.

* **Refactor**
  * Tweaked robot trajectory waypoints for a more precise in-cup placement approach.

* **Chores**
  * Updated changelog entry noting the example fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->