### PR TITLE
Fix `target_voxel_size` Being Ignored by Texture SDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Fix URDF joint dynamics friction import so specified friction values are preserved during simulation
 - Fix duplicate Reset button in brick stacking example when using the example browser
 - Cap `cbor2` dependency to `<6` to prevent recorder test failures caused by breaking deserialization changes in cbor2 6.0
+- Fix `SDF.create_from_mesh` (and `Mesh.build_sdf`) so `target_voxel_size` parameterizes the texture SDF, not just the sparse NanoVDB grid.
 
 ## [1.0.0] - 2026-03-10
 

--- a/newton/_src/geometry/sdf_texture.py
+++ b/newton/_src/geometry/sdf_texture.py
@@ -1268,7 +1268,8 @@ def create_texture_sdf_from_mesh(
     *,
     margin: float = 0.05,
     narrow_band_range: tuple[float, float] = (-0.1, 0.1),
-    max_resolution: int = 64,
+    target_voxel_size: float | None = None,
+    max_resolution: int | None = None,
     subgrid_size: int = 8,
     quantization_mode: int = QuantizationMode.UINT16,
     winding_threshold: float = 0.5,
@@ -1284,7 +1285,11 @@ def create_texture_sdf_from_mesh(
         mesh: Warp mesh with ``support_winding_number=True``.
         margin: extra AABB padding [m].
         narrow_band_range: signed narrow-band distance range [m] as ``(inner, outer)``.
-        max_resolution: maximum grid dimension [voxel].
+        target_voxel_size: target grid cell size [m]. If provided, takes
+            precedence over ``max_resolution``.
+        max_resolution: maximum grid dimension [voxel]. Used when
+            ``target_voxel_size`` is not provided. Defaults to ``64`` if both
+            parameters are ``None``.
         subgrid_size: cells per subgrid.
         quantization_mode: :class:`QuantizationMode` value.
         winding_threshold: winding number threshold for inside/outside classification.
@@ -1312,7 +1317,10 @@ def create_texture_sdf_from_mesh(
     max_ext_scalar = np.max(ext)
     if max_ext_scalar < 1e-10:
         return create_empty_texture_sdf_data(), None, None, []
-    cell_size_scalar = max_ext_scalar / max_resolution
+    if target_voxel_size is not None:
+        cell_size_scalar = target_voxel_size
+    else:
+        cell_size_scalar = max_ext_scalar / (max_resolution if max_resolution is not None else 64)
     dims = np.ceil(ext / cell_size_scalar).astype(int) + 1
     grid_x, grid_y, grid_z = int(dims[0]), int(dims[1]), int(dims[2])
     cell_size = ext / (dims - 1)

--- a/newton/_src/geometry/sdf_utils.py
+++ b/newton/_src/geometry/sdf_utils.py
@@ -395,12 +395,12 @@ class SDF:
                 signed_volume = compute_mesh_signed_volume(pos, indices)
                 winding_threshold = 0.5 if signed_volume >= 0.0 else -0.5
 
-                res = effective_max_resolution if effective_max_resolution is not None else 64
                 texture_data, coarse_texture, subgrid_texture, tex_block_coords = create_texture_sdf_from_mesh(
                     tex_mesh,
                     margin=margin,
                     narrow_band_range=narrow_band_range,
-                    max_resolution=res,
+                    target_voxel_size=target_voxel_size,
+                    max_resolution=effective_max_resolution,
                     quantization_mode=qmode,
                     winding_threshold=winding_threshold,
                     scale_baked=bake_scale,

--- a/newton/tests/test_sdf_texture.py
+++ b/newton/tests/test_sdf_texture.py
@@ -1215,6 +1215,34 @@ def test_build_sdf_texture_format_parameter(test, device):
     test.assertEqual(sdf_f32._subgrid_texture.dtype, wp.float32)
 
 
+def test_build_sdf_target_voxel_size_propagates_to_texture(test, device):
+    """``target_voxel_size`` must parameterize the texture SDF, not just the sparse grid.
+
+    When only ``target_voxel_size`` was supplied, the texture path silently fell
+    back to ``max_resolution=64``, producing a dramatically coarser secondary
+    representation than the sparse grid.
+    """
+    margin = 0.05
+
+    # Pick a voxel size small enough that the resulting texture SDF is clearly
+    # finer than the old ``max_resolution=64`` fallback would have produced.
+    mesh_default = _create_sphere_mesh(radius=0.5, subdivisions=2)
+    sdf_default = mesh_default.build_sdf(margin=margin, device=device)
+    default_subgrid_width = sdf_default._subgrid_texture.width
+
+    mesh_fine = _create_sphere_mesh(radius=0.5, subdivisions=2)
+    sdf_fine = mesh_fine.build_sdf(target_voxel_size=0.01, margin=margin, device=device)
+
+    # With the bug, ``target_voxel_size`` is ignored by the texture path and
+    # the subgrid texture matches the default (max_resolution=64) fallback.
+    test.assertGreater(sdf_fine._subgrid_texture.width, default_subgrid_width)
+
+    # The texture grid dx should reflect the requested voxel size (within a
+    # small rounding tolerance from the ceil-based sizing).
+    sampled_dx = 1.0 / float(sdf_fine.texture_data.inv_sdf_dx[0])
+    test.assertAlmostEqual(sampled_dx, 0.01, delta=5e-4)
+
+
 # Register tests for CUDA devices
 devices = get_cuda_test_devices()
 add_function_test(TestTextureSDF, "test_texture_sdf_construction", test_texture_sdf_construction, devices=devices)
@@ -1259,6 +1287,12 @@ add_function_test(
 )
 add_function_test(
     TestTextureSDF, "test_build_sdf_texture_format_parameter", test_build_sdf_texture_format_parameter, devices=devices
+)
+add_function_test(
+    TestTextureSDF,
+    "test_build_sdf_target_voxel_size_propagates_to_texture",
+    test_build_sdf_target_voxel_size_propagates_to_texture,
+    devices=devices,
 )
 add_function_test(
     TestTextureSDF,


### PR DESCRIPTION
## Description

`SDF.create_from_mesh` (and `Mesh.build_sdf`) computes two representations: a sparse NanoVDB grid and a companion texture SDF used by the GL viewer's isomesh pass, hydroelastic broadphase, and texture-based SDF sampling. The docstring promises that `target_voxel_size` "takes precedence over `max_resolution`", but that was only honored by the sparse path — the texture path never received `target_voxel_size` and silently fell back to `max_resolution=64`. Users parameterizing by world-unit voxel size therefore got a dramatically coarser texture SDF than the sparse grid, with no warning.

This PR forwards `target_voxel_size` through to `create_texture_sdf_from_mesh` and gives that function the same precedence policy as the sparse path. The `None → 64` fallback is kept inside the texture module so the caller no longer duplicates the ceil/padding math.

Closes #2524

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_build_sdf_target_voxel_size_propagates_to_texture
uv run --extra dev -m newton.tests -k test_sdf   # 93 tests, all pass
```

The new regression test was also verified to fail without the source fix applied.

## Bug fix

**Steps to reproduce:**

1. Build an SDF from a mesh using `target_voxel_size` alone (no `max_resolution`).
2. Inspect `sdf._coarse_texture` and `sdf._subgrid_texture` dimensions.
3. Observe that they correspond to a 64-resolution grid, not to the requested voxel size.

**Minimal reproduction:**

```python
import numpy as np
from pxr import Usd

import newton
import newton.examples
import newton.usd

stage = Usd.Stage.Open(newton.examples.get_asset("bunny.usd"))
usd_mesh = newton.usd.get_mesh(stage.GetPrimAtPath("/root/bunny"))
mesh = newton.Mesh(
    np.asarray(usd_mesh.vertices, dtype=np.float32),
    np.asarray(usd_mesh.indices, dtype=np.int32),
)

margin = 0.05
verts = np.asarray(usd_mesh.vertices, dtype=np.float32)
padded_longest = float((verts.max(axis=0) - verts.min(axis=0) + 2.0 * margin).max())
voxel = padded_longest / 384  # equivalent to max_resolution=384

sdf_a = mesh.build_sdf(max_resolution=384, margin=margin)
sdf_b = mesh.build_sdf(target_voxel_size=voxel, margin=margin)

# Before this PR: A -> 297x297x297, B -> 63x63x63 (4.7x coarser per axis)
# After this PR:  both -> 297x297x297
print("A subgrid:", sdf_a._subgrid_texture.width, sdf_a._subgrid_texture.height, sdf_a._subgrid_texture.depth)
print("B subgrid:", sdf_b._subgrid_texture.width, sdf_b._subgrid_texture.height, sdf_b._subgrid_texture.depth)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `target_voxel_size` parameter to properly control texture SDF resolution during mesh-to-SDF conversion, ensuring consistent control over both texture and sparse grid resolutions.

* **Tests**
  * Added test to verify `target_voxel_size` parameter propagates correctly to texture resolution calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->