### PR TITLE
Blender-Style Viewer Camera Controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
+- Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations
 - Add `SolverXPBD.update_contacts()` to populate `contacts.force` with per-contact spatial forces (linear force and torque) derived from XPBD constraint impulses
 - Raise process priority automatically in `--benchmark` mode for more stable measurements; add `--realtime` for maximum priority.
 - Import per-shape authored color from USD stages into `ModelBuilder.shape_color`
@@ -24,6 +25,7 @@
 
 - Use pre-computed local AABB for `CONVEX_MESH` shapes in `compute_shape_aabbs`, avoiding a per-frame support-function AABB computation
 - Build mesh SDFs via the texture-based sparse path only; sample via `SDF.texture_data` instead of `SDF.sparse_volume` / `SDF.coarse_volume`.
+- Change GL viewer scroll to dolly toward the orbit pivot; use Ctrl+scroll for FOV zoom
 - Render all GL viewer lines (joints, contacts, wireframes) as geometry-shader quads instead of ``GL_LINES`` for uniform width across zoom levels and non-square viewports
 - Pin `mujoco` and `mujoco-warp` dependencies to `~=3.6.0`
 - Update default environment map texture in GL viewer (source: https://polyhaven.com/a/brown_photostudio_02)

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -128,21 +128,39 @@ The ``position`` parameter controls placement: ``"side"`` (default), ``"stats"``
 
     viewer.register_ui_callback(my_ui, position="side")
 
-Keyboard shortcuts when working with the OpenGL Viewer:
+Viewer controls:
 
-.. list-table:: Keyboard Shortcuts
+.. list-table:: ViewerGL Controls
     :header-rows: 1
 
     * - Key(s)
       - Description
-    * - ``W``, ``A``, ``S``, ``D`` (or arrow keys) + mouse drag
-      - Move the camera like in a FPS game
+    * - ``W``, ``A``, ``S``, ``D`` or arrow keys
+      - Move the camera in the ground plane
+    * - ``Q`` / ``E``
+      - Move the camera down / up
+    * - Left drag
+      - Look around
+    * - Middle drag
+      - Orbit around the current camera pivot
+    * - ``Shift`` + middle drag
+      - Pan the camera and pivot
+    * - ``Ctrl`` + middle drag or mouse wheel
+      - Dolly toward or away from the pivot
+    * - ``Ctrl`` + mouse wheel
+      - Adjust field of view
+    * - ``F``
+      - Frame the visible model and set the orbit pivot
     * - ``H``
-      - Toggle Sidebar
+      - Toggle the sidebar
     * - ``SPACE``
-      - Pause/continue the simulation
+      - Pause or continue the simulation
+    * - ``ESC``
+      - Close the viewer
     * - ``Right Click``
       - Pick objects
+
+Orbit mode keeps the pivot fixed while the camera rotates around it; use ``F`` to center the pivot on the model, ``Shift`` + middle drag to move the pivot, and the wheel to change orbit distance.
 
 **Troubleshooting:**
 

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -138,14 +138,16 @@ Viewer controls:
     * - ``W``, ``A``, ``S``, ``D`` or arrow keys
       - Move the camera in the ground plane
     * - ``Q`` / ``E``
-      - Move the camera down / up
+      - Move the camera down or up
     * - Left drag
       - Look around
     * - Middle drag
       - Orbit around the current camera pivot
     * - ``Shift`` + middle drag
       - Pan the camera and pivot
-    * - ``Ctrl`` + middle drag or mouse wheel
+    * - ``Ctrl`` + middle drag
+      - Dolly toward or away from the pivot
+    * - Mouse wheel
       - Dolly toward or away from the pivot
     * - ``Ctrl`` + mouse wheel
       - Adjust field of view
@@ -157,10 +159,10 @@ Viewer controls:
       - Pause or continue the simulation
     * - ``ESC``
       - Close the viewer
-    * - ``Right Click``
+    * - Right click
       - Pick objects
 
-Orbit mode keeps the pivot fixed while the camera rotates around it; use ``F`` to center the pivot on the model, ``Shift`` + middle drag to move the pivot, and the wheel to change orbit distance.
+Orbit mode keeps the pivot fixed while the camera rotates around it. Use ``F`` to center the pivot on the model, ``Shift`` + middle drag to pan the pivot with the camera, and the mouse wheel to change the orbit distance.
 
 **Troubleshooting:**
 

--- a/newton/_src/viewer/camera.py
+++ b/newton/_src/viewer/camera.py
@@ -7,6 +7,9 @@ import numpy as np
 class Camera:
     """Camera class that encapsulates all camera settings and logic."""
 
+    DEFAULT_PIVOT_DISTANCE = 5.0
+    MIN_PIVOT_DISTANCE = 0.05
+
     def __init__(self, fov=45.0, near=0.01, far=1000.0, width=1280, height=720, pos=None, up_axis="Z"):
         """
         Initialize camera with given parameters.
@@ -50,12 +53,137 @@ class Camera:
         self.pitch = 0.0
         self.yaw = -180.0
 
+        self._pivot_distance = self.DEFAULT_PIVOT_DISTANCE
+        self.pivot = self.pos + self.get_front() * self._pivot_distance
+
+    @staticmethod
+    def _as_vec3(value):
+        """Convert a 3D sequence to pyglet's Vec3."""
+        from pyglet.math import Vec3 as PyVec3
+
+        return PyVec3(float(value[0]), float(value[1]), float(value[2]))
+
+    @staticmethod
+    def _length(value) -> float:
+        """Return the Euclidean length of a 3D vector."""
+        return float(np.linalg.norm((value[0], value[1], value[2])))
+
+    @staticmethod
+    def _clamp_pitch(pitch: float) -> float:
+        return max(min(float(pitch), 89.0), -89.0)
+
+    @staticmethod
+    def _wrap_yaw(yaw: float) -> float:
+        return (float(yaw) + 180.0) % 360.0 - 180.0
+
+    @property
+    def pivot_distance(self) -> float:
+        """Distance from the camera position to the orbit pivot [m]."""
+        distance = self._length(self.pivot - self.pos)
+        if distance > self.MIN_PIVOT_DISTANCE:
+            self._pivot_distance = distance
+        return self._pivot_distance
+
+    def _set_orientation_from_direction(self, direction):
+        """Set yaw and pitch from a normalized view direction."""
+        direction = self._as_vec3(direction).normalize()
+
+        if self.up_axis == 0:  # X up
+            pitch = np.rad2deg(np.arcsin(np.clip(direction.x, -1.0, 1.0)))
+            yaw = np.rad2deg(np.arctan2(direction.z, direction.y))
+        elif self.up_axis == 2:  # Z up
+            pitch = np.rad2deg(np.arcsin(np.clip(direction.z, -1.0, 1.0)))
+            yaw = np.rad2deg(np.arctan2(direction.y, direction.x))
+        else:  # Y up (default)
+            pitch = np.rad2deg(np.arcsin(np.clip(direction.y, -1.0, 1.0)))
+            yaw = np.rad2deg(np.arctan2(direction.z, direction.x))
+
+        self.pitch = self._clamp_pitch(pitch)
+        self.yaw = self._wrap_yaw(yaw)
+
+    def set_pivot(self, pivot):
+        """Set the orbit pivot without changing the current view direction."""
+        self.pivot = self._as_vec3(pivot)
+        distance = self._length(self.pivot - self.pos)
+        if distance <= self.MIN_PIVOT_DISTANCE:
+            self.sync_pivot_to_view(distance=self.MIN_PIVOT_DISTANCE)
+        else:
+            self._pivot_distance = distance
+
+    def sync_pivot_to_view(self, distance: float | None = None):
+        """Place the orbit pivot along the current view direction.
+
+        Args:
+            distance: Optional distance from the camera to the pivot [m].
+        """
+        if distance is None:
+            distance = self.pivot_distance
+        distance = max(float(distance), self.MIN_PIVOT_DISTANCE)
+        self._pivot_distance = distance
+        self.pivot = self.pos + self.get_front() * distance
+
+    def look_at(self, target):
+        """Point the camera at a world-space target and set it as the pivot."""
+        target = self._as_vec3(target)
+        to_target = target - self.pos
+        distance = self._length(to_target)
+        if distance <= self.MIN_PIVOT_DISTANCE:
+            self.set_pivot(target)
+            return
+
+        self._set_orientation_from_direction(to_target)
+        self.pivot = target
+        self._pivot_distance = distance
+
+    def translate(self, delta):
+        """Translate the camera and pivot by the same world-space offset [m]."""
+        delta = self._as_vec3(delta)
+        self.pos += delta
+        self.pivot += delta
+
+    def orbit(self, delta_yaw: float, delta_pitch: float):
+        """Orbit the camera around the pivot.
+
+        Args:
+            delta_yaw: Yaw delta in degrees.
+            delta_pitch: Pitch delta in degrees.
+        """
+        distance = self.pivot_distance
+        self.yaw = self._wrap_yaw(self.yaw + delta_yaw)
+        self.pitch = self._clamp_pitch(self.pitch + delta_pitch)
+        self.pos = self.pivot - self.get_front() * distance
+        self._pivot_distance = distance
+
+    def pan(self, delta_right: float, delta_up: float):
+        """Pan the camera and pivot in the camera plane [m]."""
+        delta = self.get_right() * float(delta_right) + self.get_up() * float(delta_up)
+        self.translate(delta)
+
+    def dolly(self, amount: float):
+        """Move the camera toward or away from the pivot.
+
+        Positive values move the camera toward the pivot; negative values move it
+        away. The pivot remains fixed.
+        """
+        distance = self.pivot_distance
+        to_pivot = self.pivot - self.pos
+        if self._length(to_pivot) <= self.MIN_PIVOT_DISTANCE:
+            self.sync_pivot_to_view(distance=distance)
+            to_pivot = self.pivot - self.pos
+
+        direction_to_pivot = to_pivot.normalize()
+        self._set_orientation_from_direction(direction_to_pivot)
+
+        new_distance = max(distance * float(np.exp(-amount)), self.MIN_PIVOT_DISTANCE)
+        self.pos = self.pivot - direction_to_pivot * new_distance
+        self._pivot_distance = new_distance
+
     def get_front(self):
         """Get the camera front direction vector (read-only)."""
         from pyglet.math import Vec3 as PyVec3
 
         # Clamp pitch to avoid gimbal lock
-        pitch = max(min(self.pitch, 89.0), -89.0)
+        pitch = self._clamp_pitch(self.pitch)
 
         # Calculate front vector directly in the coordinate system based on up_axis
         # This ensures yaw/pitch work correctly for each coordinate system

--- a/newton/_src/viewer/camera.py
+++ b/newton/_src/viewer/camera.py
@@ -53,8 +53,7 @@ class Camera:
         self.pitch = 0.0
         self.yaw = -180.0
 
-        self._pivot_distance = self.DEFAULT_PIVOT_DISTANCE
-        self.pivot = self.pos + self.get_front() * self._pivot_distance
+        self.pivot = self.pos + self.get_front() * self.DEFAULT_PIVOT_DISTANCE
 
     @staticmethod
     def _as_vec3(value):
@@ -80,9 +79,7 @@ class Camera:
     def pivot_distance(self) -> float:
         """Distance from the camera position to the orbit pivot [m]."""
         distance = self._length(self.pivot - self.pos)
-        if distance > self.MIN_PIVOT_DISTANCE:
-            self._pivot_distance = distance
-        return self._pivot_distance
+        return max(distance, self.MIN_PIVOT_DISTANCE)
 
     def _set_orientation_from_direction(self, direction):
         """Set yaw and pitch from a normalized view direction."""
@@ -104,11 +101,8 @@ class Camera:
     def set_pivot(self, pivot):
         """Set the orbit pivot without changing the current view direction."""
         self.pivot = self._as_vec3(pivot)
-        distance = self._length(self.pivot - self.pos)
-        if distance <= self.MIN_PIVOT_DISTANCE:
+        if self._length(self.pivot - self.pos) <= self.MIN_PIVOT_DISTANCE:
             self.sync_pivot_to_view(distance=self.MIN_PIVOT_DISTANCE)
-        else:
-            self._pivot_distance = distance
 
     def sync_pivot_to_view(self, distance: float | None = None):
         """Place the orbit pivot along the current view direction.
@@ -119,7 +113,6 @@ class Camera:
         if distance is None:
             distance = self.pivot_distance
         distance = max(float(distance), self.MIN_PIVOT_DISTANCE)
-        self._pivot_distance = distance
         self.pivot = self.pos + self.get_front() * distance
 
     def look_at(self, target):
@@ -133,7 +126,6 @@ class Camera:
 
         self._set_orientation_from_direction(to_target)
         self.pivot = target
-        self._pivot_distance = distance
 
     def translate(self, delta):
         """Translate the camera and pivot by the same world-space offset [m]."""
@@ -152,7 +144,6 @@ class Camera:
         self.yaw = self._wrap_yaw(self.yaw + delta_yaw)
         self.pitch = self._clamp_pitch(self.pitch + delta_pitch)
         self.pos = self.pivot - self.get_front() * distance
-        self._pivot_distance = distance
 
     def pan(self, delta_right: float, delta_up: float):
         """Pan the camera and pivot in the camera plane [m]."""
@@ -176,7 +167,6 @@ class Camera:
 
         new_distance = max(distance * float(np.exp(-amount)), self.MIN_PIVOT_DISTANCE)
         self.pos = self.pivot - direction_to_pivot * new_distance
-        self._pivot_distance = new_distance
 
     def get_front(self):
         """Get the camera front direction vector (read-only)."""

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -1759,8 +1759,11 @@ class ViewerGL(ViewerBase):
         return self.renderer.is_key_down(pyglet.window.key.LCTRL) or self.renderer.is_key_down(pyglet.window.key.RCTRL)
 
     def _camera_pan_scale(self) -> float:
-        """World-space meters per pixel for screen-plane camera panning."""
+        """World-space meters per window pixel for screen-plane camera panning."""
         height = max(float(self.camera.height), 1.0)
+        if hasattr(self.renderer, "window"):
+            _, window_height = self.renderer.window.get_size()
+            height = max(float(window_height), 1.0)
         distance = max(self.camera.pivot_distance, self.camera.MIN_PIVOT_DISTANCE)
         visible_height = 2.0 * distance * np.tan(np.radians(self.camera.fov) * 0.5)
         return visible_height / height

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -263,6 +263,9 @@ class ViewerGL(ViewerBase):
 
         # Camera movement settings
         self._camera_speed = 0.04
+        self._camera_orbit_sensitivity = 0.1
+        self._camera_dolly_scroll_sensitivity = 0.15
+        self._camera_dolly_drag_sensitivity = 0.01
         self._cam_vel = np.zeros(3, dtype=np.float32)
         self._cam_speed = 4.0  # m/s
         self._cam_damp_tau = 0.083  # s
@@ -685,9 +688,10 @@ class ViewerGL(ViewerBase):
             pitch: The camera pitch.
             yaw: The camera yaw.
         """
-        self.camera.pos = pos
+        self.camera.pos = self.camera._as_vec3(pos)
         self.camera.pitch = max(min(pitch, 89.0), -89.0)
         self.camera.yaw = (yaw + 180.0) % 360.0 - 180.0
+        self.camera.sync_pivot_to_view()
 
     @override
     def log_mesh(
@@ -1727,7 +1731,7 @@ class ViewerGL(ViewerBase):
 
     def on_mouse_scroll(self, x: float, y: float, scroll_x: float, scroll_y: float):
         """
-        Handle mouse scroll for zooming (FOV adjustment).
+        Handle mouse scroll for dolly and FOV adjustment.
 
         Args:
             x: Mouse X position in window coordinates.
@@ -1738,9 +1742,28 @@ class ViewerGL(ViewerBase):
         if self._ui_is_capturing_mouse():
             return
 
-        fov_delta = scroll_y * 2.0
-        self.camera.fov -= fov_delta
-        self.camera.fov = max(min(self.camera.fov, 90.0), 15.0)
+        if self._is_ctrl_down():
+            fov_delta = scroll_y * 2.0
+            self.camera.fov -= fov_delta
+            self.camera.fov = max(min(self.camera.fov, 90.0), 15.0)
+        else:
+            self.camera.dolly(scroll_y * self._camera_dolly_scroll_sensitivity)
+
+    def _is_ctrl_down(self) -> bool:
+        """Return True when either Ctrl key is currently held."""
+        try:
+            import pyglet
+        except Exception:
+            return False
+
+        return self.renderer.is_key_down(pyglet.window.key.LCTRL) or self.renderer.is_key_down(pyglet.window.key.RCTRL)
+
+    def _camera_pan_scale(self) -> float:
+        """World-space meters per pixel for screen-plane camera panning."""
+        height = max(float(self.camera.height), 1.0)
+        distance = max(self.camera.pivot_distance, self.camera.MIN_PIVOT_DISTANCE)
+        visible_height = 2.0 * distance * np.tan(np.radians(self.camera.fov) * 0.5)
+        return visible_height / height
 
     def _to_framebuffer_coords(self, x: float, y: float) -> tuple[float, float]:
         """Convert window coordinates to framebuffer coordinates."""
@@ -1812,6 +1835,17 @@ class ViewerGL(ViewerBase):
 
         import pyglet
 
+        if buttons & pyglet.window.mouse.MIDDLE:
+            if modifiers & pyglet.window.key.MOD_CTRL:
+                self.camera.dolly(dy * self._camera_dolly_drag_sensitivity)
+            elif modifiers & pyglet.window.key.MOD_SHIFT:
+                pan_scale = self._camera_pan_scale()
+                self.camera.pan(-dx * pan_scale, -dy * pan_scale)
+            else:
+                sensitivity = self._camera_orbit_sensitivity
+                self.camera.orbit(delta_yaw=-dx * sensitivity, delta_pitch=dy * sensitivity)
+            return
+
         if buttons & pyglet.window.mouse.LEFT:
             sensitivity = 0.1
             dx *= sensitivity
@@ -1821,6 +1855,7 @@ class ViewerGL(ViewerBase):
             # independent of world up-axis convention.
             self.camera.yaw = (self.camera.yaw - dx + 180.0) % 360.0 - 180.0
             self.camera.pitch = max(min(self.camera.pitch + dy, 89.0), -89.0)
+            self.camera.sync_pivot_to_view()
 
         if buttons & pyglet.window.mouse.RIGHT and self.picking_enabled:
             fb_x, fb_y = self._to_framebuffer_coords(x, y)
@@ -1959,6 +1994,7 @@ class ViewerGL(ViewerBase):
             center[2] - front.z * distance,
         )
         self.camera.pos = new_pos
+        self.camera.set_pivot(center)
 
     def _update_camera(self, dt: float):
         """
@@ -2013,7 +2049,7 @@ class ViewerGL(ViewerBase):
 
         # integrate position
         dv = type(self.camera.pos)(*self._cam_vel)
-        self.camera.pos += dv * dt
+        self.camera.translate(dv * dt)
 
     def on_resize(self, width: int, height: int):
         """
@@ -2368,7 +2404,11 @@ class ViewerGL(ViewerBase):
                 imgui.text("QE - Pan up/down")
                 imgui.text("Left Click - Look around")
                 imgui.text("Right Click - Pick objects")
-                imgui.text("Scroll - Zoom")
+                imgui.text("Middle Click - Orbit")
+                imgui.text("Shift + Middle Click - Pan")
+                imgui.text("Ctrl + Middle Click - Dolly")
+                imgui.text("Scroll - Dolly")
+                imgui.text("Ctrl + Scroll - FOV zoom")
                 imgui.text("Space - Pause/Resume")
                 imgui.text("H - Toggle UI")
                 imgui.text("F - Frame camera around model")

--- a/newton/examples/diffsim/example_diffsim_cloth.py
+++ b/newton/examples/diffsim/example_diffsim_cloth.py
@@ -108,8 +108,7 @@ class Example:
         self.viewer.set_model(self.model)
 
         if isinstance(self.viewer, newton.viewer.ViewerGL):
-            pos = type(self.viewer.camera.pos)(12.5, 0.0, 2.0)
-            self.viewer.camera.pos = pos
+            self.viewer.set_camera(wp.vec3(12.5, 0.0, 2.0), self.viewer.camera.pitch, self.viewer.camera.yaw)
 
         # capture forward/backward passes
         self.capture()

--- a/newton/examples/sensors/example_sensor_imu.py
+++ b/newton/examples/sensors/example_sensor_imu.py
@@ -115,8 +115,7 @@ class Example:
         self.viewer.set_model(self.model)
 
         if isinstance(self.viewer, newton.viewer.ViewerGL):
-            self.viewer.camera.pos = type(self.viewer.camera.pos)(3.0, 0.0, 2.0)
-            self.viewer.camera.pitch = type(self.viewer.camera.pitch)(-20)
+            self.viewer.set_camera(wp.vec3(3.0, 0.0, 2.0), -20.0, self.viewer.camera.yaw)
 
         # Warm up: run one simulate() step before graph capture to ensure the collision
         # pipeline (and any D2H copies it needs) is initialized outside of capture.

--- a/newton/tests/test_viewer_camera.py
+++ b/newton/tests/test_viewer_camera.py
@@ -41,6 +41,16 @@ class TestViewerCameraOrbit(unittest.TestCase):
         _assert_vec_close(self, _as_np(camera.pivot) - _as_np(camera.pos), start_offset)
         self.assertAlmostEqual(camera.pivot_distance, 7.0)
 
+    def test_pivot_distance_is_derived_from_pivot_and_position(self):
+        camera = Camera(pos=(0.0, 0.0, 0.0), up_axis="Z")
+        self.assertFalse(hasattr(camera, "_pivot_distance"))
+
+        camera.pivot = camera._as_vec3((0.0, 0.0, 0.0))
+        self.assertAlmostEqual(camera.pivot_distance, camera.MIN_PIVOT_DISTANCE)
+
+        camera.pos = camera._as_vec3((0.0, 0.0, 2.0))
+        self.assertAlmostEqual(camera.pivot_distance, 2.0)
+
     def test_orbit_keeps_pivot_fixed_and_points_at_pivot(self):
         camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
         camera.look_at((0.0, 0.0, 0.0))

--- a/newton/tests/test_viewer_camera.py
+++ b/newton/tests/test_viewer_camera.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import unittest
+
+import numpy as np
+import pyglet
+
+from newton._src.viewer.camera import Camera
+from newton._src.viewer.viewer_gl import ViewerGL
+
+pyglet.options["headless"] = True
+
+
+def _as_np(value):
+    return np.array((value[0], value[1], value[2]), dtype=float)
+
+
+def _assert_vec_close(test, actual, expected, tol=1.0e-6):
+    np.testing.assert_allclose(_as_np(actual), np.array(expected, dtype=float), atol=tol, rtol=0.0)
+
+
+class TestViewerCameraOrbit(unittest.TestCase):
+    def test_sync_pivot_to_view_tracks_fps_look(self):
+        camera = Camera(pos=(0.0, 0.0, 0.0), up_axis="Z")
+        camera.sync_pivot_to_view(distance=10.0)
+
+        camera.yaw = 90.0
+        camera.pitch = 30.0
+        camera.sync_pivot_to_view()
+
+        expected_pivot = _as_np(camera.pos) + _as_np(camera.get_front()) * 10.0
+        _assert_vec_close(self, camera.pivot, expected_pivot)
+        self.assertAlmostEqual(camera.pivot_distance, 10.0)
+
+    def test_translate_moves_camera_and_pivot_together(self):
+        camera = Camera(pos=(0.0, 0.0, 0.0), up_axis="Z")
+        camera.sync_pivot_to_view(distance=7.0)
+        start_offset = _as_np(camera.pivot) - _as_np(camera.pos)
+
+        camera.translate((1.0, -2.0, 3.0))
+
+        _assert_vec_close(self, camera.pos, (1.0, -2.0, 3.0))
+        _assert_vec_close(self, _as_np(camera.pivot) - _as_np(camera.pos), start_offset)
+        self.assertAlmostEqual(camera.pivot_distance, 7.0)
+
+    def test_orbit_keeps_pivot_fixed_and_points_at_pivot(self):
+        camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
+        camera.look_at((0.0, 0.0, 0.0))
+        camera.set_pivot((0.0, 0.0, 0.0))
+
+        camera.orbit(delta_yaw=45.0, delta_pitch=30.0)
+
+        _assert_vec_close(self, camera.pivot, (0.0, 0.0, 0.0))
+        self.assertAlmostEqual(camera.pivot_distance, 10.0)
+        direction_to_pivot = (_as_np(camera.pivot) - _as_np(camera.pos)) / camera.pivot_distance
+        np.testing.assert_allclose(_as_np(camera.get_front()), direction_to_pivot, atol=1.0e-6, rtol=0.0)
+
+    def test_look_at_points_front_at_pivot_for_all_up_axes(self):
+        for up_axis in ("X", "Y", "Z"):
+            with self.subTest(up_axis=up_axis):
+                camera = Camera(pos=(1.0, 2.0, 3.0), up_axis=up_axis)
+                camera.look_at((-4.0, 6.0, 2.0))
+
+                direction_to_pivot = (_as_np(camera.pivot) - _as_np(camera.pos)) / camera.pivot_distance
+                np.testing.assert_allclose(_as_np(camera.get_front()), direction_to_pivot, atol=1.0e-6, rtol=0.0)
+
+    def test_orbit_clamps_pitch_to_89_degrees(self):
+        camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
+        camera.look_at((0.0, 0.0, 0.0))
+        camera.set_pivot((0.0, 0.0, 0.0))
+
+        camera.orbit(delta_yaw=0.0, delta_pitch=200.0)
+
+        self.assertEqual(camera.pitch, 89.0)
+        self.assertTrue(math.isfinite(camera.pos[0]))
+        self.assertAlmostEqual(camera.pivot_distance, 10.0)
+
+    def test_pan_moves_camera_and_pivot_in_camera_plane(self):
+        camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
+        camera.look_at((0.0, 0.0, 0.0))
+        camera.set_pivot((0.0, 0.0, 0.0))
+
+        start_pos = _as_np(camera.pos)
+        start_pivot = _as_np(camera.pivot)
+        right = _as_np(camera.get_right())
+        up = _as_np(camera.get_up())
+
+        camera.pan(delta_right=2.0, delta_up=-3.0)
+
+        expected_delta = right * 2.0 + up * -3.0
+        _assert_vec_close(self, camera.pos, start_pos + expected_delta)
+        _assert_vec_close(self, camera.pivot, start_pivot + expected_delta)
+        self.assertAlmostEqual(camera.pivot_distance, 10.0)
+
+    def test_dolly_moves_camera_toward_pivot_without_moving_pivot(self):
+        camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
+        camera.look_at((0.0, 0.0, 0.0))
+        camera.set_pivot((0.0, 0.0, 0.0))
+
+        camera.dolly(0.5)
+        distance_after_dolly_in = camera.pivot_distance
+
+        self.assertLess(distance_after_dolly_in, 10.0)
+        _assert_vec_close(self, camera.pivot, (0.0, 0.0, 0.0))
+        direction_to_pivot = (_as_np(camera.pivot) - _as_np(camera.pos)) / camera.pivot_distance
+        np.testing.assert_allclose(_as_np(camera.get_front()), direction_to_pivot, atol=1.0e-6, rtol=0.0)
+
+        camera.dolly(-0.5)
+
+        self.assertGreater(camera.pivot_distance, distance_after_dolly_in)
+
+
+class _FakeRenderer:
+    def __init__(self):
+        self.pressed_keys = set()
+
+    def is_key_down(self, symbol):
+        return symbol in self.pressed_keys
+
+
+def _make_viewer_for_camera_input():
+    viewer = ViewerGL.__new__(ViewerGL)
+    viewer.ui = None
+    viewer.camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
+    viewer.camera.look_at((0.0, 0.0, 0.0))
+    viewer.camera.set_pivot((0.0, 0.0, 0.0))
+    viewer.renderer = _FakeRenderer()
+    viewer._camera_orbit_sensitivity = 0.1
+    viewer._camera_dolly_scroll_sensitivity = 0.15
+    viewer._camera_dolly_drag_sensitivity = 0.01
+    viewer.picking_enabled = False
+    viewer.picking = None
+    return viewer
+
+
+class TestViewerGLCameraInput(unittest.TestCase):
+    def test_scroll_dollies_toward_pivot_by_default(self):
+        viewer = _make_viewer_for_camera_input()
+        start_distance = viewer.camera.pivot_distance
+        start_fov = viewer.camera.fov
+
+        viewer.on_mouse_scroll(x=0.0, y=0.0, scroll_x=0.0, scroll_y=1.0)
+
+        self.assertLess(viewer.camera.pivot_distance, start_distance)
+        self.assertEqual(viewer.camera.fov, start_fov)
+
+    def test_ctrl_scroll_keeps_fov_zoom_escape_hatch(self):
+        viewer = _make_viewer_for_camera_input()
+        viewer.renderer.pressed_keys.add(pyglet.window.key.LCTRL)
+        start_distance = viewer.camera.pivot_distance
+        start_fov = viewer.camera.fov
+
+        viewer.on_mouse_scroll(x=0.0, y=0.0, scroll_x=0.0, scroll_y=1.0)
+
+        self.assertEqual(viewer.camera.pivot_distance, start_distance)
+        self.assertLess(viewer.camera.fov, start_fov)
+
+    def test_middle_mouse_drag_orbits_about_pivot(self):
+        viewer = _make_viewer_for_camera_input()
+        start_pos = _as_np(viewer.camera.pos)
+
+        viewer.on_mouse_drag(
+            x=0.0,
+            y=0.0,
+            dx=25.0,
+            dy=10.0,
+            buttons=pyglet.window.mouse.MIDDLE,
+            modifiers=0,
+        )
+
+        self.assertFalse(np.allclose(_as_np(viewer.camera.pos), start_pos))
+        _assert_vec_close(self, viewer.camera.pivot, (0.0, 0.0, 0.0))
+        self.assertAlmostEqual(viewer.camera.pivot_distance, 10.0)
+
+    def test_shift_middle_mouse_drag_pans_camera_and_pivot(self):
+        viewer = _make_viewer_for_camera_input()
+        start_pos = _as_np(viewer.camera.pos)
+        start_pivot = _as_np(viewer.camera.pivot)
+
+        viewer.on_mouse_drag(
+            x=0.0,
+            y=0.0,
+            dx=25.0,
+            dy=10.0,
+            buttons=pyglet.window.mouse.MIDDLE,
+            modifiers=pyglet.window.key.MOD_SHIFT,
+        )
+
+        self.assertFalse(np.allclose(_as_np(viewer.camera.pos), start_pos))
+        np.testing.assert_allclose(
+            _as_np(viewer.camera.pivot) - start_pivot,
+            _as_np(viewer.camera.pos) - start_pos,
+            atol=1.0e-6,
+            rtol=0.0,
+        )
+
+    def test_ctrl_middle_mouse_drag_dollies_without_moving_pivot(self):
+        viewer = _make_viewer_for_camera_input()
+        start_distance = viewer.camera.pivot_distance
+        start_pivot = _as_np(viewer.camera.pivot)
+
+        viewer.on_mouse_drag(
+            x=0.0,
+            y=0.0,
+            dx=0.0,
+            dy=10.0,
+            buttons=pyglet.window.mouse.MIDDLE,
+            modifiers=pyglet.window.key.MOD_CTRL,
+        )
+
+        self.assertLess(viewer.camera.pivot_distance, start_distance)
+        _assert_vec_close(self, viewer.camera.pivot, start_pivot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_viewer_camera.py
+++ b/newton/tests/test_viewer_camera.py
@@ -7,7 +7,6 @@ import unittest
 import numpy as np
 
 from newton._src.viewer.camera import Camera
-from newton._src.viewer.viewer_gl import ViewerGL
 
 
 def _as_np(value):
@@ -16,13 +15,6 @@ def _as_np(value):
 
 def _assert_vec_close(test, actual, expected, tol=1.0e-6):
     np.testing.assert_allclose(_as_np(actual), np.array(expected, dtype=float), atol=tol, rtol=0.0)
-
-
-def _pyglet_window():
-    import pyglet
-
-    pyglet.options["headless"] = True
-    return pyglet.window
 
 
 class TestViewerCameraOrbit(unittest.TestCase):
@@ -114,138 +106,6 @@ class TestViewerCameraOrbit(unittest.TestCase):
         camera.dolly(-0.5)
 
         self.assertGreater(camera.pivot_distance, distance_after_dolly_in)
-
-
-class _FakeWindow:
-    def __init__(self, size=(640, 360), framebuffer_size=(1280, 720)):
-        self._size = size
-        self._framebuffer_size = framebuffer_size
-
-    def get_size(self):
-        return self._size
-
-    def get_framebuffer_size(self):
-        return self._framebuffer_size
-
-
-class _FakeRenderer:
-    def __init__(self):
-        self.pressed_keys = set()
-        self.window = _FakeWindow()
-
-    def is_key_down(self, symbol):
-        return symbol in self.pressed_keys
-
-
-def _make_viewer_for_camera_input():
-    viewer = ViewerGL.__new__(ViewerGL)
-    viewer.ui = None
-    viewer.camera = Camera(pos=(10.0, 0.0, 0.0), up_axis="Z")
-    viewer.camera.look_at((0.0, 0.0, 0.0))
-    viewer.camera.set_pivot((0.0, 0.0, 0.0))
-    viewer.renderer = _FakeRenderer()
-    viewer._camera_orbit_sensitivity = 0.1
-    viewer._camera_dolly_scroll_sensitivity = 0.15
-    viewer._camera_dolly_drag_sensitivity = 0.01
-    viewer.picking_enabled = False
-    viewer.picking = None
-    return viewer
-
-
-class TestViewerGLCameraInput(unittest.TestCase):
-    def test_scroll_dollies_toward_pivot_by_default(self):
-        viewer = _make_viewer_for_camera_input()
-        start_distance = viewer.camera.pivot_distance
-        start_fov = viewer.camera.fov
-
-        viewer.on_mouse_scroll(x=0.0, y=0.0, scroll_x=0.0, scroll_y=1.0)
-
-        self.assertLess(viewer.camera.pivot_distance, start_distance)
-        self.assertEqual(viewer.camera.fov, start_fov)
-
-    def test_ctrl_scroll_keeps_fov_zoom_escape_hatch(self):
-        window = _pyglet_window()
-
-        viewer = _make_viewer_for_camera_input()
-        viewer.renderer.pressed_keys.add(window.key.LCTRL)
-        start_distance = viewer.camera.pivot_distance
-        start_fov = viewer.camera.fov
-
-        viewer.on_mouse_scroll(x=0.0, y=0.0, scroll_x=0.0, scroll_y=1.0)
-
-        self.assertEqual(viewer.camera.pivot_distance, start_distance)
-        self.assertLess(viewer.camera.fov, start_fov)
-
-    def test_middle_mouse_drag_orbits_about_pivot(self):
-        window = _pyglet_window()
-
-        viewer = _make_viewer_for_camera_input()
-        start_pos = _as_np(viewer.camera.pos)
-
-        viewer.on_mouse_drag(
-            x=0.0,
-            y=0.0,
-            dx=25.0,
-            dy=10.0,
-            buttons=window.mouse.MIDDLE,
-            modifiers=0,
-        )
-
-        self.assertFalse(np.allclose(_as_np(viewer.camera.pos), start_pos))
-        _assert_vec_close(self, viewer.camera.pivot, (0.0, 0.0, 0.0))
-        self.assertAlmostEqual(viewer.camera.pivot_distance, 10.0)
-
-    def test_shift_middle_mouse_drag_pans_camera_and_pivot(self):
-        window = _pyglet_window()
-
-        viewer = _make_viewer_for_camera_input()
-        start_pos = _as_np(viewer.camera.pos)
-        start_pivot = _as_np(viewer.camera.pivot)
-
-        viewer.on_mouse_drag(
-            x=0.0,
-            y=0.0,
-            dx=25.0,
-            dy=10.0,
-            buttons=window.mouse.MIDDLE,
-            modifiers=window.key.MOD_SHIFT,
-        )
-
-        self.assertFalse(np.allclose(_as_np(viewer.camera.pos), start_pos))
-        np.testing.assert_allclose(
-            _as_np(viewer.camera.pivot) - start_pivot,
-            _as_np(viewer.camera.pos) - start_pos,
-            atol=1.0e-6,
-            rtol=0.0,
-        )
-
-    def test_ctrl_middle_mouse_drag_dollies_without_moving_pivot(self):
-        window = _pyglet_window()
-
-        viewer = _make_viewer_for_camera_input()
-        start_distance = viewer.camera.pivot_distance
-        start_pivot = _as_np(viewer.camera.pivot)
-
-        viewer.on_mouse_drag(
-            x=0.0,
-            y=0.0,
-            dx=0.0,
-            dy=10.0,
-            buttons=window.mouse.MIDDLE,
-            modifiers=window.key.MOD_CTRL,
-        )
-
-        self.assertLess(viewer.camera.pivot_distance, start_distance)
-        _assert_vec_close(self, viewer.camera.pivot, start_pivot)
-
-    def test_shift_middle_pan_uses_window_pixel_scale(self):
-        viewer = _make_viewer_for_camera_input()
-        viewer.camera.fov = 90.0
-        viewer.renderer.window = _FakeWindow(size=(640, 360), framebuffer_size=(1280, 720))
-
-        pan_scale = viewer._camera_pan_scale()
-
-        self.assertAlmostEqual(pan_scale, 2.0 * viewer.camera.pivot_distance / 360.0)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_viewer_camera.py
+++ b/newton/tests/test_viewer_camera.py
@@ -5,12 +5,9 @@ import math
 import unittest
 
 import numpy as np
-import pyglet
 
 from newton._src.viewer.camera import Camera
 from newton._src.viewer.viewer_gl import ViewerGL
-
-pyglet.options["headless"] = True
 
 
 def _as_np(value):
@@ -19,6 +16,13 @@ def _as_np(value):
 
 def _assert_vec_close(test, actual, expected, tol=1.0e-6):
     np.testing.assert_allclose(_as_np(actual), np.array(expected, dtype=float), atol=tol, rtol=0.0)
+
+
+def _pyglet_window():
+    import pyglet
+
+    pyglet.options["headless"] = True
+    return pyglet.window
 
 
 class TestViewerCameraOrbit(unittest.TestCase):
@@ -112,9 +116,22 @@ class TestViewerCameraOrbit(unittest.TestCase):
         self.assertGreater(camera.pivot_distance, distance_after_dolly_in)
 
 
+class _FakeWindow:
+    def __init__(self, size=(640, 360), framebuffer_size=(1280, 720)):
+        self._size = size
+        self._framebuffer_size = framebuffer_size
+
+    def get_size(self):
+        return self._size
+
+    def get_framebuffer_size(self):
+        return self._framebuffer_size
+
+
 class _FakeRenderer:
     def __init__(self):
         self.pressed_keys = set()
+        self.window = _FakeWindow()
 
     def is_key_down(self, symbol):
         return symbol in self.pressed_keys
@@ -147,8 +164,10 @@ class TestViewerGLCameraInput(unittest.TestCase):
         self.assertEqual(viewer.camera.fov, start_fov)
 
     def test_ctrl_scroll_keeps_fov_zoom_escape_hatch(self):
+        window = _pyglet_window()
+
         viewer = _make_viewer_for_camera_input()
-        viewer.renderer.pressed_keys.add(pyglet.window.key.LCTRL)
+        viewer.renderer.pressed_keys.add(window.key.LCTRL)
         start_distance = viewer.camera.pivot_distance
         start_fov = viewer.camera.fov
 
@@ -158,6 +177,8 @@ class TestViewerGLCameraInput(unittest.TestCase):
         self.assertLess(viewer.camera.fov, start_fov)
 
     def test_middle_mouse_drag_orbits_about_pivot(self):
+        window = _pyglet_window()
+
         viewer = _make_viewer_for_camera_input()
         start_pos = _as_np(viewer.camera.pos)
 
@@ -166,7 +187,7 @@ class TestViewerGLCameraInput(unittest.TestCase):
             y=0.0,
             dx=25.0,
             dy=10.0,
-            buttons=pyglet.window.mouse.MIDDLE,
+            buttons=window.mouse.MIDDLE,
             modifiers=0,
         )
 
@@ -175,6 +196,8 @@ class TestViewerGLCameraInput(unittest.TestCase):
         self.assertAlmostEqual(viewer.camera.pivot_distance, 10.0)
 
     def test_shift_middle_mouse_drag_pans_camera_and_pivot(self):
+        window = _pyglet_window()
+
         viewer = _make_viewer_for_camera_input()
         start_pos = _as_np(viewer.camera.pos)
         start_pivot = _as_np(viewer.camera.pivot)
@@ -184,8 +207,8 @@ class TestViewerGLCameraInput(unittest.TestCase):
             y=0.0,
             dx=25.0,
             dy=10.0,
-            buttons=pyglet.window.mouse.MIDDLE,
-            modifiers=pyglet.window.key.MOD_SHIFT,
+            buttons=window.mouse.MIDDLE,
+            modifiers=window.key.MOD_SHIFT,
         )
 
         self.assertFalse(np.allclose(_as_np(viewer.camera.pos), start_pos))
@@ -197,6 +220,8 @@ class TestViewerGLCameraInput(unittest.TestCase):
         )
 
     def test_ctrl_middle_mouse_drag_dollies_without_moving_pivot(self):
+        window = _pyglet_window()
+
         viewer = _make_viewer_for_camera_input()
         start_distance = viewer.camera.pivot_distance
         start_pivot = _as_np(viewer.camera.pivot)
@@ -206,12 +231,21 @@ class TestViewerGLCameraInput(unittest.TestCase):
             y=0.0,
             dx=0.0,
             dy=10.0,
-            buttons=pyglet.window.mouse.MIDDLE,
-            modifiers=pyglet.window.key.MOD_CTRL,
+            buttons=window.mouse.MIDDLE,
+            modifiers=window.key.MOD_CTRL,
         )
 
         self.assertLess(viewer.camera.pivot_distance, start_distance)
         _assert_vec_close(self, viewer.camera.pivot, start_pivot)
+
+    def test_shift_middle_pan_uses_window_pixel_scale(self):
+        viewer = _make_viewer_for_camera_input()
+        viewer.camera.fov = 90.0
+        viewer.renderer.window = _FakeWindow(size=(640, 360), framebuffer_size=(1280, 720))
+
+        pan_scale = viewer._camera_pan_scale()
+
+        self.assertAlmostEqual(pan_scale, 2.0 * viewer.camera.pivot_distance / 360.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
🎥 Adds pivot-based orbit, pan, and dolly controls to ViewerGL, with docs and tests so model navigation behaves consistently across mouse and HiDPI setups.

Closes #2568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blender-style middle-mouse controls in the GL viewer: middle = orbit, Shift+middle = pan, Ctrl+middle = dolly; default scroll dollies toward the orbit pivot, Ctrl+scroll adjusts FOV; left-drag syncs the orbit pivot; F frames/recenters view; ESC closes viewer.

* **Documentation**
  * Viewer controls guide updated with detailed orbit/pivot semantics and key/mouse bindings (W/A/S/D, Q/E, H, SPACE, F).

* **Tests**
  * Added camera interaction tests for orbit, pan, dolly, pivot sync and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->