### PR TITLE
Allow zero volume convex hulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ### Fixed
 
-- Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds by detecting rank via SVD and emitting a well-formed fallback mesh; full-rank inputs are unchanged, and the 3D path now retries with Qhull's `QJ` joggle option as a last resort before giving up
+- Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Fixed
 
+- Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds by detecting rank via SVD and emitting a well-formed fallback mesh; full-rank inputs are unchanged, and the 3D path now retries with Qhull's `QJ` joggle option as a last resort before giving up
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled

--- a/newton/_src/geometry/utils.py
+++ b/newton/_src/geometry/utils.py
@@ -702,9 +702,15 @@ def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 
         - verts: A numpy array of shape (M, 3) containing the vertex positions of the convex hull.
         - faces: A numpy array of shape (K, 3) containing the vertex indices of the triangular faces of the convex hull.
 
+    Raises:
+        ValueError: If ``vertices`` is empty. Empty input has no geometric
+            interpretation; the caller must decide whether to skip the hull
+            computation or supply a fallback rather than having this function
+            fabricate a point at the origin.
+
     Guarantees:
-        - Never raises on degenerate input; always returns a well-formed
-          ``(verts, faces)`` pair with ``M >= 3`` and ``K >= 2``.
+        - Never raises on non-empty degenerate input; always returns a
+          well-formed ``(verts, faces)`` pair with ``M >= 3`` and ``K >= 2``.
         - ``verts`` is always a subset of the true convex hull's vertex set.
         - For full-rank (rank-3) inputs, the output is a closed 3D convex hull
           with outward-facing triangle windings, unchanged from the pre-degeneracy
@@ -735,21 +741,44 @@ def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 
           differ from what a 3D ``TAn`` pass would have selected (which is
           unavoidable, since Qhull cannot answer the 3D question for flat input).
         - As a last-resort safety net, the full-3D branch retries with Qhull's
