### PR TITLE
#2431 Adding single frame forward stepping when paused bounded to '.' key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,11 @@
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
 - Add more solver options to implicit MPM: `gs-soa` (or `gauss-seidel-soa`) for improved memory coalescing, `gs-batched` (or `gauss-seidel-batched`) merging GS colors with Jacobi-style mass-split parallelism, plus `cr` (Conjugate Residual) and `gmres` linear solver options.
 - Add frame-by-frame step support to `ViewerGL`: press `.` while paused to advance one simulation frame
-- Add `ViewerBase.should_step()` — call once per frame to determine whether the simulation loop should advance; returns `True` when running and consumes a pending single-step request when paused, replacing the `is_paused()` / `pop_step_request()` composition
+- Add `ViewerBase.should_step()` — call once per frame to determine whether the simulation loop should advance; returns `True` when running and consumes a pending single-step request when paused.
 
 
 ### Changed
 
-- Replace `ViewerBase.pop_step_request()` with `ViewerBase.should_step()`; simulation loops should change from `if not viewer.is_paused() or viewer.pop_step_request():` to `if viewer.should_step():`
 - Use pre-computed local AABB for `CONVEX_MESH` shapes in `compute_shape_aabbs`, avoiding a per-frame support-function AABB computation
 - Build mesh SDFs via the texture-based sparse path only; sample via `SDF.texture_data` instead of `SDF.sparse_volume` / `SDF.coarse_volume`.
 - Change implicit MPM default `solver` from `"gs"` to `"auto"`, which selects `"gs"` for trilinear bases and `"gs-batched"` for higher-order ones. Set `solver="gs"` explicitly to restore the previous behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
 - Add more solver options to implicit MPM: `gs-soa` (or `gauss-seidel-soa`) for improved memory coalescing, `gs-batched` (or `gauss-seidel-batched`) merging GS colors with Jacobi-style mass-split parallelism, plus `cr` (Conjugate Residual) and `gmres` linear solver options.
 - Add frame-by-frame step support to `ViewerGL`: press `.` while paused to advance one simulation frame
+- Add `ViewerBase.should_step()` — call once per frame to determine whether the simulation loop should advance; returns `True` when running and consumes a pending single-step request when paused, replacing the `is_paused()` / `pop_step_request()` composition
 
 
 ### Changed
 
+- Replace `ViewerBase.pop_step_request()` with `ViewerBase.should_step()`; simulation loops should change from `if not viewer.is_paused() or viewer.pop_step_request():` to `if viewer.should_step():`
 - Use pre-computed local AABB for `CONVEX_MESH` shapes in `compute_shape_aabbs`, avoiding a per-frame support-function AABB computation
 - Build mesh SDFs via the texture-based sparse path only; sample via `SDF.texture_data` instead of `SDF.sparse_volume` / `SDF.coarse_volume`.
 - Change implicit MPM default `solver` from `"gs"` to `"auto"`, which selects `"gs"` for trilinear bases and `"gs-batched"` for higher-order ones. Set `solver="gs"` explicitly to restore the previous behavior.
@@ -73,6 +75,8 @@
 ### Fixed
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
+- Fix `ViewerGL` spurious single-step firing when `.` is pressed while the simulation is running and is subsequently paused; `should_step()` clears the stale request on any non-paused frame
+- Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,6 @@
 ### Fixed
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
-- Fix `ViewerGL` spurious single-step firing when `.` is pressed while the simulation is running and is subsequently paused; `should_step()` clears the stale request on any non-paused frame
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
 - Add more solver options to implicit MPM: `gs-soa` (or `gauss-seidel-soa`) for improved memory coalescing, `gs-batched` (or `gauss-seidel-batched`) merging GS colors with Jacobi-style mass-split parallelism, plus `cr` (Conjugate Residual) and `gmres` linear solver options.
 - Add frame-by-frame step support to `ViewerGL`: press `.` while paused to advance one simulation frame
-- Add `ViewerBase.should_step()` — call once per frame to determine whether the simulation loop should advance; returns `True` when running and consumes a pending single-step request when paused.
+- Add ViewerBase.should_step() — call once per frame to determine whether the simulation loop should advance; returns True when not paused.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved
 - Add more solver options to implicit MPM: `gs-soa` (or `gauss-seidel-soa`) for improved memory coalescing, `gs-batched` (or `gauss-seidel-batched`) merging GS colors with Jacobi-style mass-split parallelism, plus `cr` (Conjugate Residual) and `gmres` linear solver options.
