### PR TITLE
Fix garbage collector issues in Kamino RCM solver

### DIFF
--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
@@ -136,6 +136,11 @@ class LLTBlockedRCMSolver(DirectSolver):
         self._inv_P: wp.array | None = None
         self._tile_pattern: wp.array | None = None
         self._tpo: wp.array | None = None
+        # Batched-RCM scratch (owned here so the recorded launches in
+        # ``_reorder_callback`` never reference buffers that outlive our
+        # dict). Allocated in ``_allocate_impl`` alongside the other solver
+        # buffers, and reset in ``_reset_impl``.
+        self._rcm_scratch: dict | None = None
         self._max_dim: int = 0
         # Batched-RCM launch callback: closure that replays a recorded launch
         # set over all blocks. Rebound whenever the caller-owned ``A`` buffer
@@ -259,6 +264,15 @@ class LLTBlockedRCMSolver(DirectSolver):
             self._tile_pattern = wp.zeros(shape=(total_tp_size,), dtype=int32)
             self._tpo = wp.array(tp_offsets[:-1], dtype=int32)
 
+            # Batched-RCM scratch. Owning these here matches how the other
+            # linalg solvers hold their buffers and keeps the recorded-launch
+            # inputs alive for as long as the solver is alive.
+            self._rcm_scratch = _rcm_batch.allocate_rcm_batch_scratch(
+                total_vec=info.total_vec_size,
+                num_blocks=info.num_blocks,
+                device=self._device,
+            )
+
         # The batched-RCM launch callback (``self._reorder_callback``) is
         # (re)built lazily in ``_ensure_reorder_launches_bound`` the first
         # time a concrete A buffer arrives, and rebound only if its device
@@ -296,6 +310,7 @@ class LLTBlockedRCMSolver(DirectSolver):
                 dims=info.dim,
                 mio=info.mio,
                 vio=info.vio,
+                scratch=self._rcm_scratch,
                 num_blocks=info.num_blocks,
                 max_dim=int(info.max_dimension),
                 tol=self._reorder_tol,

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
@@ -342,6 +342,7 @@ def create_rcm_batch_launch(
     dims: wp.array,
     mio: wp.array,
     vio: wp.array,
+    scratch: dict,
     num_blocks: int,
     max_dim: int,
     tol: float = 0.0,
@@ -358,6 +359,13 @@ def create_rcm_batch_launch(
         Flat buffers for the concatenated block matrices and output permutations.
     dims, mio, vio:
         ``int32`` arrays describing the per-block sizes and flat offsets.
+    scratch:
+        Caller-owned scratch buffers from :func:`allocate_rcm_batch_scratch`.
+        The caller must keep this dict alive for the lifetime of the returned
+        callback: the Warp CPU backend does not retain strong Python refs to
+        recorded-launch inputs, so scratch owned only by this function's
+        locals would be collected and the callback would write into freed
+        memory on replay.
     num_blocks, max_dim:
         Host-side sizing used to pick fixed launch dimensions.
     tol, max_bfs_iters, use_cuda_graph, device, stream:
@@ -366,15 +374,12 @@ def create_rcm_batch_launch(
     if perm_flat.dtype != wp.int32:
         raise TypeError(f"perm_flat must be int32; got {perm_flat.dtype}")
     dtype = A_flat.dtype
-    total_vec = int(perm_flat.shape[0])
 
     if device is None:
         device = A_flat.device
     if max_bfs_iters is None:
         max_bfs_iters = _default_bfs_iters(max_dim)
     max_bfs_iters = min(max_bfs_iters, max_dim)
-
-    scratch = allocate_rcm_batch_scratch(total_vec, num_blocks, device=device)
 
     K = _make_rcm_batch_kernels(dtype)
 


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Fix garbage collector issues in Kamino RCM solver

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->
Manual testing

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->
Hard to reproduce. GC frees memory but only in CPU mode. There is some inconsistency between cuda and CPU mode about GC handles are tracked.

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management for linear algebra solvers by optimizing scratch buffer allocation and lifetime handling during matrix reordering operations. Enhanced robustness of buffer handling in solver callbacks to ensure correct memory access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->