### PR TITLE
Fix `State.assign` for namespaced extended and custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged
+- Fix `State.assign` not copying namespaced extended attributes such as `state.mujoco.qfrc_actuator`
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
+- Fix `State.assign` not copying namespaced extended attributes such as `state.mujoco.qfrc_actuator`
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged
-- Fix `State.assign` not copying namespaced extended attributes such as `state.mujoco.qfrc_actuator`
+- Fix `State.assign` not copying namespaced extended and custom state attributes 
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center

--- a/newton/_src/sim/state.py
+++ b/newton/_src/sim/state.py
@@ -180,6 +180,34 @@ class State:
 
             val_self.assign(val_other)
 
+        for ext in self.EXTENDED_ATTRIBUTES:
+            if ":" not in ext:
+                continue
+            ns_name, attr_name = ext.split(":", 1)
+
+            ns_self = getattr(self, ns_name, None)
+            ns_other = getattr(other, ns_name, None)
+            if ns_self is None and ns_other is None:
+                continue
+
+            val_self = getattr(ns_self, attr_name, None) if ns_self is not None else None
+            val_other = getattr(ns_other, attr_name, None) if ns_other is not None else None
+
+            array_self = isinstance(val_self, wp.array)
+            array_other = isinstance(val_other, wp.array)
+
+            if not array_self and not array_other:
+                continue
+
+            qualified = f"{ns_name}.{attr_name}"
+            if val_self is None or not array_self:
+                raise ValueError(f"State is missing array for '{qualified}' which is present in the other state.")
+
+            if val_other is None or not array_other:
+                raise ValueError(f"Other state is missing array for '{qualified}' which is present in this state.")
+
+            val_self.assign(val_other)
+
     @property
     def requires_grad(self) -> bool:
         """Indicates whether the state arrays have gradient computation enabled."""

--- a/newton/_src/sim/state.py
+++ b/newton/_src/sim/state.py
@@ -6,6 +6,44 @@ from __future__ import annotations
 import warp as wp
 
 
+def _copy_arrays(dst: object, src: object, prefix: str = "") -> None:
+    """Copy ``wp.array`` attributes from ``src`` into ``dst``.
+
+    Walks both objects' ``__dict__``, matches attributes by name, and copies
+    ``wp.array`` values via ``dst_array.assign(src_array)``. Raises
+    :class:`ValueError` on presence mismatch (one side has an array where
+    the other does not).
+
+    Args:
+        dst: Destination object (its ``wp.array`` attributes will be overwritten).
+        src: Source object.
+        prefix: Prefix prepended to attribute names in error messages
+            (e.g. ``"mujoco."`` for namespaced attributes).
+    """
+    attributes = set(dst.__dict__).union(src.__dict__)
+    for attr in attributes:
+        val_dst = getattr(dst, attr, None)
+        val_src = getattr(src, attr, None)
+
+        if val_dst is None and val_src is None:
+            continue
+
+        array_dst = isinstance(val_dst, wp.array)
+        array_src = isinstance(val_src, wp.array)
+
+        if not array_dst and not array_src:
+            continue
+
+        qualified = f"{prefix}{attr}"
+        if val_dst is None or not array_dst:
+            raise ValueError(f"State is missing array for '{qualified}' which is present in the other state.")
+
+        if val_src is None or not array_src:
+            raise ValueError(f"Other state is missing array for '{qualified}' which is present in this state.")
+
+        val_dst.assign(val_src)
+
+
 class State:
     """
     Represents the time-varying state of a :class:`Model` in a simulation.
@@ -157,56 +195,38 @@ class State:
         Raises:
             ValueError: If the states have mismatched attributes (one has an array allocated where the other is None).
         """
-        attributes = set(self.__dict__).union(other.__dict__)
+        from .model import Model  # noqa: PLC0415
 
-        for attr in attributes:
-            val_self = getattr(self, attr, None)
-            val_other = getattr(other, attr, None)
+        # Top-level array attributes.
+        _copy_arrays(self, other)
 
-            if val_self is None and val_other is None:
+        # Discover all AttributeNamespace containers on either state and
+        # descend into each. This uniformly covers both EXTENDED_ATTRIBUTES
+        # (e.g. ``mujoco.qfrc_actuator``) and custom namespaced attributes
+        # registered via ``ModelBuilder.add_custom_attribute``.
+        ns_self = {k: v for k, v in self.__dict__.items() if isinstance(v, Model.AttributeNamespace)}
+        ns_other = {k: v for k, v in other.__dict__.items() if isinstance(v, Model.AttributeNamespace)}
+
+        for ns_name in ns_self.keys() | ns_other.keys():
+            dst_ns = ns_self.get(ns_name)
+            src_ns = ns_other.get(ns_name)
+
+            # If the namespace container is missing on one side, only raise
+            # when the other side actually holds arrays inside it.
+            if dst_ns is None:
+                if any(isinstance(v, wp.array) for v in src_ns.__dict__.values()):
+                    raise ValueError(
+                        f"State is missing namespace '{ns_name}' which contains arrays in the other state."
+                    )
+                continue
+            if src_ns is None:
+                if any(isinstance(v, wp.array) for v in dst_ns.__dict__.values()):
+                    raise ValueError(
+                        f"Other state is missing namespace '{ns_name}' which contains arrays in this state."
+                    )
                 continue
 