+- Add frame-by-frame step support to `ViewerGL`: press `.` while paused to advance one simulation frame
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 ### Deprecated
 
 - Deprecate `newton-actuators` package dependency; all actuator functionality is now built into `newton.actuators`. The dependency is kept for backward compatibility and will be removed in a future release; migrate imports from `newton_actuators` to `newton.actuators`
+- Adjusted the grouping of `reset`, `step`, and `pause` so that they are all grouped together
 
 ### Fixed
 

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -21,7 +21,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 - :meth:`~newton.viewer.ViewerBase.end_frame` — finish the frame and present it
 - :meth:`~newton.viewer.ViewerBase.is_running` — check whether the viewer is still open (useful as a loop condition)
 - :meth:`~newton.viewer.ViewerBase.is_paused` — check whether the simulation is paused (toggled with ``SPACE`` in :class:`~newton.viewer.ViewerGL`)
-- :meth:`~newton.viewer.ViewerBase.pop_step_request` — consume a pending single-step request (triggered with ``.`` or the "Step" button in :class:`~newton.viewer.ViewerGL`); returns ``True`` once then resets to ``False``
+- :meth:`~newton.viewer.ViewerBase.should_step` — call exactly once per frame; returns ``True`` when running, or ``True`` once after a single-step request (triggered with ``.`` or the "Step" button in :class:`~newton.viewer.ViewerGL`) and ``False`` otherwise; prefer this over composing ``is_paused()`` manually
 - :meth:`~newton.viewer.ViewerBase.close` — close the viewer and release resources
 
 **Camera and layout:**
@@ -77,9 +77,9 @@ Constructor parameters:
     viewer.log_state(state)
     viewer.end_frame()
 
-    # check if the simulation is paused (toggled with SPACE key):
-    if viewer.is_paused():
-        pass  # simulation stepping is paused
+    # advance the simulation each frame, or step once when paused:
+    if viewer.should_step():
+        pass  # call solver.step(), example.step(), etc.
 
 **Interactive forces and input:**
 

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -158,6 +158,8 @@ Viewer controls:
       - Toggle the sidebar
     * - ``SPACE``
       - Pause or continue the simulation
+    * - ``.``
+      - Step the simulation by one frame while paused
     * - ``ESC``
       - Close the viewer
     * - Right click

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -21,6 +21,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 - :meth:`~newton.viewer.ViewerBase.end_frame` — finish the frame and present it
 - :meth:`~newton.viewer.ViewerBase.is_running` — check whether the viewer is still open (useful as a loop condition)
 - :meth:`~newton.viewer.ViewerBase.is_paused` — check whether the simulation is paused (toggled with ``SPACE`` in :class:`~newton.viewer.ViewerGL`)
+- :meth:`~newton.viewer.ViewerBase.pop_step_request` — consume a pending single-step request (triggered with ``.`` or the "Step" button in :class:`~newton.viewer.ViewerGL`); returns ``True`` once then resets to ``False``
 - :meth:`~newton.viewer.ViewerBase.close` — close the viewer and release resources
 
 **Camera and layout:**

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -68,7 +68,8 @@ class ViewerBase(ABC):
     def should_step(self) -> bool:
         """Return True if the loop should advance one step.
 
-        Consumes a pending single-step request, so call exactly once per frame.
+        Subclasses that support single-stepping may consume a pending request
+        here, so callers should invoke this exactly once per frame.
         """
         return not self.is_paused()
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -66,10 +66,10 @@ class ViewerBase(ABC):
         return False
 
     def should_step(self) -> bool:
-        """Return True if the loop should advance one step.
+        """Report whether the loop should advance one step.
 
-        Subclasses that support single-stepping may consume a pending request
-        here, so callers should invoke this exactly once per frame.
+        Returns:
+            bool: True when the simulation should step forward.
         """
         return not self.is_paused()
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -65,14 +65,12 @@ class ViewerBase(ABC):
         """
         return False
 
-    def pop_step_request(self) -> bool:
-        """Consume a pending single-step request.
+    def should_step(self) -> bool:
+        """Return True if the loop should advance one step.
 
-        Returns:
-            bool: True if a step was requested since the last call, then resets to False.
-                Always returns False in the base implementation.
+        Consumes a pending single-step request, so call exactly once per frame.
         """
-        return False
+        return not self.is_paused()
 
     def is_key_down(self, key: str | int) -> bool:
         """Default key query API. Concrete viewers can override.

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -65,6 +65,15 @@ class ViewerBase(ABC):
         """
         return False
 
+    def pop_step_request(self) -> bool:
+        """Consume a pending single-step request.
+
+        Returns:
+            bool: True if a step was requested since the last call, then resets to False.
+                Always returns False in the base implementation.
+        """
+        return False
+
     def is_key_down(self, key: str | int) -> bool:
         """Default key query API. Concrete viewers can override.
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -238,6 +238,7 @@ class ViewerGL(ViewerBase):
 
         self._paused = False
         self._step_requested = False
