### PR TITLE
Remove redundant register_custom_attributes calls before add_mjcf

### DIFF
--- a/newton/tests/test_fixed_tendon.py
+++ b/newton/tests/test_fixed_tendon.py
@@ -63,7 +63,6 @@ class TestMujocoFixedTendon(unittest.TestCase):
 """
 
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         # Use geometry-based inertia since MJCF-defined values are unrealistic (20x too high)
         individual_builder.add_mjcf(mjcf, ignore_inertial_definitions=True)
         builder = newton.ModelBuilder(gravity=0.0)
@@ -211,7 +210,6 @@ class TestMujocoFixedTendon(unittest.TestCase):
         joint_start_velocities[2] = joint_start_velocities[0]
 
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         # Use geometry-based inertia since MJCF-defined values are unrealistic (20x too high)
         individual_builder.add_mjcf(mjcf, ignore_inertial_definitions=True)
         builder = newton.ModelBuilder(gravity=0.0)

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -1237,7 +1237,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
         nbTendonsPerBuilder = 2
 
         individual_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf)
         builder = newton.ModelBuilder()
         for _i in range(0, nbBuilders):
@@ -1696,7 +1695,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 """
 
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model, iterations=10, ls_iterations=10)
@@ -1960,7 +1958,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
         nbTendons = nbBuilders * nbTendonsPerBuilder
 
         individual_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf)
         builder = newton.ModelBuilder()
         for _i in range(0, nbBuilders):
@@ -2065,7 +2062,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 </mujoco>
 """
         individual_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf)
         builder = newton.ModelBuilder()
         builder.add_world(individual_builder)
@@ -2122,7 +2118,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 </mujoco>
 """
         individual_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf, ctrl_direct=True)
         builder = newton.ModelBuilder()
         builder.add_world(individual_builder)
@@ -2176,7 +2171,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 """
         # With autolimits=true (default), actuatorfrclimited="auto" resolves to true
         builder_true = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder_true)
         builder_true.add_mjcf(mjcf_autolimits_true)
         model_true = newton.ModelBuilder()
         model_true.add_world(builder_true)
@@ -2186,7 +2180,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 
         # With autolimits=false, actuatorfrclimited="auto" should NOT apply force limit
         builder_false = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder_false)
         builder_false.add_mjcf(mjcf_autolimits_false)
         model_false = newton.ModelBuilder()
         model_false.add_world(builder_false)
@@ -2244,7 +2237,6 @@ class TestImportMjcfGeometry(unittest.TestCase):
 """
 
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
 
