### PR TITLE
Adding test viewer mixin class and refactor hydroelastic tests

### DIFF
--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import time
 import unittest
 from enum import Enum
 
@@ -14,6 +13,7 @@ from newton.tests.unittest_utils import (
     add_function_test,
     get_selected_cuda_test_devices,
 )
+from newton.tests.viewer_test_utils import ViewerScene, ViewerTestMixin
 
 # --- Configuration ---
 
@@ -1063,7 +1063,10 @@ def test_mujoco_hydroelastic_penetration_depth(test, device):
 # --- Test class ---
 
 
-class TestHydroelastic(unittest.TestCase):
+class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
+    DEFAULT_NUM_FRAMES = VIEWER_NUM_FRAMES
+    DEFAULT_SIM_DT = SIM_DT
+
     @unittest.skip("Visual debugging - run manually to view simulation")
     def test_view_stacked_primitive_cubes(self):
         """View stacked primitive cubes simulation with hydroelastic contacts."""
@@ -1081,47 +1084,33 @@ class TestHydroelastic(unittest.TestCase):
         model, solver, state_0, state_1, control, collision_pipeline, _, _ = build_stacked_cubes_scene(
             device, solver_fn, shape_type, cube_half
         )
-
-        try:
-            viewer = newton.viewer.ViewerGL()
-            viewer.set_model(model)
-        except Exception as e:
-            self.skipTest(f"ViewerGL not available: {e}")
-            return
-
-        sim_time = 0.0
         contacts = collision_pipeline.contacts()
         collision_pipeline.collide(state_0, contacts)
 
