### PR TITLE
Enable PYTHONFAULTHANDLER in CI test workflows

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -151,6 +151,8 @@ jobs:
         run: df -h
 
       - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: uv run --extra dev --extra torch-cu13 -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
       - name: Check disk space (post-test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,8 @@ jobs:
           restore-keys: |
             warp-kernels-${{ runner.os }}-${{ runner.arch }}-
       - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: uv run --extra dev -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -126,6 +126,8 @@ jobs:
           uv tree --depth 1
 
       - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: uv run --extra dev -m newton.tests --junit-report-xml rspec.xml
 
       - name: Test Summary

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -130,6 +130,8 @@ jobs:
         run: df -h
 
       - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: uv run --no-sync -m newton.tests --junit-report-xml rspec.xml
 
       - name: Check disk space (post-test)

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -125,6 +125,8 @@ jobs:
         run: df -h
 
       - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: uv run --extra dev --extra torch-cu13 -m newton.tests --junit-report-xml rspec.xml
 
       - name: Check disk space (post-test)


### PR DESCRIPTION
Set `PYTHONFAULTHANDLER=1` in the test job environment so native crashes (segfaults, access violations) produce a Python traceback instead of a silent exit with a non-zero exit code. Applied to `ci.yml`, `aws_gpu_tests.yml`, `mujoco_warp_tests.yml`,
`minimum_deps_tests.yml`, and `warp_nightly_tests.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test execution reliability by improving error reporting capabilities in the continuous integration pipeline during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->