@@ -7056,7 +7048,6 @@ class TestActuatorShortcutTypeDefaults(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(cls.builder)
         cls.builder.add_mjcf(cls.MJCF, ctrl_direct=True)
         cls.model = cls.builder.finalize()
 
@@ -7122,7 +7113,6 @@ class TestMjcfPositionDampratioParsing(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(cls.MJCF, ctrl_direct=True)
         cls.model = builder.finalize()
 
@@ -7162,7 +7152,6 @@ class TestActuatorDefaultKpKv(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf, ctrl_direct=True)
         model = builder.finalize()
 
@@ -7187,7 +7176,6 @@ class TestActuatorDefaultKpKv(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf, ctrl_direct=True)
         model = builder.finalize()
 
@@ -7217,7 +7205,6 @@ class TestActuatorDefaultKpKv(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf, ctrl_direct=True)
         model = builder.finalize()
 
@@ -7252,7 +7239,6 @@ class TestMjcfIncludeOptionMerge(unittest.TestCase):
                 f.write(main)
 
             builder = newton.ModelBuilder()
-            SolverMuJoCo.register_custom_attributes(builder)
             builder.add_mjcf(main_path)
 
             iters = builder.custom_attributes["mujoco:iterations"].values
@@ -7287,7 +7273,6 @@ class TestMjcfIncludeOptionMerge(unittest.TestCase):
                 f.write(main)
 
             builder = newton.ModelBuilder()
-            SolverMuJoCo.register_custom_attributes(builder)
             builder.add_mjcf(main_path)
 
             iters = builder.custom_attributes["mujoco:iterations"].values
@@ -7322,7 +7307,6 @@ class TestMjcfIncludeOptionMerge(unittest.TestCase):
                 f.write(main)
 
             builder = newton.ModelBuilder()
-            SolverMuJoCo.register_custom_attributes(builder)
             builder.add_mjcf(main_path)
 
             iters = builder.custom_attributes["mujoco:iterations"].values
@@ -7407,7 +7391,6 @@ class TestContypeConaffinityZero(unittest.TestCase):
             </worldbody>
         </mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7439,7 +7422,6 @@ class TestContypeConaffinityZero(unittest.TestCase):
             </worldbody>
         </mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7474,7 +7456,6 @@ class TestContypeConaffinityZero(unittest.TestCase):
             </contact>
         </mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7499,7 +7480,6 @@ class TestJointFrictionloss(unittest.TestCase):
             </body>
         </worldbody></mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         np.testing.assert_allclose(model.joint_friction.numpy()[-1], 5.0, atol=1e-6)
@@ -7515,7 +7495,6 @@ class TestJointFrictionloss(unittest.TestCase):
             </body>
         </worldbody></mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         np.testing.assert_allclose(model.joint_friction.numpy()[-1], 2.5, atol=1e-6)
@@ -7531,7 +7510,6 @@ class TestJointFrictionloss(unittest.TestCase):
             </body>
         </worldbody></mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         np.testing.assert_allclose(model.joint_friction.numpy()[-1], 0.0, atol=1e-6)
@@ -7547,7 +7525,6 @@ class TestJointFrictionloss(unittest.TestCase):
             </body>
         </worldbody></mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7570,7 +7547,6 @@ class TestJointFrictionloss(unittest.TestCase):
             </worldbody>
         </mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         np.testing.assert_allclose(model.joint_friction.numpy()[-1], 3.3, atol=1e-5)

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -134,7 +134,6 @@ def create_newton_model_from_mjcf(
     """
     # Create articulation builder for the robot
     robot_builder = newton.ModelBuilder()
-    SolverMuJoCo.register_custom_attributes(robot_builder)
 
     # floating defaults to None, which honors the MJCF's explicit joint definitions.
     # Menagerie models define their own <freejoint> tags for floating-base robots.

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -553,7 +553,6 @@ class TestMuJoCoActuators(unittest.TestCase):
         """
 
         builder = ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf_combined_joints, ctrl_direct=False)
 
         # Verify the combined joint was created

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -3755,7 +3755,6 @@ class TestMuJoCoSolverFixedTendonProperties(TestMuJoCoSolverPropertiesBase):
 """
 
         template_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(template_builder)
         template_builder.add_mjcf(mjcf)
 
         # Create main builder with multiple worlds
@@ -7003,7 +7002,6 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             </contact>
         </mujoco>"""
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7328,7 +7326,6 @@ class TestMuJoCoSolverFreeJointBodyPos(unittest.TestCase):
         </mujoco>
         """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7363,7 +7360,6 @@ class TestMuJoCoSolverZeroMassBody(unittest.TestCase):
         </mujoco>
         """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
         solver = SolverMuJoCo(model)
@@ -7442,7 +7438,6 @@ class TestMuJoCoSolverQpos0(unittest.TestCase):
         A ball joint should produce qpos0 equal to [1, 0, 0, 0] (wxyz).
         """
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         parent = builder.add_link(mass=1.0, com=wp.vec3(0, 0, 0), inertia=wp.mat33(np.eye(3)))
         builder.add_shape_box(body=parent, hx=0.1, hy=0.1, hz=0.1)
         j0 = builder.add_joint_fixed(-1, parent)
@@ -8250,7 +8245,6 @@ class TestActuatorDampratioMultiWorld(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         robot_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(robot_builder)
         robot_builder.add_mjcf(cls.MJCF, ctrl_direct=True)
         builder = newton.ModelBuilder()
         SolverMuJoCo.register_custom_attributes(builder)
@@ -8295,7 +8289,6 @@ class TestActuatorLengthRangeRuntime(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(cls.MJCF, ctrl_direct=True)
         cls.model = builder.finalize()
         cls.solver = SolverMuJoCo(cls.model)
@@ -8334,7 +8327,6 @@ class TestActuatorDampratioMultiWorldRuntime(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         robot_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(robot_builder)
         robot_builder.add_mjcf(cls.MJCF, ctrl_direct=True)
         builder = newton.ModelBuilder()
         SolverMuJoCo.register_custom_attributes(builder)

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -9,7 +9,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton.selection import ArticulationView
-from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import assert_np_equal
 
 
@@ -433,7 +432,6 @@ class TestSelection(unittest.TestCase):
 
         # Create a single articulation with 3 joints.
         single_articuation_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(single_articuation_builder)
         single_articuation_builder.add_mjcf(mjcf, ignore_inertial_definitions=False)
 
         # Create a world with 2 articulations
@@ -836,7 +834,6 @@ class TestSelection(unittest.TestCase):
 
         # Create a single articulation
         single_articulation_builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(single_articulation_builder)
         single_articulation_builder.add_mjcf(mjcf, ignore_inertial_definitions=False)
 
         # Create a world with 2 articulations
@@ -1234,7 +1231,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_count(self):
         """Test that tendon count is correctly detected."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.TENDON_MJCF)
         model = builder.finalize()
 
@@ -1244,7 +1240,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_selection_shapes(self):
         """Test that tendon selection API returns correct shapes."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.TENDON_MJCF)
         model = builder.finalize()
 
@@ -1264,7 +1259,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_generic_api(self):
         """Test that tendon attributes are accessible via generic get/set_attribute."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.TENDON_MJCF)
         model = builder.finalize()
 
@@ -1294,7 +1288,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_multi_world(self):
         """Test that tendon selection works with multiple worlds."""
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(self.TENDON_MJCF)
 
         W = 4  # num worlds
@@ -1319,7 +1312,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_set_values(self):
         """Test that setting tendon values works correctly."""
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(self.TENDON_MJCF)
 
         W = 2  # num worlds
@@ -1340,7 +1332,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
     def test_tendon_names(self):
         """Test that tendon names are correctly populated."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.TENDON_MJCF)
         model = builder.finalize()
 
@@ -1388,7 +1379,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(with_tendons_mjcf)
         builder.add_mjcf(no_tendons_mjcf)
         model = builder.finalize()
@@ -1407,7 +1397,6 @@ class TestSelectionFixedTendons(unittest.TestCase):
         """Test tendon selection with multiple articulations in a single world."""
         # Build a single articulation with tendons
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(self.TENDON_MJCF)
 
         # Create a world with multiple copies of the articulation

--- a/newton/tests/test_spatial_tendon.py
+++ b/newton/tests/test_spatial_tendon.py
@@ -46,7 +46,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
     def test_spatial_tendon_parsing(self):
         """Verify that spatial tendon attributes are parsed correctly from MJCF."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.SPATIAL_TENDON_MJCF)
         model = builder.finalize()
 
@@ -116,7 +115,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf, ignore_inertial_definitions=True, parse_sites=True)
 
         builder = newton.ModelBuilder(gravity=0.0)
@@ -195,7 +193,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf, ignore_inertial_definitions=True)
 
         model = individual_builder.finalize()
