### PR TITLE
Disable flaky in-cup placement check in panda hydro example

### DIFF
--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -431,21 +431,26 @@ class Example:
                 f"max lift={max_lift:.3f} (expected > {min_lift_height})"
             )
 
-        # Verify that the object ended up in the cup
-        if self.put_in_cup:
-            body_q = self.state_0.body_q.numpy()
-            cup_x, cup_y, cup_z = self.cup_pos
-            tolerance_xy = 0.05
-            min_z = cup_z - 0.05
-
-            for world_idx in range(self.world_count):
-                object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
-                x, y, z = body_q[object_body_idx][:3]
-                assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
-                    f"World {world_idx}: Object is not in the cup. "
-                    f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
-                    f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
-                )
+        # In-cup placement check disabled — see newton-physics/newton#1337.
+        # Hydroelastic contact ordering on GPU still occasionally lets the pen
+        # slip out of the gripper during transport, producing both small drifts
+        # and complete misses. Lift-height check above remains as a coarse
+        # pickup verification.
+        # # Verify that the object ended up in the cup
+        # if self.put_in_cup:
+        #     body_q = self.state_0.body_q.numpy()
+        #     cup_x, cup_y, cup_z = self.cup_pos
+        #     tolerance_xy = 0.05
+        #     min_z = cup_z - 0.05
+        #
+        #     for world_idx in range(self.world_count):
+        #         object_body_idx = world_idx * self.bodies_per_world + self.object_body_local
+        #         x, y, z = body_q[object_body_idx][:3]
+        #         assert abs(x - cup_x) < tolerance_xy and abs(y - cup_y) < tolerance_xy and z > min_z, (
+        #             f"World {world_idx}: Object is not in the cup. "
+        #             f"Object pos=({x:.3f}, {y:.3f}, {z:.3f}), "
+        #             f"cup pos=({cup_x:.3f}, {cup_y:.3f}, {cup_z:.3f})"
+        #         )
 
     def setup_ik(self):
         self.ee_index = 10


### PR DESCRIPTION
## Description

Re-disables the in-cup placement assertion in `test_final()` of `example_robot_panda_hydro.py` — see #1337 (just reopened). The gripper-sequence fix in #2467 narrowed the slip window but did not close it.

Recent failure on PR #2593 CI ([job log](https://github.com/newton-physics/newton/actions/runs/24982759302/job/73148853305)):

```
AssertionError: World 0: Object is not in the cup.
Object pos=(0.157, 0.258, 0.004), cup pos=(0.130, -0.500, 0.150)
```

The pen ended ~0.76 m off in Y — a complete escape from the gripper, not a small tolerance miss. Locally on a Blackwell (sm_120, driver 12.9) the test fails ~1/3 of runs with the small-drift failure mode (~0.1 m off in X). The two failure modes together suggest the loose-grip transport phase still occasionally lets the pen go entirely under non-deterministic GPU contact ordering.

The lift-height check above the disabled assertion remains, so the test still verifies that the robot picks up the object. Same pattern as #2466 (which #2467 later reverted).

The original block is commented out rather than deleted so it can be re-enabled cheaply once the underlying contact-ordering nondeterminism is addressed (e.g. by wiring `CollisionPipeline(deterministic=True)` through this example).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A, internal test fix

## Test plan

```
uv run --extra dev -m newton.tests -k test_robot.example_robot_panda_hydro
```

The lift-height assertion still runs and exercises the pickup path.

## Bug fix

**Steps to reproduce (without this PR):**

```
for i in $(seq 1 8); do uv run --extra dev -m newton.tests -k test_robot.example_robot_panda_hydro_cuda_0; done
```

Test fails intermittently — locally observed at ~33% on a Blackwell GPU with driver 12.9. Cloud nightly has been green 10/10 (Apr 17–26) but PR-target GPU runs hit the failure (this PR is motivated by the recent failure on #2593).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated verification logic for pickup-related tests by removing the end-state position validation check while retaining lift-height assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->