### PR TITLE
Fix check-warp-array-syntax hook on Windows Git Bash

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,6 @@ repos:
       - id: check-warp-array-syntax
         name: check warp array syntax
         entry: python scripts/check_warp_array_syntax.py
-        language: system
+        language: python
         types: [python]
         exclude: ^(scripts/check_warp_array_syntax\.py|newton/_src/solvers/kamino/)


### PR DESCRIPTION
## Description

The `check-warp-array-syntax` local hook used `language: system`, which
requires a `python` executable on PATH. On Windows Git Bash, `python`
is typically not resolvable (Windows ships the `py` launcher and the
Python installer exposes `python.exe` in ways MSYS PATH handling doesn't
always pick up), so pre-commit failed for Windows contributors with:

```
check warp array syntax..................................................Failed
- hook id: check-warp-array-syntax
- exit code: 1
Executable `python` not found
```

Switch the hook to `language: python` so pre-commit provisions its own
managed virtualenv and resolves `python` inside it, matching how the
other hooks (ruff, uv-lock) avoid depending on the user's environment.
`scripts/check_warp_array_syntax.py` uses only stdlib, so no
`additional_dependencies` are needed.

Closes #2542

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

_(Contributor-tooling fix, not user-facing simulation behavior — no CHANGELOG entry.)_

## Test plan

- `uvx pre-commit run check-warp-array-syntax --all-files` on Linux — passes with the new config (pre-commit provisions the venv automatically).
- Windows Git Bash verification requested from the issue reporter.

## Bug fix

**Steps to reproduce (without this PR):**

1. On Windows, install Git for Windows and use Git Bash.
2. Clone the repo and install pre-commit.
3. Run `pre-commit run --all-files` (or attempt a commit).
4. The `check warp array syntax` hook fails with `Executable python not found`,
   which also rolls back auto-fixes from earlier hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to improve build consistency.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->