### PR TITLE
canonicalize collision pairs by GeoType instead of index

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1245,13 +1245,19 @@ class ModelBuilder:
         """Actuator entry groups accumulated from :meth:`add_actuator`, keyed by controller class and shared params."""
 
     def add_shape_collision_filter_pair(self, shape_a: int, shape_b: int) -> None:
-        """Add a collision filter pair in canonical order.
+        """Add a collision filter pair in canonical order (canonicalized by GeoType, then Index).
 
         Args:
             shape_a: First shape index
             shape_b: Second shape index
         """
-        self.shape_collision_filter_pairs.append((min(shape_a, shape_b), max(shape_a, shape_b)))
+        type1 = self.shape_type[shape_a]
+        type2 = self.shape_type[shape_b]
+        if type1 > type2:
+            shape_a, shape_b = shape_b, shape_a
+        elif type1 == type2 and shape_a > shape_b:
+            shape_a, shape_b = shape_b, shape_a
+        self.shape_collision_filter_pairs.append((shape_a, shape_b))
 
     def add_custom_attribute(self, attribute: CustomAttribute) -> None:
         """
@@ -5454,11 +5460,7 @@ class ModelBuilder:
 
         self.shape_body.append(body)
         shape = self.shape_count
-        if cfg.has_shape_collision:
-            # no contacts between shapes of the same body
-            for same_body_shape in self.body_shapes[body]:
-                self.add_shape_collision_filter_pair(same_body_shape, shape)
-        self.body_shapes[body].append(shape)
+
         self.shape_label.append(label or f"shape_{shape}")
         self.shape_transform.append(xform)
         # Get flags and clear HYDROELASTIC for unsupported shape types (PLANE, HFIELD)
@@ -5498,6 +5500,12 @@ class ModelBuilder:
         self.shape_sdf_target_voxel_size.append(cfg.sdf_target_voxel_size)
         self.shape_sdf_max_resolution.append(cfg.sdf_max_resolution)
         self.shape_sdf_texture_format.append(cfg.sdf_texture_format)
+
+        if cfg.has_shape_collision:
+            # no contacts between shapes of the same body
+            for same_body_shape in self.body_shapes[body]:
+                self.add_shape_collision_filter_pair(same_body_shape, shape)
+        self.body_shapes[body].append(shape)
 
         if cfg.has_shape_collision and cfg.collision_filter_parent and body > -1 and body in self.joint_parents:
             for parent_body in self.joint_parents[body]:
@@ -9780,9 +9788,16 @@ class ModelBuilder:
             m.shape_material_kh = wp.array(self.shape_material_kh, dtype=wp.float32, requires_grad=requires_grad)
             m.shape_gap = wp.array(self.shape_gap, dtype=wp.float32, requires_grad=requires_grad)
 
-            m.shape_collision_filter_pairs = {
-                (min(s1, s2), max(s1, s2)) for s1, s2 in self.shape_collision_filter_pairs
-            }
+            for s1, s2 in self.shape_collision_filter_pairs:
+                t1 = self.shape_type[s1]
+                t2 = self.shape_type[s2]
+                a, b = s1, s2
+                if t1 > t2:
+                    a, b = s2, s1
+                elif t1 == t2 and s1 > s2:
+                    a, b = s2, s1
+                m.shape_collision_filter_pairs.add((a, b))
+
             m.shape_collision_group = wp.array(self.shape_collision_group, dtype=wp.int32)
 
             # ---------------------
@@ -10765,7 +10780,16 @@ class ModelBuilder:
                 if not self._test_world_and_group_pair(world1, world2, collision_group1, collision_group2):
                     continue
 
-                if s1 > s2:
+                type1 = self.shape_type[s1]
+                type2 = self.shape_type[s2]
+
+                if type1 > type2:
+                    # If type1 is "larger" (e.g., MESH vs SPHERE), swap them
+                    # so the simpler shape is always shape_a
+                    shape_a, shape_b = s2, s1
+                elif type1 == type2 and s1 > s2:
+                    # If they are the same type, fall back to index sorting
+                    # to maintain a consistent unique order
                     shape_a, shape_b = s2, s1
                 else:
                     shape_a, shape_b = s1, s2

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -846,7 +846,7 @@ class CollisionPipeline:
         filters = model.shape_collision_filter_pairs
         if not filters:
             return None
