### PR TITLE
Disable flaky SDF construction benchmark

### DIFF
--- a/asv/benchmarks/setup/bench_sdf.py
+++ b/asv/benchmarks/setup/bench_sdf.py
@@ -125,7 +125,8 @@ class FastBuildSdf:
             wp.synchronize_device()
             del warm_mesh
 
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    # Disabled, see #2534.
+    @skip_benchmark_if(True)
     def time_build_sdf(self, max_resolution):
         mesh = newton.Mesh(self._vertices, self._indices, compute_inertia=False)
         mesh.build_sdf(max_resolution=max_resolution)


### PR DESCRIPTION
## Description

`setup.bench_sdf.FastBuildSdf.time_build_sdf` (added in #2483) is failing the `Pull Request - AWS GPU Benchmarks` workflow on unrelated PRs with `PERFORMANCE DECREASED`. The base measurement on the 128 grid is bimodal across CI runs (~22.5 ms vs ~25.5 ms) while within-run stddev is ~0.05 ms; when base and head land in different modes asv flags a spurious +11-14% regression and the job exits non-zero, blocking merges.

Observed failures in the last ~24h on PRs that do not touch SDF code:

| Run | Branch | `(128)` base → head |
|---|---|---|
| [24777344164](https://github.com/newton-physics/newton/actions/runs/24777344164) | `vreutskyy/mjcf-ball-joint-import` | 22.6 → 25.1 (+1.11) |
| [24777295922](https://github.com/newton-physics/newton/actions/runs/24777295922) | `vreutskyy/enable-cassie-dynamics` | 22.6 → 25.2 (+1.11) |
| [24735849179](https://github.com/newton-physics/newton/actions/runs/24735849179) | `dev/tw3/contact_matching` | 22.5 → 25.1 (+1.11) |
| [24726479129](https://github.com/newton-physics/newton/actions/runs/24726479129) | `ershi/fix-removed-warp-api` | 22.7 → 25.8 (+1.14) |

Skip the benchmark unconditionally until the runner variance is addressed. Tracking: #2534.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- Verified the `@skip_benchmark_if(True)` decorator is applied; asv will now report the benchmark as `skipped` and not contribute to the regression gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled SDF build benchmark

<!-- end of auto-generated comment: release notes by coderabbit.ai -->