-        print(
-            f"\nRunning {shape_type.value} cubes simulation with {solver_name} solver for {VIEWER_NUM_FRAMES} frames..."
+        def step(scene: ViewerScene, dt: float) -> None:
+            scene.state_0, scene.state_1 = simulate(
+                solver, scene.model, scene.state_0, scene.state_1,
+                scene.control, scene.contacts, collision_pipeline, dt, SIM_SUBSTEPS,
+            )
+
+        def log_hydro_surface(viewer, _scene: ViewerScene) -> None:
+            viewer.log_hydro_contact_surface(
+                collision_pipeline.hydroelastic_sdf.get_contact_surface()
+                if collision_pipeline.hydroelastic_sdf is not None
+                else None,
+                penetrating_only=False,
+            )
+
+        scene = ViewerScene(
+            model=model,
+            state_0=state_0,
+            state_1=state_1,
+            contacts=contacts,
+            control=control,
+            step_fn=step,
+            extra_logs=[log_hydro_surface],
         )
-        print("Close the viewer window to stop.")
-
-        try:
-            for _frame in range(VIEWER_NUM_FRAMES):
-                viewer.begin_frame(sim_time)
-                viewer.log_state(state_0)
-                viewer.log_contacts(contacts, state_0)
-                viewer.log_hydro_contact_surface(
-                    (
-                        collision_pipeline.hydroelastic_sdf.get_contact_surface()
-                        if collision_pipeline.hydroelastic_sdf is not None
-                        else None
-                    ),
-                    penetrating_only=False,
-                )
-                viewer.end_frame()
-
-                state_0, state_1 = simulate(
-                    solver, model, state_0, state_1, control, contacts, collision_pipeline, SIM_DT, SIM_SUBSTEPS
-                )
-
-                sim_time += SIM_DT
-                time.sleep(0.016)
-
-        except KeyboardInterrupt:
-            print("\nSimulation stopped by user.")
+        self._run_viewer(scene, label=f"{shape_type.value} cubes ({solver_name})")
 
 
 # --- Register tests ---

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1089,8 +1089,15 @@ class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
 
         def step(scene: ViewerScene, dt: float) -> None:
             scene.state_0, scene.state_1 = simulate(
-                solver, scene.model, scene.state_0, scene.state_1,
-                scene.control, scene.contacts, collision_pipeline, dt, SIM_SUBSTEPS,
+                solver,
+                scene.model,
+                scene.state_0,
+                scene.state_1,
+                scene.control,
+                scene.contacts,
+                collision_pipeline,
+                dt,
+                SIM_SUBSTEPS,
             )
 
         def log_hydro_surface(viewer, _scene: ViewerScene) -> None:

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1064,6 +1064,13 @@ def test_mujoco_hydroelastic_penetration_depth(test, device):
 
 
 class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
+    """Hydroelastic-contact tests plus visual-debug viewer modes.
+
+    The ``test_view_*`` methods are decorated with :func:`unittest.skip` and
+    meant for local visual debugging; the viewer loop itself is provided by
+    :class:`~newton.tests.viewer_test_utils.ViewerTestMixin`.
+    """
+
     DEFAULT_NUM_FRAMES = VIEWER_NUM_FRAMES
     DEFAULT_SIM_DT = SIM_DT
 
@@ -1078,6 +1085,14 @@ class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
         self._run_viewer_test(ShapeType.MESH)
 
     def _run_viewer_test(self, shape_type: ShapeType, solver_name: str = "xpbd", cube_half: float = CUBE_HALF_LARGE):
+        """Build the stacked-cubes scene and hand it to :class:`ViewerTestMixin`.
+
+        Args:
+            shape_type: Whether the stacked cubes are primitive boxes or meshes.
+            solver_name: Key into the module-level ``solvers`` dict.
+            cube_half: Half-extent of each cube in meters; SDF parameters scale
+                proportionally to this value.
+        """
         device = wp.get_device("cuda:0")
         solver_fn = solvers[solver_name]
 
@@ -1088,6 +1103,7 @@ class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
         collision_pipeline.collide(state_0, contacts)
 
         def step(scene: ViewerScene, dt: float) -> None:
+            """Advance the hydroelastic simulation by ``dt`` using ``SIM_SUBSTEPS`` substeps."""
             scene.state_0, scene.state_1 = simulate(
                 solver,
                 scene.model,
@@ -1101,6 +1117,7 @@ class TestHydroelastic(ViewerTestMixin, unittest.TestCase):
             )
 
         def log_hydro_surface(viewer, _scene: ViewerScene) -> None:
+            """Overlay the current hydroelastic contact surface onto the viewer frame."""
             viewer.log_hydro_contact_surface(
                 collision_pipeline.hydroelastic_sdf.get_contact_surface()
                 if collision_pipeline.hydroelastic_sdf is not None

--- a/newton/tests/viewer_test_utils.py
+++ b/newton/tests/viewer_test_utils.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visualization helper for ``unittest`` tests.
+
+This module provides :class:`ViewerScene` (a description of what to render and
+how to advance one frame of simulation) and :class:`ViewerTestMixin` (a mixin
+for ``unittest.TestCase`` that owns the viewer loop). Test writers describe a
+scene and let the mixin handle the boilerplate: viewer construction with a
+``skipTest`` fallback, optional camera placement, ``begin_frame``/``end_frame``,
+default state and contact logging, frame pacing, and ``KeyboardInterrupt``.
+
+Example
+-------
+
+.. code-block:: python
+
+    class TestMyScene(ViewerTestMixin, unittest.TestCase):
+        DEFAULT_CAMERA = (wp.vec3(8.0, 4.0, 2.5), -20.0, -90.0)
+
+        @unittest.skip("Visual debugging - run manually to view simulation")
+        def test_view(self):
+            model, solver, state_0, state_1, control, contacts = build_scene()
+
+            def step(scene, dt):
+                scene.state_0, scene.state_1 = advance(
+                    solver, scene.model, scene.state_0, scene.state_1,
+                    scene.control, scene.contacts, dt,
+                )
+
+            self._run_viewer(
+                ViewerScene(
+                    model=model,
+                    state_0=state_0,
+                    state_1=state_1,
+                    contacts=contacts,
+                    control=control,
+                    step_fn=step,
+                ),
+                label="my-scene",
+            )
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import newton
+
+__all__ = ["ViewerScene", "ViewerTestMixin"]
+
+
+@dataclass
+class ViewerScene:
+    """Description of a scene to visualize and how to advance it one frame.
+
+    Attributes:
+        model: The :class:`newton.Model` driving the visualization.
+        state_0: Current simulation state. Logged at the start of each frame.
+        state_1: Scratch state used by ``step_fn`` for double-buffering.
+        step_fn: Callable ``(scene, dt) -> None`` advancing the simulation by
+            ``dt`` and updating ``scene.state_0``/``scene.state_1`` in place.
+        contacts: Optional contact buffer; logged each frame when present.
+        control: Optional :class:`newton.Control` for the solver.
+        pre_step: Optional callable ``(scene, frame_index) -> None`` invoked
+            before ``step_fn`` each frame (e.g. apply per-frame forces or IC).
+        extra_logs: Additional per-frame log callables ``(viewer, scene) -> None``
+            invoked between the default state/contacts logs and ``end_frame``.
+            Use for scene-specific overlays (e.g. hydroelastic contact surfaces).
+    """
+
+    model: Any
+    state_0: Any
+    state_1: Any
+    step_fn: Callable[["ViewerScene", float], None]
+    contacts: Any | None = None
+    control: Any | None = None
+    pre_step: Callable[["ViewerScene", int], None] | None = None
+    extra_logs: list[Callable[[Any, "ViewerScene"], None]] = field(default_factory=list)
+
+
+class ViewerTestMixin:
+    """unittest mixin implementing the viewer loop for visualization tests.
+
+    Subclass this alongside ``unittest.TestCase``. Override class attributes
+    (``DEFAULT_CAMERA``, ``DEFAULT_NUM_FRAMES``, etc.) to change defaults, or
+    pass ``camera``/``num_frames`` per call to :meth:`_run_viewer` to override
+    them on a single test.
+    """
+
+    # Camera as ``(pos, pitch, yaw)``. ``None`` leaves the viewer's default camera.
+    DEFAULT_CAMERA: tuple | None = None
+    DEFAULT_NUM_FRAMES: int = 300
+    # Real-time (sim-time) advanced per rendered frame. ``step_fn`` receives this dt.
+    DEFAULT_SIM_DT: float = 1.0 / 60.0
+    # Wall-clock pause between frames (~60 fps presentation rate).
+    DEFAULT_FRAME_SLEEP: float = 0.016
+
+    def _run_viewer(
+        self,
+        scene: ViewerScene,
+        *,
+        camera: tuple | None = None,
+        num_frames: int | None = None,
+        label: str = "",
+    ) -> None:
+        """Run the viewer loop for ``scene``.
+
+        Args:
+            scene: The :class:`ViewerScene` to render and advance.
+            camera: Optional ``(pos, pitch, yaw)`` overriding ``DEFAULT_CAMERA``.
+            num_frames: Optional override for ``DEFAULT_NUM_FRAMES``.
+            label: Short string used in the start-of-run log line.
+        """
+        try:
+            viewer = newton.viewer.ViewerGL()
+            viewer.set_model(scene.model)
+            cam = camera if camera is not None else self.DEFAULT_CAMERA
+            if cam is not None:
+                viewer.set_camera(pos=cam[0], pitch=cam[1], yaw=cam[2])
+        except Exception as e:
+            self.skipTest(f"ViewerGL not available: {e}")
+            return
+
+        n_frames = num_frames if num_frames is not None else self.DEFAULT_NUM_FRAMES
+        run_label = label or type(self).__name__
+        print(f"\nViewer: {run_label} for {n_frames} frames. Close the viewer window or press Ctrl+C to stop.")
+
+        sim_time = 0.0
+        try:
+            for frame_index in range(n_frames):
+                viewer.begin_frame(sim_time)
+                viewer.log_state(scene.state_0)
+                if scene.contacts is not None:
+                    viewer.log_contacts(scene.contacts, scene.state_0)
+                for log_fn in scene.extra_logs:
+                    log_fn(viewer, scene)
+                viewer.end_frame()
+
+                if scene.pre_step is not None:
+                    scene.pre_step(scene, frame_index)
+                scene.step_fn(scene, self.DEFAULT_SIM_DT)
+
+                sim_time += self.DEFAULT_SIM_DT
+                time.sleep(self.DEFAULT_FRAME_SLEEP)
+        except KeyboardInterrupt:
+            print("\nSimulation stopped by user.")

--- a/newton/tests/viewer_test_utils.py
+++ b/newton/tests/viewer_test_utils.py
@@ -24,8 +24,13 @@ Example
 
             def step(scene, dt):
                 scene.state_0, scene.state_1 = advance(
-                    solver, scene.model, scene.state_0, scene.state_1,
-                    scene.control, scene.contacts, dt,
+                    solver,
+                    scene.model,
+                    scene.state_0,
+                    scene.state_1,
+                    scene.control,
+                    scene.contacts,
+                    dt,
                 )
 
             self._run_viewer(
@@ -44,8 +49,9 @@ Example
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 import newton
 
@@ -74,11 +80,11 @@ class ViewerScene:
     model: Any
     state_0: Any
     state_1: Any
-    step_fn: Callable[["ViewerScene", float], None]
+    step_fn: Callable[[ViewerScene, float], None]
     contacts: Any | None = None
     control: Any | None = None
-    pre_step: Callable[["ViewerScene", int], None] | None = None
-    extra_logs: list[Callable[[Any, "ViewerScene"], None]] = field(default_factory=list)
+    pre_step: Callable[[ViewerScene, int], None] | None = None
+    extra_logs: list[Callable[[Any, ViewerScene], None]] = field(default_factory=list)
 
 
 class ViewerTestMixin:


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

This MR adds a mixin class that provides a simple viewer framework for unit testing. This makes it simpler for new tests to implement viewers.

This also refactors `test_hydroelastic.py` to use this new framework as a demonstration.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

```
# Viewer tests
uv run --extra dev -m newton.tests -k test_view_stacked_primitive_cubes
uv run --extra dev -m newton.tests -k test_view_stacked_mesh_cubes

# Hydroelastic tests
uv run --extra dev -m newton.tests -k test_hydroelastic
```

## New feature / API change

```python
import newton
from newton.tests.viewer_test_utils import ViewerScene, ViewerTestMixin

class TestMyScene(ViewerTestMixin, unittest.TestCase):
    DEFAULT_CAMERA = (wp.vec3(8.0, 4.0, 2.5), -20.0, -90.0)
    @unittest.skip("Visual debugging - run manually to view simulation")
    def test_view(self):
        model, solver, state_0, state_1, control, contacts = build_scene()
        def step(scene, dt):
            scene.state_0, scene.state_1 = advance(
                solver, scene.model, scene.state_0, scene.state_1,
                scene.control, scene.contacts, dt,
            )
        self._run_viewer(
            ViewerScene(
                model=model,
                state_0=state_0,
                state_1=state_1,
                contacts=contacts,
                control=control,
                step_fn=step,
            ),
            label="my-scene",
        )
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated the viewer-based hydroelastic test harness into a reusable mixin-driven flow and a scene abstraction, reducing duplication and exposing sensible default viewer parameters.

* **Tests**
  * Added utilities to package simulation scenes and run frame-by-frame viewer tests with stable state swapping, per-frame hooks, optional extra logging, graceful run/skip behavior, and interrupt handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->