-          ``QJ`` (joggle) option if the initial call raises. This perturbs input
-          by ~1e-11 and returns the convex hull of the *perturbed* input.
+          ``QJ`` (joggle) option if the initial call raises. Qhull computes
+          the hull of the perturbed input, but the returned ``verts`` are
+          indexed back into the original ``vertices`` so the output remains
+          a strict subset of the caller's input (any connectivity error of
+          order ~1e-11 from the joggle is absorbed into the face topology).
+
+    Warnings:
+        Rank-0/1/2 degenerate branches emit a ``UserWarning`` describing the
+        detected degeneracy so that callers (e.g. :meth:`Mesh.convex_hull`,
+        :meth:`PointCloud.as_mesh`, :func:`remesh`) don't silently end up
+        with a zero-volume, zero-mass collider. Filter with
+        ``warnings.filterwarnings("ignore", message="remesh_convex_hull: ...")``
+        if the caller has already validated the input.
     """
 
     from scipy.spatial import ConvexHull, QhullError
 
     vertices = np.asarray(vertices, dtype=np.float64)
 
-    # Degenerate: empty or single point.
+    # Empty input has no geometric interpretation: fabricating a point at the
+    # origin would silently inject phantom geometry into the simulation. Let
+    # the caller decide whether to skip or supply a fallback.
     if vertices.shape[0] == 0:
-        return (
-            np.zeros((3, 3), dtype=np.float32),
-            np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int32),
+        raise ValueError("remesh_convex_hull requires at least one input vertex; got an empty array.")
+
+    def _warn_degenerate(rank: str) -> None:
+        # Warn so callers (Mesh.convex_hull, PointCloud.as_mesh, remesh, ...)
+        # don't silently end up with a zero-volume, zero-mass collider.
+        warnings.warn(
+            f"remesh_convex_hull: input point cloud is {rank}; returning a "
+            "zero-volume fallback mesh. Downstream inertia computations will "
+            "produce zero mass / COM / inertia.",
+            UserWarning,
+            stacklevel=2,
         )
+
     if vertices.shape[0] == 1:
+        _warn_degenerate("a single point (rank 0)")
         return _degenerate_hull_point(vertices[0])
 
     # Classify dimensionality via SVD of the centred point cloud.
@@ -764,10 +793,12 @@ def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 
 
     # Rank 0: all points coincident.
     if s0 <= eps:
+        _warn_degenerate("coincident (rank 0)")
         return _degenerate_hull_point(centre)
 
     # Rank 1: collinear.
     if s1 <= eps * scale:
+        _warn_degenerate("collinear (rank 1)")
         direction = vh[0]
         return _degenerate_hull_line(vertices, direction, centre)
 
@@ -775,6 +806,7 @@ def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 
     # convex hull, fan-triangulate, and emit each triangle twice with opposite
     # winding so the flat hull is double-sided.
     if s2 <= eps * scale:
+        _warn_degenerate("coplanar (rank 2)")
         axis_u = vh[0]
         axis_v = vh[1]
         points2d = np.stack([centred @ axis_u, centred @ axis_v], axis=1)
@@ -817,8 +849,16 @@ def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 
         hull = ConvexHull(vertices, qhull_options=qhull_options)
     except QhullError:
         # Retry with joggled input as a last resort before giving up on 3D.
+        # QJ perturbs coordinates in-place (~1e-11); it does not reorder or
+        # drop points, so hull.simplices indices still refer to the same rows
+        # of the original input array. We intentionally pull coordinates from
+        # `vertices` rather than `hull.points` below so the returned verts
+        # remain a strict subset of the caller's input (preserving the
+        # docstring invariant).
         hull = ConvexHull(vertices, qhull_options=qhull_options + " QJ")
-    verts = hull.points.copy().astype(np.float32)
+    # Index into the original (un-joggled) input so that verts is always a
+    # subset of the caller's vertices, even through the QJ retry path.
+    verts = vertices.astype(np.float32)
     faces = hull.simplices.astype(np.int32)
 
     # fix winding order of faces

--- a/newton/_src/geometry/utils.py
+++ b/newton/_src/geometry/utils.py
@@ -611,38 +611,222 @@ def remesh_quadratic(
     return simplify(vertices, faces, target_reduction=target_reduction, target_count=target_count, **kwargs)
 
 
-def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0):
+def _degenerate_hull_point(p: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Build a degenerate hull for a 0-dimensional point cloud (all vertices coincident).
+
+    Emits three coincident vertices and two opposite-winding triangles so that
+    downstream code that expects a closed triangle mesh still works.
+    """
+    verts = np.tile(p.astype(np.float32), (3, 1))
+    faces = np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int32)
+    return verts, faces
+
+
+def _degenerate_hull_line(
+    vertices: np.ndarray, direction: np.ndarray, centre: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a degenerate hull for a 1-dimensional (collinear) point cloud.
+
+    Emits the two extreme points along ``direction`` plus their midpoint as a
+    third vertex, with two opposite-winding triangles forming a zero-area sliver.
+    """
+    t = (vertices - centre) @ direction
+    i_min = int(np.argmin(t))
+    i_max = int(np.argmax(t))
+    a = vertices[i_min].astype(np.float32)
+    b = vertices[i_max].astype(np.float32)
+    mid = (0.5 * (a + b)).astype(np.float32)
+    verts = np.stack([a, b, mid], axis=0)
+    faces = np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int32)
+    return verts, faces
+
+
+def _convex_hull_2d_indices(points2d: np.ndarray) -> np.ndarray:
+    """Return indices of the 2D convex hull of ``points2d`` in CCW order.
+
+    Uses ``scipy.spatial.ConvexHull`` in 2D, which handles collinear / near-flat
+    inputs gracefully. Falls back to a monotone-chain implementation if SciPy's
+    Qhull still rejects the input.
+    """
+    from scipy.spatial import ConvexHull, QhullError
+
+    try:
+        hull = ConvexHull(points2d, qhull_options="Qt")
+        # ConvexHull.vertices in 2D are already ordered CCW.
+        return hull.vertices.astype(np.int32)
+    except QhullError:
+        pass
+
+    # Monotone chain fallback (Andrew's algorithm).
+    n = points2d.shape[0]
+    order = np.lexsort((points2d[:, 1], points2d[:, 0]))
+    sorted_pts = points2d[order]
+
+    def cross(o, a, b):
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    lower: list[int] = []
+    for i in range(n):
+        while len(lower) >= 2 and cross(sorted_pts[lower[-2]], sorted_pts[lower[-1]], sorted_pts[i]) <= 0:
+            lower.pop()
+        lower.append(i)
+    upper: list[int] = []
+    for i in range(n - 1, -1, -1):
+        while len(upper) >= 2 and cross(sorted_pts[upper[-2]], sorted_pts[upper[-1]], sorted_pts[i]) <= 0:
+            upper.pop()
+        upper.append(i)
+    chain = lower[:-1] + upper[:-1]
+    return order[np.array(chain, dtype=np.int32)]
+
+
+def remesh_convex_hull(vertices: np.ndarray, maxhullvert: int = 0, eps: float = 1e-6):
     """Compute the convex hull of a set of 3D points and return the vertices and faces of the convex hull mesh.
 
-    Uses ``scipy.spatial.ConvexHull`` to compute the convex hull.
+    Uses ``scipy.spatial.ConvexHull`` to compute the convex hull. Degenerate point
+    clouds (coincident, collinear, or coplanar) are detected up front via an SVD
+    of the centered points and handled without invoking Qhull's full 3D simplex
+    construction, which would otherwise raise
+    ``QH6154 Qhull precision error: Initial simplex is flat``.
 
     Args:
         vertices: A numpy array of shape (N, 3) containing the vertex positions.
         maxhullvert: The maximum number of vertices for the convex hull. If 0, no limit is applied.
+        eps: Relative threshold used to classify a point cloud as coincident,
+            collinear, or coplanar. A singular value is considered zero if it is
+            smaller than ``eps`` times the largest singular value (or ``eps``
+            itself in absolute terms for the zero-extent case).
 
     Returns:
         A tuple (verts, faces) where:
+
         - verts: A numpy array of shape (M, 3) containing the vertex positions of the convex hull.
         - faces: A numpy array of shape (K, 3) containing the vertex indices of the triangular faces of the convex hull.
+
+    Guarantees:
+        - Never raises on degenerate input; always returns a well-formed
+          ``(verts, faces)`` pair with ``M >= 3`` and ``K >= 2``.
+        - ``verts`` is always a subset of the true convex hull's vertex set.
+        - For full-rank (rank-3) inputs, the output is a closed 3D convex hull
+          with outward-facing triangle windings, unchanged from the pre-degeneracy
+          behavior.
+
+    Degenerate outputs (rank < 3):
+        - **Coplanar (rank 2):** a flat, zero-volume triangle soup covering the
+          planar convex hull. The 2D hull is fan-triangulated and each triangle
+          is emitted twice with opposite windings so the mesh is double-sided.
+          Callers that expect each face to appear exactly once will see twice
+          the triangle count compared to a hypothetical single-sided flat hull.
+        - **Collinear (rank 1):** the two extrema along the principal direction
+          plus their midpoint, as two zero-area triangles with opposite windings.
+        - **Coincident (rank 0):** three copies of the single point with two
+          opposite-winding triangles.
+        - In all degenerate cases the resulting mesh has zero 3D volume, so
+          ``compute_inertia_mesh`` (and anything else that integrates over the
+          interior) will return zero mass / volume / inertia. Callers that
+          require a nonzero-volume collider must guard for this themselves.
+        - The rank thresholds are relative (``s[i] <= eps * s[0]``), so highly
+          anisotropic but technically 3D inputs (e.g. a slab 1e-7 wide next to
+          1 m) are treated as flat. This matches Qhull's behavior (it would
+          fail on such input anyway) and is almost always the desired behavior
+          for a collision collider, but it does mean near-flat 3D hulls are
+          silently flattened.
+        - ``maxhullvert`` in the planar branch is implemented by uniformly
+          decimating the 2D boundary loop; the specific retained vertices may
+          differ from what a 3D ``TAn`` pass would have selected (which is
+          unavoidable, since Qhull cannot answer the 3D question for flat input).
+        - As a last-resort safety net, the full-3D branch retries with Qhull's
+          ``QJ`` (joggle) option if the initial call raises. This perturbs input
+          by ~1e-11 and returns the convex hull of the *perturbed* input.
     """
 
-    from scipy.spatial import ConvexHull
+    from scipy.spatial import ConvexHull, QhullError
 
+    vertices = np.asarray(vertices, dtype=np.float64)
+
+    # Degenerate: empty or single point.
+    if vertices.shape[0] == 0:
+        return (
+            np.zeros((3, 3), dtype=np.float32),
+            np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int32),
+        )
+    if vertices.shape[0] == 1:
+        return _degenerate_hull_point(vertices[0])
+
+    # Classify dimensionality via SVD of the centred point cloud.
+    centre = vertices.mean(axis=0)
+    centred = vertices - centre
+    # ``full_matrices=False`` gives vh of shape (3, 3); singular values sorted descending.
+    _, s, vh = np.linalg.svd(centred, full_matrices=False)
+    s0 = float(s[0]) if s.size > 0 else 0.0
+    s1 = float(s[1]) if s.size > 1 else 0.0
+    s2 = float(s[2]) if s.size > 2 else 0.0
+    scale = max(s0, eps)
+
+    # Rank 0: all points coincident.
+    if s0 <= eps:
+        return _degenerate_hull_point(centre)
+
+    # Rank 1: collinear.
+    if s1 <= eps * scale:
+        direction = vh[0]
+        return _degenerate_hull_line(vertices, direction, centre)
+
+    # Rank 2: coplanar. Project onto the two largest principal axes, run a 2D
+    # convex hull, fan-triangulate, and emit each triangle twice with opposite
+    # winding so the flat hull is double-sided.
+    if s2 <= eps * scale:
+        axis_u = vh[0]
+        axis_v = vh[1]
+        points2d = np.stack([centred @ axis_u, centred @ axis_v], axis=1)
+
+        hull_idx = _convex_hull_2d_indices(points2d)
+        if hull_idx.size < 3:
+            # Should not happen once rank >= 2, but guard anyway.
+            if hull_idx.size == 2:
+                direction = vh[0]
+                return _degenerate_hull_line(vertices, direction, centre)
+            return _degenerate_hull_point(centre)
+
+        if maxhullvert > 0 and hull_idx.size > maxhullvert:
+            # Uniformly decimate the boundary loop to respect the vertex budget.
+            sel = np.linspace(0, hull_idx.size, num=maxhullvert, endpoint=False).astype(np.int32)
+            hull_idx = hull_idx[sel]
+
+        verts = vertices[hull_idx].astype(np.float32)
+        m = verts.shape[0]
+        # Fan triangulation from vertex 0; each triangle emitted twice (CW + CCW).
+        faces_ccw = np.stack(
+            [
+                np.zeros(m - 2, dtype=np.int32),
+                np.arange(1, m - 1, dtype=np.int32),
+                np.arange(2, m, dtype=np.int32),
+            ],
+            axis=1,
+        )
+        faces_cw = faces_ccw[:, [0, 2, 1]]
+        faces = np.concatenate([faces_ccw, faces_cw], axis=0)
+        return verts, faces
+
+    # General (full 3D) case.
     qhull_options = "Qt"
     if maxhullvert > 0:
         # qhull "TA" actually means "number of vertices added after the initial simplex"
         # from mujoco's user_mesh.cc
         qhull_options += f" TA{maxhullvert - 4}"
-    hull = ConvexHull(vertices, qhull_options=qhull_options)
+    try:
+        hull = ConvexHull(vertices, qhull_options=qhull_options)
+    except QhullError:
+        # Retry with joggled input as a last resort before giving up on 3D.
+        hull = ConvexHull(vertices, qhull_options=qhull_options + " QJ")
     verts = hull.points.copy().astype(np.float32)
     faces = hull.simplices.astype(np.int32)
 
     # fix winding order of faces
-    centre = verts.mean(0)
+    centre_f = verts.mean(0)
     for i, tri in enumerate(faces):
         a, b, c = verts[tri]
         normal = np.cross(b - a, c - a)
-        if np.dot(normal, a - centre) < 0:
+        if np.dot(normal, a - centre_f) < 0:
             faces[i] = tri[[0, 2, 1]]
 
     # trim vertices to only those that are used in the faces

--- a/newton/tests/test_remesh_convex_hull.py
+++ b/newton/tests/test_remesh_convex_hull.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :func:`newton._src.geometry.utils.remesh_convex_hull`.
+
+Covers both the full-3D happy path (regression guard) and the degeneracy
+handling added on top of ``scipy.spatial.ConvexHull``:
+
+- empty and single-point input
+- coincident points (rank 0)
+- collinear points (rank 1)
+- coplanar points (rank 2), including ``maxhullvert`` decimation
+- general 3D input (rank 3), including ``maxhullvert`` and winding
+- the ``eps`` relative tolerance controlling near-flat classification
+- a randomized no-raise property over degenerate configurations
+
+The function is not re-exported from any public module, so tests import it
+directly from ``newton._src.geometry.utils`` — consistent with how
+``test_remesh.py`` already reaches into ``newton._src.geometry``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from newton._src.geometry.utils import remesh_convex_hull
+
+
+def _assert_mesh_shape(test: unittest.TestCase, verts: np.ndarray, faces: np.ndarray) -> None:
+    """Assert the basic contract: ``verts`` is (M>=3, 3) float32, ``faces`` is (K>=2, 3) int32."""
+    test.assertEqual(verts.dtype, np.float32, "verts dtype must be float32")
+    test.assertEqual(faces.dtype, np.int32, "faces dtype must be int32")
+    test.assertEqual(verts.ndim, 2)
+    test.assertEqual(faces.ndim, 2)
+    test.assertEqual(verts.shape[1], 3)
+    test.assertEqual(faces.shape[1], 3)
+    test.assertGreaterEqual(verts.shape[0], 3, "verts must have at least 3 rows")
+    test.assertGreaterEqual(faces.shape[0], 2, "faces must have at least 2 rows")
+    test.assertTrue(np.all(faces >= 0))
+    test.assertTrue(np.all(faces < verts.shape[0]))
+
+
+def _has_outward_winding(verts: np.ndarray, faces: np.ndarray) -> bool:
+    """Return True if every triangle's normal points away from the mesh centroid.
+
+    Uses the same criterion the implementation uses to flip windings. Triangles
+    with zero-area normals are ignored (they're degenerate but not wrongly wound).
+    """
+    centre = verts.mean(axis=0)
+    for tri in faces:
+        a, b, c = verts[tri]
+        normal = np.cross(b - a, c - a)
+        if np.linalg.norm(normal) < 1e-12:
+            continue
+        if np.dot(normal, a - centre) < 0:
+            return False
+    return True
+
+
+class TestRemeshConvexHullFull3D(unittest.TestCase):
+    """Regression tests for the untouched full-rank (3D) path."""
+
+    def test_unit_cube(self):
+        # The 8 corners of a unit cube centred at the origin.
+        verts_in = np.array(
+            [
+                [-1, -1, -1],
+                [-1, -1, +1],
+                [-1, +1, -1],
+                [-1, +1, +1],
+                [+1, -1, -1],
+                [+1, -1, +1],
+                [+1, +1, -1],
+                [+1, +1, +1],
+            ],
+            dtype=np.float64,
+        )
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+
+        # A cube's convex hull: 8 unique corner vertices, 12 triangles.
+        self.assertEqual(verts.shape[0], 8)
+        self.assertEqual(faces.shape[0], 12)
+        self.assertTrue(_has_outward_winding(verts, faces), "cube must have outward-facing normals")
+
+        # Every returned vertex must be one of the inputs.
+        for v in verts:
+            match = np.all(np.isclose(verts_in.astype(np.float32), v), axis=1)
+            self.assertTrue(np.any(match), f"output vertex {v} not present in input")
+
+    def test_tetrahedron(self):
+        # Minimal full-rank case (4 non-coplanar points).
+        verts_in = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape[0], 4)
+        self.assertEqual(faces.shape[0], 4)
+        self.assertTrue(_has_outward_winding(verts, faces))
+
+    def test_interior_points_are_trimmed(self):
+        # Cube corners plus an interior point. The interior point must be
+        # stripped by the "trim vertices to only those used in faces" pass.
+        cube = np.array(
+            [
+                [-1, -1, -1],
+                [-1, -1, +1],
+                [-1, +1, -1],
+                [-1, +1, +1],
+                [+1, -1, -1],
+                [+1, -1, +1],
+                [+1, +1, -1],
+                [+1, +1, +1],
+            ],
+            dtype=np.float64,
+        )
+        verts_in = np.vstack([cube, np.array([[0.0, 0.0, 0.0]])])
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape[0], 8, "interior point must be trimmed")
+        # No returned vertex equals the interior point.
+        self.assertFalse(np.any(np.all(np.isclose(verts, 0.0), axis=1)))
+
+    def test_maxhullvert_limits_vertex_count(self):
+        # Many points on the surface of a sphere → hull would have many verts.
+        # maxhullvert should cap the output vertex count.
+        rng = np.random.default_rng(42)
+        pts = rng.standard_normal((200, 3))
+        pts = pts / np.linalg.norm(pts, axis=1, keepdims=True)
+
+        verts_unlimited, _ = remesh_convex_hull(pts, maxhullvert=0)
+        verts_limited, faces_limited = remesh_convex_hull(pts, maxhullvert=16)
+        _assert_mesh_shape(self, verts_limited, faces_limited)
+
+        self.assertGreater(verts_unlimited.shape[0], 16)
+        self.assertLessEqual(verts_limited.shape[0], 16)
+        self.assertTrue(_has_outward_winding(verts_limited, faces_limited))
+
+
+class TestRemeshConvexHullDegenerate(unittest.TestCase):
+    """Degeneracy handling added by the diff."""
+
+    def test_empty_input(self):
+        verts, faces = remesh_convex_hull(np.zeros((0, 3), dtype=np.float64))
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape, (3, 3))
+        self.assertEqual(faces.shape, (2, 3))
+
+    def test_single_point(self):
+        p = np.array([[1.5, -2.25, 0.125]], dtype=np.float64)
+        verts, faces = remesh_convex_hull(p)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape, (3, 3))
+        self.assertEqual(faces.shape, (2, 3))
+        # All three output verts must equal the input point.
+        np.testing.assert_allclose(verts, np.tile(p.astype(np.float32), (3, 1)))
+        # Two triangles with opposite winding (same indices, flipped).
+        self.assertTrue(
+            np.array_equal(faces, np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int32)),
+            "two opposite-winding triangles expected",
+        )
+
+    def test_coincident_points(self):
+        # Many copies of the same point.
+        p = np.array([0.7, -1.3, 4.2], dtype=np.float64)
+        verts_in = np.tile(p, (10, 1))
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape, (3, 3))
+        self.assertEqual(faces.shape, (2, 3))
+        # All output verts match the shared input point.
+        np.testing.assert_allclose(verts, np.tile(p.astype(np.float32), (3, 1)), atol=1e-6)
+
+    def test_collinear_points(self):
+        # Points along the x-axis with varying x, identical y/z.
+        xs = np.array([-2.0, -0.5, 0.0, 0.25, 1.5, 3.0], dtype=np.float64)
+        verts_in = np.stack([xs, np.full_like(xs, 1.0), np.full_like(xs, -2.0)], axis=1)
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape, (3, 3))
+        self.assertEqual(faces.shape, (2, 3))
+
+        # The two extrema should appear among the output verts.
+        xs_out = sorted(verts[:, 0].tolist())
+        self.assertAlmostEqual(xs_out[0], xs.min(), places=5)
+        self.assertAlmostEqual(xs_out[-1], xs.max(), places=5)
+        # y and z are constant along the input line.
+        np.testing.assert_allclose(verts[:, 1], 1.0, atol=1e-5)
+        np.testing.assert_allclose(verts[:, 2], -2.0, atol=1e-5)
+
+    def test_coplanar_square(self):
+        # A unit square on the z=0 plane, with some interior points that
+        # must not appear in the output.
+        boundary = np.array(
+            [
+                [-1.0, -1.0, 0.0],
+                [+1.0, -1.0, 0.0],
+                [+1.0, +1.0, 0.0],
+                [-1.0, +1.0, 0.0],
+            ],
+            dtype=np.float64,
+        )
+        interior = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.3, -0.4, 0.0],
+                [-0.2, 0.1, 0.0],
+            ],
+            dtype=np.float64,
+        )
+        verts_in = np.vstack([boundary, interior])
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+
+        # Flat hull: every output vertex must lie on z=0.
+        np.testing.assert_allclose(verts[:, 2], 0.0, atol=1e-5)
+
+        # Interior points should not appear in the output.
+        for p in interior:
+            match = np.all(np.isclose(verts, p.astype(np.float32), atol=1e-5), axis=1)
+            self.assertFalse(np.any(match), f"interior point {p} leaked into output")
+
+        # Four corner vertices (boundary of the 2D hull).
+        self.assertEqual(verts.shape[0], 4)
+
+        # Fan triangulation emitted twice (CCW + CW): 2 * (M - 2) = 4 triangles.
+        m = verts.shape[0]
+        self.assertEqual(faces.shape[0], 2 * (m - 2))
+
+        # Every CCW triangle (first half) must have a CW twin in the second half.
+        half = faces.shape[0] // 2
+        for i in range(half):
+            ccw = faces[i]
+            cw = faces[i + half]
+            self.assertEqual(ccw[0], cw[0])
+            self.assertEqual(ccw[1], cw[2])
+            self.assertEqual(ccw[2], cw[1])
+
+    def test_coplanar_circle_maxhullvert(self):
+        # 100 points on a unit circle in the xy-plane. Request at most 8 verts.
+        n = 100
+        t = np.linspace(0, 2 * np.pi, num=n, endpoint=False)
+        verts_in = np.stack([np.cos(t), np.sin(t), np.zeros(n)], axis=1)
+
+        verts, faces = remesh_convex_hull(verts_in, maxhullvert=8)
+        _assert_mesh_shape(self, verts, faces)
+        self.assertEqual(verts.shape[0], 8, "maxhullvert must be respected on planar input")
+        np.testing.assert_allclose(verts[:, 2], 0.0, atol=1e-5)
+        self.assertEqual(faces.shape[0], 2 * (8 - 2))
+
+    def test_near_flat_treated_as_coplanar_by_default(self):
+        # A thin slab: large xy spread, z within ±1e-8. With default eps=1e-6
+        # this is classified as coplanar (rank 2) and goes through the flat
+        # branch, so every output vertex must satisfy |z| <= the input bound.
+        rng = np.random.default_rng(0)
+        xy = rng.uniform(-1.0, 1.0, size=(50, 2))
+        z = rng.uniform(-1e-8, 1e-8, size=(50, 1))
+        verts_in = np.hstack([xy, z])
+
+        verts, faces = remesh_convex_hull(verts_in)
+        _assert_mesh_shape(self, verts, faces)
+        # Flat branch → every vertex is on the original sheet, so its z is
+        # bounded by the input z range (not strictly zero, since the flat
+        # branch keeps the original 3D coordinates of the boundary points).
+        self.assertLess(np.abs(verts[:, 2]).max(), 1e-7)
+
+        # Even though it's technically rank-3, the triangle count must match
+        # the flat-branch contract (2 * (M - 2)), not the 3D-hull count.
+        m = verts.shape[0]
+        self.assertEqual(faces.shape[0], 2 * (m - 2))
+
+    def test_tight_eps_allows_near_flat_3d_path(self):
+        # Same slab as above, but with a very tight eps that forces the 3D
+        # branch. We don't assert on exact hull counts (Qhull may flatten or
+        # joggle), only that the call returns a well-formed mesh without
+        # raising.
+        rng = np.random.default_rng(0)
+        xy = rng.uniform(-1.0, 1.0, size=(50, 2))
+        z = rng.uniform(-1e-8, 1e-8, size=(50, 1))
+        verts_in = np.hstack([xy, z])
+
+        verts, faces = remesh_convex_hull(verts_in, eps=1e-12)
+        _assert_mesh_shape(self, verts, faces)
+
+
+class TestRemeshConvexHullNeverRaises(unittest.TestCase):
+    """Property-style guarantee: degenerate input must never raise."""
+
+    def test_randomized_degenerate_inputs_do_not_raise(self):
+        rng = np.random.default_rng(12345)
+        cases: list[np.ndarray] = []
+
+        # A mix of degenerate configurations.
+        for _ in range(5):
+            # Coincident cloud of random size.
+            p = rng.standard_normal(3)
+            k = int(rng.integers(1, 20))
+            cases.append(np.tile(p, (k, 1)))
+
+        for _ in range(5):
+            # Collinear cloud with random direction.
+            direction = rng.standard_normal(3)
+            direction /= np.linalg.norm(direction)
+            origin = rng.standard_normal(3)
+            ts = rng.uniform(-5.0, 5.0, size=int(rng.integers(2, 30)))
+            cases.append(origin + np.outer(ts, direction))
+
+        for _ in range(5):
+            # Coplanar cloud on a random plane.
+            basis = rng.standard_normal((3, 3))
+            q, _ = np.linalg.qr(basis)
+            u, v = q[:, 0], q[:, 1]
+            origin = rng.standard_normal(3)
+            n_pts = int(rng.integers(3, 40))
+            uv = rng.uniform(-2.0, 2.0, size=(n_pts, 2))
+            cases.append(origin + uv[:, 0:1] * u + uv[:, 1:2] * v)
+
+        # Edge cases at the boundary of the classifier.
+        cases.append(np.zeros((0, 3)))
+        cases.append(np.zeros((1, 3)))
+        cases.append(np.zeros((5, 3)))
+
+        for i, pts in enumerate(cases):
+            with self.subTest(case=i, shape=pts.shape):
+                try:
+                    verts, faces = remesh_convex_hull(pts)
+                except Exception as exc:  # noqa: BLE001
+                    self.fail(f"remesh_convex_hull raised on degenerate case {i}: {exc!r}")
+                _assert_mesh_shape(self, verts, faces)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_remesh_convex_hull.py
+++ b/newton/tests/test_remesh_convex_hull.py
@@ -22,6 +22,7 @@ directly from ``newton._src.geometry.utils`` — consistent with how
 from __future__ import annotations
 
 import unittest
+import warnings
 
 import numpy as np
 
@@ -149,11 +150,25 @@ class TestRemeshConvexHullFull3D(unittest.TestCase):
 class TestRemeshConvexHullDegenerate(unittest.TestCase):
     """Degeneracy handling added by the diff."""
 
-    def test_empty_input(self):
-        verts, faces = remesh_convex_hull(np.zeros((0, 3), dtype=np.float64))
-        _assert_mesh_shape(self, verts, faces)
-        self.assertEqual(verts.shape, (3, 3))
-        self.assertEqual(faces.shape, (2, 3))
+    def setUp(self):
+        # The degenerate branches intentionally emit a UserWarning; the tests
+        # in this class assert geometry, not the warning (see
+        # TestRemeshConvexHullDegenerateWarnings for that). Silence them here
+        # so they don't pollute test output.
+        self._warn_ctx = warnings.catch_warnings()
+        self._warn_ctx.__enter__()
+        warnings.simplefilter("ignore", UserWarning)
+
+    def tearDown(self):
+        self._warn_ctx.__exit__(None, None, None)
+
+    def test_empty_input_raises(self):
+        # Empty input must raise rather than fabricate a phantom collider
+        # at the origin; callers (Mesh.compute_convex_hull,
+        # ModelBuilder.approximate_meshes, ...) are responsible for deciding
+        # whether to skip or supply a fallback.
+        with self.assertRaises(ValueError):
+            remesh_convex_hull(np.zeros((0, 3), dtype=np.float64))
 
     def test_single_point(self):
         p = np.array([[1.5, -2.25, 0.125]], dtype=np.float64)
@@ -295,6 +310,14 @@ class TestRemeshConvexHullDegenerate(unittest.TestCase):
 class TestRemeshConvexHullNeverRaises(unittest.TestCase):
     """Property-style guarantee: degenerate input must never raise."""
 
+    def setUp(self):
+        self._warn_ctx = warnings.catch_warnings()
+        self._warn_ctx.__enter__()
+        warnings.simplefilter("ignore", UserWarning)
+
+    def tearDown(self):
+        self._warn_ctx.__exit__(None, None, None)
+
     def test_randomized_degenerate_inputs_do_not_raise(self):
         rng = np.random.default_rng(12345)
         cases: list[np.ndarray] = []
@@ -324,8 +347,9 @@ class TestRemeshConvexHullNeverRaises(unittest.TestCase):
             uv = rng.uniform(-2.0, 2.0, size=(n_pts, 2))
             cases.append(origin + uv[:, 0:1] * u + uv[:, 1:2] * v)
 
-        # Edge cases at the boundary of the classifier.
-        cases.append(np.zeros((0, 3)))
+        # Edge cases at the boundary of the classifier. The empty case is
+        # excluded here because it deliberately raises; see
+        # TestRemeshConvexHullDegenerate.test_empty_input_raises.
         cases.append(np.zeros((1, 3)))
         cases.append(np.zeros((5, 3)))
 
@@ -336,6 +360,46 @@ class TestRemeshConvexHullNeverRaises(unittest.TestCase):
                 except Exception as exc:
                     self.fail(f"remesh_convex_hull raised on degenerate case {i}: {exc!r}")
                 _assert_mesh_shape(self, verts, faces)
+
+
+class TestRemeshConvexHullDegenerateWarnings(unittest.TestCase):
+    """Each rank-0/1/2 branch must emit a UserWarning so that callers don't
+    silently end up with a zero-volume, zero-mass collider."""
+
+    def _assert_degenerate_warning(self, pts: np.ndarray) -> None:
+        with self.assertWarnsRegex(UserWarning, r"remesh_convex_hull: .* zero-volume"):
+            remesh_convex_hull(pts)
+
+    def test_single_point_warns(self):
+        self._assert_degenerate_warning(np.array([[1.0, 2.0, 3.0]], dtype=np.float64))
+
+    def test_coincident_warns(self):
+        p = np.array([0.5, -0.25, 1.0], dtype=np.float64)
+        self._assert_degenerate_warning(np.tile(p, (8, 1)))
+
+    def test_collinear_warns(self):
+        xs = np.linspace(-1.0, 1.0, 10)
+        pts = np.stack([xs, np.zeros_like(xs), np.zeros_like(xs)], axis=1)
+        self._assert_degenerate_warning(pts)
+
+    def test_coplanar_warns(self):
+        t = np.linspace(0, 2 * np.pi, num=12, endpoint=False)
+        pts = np.stack([np.cos(t), np.sin(t), np.zeros_like(t)], axis=1)
+        self._assert_degenerate_warning(pts)
+
+    def test_full_rank_does_not_warn(self):
+        # A generic 3D input must not trip any of the degeneracy warnings.
+        rng = np.random.default_rng(7)
+        pts = rng.standard_normal((50, 3))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UserWarning)
+            remesh_convex_hull(pts)
+        degeneracy_warnings = [w for w in caught if "remesh_convex_hull" in str(w.message)]
+        self.assertEqual(
+            degeneracy_warnings,
+            [],
+            f"full-rank input must not emit a degeneracy warning, got {degeneracy_warnings}",
+        )
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_remesh_convex_hull.py
+++ b/newton/tests/test_remesh_convex_hull.py
@@ -333,7 +333,7 @@ class TestRemeshConvexHullNeverRaises(unittest.TestCase):
             with self.subTest(case=i, shape=pts.shape):
                 try:
                     verts, faces = remesh_convex_hull(pts)
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:
                     self.fail(f"remesh_convex_hull raised on degenerate case {i}: {exc!r}")
                 _assert_mesh_shape(self, verts, faces)
 


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

See https://github.com/newton-physics/newton/issues/2531

Zero volume convex hulls work for collision detection. The question is what inertia and mass they should get in case they are used on dynamic bodies. Maybe the convex hull inertia calculation code should throw an exception for zero volume convexes?

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added an eps parameter for stability, deterministic fallback meshes for degenerate point clouds (coincident, collinear, coplanar), preserved outward-facing winding, and a retry path for robust 3D hull generation.
* **Bug Fixes**
  * Empty input now raises an error; degenerate cases emit warnings and return consistent zero-volume outputs.
* **Tests**
  * Comprehensive suite covering full-rank, degenerate, near-flat, vertex-limited, randomized "never-raises", and warning behavior.
* **Changelog**
  * Entry describing degenerate handling, warning behavior, empty-input error, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->