### PR TITLE
Fix URDF package URI fallback resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,7 @@
 - Fix `State.assign` not copying namespaced extended and custom state attributes 
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix triangle-mesh-vs-convex collisions silently dropping all contacts under non-uniform (and even large uniform) mesh scale: the BVH AABB query in `mesh_vs_convex_midphase` is now performed in unscaled mesh-local space (matching the BVH built over `mesh.points`), with the per-axis contact gap converted accordingly. Previously the query was performed in scaled mesh-local space, so any convex shape whose unscaled-space AABB lay outside the BVH bounds would receive 0 triangles and 0 contacts.
+- Fix URDF `package://` mesh fallback resolution without `resolve-robotics-uri-py` so package names only match full path components instead of unrelated directory-name substrings
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center
 - Fix MPR/GJK reporting wrong contacts for `CONVEX_MESH` shapes whose authoring origin lies outside the hull, and tighten heightfield-vs-convex midphase to use the convex's local AABB instead of an origin-centered bounding sphere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix MJCF `euler` producing wrong orientations for multi-component angles by treating angles as intrinsic rotations. (#3030)
 - Fix MJCF parsing so attributes from multiple `<compiler>` elements, including `<include>`-expanded children, are merged in document order. (#3030)
 - Fix MJCF worldbody static geoms bypassing the visual/collider class filter, so `parse_visuals=False` drops visual-class geoms attached directly to `<worldbody>` too. (#3030)
+- Fix URDF `package://` mesh fallback resolution without `resolve-robotics-uri-py` so package names only match full path components instead of unrelated directory-name substrings
 
 ### Removed
 
@@ -270,7 +271,6 @@
 - Fix `State.assign` not copying namespaced extended and custom state attributes 
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix triangle-mesh-vs-convex collisions silently dropping all contacts under non-uniform (and even large uniform) mesh scale: the BVH AABB query in `mesh_vs_convex_midphase` is now performed in unscaled mesh-local space (matching the BVH built over `mesh.points`), with the per-axis contact gap converted accordingly. Previously the query was performed in scaled mesh-local space, so any convex shape whose unscaled-space AABB lay outside the BVH bounds would receive 0 triangles and 0 contacts.
-- Fix URDF `package://` mesh fallback resolution without `resolve-robotics-uri-py` so package names only match full path components instead of unrelated directory-name substrings
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center
 - Fix MPR/GJK reporting wrong contacts for `CONVEX_MESH` shapes whose authoring origin lies outside the hull, and tighten heightfield-vs-convex midphase to use the convex's local AABB instead of an origin-centered bounding sphere

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import warnings
 import xml.etree.ElementTree as ET
+from pathlib import Path
 from typing import Literal
 from urllib.parse import unquote, urlsplit
 
@@ -280,8 +281,14 @@ def parse_urdf(
                     fn = filename.replace("package://", "")
                     package_name = fn.split("/")[0]
                     urdf_folder = os.path.dirname(source)
-                    if package_name in urdf_folder:
-                        filename = os.path.join(urdf_folder[: urdf_folder.rindex(package_name)], fn)
+                    package_root = None
+                    urdf_parts = Path(os.path.abspath(urdf_folder)).parts
+                    for index in range(len(urdf_parts) - 1, -1, -1):
+                        if urdf_parts[index] == package_name:
+                            package_root = Path(*urdf_parts[:index])
+                            break
+                    if package_root is not None:
+                        filename = os.path.join(os.fspath(package_root), fn)
                     else:
                         warnings.warn(
                             f'Warning: could not resolve package "{package_name}" in URI "{filename}". '

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1836,6 +1836,24 @@ class TestUrdfUriResolution(unittest.TestCase):
         self.assertIn("could not resolve", str(cm.warning).lower())
         self.assertEqual(builder.shape_count, 0)
 
+    def test_package_uri_fallback_does_not_match_substrings(self):
+        """Test fallback package resolution only matches full path components."""
+        accidental = self.base_path / "not" / "pkg" / "meshes"
+        accidental.mkdir(parents=True)
+        (accidental / "link.obj").write_text(MESH_OBJ)
+
+        misleading = self.base_path / "notpkg"
+        (misleading / "urdf").mkdir(parents=True)
+        urdf = self.SIMPLE_URDF.format(geo=self.MESH_GEO.format(filename="package://pkg/meshes/link.obj"))
+        (misleading / "urdf" / "robot.urdf").write_text(urdf)
+
+        with patch("newton._src.utils.import_urdf.resolve_robotics_uri", None):
+            builder = newton.ModelBuilder()
+            with self.assertWarns(UserWarning) as cm:
+                builder.add_urdf(str(misleading / "urdf" / "robot.urdf"), up_axis="Z")
+            self.assertIn('could not resolve package "pkg"', str(cm.warning))
+            self.assertEqual(builder.shape_count, 0)
+
     @unittest.skipUnless(resolve_robotics_uri, "resolve-robotics-uri-py not installed")
     def test_automatic_vs_manual_resolution(self):
         """Test automatic resolution matches manual workaround from original ticket."""


### PR DESCRIPTION
## Description

Fix URDF `package://` mesh fallback resolution when `resolve-robotics-uri-py` is not installed.

Previously, the fallback path logic matched package names by substring inside the URDF folder path. That could incorrectly resolve assets from unrelated directories whose names merely contained the package name. This change restricts the fallback to full path-component matches only.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
uv run --extra dev -m unittest newton.tests.test_import_urdf.TestUrdfUriResolution
```

## Bug fix

**Steps to reproduce:**

1. Load a URDF from a file path in a directory whose name merely contains the target package name as a substring, for example `.../notpkg/urdf/robot.urdf`.
2. Reference a mesh using `package://pkg/meshes/link.obj`.
3. Do not install `resolve-robotics-uri-py`.
4. Place an unrelated mesh at a path that matches the substring-derived fallback, such as `.../not/pkg/meshes/link.obj`.
5. Observe that Newton incorrectly loads the unrelated mesh instead of warning that the package URI could not be resolved.

**Minimal reproduction:**

```python
import tempfile
from pathlib import Path
from unittest.mock import patch

import newton

MESH_OBJ = """v 0 0 0
v 1 0 0
v 0 1 0
f 1 2 3
"""

with tempfile.TemporaryDirectory() as td:
    base = Path(td)
    accidental = base / "not" / "pkg" / "meshes"
    accidental.mkdir(parents=True)
    (accidental / "link.obj").write_text(MESH_OBJ)

    misleading = base / "notpkg"
    (misleading / "urdf").mkdir(parents=True)
    urdf_path = misleading / "urdf" / "robot.urdf"
    urdf_path.write_text(
        '<robot name="r"><link name="base"><visual><geometry>'
        '<mesh filename="package://pkg/meshes/link.obj"/>'
        '</geometry></visual></link></robot>'
    )

    with patch("newton._src.utils.import_urdf.resolve_robotics_uri", None):
        builder = newton.ModelBuilder()
        builder.add_urdf(str(urdf_path), up_axis="Z")
        print(builder.shape_count)  # incorrectly becomes 1 without this PR
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URDF `package://` mesh resolution fallback when the robotics URI resolver is unavailable, ensuring package matching uses full path components to avoid incorrect substring-based matches.

* **Tests**
  * Added coverage to verify `package://` fallback does not resolve using misleading path fragments and that unresolved meshes are handled as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->