### PR TITLE
Bump parallel test executor timeout to 50 min

### DIFF
--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -243,7 +243,7 @@ def main(argv=None):
                         executor_kwargs["max_tasks_per_child"] = 1
                     with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
                         test_manager = ParallelTestManager(manager, args, temp_dir)
-                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=2400))
+                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=3000))
         else:
             # This entire path is an NVIDIA Modification
 


### PR DESCRIPTION
## Summary

- macOS CI runs are routinely finishing in 38-45 min, repeatedly hitting the 40 min \`executor.map\` timeout in \`unittest_parallel\`. Linux/Windows runners stay below 35 min on the same commits.
- Raise the cap to 3000 s so macOS variance stops failing the run. The underlying suite slowdown on macOS still needs to be investigated separately.

## Test plan

- [ ] CI passes on macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution stability by extending timeout allowance for parallel test suites, reducing potential timeout-related failures during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->