### PR TITLE
Enable Cassie dynamics test in Menagerie suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Support `<joint type="ball"/>` in the MJCF importer, and preserve authored damping, stiffness, and frictionloss when exporting ball joints to MuJoCo specs (previously silently dropped)
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
-- Enable Cassie (`TestMenagerie_AgilityCassie`) in the MJCF Menagerie dynamics test suite; backfills `eq_data`, `jnt_actfrclimited`, and `jnt_solref` from native and documents why (`jnt_solref` workaround tracked in #2515)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Support `<joint type="ball"/>` in the MJCF importer, and preserve authored damping, stiffness, and frictionloss when exporting ball joints to MuJoCo specs (previously silently dropped)
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
+- Enable Cassie (`TestMenagerie_AgilityCassie`) in the MJCF Menagerie dynamics test suite; backfills `eq_data`, `jnt_actfrclimited`, and `jnt_solref` from native and documents why (`jnt_solref` workaround tracked in #2515)
 
 ### Changed
 

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -390,7 +390,10 @@ def compare_compiled_model_fields(
         fields = MODEL_BACKFILL_FIELDS
 
     # Validated by compare_inertia_tensors() with physics-equivalence check
-    skip_fields = {"body_inertia", "body_iquat"}
+    # eq_data for CONNECT constraints is body-frame dependent: when body_quat differs
+    # due to inertia re-diagonalization, the body2-frame anchor differs structurally
+    # but remains physically equivalent (validated by dynamics after backfill).
+    skip_fields = {"body_inertia", "body_iquat", "eq_data"}
 
     for field in fields:
         if field in skip_fields:
@@ -2236,7 +2239,36 @@ class TestMenagerie_AgilityCassie(TestMenagerieMJCF):
     """Agility Robotics Cassie biped."""
 
     robot_folder = "agility_cassie"
-    skip_reason = "Closed-loop kinematic chains cause different DOF layout"
+    num_steps = 20
+    # On CPU the Newton-vs-native qvel diff is effectively bit-exact after
+    # backfill (~5e-7 float accumulation over 20 steps). On AWS EC2 GPU the
+    # mjwarp constraint solver's atomic reductions are non-deterministic for
+    # Cassie's closed-loop chain (verified: two native-vs-native runs on
+    # identical inputs peaked at 5e-6 on some runs, 5e-5 on others). The
+    # Newton-vs-native diff rides on top of this noise. Tolerance set above
+    # the observed native-vs-native variance with safety margin.
+    dynamics_tolerance = 1e-4
+    backfill_model = True
+    # Cassie's MJCF doesn't specify <option integrator=...>, so native uses
+    # MuJoCo's default (Euler). Pin Newton's integrator to match.
+    solver_integrator = "euler"
+    # eq_data: compilation-dependent for CONNECT constraints; body2 anchor is
+    # derived from body_quat, which differs due to inertia re-diagonalization.
+    # jnt_actfrclimited: Newton unconditionally sets True with effort_limit=1e6,
+    # while native keeps False when no actuatorfrcrange is specified. Flagged as
+    # "no effect" in DEFAULT_MODEL_SKIP_FIELDS, but Cassie's closed-loop dynamics
+    # show a measurable divergence without this backfill (qvel step 0 diff ~2e-5).
+    # jnt_solref: Newton's solref standard->direct conversion omits the dmax
+    # (solimp[0]) factor, so its stored direct-mode values are ~11% lower
+    # stiffness/damping than native's internal values for the same MJCF input
+    # (tracked in #2515). Cassie's closed-loop limit constraints amplify this
+    # into measurable qvel divergence; backfill until the conversion is fixed.
+    backfill_fields = MODEL_BACKFILL_FIELDS + [  # noqa: RUF005
+        "eq_data",
+        "jnt_actfrclimited",
+        "jnt_solref",
+    ]
+    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"eq_data"}
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Turn on `TestMenagerie_AgilityCassie` with `num_steps=20` and `dynamics_tolerance=1e-4`. Remaining Newton-vs-native differences are handled via the existing backfill mechanism (`eq_data`, `jnt_actfrclimited`, `jnt_solref`), documented inline.

Prerequisite importer fixes (#2508, #2509, #2510) have landed on `main`; this PR is now a single-commit delta that adds the Cassie test configuration.

## Why the backfills?

- **`eq_data`**: CONNECT constraints store the body2 anchor as `body2_quat^-1 · (anchor_world − body2_pos_world)`. `body_quat` already differs between Newton and native (inertia re-diagonalization) and is already backfilled, but `mj_setConst` is not re-invoked after backfill, so `eq_data` stays stale. The hardcoded-skip addition in `compare_compiled_model_fields` lets the 1e-3 validator ignore the structurally-different-but-physically-equivalent `eq_data`.
- **`jnt_actfrclimited`**: Newton unconditionally sets this to `True` with `effort_limit=1e6`, while native keeps `False` when no `actuatorfrcrange` is specified. Documented as "no effect in practice" but measurably diverges (~2e-5 qvel at step 0) for Cassie's closed-loop dynamics.
- **`jnt_solref`**: Newton's standard-mode → direct-mode conversion omits the `dmax = solimp[0]` factor, so stored values are ~11% low. Workaround tracked in #2515.

## Tolerance

`1e-4` is chosen above the observed native-vs-native noise floor on AWS EC2 GPU (Cassie's closed-loop chain shows ~5e-5 max on some CI runs due to mjwarp's atomic-reduction non-determinism). The Newton-vs-native diff rides on top of this noise.

## Test plan

- [x] `uv run --extra dev -m newton.tests -k TestMenagerie_AgilityCassie.test_dynamics` (OK, 20 steps, tol 1e-4)
- [x] `uv run --extra dev -m newton.tests -k test_dynamics` (24 OK, 117 skipped)
- [x] `uv run --extra dev -m newton.tests -k test_model_comparison` (24 OK, 110 skipped)

Fixes #2507

🤖 Generated with [Claude Code](https://claude.com/claude-code)