### PR TITLE
Update API design skill to use bracket syntax

### DIFF
--- a/.claude/skills/newton-api-design/SKILL.md
+++ b/.claude/skills/newton-api-design/SKILL.md
@@ -16,11 +16,12 @@ def add_shape_cone(
     self,
     body: int,
     xform: Transform | None = None,
-    # shape-specific params here (radius, height, etc.)
-    radius: float = 0.5,
-    height: float = 1.0,
+    # shape-specific params here (radius, half_height, etc.)
+    radius: float = 1.0,
+    half_height: float = 0.5,
     cfg: ShapeConfig | None = None,
     as_site: bool = False,
+    color: Vec3 | None = None,
     label: str | None = None,
     custom_attributes: dict[str, Any] | None = None,
 ) -> int:
@@ -31,10 +32,12 @@ def add_shape_cone(
         xform: Transform in parent body's local frame. If ``None``,
             identity transform is used.
         radius: Cone base radius [m].
-        height: Cone height [m].
+        half_height: Half the cone height [m].
         cfg: Shape configuration. If ``None``, uses
             :attr:`default_shape_cfg`.
         as_site: If ``True``, creates a site instead of a collision shape.
+        color: Optional display RGB color in [0, 1]. If ``None``, uses
+            the per-shape palette color.
         label: Optional label for identifying the shape.
         custom_attributes: Dictionary of custom attribute names to values.
 
@@ -46,7 +49,7 @@ def add_shape_cone(
 **Key conventions:**
 - `xform` (not `tf`, `transform`, or `pose`) — always `Transform | None = None`
 - `cfg` (not `config`, `shape_config`) — always `ShapeConfig | None = None`
-- `body`, `label`, `custom_attributes` — standard params on all builder methods
+- `body`, `color`, `label`, `custom_attributes` — standard params on all builder methods
 - Defaults are `None`, not constructed objects like `wp.transform()`
 
 ## Nested Classes
@@ -85,12 +88,13 @@ class ShapeConfig:
 
 ## Array Documentation Format
 
-Document shape, dtype, and units in attribute docstrings:
+Annotate Warp arrays with the dtype, e.g. `wp.array[wp.vec3]`, `wp.array2d[float]`, `wp.array[wp.spatial_vector] | None`.
+Document units and shape in the docstring.
 
 ```python
-"""Rigid body velocities [m/s, rad/s], shape (body_count,), dtype :class:`spatial_vector`."""
-"""Joint forces [N or N·m], shape (joint_dof_count,), dtype float."""
-"""Contact points [m], shape [count, 3], float."""
+"""Rigid body velocities [m/s, rad/s], shape [body_count]."""
+"""Joint forces [N or N·m], shape [joint_dof_count]."""
+"""Contact points [m], shape [count, 3]."""
 ```
 
 For compound arrays, list per-component units:
@@ -98,7 +102,7 @@ For compound arrays, list per-component units:
 """[0] k_mu [Pa], [1] k_lambda [Pa], ..."""
 ```
 
-For **public API** attributes and method signatures, use bare `wp.array | None` and document the concrete dtype in the docstring (e.g., `dtype :class:\`vec3\``). Warp kernel parameters require concrete dtypes inline (`wp.array(dtype=wp.vec3)`) per AGENTS.md.
+Use `wp.array[X]` for 1-D, `wp.array2d[X]` for 2-D, and `wp.array[Any]` for polymorphic dtypes.
 
 ## Quick Checklist
 
@@ -109,5 +113,5 @@ When reviewing new API, verify:
 - [ ] Nested enumerations use `IntEnum` with int values
 - [ ] Enumerations with `NONE` define `NONE = 0` first
 - [ ] Dataclass fields have docstrings on the line below
-- [ ] Array docs include shape, dtype, and units
-- [ ] Builder methods include `as_site`, `label`, `custom_attributes`
+- [ ] Warp array annotations include the dtype (e.g. `wp.array[wp.vec3]`); docstrings give units and shape
+- [ ] Builder methods include `as_site`, `color`, `label`, `custom_attributes`


### PR DESCRIPTION
## Description

* Uses bracket syntax in API design skill
* Adapts example for builder methods to status quo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional color parameter to shape builders for visual customization.
* **Documentation**
  * Redesigned documentation conventions to encode array data types directly in type annotations. Updated docstring standards to simplify examples while maintaining clarity about shapes, data types, and specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->