### PR TITLE
Fix MJCF visual geom explicit mass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Fix MJCF importer creating finite planes from MuJoCo visual half-sizes instead of infinite planes
 - Fix USD import of joint limit stiffness/damping from `MjcJointAPI`: `SchemaResolverMjc` now reads the schema-correct `mjc:solreflimit` attribute instead of the generic `mjc:solref`, which was never authored on joints
 - Fix MJCF importer in `compiler.angle="degree"` mode: (1) stop multiplying joint `damping`/`stiffness` by `180/π` (MuJoCo stores these in `N·m·s/rad` and `N·m/rad` regardless of `angle`); (2) stop `deg2rad`-scaling the default `±MAXVAL` sentinel for joints without an explicit `range=`, which was turning unlimited hinges into bounded joints with `~1.75e8 rad` range
+- Fix MJCF importer ignoring explicit `mass=` on visual geoms loaded via `parse_visuals=True`; authored visual-only mass now contributes to body mass and inertia like visual-only density already does
 - Fix ViewerViser mesh popping artifacts caused by viser's automatic LOD simplification creating holes in complex geometry
 - Fix degenerate zero-area triangles in SDF marching-cubes isosurface extraction by clamping edge interpolation away from cube corners and guarding against near-zero cross products
 - Fix multi-world coordinate conversion using the wrong body center of mass for replicated worlds

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1017,8 +1017,9 @@ def parse_mjcf(
                 if verbose:
                     print(f"MJCF parsing shape {geom_name} issue: geom type {geom_type} is unsupported")
 
-            # Handle explicit mass: compute inertia using existing functions, add to body
-            if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0 and not just_visual:
+            # Handle explicit mass: compute inertia using existing functions, add to body.
+            # Visual geoms can still contribute authored mass when parse_visuals=True.
+            if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0:
                 from ..geometry.inertia import (  # noqa: PLC0415
                     compute_inertia_box_from_mass,
                     compute_inertia_capsule,

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2312,6 +2312,32 @@ class TestImportMjcfGeometry(unittest.TestCase):
             msg=f"Visual geom with default density should produce mass={expected_mass}, got {actual_mass}",
         )
 
+    def test_visual_geom_explicit_mass_with_parse_visuals(self):
+        """Regression: visual geoms must honor explicit mass when parse_visuals=True."""
+        mjcf = """<?xml version="1.0" ?>
+<mujoco>
+  <worldbody>
+    <body name="test" pos="0 0 0.5">
+      <joint type="hinge" axis="0 0 1"/>
+      <geom name="vis" type="box" size="0.1 0.1 0.1"
+            contype="0" conaffinity="0" group="2" mass="5"/>
+      <geom name="col" type="box" size="0.1 0.1 0.1"
+            mass="0" group="3"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf, parse_visuals=True)
+        model = builder.finalize()
+
+        actual_mass = float(model.body_mass.numpy()[0])
+        self.assertAlmostEqual(actual_mass, 5.0, places=4, msg=f"Expected visual geom mass=5.0, got {actual_mass}")
+        self.assertGreater(
+            float(np.trace(model.body_inertia.numpy()[0])),
+            0.0,
+            msg="Visual geom with explicit mass should contribute non-zero inertia",
+        )
+
     def test_inertial_locks_body_against_frame_geom_mass(self):
         """Regression: explicit <inertial> must lock body mass/COM against later frame geoms.
 


### PR DESCRIPTION
## Description

Honor explicit `mass=` on visual geoms loaded via `parse_visuals=True`.

This is a follow-up to the earlier explicit-geom-mass support: visual geoms
already contribute default-density mass when visuals are parsed, but authored
explicit mass was still skipped by the `not just_visual` guard. That left
visual-only mass and inertia at zero even though the geom itself was loaded.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m unittest \
  newton.tests.test_import_mjcf.TestImportMjcfGeometry.test_visual_geom_density_with_parse_visuals \
  newton.tests.test_import_mjcf.TestImportMjcfGeometry.test_visual_geom_explicit_mass_with_parse_visuals

uv run --extra dev -m unittest \
  newton.tests.test_import_mjcf.TestImportMjcfGeometry.test_explicit_geom_mass \
  newton.tests.test_import_mjcf.TestImportMjcfGeometry.test_visual_geom_density_with_parse_visuals \
  newton.tests.test_import_mjcf.TestImportMjcfGeometry.test_visual_geom_explicit_mass_with_parse_visuals

uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Build a body with one visual geom carrying `mass="5"` and one collider carrying `mass="0"`.
2. Import the MJCF with `parse_visuals=True`.
3. Finalize the model and inspect `body_mass` and `body_inertia`.
4. Observe that both remain zero without this fix.

**Minimal reproduction:**

```python
import newton
import numpy as np

mjcf = """<?xml version=\"1.0\" ?>
<mujoco>
  <worldbody>
    <body name=\"test\" pos=\"0 0 0.5\">
      <joint type=\"hinge\" axis=\"0 0 1\"/>
      <geom name=\"vis\" type=\"box\" size=\"0.1 0.1 0.1\"
            contype=\"0\" conaffinity=\"0\" group=\"2\" mass=\"5\"/>
      <geom name=\"col\" type=\"box\" size=\"0.1 0.1 0.1\"
            mass=\"0\" group=\"3\"/>
    </body>
  </worldbody>
</mujoco>"""

builder = newton.ModelBuilder()
builder.add_mjcf(mjcf, parse_visuals=True)
model = builder.finalize()

print(model.body_mass.numpy()[0])
print(np.trace(model.body_inertia.numpy()[0]))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MJCF importer now correctly applies explicit mass values specified on visual geometry elements when visual parsing is enabled. Visual-only geoms with authored mass now contribute to body mass and inertia calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->