### PR TITLE
Document release-audit skill in release process

### DIFF
--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -76,6 +76,10 @@ Pre-release planning
          migration guidance (see :ref:`deprecation-timeline`).
        - Confirm new public API has complete docstrings and is included in
          Sphinx docs (run ``uv run docs/generate_api.py``).
+
+       Run the ``release-audit`` Claude Code skill
+       (``.claude/skills/release-audit``) in **pre-release mode** to automate
+       this audit.
    * - ☐
      - Communicate the timeline to the community.
 
@@ -103,12 +107,13 @@ Code freeze and release branch creation
        the release wheel installs purely from PyPI, then regenerate
        ``uv.lock`` (``uv lock``) and commit.
    * - ☐
-     - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
-       (build wheel → PyPI publish with manual approval).
+     - Run the ``release-audit`` skill in **release-candidate mode** against
+       ``release-X.Y``; address or acknowledge flagged entries before
+       tagging.
    * - ☐
      - Manually trigger the **minimum-dependency** and **multi-GPU** CI
        workflows on the ``release-X.Y`` branch (the nightly orchestrator
-       only runs on ``main``).  Verify both pass before announcing the RC.
+       only runs on ``main``).  Verify both pass before tagging.
 
        .. code-block:: bash
 
@@ -118,6 +123,9 @@ Code freeze and release branch creation
           # Multi-GPU tests (g7e.12xlarge = 4× L40S GPUs)
           gh workflow run aws_gpu_tests.yml --ref release-X.Y \
               -f instance-type=g7e.12xlarge
+   * - ☐
+     - Push tag ``vX.Y.Zrc1``.  This triggers the ``release.yml`` workflow
+       (build wheel → PyPI publish with manual approval).
    * - ☐
      - RC1 published to PyPI (approve in GitHub environment).
 
@@ -165,6 +173,9 @@ As a guideline, an RC is typically ready for GA when:
    * - ☐
      - All release-targeted fixes cherry-picked from ``main``.
    * - ☐
+     - Re-run the ``release-audit`` skill after final cherry-picks; confirm
+       no new flags since the last RC.
+   * - ☐
      - :ref:`Testing criteria <testing-criteria>` satisfied.
    * - ☐
      - No outstanding release-blocking issues.
@@ -199,6 +210,9 @@ otherwise.
          within the same release period (e.g. a bug fix for a feature added
          in the same cycle should not appear as both an "Added" and a "Fixed"
          entry).
+
+       The ``release-audit`` skill's CHANGELOG language review is a useful
+       first pass before this manual sweep.
    * - ☐
      - Update ``README.md`` documentation links to point to versioned URLs
        (e.g. ``/X.Y.Z/guide.html`` instead of ``/latest/``).


### PR DESCRIPTION
## Description

Reference the `release-audit` Claude Code skill (`.claude/skills/release-audit`) at four points in `docs/guide/release.rst` so maintainers know when to invoke it:

- **Pre-release planning**: run in pre-release mode to automate the public API audit bullet.
- **Code freeze**: run in release-candidate mode against `release-X.Y` before tagging the first RC.
- **RC stabilization**: re-run after final cherry-picks to catch new flags since the last RC.
- **Final GA**: use the CHANGELOG language review as a first pass before the manual missing/redundant sweep.

Also reorders the code-freeze checklist so the audit and the minimum-dependency / multi-GPU CI workflows run **before** the RC tag push rather than after. Tagging is the public, hard-to-undo step; catching flags or CI failures beforehand avoids burning an RC number and kicking off a PyPI publish flow on a release that has to be respun.

## Checklist

- [x] New or existing tests cover these changes (docs-only; no tests needed)
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — maintainer-facing docs, no CHANGELOG entry

## Test plan

- Built Sphinx docs locally (`cd docs && uv run --extra docs make html`) and verified the rendered release page reads correctly and the reordered code-freeze checklist renders in the intended order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release guide enhanced with additional audit procedures during pre-release and release-candidate stages for improved quality assurance
  * Added GA readiness checklist items for comprehensive validation before final release
  * Incorporated guidance on leveraging automated changelog review processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->