### PR TITLE
Apply <default><equality/></default> attributes in MJCF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fix MJCF importer creating finite planes from MuJoCo visual half-sizes instead of infinite planes
 - Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
 - Fix degenerate zero-area triangles in SDF marching-cubes isosurface extraction by clamping edge interpolation away from cube corners and guarding against near-zero cross products
+- Fix MJCF importer ignoring `<default><equality/></default>` attribute defaults (e.g. `solref`, `solimp`) for `<connect>`/`<weld>`/`<joint>` equality constraints
 
 ## [1.1.0] - 2026-04-13
 

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1820,10 +1820,20 @@ def parse_mjcf(
         )
 
     def parse_equality_constraints(equality):
-        def parse_common_attributes(element):
+        def merge_equality_defaults(element):
+            """Merge <default><equality .../></default> attributes into the element's attrib.
+
+            Supports a per-element ``class="..."`` override like other defaults.
+            Explicit element attributes take precedence over defaults.
+            """
+            cls = element.attrib.get("class", "__all__")
+            defaults = class_defaults.get(cls, {}).get("equality", {})
+            return merge_attrib(defaults, element.attrib)
+
+        def parse_common_attributes(attribs):
             return {
-                "name": element.attrib.get("name"),
-                "active": element.attrib.get("active", "true").lower() == "true",
+                "name": attribs.get("name"),
+                "active": attribs.get("active", "true").lower() == "true",
             }
 
         def get_site_body_and_anchor(site_name: str) -> tuple[int, wp.vec3] | None:
