### PR TITLE
Default `newton.examples` CLI to basic_pendulum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
 - Disable process reuse in the test runner on multi-GPU systems to prevent CUDA errors from cascading across test suites, keeping process reuse enabled on single-GPU systems for faster throughput
+- Default `python -m newton.examples` with no argument to launch `basic_pendulum`; use `--list` to print available examples
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For detailed system requirements and tested configurations, see the [installatio
 
 ```bash
 pip install "newton[examples]"
-python -m newton.examples basic_pendulum
+python -m newton.examples
 ```
 
 To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html).
@@ -782,7 +782,7 @@ Some examples may add additional arguments (see their respective source files fo
 
 ```bash
 # List available examples
-python -m newton.examples
+python -m newton.examples --list
 
 # Run with the USD viewer and save to my_output.usd
 python -m newton.examples basic_viewer --viewer usd --output-path my_output.usd

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -55,7 +55,7 @@ available examples:
 
 .. code-block:: console
 
-    uv run -m newton.examples
+    uv run -m newton.examples --list
 
 See the :ref:`extra-dependencies` section of the installation guide for a
 description of all available extras.
@@ -659,7 +659,7 @@ New examples must also be registered in the examples ``README.md`` with a
         .. code-block:: console
 
             # list all available examples
-            uv run -m newton.examples
+            uv run -m newton.examples --list
 
             # run an example by short name
             uv run -m newton.examples basic_pendulum
@@ -673,7 +673,7 @@ New examples must also be registered in the examples ``README.md`` with a
         .. code-block:: console
 
             # list all available examples
-            python -m newton.examples
+            python -m newton.examples --list
 
             # run an example by short name
             python -m newton.examples basic_pendulum

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -164,11 +164,12 @@ with other packages:
 Running Examples
 ^^^^^^^^^^^^^^^^
 
-After installing Newton with the ``examples`` extra, run an example with:
+After installing Newton with the ``examples`` extra, launch the default
+``basic_pendulum`` example — you can browse other examples from the side panel:
 
 .. code-block:: console
 
-    python -m newton.examples basic_pendulum
+    python -m newton.examples
 
 Run an example that runs RL policy inference. Choose the extra matching your
 NVIDIA driver's CUDA support (``torch-cu12`` for CUDA 12.x, ``torch-cu13`` for
@@ -191,11 +192,11 @@ to check the supported CUDA version (shown in the top-right corner of the output
         pip install "newton[examples]"
         pip install torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
 
-See a list of all available examples:
+See a list of all available examples (also browsable from the viewer's side panel):
 
 .. code-block:: console
 
-    python -m newton.examples
+    python -m newton.examples --list
 
 Quick Start
 ^^^^^^^^^^^
@@ -329,5 +330,5 @@ to the same compatibility guarantees as stable releases.
 Next Steps
 ----------
 
-- Run ``python -m newton.examples`` to see all available examples and check out the :doc:`visualization` guide to learn how to interact with the example simulations.
+- Run ``python -m newton.examples --list`` to see all available examples and check out the :doc:`visualization` guide to learn how to interact with the example simulations.
 - Check out the :doc:`development` guide to learn how to contribute to Newton, or how to use alternative installation methods.

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -407,6 +407,12 @@ def get_examples() -> dict[str, str]:
     return example_map
 
 
+def _print_examples(examples: dict[str, str]) -> None:
+    print("Available examples:")
+    for name in examples:
+        print(f"  {name}")
+
+
 def create_parser():
     """Create a base argument parser with common parameters for Newton examples.
 
@@ -708,20 +714,27 @@ def main():
 
     examples = get_examples()
 
-    if len(sys.argv) < 2:
-        print("Usage: python -m newton.examples <example_name>")
-        print("\nAvailable examples:")
-        for name in examples:
-            print(f"  {name}")
-        sys.exit(1)
+    if len(sys.argv) >= 2 and sys.argv[1] in ("-h", "--help"):
+        print("Usage: python -m newton.examples <example_name> [options]")
+        print("       python -m newton.examples          # run default basic_pendulum")
+        print("       python -m newton.examples --list   # print available examples")
+        print()
+        print("Run 'python -m newton.examples <example_name> --help' to see the")
+        print("options supported by a given example.")
+        sys.exit(0)
 
-    example_name = sys.argv[1]
+    if len(sys.argv) >= 2 and sys.argv[1] == "--list":
+        _print_examples(examples)
+        sys.exit(0)
+
+    if len(sys.argv) < 2:
+        example_name = "basic_pendulum"
+    else:
+        example_name = sys.argv[1]
 
     if example_name not in examples:
-        print(f"Error: Unknown example '{example_name}'")
-        print("\nAvailable examples:")
-        for name in examples:
-            print(f"  {name}")
+        print(f"Error: Unknown example '{example_name}'\n")
+        _print_examples(examples)
         sys.exit(1)
 
     # Set up sys.argv for the target script


### PR DESCRIPTION
## Description

`python -m newton.examples` now launches `basic_pendulum` by default; users switch examples via the viewer browser. Use `python -m newton.examples --list` to print available examples.

## Checklist

- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated

## Test plan

- `python -m newton.examples` → launches `basic_pendulum`
- `python -m newton.examples --list` → prints example list
- `python -m newton.examples --help` → prints usage
- `python -m newton.examples basic_viewer --viewer usd --output-path /tmp/x.usd` → named example with flags still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--list` flag to display available examples.
  * Running `python -m newton.examples` without arguments now defaults to launching the basic pendulum example.

* **Documentation**
  * Updated installation, development, and quickstart guides to reflect new CLI behavior and `--list` flag usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->