### PR TITLE
Backfill actuator_biasprm to eliminate G1 precision diff

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -349,6 +349,10 @@ DEFAULT_MODEL_SKIP_FIELDS: set[str] = {
     # Computed from mass matrix and actuator moment at qpos0; differs due to inertia
     # re-diagonalization. Backfilled instead.
     "actuator_acc0",
+    # Position actuators with `dampratio` encode -kd = -2*dampratio*sqrt(kp*M_eff) in
+    # biasprm[2]; M_eff is joint-space inertia which differs when inertia representation
+    # differs. Backfilled instead.
+    "actuator_biasprm",
     "actuator_lengthrange",  # Derived from joint ranges, computed by set_length_range
     "stat",  # meaninertia derived from invweight0
     # Meshes: Newton / trimesh may create a different number of meshes (nmesh differs),
@@ -1105,6 +1109,8 @@ def _expand_batched_fields(target_obj: Any, reference_obj: Any, field_names: lis
 # - body_mass, body_subtreemass: Newton computes EXACT mesh volume, native uses LEGACY
 # - body_invweight0, dof_invweight0, actuator_acc0: derived from inertia/mass
 # - body_pos, body_quat: Newton recomputes from joint transforms (~3e-8 float diff)
+# - actuator_biasprm: derived from joint-space inertia for position actuators with
+#   `dampratio` (kd = 2*dampratio*sqrt(kp*M_eff)); tiny diffs propagate from inertia.
 MODEL_BACKFILL_FIELDS: list[str] = [
     "body_inertia",
     "body_ipos",
@@ -1116,6 +1122,7 @@ MODEL_BACKFILL_FIELDS: list[str] = [
     "body_quat",
     "body_subtreemass",
     "actuator_acc0",
+    "actuator_biasprm",
 ]
 
 
@@ -2214,8 +2221,6 @@ class TestMenagerie_UnitreeG1(TestMenagerieMJCF):
     num_steps = 20
     dynamics_tolerance = 1e-4  # GPU non-determinism: qvel diff up to 1.2e-5 across runs
     fk_enabled = True
-    # TODO(#2495): actuator_biasprm has tiny fp diffs (1.7e-5), likely precision issue
-    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"actuator_biasprm"}
 
 
 class TestMenagerie_UnitreeH1(TestMenagerieMJCF):

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2221,6 +2221,7 @@ class TestMenagerie_UnitreeG1(TestMenagerieMJCF):
     num_steps = 20
     dynamics_tolerance = 1e-4  # GPU non-determinism: qvel diff up to 1.2e-5 across runs
     fk_enabled = True
+    backfill_model = True
 
 
 class TestMenagerie_UnitreeH1(TestMenagerieMJCF):


### PR DESCRIPTION
## Summary

`TestMenagerie_UnitreeG1.test_model_comparison` previously skipped `actuator_biasprm` because Newton and native differ by `~2e-5` on G1's `<position kp="500" dampratio="1"/>` actuators.

Root cause is the same class as other inertia-derived backfills: MuJoCo's `mj_setConst` encodes `-kd = -2·dampratio·sqrt(kp·M_eff)` in `biasprm[2]`, where `M_eff` is a joint-space inertia diagonal entry. Newton and native compute slightly different `M_eff` because of inertia re-diagonalization — the same reason `body_invweight0`, `dof_invweight0`, and `actuator_acc0` are already backfilled. The `~1e-6` `M_eff` diff propagates through the square root into a `~2e-5` `actuator_biasprm` diff. MuJoCo itself does the math correctly on both sides; only the inertia input differs.

Fix: add `actuator_biasprm` to both `DEFAULT_MODEL_SKIP_FIELDS` (strict compare skips it) and `MODEL_BACKFILL_FIELDS` (copied from native before dynamics stepping). Remove G1's `model_skip_fields` override.

## Test plan

- [x] G1 `actuator_biasprm` diff drops from `2.29e-5` → exactly `0.0` after backfill
- [x] `uv run python -m unittest discover -s newton/tests -p "test_menagerie_mujoco.py"` — 48/48 pass, 50 skipped

Fixes #2495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UnitreeG1 now imports actuator bias parameters from MuJoCo so actuator settings are fully preserved during model initialization; validation now allows backfilled actuator values.

* **Documentation**
  * Clarified actuator parameter behavior for position actuators, noting expected differences driven by joint-space inertia representation and damping ratio.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->