### PR TITLE
Raise BoosterT1 dynamics tolerance to 1e-4

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2154,7 +2154,7 @@ class TestMenagerie_BoosterT1(TestMenagerieMJCF):
 
     robot_folder = "booster_t1"
     num_steps = 20
-    dynamics_tolerance = 2e-5  # float32 noise varies when running in batch
+    dynamics_tolerance = 1e-4  # GPU atomic-reduction non-determinism: qvel diff up to 4.8e-5 observed on CI (#2526)
     fk_enabled = True
     backfill_model = True
 


### PR DESCRIPTION
## Summary

`TestMenagerie_BoosterT1.test_dynamics` intermittently fails on CI when the `qvel` diff exceeds the current `2e-5` tolerance due to GPU atomic-reduction non-determinism in the mjwarp constraint solver. Reported failure on #2526: max diff `4.824996e-05` at step 1.

Bump the tolerance to `1e-4`, matching the pattern used for the sibling humanoid robots in #2493:
- `UnitreeG1`: `1e-4`
- `UnitreeGo2`: `5e-4`

## Test plan

- [x] `uv run python -m unittest newton.tests.test_menagerie_mujoco.TestMenagerie_BoosterT1` — 3 tests OK on CPU.
- [ ] CI passes on the runner that previously failed (`g7e.2xlarge`, L40S GPU).

Fixes #2526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test tolerances for physics simulation validation to ensure robust testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->