### PR TITLE
Draft: Rework `Contacts` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
 - Add `Mesh.is_watertight` property (cached) that reports whether every geometric edge is shared by exactly two triangles
 - Add `deterministic` flag to `CollisionPipeline` and `NarrowPhase` for GPU-thread-scheduling-independent contact ordering via radix sort and deterministic fingerprint tiebreaking in contact reduction
 - Add fast parity-based SDF construction path for watertight meshes in `SDF.create_from_mesh`, using `wp.mesh_query_point_sign_parity` instead of winding numbers; selected via the new `sign_method` argument (`"auto"` — the default — picks parity when `Mesh.is_watertight` is true, or `"parity"` / `"winding"` to force either strategy)
-- Enable full CPU execution of the collision pipeline, including mesh–mesh and mesh–heightfield SDF contacts that were previously CUDA-only; contact reduction (`reduce_contacts`) also runs on CPU. The previous `"NarrowPhase running on CPU: mesh-mesh contacts will be skipped"` warning is no longer emitted — CPU runs now execute the same kernels as CUDA.
-- Add `Contacts.rigid_distance` (signed contact gap) and the request-gated `rigid_velocity` / `rigid_key` extended attributes (solver-populated spatial velocity and cross-step warmstart identifier)
+- Add `Contacts.rigid_distance` (signed contact gap) and the request-gated extended attributes `rigid_velocity` and `rigid_key`
 - Add `ViewerBase.log_arrows()` for arrow rendering (wide line + arrowhead) in the GL viewer with a dedicated geometry shader
 - Add frame-to-frame contact matching via `CollisionPipeline(contact_matching=...)` with modes `"latest"` (populates `contacts.rigid_match_index`) and `"sticky"` (experimental; additionally replays previous-frame contact geometry on matched contacts — the sticky update strategy may change without warning). Optional `contact_report=True` exposes new/broken contact index lists on `Contacts`.
 - Add `enable_multiccd` parameter to `SolverMuJoCo` for multi-CCD contact generation (up to 4 contact points per geom pair)
@@ -27,9 +26,8 @@
 ### Changed
 
 - Use pre-computed local AABB for `CONVEX_MESH` shapes in `compute_shape_aabbs`, avoiding a per-frame support-function AABB computation
-- Rename `Contacts` attributes to drop the `_contact` infix and pack paired arrays: `rigid_contact_point0/1` → `rigid_point_0/1`, `rigid_contact_shape0/1` → `rigid_shapes` (packed `vec2i`), `rigid_contact_margin0/1` → `rigid_margins` (packed `vec2f`), `rigid_contact_normal` → `rigid_normal`, `rigid_contact_count`/`max` → `rigid_count_active`/`rigid_count_max`, `soft_contact_*` → `soft_*`, plus matching renames for `rigid_contact_force/stiffness/damping/friction/tids/diff_*`. All old names remain as deprecated `@property` aliases backed by views (no data copy); update call sites to the new names at your convenience.
-- Flip the sign convention of the `Contacts` contact-force attribute to represent the spatial force exerted **by body 0 on body 1** (collinear with `rigid_normal`, which points from shape 0 toward shape 1) instead of the force on body 0. Solvers (`SolverMuJoCo`, `SolverXPBD.update_contacts`) and `SensorContact` have been updated to match; code reading the attribute directly must negate previous expectations.
-- Rename the rigid-contact extended attributes on `Contacts` to carry a `rigid_` prefix for dichotomy with `rigid_*` / `soft_*`: `force` → `rigid_force`, sized `rigid_count_max` (the former rigid-plus-soft sizing is dropped; add separate `soft_*` attributes if soft-contact values are ever needed). Old names (`force`, `velocity`, `key`) remain as deprecated read-only property aliases; passing them to `Model.request_contact_attributes()` is also accepted with a deprecation warning.
+- Rename `Contacts` attributes to drop the `_contact_` infix and pack paired scalars into `vec2` buffers (e.g. `rigid_contact_normal` → `rigid_normal`, `rigid_contact_shape0/1` → `rigid_shapes` (`vec2i`), `soft_contact_*` → `soft_*`); old names kept as deprecated property aliases backed by views
+- Replace the `force` extended attribute with `Contacts.rigid_force`, sized `rigid_count_max` only (was rigid+soft) and flip its sign convention to the spatial force exerted **by body 0 on body 1**, codirectional with `rigid_normal` (previously anti-directional); `SolverMuJoCo`, `SolverXPBD.update_contacts`, and `SensorContact` are updated; `Model.request_contact_attributes("force")` is still accepted with a deprecation warning
 - Build mesh SDFs via the texture-based sparse path only; sample via `SDF.texture_data` instead of `SDF.sparse_volume` / `SDF.coarse_volume`.
 - Change GL viewer scroll to dolly toward the orbit pivot; use Ctrl+scroll for FOV zoom
 - Render all GL viewer lines (joints, contacts, wireframes) as geometry-shader quads instead of ``GL_LINES`` for uniform width across zoom levels and non-square viewports
@@ -44,7 +42,8 @@
 
 ### Deprecated
 
-- Deprecate `Contacts.rigid_contact_offset0` / `rigid_contact_offset1`; will be removed in a future release. `SolverXPBD` now computes its body-frame friction-anchor offsets internally and no other solver consumed them.
+- Deprecate `Contacts.rigid_contact_offset0` / `rigid_contact_offset1`: trivial to derive from `rigid_normal` and `rigid_margins`; `SolverXPBD` and `ViewerBase` (the only consumers) updated to derive them locally
+- Deprecate the always-allocated `Contacts.rigid_contact_force` (vec3): solver-internal, replaced by the request-gated `rigid_force` extended attribute
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
 - Add `Mesh.is_watertight` property (cached) that reports whether every geometric edge is shared by exactly two triangles
 - Add `deterministic` flag to `CollisionPipeline` and `NarrowPhase` for GPU-thread-scheduling-independent contact ordering via radix sort and deterministic fingerprint tiebreaking in contact reduction
 - Add fast parity-based SDF construction path for watertight meshes in `SDF.create_from_mesh`, using `wp.mesh_query_point_sign_parity` instead of winding numbers; selected via the new `sign_method` argument (`"auto"` — the default — picks parity when `Mesh.is_watertight` is true, or `"parity"` / `"winding"` to force either strategy)
+- Enable full CPU execution of the collision pipeline, including mesh–mesh and mesh–heightfield SDF contacts that were previously CUDA-only; contact reduction (`reduce_contacts`) also runs on CPU. The previous `"NarrowPhase running on CPU: mesh-mesh contacts will be skipped"` warning is no longer emitted — CPU runs now execute the same kernels as CUDA.
+- Add `Contacts.rigid_distance` (signed contact gap) and the request-gated `rigid_velocity` / `rigid_key` extended attributes (solver-populated spatial velocity and cross-step warmstart identifier)
 - Add `ViewerBase.log_arrows()` for arrow rendering (wide line + arrowhead) in the GL viewer with a dedicated geometry shader
-- Add frame-to-frame contact matching via `CollisionPipeline(contact_matching=...)` with modes `"latest"` (populates `contacts.rigid_contact_match_index`) and `"sticky"` (experimental; additionally replays previous-frame contact geometry on matched contacts — the sticky update strategy may change without warning). Optional `contact_report=True` exposes new/broken contact index lists on `Contacts`.
+- Add frame-to-frame contact matching via `CollisionPipeline(contact_matching=...)` with modes `"latest"` (populates `contacts.rigid_match_index`) and `"sticky"` (experimental; additionally replays previous-frame contact geometry on matched contacts — the sticky update strategy may change without warning). Optional `contact_report=True` exposes new/broken contact index lists on `Contacts`.
 - Add `enable_multiccd` parameter to `SolverMuJoCo` for multi-CCD contact generation (up to 4 contact points per geom pair)
 - Support `<joint type="ball"/>` in the MJCF importer, and preserve authored damping, stiffness, and frictionloss when exporting ball joints to MuJoCo specs (previously silently dropped)
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
@@ -25,6 +27,9 @@
 ### Changed
 
 - Use pre-computed local AABB for `CONVEX_MESH` shapes in `compute_shape_aabbs`, avoiding a per-frame support-function AABB computation
+- Rename `Contacts` attributes to drop the `_contact` infix and pack paired arrays: `rigid_contact_point0/1` → `rigid_point_0/1`, `rigid_contact_shape0/1` → `rigid_shapes` (packed `vec2i`), `rigid_contact_margin0/1` → `rigid_margins` (packed `vec2f`), `rigid_contact_normal` → `rigid_normal`, `rigid_contact_count`/`max` → `rigid_count_active`/`rigid_count_max`, `soft_contact_*` → `soft_*`, plus matching renames for `rigid_contact_force/stiffness/damping/friction/tids/diff_*`. All old names remain as deprecated `@property` aliases backed by views (no data copy); update call sites to the new names at your convenience.
+- Flip the sign convention of the `Contacts` contact-force attribute to represent the spatial force exerted **by body 0 on body 1** (collinear with `rigid_normal`, which points from shape 0 toward shape 1) instead of the force on body 0. Solvers (`SolverMuJoCo`, `SolverXPBD.update_contacts`) and `SensorContact` have been updated to match; code reading the attribute directly must negate previous expectations.
+- Rename the rigid-contact extended attributes on `Contacts` to carry a `rigid_` prefix for dichotomy with `rigid_*` / `soft_*`: `force` → `rigid_force`, sized `rigid_count_max` (the former rigid-plus-soft sizing is dropped; add separate `soft_*` attributes if soft-contact values are ever needed). Old names (`force`, `velocity`, `key`) remain as deprecated read-only property aliases; passing them to `Model.request_contact_attributes()` is also accepted with a deprecation warning.
 - Build mesh SDFs via the texture-based sparse path only; sample via `SDF.texture_data` instead of `SDF.sparse_volume` / `SDF.coarse_volume`.
 - Change GL viewer scroll to dolly toward the orbit pivot; use Ctrl+scroll for FOV zoom
 - Render all GL viewer lines (joints, contacts, wireframes) as geometry-shader quads instead of ``GL_LINES`` for uniform width across zoom levels and non-square viewports
@@ -36,6 +41,10 @@
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
 - Disable process reuse in the test runner on multi-GPU systems to prevent CUDA errors from cascading across test suites, keeping process reuse enabled on single-GPU systems for faster throughput
 - Default `python -m newton.examples` with no argument to launch `basic_pendulum`; use `--list` to print available examples
+
+### Deprecated
+
+- Deprecate `Contacts.rigid_contact_offset0` / `rigid_contact_offset1`; will be removed in a future release. `SolverXPBD` now computes its body-frame friction-anchor offsets internally and no other solver consumed them.
 
 ### Fixed
 

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1254,25 +1254,20 @@ and is consumed by the solver :meth:`~solvers.SolverBase.step` method for contac
    * - ``rigid_contact_point0``, ``rigid_contact_point1``
      - Contact point on each shape (body frame). This is the narrow-phase contact
        location used by the solver for the normal constraint and lever-arm computation.
-   * - ``rigid_contact_offset0``, ``rigid_contact_offset1``
-     - Body-frame friction-anchor offset per shape, equal to the contact normal scaled
-       by ``effective_radius + margin``. Added to the contact point to form a shifted
-       friction anchor that accounts for rotational effects of finite contact thickness
-       in tangential friction calculations.
    * - ``rigid_contact_normal``
      - Contact normal, pointing from shape 0 toward shape 1 (world frame).
    * - ``rigid_contact_margin0``, ``rigid_contact_margin1``
      - Per-shape thickness: effective radius + margin (scalar).
-   * - ``rigid_contact_match_index``
+   * - ``rigid_match_index``
      - Per-contact frame-to-frame match result (int32). ``>= 0``: matched old
        index, ``-1``: new, ``-2``: broken.  Only allocated when
        ``contact_matching`` is not ``"disabled"``.
        See :ref:`Contact Matching`.
-   * - ``rigid_contact_new_indices``, ``rigid_contact_new_count``
+   * - ``rigid_new_indices``, ``rigid_new_count``
      - Compact index list of new contacts in the current sorted buffer (where
        ``match_index < 0``). Only allocated when ``contact_report=True``.
        See :ref:`Contact Reports`.
-   * - ``rigid_contact_broken_indices``, ``rigid_contact_broken_count``
+   * - ``rigid_broken_indices``, ``rigid_broken_count``
      - Compact index list of contacts from the previous frame that no current
        contact matched. Only allocated when ``contact_report=True``.
        See :ref:`Contact Reports`.
@@ -1703,7 +1698,7 @@ argument on :class:`~CollisionPipeline` selects one of three modes:
 
 - ``"disabled"`` (default) — no matching, no extra buffers.
 - ``"latest"`` — match current contacts against the previous
-  frame and populate :attr:`Contacts.rigid_contact_match_index`, but keep the
+  frame and populate :attr:`Contacts.rigid_match_index`, but keep the
   current frame's freshly generated contact geometry in the returned
   :class:`Contacts` buffer.
 - ``"sticky"`` (experimental) — match like ``"latest"``, then overwrite
@@ -1751,7 +1746,7 @@ Any non-disabled mode implies ``deterministic=True``.
     #   >= 0 : index of the matched contact in the previous frame
     #     -1 : new contact (no match found)
     #     -2 : key matched but position/normal thresholds exceeded (broken)
-    match_idx = contacts.rigid_contact_match_index.numpy()
+    match_idx = contacts.rigid_match_index.numpy()
 
 Each frame, the matcher binary-searches the current contacts against the
 previous frame's sorted keys, then verifies candidates against a world-space
@@ -1807,21 +1802,21 @@ matching mode:
     contacts = pipeline.contacts()
     pipeline.collide(state, contacts)
 
-    n_new = contacts.rigid_contact_new_count.numpy()[0]
-    new_indices = contacts.rigid_contact_new_indices.numpy()[:n_new]
+    n_new = contacts.rigid_new_count.numpy()[0]
+    new_indices = contacts.rigid_new_indices.numpy()[:n_new]
 
-    n_broken = contacts.rigid_contact_broken_count.numpy()[0]
-    broken_indices = contacts.rigid_contact_broken_indices.numpy()[:n_broken]
+    n_broken = contacts.rigid_broken_count.numpy()[0]
+    broken_indices = contacts.rigid_broken_indices.numpy()[:n_broken]
 
-``rigid_contact_new_indices`` holds indices into the current frame's sorted
+``rigid_new_indices`` holds indices into the current frame's sorted
 contact buffer for every contact with ``match_index < 0``.  This includes both
 genuinely new contacts (``MATCH_NOT_FOUND``, ``match_index == -1``) and
 threshold-broken contacts whose sort key matched a previous-frame contact but
 whose position or normal exceeded the configured thresholds
 (``MATCH_BROKEN``, ``match_index == -2``).  Inspect
-``contacts.rigid_contact_match_index`` to distinguish the two cases.
+``contacts.rigid_match_index`` to distinguish the two cases.
 
-``rigid_contact_broken_indices`` holds indices into the *previous* frame's
+``rigid_broken_indices`` holds indices into the *previous* frame's
 sorted buffer for contacts that no current contact matched.
 
 .. _Performance:

