### PR TITLE
Fix USD root joint override

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2065,6 +2065,11 @@ def parse_usd(
                                 parent_xform=parent_xform,
                             )
                             articulation_joint_indices.append(base_joint_id)
+                            group = merged_joint_groups.get(joint_names[i])
+                            if group is not None:
+                                processed_joints.update(group)
+                            else:
+                                processed_joints.add(joint_names[i])
                             continue  # Skip parsing the USD's root joint
                         # When body0 maps to world the physics API may resolve
                         # localPose0 into world space (baking the non-body prim's

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -787,6 +787,61 @@ class TestImportUsdJoints(unittest.TestCase):
         self.assertEqual(builder.joint_child[fixed_idx], root_idx)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_floating_override_replaces_authored_root_joint(self):
+        """Explicit floating overrides must not leave a duplicate USD root joint."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        def create_stage():
+            stage = Usd.Stage.CreateInMemory()
+            UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+            UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+            articulation = UsdGeom.Xform.Define(stage, "/World/Articulation")
+            UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+            def define_body(path):
+                body = UsdGeom.Xform.Define(stage, path)
+                UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+                return body
+
+            root = define_body("/World/Articulation/Root")
+            link = define_body("/World/Articulation/Link")
+
+            root_joint = UsdPhysics.FixedJoint.Define(stage, "/World/Articulation/RootToWorld")
+            root_joint.CreateBody1Rel().SetTargets([root.GetPath()])
+            root_joint.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            root_joint.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            root_joint.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            root_joint.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+
+            child_joint = UsdPhysics.RevoluteJoint.Define(stage, "/World/Articulation/RootToLink")
+            child_joint.CreateBody0Rel().SetTargets([root.GetPath()])
+            child_joint.CreateBody1Rel().SetTargets([link.GetPath()])
+            child_joint.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            child_joint.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            child_joint.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            child_joint.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            child_joint.CreateAxisAttr().Set("Z")
+
+            return stage
+
+        for floating, expected_type in ((False, newton.JointType.FIXED), (True, newton.JointType.FREE)):
+            with self.subTest(floating=floating):
+                builder = newton.ModelBuilder()
+                builder.add_usd(create_stage(), floating=floating)
+
+                root_idx = builder.body_label.index("/World/Articulation/Root")
+                root_joints = [
+                    joint_idx for joint_idx, child_idx in enumerate(builder.joint_child) if child_idx == root_idx
+                ]
+
+                self.assertEqual(len(root_joints), 1)
+                root_joint_idx = root_joints[0]
+                self.assertEqual(builder.joint_parent[root_joint_idx], -1)
+                self.assertEqual(builder.joint_type[root_joint_idx], expected_type)
+                self.assertNotIn("/World/Articulation/RootToWorld", builder.joint_label)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_reversed_joint_unsupported_d6_raises(self):
         """Reversing a D6 joint should raise an error."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics


### PR DESCRIPTION
## Description

Fix USD imports where an explicit `floating` or `base_joint` override replaces an authored root joint but the skipped authored joint is later parsed as an orphan joint. The override path now marks the skipped USD joint as processed so the imported model keeps a single root joint.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable: focused bug fix test coverage only)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_floating_override_replaces_authored_root_joint
uv run python -m newton.examples robot_robotiq_2f85 --viewer null --num-frames 1 --test --quiet
```

## Bug fix

**Steps to reproduce:**

1. Import a USD articulation with an authored fixed root joint to world/non-rigid parent.
2. Pass `floating=False` or `floating=True` to `ModelBuilder.add_usd()`.
3. Observe that the synthetic base joint and the authored root joint both target the root body, which can make MuJoCo conversion fail with `Multiple joints lead to body 0`.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
builder.add_usd(stage_with_authored_root_joint, floating=False)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved articulation root joint parsing in USD import. When overriding base joints and floating root configurations, the importer now correctly processes all related merged joint groups.

* **Tests**
  * Added regression test for floating mode interaction with authored root fixed joints in USD articulation import, ensuring proper joint handling and type transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->