### PR TITLE
Remove unused mjc:damping -> rigid_body_linear_damping mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
 - Fix degenerate zero-area triangles in SDF marching-cubes isosurface extraction by clamping edge interpolation away from cube corners and guarding against near-zero cross products
 - Fix MJCF importer ignoring `<default><equality/></default>` attribute defaults (e.g. `solref`, `solimp`) for `<connect>`/`<weld>`/`<joint>` equality constraints
+- Remove incorrect body-level `mjc:damping` -> `rigid_body_linear_damping` mapping from `SchemaResolverMjc`; `mjc:damping` is defined on `MjcJointAPI`, not on bodies
 
 ## [1.1.0] - 2026-04-13
 

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -336,10 +336,6 @@ class SchemaResolverMjc(SchemaResolver):
             "stiffness": SchemaAttribute("mjc:solref", [0.02, 1.0], solref_to_stiffness),
             "damping": SchemaAttribute("mjc:solref", [0.02, 1.0], solref_to_damping),
         },
-        PrimType.BODY: {
-            # Rigid body / joint domain
-            "rigid_body_linear_damping": SchemaAttribute("mjc:damping", 0.0),
-        },
         PrimType.ACTUATOR: {
             # Actuators
             "ctrl_low": SchemaAttribute("mjc:ctrlRange:min", 0.0),


### PR DESCRIPTION
## Description

`SchemaResolverMjc` mapped body-level `mjc:damping` to `rigid_body_linear_damping`, but:

- Upstream `mjcPhysics` defines `mjc:damping` on `MjcJointAPI`, not as a body/rigid-body schema attribute.
- `rigid_body_linear_damping` is not consumed by any Newton model or solver; `grep -r rigid_body_linear_damping` hits only the USD schema mapping layer.

Joint-level `mjc:damping` consumption via `SolverMuJoCo` custom attributes is untouched: it flows through the `mjc` namespace collection path (`SchemaResolver.collect_prim_attrs` -> `_collect_attrs_by_namespace`), not through this mapping entry.

Closes #2344

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_schema_resolver
uv run --extra dev -m newton.tests -k test_mjc_damping_from_usd_via_schema_resolver
uv run --extra dev -m newton.tests -k test_import_usd
```

All pass (25, 1, and 184 tests respectively).

## Bug fix

**Steps to reproduce:**

1. Author `mjc:damping` on a USD body prim.
2. Parse via `SchemaResolverMjc`.
3. The value is silently collected into `schema_attrs` under the body as if it mapped to `rigid_body_linear_damping` — a key no solver or model reads, and a USD location upstream MjcPhysics does not define.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected damping behavior: the MuJoCo damping attribute now applies to joints only, not bodies—damping will no longer be treated as a body-level property.

* **Documentation**
  * Changelog updated to accurately reflect the corrected damping mapping so users see joint-only damping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->