### PR TITLE
Stop using warp.utils.warn / warp_showwarning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,15 +196,13 @@ extlinks = {
 }
 
 doctest_global_setup = """
+import warnings
 from typing import Any
 import numpy as np
 import warp as wp
 import newton
 
-# Suppress warnings by setting warp_showwarning to an empty function
-def empty_warning(*args, **kwargs):
-    pass
-wp.utils.warp_showwarning = empty_warning
+warnings.filterwarnings("ignore")
 
 wp.config.quiet = True
 wp.init()

--- a/newton/examples/basic/example_basic_plotting.py
+++ b/newton/examples/basic/example_basic_plotting.py
@@ -20,6 +20,8 @@
 #
 ###########################################################################
 
+import warnings
+
 import numpy as np
 import warp as wp
 
@@ -89,7 +91,7 @@ class Example:
                 self.graph = capture.graph
             except Exception as exc:
                 self.graph = None
-                wp.utils.warn(f"CUDA graph capture failed: {exc}")
+                warnings.warn(f"CUDA graph capture failed: {exc}", stacklevel=2)
         else:
             self.graph = None
 

--- a/newton/examples/mpm/example_mpm_beam_twist.py
+++ b/newton/examples/mpm/example_mpm_beam_twist.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import numpy as np
 import warp as wp
 
@@ -131,7 +133,7 @@ class Example:
         self.graph = None
         if wp.get_device().is_cuda and self.solver.grid_type == "fixed":
             if self.sim_substeps % 2 != 0:
-                wp.utils.warn("Sim substeps must be even for graph capture of MPM step")
+                warnings.warn("Sim substeps must be even for graph capture of MPM step", stacklevel=2)
             else:
                 with wp.ScopedCapture() as capture:
                     self.simulate()

--- a/newton/examples/mpm/example_mpm_granular.py
+++ b/newton/examples/mpm/example_mpm_granular.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import numpy as np
 import warp as wp
 
@@ -110,7 +112,7 @@ class Example:
         self.graph = None
         if wp.get_device().is_cuda and self.solver.grid_type == "fixed":
             if self.sim_substeps % 2 != 0:
-                wp.utils.warn("Sim substeps must be even for graph capture of MPM step")
+                warnings.warn("Sim substeps must be even for graph capture of MPM step", stacklevel=2)
             else:
                 with wp.ScopedCapture() as capture:
                     self.simulate()

--- a/newton/examples/mpm/example_mpm_snow_ball.py
+++ b/newton/examples/mpm/example_mpm_snow_ball.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import numpy as np
 import warp as wp
 
@@ -297,7 +299,7 @@ class Example:
         self.graph = None
         if wp.get_device().is_cuda and self.solver.grid_type == "fixed":
             if self.sim_substeps % 2 != 0:
-                wp.utils.warn("Sim substeps must be even for graph capture of MPM step")
+                warnings.warn("Sim substeps must be even for graph capture of MPM step", stacklevel=2)
             else:
                 with wp.ScopedCapture() as capture:
                     self.simulate()


### PR DESCRIPTION
## Description

Warp's 1.11 deprecation forwarder for `warp.utils.warn` and `warp.utils.warp_showwarning` is being removed in Warp 1.13 (see [NVIDIA/warp#1352](https://github.com/NVIDIA/warp/issues/1352)). After removal, the four example sites and the doctest setup that reach through these names raise `AttributeError`.

Fix by routing through the stdlib `warnings` module:
- Four examples (`example_mpm_beam_twist`, `example_mpm_granular`, `example_mpm_snow_ball`, `example_basic_plotting`) — `wp.utils.warn(msg)` → `warnings.warn(msg, stacklevel=2)`. These all live in `except` / odd-substep branches so they weren't exercised on the normal path.
- `docs/conf.py` `doctest_global_setup` — replace `wp.utils.warp_showwarning = empty_warning` monkey-patch with `warnings.filterwarnings(\"ignore\")`. Same silent-doctest behavior, no reach into Warp internals.

No changelog entry since Warp 1.13 hasn't shipped yet.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] \`CHANGELOG.md\` has been updated (if user-facing change) — N/A, pre-release fix

## Test plan

- \`uvx pre-commit run --files\` on the five changed files — passed
- Manual: confirmed all four example sites now import \`warnings\` and call \`warnings.warn(..., stacklevel=2)\`; no remaining \`wp.utils.warn\` or \`wp.utils.warp_showwarning\` usages in the repo
- Runtime verification of the example warning paths (CUDA-graph-capture failure, odd substeps) would require a CUDA device; not exercised here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced project-specific warning utilities with Python’s standard warnings module for consistent behavior.
  * Suppressed doctest warnings during docs setup to reduce noise in documentation tests.
  * Updated example warning emissions to include stacklevel so reported warning locations point to calling code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->