@@ -1847,15 +1857,14 @@ def parse_mjcf(
             return (body_idx, anchor)
 
         for connect in equality.findall("connect"):
-            common = parse_common_attributes(connect)
-            custom_attrs = parse_custom_attributes(connect.attrib, builder_custom_attr_eq, parsing_mode="mjcf")
-            body1_name = sanitize_name(connect.attrib.get("body1", "")) if connect.attrib.get("body1") else None
-            body2_name = (
-                sanitize_name(connect.attrib.get("body2", "worldbody")) if connect.attrib.get("body2") else None
-            )
-            anchor = connect.attrib.get("anchor")
-            site1 = connect.attrib.get("site1")
-            site2 = connect.attrib.get("site2")
+            attribs = merge_equality_defaults(connect)
+            common = parse_common_attributes(attribs)
+            custom_attrs = parse_custom_attributes(attribs, builder_custom_attr_eq, parsing_mode="mjcf")
+            body1_name = sanitize_name(attribs.get("body1", "")) if attribs.get("body1") else None
+            body2_name = sanitize_name(attribs.get("body2", "worldbody")) if attribs.get("body2") else None
+            anchor = attribs.get("anchor")
+            site1 = attribs.get("site1")
+            site2 = attribs.get("site2")
 
             if body1_name and anchor:
                 if verbose:
@@ -1909,15 +1918,16 @@ def parse_mjcf(
                         )
 
         for weld in equality.findall("weld"):
-            common = parse_common_attributes(weld)
-            custom_attrs = parse_custom_attributes(weld.attrib, builder_custom_attr_eq, parsing_mode="mjcf")
-            body1_name = sanitize_name(weld.attrib.get("body1", "")) if weld.attrib.get("body1") else None
-            body2_name = sanitize_name(weld.attrib.get("body2", "worldbody")) if weld.attrib.get("body2") else None
-            anchor = weld.attrib.get("anchor", "0 0 0")
-            relpose = weld.attrib.get("relpose", "0 1 0 0 0 0 0")
-            torquescale = parse_float(weld.attrib, "torquescale", 1.0)
-            site1 = weld.attrib.get("site1")
-            site2 = weld.attrib.get("site2")
+            attribs = merge_equality_defaults(weld)
+            common = parse_common_attributes(attribs)
+            custom_attrs = parse_custom_attributes(attribs, builder_custom_attr_eq, parsing_mode="mjcf")
+            body1_name = sanitize_name(attribs.get("body1", "")) if attribs.get("body1") else None
+            body2_name = sanitize_name(attribs.get("body2", "worldbody")) if attribs.get("body2") else None
+            anchor = attribs.get("anchor", "0 0 0")
+            relpose = attribs.get("relpose", "0 1 0 0 0 0 0")
+            torquescale = parse_float(attribs, "torquescale", 1.0)
+            site1 = attribs.get("site1")
+            site2 = attribs.get("site2")
 
             if body1_name:
                 if verbose:
@@ -1984,11 +1994,12 @@ def parse_mjcf(
                         )
 
         for joint in equality.findall("joint"):
-            common = parse_common_attributes(joint)
-            custom_attrs = parse_custom_attributes(joint.attrib, builder_custom_attr_eq, parsing_mode="mjcf")
-            joint1_name = joint.attrib.get("joint1")
-            joint2_name = joint.attrib.get("joint2")
-            polycoef = joint.attrib.get("polycoef", "0 1 0 0 0")
+            attribs = merge_equality_defaults(joint)
+            common = parse_common_attributes(attribs)
+            custom_attrs = parse_custom_attributes(attribs, builder_custom_attr_eq, parsing_mode="mjcf")
+            joint1_name = attribs.get("joint1")
+            joint2_name = attribs.get("joint2")
+            polycoef = attribs.get("polycoef", "0 1 0 0 0")
 
             if joint1_name:
                 if verbose:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -3989,6 +3989,41 @@ class TestImportMjcfActuatorsFrames(unittest.TestCase):
             for i, (a, e) in enumerate(zip(actual, expected, strict=False)):
                 self.assertAlmostEqual(a, e, places=4, msg=f"eq_solref[{eq_idx}][{i}] should be {e}, got {a}")
 
+    def test_eq_solref_from_default(self):
+        """Regression test: <default><equality solref="..."/></default> attributes propagate.
+
+        Before the fix, equality constraints that didn't specify solref inline
+        fell back to MuJoCo's hardcoded [0.02, 1] instead of the class default.
+        """
+        mjcf = """<?xml version="1.0" ?>
+<mujoco>
+    <default>
+        <equality solref="0.005 1"/>
+    </default>
+    <worldbody>
+        <body name="body1">
+            <freejoint/>
+            <geom type="sphere" size="0.05"/>
+        </body>
+        <body name="body2">
+            <freejoint/>
+            <geom type="sphere" size="0.05"/>
+        </body>
+    </worldbody>
+    <equality>
+        <connect body1="body1" body2="body2" anchor="0 0 0"/>
+    </equality>
+</mujoco>
+"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+
+        self.assertEqual(model.equality_constraint_count, 1)
+        eq_solref = model.mujoco.eq_solref.numpy()[0].tolist()
+        self.assertAlmostEqual(eq_solref[0], 0.005, places=6)
+        self.assertAlmostEqual(eq_solref[1], 1.0, places=6)
+
     def test_parse_mujoco_options_disabled(self):
         """Test that solver options from <option> tag are not parsed when parse_mujoco_options=False."""
         mjcf = """<?xml version="1.0" ?>


### PR DESCRIPTION
## Summary

Newton's MJCF importer read `<connect>`/`<weld>`/`<joint>` attributes directly off each element, skipping the class-default merging that other paths (body, geom, joint) already do. Defaults defined under `<default><equality .../></default>` (e.g. `solref`, `solimp`) were ignored, and individual constraints fell back to MuJoCo's hardcoded defaults.

This PR adds a `merge_equality_defaults` helper in `parse_equality_constraints` and uses it in all three constraint loops (connect, weld, joint). Per-element `class="..."` overrides are supported.

Verified on Cassie: `eq_solref` now matches native exactly (`[0.005, 1]`) without any runtime backfill.

## Test plan

- [x] `uv run --extra dev -m newton.tests -k test_import_mjcf` (205 tests, OK)

Fixes #2506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MJCF importer now respects default equality attributes (e.g., solref, solimp) when creating constraints for connects, welds, and joints so imported constraints honor project-level defaults.

* **Tests**
  * Added a regression test confirming solref from MJCF defaults is propagated into generated equality constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->