### PR TITLE
Make ShapeConfig strict with slots=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
 
+### Deprecated
+
+- Writing undeclared attributes on `ModelBuilder.ShapeConfig` now emits a `DeprecationWarning` and is scheduled to raise `AttributeError` in a future release. Migrate stale writes (e.g. `cfg.contact_margin = ...` left over from the rename to `gap`) to current field names; see the `ShapeConfig` declared fields for the canonical list.
+
 ### Fixed
 
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Deprecated
 
-- Writing undeclared attributes on `ModelBuilder.ShapeConfig` now emits a `DeprecationWarning` and is scheduled to raise `AttributeError` in a future release. Migrate stale writes (e.g. `cfg.contact_margin = ...` left over from the rename to `gap`) to current field names; see the `ShapeConfig` declared fields for the canonical list.
+- Deprecate writing undeclared attributes on `ModelBuilder.ShapeConfig`; attempting to set attributes not in the declared fields emits a `DeprecationWarning` and will raise `AttributeError` in a future release. Migrate stale writes (e.g. `cfg.contact_margin = ...` left over from the rename to `gap`) to current field names; see the `ShapeConfig` declared fields for the canonical list.
 
 ### Fixed
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -210,7 +210,7 @@ class ModelBuilder:
         output_indices: list[list[int]]  # Per-actuator output indices
         args: list[dict[str, Any]]  # Per-actuator array params (scalar params in dict key)
 
-    @dataclass
+    @dataclass(slots=True)
     class ShapeConfig:
         """
         Represents the properties of a collision shape used in simulation.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -210,7 +210,7 @@ class ModelBuilder:
         output_indices: list[list[int]]  # Per-actuator output indices
         args: list[dict[str, Any]]  # Per-actuator array params (scalar params in dict key)
 
-    @dataclass(slots=True)
+    @dataclass
     class ShapeConfig:
         """
         Represents the properties of a collision shape used in simulation.
@@ -418,6 +418,26 @@ class ModelBuilder:
                 self.collision_group = defaults.collision_group
                 self.has_shape_collision = bool(value & ShapeFlags.COLLIDE_SHAPES)
                 self.has_particle_collision = bool(value & ShapeFlags.COLLIDE_PARTICLES)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            # Guard against silent dead writes after a field rename (see PR #2553):
+            # warn on any name that is not a declared dataclass field, a property,
+            # or a private/dunder attribute. Scheduled to become a hard AttributeError
+            # in a future release.
+            if (
+                not name.startswith("_")
+                and name not in type(self).__dataclass_fields__
+                and not isinstance(getattr(type(self), name, None), property)
+            ):
+                valid = sorted(type(self).__dataclass_fields__)
+                warnings.warn(
+                    f"Setting undeclared attribute {name!r} on ShapeConfig is deprecated "
+                    f"and will raise AttributeError in a future release. "
+                    f"Declared fields: {valid}.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            object.__setattr__(self, name, value)
 
         def copy(self) -> ModelBuilder.ShapeConfig:
             return copy.copy(self)


### PR DESCRIPTION
## Description

`ModelBuilder.ShapeConfig` is a plain `@dataclass`. Python silently accepts writes to undeclared attribute names on such classes, so a downstream `cfg.old_name = value` becomes a dead no-op when `old_name` is renamed upstream.

Seen in practice in [isaac-sim/IsaacLab#5289](https://github.com/isaac-sim/IsaacLab/pull/5289): PR #1732 renamed `ShapeConfig.contact_margin` → `gap`, and Isaac Lab's stale write `builder.default_shape_cfg.contact_margin = 0.01` continued to run for weeks after the pin bump, created a dead attribute, and the intended 1 cm shape gap was never applied.

## Change

Soft-deprecate undeclared writes on `ShapeConfig` (replacing the original `slots=True` hard fail per maintainer feedback).

`ShapeConfig` keeps its `__dict__` storage, but overrides `__setattr__` to emit a `DeprecationWarning` when a write targets a name that is not:

- a declared dataclass field, or
- a property (e.g. the `flags` setter), or
- a private / dunder attribute.

The write still goes through, so any out-of-tree caller that legitimately stashes extra metadata on `ShapeConfig` keeps working unchanged — they just get a loud warning at the write site. Stale writes after a rename (e.g. the IsaacLab `cfg.contact_margin = 0.01` case) become attributable instead of silent.

Scheduled to flip to a hard `AttributeError` in a future release; the CHANGELOG entry under `Deprecated` tracks the migration window.

Scope is intentionally narrow to `ShapeConfig`. Happy to apply the same to `ActuatorEntry`, `CustomAttribute`, `CustomFrequency` in a follow-up.

## Compatibility

Sanity-checked locally:

- Valid writes (`cfg.gap`, `cfg.margin`, `cfg.density`, …) are silent — no warning.
- `cfg.flags = ...` (property setter) is silent — no warning.
- `cfg.contact_margin = 0.01` (the IsaacLab#5289 case) raises a `DeprecationWarning` naming the bad attr and listing the declared fields; the write still lands so today's behavior is byte-identical (just noisy).
- `dataclasses.replace`, `copy.copy`, the existing `ShapeConfig.copy()` method, and `pickle` round-trips all continue to work.

No behavior change for existing valid callers; no API surface added or removed.

## Newton Migration Guide

- [ ] The migration guide in `docs/migration.rst` is up-to-date

(CHANGELOG entry added under `[Unreleased]` → `Deprecated`. Happy to mirror the note into `docs/migration.rst` if maintainers prefer.)

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (no new tests required; existing `ShapeConfig`-touching tests in `newton/tests/test_mesh_backface.py` continue to pass and the deprecation path is exercised by the in-PR sanity checks)
- [x] Documentation is up-to-date (CHANGELOG `Deprecated` entry added)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Writing undeclared attributes on shape/config objects now emits a DeprecationWarning; such writes will become disallowed in a future release.

* **Documentation**
  * CHANGELOG updated under "Deprecated" with a deprecation notice and guidance to migrate stale attribute writes to the canonical declared field names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->