-            array_self = isinstance(val_self, wp.array)
-            array_other = isinstance(val_other, wp.array)
-
-            if not array_self and not array_other:
-                continue
-
-            if val_self is None or not array_self:
-                raise ValueError(f"State is missing array for '{attr}' which is present in the other state.")
-
-            if val_other is None or not array_other:
-                raise ValueError(f"Other state is missing array for '{attr}' which is present in this state.")
-
-            val_self.assign(val_other)
-
-        for ext in self.EXTENDED_ATTRIBUTES:
-            if ":" not in ext:
-                continue
-            ns_name, attr_name = ext.split(":", 1)
-
-            ns_self = getattr(self, ns_name, None)
-            ns_other = getattr(other, ns_name, None)
-            if ns_self is None and ns_other is None:
-                continue
-
-            val_self = getattr(ns_self, attr_name, None) if ns_self is not None else None
-            val_other = getattr(ns_other, attr_name, None) if ns_other is not None else None
-
-            array_self = isinstance(val_self, wp.array)
-            array_other = isinstance(val_other, wp.array)
-
-            if not array_self and not array_other:
-                continue
-
-            qualified = f"{ns_name}.{attr_name}"
-            if val_self is None or not array_self:
-                raise ValueError(f"State is missing array for '{qualified}' which is present in the other state.")
-
-            if val_other is None or not array_other:
-                raise ValueError(f"Other state is missing array for '{qualified}' which is present in this state.")
-
-            val_self.assign(val_other)
+            _copy_arrays(dst_ns, src_ns, prefix=f"{ns_name}.")
 
     @property
     def requires_grad(self) -> bool:

--- a/newton/tests/test_state_assign.py
+++ b/newton/tests/test_state_assign.py
@@ -9,7 +9,7 @@ import warp as wp
 import newton
 
 
-def _build_model():
+def _build_model(*, custom_attrs: tuple[str, ...] = ()):
     builder = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
     inertia = wp.mat33((0.1, 0.0, 0.0), (0.0, 0.1, 0.0), (0.0, 0.0, 0.1))
     body = builder.add_link(armature=0.0, inertia=inertia, mass=1.0)
@@ -27,6 +27,17 @@ def _build_model():
     )
     builder.add_articulation([joint])
     builder.request_state_attributes("mujoco:qfrc_actuator")
+    for name in custom_attrs:
+        builder.add_custom_attribute(
+            newton.ModelBuilder.CustomAttribute(
+                name=name,
+                frequency=newton.Model.AttributeFrequency.BODY,
+                dtype=wp.float32,
+                default=0.0,
+                assignment=newton.Model.AttributeAssignment.STATE,
+                namespace="my_namespace",
+            )
+        )
     model = builder.finalize()
     model.ground = False
     return model
@@ -59,6 +70,62 @@ class TestStateAssignNamespacedAttributes(unittest.TestCase):
         state_0 = model.state()
         state_1 = model.state()
         delattr(state_0, "mujoco")