@@ -254,7 +251,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(mjcf, ignore_inertial_definitions=True)
 
         builder = newton.ModelBuilder(gravity=0.0)
@@ -329,7 +325,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
 
@@ -372,7 +367,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
 
@@ -421,7 +415,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf, parse_sites=True)
         model = builder.finalize()
 
@@ -455,7 +448,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
     def test_spatial_tendon_multi_world_wrap_offsets(self):
         """Verify that wrap address and shape references are offset correctly across worlds."""
         individual_builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(individual_builder)
         individual_builder.add_mjcf(self.SPATIAL_TENDON_MJCF, parse_sites=True)
 
         builder = newton.ModelBuilder(gravity=0.0)
@@ -515,7 +507,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
 </mujoco>
 """
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -537,7 +528,6 @@ class TestMujocoSpatialTendon(unittest.TestCase):
     def test_spatial_tendon_warning_out_of_bounds_wrap(self):
         """Verify that out-of-bounds wrap ranges produce a warning during solver init."""
         builder = newton.ModelBuilder(gravity=0.0)
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(self.SPATIAL_TENDON_MJCF, parse_sites=True)
 
         # Corrupt the wrap address to be out of bounds

--- a/newton/tests/test_tolerance_clamping.py
+++ b/newton/tests/test_tolerance_clamping.py
@@ -31,7 +31,6 @@ class TestToleranceClamping(unittest.TestCase):
 
         # Build model with 2 worlds to test per-world clamping
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
 
         scene_builder = newton.ModelBuilder()
@@ -84,7 +83,6 @@ class TestToleranceClamping(unittest.TestCase):
 """
 
         builder = newton.ModelBuilder()
-        SolverMuJoCo.register_custom_attributes(builder)
         builder.add_mjcf(mjcf)
         model = builder.finalize()
 


### PR DESCRIPTION
## Description

`ModelBuilder.add_mjcf()` already calls `SolverMuJoCo.register_custom_attributes()` internally (at `builder.py:2587`), so explicit calls immediately before `add_mjcf()` on the same builder are idempotent no-ops. This removes 58 such redundant calls across 8 test files.

Calls before `parse_mjcf()`, `add_usd()`, or programmatic model construction are left intact — those paths do not register MuJoCo attributes automatically.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

All 8 affected test suites pass:

```
uv run --extra dev -m newton.tests -k test_import_mjcf          # 204 tests
uv run --extra dev -m newton.tests -k test_spatial_tendon        # 10 tests
uv run --extra dev -m newton.tests -k test_selection             # 34 tests
uv run --extra dev -m newton.tests -k test_tolerance_clamping    # 2 tests
uv run --extra dev -m newton.tests -k test_fixed_tendon          # 7 tests
uv run --extra dev -m newton.tests -k test_mujoco_general_actuators  # 9 tests
uv run --extra dev -m newton.tests -k test_menagerie_mujoco      # 3 tests (spot check)
uv run --extra dev -m newton.tests -k test_mujoco_solver.TestMuJoCoSolverQpos0  # 21 tests (spot check)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined test setup by removing redundant configuration steps across multiple test modules, improving code maintainability while preserving comprehensive test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->