### PR TITLE
Add example render FPS cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@
 - Add Kamino-specific simulation examples in `newton/examples/kamino`
 - Add per-mesh `color` override to `ViewerBase.log_mesh()` for tinting individual meshes without authoring per-vertex colors
 - Add per-mesh `roughness` and `metallic` PBR overrides to `ViewerBase.log_mesh()`
+- Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `cloth_stiff_material_hanging` and `cloth_stiff_material_stretch` examples regression-guarding the new Neo-Hookean triangle material (stability under gravity at extreme stiffness, and bulk area-preservation across a Poisson-ratio sweep)
+- Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 
 ### Changed
 
@@ -208,7 +209,6 @@
 - Add Kamino-specific simulation examples in `newton/examples/kamino`
 - Add per-mesh `color` override to `ViewerBase.log_mesh()` for tinting individual meshes without authoring per-vertex colors
 - Add per-mesh `roughness` and `metallic` PBR overrides to `ViewerBase.log_mesh()`
-- Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 
 ### Changed
 

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -397,6 +397,7 @@ def run(example, args):
         if example is None:
             viewer.begin_frame(0.0)
             viewer.end_frame()
+            _throttle_render_fps(frame_start_time, render_fps)
             continue
 
         if viewer.should_step():

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -5,7 +5,9 @@ import ast
 import copy
 import gc
 import importlib
+import math
 import os
+import time
 import warnings
 from collections import defaultdict
 from collections.abc import Callable
@@ -306,9 +308,62 @@ def _format_fps(fps: float) -> str:
     return f"{fps:.3f}"
 
 