-        sorted_pairs = sorted(filters)  # lexicographic (already canonical min,max)
+        sorted_pairs = sorted(filters)  # lexicographic (canonicalized by GeoType, then Index)
         return wp.array(
             np.array(sorted_pairs),
             dtype=wp.vec2i,

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -244,7 +244,7 @@ class Model:
         self.shape_collision_group: wp.array[wp.int32] | None = None
         """Collision group of each shape, shape [shape_count], int. Array populated during finalization."""
         self.shape_collision_filter_pairs: set[tuple[int, int]] = set()
-        """Pairs of shape indices (s1, s2) that should not collide. Pairs are in canonical order: s1 < s2."""
+        """Pairs of shape indices (s1, s2) that should not collide. Pairs are in canonical order (First GeoType then Index): t2 < t1, s1 < s2."""
         self.shape_collision_radius: wp.array[wp.float32] | None = None
         """Collision radius [m] for bounding sphere broadphase, shape [shape_count], float. Not supported by :class:`~newton.solvers.SolverMuJoCo`."""
         self.shape_contact_pairs: wp.array[wp.vec2i] | None = None

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -244,7 +244,7 @@ class Model:
         self.shape_collision_group: wp.array[wp.int32] | None = None
         """Collision group of each shape, shape [shape_count], int. Array populated during finalization."""
         self.shape_collision_filter_pairs: set[tuple[int, int]] = set()
-        """Pairs of shape indices (s1, s2) that should not collide. Pairs are in canonical order (First GeoType then Index): t2 < t1, s1 < s2."""
+        """Pairs of shape indices (s1, s2) that should not collide. Pairs are in canonical order (First GeoType then Index): t1 < t2, t1 == t2 and s1 < s2, s1 < s2."""
         self.shape_collision_radius: wp.array[wp.float32] | None = None
         """Collision radius [m] for bounding sphere broadphase, shape [shape_count], float. Not supported by :class:`~newton.solvers.SolverMuJoCo`."""
         self.shape_contact_pairs: wp.array[wp.vec2i] | None = None

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -237,9 +237,7 @@ def compute_required_contact_capacity(
         s2 = int(shape_pair[1])
         type1 = int(shape_type_np[s1])
         type2 = int(shape_type_np[s2])
-        if type1 > type2:
-            s1, s2 = s2, s1
-            type1, type2 = type2, type1
+
         num_contacts_a, num_contacts_b = max_contacts_for_shape_pair(
             type_a=type1,
             type_b=type2,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3721,7 +3721,11 @@ class SolverMuJoCo(SolverBase):
             excluded = True
             for shape_1 in shapes_1:
                 for shape_2 in shapes_2:
-                    if shape_1 > shape_2:
+                    type_1 = model.shape_type[shape_1]
+                    type_2 = model.shape_type[shape_2]
+                    if type_1 > type_2:
+                        s1, s2 = shape_2, shape_1
+                    elif type_1 == type_2 and shape_1 > shape_2:
                         s1, s2 = shape_2, shape_1
                     else:
                         s1, s2 = shape_1, shape_2
@@ -3762,15 +3766,20 @@ class SolverMuJoCo(SolverBase):
         shape_collision_group_np = model.shape_collision_group.numpy()
         cgroup = [shape_collision_group_np[i] for i in selected_shapes]
         # edges representing colliding shape pairs
-        graph_edges = [
-            (i, j)
-            for i, j in zip(shape_a, shape_b, strict=True)
-            if (
-                (min(selected_shapes[i], selected_shapes[j]), max(selected_shapes[i], selected_shapes[j]))
-                not in model.shape_collision_filter_pairs
-                and (cgroup[i] == cgroup[j] or cgroup[i] == -1 or cgroup[j] == -1)
-            )
-        ]
+        graph_edges = []
+        for i, j in zip(shape_a, shape_b, strict=True):
+            s1 = selected_shapes[i]
+            s2 = selected_shapes[j]
+            t1 = model.shape_type[s1]
+            t2 = model.shape_type[s2]
+            if t1 > t2:
+                s1, s2 = s2, s1
+            elif t1 == t2 and s1 > s2:
+                s1, s2 = s2, s1
+            if (s1, s2) not in model.shape_collision_filter_pairs:
+                if cgroup[i] == cgroup[j] or cgroup[i] == -1 or cgroup[j] == -1:
+                    graph_edges.append((i, j))
+
         shape_color = np.zeros(model.shape_count, dtype=np.int32)
         if len(graph_edges) > 0:
             color_groups = color_graph(

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3721,8 +3721,8 @@ class SolverMuJoCo(SolverBase):
             excluded = True
             for shape_1 in shapes_1:
                 for shape_2 in shapes_2:
-                    type_1 = model.shape_type[shape_1]
-                    type_2 = model.shape_type[shape_2]
+                    type_1 = model.shape_type.numpy()[shape_1]
+                    type_2 = model.shape_type.numpy()[shape_2]
                     if type_1 > type_2:
                         s1, s2 = shape_2, shape_1
                     elif type_1 == type_2 and shape_1 > shape_2:
@@ -3770,8 +3770,8 @@ class SolverMuJoCo(SolverBase):
         for i, j in zip(shape_a, shape_b, strict=True):
             s1 = selected_shapes[i]
             s2 = selected_shapes[j]
-            t1 = model.shape_type[s1]
-            t2 = model.shape_type[s2]
+            t1 = model.shape_type.numpy()[s1]
+            t2 = model.shape_type.numpy()[s2]
             if t1 > t2:
                 s1, s2 = s2, s1
             elif t1 == t2 and s1 > s2:

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -3576,8 +3576,8 @@ def _cable_graph_collision_filter_pairs_impl(test: unittest.TestCase, device):
         test.assertEqual(len(builder.body_shapes[body_b]), 1, msg="expected one shape per rod body in this test")
         sa = int(builder.body_shapes[body_a][0])
         sb = int(builder.body_shapes[body_b][0])
-        t1 = model.shape_body[sa]
-        t2 = model.shape_body[sb]
+        t1 = model.shape_body.numpy()[sa]
+        t2 = model.shape_body.numpy()[sb]
         if t1 > t2:
             sa, sb = sb, sa
         elif t1 == t2 and sa > sb:

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -3576,7 +3576,13 @@ def _cable_graph_collision_filter_pairs_impl(test: unittest.TestCase, device):
         test.assertEqual(len(builder.body_shapes[body_b]), 1, msg="expected one shape per rod body in this test")
         sa = int(builder.body_shapes[body_a][0])
         sb = int(builder.body_shapes[body_b][0])
-        pair = (min(sa, sb), max(sa, sb))
+        t1 = model.shape_body[sa]
+        t2 = model.shape_body[sb]
+        if t1 > t2:
+            sa, sb = sb, sa
+        elif t1 == t2 and sa > sb:
+            sa, sb = sb, sa
+        pair = (sa, sb)
         test.assertIn(
             pair, model.shape_collision_filter_pairs, msg=f"missing collision filter pair for bodies {body_a}-{body_b}"
         )

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -3576,8 +3576,8 @@ def _cable_graph_collision_filter_pairs_impl(test: unittest.TestCase, device):
         test.assertEqual(len(builder.body_shapes[body_b]), 1, msg="expected one shape per rod body in this test")
         sa = int(builder.body_shapes[body_a][0])
         sb = int(builder.body_shapes[body_b][0])
-        t1 = model.shape_body.numpy()[sa]
-        t2 = model.shape_body.numpy()[sb]
+        t1 = model.shape_type.numpy()[sa]
+        t2 = model.shape_type.numpy()[sb]
         if t1 > t2:
             sa, sb = sb, sa
         elif t1 == t2 and sa > sb:

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -485,8 +485,8 @@ def test_shape_collision_filter_pairs(test, device, broad_phase: str):
         for i in range(n):
             s0 = int(contacts.rigid_contact_shape0.numpy()[i])
             s1 = int(contacts.rigid_contact_shape1.numpy()[i])
-            t1 = model.shape_type[s0]
-            t2 = model.shape_type[s1]
+            t1 = model.shape_type.numpy()[s0]
+            t2 = model.shape_type.numpy()[s1]
             if t1 > t2:
                 s0, s1 = s1, s0
             elif t1 == t2 and s1 > s2:
@@ -537,8 +537,17 @@ def test_collision_filter_consistent_across_broadphases(test, device):
 
         # Exclude one pair so only two pairs should generate contacts
         builder.add_shape_collision_filter_pair(shape_a, shape_b)
-
+        t1 = builder.shape_type
         model = builder.finalize(device=device)
+
+        t1 = model.shape_type.numpy()[shape_a]
+        t2 = model.shape_type.numpy()[shape_b]
+        if t1 > t2:
+            shape_a, shape_b = shape_b, shape_a
+        elif t1 == t2 and shape_a > shape_b:
+            shape_a, shape_b = shape_b, shape_a
+
+        excluded = (shape_a, shape_b)
 
         def _contact_pairs(broad_phase):
             pipeline = newton.CollisionPipeline(model, broad_phase=broad_phase)

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -548,6 +548,14 @@ def test_collision_filter_consistent_across_broadphases(test, device):
 
         excluded = (shape_a, shape_b)
 
+        shape_type_np = model.shape_type.numpy()
+
+        def _canonical(s0: int, s1: int) -> tuple[int, int]:
+            t0, t1 = shape_type_np[s0], shape_type_np[s1]
+            if t0 > t1 or (t0 == t1 and s0 > s1):
+                return (s1, s0)
+            return (s0, s1)
+
         def _contact_pairs(broad_phase):
             pipeline = newton.CollisionPipeline(model, broad_phase=broad_phase)
             state = model.state()
@@ -560,7 +568,7 @@ def test_collision_filter_consistent_across_broadphases(test, device):
             for i in range(n):
                 s0 = int(shape0_np[i])
                 s1 = int(shape1_np[i])
-                pairs.add((min(s0, s1), max(s0, s1)))
+                pairs.add(_canonical(s0, s1))
             return pairs
 
         pairs_explicit = _contact_pairs("explicit")

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -481,12 +481,17 @@ def test_shape_collision_filter_pairs(test, device, broad_phase: str):
         contacts = pipeline.contacts()
         pipeline.collide(state, contacts)
         n = contacts.rigid_contact_count.numpy()[0]
-        excluded = (min(shape_a, shape_b), max(shape_a, shape_b))
+        shape_type_np = model.shape_type.numpy()
+        ta, tb = shape_type_np[shape_a], shape_type_np[shape_b]
+        if ta > tb or (ta == tb and shape_a > shape_b):
+            excluded = (shape_b, shape_a)
+        else:
+            excluded = (shape_a, shape_b)
         for i in range(n):
             s0 = int(contacts.rigid_contact_shape0.numpy()[i])
             s1 = int(contacts.rigid_contact_shape1.numpy()[i])
-            t1 = model.shape_type.numpy()[s0]
-            t2 = model.shape_type.numpy()[s1]
+            t1 = shape_type_np[s0]
+            t2 = shape_type_np[s1]
             if t1 > t2:
                 s0, s1 = s1, s0
             elif t1 == t2 and s0 > s1:

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -489,7 +489,7 @@ def test_shape_collision_filter_pairs(test, device, broad_phase: str):
             t2 = model.shape_type.numpy()[s1]
             if t1 > t2:
                 s0, s1 = s1, s0
-            elif t1 == t2 and s1 > s2:
+            elif t1 == t2 and s0 > s1:
                 s0, s1 = s1, s0
             pair = (s0, s1)
             test.assertNotEqual(
@@ -537,7 +537,6 @@ def test_collision_filter_consistent_across_broadphases(test, device):
 
         # Exclude one pair so only two pairs should generate contacts
         builder.add_shape_collision_filter_pair(shape_a, shape_b)
-        t1 = builder.shape_type
         model = builder.finalize(device=device)
 
         t1 = model.shape_type.numpy()[shape_a]

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -474,7 +474,7 @@ def test_shape_collision_filter_pairs(test, device, broad_phase: str):
         body_b = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.0)))
         shape_b = builder.add_shape_sphere(body=body_b, radius=0.5)
         # Exclude this pair so they must not generate contacts
-        builder.shape_collision_filter_pairs.append((min(shape_a, shape_b), max(shape_a, shape_b)))
+        builder.add_shape_collision_filter_pair(shape_a, shape_b)
         model = builder.finalize(device=device)
         pipeline = newton.CollisionPipeline(model, broad_phase=broad_phase)
         state = model.state()
@@ -485,7 +485,13 @@ def test_shape_collision_filter_pairs(test, device, broad_phase: str):
         for i in range(n):
             s0 = int(contacts.rigid_contact_shape0.numpy()[i])
             s1 = int(contacts.rigid_contact_shape1.numpy()[i])
-            pair = (min(s0, s1), max(s0, s1))
+            t1 = model.shape_type[s0]
+            t2 = model.shape_type[s1]
+            if t1 > t2:
+                s0, s1 = s1, s0
+            elif t1 == t2 and s1 > s2:
+                s0, s1 = s1, s0
+            pair = (s0, s1)
             test.assertNotEqual(
                 pair,
                 excluded,
@@ -530,8 +536,7 @@ def test_collision_filter_consistent_across_broadphases(test, device):
         builder.add_shape_sphere(body=body_c, radius=0.5)
 
         # Exclude one pair so only two pairs should generate contacts
-        excluded = (min(shape_a, shape_b), max(shape_a, shape_b))
-        builder.shape_collision_filter_pairs.append(excluded)
+        builder.add_shape_collision_filter_pair(shape_a, shape_b)
 
         model = builder.finalize(device=device)
 

--- a/newton/tests/test_environment_group_collision.py
+++ b/newton/tests/test_environment_group_collision.py
@@ -266,11 +266,14 @@ class TestEnvironmentGroupCollision(unittest.TestCase):
         child_body = builder.add_link(xform=wp.transform_identity())
         builder.add_shape_box(body=child_body, hx=0.5, hy=0.5, hz=0.5)  # index 0
         builder.add_shape_box(body=child_body, hx=0.5, hy=0.5, hz=0.5)  # index 1
+        builder.add_shape_cone(
+            body=child_body, radius=0.5, half_height=0.5
+        )  # index 2 (non-box shape to test mixed types)
 
         # Create parent body with shapes after
         parent_body = builder.add_link(xform=wp.transform((2.0, 0, 0), wp.quat_identity()))
-        builder.add_shape_box(body=parent_body, hx=0.5, hy=0.5, hz=0.5)  # index 2
         builder.add_shape_box(body=parent_body, hx=0.5, hy=0.5, hz=0.5)  # index 3
+        builder.add_shape_box(body=parent_body, hx=0.5, hy=0.5, hz=0.5)  # index 4
 
         # Connect with joint - this will naturally create non-canonical pairs!
         # Without canonicalization, this would add pairs like (2,0), (2,1), (3,0), (3,1)
@@ -291,7 +294,7 @@ class TestEnvironmentGroupCollision(unittest.TestCase):
         sub_builder.add_shape_box(body=sub_body, hx=0.5, hy=0.5, hz=0.5)
 
         # Add more shapes to main builder to create offset
-        builder.add_shape_box(body=child_body, hx=0.5, hy=0.5, hz=0.5)  # index 4
+        builder.add_shape_box(body=child_body, hx=0.5, hy=0.5, hz=0.5)  # index 5
 
         # Merge sub_builder - its filter pairs need canonicalization after offset
         builder.add_builder(sub_builder)
@@ -301,15 +304,26 @@ class TestEnvironmentGroupCollision(unittest.TestCase):
 
         # Verify that parent-child filtering worked correctly
         contact_pairs = model.shape_contact_pairs.numpy()
-        contact_set = {tuple(sorted(pair)) for pair in contact_pairs}
+        contact_set = {tuple(pair) for pair in contact_pairs}
+
+        def get_canonical_pair(t1, t2, s1, s2):
+            if t1 > t2:
+                return (s2, s1)
+            elif t1 == t2 and s1 > s2:
+                return (s2, s1)
+            return (s1, s2)
 
         # Parent shapes (2,3) should not collide with child shapes (0,1,4)
-        for parent_shape in [2, 3]:
-            for child_shape in [0, 1, 4]:
+        for parent_shape in [3, 4]:
+            for child_shape in [0, 1, 2, 5]:
+                type1 = model.shape_type.numpy()[parent_shape]
+                type2 = model.shape_type.numpy()[child_shape]
+                pair_to_check = get_canonical_pair(type1, type2, parent_shape, child_shape)
+
                 self.assertNotIn(
-                    (min(parent_shape, child_shape), max(parent_shape, child_shape)),
+                    pair_to_check,
                     contact_set,
-                    f"Parent shape {parent_shape} should not collide with child shape {child_shape}",
+                    f"Pair {pair_to_check} (Types: {type1}, {type2}) should have been filtered out!",
                 )
 
 

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -491,17 +491,27 @@ class TestModelMesh(unittest.TestCase):
         model = builder.finalize()
 
         # Verify all collision filter pairs are in canonical order (s1 < s2)
+
+        shape_type = model.shape_type.numpy()
+
+        def normalize_pair(s1, s2):
+            t1 = shape_type[s1]
+            t2 = shape_type[s2]
+            if t1 > t2 or (t1 == t2 and s1 > s2):
+                return (s2, s1)
+            return (s1, s2)
+
         for s1, s2 in model.shape_collision_filter_pairs:
-            self.assertLess(
-                model.shape_type.numpy()[s1],
-                model.shape_type.numpy()[s2],
-                f"Collision filter pair ({s1}, {s2}) type ({model.shape_type.numpy()[s1]}, {model.shape_type.numpy()[s2]})is not in canonical order",
+            self.assertEqual(
+                (s1, s2),
+                normalize_pair(s1, s2),
+                f"Collision filter pair ({s1}, {s2}) with types ({shape_type[s1]}, {shape_type[s2]}) is not in canonical order",
             )
 
         # Verify we have the expected pairs (should be normalized to canonical order)
-        self.assertIn((shape0, shape1), model.shape_collision_filter_pairs)
-        self.assertIn((shape0, shape2), model.shape_collision_filter_pairs)
-        self.assertIn((shape2, shape1), model.shape_collision_filter_pairs)
+        self.assertIn(normalize_pair(shape0, shape1), model.shape_collision_filter_pairs)
+        self.assertIn(normalize_pair(shape0, shape2), model.shape_collision_filter_pairs)
+        self.assertIn(normalize_pair(shape2, shape1), model.shape_collision_filter_pairs)
 
     def test_validate_structure_invalid_shape_body(self):
         """Test that _validate_structure catches invalid shape_body references."""

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -330,7 +330,7 @@ class TestModelMesh(unittest.TestCase):
             t2 = builder.shape_type[b]
             if t1 > t2:
                 return (b, a)
-            elif t1 == t2 and s1 > s2:
+            elif t1 == t2 and a > b:
                 return (b, a)
             return (a, b)
 
@@ -493,9 +493,9 @@ class TestModelMesh(unittest.TestCase):
         # Verify all collision filter pairs are in canonical order (s1 < s2)
         for s1, s2 in model.shape_collision_filter_pairs:
             self.assertLess(
-                mode.shape_type[s1],
-                model.shape_type[s2],
-                f"Collision filter pair ({s1}, {s2}) type ({model.shape_type[s1]}, {model.shape_type[s2]})is not in canonical order",
+                model.shape_type.numpy()[s1],
+                model.shape_type.numpy()[s2],
+                f"Collision filter pair ({s1}, {s2}) type ({model.shape_type.numpy()[s1]}, {model.shape_type.numpy()[s2]})is not in canonical order",
             )
 
         # Verify we have the expected pairs (should be normalized to canonical order)

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -325,11 +325,17 @@ class TestModelMesh(unittest.TestCase):
         self.assertAlmostEqual(model.approx_attr.numpy()[extra_shape], shape_attr, places=6)
 
     def test_approximate_meshes_collision_filter_child_bodies(self):
-        def normalize_pair(a, b):
-            return (min(a, b), max(a, b))
+        def normalize_pair(builder, a, b):
+            t1 = builder.shape_type[a]
+            t2 = builder.shape_type[b]
+            if t1 > t2:
+                return (b, a)
+            elif t1 == t2 and s1 > s2:
+                return (b, a)
+            return (a, b)
 
         def get_filter_set(builder):
-            return {normalize_pair(a, b) for a, b in builder.shape_collision_filter_pairs}
+            return {normalize_pair(builder, a, b) for a, b in builder.shape_collision_filter_pairs}
 
         builder = ModelBuilder()
 
@@ -353,12 +359,12 @@ class TestModelMesh(unittest.TestCase):
         # At this point, initial shapes should be filtered between adjacent bodies
         filter_set = get_filter_set(builder)
         self.assertIn(
-            normalize_pair(shape0_initial, shape1_initial),
+            normalize_pair(builder, shape0_initial, shape1_initial),
             filter_set,
             "Initial body0-body1 shapes should be filtered",
         )
         self.assertIn(
-            normalize_pair(shape1_initial, shape2_initial),
+            normalize_pair(builder, shape1_initial, shape2_initial),
             filter_set,
             "Initial body1-body2 shapes should be filtered",
         )
@@ -374,7 +380,7 @@ class TestModelMesh(unittest.TestCase):
         # Verify: new body0 shapes should filter with ALL body1 shapes (including initial)
         for parent_shape in [shape0_extra1, shape0_extra2]:
             for child_shape in [shape1_initial, shape1_extra1]:
-                expected_pair = normalize_pair(parent_shape, child_shape)
+                expected_pair = normalize_pair(builder, parent_shape, child_shape)
                 self.assertIn(
                     expected_pair,
                     filter_set,
@@ -384,7 +390,7 @@ class TestModelMesh(unittest.TestCase):
         # Verify: new body1 shapes should filter with ALL body0 shapes (parent)
         for child_shape in [shape1_extra1]:
             for parent_shape in [shape0_initial, shape0_extra1, shape0_extra2]:
-                expected_pair = normalize_pair(parent_shape, child_shape)
+                expected_pair = normalize_pair(builder, parent_shape, child_shape)
                 self.assertIn(
                     expected_pair,
                     filter_set,
@@ -393,7 +399,7 @@ class TestModelMesh(unittest.TestCase):
 
         # Verify: new body1 shapes should filter with ALL body2 shapes (child)
         for parent_shape in [shape1_extra1]:
-            expected_pair = normalize_pair(parent_shape, shape2_initial)
+            expected_pair = normalize_pair(builder, parent_shape, shape2_initial)
             self.assertIn(
                 expected_pair,
                 filter_set,
@@ -486,12 +492,16 @@ class TestModelMesh(unittest.TestCase):
 
         # Verify all collision filter pairs are in canonical order (s1 < s2)
         for s1, s2 in model.shape_collision_filter_pairs:
-            self.assertLess(s1, s2, f"Collision filter pair ({s1}, {s2}) is not in canonical order")
+            self.assertLess(
+                mode.shape_type[s1],
+                model.shape_type[s2],
+                f"Collision filter pair ({s1}, {s2}) type ({model.shape_type[s1]}, {model.shape_type[s2]})is not in canonical order",
+            )
 
         # Verify we have the expected pairs (should be normalized to canonical order)
         self.assertIn((shape0, shape1), model.shape_collision_filter_pairs)
         self.assertIn((shape0, shape2), model.shape_collision_filter_pairs)
-        self.assertIn((shape1, shape2), model.shape_collision_filter_pairs)
+        self.assertIn((shape2, shape1), model.shape_collision_filter_pairs)
 
     def test_validate_structure_invalid_shape_body(self):
         """Test that _validate_structure catches invalid shape_body references."""


### PR DESCRIPTION
closes #1281

## Description

This PR refactors the canonicalization logic for collision shape pairs throughout the ecosystem. Previously, pairs were ordered based solely on their creation index: (min(id1, id2), max(id1, id2)). This created a logic mismatch with solver kernels and contact capacity logic that require GeoType sorting for efficient contact math, leading to redundant allocations and potential filtering failures.

Key Changes:

Unified Canonicalization: All shape pairs are now ordered by GeoType first, with the Shape Index acting as a tie-breaker.

Builder Robustness: Fixed an IndexError in add_shape() where collision filters were being generated before shape metadata (like type) was appended to the builder's internal lists.

Solver Synchronicity: Updated Kamino conversions and MuJoCo solver logic to ensure that geom-pair exclusions and contact manifolds match the new engine-wide ordering.

Logic Simplification: Removed redundant type-swapping logic in model.py and collide.py, as the builder now guarantees the incoming order.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

uv run --extra dev -m newton.tests.test_collision_pipeline
uv run --extra dev -m newton.tests.test_model
uv run --extra dev -m newton.tests.cable
uv run --extra dev -m newton.tests.test_enviornment_group_collision

## New feature / API change

New Feature / API Change

Internal API change to shape pair ordering. Downstream code relying on model.shape_contact_pairs or model.shape_collision_filter_pairs should expect the following sort priority:

1. GeoType (Ascending)
2. Shape Index (Ascending)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Collision-filter pair canonicalization now orders by shape type first, then index, yielding consistent behavior for mixed-shape interactions.
  * Solver contact-capacity logic aligned with the new type-aware pair ordering to ensure consistent contact handling.

* **Tests**
  * Collision-filtering and contact-pair tests updated and expanded to validate the type-first canonical ordering and consistent exclusion across pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->