### PR TITLE
Add CODEOWNERS for review gating

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,21 +14,11 @@
 /.claude/                                @newton-physics/maintainers
 
 # Public API surface
-/newton/__init__.py                      @newton-physics/maintainers
-/newton/_version.py                      @newton-physics/maintainers
-/newton/actuators.py                     @newton-physics/maintainers
-/newton/geometry.py                      @newton-physics/maintainers
-/newton/ik.py                            @newton-physics/maintainers
+/newton/*                                @newton-physics/maintainers
+
+# Bundled license texts
 /newton/licenses/                        @newton-physics/maintainers
-/newton/math.py                          @newton-physics/maintainers
-/newton/py.typed                         @newton-physics/maintainers
-/newton/selection.py                     @newton-physics/maintainers
-/newton/sensors.py                       @newton-physics/maintainers
-/newton/solvers.py                       @newton-physics/maintainers
-/newton/usd.py                           @newton-physics/maintainers
-/newton/utils.py                         @newton-physics/maintainers
-/newton/viewer.py                        @newton-physics/maintainers
 
 # Solver-specific owners
 /newton/_src/solvers/kamino/             @newton-physics/disney-research
-/newton/_src/solvers/style3d/            @WenchaoHuang
+/newton/_src/solvers/style3d/            @newton-physics/style3d-research

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# Newton CODEOWNERS
+#
+# A PR that touches a path below requires review approval from the listed
+# owner before it can be merged.
+
+# Root-level policy, config, and docs
+/*                                       @newton-physics/maintainers
+
+# Repo tooling and config
+/.github/                                @newton-physics/maintainers
+/scripts/                                @newton-physics/maintainers
+
+# Coding agent files
+/.claude/                                @newton-physics/maintainers
+
+# Public API surface
+/newton/__init__.py                      @newton-physics/maintainers
+/newton/_version.py                      @newton-physics/maintainers
+/newton/actuators.py                     @newton-physics/maintainers
+/newton/geometry.py                      @newton-physics/maintainers
+/newton/ik.py                            @newton-physics/maintainers
+/newton/licenses/                        @newton-physics/maintainers
+/newton/math.py                          @newton-physics/maintainers
+/newton/py.typed                         @newton-physics/maintainers
+/newton/selection.py                     @newton-physics/maintainers
+/newton/sensors.py                       @newton-physics/maintainers
+/newton/solvers.py                       @newton-physics/maintainers
+/newton/usd.py                           @newton-physics/maintainers
+/newton/utils.py                         @newton-physics/maintainers
+/newton/viewer.py                        @newton-physics/maintainers
+
+# Solver-specific owners
+/newton/_src/solvers/kamino/             @newton-physics/disney-research
+/newton/_src/solvers/style3d/            @WenchaoHuang


### PR DESCRIPTION
Closes #815.

## Description

Introduces `.github/CODEOWNERS` to gate review approval on:

- Root-level policy/config/docs (single `/*` rule).
- `/.github/`, `/.claude/`, `/scripts/` — repo tooling and CI.
- The public API surface under `/newton/` (matches user-facing modules at depth 1) plus `/newton/licenses/` for bundled license texts.
- Partner-owned solvers — Kamino (`@newton-physics/disney-research`) and Style3D (`@newton-physics/style3d-research`).

Most paths route to `@newton-physics/maintainers`. Once branch protection's "Require review from Code Owners" toggle is enabled, PRs touching these paths require a listed owner's approval before merge.

Will target Newton 1.3 to give the team time to discuss scope and set up the partner-solver teams, and not introduce risk to the 1.2 delivery.

**Intentionally unowned:** `/newton/_src/` internals (other than the two partner solvers), `/newton/examples/`, `/newton/tests/`, `/docs/`. Keeps day-to-day contributor friction low.

**Potential downside:** every PR touching a gated path will auto-request the listed owner as a reviewer. In theory the gated set (root config, public API headers, partner solvers) doesn't change often, so the noise should be limited — but worth flagging. If notifications become an issue, we could try GitHub repository rulesets, which provide finer control over required-reviewer behavior (**edit** but I'm not sure if they solve the notification issue) — see [Required reviewers in rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#required-reviewers).

**Once we agree and merge, I'll:**

- Configure branch protection on protected branches to enable "Require review from Code Owners".
- Coordinate creation of the `@newton-physics/disney-research` and `@newton-physics/style3d-research` teams so the partner-solver gates resolve.

**Open question for the team:**

- Anything missing or over-reaching in the gated set? In particular, are `/scripts/` and `/.claude/` the right scope?

## Checklist

- [ ] N/A — config-only file, no test/doc/changelog surface.

## Test plan

- After branch protection is enabled, open a test PR touching a gated path and confirm the listed owner's approval is required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for code ownership and review workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->