--- a/docs/concepts/extended_attributes.rst
+++ b/docs/concepts/extended_attributes.rst
@@ -70,8 +70,12 @@ The canonical list is :attr:`Contacts.EXTENDED_ATTRIBUTES <newton.Contacts.EXTEN
 
    * - Attribute
      - Description
-   * - :attr:`~newton.Contacts.force`
-     - Contact spatial forces (used by :class:`~newton.sensors.SensorContact`)
+   * - :attr:`~newton.Contacts.rigid_force`
+     - Rigid contact spatial forces (used by :class:`~newton.sensors.SensorContact`)
+   * - :attr:`~newton.Contacts.rigid_velocity`
+     - Rigid contact spatial velocities (solver output)
+   * - :attr:`~newton.Contacts.rigid_key`
+     - Cross-step rigid contact identifier for warmstart matching (solver-populated)
 
 
 .. _extended_state_attributes:

--- a/newton/_src/geometry/contact_sort.py
+++ b/newton/_src/geometry/contact_sort.py
@@ -117,6 +117,7 @@ class _FullContactArrays:
     offset0: wp.array[wp.vec3]
     offset1: wp.array[wp.vec3]
     normal: wp.array[wp.vec3]
+    distance: wp.array[float]
     margin0: wp.array[float]
     margin1: wp.array[float]
     tids: wp.array[wp.int32]
@@ -131,6 +132,7 @@ class _FullContactArrays:
     offset0_buf: wp.array[wp.vec3]
     offset1_buf: wp.array[wp.vec3]
     normal_buf: wp.array[wp.vec3]
+    distance_buf: wp.array[float]
     margin0_buf: wp.array[float]
     margin1_buf: wp.array[float]
     tids_buf: wp.array[wp.int32]
@@ -155,6 +157,7 @@ def _backup_full_kernel(data: _FullContactArrays, count: wp.array[int]):
     data.offset0_buf[i] = data.offset0[i]
     data.offset1_buf[i] = data.offset1[i]
     data.normal_buf[i] = data.normal[i]
+    data.distance_buf[i] = data.distance[i]
     data.margin0_buf[i] = data.margin0[i]
     data.margin1_buf[i] = data.margin1[i]
     data.tids_buf[i] = data.tids[i]
@@ -180,6 +183,7 @@ def _gather_full_kernel(data: _FullContactArrays, perm: wp.array[wp.int32], coun
     data.offset0[i] = data.offset0_buf[p]
     data.offset1[i] = data.offset1_buf[p]
     data.normal[i] = data.normal_buf[p]
+    data.distance[i] = data.distance_buf[p]
     data.margin0[i] = data.margin0_buf[p]
     data.margin1[i] = data.margin1_buf[p]
     data.tids[i] = data.tids_buf[p]
@@ -229,6 +233,7 @@ class ContactSorter:
             self._full_offset0_buf = wp.zeros(capacity, dtype=wp.vec3)
             self._full_offset1_buf = wp.zeros(capacity, dtype=wp.vec3)
             self._full_normal_buf = wp.zeros(capacity, dtype=wp.vec3)
+            self._full_distance_buf = wp.zeros(capacity, dtype=float)
             self._full_margin0_buf = wp.zeros(capacity, dtype=float)
             self._full_margin1_buf = wp.zeros(capacity, dtype=float)
             self._full_tids_buf = wp.zeros(capacity, dtype=wp.int32)
@@ -313,6 +318,7 @@ class ContactSorter:
         offset0: wp.array,
         offset1: wp.array,
         normal: wp.array,
+        distance: wp.array,
         margin0: wp.array,
         margin1: wp.array,
         tids: wp.array,
@@ -336,6 +342,7 @@ class ContactSorter:
             offset0: vec3 body-frame friction anchor offsets for shape 0.
             offset1: vec3 body-frame friction anchor offsets for shape 1.
             normal: vec3 contact normals.
+            distance: float per-contact signed surface-to-surface distance.
             margin0: float surface thickness for shape 0.
             margin1: float surface thickness for shape 1.
             tids: int tid array.
@@ -361,6 +368,7 @@ class ContactSorter:
         data.offset0 = offset0
         data.offset1 = offset1
         data.normal = normal
+        data.distance = distance
         data.margin0 = margin0
         data.margin1 = margin1
         data.tids = tids
@@ -379,6 +387,7 @@ class ContactSorter:
         data.offset0_buf = self._full_offset0_buf
         data.offset1_buf = self._full_offset1_buf
         data.normal_buf = self._full_normal_buf
+        data.distance_buf = self._full_distance_buf
         data.margin0_buf = self._full_margin0_buf
         data.margin1_buf = self._full_margin1_buf
         data.tids_buf = self._full_tids_buf

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -81,11 +81,11 @@ def accumulate_contact_forces_kernel(
     if total_force:
         assert total_force_friction
         if row0 >= 0:
-            wp.atomic_add(total_force, row0, force)
-            wp.atomic_add(total_force_friction, row0, friction)
+            wp.atomic_add(total_force, row0, -force)
+            wp.atomic_add(total_force_friction, row0, -friction)
         if row1 >= 0:
-            wp.atomic_add(total_force, row1, -force)
-            wp.atomic_add(total_force_friction, row1, -friction)
+            wp.atomic_add(total_force, row1, force)
+            wp.atomic_add(total_force_friction, row1, friction)
 
     # per-counterpart forces and friction
     if force_matrix:
@@ -93,11 +93,11 @@ def accumulate_contact_forces_kernel(
         col0 = counterpart_shape_to_col[shape0]
         col1 = counterpart_shape_to_col[shape1]
         if row0 >= 0 and col1 >= 0:
-            wp.atomic_add(force_matrix, row0, col1, force)
-            wp.atomic_add(force_matrix_friction, row0, col1, friction)
+            wp.atomic_add(force_matrix, row0, col1, -force)
+            wp.atomic_add(force_matrix_friction, row0, col1, -friction)
         if row1 >= 0 and col0 >= 0:
-            wp.atomic_add(force_matrix, row1, col0, -force)
-            wp.atomic_add(force_matrix_friction, row1, col0, -friction)
+            wp.atomic_add(force_matrix, row1, col0, force)
+            wp.atomic_add(force_matrix_friction, row1, col0, friction)
 
 
 @wp.kernel(enable_backward=False)

--- a/newton/_src/sim/collide.py
+++ b/newton/_src/sim/collide.py
@@ -48,6 +48,7 @@ class ContactWriterData:
     out_offset0: wp.array[wp.vec3]
     out_offset1: wp.array[wp.vec3]
     out_normal: wp.array[wp.vec3]
+    out_distance: wp.array[float]
     out_margin0: wp.array[float]
     out_margin1: wp.array[float]
     out_tids: wp.array[int]
@@ -131,6 +132,7 @@ def write_contact(
     writer_data.out_offset1[index] = wp.transform_vector(X_bw_b, -offset_mag_b * contact_normal)
 
     writer_data.out_normal[index] = contact_normal
+    writer_data.out_distance[index] = d
     writer_data.out_margin0[index] = offset_mag_a
     writer_data.out_margin1[index] = offset_mag_b
     writer_data.out_tids[index] = 0  # tid not available in this context
@@ -173,8 +175,8 @@ def compute_shape_aabbs(
 ):
     """Compute AABBs, narrow-phase geometry data, and zero collision counters.
 
-    Fuses AABB computation, narrow-phase data preparation, contact counter
-    zeroing, and generation bumping into a single kernel launch.
+    Fuses AABB computation, narrow-phase data preparation, contact counter zeroing, and generation
+    bumping into a single kernel launch.
     """
     shape_id = wp.tid()
 
@@ -453,7 +455,7 @@ class CollisionPipeline:
     For most users, construct with ``CollisionPipeline(model, ...)``.
 
     .. note::
-        Differentiable rigid contacts (the ``rigid_contact_diff_*`` arrays when
+        Differentiable rigid contacts (the ``rigid_diff_*`` arrays when
         ``requires_grad`` is enabled) are **experimental**. The narrow phase stays
         frozen and gradients are a tangent approximation; validate accuracy and
         usefulness on your workflow before relying on them in optimization loops.
@@ -520,7 +522,7 @@ class CollisionPipeline:
             contact_matching: Frame-to-frame contact matching mode.  One of
                 ``"disabled"``, ``"latest"``, or ``"sticky"``.  Any
                 non-disabled mode implies ``deterministic=True`` and
-                populates :attr:`Contacts.rigid_contact_match_index`.
+                populates :attr:`Contacts.rigid_match_index`.
                 Defaults to ``"disabled"``.
             contact_matching_pos_threshold: World-space distance threshold [m]
                 between the previous and current contact midpoints
@@ -529,9 +531,9 @@ class CollisionPipeline:
                 to ``0.0005``.
             contact_matching_normal_dot_threshold: Minimum dot product between
                 old and new contact normals for a match.
-            contact_report: Allocate ``rigid_contact_new_indices`` /
-                ``rigid_contact_new_count`` / ``rigid_contact_broken_indices``
-                / ``rigid_contact_broken_count`` on the :class:`Contacts`
+            contact_report: Allocate ``rigid_new_indices`` /
+                ``rigid_new_count`` / ``rigid_broken_indices``
+                / ``rigid_broken_count`` on the :class:`Contacts`
                 container, populated each frame.  Requires a non-disabled
                 ``contact_matching`` mode.
             verify_buffers: Run a ``dim=[1]`` diagnostic kernel at the end of
@@ -544,7 +546,7 @@ class CollisionPipeline:
 
         .. note::
             When ``requires_grad`` is true (explicitly or via ``model.requires_grad``),
-            rigid-contact autodiff via ``rigid_contact_diff_*`` is **experimental**;
+            rigid-contact autodiff via ``rigid_diff_*`` is **experimental**;
             see :meth:`collide`.
         """
         if contact_matching not in ("disabled", "latest", "sticky"):
@@ -820,7 +822,7 @@ class CollisionPipeline:
             A newly allocated contacts buffer sized for this pipeline.
 
         .. note::
-            If ``requires_grad`` is true, ``rigid_contact_diff_*`` arrays may be
+            If ``requires_grad`` is true, ``rigid_diff_*`` arrays may be
             allocated; rigid-contact differentiability is **experimental** (see
             :meth:`collide`).
         """
@@ -870,7 +872,7 @@ class CollisionPipeline:
         ``state.particle_q``.
 
         When ``requires_grad=True``, the differentiable rigid-contact arrays
-        (``contacts.rigid_contact_diff_*``) are populated by a lightweight
+        (``contacts.rigid_diff_*``) are populated by a lightweight
         augmentation kernel that reconstructs world-space contact points from
         the frozen narrow-phase output through the body transforms.
 
@@ -920,7 +922,7 @@ class CollisionPipeline:
                 model.shape_collision_aabb_lower,
                 model.shape_collision_aabb_upper,
                 contacts.contact_counters,
-                contacts.contact_generation,
+                contacts.generation,
                 self.broad_phase_pair_count,
                 contacts.contact_counters.shape[0],
             ],
@@ -992,6 +994,7 @@ class CollisionPipeline:
         writer_data.out_offset0 = contacts.rigid_contact_offset0
         writer_data.out_offset1 = contacts.rigid_contact_offset1
         writer_data.out_normal = contacts.rigid_contact_normal
+        writer_data.out_distance = contacts.rigid_distance
         writer_data.out_margin0 = contacts.rigid_contact_margin0
         writer_data.out_margin1 = contacts.rigid_contact_margin1
         writer_data.out_tids = contacts.rigid_contact_tids
@@ -1036,7 +1039,7 @@ class CollisionPipeline:
 
         # Match contacts against previous frame before sorting.
         if self._contact_matcher is not None:
-            if contacts.rigid_contact_match_index is None:
+            if contacts.rigid_match_index is None:
                 raise ValueError(
                     "CollisionPipeline has contact_matching enabled but the "
                     "Contacts buffer was created without contact_matching. "
@@ -1052,7 +1055,7 @@ class CollisionPipeline:
                 normal=contacts.rigid_contact_normal,
                 body_q=state.body_q,
                 shape_body=model.shape_body,
-                match_index_out=contacts.rigid_contact_match_index,
+                match_index_out=contacts.rigid_match_index,
                 device=self.device,
             )
 
@@ -1067,13 +1070,14 @@ class CollisionPipeline:
                 offset0=contacts.rigid_contact_offset0,
                 offset1=contacts.rigid_contact_offset1,
                 normal=contacts.rigid_contact_normal,
+                distance=contacts.rigid_distance,
                 margin0=contacts.rigid_contact_margin0,
                 margin1=contacts.rigid_contact_margin1,
                 tids=contacts.rigid_contact_tids,
                 stiffness=contacts.rigid_contact_stiffness,
                 damping=contacts.rigid_contact_damping,
                 friction=contacts.rigid_contact_friction,
-                match_index=contacts.rigid_contact_match_index,
+                match_index=contacts.rigid_match_index,
                 device=self.device,
             )
 
@@ -1085,7 +1089,7 @@ class CollisionPipeline:
         if self._matching_sticky:
             self._contact_matcher.replay_matched(
                 contact_count=contacts.rigid_contact_count,
-                match_index=contacts.rigid_contact_match_index,
+                match_index=contacts.rigid_match_index,
                 point0=contacts.rigid_contact_point0,
                 point1=contacts.rigid_contact_point1,
                 offset0=contacts.rigid_contact_offset0,
@@ -1098,19 +1102,19 @@ class CollisionPipeline:
         # overwrites _prev_count and the report needs the old value.
         if self._contact_matcher is not None:
             if self._contact_matcher.has_report:
-                if contacts.rigid_contact_new_indices is None:
+                if contacts.rigid_new_indices is None:
                     raise ValueError(
                         "CollisionPipeline has contact_report enabled but the Contacts "
                         "buffer was created without contact_report=True. "
                         "Use pipeline.contacts() to create a compatible buffer."
                     )
                 self._contact_matcher.build_report(
-                    contacts.rigid_contact_match_index,
+                    contacts.rigid_match_index,
                     contacts.rigid_contact_count,
-                    contacts.rigid_contact_new_indices,
-                    contacts.rigid_contact_new_count,
-                    contacts.rigid_contact_broken_indices,
-                    contacts.rigid_contact_broken_count,
+                    contacts.rigid_new_indices,
+                    contacts.rigid_new_count,
+                    contacts.rigid_broken_indices,
+                    contacts.rigid_broken_count,
                     device=self.device,
                 )
             sticky_offsets: dict[str, wp.array] = (
@@ -1137,7 +1141,7 @@ class CollisionPipeline:
 
         # Differentiable contact augmentation: reconstruct world-space contact
         # quantities through body_q so that gradients flow via wp.Tape.
-        if self.requires_grad and contacts.rigid_contact_diff_distance is not None:
+        if self.requires_grad and contacts.rigid_diff_distance is not None:
             launch_differentiable_contact_augment(
                 contacts=contacts,
                 body_q=state.body_q,

--- a/newton/_src/sim/contacts.py
+++ b/newton/_src/sim/contacts.py
@@ -3,15 +3,40 @@
 
 from __future__ import annotations
 
+import warnings
+from typing import ClassVar
+
 import warp as wp
 from warp import DeviceLike as Devicelike
+
+
+def _deprecated_alias(fq_old: str, new: str, extra: str = "") -> property:
+    """Build a read-only ``@property`` that warns and forwards ``getattr(self, new)``.
+
+    Args:
+        fq_old: Fully-qualified old name used in the ``DeprecationWarning`` message
+            (e.g. ``"Contacts.rigid_contact_max"``).
+        new: Target attribute name on the instance.
+        extra: Optional extra sentence appended to the warning (e.g. semantic changes).
+    """
+    msg = f"{fq_old} is deprecated; use {new}."
+    if extra:
+        msg = f"{msg} {extra}"
+
+    def getter(self):
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        return getattr(self, new)
+
+    getter.__doc__ = f"Deprecated; use :attr:`{new}`."
+    return property(getter)
+
 
 GENERATION_SENTINEL = -1
 """Value reserved as an impossible generation; the increment kernel skips it."""
 
 
 @wp.kernel(enable_backward=False)
-def _increment_contact_generation(generation: wp.array[wp.int32]):
+def _increment_generation(generation: wp.array[wp.int32]):
     g = generation[0]
     if g == 2147483647:
         g = 0
@@ -41,20 +66,16 @@ def _clear_counters_and_bump_generation(
 
 
 class Contacts:
-    """
-    Stores contact information for rigid and soft body collisions, to be consumed by a solver.
+    """Stores contact information for rigid and soft body collisions, to be consumed by a solver.
 
     This class manages buffers for contact data such as positions, normals, margins, and shape indices
     for both rigid-rigid and soft-rigid contacts. The buffers are allocated on the specified device and can
     optionally require gradients for differentiable simulation.
 
-    .. note::
-        This class is a temporary solution and its interface may change in the future.
     """
 
-    EXTENDED_ATTRIBUTES: frozenset[str] = frozenset(("force",))
-    """
-    Names of optional extended contact attributes that are not allocated by default.
+    EXTENDED_ATTRIBUTES: frozenset[str] = frozenset(("rigid_force", "rigid_velocity", "rigid_key"))
+    """Names of optional extended contact attributes that are not allocated by default.
 
     These can be requested via :meth:`newton.ModelBuilder.request_contact_attributes` or
     :meth:`newton.Model.request_contact_attributes` before calling :meth:`newton.Model.contacts` or
@@ -63,22 +84,199 @@ class Contacts:
     See :ref:`extended_contact_attributes` for details and usage.
     """
 
+    _LEGACY_EXTENDED_ATTRIBUTES: ClassVar[dict[str, str]] = {
+        "force": "rigid_force",
+        "velocity": "rigid_velocity",
+        "key": "rigid_key",
+    }
+    """Deprecated request-name aliases. Callers passing ``"force"``/``"velocity"``/``"key"`` to
+    ``request_contact_attributes`` are translated to the new ``rigid_*`` names with a
+    ``DeprecationWarning``."""
+
+    # Configuration
+    rigid_count_max: int
+    """Maximum permissible number of rigid contacts."""
+
+    soft_count_max: int
+    """Maximum permissible number of soft contacts."""
+
+    per_contact_shape_properties: bool
+    """Whether per-contact stiffness/damping/friction arrays are allocated."""
+
+    clear_buffers: bool
+    """Whether :meth:`clear` performs a full buffer wipe (slower, debugging aid)."""
+
+    requires_grad: bool
+    """Whether differentiable contact arrays are allocated."""
+
+    # Device-side counters
+    contact_counters: wp.array[wp.int32]
+    """Packed contact counts ``[rigid_count_active, soft_count_active]``, shape (2,).
+
+    The counts share one allocation so producers can reset them together. Use the sliced views
+    :attr:`rigid_count_active` and :attr:`soft_count_active` for access.
+    """
+
+    rigid_count_active: wp.array[wp.int32]
+    """Single-element device view into :attr:`contact_counters` holding the active rigid contact count, shape (1,)."""
+
+    soft_count_active: wp.array[wp.int32]
+    """Single-element device view into :attr:`contact_counters` holding the active soft contact count, shape (1,)."""
+
+    # Rigid contacts (core)
+    rigid_distance: wp.array[wp.float32]
+    """Signed contact distance, raw surface distance minus per-shape margins [m], shape (rigid_count_max,).
+
+    Negative when penetrating.
+    """
+
+    rigid_normal: wp.array[wp.vec3]
+    """Contact normal pointing from shape 0 toward shape 1 (A-to-B) [unitless], shape (rigid_count_max,)."""
+
+    rigid_point_0: wp.array[wp.vec3]
+    """Contact point in body-0 frame [m], shape (rigid_count_max,)."""
+
+    rigid_point_1: wp.array[wp.vec3]
+    """Contact point in body-1 frame [m], shape (rigid_count_max,)."""
+
+    rigid_shapes: wp.array[wp.vec2i]
+    """Shape-pair global indices ``(shape_0, shape_1)``, shape (rigid_count_max,).
+
+    Stores both shape indices per contact as a single packed pair; unused slots are filled with ``(-1, -1)``.
+    """
+
+    rigid_margins: wp.array[wp.vec2f]
+    """Surface thickness ``(margin_0, margin_1)`` [m], shape (rigid_count_max,).
+
+    Per-shape effective radius plus margin, stored as a packed pair.
+    """
+
+    # storage for deprecated offset arrays
+    _deprecated_rigid_offset_0: wp.array[wp.vec3]
+    _deprecated_rigid_offset_1: wp.array[wp.vec3]
+
+    rigid_tids: wp.array[wp.int32]
+    """Narrow-phase thread index that produced each contact [dimensionless], shape (rigid_count_max,).
+
+    Used for gradient routing through the differentiable collision path.
+    """
+
+    # Rigid contacts (gated on ``per_contact_shape_properties``)
+    rigid_stiffness: wp.array[wp.float32] | None
+    """Per-contact stiffness [N/m], shape (rigid_count_max,).
+
+    ``None`` unless ``per_contact_shape_properties=True`` was passed to the constructor.
+    """
+
+    rigid_damping: wp.array[wp.float32] | None
+    """Per-contact damping [N·s/m], shape (rigid_count_max,).
+
+    ``None`` unless ``per_contact_shape_properties=True`` was passed to the constructor.
+    """
+
+    rigid_friction: wp.array[wp.float32] | None
+    """Per-contact friction coefficient [dimensionless], shape (rigid_count_max,).
+
+    ``None`` unless ``per_contact_shape_properties=True`` was passed to the constructor.
+    """
+
+    # Rigid contacts (gated on ``requires_grad``)
+    rigid_diff_distance: wp.array[wp.float32] | None
+    """Differentiable signed distance [m], shape (rigid_count_max,).
+
+    ``None`` unless ``requires_grad=True``. Populated by :meth:`newton.CollisionPipeline.collide`
+    when ``requires_grad=True``. **Experimental.**
+    """
+
+    rigid_diff_normal: wp.array[wp.vec3] | None
+    """Contact normal (A-to-B, world frame) [unitless], shape (rigid_count_max,).
+
+    ``None`` unless ``requires_grad=True``. **Experimental.**
+    """
+
+    rigid_diff_point_0_world: wp.array[wp.vec3] | None
+    """World-space contact point on shape 0 [m], shape (rigid_count_max,).
+
+    ``None`` unless ``requires_grad=True``. **Experimental.**
+    """
+
+    rigid_diff_point_1_world: wp.array[wp.vec3] | None
+    """World-space contact point on shape 1 [m], shape (rigid_count_max,).
+
+    ``None`` unless ``requires_grad=True``. **Experimental.**
+    """
+
+    # Soft contacts
+    soft_particle: wp.array[wp.int32]
+    """Particle index per contact [dimensionless], shape (soft_count_max,)."""
+
+    soft_shape: wp.array[wp.int32]
+    """Shape index per contact [dimensionless], shape (soft_count_max,)."""
+
+    soft_body_pos: wp.array[wp.vec3]
+    """Contact position on body [m], shape (soft_count_max,)."""
+
+    soft_body_vel: wp.array[wp.vec3]
+    """Contact velocity on body [m/s], shape (soft_count_max,)."""
+
+    soft_normal: wp.array[wp.vec3]
+    """Contact normal direction [unitless], shape (soft_count_max,)."""
+
+    soft_tids: wp.array[wp.int32]
+    """Narrow-phase thread index that produced each contact [dimensionless], shape (soft_count_max,).
+
+    Used for gradient routing through the differentiable collision path.
+    """
+
+    # Extended rigid attributes (request-gated)
+    rigid_force: wp.array[wp.spatial_vector] | None
+    """Rigid contact spatial force [N, N·m], shape (rigid_count_max,).
+    First three entries: linear force [N]; last three: torque [N·m]. Solvers may populate the wrench
+    partially (e.g., linear only). ``None`` unless requested.
+
+    This is an extended contact attribute; see :ref:`extended_contact_attributes` for more information.
+
+    .. note::
+        Wrench exerted **by body 0 on body 1** in world frame; the linear part is broadly collinear
+        with :attr:`rigid_normal`.
+    """
+
+    rigid_velocity: wp.array[wp.spatial_vector] | None
+    """Rigid contact spatial velocity (solver output) [m/s, rad/s], shape (rigid_count_max,).
+
+    ``None`` unless requested.
+
+    This is an extended contact attribute; see :ref:`extended_contact_attributes` for more information.
+    """
+
+    rigid_key: wp.array[wp.uint64] | None
+    """Cross-step rigid contact identifier for warmstart/matching [dimensionless], shape (rigid_count_max,).
+
+    Solver-populated.  ``None`` unless requested.
+
+    This is an extended contact attribute; see :ref:`extended_contact_attributes` for more information.
+    """
+
     @classmethod
     def validate_extended_attributes(cls, attributes: tuple[str, ...]) -> None:
         """Validate names passed to request_contact_attributes().
 
         Only extended contact attributes listed in :attr:`EXTENDED_ATTRIBUTES` are accepted.
+        Legacy aliases in :attr:`_LEGACY_EXTENDED_ATTRIBUTES` are accepted for backward
+        compatibility (translated to their new names in :meth:`__init__` with a deprecation
+        warning).
 
         Args:
             attributes: Tuple of attribute names to validate.
 
         Raises:
-            ValueError: If any attribute name is not in :attr:`EXTENDED_ATTRIBUTES`.
+            ValueError: If any attribute name is not recognised.
         """
         if not attributes:
             return
 
-        invalid = sorted(set(attributes).difference(cls.EXTENDED_ATTRIBUTES))
+        accepted = cls.EXTENDED_ATTRIBUTES | cls._LEGACY_EXTENDED_ATTRIBUTES.keys()
+        invalid = sorted(set(attributes).difference(accepted))
         if invalid:
             allowed = ", ".join(sorted(cls.EXTENDED_ATTRIBUTES))
             bad = ", ".join(invalid)
@@ -86,8 +284,8 @@ class Contacts:
 
     def __init__(
         self,
-        rigid_contact_max: int,
-        soft_contact_max: int,
+        rigid_count_max: int | None = None,
+        soft_count_max: int | None = None,
         requires_grad: bool = False,
         device: Devicelike = None,
         per_contact_shape_properties: bool = False,
@@ -95,200 +293,170 @@ class Contacts:
         requested_attributes: set[str] | None = None,
         contact_matching: bool = False,
         contact_report: bool = False,
+        rigid_contact_max: int | None = None,
+        soft_contact_max: int | None = None,
     ):
-        """
-        Initialize Contacts storage.
+        """Initialize Contacts storage.
 
         Args:
-            rigid_contact_max: Maximum number of rigid contacts
-            soft_contact_max: Maximum number of soft contacts
-            requires_grad: Whether contact arrays require gradients for differentiable
-                simulation.  When ``True``, soft contact arrays (body_pos, body_vel, normal)
-                are allocated with gradients so that gradient-based optimization can flow
-                through particle-shape contacts, **and** additional differentiable rigid
-                contact arrays are allocated (``rigid_contact_diff_*``) that provide
-                first-order gradients of contact distance and world-space points with
-                respect to body poses.
-            device: Device to allocate buffers on
-            per_contact_shape_properties: Enable per-contact stiffness/damping/friction arrays
-            clear_buffers: If True, clear() will zero all contact buffers (slower but conservative).
-                If False (default), clear() only resets counts in a single fused kernel launch,
-                relying on collision detection to overwrite active contacts. This is much faster
-                than the conservative path and safe since solvers only read up to contact_count.
-            requested_attributes: Set of extended contact attribute names to allocate.
-                See :attr:`EXTENDED_ATTRIBUTES` for available options.
+            rigid_count_max: Maximum number of rigid contacts. Required.
+            soft_count_max: Maximum number of soft contacts. Required.
+            requires_grad: Whether contact arrays require gradients for differentiable simulation.
+                When ``True``, soft contact arrays (body_pos, body_vel, normal) are allocated with
+                gradients so that gradient-based optimization can flow through particle-shape contacts,
+                **and** additional differentiable rigid contact arrays are allocated
+                (``rigid_diff_*``) that provide first-order gradients of contact distance and
+                world-space points with respect to body poses.
+            device: Device to allocate buffers on.
+            per_contact_shape_properties: Enable per-contact stiffness/damping/friction arrays.
+            clear_buffers: If ``True``, :meth:`clear` will zero all contact buffers (slower but
+                conservative). If ``False`` (default), :meth:`clear` only resets counts in a single
+                fused kernel launch, relying on collision detection to overwrite active contacts.
+                Safe since solvers only read up to ``rigid_count_active``.
+            requested_attributes: Set of extended contact attribute names to allocate. See
+                :attr:`EXTENDED_ATTRIBUTES` for available options.
             contact_matching: Allocate a per-contact match index array
-                (:attr:`rigid_contact_match_index`) that stores frame-to-frame
-                contact correspondences filled by the collision pipeline.
-            contact_report: Allocate compact index lists of new and broken
-                contacts (:attr:`rigid_contact_new_indices`,
-                :attr:`rigid_contact_new_count`,
-                :attr:`rigid_contact_broken_indices`,
-                :attr:`rigid_contact_broken_count`) populated each frame by
-                the collision pipeline.  Requires ``contact_matching=True``.
+                (:attr:`rigid_match_index`) that stores frame-to-frame contact
+                correspondences filled by the collision pipeline.
+            contact_report: Allocate compact index lists of new and broken contacts
+                (:attr:`rigid_new_indices`, :attr:`rigid_new_count`,
+                :attr:`rigid_broken_indices`, :attr:`rigid_broken_count`)
+                populated each frame by the collision pipeline. Requires ``contact_matching=True``.
+            rigid_contact_max: Deprecated alias for ``rigid_count_max``.
+            soft_contact_max: Deprecated alias for ``soft_count_max``.
 
         .. note::
-            The ``rigid_contact_diff_*`` arrays allocated when ``requires_grad=True`` are
-            **experimental**; see :meth:`newton.CollisionPipeline.collide`.
+            The ``rigid_diff_*`` arrays allocated when ``requires_grad=True`` are **experimental**;
+            see :meth:`newton.CollisionPipeline.collide`.
         """
         if contact_report and not contact_matching:
             raise ValueError("contact_report=True requires contact_matching=True")
+        if rigid_contact_max is not None:
+            warnings.warn(
+                "Contacts(rigid_contact_max=...) is deprecated; use rigid_count_max.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if rigid_count_max is not None:
+                raise TypeError("Pass either rigid_count_max or the deprecated rigid_contact_max, not both.")
+            rigid_count_max = rigid_contact_max
+        if soft_contact_max is not None:
+            warnings.warn(
+                "Contacts(soft_contact_max=...) is deprecated; use soft_count_max.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if soft_count_max is not None:
+                raise TypeError("Pass either soft_count_max or the deprecated soft_contact_max, not both.")
+            soft_count_max = soft_contact_max
+        if rigid_count_max is None or soft_count_max is None:
+            raise TypeError("Contacts requires rigid_count_max and soft_count_max.")
+
+        self.rigid_count_max = rigid_count_max
+        self.soft_count_max = soft_count_max
         self.per_contact_shape_properties = per_contact_shape_properties
         self.clear_buffers = clear_buffers
-        with wp.ScopedDevice(device):
-            # Packed counter array [rigid_contact_count, soft_contact_count] so
-            # all counts can be zeroed together in one fused kernel launch.
-            # Every entry must be safe to reset to zero at the start of a
-            # collision pass.
-            self.contact_counters = wp.zeros(2, dtype=wp.int32)
-            # Create sliced views for individual counters (no additional allocation)
-            self.rigid_contact_count = self.contact_counters[0:1]
+        self.contact_matching = contact_matching
+        self.contact_report = contact_report
+        self.requires_grad = requires_grad
 
-            self.contact_generation = wp.zeros(1, dtype=wp.int32)
+        with wp.ScopedDevice(device):
+            self.contact_counters = wp.zeros(2, dtype=wp.int32)
+            self.rigid_count_active = self.contact_counters[0:1]
+            self.soft_count_active = self.contact_counters[1:2]
+            self.generation = wp.zeros(1, dtype=wp.int32)
             """Device-side generation counter, incremented each time :meth:`clear` is called.
 
             Solvers can compare this against a cached value to detect whether the
             contact set changed since the last conversion pass."""
 
-            # rigid contacts — never requires_grad (narrow phase has enable_backward=False)
-            self.rigid_contact_point_id = wp.zeros(rigid_contact_max, dtype=wp.int32)
-            self.rigid_contact_shape0 = wp.full(rigid_contact_max, -1, dtype=wp.int32)
-            self.rigid_contact_shape1 = wp.full(rigid_contact_max, -1, dtype=wp.int32)
-            self.rigid_contact_point0 = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Body-frame contact point on shape 0 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
-            self.rigid_contact_point1 = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Body-frame contact point on shape 1 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
-            self.rigid_contact_offset0 = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Body-frame friction anchor offset for shape 0 [m], shape (rigid_contact_max,), dtype :class:`vec3`.
+            # Rigid core
+            self.rigid_distance = wp.zeros(rigid_count_max, dtype=wp.float32)
+            self.rigid_normal = wp.zeros(rigid_count_max, dtype=wp.vec3)
+            self.rigid_point_0 = wp.zeros(rigid_count_max, dtype=wp.vec3)
+            self.rigid_point_1 = wp.zeros(rigid_count_max, dtype=wp.vec3)
+            self.rigid_shapes = wp.full(rigid_count_max, wp.vec2i(-1, -1), dtype=wp.vec2i)
+            self.rigid_margins = wp.zeros(rigid_count_max, dtype=wp.vec2f)
+            self._deprecated_rigid_offset_0 = wp.zeros(rigid_count_max, dtype=wp.vec3)
+            self._deprecated_rigid_offset_1 = wp.zeros(rigid_count_max, dtype=wp.vec3)
+            self.rigid_tids = wp.full(rigid_count_max, -1, dtype=wp.int32)
 
-            Equal to the contact normal scaled by ``effective_radius + margin`` and
-            expressed in shape 0's body frame. Combined with
-            ``rigid_contact_point0`` to form a shifted friction anchor that accounts
-            for rotational effects of finite contact thickness in tangential friction
-            calculations."""
-            self.rigid_contact_offset1 = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Body-frame friction anchor offset for shape 1 [m], shape (rigid_contact_max,), dtype :class:`vec3`.
-
-            Equal to the contact normal scaled by ``effective_radius + margin`` and
-            expressed in shape 1's body frame. Combined with
-            ``rigid_contact_point1`` to form a shifted friction anchor that accounts
-            for rotational effects of finite contact thickness in tangential friction
-            calculations."""
-            self.rigid_contact_normal = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Contact normal pointing from shape 0 toward shape 1 (A-to-B) [unitless], shape (rigid_contact_max,), dtype :class:`vec3`."""
-            self.rigid_contact_margin0 = wp.zeros(rigid_contact_max, dtype=wp.float32)
-            """Surface thickness for shape 0: effective radius + margin [m], shape (rigid_contact_max,), dtype float."""
-            self.rigid_contact_margin1 = wp.zeros(rigid_contact_max, dtype=wp.float32)
-            """Surface thickness for shape 1: effective radius + margin [m], shape (rigid_contact_max,), dtype float."""
-            self.rigid_contact_tids = wp.full(rigid_contact_max, -1, dtype=wp.int32)
-            # to be filled by the solver (currently unused)
-            self.rigid_contact_force = wp.zeros(rigid_contact_max, dtype=wp.vec3)
-            """Contact force [N], shape (rigid_contact_max,), dtype :class:`vec3`."""
-
-            # Differentiable rigid contact arrays -- only allocated when requires_grad
-            # is True.  Populated by the post-processing kernel in
-            # :mod:`newton._src.geometry.differentiable_contacts`.
+            # Rigid differentiable arrays (gated on requires_grad)
             if requires_grad:
-                self.rigid_contact_diff_distance = wp.zeros(rigid_contact_max, dtype=wp.float32, requires_grad=True)
-                """Differentiable signed distance [m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_diff_normal = wp.zeros(rigid_contact_max, dtype=wp.vec3, requires_grad=False)
-                """Contact normal (A-to-B, world frame) [unitless], shape (rigid_contact_max,), dtype :class:`vec3`."""
-                self.rigid_contact_diff_point0_world = wp.zeros(rigid_contact_max, dtype=wp.vec3, requires_grad=True)
-                """World-space contact point on shape 0 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
-                self.rigid_contact_diff_point1_world = wp.zeros(rigid_contact_max, dtype=wp.vec3, requires_grad=True)
-                """World-space contact point on shape 1 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
+                self.rigid_diff_distance = wp.zeros(rigid_count_max, dtype=wp.float32, requires_grad=True)
+                self.rigid_diff_normal = wp.zeros(rigid_count_max, dtype=wp.vec3, requires_grad=False)
+                self.rigid_diff_point_0_world = wp.zeros(rigid_count_max, dtype=wp.vec3, requires_grad=True)
+                self.rigid_diff_point_1_world = wp.zeros(rigid_count_max, dtype=wp.vec3, requires_grad=True)
             else:
-                self.rigid_contact_diff_distance = None
-                """Differentiable signed distance [m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_diff_normal = None
-                """Contact normal (A-to-B, world frame) [unitless], shape (rigid_contact_max,), dtype :class:`vec3`."""
-                self.rigid_contact_diff_point0_world = None
-                """World-space contact point on shape 0 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
-                self.rigid_contact_diff_point1_world = None
-                """World-space contact point on shape 1 [m], shape (rigid_contact_max,), dtype :class:`vec3`."""
+                self.rigid_diff_distance = None
+                self.rigid_diff_normal = None
+                self.rigid_diff_point_0_world = None
+                self.rigid_diff_point_1_world = None
 
-            # contact stiffness/damping/friction (only allocated if per_contact_shape_properties is enabled)
-            if self.per_contact_shape_properties:
-                self.rigid_contact_stiffness = wp.zeros(rigid_contact_max, dtype=wp.float32)
-                """Per-contact stiffness [N/m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_damping = wp.zeros(rigid_contact_max, dtype=wp.float32)
-                """Per-contact damping [N·s/m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_friction = wp.zeros(rigid_contact_max, dtype=wp.float32)
-                """Per-contact friction coefficient [dimensionless], shape (rigid_contact_max,), dtype float."""
+            # Rigid per-shape-properties (gated)
+            if per_contact_shape_properties:
+                self.rigid_stiffness = wp.zeros(rigid_count_max, dtype=wp.float32)
+                self.rigid_damping = wp.zeros(rigid_count_max, dtype=wp.float32)
+                self.rigid_friction = wp.zeros(rigid_count_max, dtype=wp.float32)
             else:
-                self.rigid_contact_stiffness = None
-                """Per-contact stiffness [N/m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_damping = None
-                """Per-contact damping [N·s/m], shape (rigid_contact_max,), dtype float."""
-                self.rigid_contact_friction = None
-                """Per-contact friction coefficient [dimensionless], shape (rigid_contact_max,), dtype float."""
+                self.rigid_stiffness = None
+                self.rigid_damping = None
+                self.rigid_friction = None
 
-            # Contact matching index — filled by the collision pipeline when
-            # contact_matching is enabled.
-            self.contact_matching = contact_matching
-            self.contact_report = contact_report
+            # Contact matching / reporting (gated)
+            # Filled by the collision pipeline when contact_matching is enabled.
             if contact_matching:
-                self.rigid_contact_match_index = wp.full(rigid_contact_max, -1, dtype=wp.int32)
-                """Per-contact match index from frame-to-frame matching.
-
-                Values: ``>= 0`` matched old contact index;
-                :data:`newton.geometry.MATCH_NOT_FOUND` (``-1``) new contact;
-                :data:`newton.geometry.MATCH_BROKEN` (``-2``) key matched but
-                position/normal thresholds exceeded.
-                Shape (rigid_contact_max,), dtype int32."""
+                self.rigid_match_index = wp.full(rigid_count_max, -1, dtype=wp.int32)
             else:
-                self.rigid_contact_match_index = None
+                self.rigid_match_index = None
 
             if contact_report:
-                self.rigid_contact_new_indices = wp.zeros(rigid_contact_max, dtype=wp.int32)
-                """Indices of new contacts in the current sorted buffer (where ``match_index < 0``).
-
-                Valid after the collision pipeline runs.
-                Shape (rigid_contact_max,), dtype int32."""
-                self.rigid_contact_new_count = wp.zeros(1, dtype=wp.int32)
-                """Device-side count of new contacts (single-element int32)."""
-                self.rigid_contact_broken_indices = wp.zeros(rigid_contact_max, dtype=wp.int32)
-                """Indices of broken contacts in the previous frame's sorted buffer.
-
-                Valid after the collision pipeline runs.
-                Shape (rigid_contact_max,), dtype int32."""
-                self.rigid_contact_broken_count = wp.zeros(1, dtype=wp.int32)
-                """Device-side count of broken contacts (single-element int32)."""
+                self.rigid_new_indices = wp.zeros(rigid_count_max, dtype=wp.int32)
+                self.rigid_new_count = wp.zeros(1, dtype=wp.int32)
+                self.rigid_broken_indices = wp.zeros(rigid_count_max, dtype=wp.int32)
+                self.rigid_broken_count = wp.zeros(1, dtype=wp.int32)
             else:
-                self.rigid_contact_new_indices = None
-                self.rigid_contact_new_count = None
-                self.rigid_contact_broken_indices = None
-                self.rigid_contact_broken_count = None
+                self.rigid_new_indices = None
+                self.rigid_new_count = None
+                self.rigid_broken_indices = None
+                self.rigid_broken_count = None
 
-            # soft contacts — requires_grad flows through here for differentiable simulation
-            self.soft_contact_count = self.contact_counters[1:2]
-            self.soft_contact_particle = wp.full(soft_contact_max, -1, dtype=int)
-            self.soft_contact_shape = wp.full(soft_contact_max, -1, dtype=int)
-            self.soft_contact_body_pos = wp.zeros(soft_contact_max, dtype=wp.vec3, requires_grad=requires_grad)
-            """Contact position on body [m], shape (soft_contact_max,), dtype :class:`vec3`."""
-            self.soft_contact_body_vel = wp.zeros(soft_contact_max, dtype=wp.vec3, requires_grad=requires_grad)
-            """Contact velocity on body [m/s], shape (soft_contact_max,), dtype :class:`vec3`."""
-            self.soft_contact_normal = wp.zeros(soft_contact_max, dtype=wp.vec3, requires_grad=requires_grad)
-            """Contact normal direction [unitless], shape (soft_contact_max,), dtype :class:`vec3`."""
-            self.soft_contact_tids = wp.full(soft_contact_max, -1, dtype=int)
+            # Soft contacts
+            # requires_grad flows through here for differentiable simulation.
+            self.soft_particle = wp.full(soft_count_max, -1, dtype=wp.int32)
+            self.soft_shape = wp.full(soft_count_max, -1, dtype=wp.int32)
+            self.soft_body_pos = wp.zeros(soft_count_max, dtype=wp.vec3, requires_grad=requires_grad)
+            self.soft_body_vel = wp.zeros(soft_count_max, dtype=wp.vec3, requires_grad=requires_grad)
+            self.soft_normal = wp.zeros(soft_count_max, dtype=wp.vec3, requires_grad=requires_grad)
+            self.soft_tids = wp.full(soft_count_max, -1, dtype=wp.int32)
 
-            # Extended contact attributes (optional, allocated on demand)
-            self.force: wp.array | None = None
-            """Contact forces (spatial) [N, N·m], shape (rigid_contact_max + soft_contact_max,), dtype :class:`spatial_vector`.
-            Force and torque exerted on body0 by body1, referenced to the center of mass (COM) of body0, and in world frame, where body0 and body1 are the bodies of shape0 and shape1.
-            First three entries: linear force [N]; last three entries: torque (moment) [N·m].
-            When both rigid and soft contacts are present, soft contact forces follow rigid contact forces.
+            # Extended rigid attributes (request-gated)
+            self.rigid_force = None
+            self.rigid_velocity = None
+            self.rigid_key = None
+            if requested_attributes:
+                self.validate_extended_attributes(tuple(requested_attributes))
+                normalized: set[str] = set()
+                for attr in requested_attributes:
+                    new_name = self._LEGACY_EXTENDED_ATTRIBUTES.get(attr)
+                    if new_name is not None:
+                        warnings.warn(
+                            f"Contacts extended attribute '{attr}' is deprecated; use '{new_name}'.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        normalized.add(new_name)
+                    else:
+                        normalized.add(attr)
 
-            This is an extended contact attribute; see :ref:`extended_contact_attributes` for more information.
-            """
-            if requested_attributes and "force" in requested_attributes:
-                total_contacts = rigid_contact_max + soft_contact_max
-                self.force = wp.zeros(total_contacts, dtype=wp.spatial_vector, requires_grad=requires_grad)
-
-        self.requires_grad = requires_grad
-
-        self.rigid_contact_max = rigid_contact_max
-        self.soft_contact_max = soft_contact_max
+                if "rigid_force" in normalized:
+                    self.rigid_force = wp.zeros(rigid_count_max, dtype=wp.spatial_vector, requires_grad=requires_grad)
+                if "rigid_velocity" in normalized:
+                    self.rigid_velocity = wp.zeros(
+                        rigid_count_max, dtype=wp.spatial_vector, requires_grad=requires_grad
+                    )
+                if "rigid_key" in normalized:
+                    self.rigid_key = wp.zeros(rigid_count_max, dtype=wp.uint64)
 
     def clear(self, bump_generation: bool = True):
         """
@@ -303,7 +471,7 @@ class Contacts:
         values and zeros. This requires several additional kernel launches but may be useful for debugging.
 
         Args:
-            bump_generation: If True (default), increment ``contact_generation`` to invalidate
+            bump_generation: If True (default), increment ``generation`` to invalidate
                 previously-observed contact data. Callers that will immediately re-bump the
                 generation via another fused kernel (e.g. :func:`compute_shape_aabbs`) can pass
                 ``False`` to avoid an unnecessary double-bump per collision pass.
@@ -313,46 +481,172 @@ class Contacts:
         wp.launch(
             _clear_counters_and_bump_generation,
             dim=max(num_counters, 1),
-            inputs=[self.contact_counters, self.contact_generation, num_counters, int(bump_generation)],
-            device=self.contact_generation.device,
+            inputs=[self.contact_counters, self.generation, num_counters, int(bump_generation)],
+            device=self.generation.device,
             record_tape=False,
         )
 
         if self.clear_buffers:
             # Conservative path: clear all buffers with sentinel values and zeros.
             # Slower than the fast path but may be useful for debugging or special cases.
-            self.rigid_contact_shape0.fill_(-1)
-            self.rigid_contact_shape1.fill_(-1)
-            self.rigid_contact_tids.fill_(-1)
-            self.rigid_contact_force.zero_()
+            self.rigid_shapes.fill_(wp.vec2i(-1, -1))
+            self.rigid_tids.fill_(-1)
+            self.rigid_distance.zero_()
+            self.rigid_normal.zero_()
+            self.rigid_point_0.zero_()
+            self.rigid_point_1.zero_()
+            self.rigid_margins.zero_()
+            self._deprecated_rigid_offset_0.zero_()
+            self._deprecated_rigid_offset_1.zero_()
 
-            if self.force is not None:
-                self.force.zero_()
+            if self.rigid_force is not None:
+                self.rigid_force.zero_()
+            if self.rigid_velocity is not None:
+                self.rigid_velocity.zero_()
+            if self.rigid_key is not None:
+                self.rigid_key.zero_()
 
-            if self.rigid_contact_diff_distance is not None:
-                self.rigid_contact_diff_distance.zero_()
-                self.rigid_contact_diff_normal.zero_()
-                self.rigid_contact_diff_point0_world.zero_()
-                self.rigid_contact_diff_point1_world.zero_()
+            if self.rigid_diff_distance is not None:
+                self.rigid_diff_distance.zero_()
+                self.rigid_diff_normal.zero_()
+                self.rigid_diff_point_0_world.zero_()
+                self.rigid_diff_point_1_world.zero_()
 
             if self.per_contact_shape_properties:
-                self.rigid_contact_stiffness.zero_()
-                self.rigid_contact_damping.zero_()
-                self.rigid_contact_friction.zero_()
+                self.rigid_stiffness.zero_()
+                self.rigid_damping.zero_()
+                self.rigid_friction.zero_()
 
-            if self.rigid_contact_match_index is not None:
-                self.rigid_contact_match_index.fill_(-1)
+            if self.rigid_match_index is not None:
+                self.rigid_match_index.fill_(-1)
 
-            self.soft_contact_particle.fill_(-1)
-            self.soft_contact_shape.fill_(-1)
-            self.soft_contact_tids.fill_(-1)
+            self.soft_particle.fill_(-1)
+            self.soft_shape.fill_(-1)
+            self.soft_tids.fill_(-1)
+            self.soft_body_pos.zero_()
+            self.soft_body_vel.zero_()
+            self.soft_normal.zero_()
         # else: Optimized path (default) - only counter clear needed
         #   Collision detection overwrites all active contacts [0, contact_count)
         #   Solvers only read [0, contact_count), so stale data is never accessed
 
     @property
     def device(self):
+        """Returns the device on which the contact buffers are allocated."""
+        return self.rigid_count_active.device
+
+    rigid_contact_max = _deprecated_alias("Contacts.rigid_contact_max", "rigid_count_max")
+    soft_contact_max = _deprecated_alias("Contacts.soft_contact_max", "soft_count_max")
+    rigid_contact_count = _deprecated_alias("Contacts.rigid_contact_count", "rigid_count_active")
+    soft_contact_count = _deprecated_alias("Contacts.soft_contact_count", "soft_count_active")
+    rigid_contact_normal = _deprecated_alias("Contacts.rigid_contact_normal", "rigid_normal")
+    rigid_contact_point0 = _deprecated_alias("Contacts.rigid_contact_point0", "rigid_point_0")
+    rigid_contact_point1 = _deprecated_alias("Contacts.rigid_contact_point1", "rigid_point_1")
+    rigid_contact_tids = _deprecated_alias("Contacts.rigid_contact_tids", "rigid_tids")
+
+    @property
+    def rigid_contact_offset0(self) -> wp.array:
+        """Deprecated."""
+        warnings.warn("Contacts.rigid_contact_offset0 is deprecated.", DeprecationWarning, stacklevel=2)
+        return self._deprecated_rigid_offset_0
+
+    @property
+    def rigid_contact_offset1(self) -> wp.array:
+        """Deprecated."""
+        warnings.warn("Contacts.rigid_contact_offset1 is deprecated.", DeprecationWarning, stacklevel=2)
+        return self._deprecated_rigid_offset_1
+
+    rigid_contact_stiffness = _deprecated_alias("Contacts.rigid_contact_stiffness", "rigid_stiffness")
+    rigid_contact_damping = _deprecated_alias("Contacts.rigid_contact_damping", "rigid_damping")
+    rigid_contact_friction = _deprecated_alias("Contacts.rigid_contact_friction", "rigid_friction")
+    rigid_contact_diff_distance = _deprecated_alias("Contacts.rigid_contact_diff_distance", "rigid_diff_distance")
+    rigid_contact_diff_normal = _deprecated_alias("Contacts.rigid_contact_diff_normal", "rigid_diff_normal")
+    rigid_contact_diff_point0_world = _deprecated_alias(
+        "Contacts.rigid_contact_diff_point0_world", "rigid_diff_point_0_world"
+    )
+    rigid_contact_diff_point1_world = _deprecated_alias(
+        "Contacts.rigid_contact_diff_point1_world", "rigid_diff_point_1_world"
+    )
+    soft_contact_particle = _deprecated_alias("Contacts.soft_contact_particle", "soft_particle")
+    soft_contact_shape = _deprecated_alias("Contacts.soft_contact_shape", "soft_shape")
+    soft_contact_body_pos = _deprecated_alias("Contacts.soft_contact_body_pos", "soft_body_pos")
+    soft_contact_body_vel = _deprecated_alias("Contacts.soft_contact_body_vel", "soft_body_vel")
+    soft_contact_normal = _deprecated_alias("Contacts.soft_contact_normal", "soft_normal")
+    soft_contact_tids = _deprecated_alias("Contacts.soft_contact_tids", "soft_tids")
+    force = _deprecated_alias(
+        "Contacts.force",
+        "rigid_force",
+        extra="Sign convention also changed: rigid_force is the force BY body 0 ON body 1 (negate the legacy values).",
+    )
+    velocity = _deprecated_alias("Contacts.velocity", "rigid_velocity")
+    key = _deprecated_alias("Contacts.key", "rigid_key")
+
+    # Variants with extra logic
+
+    @property
+    def rigid_contact_shape0(self) -> wp.array:
+        """Deprecated; use :attr:`rigid_shapes` (packed ``vec2i``)."""
+        warnings.warn(
+            "Contacts.rigid_contact_shape0 is deprecated; use rigid_shapes (packed vec2i).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.rigid_shapes.view(wp.int32)[:, 0]
+
+    @property
+    def rigid_contact_shape1(self) -> wp.array:
+        """Deprecated; use :attr:`rigid_shapes` (packed ``vec2i``)."""
+        warnings.warn(
+            "Contacts.rigid_contact_shape1 is deprecated; use rigid_shapes (packed vec2i).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.rigid_shapes.view(wp.int32)[:, 1]
+
+    @property
+    def rigid_contact_margin0(self) -> wp.array:
+        """Deprecated; use :attr:`rigid_margins` (packed ``vec2f``)."""
+        warnings.warn(
+            "Contacts.rigid_contact_margin0 is deprecated; use rigid_margins (packed vec2f).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.rigid_margins.view(wp.float32)[:, 0]
+
+    @property
+    def rigid_contact_margin1(self) -> wp.array:
+        """Deprecated; use :attr:`rigid_margins` (packed ``vec2f``)."""
+        warnings.warn(
+            "Contacts.rigid_contact_margin1 is deprecated; use rigid_margins (packed vec2f).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.rigid_margins.view(wp.float32)[:, 1]
+
+    @property
+    def rigid_contact_point_id(self) -> None:
+        """Deprecated; attribute removed (had no consumers)."""
+        warnings.warn(
+            "Contacts.rigid_contact_point_id is deprecated and no longer allocated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return None
+
+    @property
+    def rigid_contact_force(self) -> wp.array | None:
+        """Deprecated; use extended attribute :attr:`rigid_force` (``spatial_vector``).
+
+        Returns a strided ``vec3`` view over the linear part of :attr:`rigid_force`, or ``None`` if
+        ``rigid_force`` was not requested. Solvers that write through this shim must ensure their
+        model has requested ``"rigid_force"`` first.
         """
-        Returns the device on which the contact buffers are allocated.
-        """
-        return self.rigid_contact_count.device
+        warnings.warn(
+            "Contacts.rigid_contact_force is deprecated; use the extended attribute 'rigid_force' "
+            "(spatial_vector, request via request_contact_attributes).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if self.rigid_force is None:
+            return None
+        return self.rigid_force.view(wp.float32)[:, :3].view(wp.vec3)

--- a/newton/_src/sim/contacts.py
+++ b/newton/_src/sim/contacts.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import ClassVar
 
 import warp as wp
 from warp import DeviceLike as Devicelike
@@ -83,7 +84,7 @@ class Contacts:
     See :ref:`extended_contact_attributes` for details and usage.
     """
 
-    _LEGACY_EXTENDED_ATTRIBUTES: dict[str, str] = {
+    _LEGACY_EXTENDED_ATTRIBUTES: ClassVar[dict[str, str]] = {
         "force": "rigid_force",
         "velocity": "rigid_velocity",
         "key": "rigid_key",

--- a/newton/_src/sim/contacts.py
+++ b/newton/_src/sim/contacts.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import warnings
-from typing import ClassVar
 
 import warp as wp
 from warp import DeviceLike as Devicelike
@@ -84,7 +83,7 @@ class Contacts:
     See :ref:`extended_contact_attributes` for details and usage.
     """
 
-    _LEGACY_EXTENDED_ATTRIBUTES: ClassVar[dict[str, str]] = {
+    _LEGACY_EXTENDED_ATTRIBUTES: dict[str, str] = {
         "force": "rigid_force",
         "velocity": "rigid_velocity",
         "key": "rigid_key",

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -896,6 +896,7 @@ def _convert_contacts_kamino_to_newton(
     rigid_contact_point0: wp.array(dtype=vec3f),
     rigid_contact_point1: wp.array(dtype=vec3f),
     rigid_contact_normal: wp.array(dtype=vec3f),
+    rigid_contact_distance: wp.array(dtype=float32),
 ):
     """Converts Kamino's internal contact representation to Newton's Contacts format."""
     # Retrieve the contact index for this thread
@@ -940,6 +941,7 @@ def _convert_contacts_kamino_to_newton(
     rigid_contact_shape0[cid] = shape0
     rigid_contact_shape1[cid] = shape1
     rigid_contact_normal[cid] = vec3f(gapfunc[0], gapfunc[1], gapfunc[2])
+    rigid_contact_distance[cid] = gapfunc[3]
     rigid_contact_point0[cid] = wp.transform_point(X_inv_a, position_A)
     rigid_contact_point1[cid] = wp.transform_point(X_inv_b, position_B)
 
@@ -1047,6 +1049,7 @@ def convert_contacts_kamino_to_newton(
     """
     # Skip conversion if there are no contacts to convert or no capacity to store them.
     if contacts_in.data.model_max_contacts_host == 0 or contacts_out.rigid_contact_max == 0:
+        contacts_out.clear()
         return
 
     # Issue warning to the user if the number of contacts to convert exceeds the capacity of the output contacts.
@@ -1080,6 +1083,7 @@ def convert_contacts_kamino_to_newton(
             contacts_out.rigid_contact_point0,
             contacts_out.rigid_contact_point1,
             contacts_out.rigid_contact_normal,
+            contacts_out.rigid_distance,
         ],
         device=model.device,
     )

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -1206,7 +1206,9 @@ def create_convert_mjw_contacts_to_newton_kernel():
         mj_geom_bodyid: wp.array[int],
         mj_xpos: wp.array2d[wp.vec3],
         mj_xquat: wp.array2d[wp.quatf],
+        shape_margin: wp.array[float],
         njmax: int,
+        rigid_count_max: int,
         # outputs
         rigid_contact_count: wp.array[wp.int32],
         rigid_contact_shape0: wp.array[wp.int32],
@@ -1214,6 +1216,8 @@ def create_convert_mjw_contacts_to_newton_kernel():
         rigid_contact_point0: wp.array[wp.vec3],
         rigid_contact_point1: wp.array[wp.vec3],
         rigid_contact_normal: wp.array[wp.vec3],
+        rigid_contact_distance: wp.array[float],
+        rigid_margins: wp.array[wp.vec2f],
         contact_force: wp.array[wp.spatial_vector],
     ):
         """Convert MuJoCo contacts to Newton contact format.
@@ -1226,6 +1230,7 @@ def create_convert_mjw_contacts_to_newton_kernel():
         n_contacts = mj_nacon[0]
 
         if contact_idx == 0:
+            assert n_contacts <= rigid_count_max
             rigid_contact_count[0] = n_contacts
 
         if contact_idx >= n_contacts:
@@ -1237,8 +1242,10 @@ def create_convert_mjw_contacts_to_newton_kernel():
         normal = mj_contact_frame[contact_idx][0]
         pos_world = mj_contact_pos[contact_idx]
 
-        rigid_contact_shape0[contact_idx] = mjc_geom_to_newton_shape[world, geoms_mjw[0]]
-        rigid_contact_shape1[contact_idx] = mjc_geom_to_newton_shape[world, geoms_mjw[1]]
+        shape_a = mjc_geom_to_newton_shape[world, geoms_mjw[0]]
+        shape_b = mjc_geom_to_newton_shape[world, geoms_mjw[1]]
+        rigid_contact_shape0[contact_idx] = shape_a
+        rigid_contact_shape1[contact_idx] = shape_b
         rigid_contact_normal[contact_idx] = normal
 
         # Convert contact position from world frame to body-local frame for each shape.
@@ -1261,9 +1268,15 @@ def create_convert_mjw_contacts_to_newton_kernel():
         rigid_contact_point0[contact_idx] = wp.transform_point(wp.transform_inverse(X_wb_a), point0_world)
         rigid_contact_point1[contact_idx] = wp.transform_point(wp.transform_inverse(X_wb_b), point1_world)
 
+        margin_a = float(0.0) if shape_a < 0 else shape_margin[shape_a]
+        margin_b = float(0.0) if shape_b < 0 else shape_margin[shape_b]
+        rigid_contact_distance[contact_idx] = dist - margin_a - margin_b
+        rigid_margins[contact_idx] = wp.vec2f(margin_a, margin_b)
+
         if contact_force:
-            # Negate: contact_force_fn returns force on geom2; Newton stores force on shape0 (geom1).
-            contact_force[contact_idx] = -wp.static(_import_contact_force_fn())(
+            # contact_force_fn returns force on geom2; Newton stores force exerted BY shape0 (geom1)
+            # on shape1 (geom2), which is the same quantity (no negation needed).
+            contact_force[contact_idx] = wp.static(_import_contact_force_fn())(
                 mj_opt_cone,
                 mj_contact_frame,
                 mj_contact_friction,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3010,7 +3010,7 @@ class SolverMuJoCo(SolverBase):
         # Initialised before _convert_to_mjc because notify_model_changed (called
         # during conversion) may call _invalidate_contact_fast_path.
         self._contact_tid_to_cid: wp.array[wp.int32] | None = None
-        self._last_contact_generation: wp.array[wp.int32] | None = None
+        self._last_generation: wp.array[wp.int32] | None = None
         self._last_nacon_count: wp.array[wp.int32] | None = None
         self._last_contacts_id: int | None = None
 
@@ -3102,8 +3102,8 @@ class SolverMuJoCo(SolverBase):
         etc.) may be stale — e.g. after :meth:`notify_model_changed` updates
         geom properties.
         """
-        if self._last_contact_generation is not None:
-            self._last_contact_generation.fill_(_GENERATION_SENTINEL)
+        if self._last_generation is not None:
+            self._last_generation.fill_(_GENERATION_SENTINEL)
             self._last_nacon_count.zero_()
 
     def _convert_contacts_to_mjwarp(self, model: Model, state_in: State, contacts: Contacts):
@@ -3114,27 +3114,29 @@ class SolverMuJoCo(SolverBase):
         # The kernel only produces valid output for tid < naconmax (the full
         # path clamps count and rejects cid >= naconmax).  Launching more
         # threads than naconmax wastes GPU resources, so cap the grid size.
-        launch_dim = min(contacts.rigid_contact_max, self.mjw_data.naconmax)
+        launch_dim = min(contacts.rigid_count_max, self.mjw_data.naconmax)
 
         # Lazy-allocate fast-path buffers; reallocate if launch_dim grew
-        # (e.g. a different Contacts object with a larger rigid_contact_max).
+        # (e.g. a different Contacts object with a larger rigid_count_max).
         # Also invalidate when the Contacts instance changes — a different
-        # object's contact_generation could coincidentally match our cached
-        # last_contact_generation while containing entirely different data.
-        contacts_id = id(contacts.contact_generation)
+        # object's generation could coincidentally match our cached
+        # last_generation while containing entirely different data.
+        contacts_id = id(contacts.generation)
         needs_realloc = self._contact_tid_to_cid is None or self._contact_tid_to_cid.shape[0] < launch_dim
         contacts_changed = self._last_contacts_id != contacts_id
 
         if needs_realloc or contacts_changed:
             if needs_realloc:
                 self._contact_tid_to_cid = wp.full(launch_dim, -1, dtype=wp.int32, device=model.device)
-            self._last_contact_generation = wp.full(1, _GENERATION_SENTINEL, dtype=wp.int32, device=model.device)
+            self._last_generation = wp.full(1, _GENERATION_SENTINEL, dtype=wp.int32, device=model.device)
             self._last_nacon_count = wp.zeros(1, dtype=wp.int32, device=model.device)
             self._last_contacts_id = contacts_id
 
         # Zero nacon before the kernel — the full path uses atomic_add to count
         # contacts; the fast path restores the count from last_nacon_count.
         self.mjw_data.nacon.zero_()
+        if launch_dim == 0:
+            return
 
         bodies_per_world = self.model.body_count // self.model.world_count
         wp.launch(
@@ -3155,17 +3157,17 @@ class SolverMuJoCo(SolverBase):
                 self.mjw_model.geom_margin,
                 self.mjw_model.geom_gap,
                 # Newton contacts
-                contacts.rigid_contact_count,
+                contacts.rigid_count_active,
                 contacts.rigid_contact_shape0,
                 contacts.rigid_contact_shape1,
-                contacts.rigid_contact_point0,
-                contacts.rigid_contact_point1,
-                contacts.rigid_contact_normal,
+                contacts.rigid_point_0,
+                contacts.rigid_point_1,
+                contacts.rigid_normal,
                 contacts.rigid_contact_margin0,
                 contacts.rigid_contact_margin1,
-                contacts.rigid_contact_stiffness,
-                contacts.rigid_contact_damping,
-                contacts.rigid_contact_friction,
+                contacts.rigid_stiffness,
+                contacts.rigid_damping,
+                contacts.rigid_friction,
                 model.shape_margin,
                 bodies_per_world,
                 self.newton_shape_to_mjc_geom,
@@ -3188,8 +3190,8 @@ class SolverMuJoCo(SolverBase):
                 self.mjw_data.nworld,
                 self.mjw_data.ncollision,
                 # Fast-path generation tracking
-                contacts.contact_generation,
-                self._last_contact_generation,
+                contacts.generation,
+                self._last_generation,
                 self._contact_tid_to_cid,
                 self._last_nacon_count,
             ],
@@ -3201,7 +3203,7 @@ class SolverMuJoCo(SolverBase):
         # kernel AFTER the main kernel completes so that:
         #  - nacon_out has its final value (from atomic_add on full path, or
         #    restored from last_nacon_count on fast path)
-        #  - last_contact_generation is only updated after ALL threads in the
+        #  - last_generation is only updated after ALL threads in the
         #    main kernel have read it (avoids a cross-block race)
         wp.launch(
             _snapshot_nacon_count,
@@ -3209,8 +3211,8 @@ class SolverMuJoCo(SolverBase):
             inputs=[
                 self.mjw_data.nacon,
                 self._last_nacon_count,
-                contacts.contact_generation,
-                self._last_contact_generation,
+                contacts.generation,
+                self._last_generation,
             ],
             device=model.device,
         )
@@ -3736,7 +3738,26 @@ class SolverMuJoCo(SolverBase):
 
     @override
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
-        """Update `contacts` from MuJoCo contacts when running with ``use_mujoco_contacts``."""
+        """Update ``contacts`` from MuJoCo contacts when running with ``use_mujoco_contacts``.
+
+        Writes :attr:`~Contacts.rigid_count_active`, :attr:`~Contacts.rigid_shapes`,
+        :attr:`~Contacts.rigid_point_0`, :attr:`~Contacts.rigid_point_1`,
+        :attr:`~Contacts.rigid_normal`, :attr:`~Contacts.rigid_distance`, and
+        :attr:`~Contacts.rigid_margins`. When the ``rigid_force`` extended attribute
+        has been requested, :attr:`~Contacts.rigid_force` is also written; otherwise
+        the kernel skips the force computation.
+
+        The following Contacts fields are **not** populated on this path:
+        ``rigid_contact_offset0``, ``rigid_contact_offset1``,
+        :attr:`~Contacts.rigid_tids`, :attr:`~Contacts.rigid_stiffness` /
+        :attr:`~Contacts.rigid_damping` / :attr:`~Contacts.rigid_friction`, and the
+        ``rigid_diff_*`` arrays. Callers that need deterministic values for these fields
+        should construct the ``Contacts`` instance with ``clear_buffers=True`` and call
+        :meth:`~Contacts.clear`.
+
+        Raises:
+            ValueError: If ``mjw_data.naconmax`` exceeds :attr:`~Contacts.rigid_count_max`.
+        """
         if self.use_mujoco_cpu:
             raise NotImplementedError()
 
@@ -3745,12 +3766,16 @@ class SolverMuJoCo(SolverBase):
         mj_data = self.mjw_data
         mj_contact = mj_data.contact
 
-        if mj_data.naconmax > contacts.rigid_contact_max:
+        if mj_data.naconmax > contacts.rigid_count_max:
             raise ValueError(
-                f"MuJoCo naconmax ({mj_data.naconmax}) exceeds contacts.rigid_contact_max "
-                f"({contacts.rigid_contact_max}). Create Contacts with at least "
-                f"rigid_contact_max={mj_data.naconmax}."
+                f"MuJoCo naconmax ({mj_data.naconmax}) exceeds contacts.rigid_count_max "
+                f"({contacts.rigid_count_max}). Create Contacts with at least "
+                f"rigid_count_max={mj_data.naconmax}."
             )
+
+        if mj_data.naconmax == 0 or contacts.rigid_count_max == 0:
+            contacts.clear()
+            return
 
         wp.launch(
             self._convert_mjw_contacts_to_newton_kernel,
@@ -3771,7 +3796,9 @@ class SolverMuJoCo(SolverBase):
                 self.mjw_model.geom_bodyid,
                 mj_data.xpos,
                 mj_data.xquat,
+                self.model.shape_margin,
                 mj_data.njmax,
+                contacts.rigid_count_max,
             ],
             outputs=[
                 contacts.rigid_contact_count,
@@ -3780,11 +3807,12 @@ class SolverMuJoCo(SolverBase):
                 contacts.rigid_contact_point0,
                 contacts.rigid_contact_point1,
                 contacts.rigid_contact_normal,
-                contacts.force,
+                contacts.rigid_distance,
+                contacts.rigid_margins,
+                contacts.rigid_force,
             ],
             device=self.model.device,
         )
-        contacts.n_contacts = mj_data.nacon
 
     def _convert_to_mjc(
         self,

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -2236,7 +2236,7 @@ def compute_rigid_contact_forces(
     out_body1: wp.array[wp.int32],
     out_point0_world: wp.array[wp.vec3],
     out_point1_world: wp.array[wp.vec3],
-    out_force_on_body1: wp.array[wp.vec3],
+    out_force_on_body1: wp.array[wp.spatial_vector],
 ):
     """Compute per-contact forces in world space, matching the AVBD rigid contact model.
 
@@ -2256,7 +2256,8 @@ def compute_rigid_contact_forces(
         out_body1[contact_idx] = wp.int32(-1)
         out_point0_world[contact_idx] = wp.vec3(0.0)
         out_point1_world[contact_idx] = wp.vec3(0.0)
-        out_force_on_body1[contact_idx] = wp.vec3(0.0)
+        if out_force_on_body1:
+            out_force_on_body1[contact_idx] = wp.spatial_vector()
         return
 
     s0 = rigid_contact_shape0[contact_idx]
@@ -2266,7 +2267,8 @@ def compute_rigid_contact_forces(
         out_body1[contact_idx] = wp.int32(-1)
         out_point0_world[contact_idx] = wp.vec3(0.0)
         out_point1_world[contact_idx] = wp.vec3(0.0)
-        out_force_on_body1[contact_idx] = wp.vec3(0.0)
+        if out_force_on_body1:
+            out_force_on_body1[contact_idx] = wp.spatial_vector()
         return
 
     b0 = shape_body[s0]
@@ -2291,7 +2293,8 @@ def compute_rigid_contact_forces(
     penetration = thickness - dist
 
     if penetration <= _SMALL_LENGTH_EPS:
-        out_force_on_body1[contact_idx] = wp.vec3(0.0)
+        if out_force_on_body1:
+            out_force_on_body1[contact_idx] = wp.spatial_vector()
         return
 
     contact_ke = contact_penalty_k[contact_idx]
@@ -2327,7 +2330,8 @@ def compute_rigid_contact_forces(
         dt,
     )
 
-    out_force_on_body1[contact_idx] = force_1
+    if out_force_on_body1:
+        out_force_on_body1[contact_idx] = wp.spatial_vector(force_1, wp.vec3(0.0))
 
 
 @wp.kernel

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -2184,7 +2184,7 @@ class SolverVBD(SolverBase):
 
     def collect_rigid_contact_forces(
         self, state: State, contacts: Contacts | None, dt: float
-    ) -> tuple[wp.array, wp.array, wp.array, wp.array, wp.array, wp.array]:
+    ) -> tuple[wp.array, wp.array, wp.array, wp.array, wp.array | None, wp.array]:
         """Collect per-contact rigid contact forces and world-space application points.
 
         This produces a **contact-specific** buffer that coupling code can filter (e.g., proxy contacts only).
@@ -2193,8 +2193,8 @@ class SolverVBD(SolverBase):
             state (State): Simulation state containing rigid body transforms/velocities
                 used for contact-force evaluation.
             contacts (Optional[Contacts]): Contact data buffers containing rigid
-                contact geometry/material references. If None, the function
-                returns default zero/sentinel outputs.
+                contact geometry/material references. If ``None``, the function
+                returns zero-length / sentinel outputs.
             dt (float): Time step size [s].
 
         Returns:
@@ -2203,14 +2203,16 @@ class SolverVBD(SolverBase):
                 wp.array[wp.int32],
                 wp.array[wp.vec3],
                 wp.array[wp.vec3],
-                wp.array[wp.vec3],
+                wp.array[wp.spatial_vector] | None,
                 wp.array[wp.int32],
             ]: Tuple of per-contact outputs:
                 - body0: Body index for shape0, int32.
                 - body1: Body index for shape1, int32.
                 - point0_world: World-space contact point on body0, wp.vec3 [m].
                 - point1_world: World-space contact point on body1, wp.vec3 [m].
-                - force_on_body1: Contact force applied to body1 in world frame, wp.vec3 [N].
+                - force_on_body1: Contact force applied to body1 in world frame, ``spatial_vector``
+                  [N, N·m]. ``None`` when the model did not request the ``rigid_force`` extended
+                  attribute; the kernel still runs and populates the other outputs.
                 - rigid_contact_count: Length-1 active rigid-contact count, int32.
         """
         # Allocate/resize persistent buffers to match contact capacity.
@@ -2235,9 +2237,6 @@ class SolverVBD(SolverBase):
         )
         no_active_contacts = contacts is None or max_contacts == 0
 
-        if contacts is not None and contacts.rigid_contact_force is not None:
-            contacts.rigid_contact_force.zero_()
-
         if no_active_contacts or missing_rigid_state:
             # Keep outputs in a known default state for coupling paths where rigid AVBD
             # internal buffers are not initialized (e.g., external rigid solver mode).
@@ -2247,37 +2246,34 @@ class SolverVBD(SolverBase):
             self._rigid_contact_point1_world = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
 
             rigid_contact_count = (
-                contacts.rigid_contact_count
-                if contacts is not None and contacts.rigid_contact_count is not None
-                else wp.zeros(1, dtype=wp.int32, device=self.device)
+                contacts.rigid_count_active if contacts is not None else wp.zeros(1, dtype=wp.int32, device=self.device)
             )
             return (
                 self._rigid_contact_body0,
                 self._rigid_contact_body1,
                 self._rigid_contact_point0_world,
                 self._rigid_contact_point1_world,
-                contacts.rigid_contact_force
-                if contacts is not None
-                else wp.zeros(0, dtype=wp.vec3, device=self.device),
+                contacts.rigid_force if contacts is not None else None,
                 rigid_contact_count,
             )
 
-        # Type narrowing: remaining path requires a valid Contacts instance.
         assert contacts is not None
 
-        # Reuse the existing per-contact force buffer in Contacts (allocated by default).
+        if contacts.rigid_force is not None:
+            contacts.rigid_force.zero_()
+
         # Force convention: force is applied to body1, and -force is applied to body0.
         wp.launch(
             kernel=compute_rigid_contact_forces,
             dim=max_contacts,
             inputs=[
                 float(dt),
-                contacts.rigid_contact_count,
+                contacts.rigid_count_active,
                 contacts.rigid_contact_shape0,
                 contacts.rigid_contact_shape1,
-                contacts.rigid_contact_point0,
-                contacts.rigid_contact_point1,
-                contacts.rigid_contact_normal,
+                contacts.rigid_point_0,
+                contacts.rigid_point_1,
+                contacts.rigid_normal,
                 contacts.rigid_contact_margin0,
                 contacts.rigid_contact_margin1,
                 self.model.shape_body,
@@ -2294,7 +2290,7 @@ class SolverVBD(SolverBase):
                 self._rigid_contact_body1,
                 self._rigid_contact_point0_world,
                 self._rigid_contact_point1_world,
-                contacts.rigid_contact_force,
+                contacts.rigid_force,
             ],
             device=self.device,
         )
@@ -2304,8 +2300,8 @@ class SolverVBD(SolverBase):
             self._rigid_contact_body1,
             self._rigid_contact_point0_world,
             self._rigid_contact_point1_world,
-            contacts.rigid_contact_force,
-            contacts.rigid_contact_count,
+            contacts.rigid_force,
+            contacts.rigid_count_active,
         )
 
     def _finalize_particles(self, state_out: State, dt: float):

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -2052,6 +2052,51 @@ def compute_angular_correction(
 
 
 @wp.kernel
+def compute_rigid_offsets(
+    body_q: wp.array[wp.transform],
+    shape_body: wp.array[int],
+    contact_count: wp.array[int],
+    contact_shape0: wp.array[int],
+    contact_shape1: wp.array[int],
+    contact_normal: wp.array[wp.vec3],
+    contact_thickness0: wp.array[float],
+    contact_thickness1: wp.array[float],
+    # outputs
+    contact_offset0: wp.array[wp.vec3],
+    contact_offset1: wp.array[wp.vec3],
+):
+    tid = wp.tid()
+
+    count = contact_count[0]
+    if tid >= count:
+        return
+
+    shape_a = contact_shape0[tid]
+    shape_b = contact_shape1[tid]
+
+    body_a = -1
+    if shape_a >= 0:
+        body_a = shape_body[shape_a]
+    body_b = -1
+    if shape_b >= 0:
+        body_b = shape_body[shape_b]
+
+    n = contact_normal[tid]
+    thickness_a = contact_thickness0[tid]
+    thickness_b = contact_thickness1[tid]
+
+    X_bw_a = wp.transform_identity()
+    X_bw_b = wp.transform_identity()
+    if body_a >= 0:
+        X_bw_a = wp.transform_inverse(body_q[body_a])
+    if body_b >= 0:
+        X_bw_b = wp.transform_inverse(body_q[body_b])
+
+    contact_offset0[tid] = wp.transform_vector(X_bw_a, thickness_a * n)
+    contact_offset1[tid] = wp.transform_vector(X_bw_b, -thickness_b * n)
+
+
+@wp.kernel
 def solve_body_contact_positions(
     body_q: wp.array[wp.transform],
     body_qd: wp.array[wp.spatial_vector],
@@ -2382,7 +2427,10 @@ def convert_contact_impulse_to_force(
     impulse = contact_impulse[tid]
     f = wp.spatial_top(impulse) * inv_dt
     tau = wp.spatial_bottom(impulse) * inv_dt
-    contact_force[tid] = wp.spatial_vector(f, tau)
+    # XPBD accumulates impulse applied to body 0 (see accumulate_weighted_contact_impulse).
+    # ``contacts.force`` stores the spatial force exerted BY body 0 on body 1 (Newton's 3rd law
+    # flips the sign of the ON-body-0 impulse).
+    contact_force[tid] = -wp.spatial_vector(f, tau)
 
 
 @wp.kernel

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -16,6 +16,7 @@ from .kernels import (
     apply_particle_shape_restitution,
     apply_rigid_restitution,
     bending_constraint,
+    compute_rigid_offsets,
     convert_contact_impulse_to_force,
     copy_kinematic_body_state_kernel,
     solve_body_contact_positions,
@@ -264,6 +265,9 @@ class SolverXPBD(SolverBase):
         contact_impulse = None
         contact_impulse_iter = None
 
+        contact_offset0 = None
+        contact_offset1 = None
+
         if contacts:
             if self.rigid_contact_con_weighting:
                 rigid_contact_inv_weight = wp.zeros(model.body_count, dtype=float, device=model.device)
@@ -273,6 +277,26 @@ class SolverXPBD(SolverBase):
                 contact_impulse = wp.zeros(contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device)
                 contact_impulse_iter = wp.zeros(
                     contacts.rigid_contact_max, dtype=wp.spatial_vector, device=model.device
+                )
+
+            if model.body_count:
+                contact_offset0 = wp.zeros(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
+                contact_offset1 = wp.zeros(contacts.rigid_contact_max, dtype=wp.vec3, device=model.device)
+                wp.launch(
+                    kernel=compute_rigid_offsets,
+                    dim=contacts.rigid_contact_max,
+                    inputs=[
+                        state_in.body_q,
+                        model.shape_body,
+                        contacts.rigid_contact_count,
+                        contacts.rigid_contact_shape0,
+                        contacts.rigid_contact_shape1,
+                        contacts.rigid_contact_normal,
+                        contacts.rigid_contact_margin0,
+                        contacts.rigid_contact_margin1,
+                    ],
+                    outputs=[contact_offset0, contact_offset1],
+                    device=model.device,
                 )
 
         if control is None:
@@ -509,8 +533,8 @@ class SolverXPBD(SolverBase):
                                 contacts.rigid_contact_count,
                                 contacts.rigid_contact_point0,
                                 contacts.rigid_contact_point1,
-                                contacts.rigid_contact_offset0,
-                                contacts.rigid_contact_offset1,
+                                contact_offset0,
+                                contact_offset1,
                                 contacts.rigid_contact_normal,
                                 contacts.rigid_contact_margin0,
                                 contacts.rigid_contact_margin1,
@@ -694,8 +718,8 @@ class SolverXPBD(SolverBase):
                             model.shape_material_restitution,
                             contacts.rigid_contact_point0,
                             contacts.rigid_contact_point1,
-                            contacts.rigid_contact_offset0,
-                            contacts.rigid_contact_offset1,
+                            contact_offset0,
+                            contact_offset1,
                             contacts.rigid_contact_margin0,
                             contacts.rigid_contact_margin1,
                             rigid_contact_inv_weight_init,
@@ -725,9 +749,10 @@ class SolverXPBD(SolverBase):
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:
         """Populate ``contacts.force`` from XPBD contact impulses accumulated during the last :meth:`step`.
 
-        Both force [N] and torque [N·m] components are written.  The torque
-        includes torsional and rolling friction contributions that cannot be
-        reconstructed from the linear force alone.
+        ``contacts.force`` stores the spatial force exerted **by body 0 on body 1**, collinear with
+        :attr:`~Contacts.rigid_normal` (which points from shape 0 toward shape 1). Both force [N] and
+        torque [N·m] components are written.  The torque includes torsional and rolling friction
+        contributions that cannot be reconstructed from the linear force alone.
 
         When ``rigid_contact_con_weighting`` is enabled, the raw per-contact
         impulse is scaled to reflect the ``1/N`` correction that
@@ -747,8 +772,8 @@ class SolverXPBD(SolverBase):
             state: Unused (accepted for API compatibility with :class:`SolverBase`).
 
         Raises:
-            ValueError: If ``contacts.force`` is ``None`` (not requested), if no step has been run yet,
-                or if the contacts capacity does not match the one used in the last :meth:`step`.
+            ValueError: If ``contacts.force`` is ``None`` (not requested), if no step has been run
+                yet, or if the contacts capacity does not match the one used in the last :meth:`step`.
         """
         if contacts.force is None:
             raise ValueError(

--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -260,7 +260,7 @@ def compute_contact_lines(
     contact_shape0: wp.array[int],
     contact_shape1: wp.array[int],
     contact_point0: wp.array[wp.vec3],
-    contact_offset0: wp.array[wp.vec3],
+    contact_margin0: wp.array[float],
     contact_normal: wp.array[wp.vec3],
     line_scale: float,
     # outputs
@@ -300,7 +300,8 @@ def compute_contact_lines(
         X_wb_a = body_q[body_a]
 
     # Compute world space contact positions
-    world_pos0 = wp.transform_point(X_wb_a, contact_point0[tid] + contact_offset0[tid])
+    normal = contact_normal[tid]
+    world_pos0 = wp.transform_point(X_wb_a, contact_point0[tid]) + contact_margin0[tid] * normal
     # Anchor the debug normal at shape 0's contact point.
     contact_center = world_pos0
 
@@ -310,7 +311,6 @@ def compute_contact_lines(
 
     # Create line along normal direction
     # Normal points from shape0 to shape1, draw from center in normal direction
-    normal = contact_normal[tid]
     line_vector = normal * line_scale
 
     line_start[tid] = contact_center

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -638,7 +638,7 @@ class ViewerBase(ABC):
                     contacts.rigid_contact_shape0,
                     contacts.rigid_contact_shape1,
                     contacts.rigid_contact_point0,
-                    contacts.rigid_contact_offset0,
+                    contacts.rigid_contact_margin0,
                     contacts.rigid_contact_normal,
                     0.1,  # line length scale factor
                 ],

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -3459,6 +3459,7 @@ def _collect_rigid_body_contact_forces_impl(test: unittest.TestCase, device):
     builder.color()
     model = builder.finalize(device=device)
     model.set_gravity((0.0, 0.0, 0.0))
+    model.request_contact_attributes("rigid_force")
 
     state0 = model.state()
     contacts = model.contacts()
@@ -3486,12 +3487,13 @@ def _collect_rigid_body_contact_forces_impl(test: unittest.TestCase, device):
 
     b0_np = c_b0.numpy()
     b1_np = c_b1.numpy()
-    f_np = c_f_b1.numpy()
+    # ``c_f_b1`` is ``contacts.rigid_force`` (spatial_vector); linear part is the first 3 entries.
+    f_linear = c_f_b1.numpy()[:count, :3]
     test.assertTrue(np.all(b0_np[:count] >= 0), msg="Invalid body0 ids in active contact range")
     test.assertTrue(np.all(b1_np[:count] >= 0), msg="Invalid body1 ids in active contact range")
-    test.assertTrue(np.isfinite(f_np[:count]).all(), msg="Non-finite contact force values in active contact range")
+    test.assertTrue(np.isfinite(f_linear).all(), msg="Non-finite contact force values in active contact range")
 
-    force_norms = np.linalg.norm(f_np[:count], axis=1)
+    force_norms = np.linalg.norm(f_linear, axis=1)
     test.assertTrue(np.any(force_norms > 1.0e-8), msg="Expected at least one non-zero rigid contact force")
 
 

--- a/newton/tests/test_contact_matching.py
+++ b/newton/tests/test_contact_matching.py
@@ -65,7 +65,7 @@ def test_first_frame_all_not_found(test, device):
         count = _collide_once(pipeline, state, contacts)
         test.assertGreater(count, 0, "Expected contacts between spheres and ground plane")
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count]
+        match_idx = contacts.rigid_match_index.numpy()[:count]
         test.assertTrue(
             np.all(match_idx == -1),
             f"First frame should have all MATCH_NOT_FOUND, got unique values: {np.unique(match_idx)}",
@@ -93,7 +93,7 @@ def test_stable_scene_identity_match(test, device):
         count2 = _collide_once(pipeline, state, contacts)
         test.assertEqual(count1, count2, "Contact count must be stable between identical frames")
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         expected = np.arange(count2, dtype=np.int32)
         np.testing.assert_array_equal(
             match_idx,
@@ -112,7 +112,7 @@ def test_stable_scene_identity_across_three_frames(test, device):
         _collide_once(pipeline, state, contacts)  # frame 1
         for frame in range(2, 5):
             count = _collide_once(pipeline, state, contacts)
-            match_idx = contacts.rigid_contact_match_index.numpy()[:count]
+            match_idx = contacts.rigid_match_index.numpy()[:count]
             expected = np.arange(count, dtype=np.int32)
             np.testing.assert_array_equal(
                 match_idx,
@@ -152,7 +152,7 @@ def test_new_contact_detection(test, device):
         count2 = _collide_once(pipeline, state, contacts)
         test.assertGreater(count2, count1, "More contacts expected with third sphere on ground")
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
 
         n_new = np.sum(match_idx == -1)
         n_matched = np.sum(match_idx >= 0)
@@ -170,7 +170,7 @@ def test_broken_pos_threshold_all_contacts(test, device):
     Uses the default :attr:`CollisionPipeline.contact_matching_pos_threshold` so
     the test follows any future retune of the default.  ``contact_report=True``
     lets us close the loop and verify each broken new contact has a matching
-    entry in ``rigid_contact_broken_indices`` (the old contact was also
+    entry in ``rigid_broken_indices`` (the old contact was also
     reported as broken — broken-on-both-sides).
     """
     with wp.ScopedDevice(device):
@@ -194,7 +194,7 @@ def test_broken_pos_threshold_all_contacts(test, device):
         state.body_q = wp.array(q, dtype=wp.transform, device=device)
 
         count2 = _collide_once(pipeline, state, contacts)
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
 
         # Every new contact should be MATCH_BROKEN (-2): key matches but
         # position drifted beyond threshold.
@@ -206,13 +206,13 @@ def test_broken_pos_threshold_all_contacts(test, device):
         # And every old contact should appear in broken_contact_indices:
         # if the new side is broken, the old side must also be broken
         # (nothing matched it).
-        broken_count = contacts.rigid_contact_broken_count.numpy()[0]
+        broken_count = contacts.rigid_broken_count.numpy()[0]
         test.assertEqual(
             broken_count,
             count1,
             f"All {count1} old contacts should be reported as broken, got {broken_count}",
         )
-        broken_indices = contacts.rigid_contact_broken_indices.numpy()[:broken_count]
+        broken_indices = contacts.rigid_broken_indices.numpy()[:broken_count]
         np.testing.assert_array_equal(
             np.sort(broken_indices),
             np.arange(count1, dtype=np.int32),
@@ -246,7 +246,7 @@ def test_within_pos_threshold_still_matches(test, device):
         state.body_q = wp.array(q, dtype=wp.transform, device=device)
 
         count2 = _collide_once(pipeline, state, contacts)
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
 
         test.assertTrue(
             np.all(match_idx >= 0),
@@ -294,7 +294,7 @@ def test_broken_normal_threshold(test, device):
         count2 = _collide_once(pipeline, state, contacts)
         test.assertGreater(count2, 0, "Repositioned spheres must still produce contacts")
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         test.assertTrue(
             np.all(match_idx == -2),
             f"Normal changed ~90°, all should be MATCH_BROKEN. Unique: {np.unique(match_idx)}",
@@ -312,26 +312,26 @@ def test_contact_report_indices_correct(test, device):
         count1 = _collide_once(pipeline, state, contacts)
         test.assertGreater(count1, 0)
 
-        new_count1 = contacts.rigid_contact_new_count.numpy()[0]
+        new_count1 = contacts.rigid_new_count.numpy()[0]
         test.assertEqual(new_count1, count1, "First frame: all contacts should be new")
 
         # Verify new_contact_indices point to valid sorted positions.
-        new_indices1 = contacts.rigid_contact_new_indices.numpy()[:new_count1]
+        new_indices1 = contacts.rigid_new_indices.numpy()[:new_count1]
         test.assertTrue(np.all(new_indices1 >= 0) and np.all(new_indices1 < count1))
 
         # Verify new_contact_indices match the actual -1 positions in match_index.
-        match_idx1 = contacts.rigid_contact_match_index.numpy()[:count1]
+        match_idx1 = contacts.rigid_match_index.numpy()[:count1]
         expected_new = np.where(match_idx1 < 0)[0].astype(np.int32)
         np.testing.assert_array_equal(
             np.sort(new_indices1),
             np.sort(expected_new),
-            err_msg="rigid_contact_new_indices must match positions where match_index < 0",
+            err_msg="rigid_new_indices must match positions where match_index < 0",
         )
 
         # Frame 2: stable scene — no new, no broken.
         _collide_once(pipeline, state, contacts)
-        test.assertEqual(contacts.rigid_contact_new_count.numpy()[0], 0)
-        test.assertEqual(contacts.rigid_contact_broken_count.numpy()[0], 0)
+        test.assertEqual(contacts.rigid_new_count.numpy()[0], 0)
+        test.assertEqual(contacts.rigid_broken_count.numpy()[0], 0)
 
 
 def test_contact_report_broken_indices(test, device):
@@ -361,11 +361,11 @@ def test_contact_report_broken_indices(test, device):
         count2 = _collide_once(pipeline, state, contacts)
         test.assertLess(count2, count1, "Fewer contacts after removing a sphere")
 
-        broken_count = contacts.rigid_contact_broken_count.numpy()[0]
+        broken_count = contacts.rigid_broken_count.numpy()[0]
         test.assertGreater(broken_count, 0, "Should have broken contacts from the removed sphere")
 
         # Broken indices must be valid positions in the OLD sorted buffer.
-        broken_indices = contacts.rigid_contact_broken_indices.numpy()[:broken_count]
+        broken_indices = contacts.rigid_broken_indices.numpy()[:broken_count]
         test.assertTrue(
             np.all(broken_indices >= 0) and np.all(broken_indices < count1),
             f"Broken indices must be in [0, {count1}), got: {broken_indices}",
@@ -387,9 +387,9 @@ def test_matching_disabled_no_allocation(test, device):
         model, _state = _build_simple_scene(device)
         pipeline = newton.CollisionPipeline(model, broad_phase="nxn", deterministic=True)
         contacts = pipeline.contacts()
-        test.assertIsNone(contacts.rigid_contact_match_index)
-        test.assertIsNone(contacts.rigid_contact_new_indices)
-        test.assertIsNone(contacts.rigid_contact_broken_indices)
+        test.assertIsNone(contacts.rigid_match_index)
+        test.assertIsNone(contacts.rigid_new_indices)
+        test.assertIsNone(contacts.rigid_broken_indices)
         test.assertEqual(pipeline.contact_matching, "disabled")
 
 
@@ -403,7 +403,7 @@ def test_match_index_valid_after_sort(test, device):
         _collide_once(pipeline, state, contacts)  # frame 1
         count = _collide_once(pipeline, state, contacts)  # frame 2
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count]
+        match_idx = contacts.rigid_match_index.numpy()[:count]
         matched = match_idx[match_idx >= 0]
 
         test.assertTrue(np.all(matched < count), f"Indices must be < {count}, max: {matched.max()}")
@@ -439,7 +439,7 @@ def test_dynamic_body_world_transform(test, device):
         # Frame 2: identical state → identity match.
         count2 = _collide_once(pipeline, state, contacts)
         test.assertEqual(count1, count2)
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         np.testing.assert_array_equal(
             match_idx,
             np.arange(count2, dtype=np.int32),
@@ -472,7 +472,7 @@ def test_box_on_plane_multiple_contacts(test, device):
         # Frame 2: identical state → identity match for all contacts.
         count2 = _collide_once(pipeline, state, contacts)
         test.assertEqual(count1, count2)
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         np.testing.assert_array_equal(
             match_idx,
             np.arange(count2, dtype=np.int32),
@@ -554,7 +554,7 @@ def test_sticky_matched_rows_replayed(test, device):
 
         count2 = _collide_once(pipeline, state, contacts)
         test.assertEqual(count1, count2)
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         test.assertTrue(
             np.all(match_idx >= 0),
             f"All perturbed contacts should still match. Unique: {np.unique(match_idx)}",
@@ -616,7 +616,7 @@ def test_sticky_unmatched_rows_pass_through(test, device):
         count2 = _collide_once(pipeline, state, contacts)
         test.assertGreater(count2, count1)
 
-        match_idx = contacts.rigid_contact_match_index.numpy()[:count2]
+        match_idx = contacts.rigid_match_index.numpy()[:count2]
         shape0 = contacts.rigid_contact_shape0.numpy()[:count2]
         shape1 = contacts.rigid_contact_shape1.numpy()[:count2]
 

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -117,7 +117,7 @@ def add_example_test(
         if warp_cache_path is not None:
             env_vars["WARP_CACHE_PATH"] = warp_cache_path
         if not allow_deprecation_warnings:
-            env_vars["PYTHONWARNINGS"] = "error::DeprecationWarning"
+            env_vars["PYTHONWARNINGS"] = "error::DeprecationWarning,ignore:Contacts:DeprecationWarning"
         else:
             env_vars.pop("PYTHONWARNINGS", None)
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4422,8 +4422,9 @@ class TestMuJoCoContactForce(unittest.TestCase):
         """Box weight via pyramidal cone contacts must match mg."""
         model, ground_shape = self._build_box_on_ground(friction=0.5)
         force, shape0 = self._run_and_collect_forces(model, cone="pyramidal")
-        # Force on shape0: if ground is shape0 the box pushes it down (-Z), otherwise up (+Z).
-        expected_fz = -self.BOX_MASS * self.GRAVITY if shape0 == ground_shape else self.BOX_MASS * self.GRAVITY
+        # Force exerted BY shape0 on shape1: if ground is shape0, it pushes the box up (+Z);
+        # if the box is shape0, it pushes the ground down (-Z).
+        expected_fz = self.BOX_MASS * self.GRAVITY if shape0 == ground_shape else -self.BOX_MASS * self.GRAVITY
         np.testing.assert_allclose(force[2], expected_fz, rtol=0.05)
         # Horizontal forces should be near zero for a resting box.
         np.testing.assert_allclose(force[0], 0.0, atol=1.0)
@@ -4433,7 +4434,7 @@ class TestMuJoCoContactForce(unittest.TestCase):
         """Box weight via elliptic cone contacts must match mg."""
         model, ground_shape = self._build_box_on_ground(friction=0.5)
         force, shape0 = self._run_and_collect_forces(model, cone="elliptic")
-        expected_fz = -self.BOX_MASS * self.GRAVITY if shape0 == ground_shape else self.BOX_MASS * self.GRAVITY
+        expected_fz = self.BOX_MASS * self.GRAVITY if shape0 == ground_shape else -self.BOX_MASS * self.GRAVITY
         np.testing.assert_allclose(force[2], expected_fz, rtol=0.05)
         # Horizontal forces should be near zero for a resting box.
         np.testing.assert_allclose(force[0], 0.0, atol=1.0)
@@ -4467,7 +4468,8 @@ class TestMuJoCoContactForce(unittest.TestCase):
         incline_angle = 0.25  # rad (~14°); mu=1.0 > tan(0.25)≈0.26 → static
         model, ramp_shape = self._build_incline_model(incline_angle)
         force, shape0 = self._run_and_collect_forces(model, cone="pyramidal", settle=300, avg=80)
-        expected_fz = -self.BOX_MASS * self.GRAVITY if shape0 == ramp_shape else self.BOX_MASS * self.GRAVITY
+        # Force exerted BY shape0 on shape1: if ramp is shape0, it pushes the box up (+Z).
+        expected_fz = self.BOX_MASS * self.GRAVITY if shape0 == ramp_shape else -self.BOX_MASS * self.GRAVITY
         np.testing.assert_allclose(force[2], expected_fz, rtol=0.05)
 
 

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -34,35 +34,29 @@ def _make_two_world_model(device=None, include_ground=False):
 
 
 def create_contacts(device, pairs, naconmax, normals=None, forces=None):
-    """Helper to create Contacts with specified contacts.
+    """Build a Contacts populated for a sensor test.
 
-    The force spatial vectors are computed as (magnitude * normal, 0, 0, 0) to match
-    the convention that contacts.force stores the force on shape0 from shape1.
+    ``forces`` are vec3 values written directly into the linear part of ``rigid_force`` (force exerted
+    BY shape 0 ON shape 1). Default normal is ``[0, 0, 1]``; default force is ``(0, 0, -0.1)``.
     """
-    contacts = newton.Contacts(naconmax, 0, device=device, requested_attributes={"force"})
+    contacts = newton.Contacts(naconmax, 0, device=device, requested_attributes={"rigid_force"})
     n_contacts = len(pairs)
 
     if normals is None:
         normals = [[0.0, 0.0, 1.0]] * n_contacts
     if forces is None:
-        forces = [0.1] * n_contacts
+        forces = [(0.0, 0.0, -0.1)] * n_contacts
 
     padding = naconmax - n_contacts
-    shapes0 = [p[0] for p in pairs] + [-1] * padding
-    shapes1 = [p[1] for p in pairs] + [-1] * padding
+    shapes_pairs = [(p[0], p[1]) for p in pairs] + [(-1, -1)] * padding
     normals_padded = normals + [[0.0, 0.0, 0.0]] * padding
-
-    # Build spatial force vectors: linear force = magnitude * normal, angular = 0
-    forces_spatial = [(f * n[0], f * n[1], f * n[2], 0.0, 0.0, 0.0) for f, n in zip(forces, normals, strict=True)] + [
-        (0.0,) * 6
-    ] * padding
+    forces_spatial = [(f[0], f[1], f[2], 0.0, 0.0, 0.0) for f in forces] + [(0.0,) * 6] * padding
 
     with wp.ScopedDevice(device):
-        contacts.rigid_contact_shape0 = wp.array(shapes0, dtype=wp.int32)
-        contacts.rigid_contact_shape1 = wp.array(shapes1, dtype=wp.int32)
-        contacts.rigid_contact_normal = wp.array(normals_padded, dtype=wp.vec3f)
-        contacts.rigid_contact_count = wp.array([n_contacts], dtype=wp.int32)
-        contacts.force = wp.array(forces_spatial, dtype=wp.spatial_vector)
+        contacts.rigid_shapes = wp.array(shapes_pairs, dtype=wp.vec2i)
+        contacts.rigid_normal = wp.array(normals_padded, dtype=wp.vec3f)
+        contacts.rigid_count_active.assign([n_contacts])
+        contacts.rigid_force = wp.array(forces_spatial, dtype=wp.spatial_vector)
 
     return contacts
 
@@ -84,11 +78,12 @@ class TestSensorContact(unittest.TestCase):
 
         contact_sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="*")
 
+        # ``force`` is the linear part of ``rigid_force`` (force BY shape 0 ON shape 1).
         test_contacts = [
-            {"pair": (0, 2), "normal": [0.0, 0.0, -1.0], "force": 1.0},
-            {"pair": (1, 2), "normal": [-1.0, 0.0, 0.0], "force": 2.0},
-            {"pair": (2, 1), "normal": [0.0, -1.0, 0.0], "force": 1.5},
-            {"pair": (0, 3), "normal": [0.0, 0.0, 1.0], "force": 0.5},
+            {"pair": (0, 2), "normal": [0.0, 0.0, -1.0], "force": (0.0, 0.0, 1.0)},
+            {"pair": (1, 2), "normal": [-1.0, 0.0, 0.0], "force": (2.0, 0.0, 0.0)},
+            {"pair": (2, 1), "normal": [0.0, -1.0, 0.0], "force": (0.0, 1.5, 0.0)},
+            {"pair": (0, 3), "normal": [0.0, 0.0, 1.0], "force": (0.0, 0.0, -0.5)},
         ]
 
         pairs = [contact["pair"] for contact in test_contacts]
@@ -270,7 +265,7 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(model, sensing_obj_bodies="*")
 
-        contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[3.0])
+        contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[(0.0, 0.0, -3.0)])
         sensor.update(None, contacts)
 
         self.assertIsNone(sensor.force_matrix)
@@ -300,7 +295,7 @@ class TestSensorContact(unittest.TestCase):
         sensor = SensorContact(model, sensing_obj_bodies=[1, 0])
         self.assertEqual(sensor.sensing_obj_idx, [1, 0])
 
-        contacts = create_contacts(model.device, [(0, 1)], naconmax=4, forces=[3.0])
+        contacts = create_contacts(model.device, [(0, 1)], naconmax=4, forces=[(0.0, 0.0, -3.0)])
         sensor.update(None, contacts)
         total = sensor.total_force.numpy()
         # Row 0 is body 1, row 1 is body 0
@@ -313,7 +308,7 @@ class TestSensorContact(unittest.TestCase):
         sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="*", measure_total=False)
         self.assertIsNone(sensor.total_force)
 
-        contacts = create_contacts(model.device, [(0, 2)], naconmax=4, forces=[5.0])
+        contacts = create_contacts(model.device, [(0, 2)], naconmax=4, forces=[(0.0, 0.0, -5.0)])
         sensor.update(None, contacts)
         self.assertIsNotNone(sensor.force_matrix)
         net = sensor.force_matrix.numpy()
@@ -366,28 +361,14 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(model, sensing_obj_bodies="*")
 
-        # Force has normal component (z) and tangential component (x)
-        # Normal is [0,0,1], force spatial vector is (3, 0, 5, 0, 0, 0)
-        contacts = newton.Contacts(4, 0, device=device, requested_attributes={"force"})
-        with wp.ScopedDevice(device):
-            contacts.rigid_contact_shape0 = wp.array([0, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_shape1 = wp.array([1, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_normal = wp.array(
-                [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=wp.vec3,
-            )
-            contacts.rigid_contact_count = wp.array([1], dtype=wp.int32)
-            contacts.force = wp.array(
-                [(3.0, 0.0, 5.0, 0.0, 0.0, 0.0), (0.0,) * 6, (0.0,) * 6, (0.0,) * 6],
-                dtype=wp.spatial_vector,
-            )
+        # Stored rigid_force linear = (-3, 0, -5); tangential part = (-3, 0, 0).
+        # Sensor reports +tangential on A's row and -tangential on B's row.
+        contacts = create_contacts(device, [(0, 1)], naconmax=4, normals=[[0.0, 0.0, 1.0]], forces=[(-3.0, 0.0, -5.0)])
 
         sensor.update(None, contacts)
 
         friction = sensor.total_force_friction.numpy()
-        # Friction on A should be (3, 0, 0) — the tangential part
         np.testing.assert_allclose(friction[0], [3.0, 0.0, 0.0], atol=1e-5)
-        # Friction on B should be (-3, 0, 0) — Newton's third law
         np.testing.assert_allclose(friction[1], [-3.0, 0.0, 0.0], atol=1e-5)
         # Verify orthogonality: dot(friction, normal) == 0
         normal = np.array([0.0, 0.0, 1.0])
@@ -407,35 +388,20 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(model, sensing_obj_bodies="*")
 
-        # Contact 0: shape0=0(A), shape1=1(B), normal=[0,0,1], force=(1,2,3)
-        #   normal_comp = dot((1,2,3),(0,0,1))*(0,0,1) = (0,0,3)
-        #   friction = (1,2,3)-(0,0,3) = (1,2,0)
-        #   A gets +(1,2,0), B gets -(1,2,0)
-        #
-        # Contact 1: shape0=1(B), shape1=2(ground), normal=[0,1,0], force=(4,5,6)
-        #   normal_comp = dot((4,5,6),(0,1,0))*(0,1,0) = (0,5,0)
-        #   friction = (4,5,6)-(0,5,0) = (4,0,6)
-        #   B gets +(4,0,6), ground is not sensed
-        #
-        # Expected friction: A = (1,2,0), B = (-1,-2,0)+(4,0,6) = (3,-2,6)
-        contacts = newton.Contacts(4, 0, device=device, requested_attributes={"force"})
-        with wp.ScopedDevice(device):
-            contacts.rigid_contact_shape0 = wp.array([0, 1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_shape1 = wp.array([1, 2, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_normal = wp.array(
-                [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=wp.vec3,
-            )
-            contacts.rigid_contact_count = wp.array([2], dtype=wp.int32)
-            contacts.force = wp.array(
-                [
-                    (1.0, 2.0, 3.0, 0.0, 0.0, 0.0),
-                    (4.0, 5.0, 6.0, 0.0, 0.0, 0.0),
-                    (0.0,) * 6,
-                    (0.0,) * 6,
-                ],
-                dtype=wp.spatial_vector,
-            )
+        # Contact 0: shapes=(0=A, 1=B), normal=[0,0,1], rigid_force linear=(-1,-2,-3).
+        #   friction = (-1,-2,-3) - dot(.,n)*n = (-1,-2,-3) - (0,0,-3) = (-1,-2,0).
+        #   Sensor: A row += -friction = (1,2,0); B row += friction = (-1,-2,0).
+        # Contact 1: shapes=(1=B, 2=ground), normal=[0,1,0], rigid_force linear=(-4,-5,-6).
+        #   friction = (-4,-5,-6) - (0,-5,0) = (-4,0,-6).
+        #   Sensor: B row += -friction = (4,0,6); ground is not sensed.
+        # Expected friction: A = (1,2,0); B = (-1,-2,0) + (4,0,6) = (3,-2,6).
+        contacts = create_contacts(
+            device,
+            [(0, 1), (1, 2)],
+            naconmax=4,
+            normals=[[0.0, 0.0, 1.0], [0.0, 1.0, 0.0]],
+            forces=[(-1.0, -2.0, -3.0), (-4.0, -5.0, -6.0)],
+        )
 
         sensor.update(None, contacts)
 
@@ -456,29 +422,15 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="*")
 
-        # Force with tangential component: normal=[0,0,1], force=(2, 3, 7, 0, 0, 0)
-        contacts = newton.Contacts(4, 0, device=device, requested_attributes={"force"})
-        with wp.ScopedDevice(device):
-            contacts.rigid_contact_shape0 = wp.array([0, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_shape1 = wp.array([1, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_normal = wp.array(
-                [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=wp.vec3,
-            )
-            contacts.rigid_contact_count = wp.array([1], dtype=wp.int32)
-            contacts.force = wp.array(
-                [(2.0, 3.0, 7.0, 0.0, 0.0, 0.0), (0.0,) * 6, (0.0,) * 6, (0.0,) * 6],
-                dtype=wp.spatial_vector,
-            )
+        # Stored rigid_force linear = (-2, -3, -7); tangential part = (-2, -3, 0).
+        contacts = create_contacts(device, [(0, 1)], naconmax=4, normals=[[0.0, 0.0, 1.0]], forces=[(-2.0, -3.0, -7.0)])
 
         sensor.update(None, contacts)
 
         self.assertIsNotNone(sensor.force_matrix_friction)
         fmat = sensor.force_matrix_friction.numpy()
         self.assertEqual(fmat.shape, sensor.force_matrix.numpy().shape)
-        # A's friction from B: tangential part = (2, 3, 0)
         np.testing.assert_allclose(fmat[0, 1], [2.0, 3.0, 0.0], atol=1e-5)
-        # B's friction from A: (-2, -3, 0)
         np.testing.assert_allclose(fmat[1, 0], [-2.0, -3.0, 0.0], atol=1e-5)
 
     def test_friction_force_measure_total_false(self):
@@ -502,8 +454,7 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(model, sensing_obj_bodies="*")
 
-        # create_contacts builds force = magnitude * normal, so purely normal
-        contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[5.0])
+        contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[(0.0, 0.0, -5.0)])
         sensor.update(None, contacts)
 
         friction = sensor.total_force_friction.numpy()
@@ -532,19 +483,9 @@ class TestSensorContact(unittest.TestCase):
         d = float(np.dot(force_vec, n))  # 1*0 + 2*(-0.5) + 3*(sqrt(3)/2) = -1 + 2.598 = 1.598
         expected_friction = force_vec - d * n
 
-        contacts = newton.Contacts(4, 0, device=device, requested_attributes={"force"})
-        with wp.ScopedDevice(device):
-            contacts.rigid_contact_shape0 = wp.array([0, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_shape1 = wp.array([1, -1, -1, -1], dtype=wp.int32)
-            contacts.rigid_contact_normal = wp.array(
-                [n.tolist(), [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-                dtype=wp.vec3,
-            )
-            contacts.rigid_contact_count = wp.array([1], dtype=wp.int32)
-            contacts.force = wp.array(
-                [(*force_vec.tolist(), 0.0, 0.0, 0.0), (0.0,) * 6, (0.0,) * 6, (0.0,) * 6],
-                dtype=wp.spatial_vector,
-            )
+        contacts = create_contacts(
+            device, [(0, 1)], naconmax=4, normals=[n.tolist()], forces=[tuple((-force_vec).tolist())]
+        )
 
         sensor.update(None, contacts)
 

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -473,9 +473,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
     and one averaging window. Each scenario is placed far apart on the X axis so
     contact pairs never mix between scenarios:
 
-    - small sphere on plane (Fz = -mg)
-    - heavy sphere on plane (Fz = -mg, mass-independent)
-    - box on plane (4 corner contacts; summed Fz = -mg, regression for the
+    - small sphere on plane (Fz = +mg)
+    - heavy sphere on plane (Fz = +mg, mass-independent)
+    - box on plane (4 corner contacts; summed Fz = +mg, regression for the
       ``rigid_contact_con_weighting`` N*mg inflation bug)
     - mini pyramid (two bottom cubes + one top cube; ground reaction on each
       bottom cube = own weight + half the top cube ≈ 1.5*mg)
@@ -572,9 +572,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
 
         box_step_count = 0
         for ci in range(nc):
-            # ``contacts.force`` is force on body0 by body1. Sum into a "force-on-ground"
-            # bucket regardless of which side ground was recorded as: flip sign when
-            # ground is shape1 so the final values consistently match -mg downward.
+            # ``contacts.force`` is the spatial force exerted BY shape0 ON shape1. We want the
+            # force on the non-ground body, so flip the sign whenever ground is shape0 — the
+            # accumulated ``f`` is then the upward ground reaction (+mg) in every case.
             if s0[ci] == ground_shape:
                 other_shape = s1[ci]
                 f = forces[ci]
@@ -594,9 +594,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
                 box_force += f
                 box_step_count += 1
             elif other_body == cube_left_body:
-                cube_left_fz_on_body += -f[2]
+                cube_left_fz_on_body += f[2]
             elif other_body == cube_right_body:
-                cube_right_fz_on_body += -f[2]
+                cube_right_fz_on_body += f[2]
 
         test.assertGreater(box_step_count, 1, "Box should generate multiple ground contact points")
 
@@ -608,9 +608,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
 
     np.testing.assert_allclose(
         sphere_force[2],
-        -sphere_mass * gravity,
+        sphere_mass * gravity,
         rtol=0.05,
-        err_msg="Sphere on plane: vertical contact force should match -mg",
+        err_msg="Sphere on plane: vertical contact force should match +mg",
     )
     np.testing.assert_allclose(
         sphere_force[0], 0.0, atol=0.5, err_msg="Sphere on plane: horizontal X force should be ~0"
@@ -621,9 +621,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
 
     np.testing.assert_allclose(
         heavy_force[2],
-        -heavy_mass * gravity,
+        heavy_mass * gravity,
         rtol=0.05,
-        err_msg="Heavy sphere on plane: vertical contact force should match -mg",
+        err_msg="Heavy sphere on plane: vertical contact force should match +mg",
     )
     np.testing.assert_allclose(
         heavy_force[0], 0.0, atol=0.5, err_msg="Heavy sphere on plane: horizontal X force should be ~0"
@@ -634,9 +634,9 @@ def test_xpbd_contact_force_static_equilibrium(test, device):
 
     np.testing.assert_allclose(
         box_force[2],
-        -box_mass * gravity,
+        box_mass * gravity,
         rtol=0.10,
-        err_msg="Box on plane: total vertical contact force over multiple contacts should match -mg, not N*mg",
+        err_msg="Box on plane: total vertical contact force over multiple contacts should match +mg, not N*mg",
     )
     np.testing.assert_allclose(box_force[0], 0.0, atol=1.0, err_msg="Box on plane: horizontal X force should be ~0")
     np.testing.assert_allclose(box_force[1], 0.0, atol=1.0, err_msg="Box on plane: horizontal Y force should be ~0")


### PR DESCRIPTION
## Changes
* Rename attributes, removing the `_contact_` infix, e.g. `Contacts.rigid_contact_normal` -> `Contacts.rigid_normal`
* Pack paired scalar arrays, e.g. `Contacts.rigid_contact_shape0/1` -> `Contacts.rigid_shapes` (vec2i)
* Introduce `Contacts.rigid_distance`, allowing for quick identification of inactive contacts (when using fresh `Contacts`).
* Introduce extended attributes `Contacts.rigid_velocity`, `Contacts.rigid_key`, and `Contacts.rigid_force` (in place of mixed rigid and soft `force`).
* Sign-convention flip: `Contacts.rigid_force` is now the spatial force exerted by body 0 on body 1, making it codirectional with `rigid_normal` (previously they were anti-directional).
* Deprecate `Contacts.rigid_contact_offset0/1` attributes: Values are trivial to compute and not used outside `SolverXPBD` and `Viewer`.
* Deprecate always-allocated `Contacts.rigid_contact_force`: Used only by `SolverVBD` for exporting contact forces from the solver, replaced by the `Contacts.rigid_force` extended attribute like `SolverXPBD` and `SolverMuJoCo`.
* Add deprecation shims for all renamed attributes, as well as those scheduled for removal (except those added in 1.2).

## Status

This is a partial migration. It includes adaptations across the codebase to verify the design. This also serves to validate the shim logic.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signed per-contact gap plus two gated solver-produced contact attributes (velocity and warm-start key).

* **Bug Fixes**
  * Corrected contact-force sign conventions and reporting; per-contact force output is now optional and uses a spatial-vector format.

* **Documentation**
  * Updated contact attribute docs, examples, and deprecated-field notices to reflect renamed/reporting fields.

* **Refactor**
  * Renamed contact-matching/reporting fields for consistency and added backward-compatible deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->