+def _positive_float(value: str) -> float:
+    """Parse a finite, positive float for example CLI arguments."""
+    import argparse  # noqa: PLC0415
+
+    try:
+        result = float(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a valid float") from e
+
+    if not math.isfinite(result) or result <= 0.0:
+        raise argparse.ArgumentTypeError("must be a finite value greater than 0")
+
+    return result
+
+
+def _throttle_render_fps(
+    frame_start_time: float,
+    render_fps: float | None,
+    *,
+    time_fn: Callable[[], float] = time.perf_counter,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> float:
+    """Sleep to cap a render loop to ``render_fps``.
+
+    Args:
+        frame_start_time: Wall-clock time at the start of the current frame.
+        render_fps: Maximum render rate in frames per second, or ``None`` for
+            no cap.
+        time_fn: Clock function used to measure elapsed frame time.
+        sleep_fn: Sleep function used to delay the next frame.
+
+    Returns:
+        The sleep duration in seconds, or ``0.0`` when no sleep was needed.
+
+    Raises:
+        ValueError: If ``render_fps`` is not finite and positive.
+    """
+    if render_fps is None:
+        return 0.0
+
+    if not math.isfinite(render_fps) or render_fps <= 0.0:
+        raise ValueError("render_fps must be a finite value greater than 0")
+
+    target_period = 1.0 / render_fps
+    sleep_time = target_period - (time_fn() - frame_start_time)
+    if sleep_time <= 0.0:
+        return 0.0
+
+    sleep_fn(sleep_time)
+    return sleep_time
+
+
 def run(example, args):
     viewer = example.viewer
     example_class = type(example)
+    render_fps = getattr(args, "render_fps", None)
 
     if hasattr(viewer, "hide_loading_splash"):
         viewer.hide_loading_splash()
@@ -323,6 +378,8 @@ def run(example, args):
         viewer.register_ui_callback(lambda ui, ex=example: ex.gui(ui), position="side")
 
     while viewer.is_running():
+        frame_start_time = time.perf_counter()
+
         if browser is not None and browser.switch_target is not None:
             example, example_class = browser.switch(example_class)
             continue
@@ -350,6 +407,8 @@ def run(example, args):
 
         with wp.ScopedTimer("render", active=False):
             example.render()
+
+        _throttle_render_fps(frame_start_time, render_fps)
 
     if perform_test:
         if test_final:
@@ -442,6 +501,12 @@ def create_parser():
     )
     parser.add_argument("--num-frames", type=int, default=100, help="Total number of frames.")
     parser.add_argument(
+        "--render-fps",
+        type=_positive_float,
+        default=None,
+        help="Maximum render rate in frames per second. Does not change simulation frame timing.",
+    )
+    parser.add_argument(
         "--headless",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -505,7 +570,7 @@ def add_broad_phase_arg(parser):
 
 def add_mujoco_contacts_arg(parser):
     """Add ``--use-mujoco-contacts`` argument to *parser*."""
-    import argparse  # noqa: PLC0415  — needed for BooleanOptionalAction
+    import argparse  # noqa: PLC0415
 
     parser.add_argument(
         "--use-mujoco-contacts",

--- a/newton/tests/test_render_fps_cli.py
+++ b/newton/tests/test_render_fps_cli.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``--render-fps`` example CLI option."""
+
+import contextlib
+import io
+import unittest
+
+from newton.examples import _throttle_render_fps, create_parser
+
+
+class TestRenderFPSCLI(unittest.TestCase):
+    """Tests for render FPS parsing and throttling."""
+
+    def test_parser_has_render_fps_arg(self):
+        """The base parser should include --render-fps."""
+        parser = create_parser()
+        args = parser.parse_known_args(["--render-fps", "30"])[0]
+        self.assertEqual(args.render_fps, 30.0)
+
+    def test_default_render_fps_none(self):
+        """Render FPS should be uncapped by default."""
+        parser = create_parser()
+        args = parser.parse_known_args([])[0]
+        self.assertIsNone(args.render_fps)
+
+    def test_render_fps_rejects_non_positive_values(self):
+        """Non-positive render FPS limits should be rejected."""
+        parser = create_parser()
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit):
+                parser.parse_known_args(["--render-fps", "0"])
+            with self.assertRaises(SystemExit):
+                parser.parse_known_args(["--render-fps", "-10"])
+            with self.assertRaises(SystemExit):
+                parser.parse_known_args(["--render-fps", "nan"])
+        self.assertIn("must be a finite value greater than 0", stderr.getvalue())
+
+    def test_throttle_sleeps_for_remaining_frame_time(self):
+        """Throttle should sleep for the remaining frame period."""
+        sleeps = []
+
+        slept = _throttle_render_fps(
+            frame_start_time=10.0,
+            render_fps=20.0,
+            time_fn=lambda: 10.02,
+            sleep_fn=sleeps.append,
+        )
+
+        self.assertAlmostEqual(slept, 0.03)
+        self.assertEqual(sleeps, [slept])
+
+    def test_throttle_skips_sleep_when_frame_is_slow(self):
+        """Throttle should not sleep once a frame exceeds the target period."""
+        sleeps = []
+
+        slept = _throttle_render_fps(
+            frame_start_time=10.0,
+            render_fps=20.0,
+            time_fn=lambda: 10.07,
+            sleep_fn=sleeps.append,
+        )
+
+        self.assertEqual(slept, 0.0)
+        self.assertEqual(sleeps, [])
+
+    def test_throttle_skips_sleep_without_render_fps(self):
+        """No cap should be applied when render FPS is None."""
+        sleeps = []
+
+        slept = _throttle_render_fps(
+            frame_start_time=10.0,
+            render_fps=None,
+            time_fn=lambda: 10.0,
+            sleep_fn=sleeps.append,
+        )
+
+        self.assertEqual(slept, 0.0)
+        self.assertEqual(sleeps, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_render_fps_cli.py
+++ b/newton/tests/test_render_fps_cli.py
@@ -6,7 +6,10 @@
 import contextlib
 import io
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
+import newton.examples as examples_module
 from newton.examples import _throttle_render_fps, create_parser
 
 
@@ -79,6 +82,60 @@ class TestRenderFPSCLI(unittest.TestCase):
 
         self.assertEqual(slept, 0.0)
         self.assertEqual(sleeps, [])
+
+    def test_run_throttles_idle_frames(self):
+        """The main run loop should throttle empty idle frames."""
+
+        class DummyViewer:
+            def __init__(self):
+                self._running = [True, True, False]
+                self.frames = []
+                self.closed = False
+
+            def is_running(self):
+                return self._running.pop(0)
+
+            def begin_frame(self, dt):
+                self.frames.append(("begin", dt))
+
+            def end_frame(self):
+                self.frames.append(("end",))
+
+            def should_step(self):
+                raise AssertionError("idle branch should skip stepping")
+
+            def close(self):
+                self.closed = True
+
+        class DummyBrowser:
+            def __init__(self):
+                self.switch_target = object()
+                self._reset_requested = False
+
+            def switch(self, example_class):
+                self.switch_target = None
+                return None, example_class
+
+        viewer = DummyViewer()
+        example = SimpleNamespace(viewer=viewer)
+        args = SimpleNamespace(render_fps=30.0, test=False)
+        browser = DummyBrowser()
+        throttle_calls = []
+
+        def record_throttle(frame_start_time, render_fps):
+            throttle_calls.append((frame_start_time, render_fps))
+            return 0.0
+
+        with (
+            patch.object(examples_module, "_ExampleBrowser", return_value=browser),
+            patch.object(examples_module, "_throttle_render_fps", side_effect=record_throttle),
+            patch.object(examples_module.time, "perf_counter", side_effect=[10.0, 11.0]),
+        ):
+            examples_module.run(example, args)
+
+        self.assertEqual(viewer.frames, [("begin", 0.0), ("end",)])
+        self.assertEqual(throttle_calls, [(11.0, 30.0)])
+        self.assertTrue(viewer.closed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Add a shared `--render-fps` option for Newton examples so users can cap rendering throughput without changing simulation `frame_dt` or example `--fps` behavior.

The option is parsed by the common example CLI and applied in the shared run loop after each render call. Invalid values such as `0`, negative numbers, and `nan` are rejected at parse time.

Fixes #2605

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
python -m newton.tests -k test_render_fps_cli
python -m newton.tests -k test_warp_config_cli
SKIP=uv-lock uvx pre-commit run -a
```

## New feature / API change

```bash
python -m newton.examples basic_pendulum --render-fps 30
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--render-fps` CLI option to cap example rendering frame rate independently of simulation timing. Accepts only positive finite values.

* **Tests**
  * Added comprehensive test suite for the new CLI feature, validating argument parsing, input validation, and rendering throttle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->