### PR TITLE
Fix MuJoCo geom_dataid indexing for mesh geoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
+- Fix MuJoCo mesh geom property updates indexing `geom_dataid` as a per-world array instead of the model-level array used by `mujoco_warp`, which could select the wrong mesh id for mesh geoms
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2244,7 +2244,7 @@ def update_geom_properties_kernel(
     mjc_geom_to_newton_shape: wp.array2d[wp.int32],
     geom_type: wp.array[int],
     GEOM_TYPE_MESH: int,
-    geom_dataid: wp.array2d[int],
+    geom_dataid: wp.array[int],
     mesh_pos: wp.array[wp.vec3],
     mesh_quat: wp.array[wp.quat],
     shape_mu_torsional: wp.array[float],
@@ -2321,7 +2321,7 @@ def update_geom_properties_kernel(
 
     # check if this is a mesh geom and apply mesh transformation
     if geom_type[geom_idx] == GEOM_TYPE_MESH:
-        mesh_id = geom_dataid[world, geom_idx]
+        mesh_id = geom_dataid[geom_idx]
         mesh_p = mesh_pos[mesh_id]
         mesh_q = mesh_quat[mesh_id]
         mesh_tf = wp.transform(mesh_p, quat_wxyz_to_xyzw(mesh_q))


### PR DESCRIPTION
## Description

Fix MuJoCo mesh geom property updates to use the correct `geom_dataid`
layout from `mujoco_warp`.

`mujoco_warp` stores `geom_dataid` as a model-level 1-D array, but
Newton's bridge kernel treated it as a per-world 2-D array. For mesh
geoms, that can read the wrong mesh id during property updates.

This PR aligns the kernel signature and indexing with the actual
`mujoco_warp` model layout and adds a changelog entry for the fix.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
uv run python -m unittest newton/tests/test_body_velocity.py
uv run python -m unittest newton/tests/test_examples.py
```

## Bug fix

**Steps to reproduce:**

1. Run a MuJoCo-backed scene that includes mesh geoms.
2. Trigger the bridge path that updates MuJoCo geom properties.
3. Observe that `geom_dataid` is indexed as `[world, geom]` even though
   `mujoco_warp` stores it as a model-level 1-D array.

**Minimal reproduction:**

```python
import newton
from newton.solvers import SolverMuJoCo

builder = newton.ModelBuilder()
model = builder.finalize()
solver = SolverMuJoCo(model)
```

## New feature / API change

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mesh geometry property updates in MuJoCo simulations where incorrect mesh IDs could be selected due to improper indexing. Mesh lookup now follows model-level semantics, ensuring geometries receive the correct mesh assignment. This improves visual/physical consistency of mesh geoms, prevents mis-assigned meshes during simulation updates, and reduces related selection errors and instability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->