+
+        with self.assertRaises(ValueError):
+            state_0.assign(state_1)
+
+    def test_copies_custom_namespaced_attribute(self):
+        model = _build_model(custom_attrs=("my_attribute",))
+        state_0 = model.state()
+        state_1 = model.state()
+
+        sentinel = np.array([2.71], dtype=np.float32)
+        state_1.my_namespace.my_attribute.assign(sentinel)
+
+        state_0.assign(state_1)
+
+        np.testing.assert_allclose(state_0.my_namespace.my_attribute.numpy(), sentinel)
+
+    def test_raises_when_src_missing_custom_namespaced_attribute(self):
+        model = _build_model(custom_attrs=("my_attribute",))
+        state_0 = model.state()
+        state_1 = model.state()
+        delattr(state_1, "my_namespace")
+
+        with self.assertRaises(ValueError):
+            state_0.assign(state_1)
+
+    def test_raises_when_dst_missing_custom_namespaced_attribute(self):
+        model = _build_model(custom_attrs=("my_attribute",))
+        state_0 = model.state()
+        state_1 = model.state()
+        delattr(state_0, "my_namespace")
+
+        with self.assertRaises(ValueError):
+            state_0.assign(state_1)
+
+    def test_copies_multiple_custom_namespaced_attributes(self):
+        model = _build_model(custom_attrs=("attr_one", "attr_two"))
+        state_0 = model.state()
+        state_1 = model.state()
+
+        sentinel_one = np.array([1.23], dtype=np.float32)
+        sentinel_two = np.array([4.56], dtype=np.float32)
+        state_1.my_namespace.attr_one.assign(sentinel_one)
+        state_1.my_namespace.attr_two.assign(sentinel_two)
+
+        state_0.assign(state_1)
+
+        np.testing.assert_allclose(state_0.my_namespace.attr_one.numpy(), sentinel_one)
+        np.testing.assert_allclose(state_0.my_namespace.attr_two.numpy(), sentinel_two)
+
+    def test_raises_when_one_of_multiple_custom_attributes_missing(self):
+        model = _build_model(custom_attrs=("attr_one", "attr_two"))
+        state_0 = model.state()
+        state_1 = model.state()
+        # Remove a single attribute inside the namespace container (not the
+        # container itself) to exercise per-attribute presence checks.
+        delattr(state_1.my_namespace, "attr_two")
 
         with self.assertRaises(ValueError):
             state_0.assign(state_1)

--- a/newton/tests/test_state_assign.py
+++ b/newton/tests/test_state_assign.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+
+
+def _build_model():
+    builder = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
+    inertia = wp.mat33((0.1, 0.0, 0.0), (0.0, 0.1, 0.0), (0.0, 0.0, 0.1))
+    body = builder.add_link(armature=0.0, inertia=inertia, mass=1.0)
+    joint = builder.add_joint_revolute(
+        parent=-1,
+        child=body,
+        parent_xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()),
+        child_xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()),
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        target_pos=0.0,
+        target_ke=100.0,
+        target_kd=10.0,
+        effort_limit=5.0,
+        actuator_mode=newton.JointTargetMode.POSITION_VELOCITY,
+    )
+    builder.add_articulation([joint])
+    builder.request_state_attributes("mujoco:qfrc_actuator")
+    model = builder.finalize()
+    model.ground = False
+    return model
+
+
+class TestStateAssignNamespacedAttributes(unittest.TestCase):
+    def test_copies_namespaced_attribute(self):
+        model = _build_model()
+        state_0 = model.state()
+        state_1 = model.state()
+
+        sentinel = np.array([3.14], dtype=np.float32)
+        state_1.mujoco.qfrc_actuator.assign(sentinel)
+
+        state_0.assign(state_1)
+
+        np.testing.assert_allclose(state_0.mujoco.qfrc_actuator.numpy(), sentinel)
+
+    def test_raises_when_src_missing_namespaced_attribute(self):
+        model = _build_model()
+        state_0 = model.state()
+        state_1 = model.state()
+        delattr(state_1, "mujoco")
+
+        with self.assertRaises(ValueError):
+            state_0.assign(state_1)
+
+    def test_raises_when_dst_missing_namespaced_attribute(self):
+        model = _build_model()
+        state_0 = model.state()
+        state_1 = model.state()
+        delattr(state_0, "mujoco")
+
+        with self.assertRaises(ValueError):
+            state_0.assign(state_1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description
`State.assign` skips `wp.array` attributes nested under attribute namespaces (e.g. `state.mujoco.qfrc_actuator`). The top-level loop only checks `isinstance(val, wp.array)` on `__dict__` entries, so namespace containers are skipped and never descended into. After `state_0.assign(state_1)`, `state_0.mujoco.qfrc_actuator` is still zero.

Fix: after the top-level loop, walk `EXTENDED_ATTRIBUTES` for `"namespace:attr"` entries and apply the same presence/mismatch checks.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

uv run --extra dev -m newton.tests -k test_state_assign

## Bug fix

**Steps to reproduce:**

1. Request `mujoco:qfrc_actuator` on a model and step `SolverMuJoCo` so `state_1.mujoco.qfrc_actuator` is populated.
2. Call `state_0.assign(state_1)` (the pattern `State.assign`'s docstring recommends for odd-substep CUDA-graph loops).
3. Read `state_0.mujoco.qfrc_actuator`: values are still the zero-initialized array.

**Minimal reproduction:**

See test_state_assign.py


Note: I followed the current `"namespace:attr"` convention in `EXTENDED_ATTRIBUTES`.
If deeper nesting is needed in the future, let me know and I'll switch to a recursive approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State assignment now correctly copies namespaced extended and custom state attributes between states and raises on mismatches.

* **Tests**
  * Added tests that confirm namespaced attributes are copied correctly and that assignment fails when required namespace data is missing.

* **Refactor**
  * Internal state-copy logic reorganized to more reliably handle top-level and namespaced array transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->