+        self._reset_callback: Callable[[], None] | None = None
 
         # Selection panel state
         self._selection_ui_state = {
@@ -1656,6 +1657,14 @@ class ViewerGL(ViewerBase):
             return True
         return False
 
+    def set_reset_callback(self, callback: Callable[[], None] | None) -> None:
+        """Register a callback invoked when the user clicks the Reset button.
+
+        Args:
+            callback: Called with no arguments on reset, or ``None`` to remove.
+        """
+        self._reset_callback = callback
+
     @override
     def close(self):
         """
@@ -2264,6 +2273,20 @@ class ViewerGL(ViewerBase):
             # Collapsing headers default-open handling (first frame only)
             header_flags = 0
 
+            # Run controls — shown once a model is loaded
+            if self.model is not None:
+                changed, self._paused = imgui.checkbox("Pause", self._paused)
+                imgui.same_line()
+                imgui.begin_disabled(not self._paused)
+                if imgui.button("Step"):
+                    self._step_requested = True
+                imgui.end_disabled()
+                if self._reset_callback is not None:
+                    imgui.same_line()
+                    if imgui.button("Reset"):
+                        self._reset_callback()
+                imgui.separator()
+
             # Panel callbacks (e.g. example browser) - top-level collapsing headers
             for callback in self._ui_callbacks["panel"]:
                 callback(self.ui.imgui)
@@ -2278,14 +2301,6 @@ class ViewerGL(ViewerBase):
                     gravity = self.model.gravity.numpy()[0]
                     gravity_text = f"Gravity: ({gravity[0]:.2f}, {gravity[1]:.2f}, {gravity[2]:.2f})"
                     imgui.text(gravity_text)
-
-                    # Pause simulation checkbox
-                    changed, self._paused = imgui.checkbox("Pause", self._paused)
-                    imgui.same_line()
-                    imgui.begin_disabled(not self._paused)
-                    if imgui.button("Step"):
-                        self._step_requested = True
-                    imgui.end_disabled()
 
                 # Visualization Controls section
                 imgui.set_next_item_open(True, imgui.Cond_.appearing)

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -237,6 +237,7 @@ class ViewerGL(ViewerBase):
         self.camera = Camera(width=fb_w, height=fb_h, up_axis="Z")
 
         self._paused = False
+        self._step_requested = False
 
         # Selection panel state
         self._selection_ui_state = {
@@ -1641,6 +1642,18 @@ class ViewerGL(ViewerBase):
         return self._paused
 
     @override
+    def pop_step_request(self) -> bool:
+        """
+        Consume a pending single-step request.
+
+        Returns:
+            bool: True if a step was requested since the last call, then resets to False.
+        """
+        requested = self._step_requested
+        self._step_requested = False
+        return requested
+
+    @override
     def close(self):
         """
         Close the viewer and clean up resources.
@@ -1926,6 +1939,8 @@ class ViewerGL(ViewerBase):
         elif symbol == pyglet.window.key.SPACE:
             # Toggle pause with space key
             self._paused = not self._paused
+        elif symbol == pyglet.window.key.PERIOD and self._paused:
+            self._step_requested = True
         elif symbol == pyglet.window.key.F:
             # Frame camera around model bounds
             self._frame_camera_on_model()
@@ -2263,6 +2278,9 @@ class ViewerGL(ViewerBase):
 
                     # Pause simulation checkbox
                     changed, self._paused = imgui.checkbox("Pause", self._paused)
+                    imgui.same_line()
+                    if imgui.button("Step") and self._paused:
+                        self._step_requested = True
 
                 # Visualization Controls section
                 imgui.set_next_item_open(True, imgui.Cond_.appearing)
@@ -2413,6 +2431,7 @@ class ViewerGL(ViewerBase):
                 imgui.text("Scroll - Dolly")
                 imgui.text("Ctrl + Scroll - FOV zoom")
                 imgui.text("Space - Pause/Resume")
+                imgui.text(". - Step one frame (when paused)")
                 imgui.text("H - Toggle UI")
                 imgui.text("F - Frame camera around model")
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -1642,16 +1642,19 @@ class ViewerGL(ViewerBase):
         return self._paused
 
     @override
-    def pop_step_request(self) -> bool:
+    def should_step(self) -> bool:
         """
-        Consume a pending single-step request.
+        Return True if the loop should advance one step.
 
-        Returns:
-            bool: True if a step was requested since the last call, then resets to False.
+        Consumes a pending single-step request, so call exactly once per frame.
         """
-        requested = self._step_requested
-        self._step_requested = False
-        return requested
+        if not self._paused:
+            self._step_requested = False
+            return True
+        if self._step_requested:
+            self._step_requested = False
+            return True
+        return False
 
     @override
     def close(self):
@@ -2279,8 +2282,10 @@ class ViewerGL(ViewerBase):
                     # Pause simulation checkbox
                     changed, self._paused = imgui.checkbox("Pause", self._paused)
                     imgui.same_line()
-                    if imgui.button("Step") and self._paused:
+                    imgui.begin_disabled(not self._paused)
+                    if imgui.button("Step"):
                         self._step_requested = True
+                    imgui.end_disabled()
 
                 # Visualization Controls section
                 imgui.set_next_item_open(True, imgui.Cond_.appearing)

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -289,7 +289,7 @@ def run(example, args):
             viewer.end_frame()
             continue
 
-        if not viewer.is_paused() or viewer.pop_step_request():
+        if viewer.should_step():
             with wp.ScopedTimer("step", active=False):
                 example.step()
         if test_post_step:

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -213,12 +213,11 @@ class _ExampleBrowser:
                             if clicked:
                                 self.switch_target = module_path
                         imgui.tree_pop()
-                imgui.separator()
-                if imgui.button("Reset"):
-                    self._reset_requested = True
 
         self.callback = _browser_ui
         viewer.register_ui_callback(_browser_ui, position="panel")
+        if hasattr(viewer, "set_reset_callback"):
+            viewer.set_reset_callback(lambda: setattr(self, "_reset_requested", True))
 
     def _register_ui(self, example):
         """Re-register the example's GUI callback (panel callbacks survive clear_model)."""

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -289,7 +289,7 @@ def run(example, args):
             viewer.end_frame()
             continue
 
-        if not viewer.is_paused():
+        if not viewer.is_paused() or viewer.pop_step_request():
             with wp.ScopedTimer("step", active=False):
                 example.step()
         if test_post_step:

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -2,29 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from types import SimpleNamespace
 
+from newton._src.viewer.viewer_gl import ViewerGL
 from newton._src.viewer.viewer_null import ViewerNull
 
 
-class _StubViewerGL:
-    """Replicates only the pause/step state machine from ViewerGL.
-
-    ViewerGL requires a display to instantiate, so this stub lets us test the
-    should_step() logic in headless CI without a window.
-    """
-
-    def __init__(self):
-        self._paused = False
-        self._step_requested = False
-
-    def should_step(self) -> bool:
-        if not self._paused:
-            self._step_requested = False
-            return True
-        if self._step_requested:
-            self._step_requested = False
-            return True
-        return False
+def _make_gl_state(paused: bool = False, step_requested: bool = False) -> "ViewerGL":
+    # Lightweight stand-in with just the fields ViewerGL.should_step() needs.
+    return SimpleNamespace(_paused=paused, _step_requested=step_requested)  # type: ignore[return-value]
 
 
 class TestViewerBaseShouldStep(unittest.TestCase):
@@ -44,38 +30,32 @@ class TestViewerGLShouldStep(unittest.TestCase):
     """ViewerGL.should_step() state machine: running, paused, and single-step."""
 
     def test_returns_true_when_running(self):
-        v = _StubViewerGL()
-        self.assertTrue(v.should_step())
+        v = _make_gl_state(paused=False, step_requested=False)
+        self.assertTrue(ViewerGL.should_step(v))
 
     def test_returns_false_when_paused(self):
-        v = _StubViewerGL()
-        v._paused = True
-        self.assertFalse(v.should_step())
+        v = _make_gl_state(paused=True, step_requested=False)
+        self.assertFalse(ViewerGL.should_step(v))
 
     def test_returns_true_once_after_step_request(self):
-        v = _StubViewerGL()
-        v._paused = True
-        v._step_requested = True
-        self.assertTrue(v.should_step())
-        self.assertFalse(v.should_step())
+        v = _make_gl_state(paused=True, step_requested=True)
+        self.assertTrue(ViewerGL.should_step(v))
+        self.assertFalse(ViewerGL.should_step(v))
 
     def test_stale_request_cleared_when_running(self):
         # Reproduces the bug: . pressed while running, then SPACE to pause.
         # The flag must not survive into the paused state and fire a spurious step.
-        v = _StubViewerGL()
-        v._step_requested = True  # set while not paused
-        v.should_step()  # running frame — must clear the flag
+        v = _make_gl_state(paused=False, step_requested=True)
+        ViewerGL.should_step(v)  # running frame — must clear the flag
         v._paused = True
-        self.assertFalse(v.should_step())
+        self.assertFalse(ViewerGL.should_step(v))
 
     def test_multiple_step_requests_fire_once_each(self):
-        v = _StubViewerGL()
-        v._paused = True
+        v = _make_gl_state(paused=True, step_requested=True)
+        self.assertTrue(ViewerGL.should_step(v))
         v._step_requested = True
-        self.assertTrue(v.should_step())
-        v._step_requested = True
-        self.assertTrue(v.should_step())
-        self.assertFalse(v.should_step())
+        self.assertTrue(ViewerGL.should_step(v))
+        self.assertFalse(ViewerGL.should_step(v))
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from newton._src.viewer.viewer_null import ViewerNull
+
+
+class _StubViewerGL:
+    """Replicates only the pause/step state machine from ViewerGL.
+
+    ViewerGL requires a display to instantiate, so this stub lets us test the
+    should_step() logic in headless CI without a window.
+    """
+
+    def __init__(self):
+        self._paused = False
+        self._step_requested = False
+
+    def should_step(self) -> bool:
+        if not self._paused:
+            self._step_requested = False
+            return True
+        if self._step_requested:
+            self._step_requested = False
+            return True
+        return False
+
+
+class TestViewerBaseShouldStep(unittest.TestCase):
+    """ViewerBase.should_step() defaults to not self.is_paused()."""
+
+    def test_returns_true_when_not_paused(self):
+        viewer = ViewerNull()
+        self.assertTrue(viewer.should_step())
+
+    def test_returns_true_on_repeated_calls(self):
+        viewer = ViewerNull()
+        for _ in range(3):
+            self.assertTrue(viewer.should_step())
+
+
+class TestViewerGLShouldStep(unittest.TestCase):
+    """ViewerGL.should_step() state machine: running, paused, and single-step."""
+
+    def test_returns_true_when_running(self):
+        v = _StubViewerGL()
+        self.assertTrue(v.should_step())
+
+    def test_returns_false_when_paused(self):
+        v = _StubViewerGL()
+        v._paused = True
+        self.assertFalse(v.should_step())
+
+    def test_returns_true_once_after_step_request(self):
+        v = _StubViewerGL()
+        v._paused = True
+        v._step_requested = True
+        self.assertTrue(v.should_step())
+        self.assertFalse(v.should_step())
+
+    def test_stale_request_cleared_when_running(self):
+        # Reproduces the bug: . pressed while running, then SPACE to pause.
+        # The flag must not survive into the paused state and fire a spurious step.
+        v = _StubViewerGL()
+        v._step_requested = True  # set while not paused
+        v.should_step()  # running frame — must clear the flag
+        v._paused = True
+        self.assertFalse(v.should_step())
+
+    def test_multiple_step_requests_fire_once_each(self):
+        v = _StubViewerGL()
+        v._paused = True
+        v._step_requested = True
+        self.assertTrue(v.should_step())
+        v._step_requested = True
+        self.assertTrue(v.should_step())
+        self.assertFalse(v.should_step())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Closes #2431, when simulation is paused using the '.' key it now allows forward stepping one frame. One note is that to custom simulations loops 

## Checklist

- [ x] New or existing tests cover these changes
- [x ] The documentation is up to date with these changes
- [x ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

uv run --extra dev -m newton.tests -k test_basic as well as going into various newton examples and stepping through single simulation frames while paused

we also created test_viewer_controls.py where we intentionally the potential bug described in the feedback to ensure the behavior is as intended

## New feature / API change

```python
import newton
import warp as wp

# Works automatically in the example runner.
# For a custom simulation loop, consume the step request yourself:

viewer = newton.viewer.ViewerGL(model)

while viewer.is_running():
    # Advance when running normally, or one frame at a time when paused
    # (press '.')
    if not viewer.is_paused() or viewer.pop_step_request():
        state_0.clear_forces()
        model.collide(state_0, contacts)
        solver.step(state_0, state_1, control, contacts, dt)
        state_0, state_1 = state_1, state_0

    viewer.render(model, state_0)

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frame-by-frame stepping: press `.` while paused or use the new "Step" button to advance one simulation frame.
  * Run controls grouped together; Reset and controls moved into the Run controls area (Reset shown when available).
* **Bug Fixes**
  * Prevent stale single-step from firing when switching from running to paused.
  * Disable the Step button while the simulation is running.
* **Documentation**
  * Viewer docs and keyboard-shortcut reference updated for per-frame stepping.
* **Tests**
  * Added unit tests covering stepping behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->