### PR TITLE
Install ASV comparison wheels from nvidia index

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -20,6 +20,6 @@
     "python -m pip install -U mujoco==3.7.0",
     "python -m pip install -U mujoco-warp==3.7.0.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
-    "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
+    "in-dir={env_dir} python -m pip install --extra-index-url=https://pypi.nvidia.com/ {wheel_file}[dev]"
   ]
 }


### PR DESCRIPTION
## Description

ASV compares two commits by reusing a single virtualenv. The shared `install_command` pre-installs `warp-lang` from `pypi.nvidia.com`, but the final per-commit step — `pip install {wheel_file}[dev]` — carried no index URL, so it resolved dependencies against public PyPI only.

That was invisible while `pyproject.toml` used a loose `warp-lang>=...` bound: the pre-installed warp always satisfied the constraint on both sides of the comparison. It also had an **unintended methodology side effect**: warp-bump PRs were measured as `newton-new+warp-new` vs `newton-old+warp-new`, so the warp change itself was never exercised and those PRs reported flat benchmarks regardless of real impact.

Since #2528, `pyproject.toml` pins an exact dev-nightly version. The baseline wheel now requires that exact version, public PyPI does not have it, and the comparison job exits 2. PRs whose branches predate a warp bump on main (e.g. #2275) fail for the same reason — any mismatch between the shared env's warp version and a compared commit's pin surfaces this bug.

**Fix:** pass `--extra-index-url=https://pypi.nvidia.com/` to the final wheel install so each compared commit can resolve its own warp pin from the nvidia index. This restores benchmark methodology: warp-bump PRs will now benchmark against their actual predecessor warp version rather than masking the change.

**Trade-off:** comparisons against very old baselines will fail if their pinned dev wheel has aged out of the nvidia index. This is acceptable — such comparisons are rare, and the failure is loud rather than silent.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] \`CHANGELOG.md\` has been updated (if user-facing change)

## Test plan

This only affects the ASV benchmarking workflow on AWS EC2 runners, so verification is the GPU Benchmarks CI job. Expected behavior on subsequent warp-bump or stale-branch PRs: the per-commit `pip install {wheel_file}[dev]` step resolves warp from `pypi.nvidia.com` and the comparison completes instead of exiting 2.

Repro of the failure mode this fixes:
- https://github.com/newton-physics/newton/actions/runs/24877884437/job/72838956807 (warp-bump PR, baseline build fails)
- https://github.com/newton-physics/newton/actions/runs/24844553150/job/72837101180 (stale branch #2275, same failure against main baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark environment configuration to include NVIDIA's package index during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->