### PR TITLE
Precompute Style3D solver matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
+- Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged
 - Fix `State.assign` not copying namespaced extended and custom state attributes 

--- a/newton/_src/solvers/style3d/solver_style3d.py
+++ b/newton/_src/solvers/style3d/solver_style3d.py
@@ -134,6 +134,7 @@ class SolverStyle3D(SolverBase):
         # Fixed PD matrix
         self.pd_non_diags = SparseMatrixELL()
         self.pd_diags = wp.zeros(model.particle_count, dtype=float, device=self.device)
+        self._precompute(model)
 
         # Non-linear equation variables
         self.dx = wp.zeros(model.particle_count, dtype=wp.vec3, device=self.device)
@@ -385,30 +386,33 @@ class SolverStyle3D(SolverBase):
             )
         )
 
-    def _precompute(self, builder: ModelBuilder):
+    def _precompute(self, model: Model):
         with wp.ScopedTimer("SolverStyle3D::precompute()"):
-            tri_aniso_attr = builder.custom_attributes.get("style3d:tri_aniso_ke")
-            edge_rest_area_attr = builder.custom_attributes.get("style3d:edge_rest_area")
-            edge_bending_cot_attr = builder.custom_attributes.get("style3d:edge_bending_cot")
-
-            if tri_aniso_attr is None or edge_rest_area_attr is None or edge_bending_cot_attr is None:
+            if (
+                not hasattr(model, "style3d")
+                or not hasattr(model.style3d, "tri_aniso_ke")
+                or not hasattr(model.style3d, "edge_rest_area")
+                or not hasattr(model.style3d, "edge_bending_cot")
+            ):
                 raise AttributeError(
-                    "Style3D custom attributes are missing from the builder. "
+                    "Style3D custom attributes are missing from the model. "
                     "Call SolverStyle3D.register_custom_attributes() before building the model."
                 )
 
-            tri_aniso_ke = tri_aniso_attr.build_array(len(builder.tri_indices), device="cpu").numpy().tolist()
-            edge_rest_area = edge_rest_area_attr.build_array(len(builder.edge_indices), device="cpu").numpy().tolist()
-            edge_bending_cot = (
-                edge_bending_cot_attr.build_array(len(builder.edge_indices), device="cpu").numpy().tolist()
-            )
+            self.pd_matrix_builder = PDMatrixBuilder(model.particle_count)
+            tri_indices = model.tri_indices.numpy().tolist()
+            tri_poses = model.tri_poses.numpy().tolist()
+            tri_areas = model.tri_areas.numpy().tolist()
+            edge_indices = model.edge_indices.numpy().tolist()
+            edge_bending_properties = model.edge_bending_properties.numpy().tolist()
+            tri_aniso_ke = model.style3d.tri_aniso_ke.numpy().tolist()
+            edge_rest_area = model.style3d.edge_rest_area.numpy().tolist()
+            edge_bending_cot = model.style3d.edge_bending_cot.numpy().tolist()
 
-            self.pd_matrix_builder.add_stretch_constraints(
-                builder.tri_indices, builder.tri_poses, tri_aniso_ke, builder.tri_areas
-            )
+            self.pd_matrix_builder.add_stretch_constraints(tri_indices, tri_poses, tri_aniso_ke, tri_areas)
             self.pd_matrix_builder.add_bend_constraints(
-                builder.edge_indices,
-                builder.edge_bending_properties,
+                edge_indices,
+                edge_bending_properties,
                 edge_rest_area,
                 edge_bending_cot,
             )

--- a/newton/_src/solvers/style3d/solver_style3d.py
+++ b/newton/_src/solvers/style3d/solver_style3d.py
@@ -128,7 +128,6 @@ class SolverStyle3D(SolverBase):
         self.nonlinear_iterations = iterations
         self.drag_spring_stiff = drag_spring_stiff
         self.enable_mouse_dragging = enable_mouse_dragging
-        self.pd_matrix_builder = PDMatrixBuilder(model.particle_count)
         self.linear_solver = PcgSolver(model.particle_count, self.device)
 
         # Fixed PD matrix
@@ -399,7 +398,7 @@ class SolverStyle3D(SolverBase):
                     "Call SolverStyle3D.register_custom_attributes() before building the model."
                 )
 
-            self.pd_matrix_builder = PDMatrixBuilder(model.particle_count)
+            pd_matrix_builder = PDMatrixBuilder(model.particle_count)
             tri_indices = model.tri_indices.numpy().tolist()
             tri_poses = model.tri_poses.numpy().tolist()
             tri_areas = model.tri_areas.numpy().tolist()
@@ -409,16 +408,14 @@ class SolverStyle3D(SolverBase):
             edge_rest_area = model.style3d.edge_rest_area.numpy().tolist()
             edge_bending_cot = model.style3d.edge_bending_cot.numpy().tolist()
 
