### PR TITLE
Bump warp-lang to 1.13.0 dev nightly

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.13.0.dev20260422 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.13.0.dev20260421 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.7.0",
     "python -m pip install -U mujoco-warp==3.7.0.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.13.0.dev20260421 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.13.0.dev20260423 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.7.0",
     "python -m pip install -U mujoco-warp==3.7.0.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U warp-lang==1.12.1 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.13.0.dev20260422 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.7.0",
     "python -m pip install -U mujoco-warp==3.7.0.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -259,7 +259,7 @@ def write_module_page(mod_name: str) -> None:
 
             # unpack the warp scalar value, we can remove this
             # when the warp.types.scalar_base supports __str__()
-            if type(value) in wp.types.scalar_types:
+            if wp.types.is_scalar(value):
                 value = getattr(value, "value", value)
 
             lines.extend(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang==1.13.0.dev20260421",
+    "warp-lang==1.13.0.dev20260423",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.12.0",
+    "warp-lang==1.13.0.dev20260421",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3108,7 +3108,7 @@ requires-dist = [
     { name = "usd-core", marker = "python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5" },
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = ">=1.0.16" },
-    { name = "warp-lang", specifier = "==1.13.0.dev20260421", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = "==1.13.0.dev20260423", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -5906,17 +5906,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.13.0.dev20260421"
+version = "1.13.0.dev20260423"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9850a5e31f2d5a54ede9bfe6a96cd0f45baf09b1ee1ff536087ea4251941557d" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:74e2f32185fe97958c1d9aec9a65b8885d25f5f53989f5d3f33ca2c6eb2cbc30" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5cc99c7fd107a9bb8322bc547f74264b122a22a2857ffb893491b073c080605b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-win_amd64.whl", hash = "sha256:7def82c24f4165fbfc7e2ccfd2e89ae187de3a79f97a6fb028db5b767300a2bb" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260423-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86b2b096c71dec8cfdbce8cf6d5c0adbd65e4b185983671b46219900fe8e94c0" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260423-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cfa0cae9e4d1ab1f874eb07109b1f800c600ffa18651e3a49ce3685c62074420" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260423-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d130cbb9bd0571d2e3f2440541dcb62219ba948a830076dc98b79a06bffef160" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260423-py3-none-win_amd64.whl", hash = "sha256:5fec8c5fb3a66904553315558bde8cb1055f943f86b243e2a3be990a49280c6a" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3108,7 +3108,7 @@ requires-dist = [
     { name = "usd-core", marker = "python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5" },
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = ">=1.0.16" },
-    { name = "warp-lang", specifier = ">=1.12.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = "==1.13.0.dev20260421", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -5906,17 +5906,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.13.0.dev20260422"
+version = "1.13.0.dev20260421"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e93536f8be21c30a396c2efb75dda0c2394682c62032f15e76dc2ec4b783c062" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3f0ce7d03cb396094a06bd22cebd71a9c82dd5356cebc4754d25bef4a0ed47d0" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:ac12bf9ae4455fde60375f097242454f3028b5db1b3f8a852ee084b50c94afbf" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-win_amd64.whl", hash = "sha256:7a9b50ca7831556460b7375408c02dc81dce6ab94ed5b456445c5f3d8c7fdf59" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9850a5e31f2d5a54ede9bfe6a96cd0f45baf09b1ee1ff536087ea4251941557d" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:74e2f32185fe97958c1d9aec9a65b8885d25f5f53989f5d3f33ca2c6eb2cbc30" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:5cc99c7fd107a9bb8322bc547f74264b122a22a2857ffb893491b073c080605b" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260421-py3-none-win_amd64.whl", hash = "sha256:7def82c24f4165fbfc7e2ccfd2e89ae187de3a79f97a6fb028db5b767300a2bb" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5906,17 +5906,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.12.1"
+version = "1.13.0.dev20260422"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98df3533a6c40a33cce961f8efa991006b30c9d286356e4cd77ea8ce86928f1d" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6bf01f10509488ba8eacaf4ec7fcf7cfbd503118b22e002ecba407b40a17424e" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:af6d680e79c1be6e46ddf80ecaa358f222804f882f4683260a7b4abd80a0981b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.12.1-py3-none-win_amd64.whl", hash = "sha256:826b2f93df8e47eac0c751a8eb5a0533e2fc5434158c8896a63be53bfbd728c7" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e93536f8be21c30a396c2efb75dda0c2394682c62032f15e76dc2ec4b783c062" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3f0ce7d03cb396094a06bd22cebd71a9c82dd5356cebc4754d25bef4a0ed47d0" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:ac12bf9ae4455fde60375f097242454f3028b5db1b3f8a852ee084b50c94afbf" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0.dev20260422-py3-none-win_amd64.whl", hash = "sha256:7a9b50ca7831556460b7375408c02dc81dce6ab94ed5b456445c5f3d8c7fdf59" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Reinstate the warp-lang nightly bump that was reverted in #2448, pointing at the latest nightly build `1.13.0.dev20260422`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Rely on CI to validate the updated nightly against the existing test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance testing environment to use a runtime installer that can fetch pre-release binaries.
  * Pinned the core runtime dependency to a specific development build in project configuration.

* **Documentation**
  * Improved API doc generation so constants wrapped by scalar-like types are detected and rendered more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->