### PR TITLE
Fix wp.tid() / launch-dim mismatches exposed by warp-lang 1.13 templated launch_bounds

### DIFF
--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -45,7 +45,7 @@ def _tiled_sum_kernel(
     data: wp.array2d[float],
     partial_sums: wp.array2d[float],
 ):
-    block_id = wp.tid()
+    block_id, _ = wp.tid()
 
     tile = wp.tile_load(data[0], shape=_TILED_SUM_BLOCK_DIM, offset=block_id * _TILED_SUM_BLOCK_DIM)
     wp.tile_store(partial_sums[0], wp.tile_sum(tile), offset=block_id)

--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -154,7 +154,7 @@ class Example:
             joint_f = self.cartpoles.get_attribute("joint_f", self.control)
             wp.launch(
                 apply_forces_kernel,
-                dim=joint_f.shape,
+                dim=joint_f.shape[0],
                 inputs=[joint_q, joint_f],
             )
 


### PR DESCRIPTION
## Description

Two latent `wp.tid()` / launch-dim mismatches that are silently benign on `warp-lang` 1.12.x but become out-of-bounds reads (or, for `_tiled_sum_kernel`, wildly wrong tile offsets) on 1.13 nightlies because of the templated `launch_bounds_t<N>` work landed in `NVIDIA/warp#1270`. Under the old `shape[4] + ndim` launch bounds, a single-variable `wp.tid()` unravelled to the first-dim index `coord.i`; under the new templated bounds, `kernel_dim` is inferred from the number of values unpacked from `wp.tid()` and the launch dim is normalised to match, so a scalar `tid = wp.tid()` now returns a flat index across all launch dims.

### 1. `apply_forces_kernel` in `example_selection_cartpole.py`

```python
@wp.kernel
def apply_forces_kernel(joint_q: wp.array3d[float], joint_f: wp.array3d[float]):
    tid = wp.tid()
    if joint_q[tid, 0, 0] > 0.0:
        ...

wp.launch(apply_forces_kernel, dim=joint_f.shape, inputs=[joint_q, joint_f])
```

The launch passes a 3-tuple shape `(nworld, 1, ndof)`. Old: `tid ∈ [0, nworld)` — the kernel just ran the same work `ndof` times per world. New: `tid ∈ [0, nworld*ndof)`, driving `joint_q[tid, 0, 0]` out of bounds.

The kernel only needs one thread per world, so the launch is fixed to `dim=joint_f.shape[0]`.

### 2. `_tiled_sum_kernel` in `solve_rheology.py`

```python
@wp.kernel
def _tiled_sum_kernel(data, partial_sums):
    block_id = wp.tid()
    tile = wp.tile_load(data[0], shape=TILE_SIZE, offset=block_id * TILE_SIZE)
    ...

wp.launch(_tiled_sum_kernel, dim=(num_blocks, tile_size), ..., block_dim=tile_size, record_cmd=True)
```

This is a manual 2-D launch equivalent to the old `wp.launch_tiled` desugaring (pre-GH-1270 `launch_tiled` appended `block_dim` onto `dim`). Under the new semantics, `kernel_dim=1` collapses the launch to a flat `(num_blocks*tile_size,)`, and `block_id * TILE_SIZE` walks far past the data buffer.

Fixed by unpacking the second index: `block_id, _ = wp.tid()`. That's launcher-agnostic — works with both the current `wp.launch(dim=(num_blocks, tile_size), block_dim=tile_size)` and a future `wp.launch_tiled(dim=num_blocks, block_dim=tile_size)` (which takes the `kernel_dim == ndim + 1` branch in `_construct_tiled_bounds`).

Not migrating to `wp.launch_tiled` here because the code caches a `wp.Launch` via `record_cmd=True` and calls `Launch.set_dim(...)` each iteration, and `set_dim` currently rebuilds `bounds` from scratch via `launch_bounds_t(...)`, which drops the `tiled=True` flag. That looks like a separate follow-on issue in warp-lang worth fixing upstream.

## Checklist

- [x] New or existing tests cover these changes (`test_selection.example_selection_cartpole_cpu`; `test_implicit_mpm` covers `_tiled_sum_kernel` on CUDA via `ArraySquaredNorm`)
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- On `warp-lang==1.13.0.dev20260415` and `1.13.0.dev20260422`, `test_selection.example_selection_cartpole_cpu` went from a 0–30% pass rate to 10/10 locally:
  ```
  CUDA_VISIBLE_DEVICES= uv run --extra dev -m newton.tests \
      -k test_selection.example_selection_cartpole_cpu
  ```
- Verified with `wp.config.mode="debug"` that the same test no longer trips `array.h:457` (3-D index bounds) after the cartpole fix.
- `_tiled_sum_kernel` is exercised by `SolverImplicitMPM` (CUDA-only path via `ArraySquaredNorm`). `test_implicit_mpm` covers it on CUDA.

## Bug fix

**Steps to reproduce** (without this PR, against any `warp-lang>=1.13.0.dev20260415`):

```
CUDA_VISIBLE_DEVICES= uv run --extra dev -m newton.tests -k test_selection.example_selection_cartpole_cpu
```

Fails intermittently with `AssertionError: -11 != 0` (SIGSEGV) or `-6` (SIGABRT / `double free or corruption`). Under `wp.config.mode="debug"` the assertion is caught explicitly in `warp/native/array.h:457` as an out-of-bounds read into the `joint_q` array.

**Related**

Also unblocks https://github.com/newton-physics/newton/pull/2528 (warp-lang nightly bump), where the same test fails on every OS.

Reference: https://github.com/NVIDIA/warp/issues/1385 (discussion of the surfaced bugs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kernel execution sizing in the CartPole example to ensure correct force application across batches, improving simulation accuracy.
  * Resolved thread-indexing behavior in the implicit MPM rheology solver for stable and correct tile-based reductions, improving solver reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->