-            self.pd_matrix_builder.add_stretch_constraints(tri_indices, tri_poses, tri_aniso_ke, tri_areas)
-            self.pd_matrix_builder.add_bend_constraints(
+            pd_matrix_builder.add_stretch_constraints(tri_indices, tri_poses, tri_aniso_ke, tri_areas)
+            pd_matrix_builder.add_bend_constraints(
                 edge_indices,
                 edge_bending_properties,
                 edge_rest_area,
                 edge_bending_cot,
             )
-            self.pd_diags, self.pd_non_diags.num_nz, self.pd_non_diags.nz_ell = self.pd_matrix_builder.finalize(
-                self.device
-            )
+            self.pd_diags, self.pd_non_diags.num_nz, self.pd_non_diags.nz_ell = pd_matrix_builder.finalize(self.device)
 
     def _update_drag_info(self, index: int, pos: wp.vec3, bary_coord: wp.vec3):
         """Should be invoked when state changed."""

--- a/newton/examples/cloth/example_cloth_h1.py
+++ b/newton/examples/cloth/example_cloth_h1.py
@@ -177,7 +177,6 @@ class Example:
             model=self.model,
             iterations=self.iterations,
         )
-        self.cloth_solver._precompute(h1)
         self.cloth_solver.collision.radius = 3.5e-3
         self.control = self.model.control()
 

--- a/newton/examples/cloth/example_cloth_hanging.py
+++ b/newton/examples/cloth/example_cloth_hanging.py
@@ -128,7 +128,6 @@ class Example:
                 model=self.model,
                 iterations=self.iterations,
             )
-            self.solver._precompute(builder)
         elif self.solver_type == "xpbd":
             self.solver = newton.solvers.SolverXPBD(
                 model=self.model,

--- a/newton/examples/cloth/example_cloth_style3d.py
+++ b/newton/examples/cloth/example_cloth_style3d.py
@@ -124,9 +124,6 @@ class Example:
             model=self.model,
             iterations=self.iterations,
         )
-        self.solver._precompute(
-            builder,
-        )
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
         self.control = self.model.control()

--- a/newton/tests/test_solver_style3d.py
+++ b/newton/tests/test_solver_style3d.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+import warp as wp
+
+import newton
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+
+def test_constructor_precomputes_fixed_pd_matrix(test, device):
+    builder = newton.ModelBuilder()
+    newton.solvers.SolverStyle3D.register_custom_attributes(builder)
+    newton.solvers.style3d.add_cloth_grid(
+        builder,
+        pos=wp.vec3(0.0, 0.0, 1.0),
+        rot=wp.quat_identity(),
+        vel=wp.vec3(0.0, 0.0, 0.0),
+        dim_x=2,
+        dim_y=2,
+        cell_x=0.1,
+        cell_y=0.1,
+        mass=0.1,
+        tri_aniso_ke=wp.vec3(1.0e2, 1.0e2, 1.0e1),
+        edge_aniso_ke=wp.vec3(2.0e-4, 1.0e-4, 5.0e-5),
+    )
+    model = builder.finalize(device=device)
+
+    solver = newton.solvers.SolverStyle3D(model, iterations=1, linear_iterations=1)
+
+    test.assertGreater(float(solver.pd_diags.numpy().sum()), 0.0)
+    test.assertGreater(int(solver.pd_non_diags.num_nz.numpy().sum()), 0)
+
+
+devices = get_test_devices(mode="basic")
+
+
+class TestSolverStyle3D(unittest.TestCase):
+    pass
+
+
+add_function_test(
+    TestSolverStyle3D,
+    "test_constructor_precomputes_fixed_pd_matrix",
+    test_constructor_precomputes_fixed_pd_matrix,
+    devices=devices,
+    check_output=False,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, failfast=True)


### PR DESCRIPTION
## Description

Move the Style3D fixed PD matrix precompute into `SolverStyle3D` construction so callers only need to pass a finalized model before stepping. The internal `_precompute()` helper now reads Style3D data from `Model` arrays, and examples no longer call the private method.

Fixes #2587

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_constructor_precomputes_fixed_pd_matrix
uv run --extra dev python -c "<issue #2587 first-step CUDA reproducer>"
uv run --extra dev -m newton.tests -k example_cloth_style3d
uv run --extra dev -m newton.tests -k example_cloth_hanging_style3d
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Register Style3D custom attributes on a `ModelBuilder`.
2. Add a Style3D cloth grid and finalize the model on CUDA.
3. Construct `SolverStyle3D(model)` and call `solver.step(...)` without manually invoking `solver._precompute(builder)`.
4. Before this PR, the first step could enter the PCG solve with an empty fixed PD matrix and fail with CUDA error 700 on L40.

**Minimal reproduction:**

```python
import warp as wp
import newton
from newton.solvers import style3d

wp.init()
builder = newton.ModelBuilder()
newton.solvers.SolverStyle3D.register_custom_attributes(builder)
style3d.add_cloth_grid(
    builder,
    pos=wp.vec3(0.0, 0.0, 4.0),
    rot=wp.quat_identity(),
    vel=wp.vec3(0.0, 0.0, 0.0),
    dim_x=8,
    dim_y=8,
    cell_x=0.1,
    cell_y=0.1,
    mass=0.1,
    tri_aniso_ke=wp.vec3(1.0e4, 1.0e4, 1.0e3),
    edge_aniso_ke=wp.vec3(2.0e-6, 1.0e-6, 5.0e-6),
)
model = builder.finalize("cuda:0")
solver = newton.solvers.SolverStyle3D(model, iterations=5)
```

## New feature / API change

```python
solver = newton.solvers.SolverStyle3D(model)
# No call to private solver._precompute(...) is required before solver.step(...).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SolverStyle3D now precomputes its fixed partitioned-diagonal matrix from the finalized model during construction, improving initialization correctness and consistency.

* **Tests**
  * Added unit tests validating that SolverStyle3D precomputes non-empty fixed matrix structures on supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->