### PR TITLE
Use bracket syntax for Warp array annotations in docs

### DIFF
--- a/docs/concepts/articulations.rst
+++ b/docs/concepts/articulations.rst
@@ -466,13 +466,13 @@ A robust pattern is:
 
     @wp.kernel
     def center_joint_q_from_limits(
-        joint_q_start: wp.array(dtype=wp.int32),
-        joint_qd_start: wp.array(dtype=wp.int32),
-        joint_dof_dim: wp.array2d(dtype=wp.int32),
-        joint_type: wp.array(dtype=wp.int32),
-        joint_limit_lower: wp.array(dtype=float),
-        joint_limit_upper: wp.array(dtype=float),
-        joint_q: wp.array(dtype=float),
+        joint_q_start: wp.array[wp.int32],
+        joint_qd_start: wp.array[wp.int32],
+        joint_dof_dim: wp.array2d[wp.int32],
+        joint_type: wp.array[wp.int32],
+        joint_limit_lower: wp.array[float],
+        joint_limit_upper: wp.array[float],
+        joint_q: wp.array[float],
     ):
         joint_id = wp.tid()
 

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1942,7 +1942,7 @@ You can replace or compose these stages independently.
 **Broad phase classes**
 
 All broad phase classes expose a ``launch`` method that writes candidate pairs
-(``wp.array(dtype=wp.vec2i)``) and a pair count:
+(``wp.array[wp.vec2i]``) and a pair count:
 
 .. list-table::
    :header-rows: 1

--- a/docs/concepts/conventions.rst
+++ b/docs/concepts/conventions.rst
@@ -116,7 +116,7 @@ in the world frame.
 .. code-block:: python
 
   @wp.kernel
-  def get_body_twist(body_qd: wp.array(dtype=wp.spatial_vector)):
+  def get_body_twist(body_qd: wp.array[wp.spatial_vector]):
     body_id = wp.tid()
     # body_qd is a 6D wp.spatial_vector in world frame
     twist = body_qd[body_id]

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -320,8 +320,8 @@ For example:
 
    @wp.kernel
    def world_body_2d_kernel(
-       body_world_start: wp.array(dtype=wp.int32),
-       body_qd: wp.array(dtype=wp.spatial_vectorf),
+       body_world_start: wp.array[wp.int32],
+       body_qd: wp.array[wp.spatial_vectorf],
    ):
        world_id, body_world_id = wp.tid()
        world_start = body_world_start[world_id]

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -516,8 +516,8 @@ Use :meth:`~newton.viewer.ViewerBase.log_lines` to draw line segments — useful
     # Draw force vectors at body positions
     viewer.log_lines(
         "/debug/forces",
-        starts=positions,       # wp.array(dtype=wp.vec3)
-        ends=positions + forces, # wp.array(dtype=wp.vec3)
+        starts=positions,        # wp.array[wp.vec3]
+        ends=positions + forces, # wp.array[wp.vec3]
         colors=(1.0, 0.0, 0.0), # red
         width=0.005,
     )
@@ -530,9 +530,9 @@ Use :meth:`~newton.viewer.ViewerBase.log_points` to draw a point cloud:
 
     viewer.log_points(
         "/debug/targets",
-        points=target_positions, # wp.array(dtype=wp.vec3)
-        radii=0.02,              # uniform radius, or wp.array(dtype=wp.float32)
-        colors=(0.0, 1.0, 0.0), # green
+        points=target_positions, # wp.array[wp.vec3]
+        radii=0.02,              # uniform radius, or wp.array[wp.float32]
+        colors=(0.0, 1.0, 0.0),  # green
     )
 
 **Visualizing contacts:**


### PR DESCRIPTION
## Description

Update documentation examples to use bracket-based Warp array type annotations (`wp.array[...]` and `wp.array2d[...]`) instead of the legacy `wp.array(dtype=...)` form. This keeps the concept and visualization docs aligned with Newton's documented annotation style.