### PR TITLE
Randomize changelog entry placement to reduce merge conflicts

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -21,8 +21,10 @@ reviews:
         CHANGELOG.md under the [Unreleased] section. Entries should use
         imperative present tense ("Add X", not "Added X") and be placed under
         the correct category (Added, Changed, Deprecated, Removed, or Fixed).
-        For Deprecated, Changed, and Removed entries, verify the entry includes
-        migration guidance telling users what replaces the old behavior.
+        Entries may appear at any position within their category — do not flag
+        placement order. For Deprecated, Changed, and Removed entries, verify
+        the entry includes migration guidance telling users what replaces the
+        old behavior.
 chat:
   auto_reply: true
 issue_enrichment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ uvx --with virtualenv asv run --launch-method spawn main^!
 ## PR Instructions
 
 - If opening a pull request on GitHub, use the template in `.github/PULL_REQUEST_TEMPLATE.md`.
-- If a change modifies user-facing behavior, append an entry at the end of the correct category (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`) in `CHANGELOG.md`'s `[Unreleased]` section. Use imperative present tense ("Add X") and avoid internal implementation details.
+- If a change modifies user-facing behavior, insert an entry at a random position within the correct category (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`) in `CHANGELOG.md`'s `[Unreleased]` section. Use imperative present tense ("Add X") and avoid internal implementation details.
 - For `Deprecated`, `Changed`, and `Removed` entries, include migration guidance: "Deprecate `Model.geo_meshes` in favor of `Model.shapes`".
 
 ## Examples


### PR DESCRIPTION
## Description

Insert changelog entries at a random position within their category instead of always appending at the end. When multiple PRs target the same category, this reduces the chance of merge conflicts.

- **AGENTS.md**: "append at the end" → "insert at a random position within"
- **.coderabbit.yml**: Tell CodeRabbit not to flag entry placement order

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

No code changes — documentation/config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation and configuration for changelog entry formatting guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->