### PR TITLE
Fix flaky test example_cloth_twist

### DIFF
--- a/newton/examples/cloth/example_cloth_twist.py
+++ b/newton/examples/cloth/example_cloth_twist.py
@@ -292,7 +292,7 @@ class Example:
         newton.examples.test_particle_state(
             self.state_0,
             "particle velocities are within a reasonable range",
-            lambda q, qd: max(abs(qd)) < 1.0,
+            lambda q, qd: max(abs(qd)) < 1.5,
         )
 
 


### PR DESCRIPTION
## Description
Adjust threshold in the `example_cloth_twist.py`.
Will fix #1577.

During the simulation the peak velocity was always higher than the threshold, the test was relying on damping to reach the threshold.
Now the threshold is higher than the peak velocity and we rather check for explosion.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Run it 50 times on main and got a failure rate of 8%.
Run 200 times with the fixed and got 0 failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated particle velocity validation threshold in the cloth twist example to allow slightly higher velocity magnitudes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->