### PR TITLE
Support <joint type="ball"/> in MJCF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add fast parity-based SDF construction path for watertight meshes in `SDF.create_from_mesh`, using `wp.mesh_query_point_sign_parity` instead of winding numbers; selected via the new `sign_method` argument (`"auto"` — the default — picks parity when `Mesh.is_watertight` is true, or `"parity"` / `"winding"` to force either strategy)
 - Add `ViewerBase.log_arrows()` for arrow rendering (wide line + arrowhead) in the GL viewer with a dedicated geometry shader
 - Add `enable_multiccd` parameter to `SolverMuJoCo` for multi-CCD contact generation (up to 4 contact points per geom pair)
+- Support `<joint type="ball"/>` in the MJCF importer, and preserve authored damping, stiffness, and frictionloss when exporting ball joints to MuJoCo specs (previously silently dropped)
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -4589,16 +4589,20 @@ class SolverMuJoCo(SolverBase):
                 num_qpos += 7
                 num_mjc_joints += 1
             elif j_type == JointType.BALL:
-                body.add_joint(
-                    name=name,
-                    type=mujoco.mjtJoint.mjJNT_BALL,
-                    axis=wp.quat_rotate(joint_rot, wp.vec3(1.0, 0.0, 0.0)),
-                    pos=joint_pos,
-                    damping=0.0,
-                    limited=False,
-                    armature=self._KINEMATIC_ARMATURE if child_is_kinematic else joint_armature[qd_start],
-                    frictionloss=joint_friction[qd_start],
-                )
+                ball_params = {
+                    "name": name,
+                    "type": mujoco.mjtJoint.mjJNT_BALL,
+                    "axis": wp.quat_rotate(joint_rot, wp.vec3(1.0, 0.0, 0.0)),
+                    "pos": joint_pos,
+                    "limited": False,
+                    "armature": self._KINEMATIC_ARMATURE if child_is_kinematic else joint_armature[qd_start],
+                    "frictionloss": joint_friction[qd_start],
+                }
+                if joint_stiffness is not None:
+                    ball_params["stiffness"] = float(joint_stiffness[qd_start])
+                if joint_damping is not None:
+                    ball_params["damping"] = float(joint_damping[qd_start])
+                body.add_joint(**ball_params)
                 mjc_joint_names.append(name)
                 # For ball joints, all 3 DOFs map to the same MuJoCo joint
                 for i in range(3):

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1478,6 +1478,9 @@ def parse_mjcf(
             current_dof_index = 0
             # Track MJCF joint names and their DOF offsets within the combined Newton joint
             mjcf_joint_dof_offsets: list[tuple[str, int]] = []
+            # frictionloss for a native <joint type="ball"/>; captured in the ball branch
+            # and read by the add_joint_ball call. Default 0.0 matches MJCF.
+            ball_friction = 0.0
             joints = body.findall("joint")
             for i, joint in enumerate(joints):
                 joint_defaults = defaults
@@ -1503,6 +1506,26 @@ def parse_mjcf(
                     break
                 if joint_type_str == "fixed":
                     joint_type = JointType.FIXED
+                    break
+                if joint_type_str == "ball":
+                    joint_type = JointType.BALL
+                    dof_attr = parse_custom_attributes(
+                        joint_attrib,
+                        builder_custom_attr_dof,
+                        parsing_mode="mjcf",
+                        context={"use_degrees": use_degrees, "joint_type": joint_type_str},
+                    )
+                    # ball joint has 3 DOFs; replicate attribute value across all of them
+                    for key, value in dof_attr.items():
+                        if key not in dof_custom_attributes:
+                            dof_custom_attributes[key] = {}
+                        for dof_offset in range(3):
+                            dof_custom_attributes[key][current_dof_index + dof_offset] = value
+                    # Lift frictionloss into the builder's per-DOF friction array so it
+                    # reaches the MuJoCo spec (joint_friction[qd_start]) on export.
+                    ball_friction = parse_float(joint_attrib, "frictionloss", 0.0)
+                    mjcf_joint_dof_offsets.append((joint_name[-1], current_dof_index))
+                    current_dof_index += 3
                     break
                 is_angular = joint_type_str == "hinge"
                 axis_vec = parse_vec(joint_attrib, "axis", (0.0, 0.0, 1.0))
@@ -1678,6 +1701,27 @@ def parse_mjcf(
                 )
                 joint_indices.append(joint_idx)
                 # Map free joint names so actuators can target them
+                for jn in joint_name:
+                    joint_name_to_idx[jn] = joint_idx
+            elif joint_type == JointType.BALL and not angular_axes:
+                # MJCF <joint type="ball"/>: native ball joint with a single DOF entry.
+                # (The 3-hinge->ball conversion fills angular_axes and uses the generic path below.)
+                if parent == -1:
+                    parent_xform_for_joint = world_xform * wp.transform(joint_pos, wp.quat_identity())
+                else:
+                    rotated_joint_pos = wp.quat_rotate(body_ori_for_joints, joint_pos)
+                    parent_xform_for_joint = wp.transform(body_pos_for_joints + rotated_joint_pos, body_ori_for_joints)
+                joint_idx = builder.add_joint_ball(
+                    parent=parent,
+                    child=link,
+                    parent_xform=parent_xform_for_joint,
+                    child_xform=wp.transform(joint_pos, wp.quat_identity()),
+                    armature=joint_armature[-1] if joint_armature else None,
+                    friction=ball_friction,
+                    label=joint_label,
+                    custom_attributes=joint_custom_attributes | dof_custom_attributes,
+                )
+                joint_indices.append(joint_idx)
                 for jn in joint_name:
                     joint_name_to_idx[jn] = joint_idx
             else:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -667,6 +667,24 @@ class TestImportMjcfBasic(unittest.TestCase):
         np.testing.assert_allclose(leaf2_pos, expected_leaf2_xform.p, atol=1e-6)
         np.testing.assert_allclose(leaf2_quat, expected_leaf2_xform.q, atol=1e-6)
 
+    def test_native_ball_joint_preserves_friction(self):
+        """Regression: authored frictionloss on <joint type="ball"/> must reach joint_friction."""
+        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test">
+    <worldbody>
+        <body name="root">
+            <joint name="j" type="ball" armature="0.5" frictionloss="1.25"/>
+            <geom type="sphere" size="0.05"/>
+        </body>
+    </worldbody>
+</mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content)
+        self.assertEqual(builder.joint_count, 1)
+        self.assertEqual(builder.joint_type[0], newton.JointType.BALL)
+        # Ball joint has 3 DOFs; all three should carry the authored friction.
+        self.assertEqual(builder.joint_friction, [1.25, 1.25, 1.25])
+
     def test_replace_3d_hinge_with_ball_joint(self):
         """Test that 3D hinge joints are replaced with ball joints."""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Summary

- Add a native `type="ball"` import path in `parse_mjcf` that routes through `builder.add_joint_ball` and replicates DOF-level custom attributes across all three ball DOFs.
- Stop hardcoding `damping=0.0` for ball joints in the MuJoCo spec export; pass `joint_damping`/`joint_stiffness` through like other joint types.

The existing `convert_3d_hinge_to_ball_joints` conversion path is preserved (guarded by `and not angular_axes`).

## Test plan

- [x] `uv run --extra dev -m newton.tests -k test_import_mjcf` (205 tests, OK)
- [x] `test_replace_3d_hinge_with_ball_joint` (conversion path) still passes with the per-axis armatures preserved

Fixes #2505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MJCF importer now recognizes native ball joints and preserves authored damping, stiffness, and frictionloss during import/export.

* **Tests**
  * Added a regression test ensuring ball-joint friction is preserved across the three DOFs.

* **Documentation**
  * Changelog updated to document the corrected ball-joint import/export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->