### PR TITLE
Add Per-Mesh Color and PBR Material Overrides to `log_mesh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add ViewerBase.should_step() — call once per frame to determine whether the simulation loop should advance; returns True when not paused.
 - Add Kamino-specific simulation examples in `newton/examples/kamino`
 - Add per-mesh `color` override to `ViewerBase.log_mesh()` for tinting individual meshes without authoring per-vertex colors
+- Add per-mesh `roughness` and `metallic` PBR overrides to `ViewerBase.log_mesh()`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Add frame-by-frame step support to `ViewerGL`: press `.` while paused to advance one simulation frame
 - Add ViewerBase.should_step() — call once per frame to determine whether the simulation loop should advance; returns True when not paused.
 - Add Kamino-specific simulation examples in `newton/examples/kamino`
+- Add per-mesh `color` override to `ViewerBase.log_mesh()` for tinting individual meshes without authoring per-vertex colors
 
 ### Changed
 

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -226,12 +226,11 @@ class MeshGL:
         #   column 3  (0,0,0,1)
         gl.glVertexAttrib4f(6, 0.0, 0.0, 0.0, 1.0)
 
-        # albedo
-        gl.glVertexAttrib3f(7, 0.7, 0.5, 0.3)
-        # material = (roughness, metallic, checker, texture_enable)
-        gl.glVertexAttrib4f(8, 0.5, 0.0, 0.0, 0.0)
-
         gl.glBindVertexArray(0)
+
+        # Per-mesh albedo and material (applied in render()).
+        self.color = (0.7, 0.5, 0.3)
+        self.material = (0.5, 0.0, 0.0, 0.0)
 
         # Create CUDA-GL interop buffer for efficient updates
         if ENABLE_CUDA_INTEROP and self.device.is_cuda:
@@ -362,6 +361,10 @@ class MeshGL:
                 gl.glBindTexture(gl.GL_TEXTURE_2D, self.texture_id)
             else:
                 gl.glBindTexture(gl.GL_TEXTURE_2D, RendererGL.get_fallback_texture())
+
+            # Set per-mesh albedo and material (global state, not per-VAO).
+            gl.glVertexAttrib3f(7, *self.color)
+            gl.glVertexAttrib4f(8, *self.material)
 
             gl.glBindVertexArray(self.vao)
             gl.glDrawElements(gl.GL_TRIANGLES, self.num_indices, gl.GL_UNSIGNED_INT, None)

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -1016,6 +1016,7 @@ class ViewerBase(ABC):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         Register or update a mesh prototype in the viewer backend.
@@ -1029,6 +1030,8 @@ class ViewerBase(ABC):
             texture: Optional texture image array or path.
             hidden: Whether the mesh should be hidden.
             backface_culling: Whether back-face culling should be enabled.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         pass
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -1017,6 +1017,8 @@ class ViewerBase(ABC):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         Register or update a mesh prototype in the viewer backend.
@@ -1032,6 +1034,10 @@ class ViewerBase(ABC):
             backface_culling: Whether back-face culling should be enabled.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         pass
 

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -1243,6 +1243,8 @@ class ViewerFile(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """File viewer does not render meshes.
 
@@ -1257,6 +1259,10 @@ class ViewerFile(ViewerBase):
             backface_culling: Whether back-face culling is enabled.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         pass
 

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -1242,6 +1242,7 @@ class ViewerFile(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """File viewer does not render meshes.
 
@@ -1254,6 +1255,8 @@ class ViewerFile(ViewerBase):
             texture: Optional texture path/URL or image array.
             hidden: Whether the mesh is hidden.
             backface_culling: Whether back-face culling is enabled.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         pass
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -728,6 +728,7 @@ class ViewerGL(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         Log a mesh for rendering.
@@ -741,6 +742,8 @@ class ViewerGL(ViewerBase):
             texture: Texture path/URL or image array (H, W, C).
             hidden: Whether the mesh is hidden.
             backface_culling: Enable backface culling.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         assert isinstance(points, wp.array)
         assert isinstance(indices, wp.array)
@@ -755,6 +758,9 @@ class ViewerGL(ViewerBase):
         self.objects[name].update(points, indices, normals, uvs, texture)
         self.objects[name].hidden = hidden
         self.objects[name].backface_culling = backface_culling
+
+        if color is not None:
+            self.objects[name].color = (float(color[0]), float(color[1]), float(color[2]))
 
     @override
     def log_instances(

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -729,6 +729,8 @@ class ViewerGL(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         Log a mesh for rendering.
@@ -744,6 +746,10 @@ class ViewerGL(ViewerBase):
             backface_culling: Enable backface culling.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         assert isinstance(points, wp.array)
         assert isinstance(indices, wp.array)
@@ -761,6 +767,14 @@ class ViewerGL(ViewerBase):
 
         if color is not None:
             self.objects[name].color = (float(color[0]), float(color[1]), float(color[2]))
+
+        if roughness is not None or metallic is not None:
+            r, m, c, t = self.objects[name].material
+            if roughness is not None:
+                r = float(roughness)
+            if metallic is not None:
+                m = float(metallic)
+            self.objects[name].material = (r, m, c, t)
 
     @override
     def log_instances(

--- a/newton/_src/viewer/viewer_null.py
+++ b/newton/_src/viewer/viewer_null.py
@@ -67,6 +67,7 @@ class ViewerNull(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         No-op implementation for logging a mesh.
@@ -80,6 +81,8 @@ class ViewerNull(ViewerBase):
             texture: Optional texture path/URL or image array.
             hidden: Whether the mesh is hidden.
             backface_culling: Whether to enable backface culling.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         pass
 

--- a/newton/_src/viewer/viewer_null.py
+++ b/newton/_src/viewer/viewer_null.py
@@ -68,6 +68,8 @@ class ViewerNull(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         No-op implementation for logging a mesh.
@@ -83,6 +85,10 @@ class ViewerNull(ViewerBase):
             backface_culling: Whether to enable backface culling.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         pass
 

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -218,6 +218,8 @@ class ViewerRerun(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         Log a mesh to rerun for visualization.
@@ -233,6 +235,10 @@ class ViewerRerun(ViewerBase):
             backface_culling: Whether to enable backface culling (unused).
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         if not hidden:
             assert isinstance(points, wp.array)

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -217,6 +217,7 @@ class ViewerRerun(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         Log a mesh to rerun for visualization.
@@ -230,6 +231,8 @@ class ViewerRerun(ViewerBase):
             texture: Optional texture path/URL or image array.
             hidden: Whether the mesh is hidden.
             backface_culling: Whether to enable backface culling (unused).
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         if not hidden:
             assert isinstance(points, wp.array)

--- a/newton/_src/viewer/viewer_usd.py
+++ b/newton/_src/viewer/viewer_usd.py
@@ -214,6 +214,7 @@ class ViewerUSD(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         Create a USD mesh prototype from vertex and index data.
@@ -227,6 +228,8 @@ class ViewerUSD(ViewerBase):
             texture: Optional texture path/URL or image array.
             hidden: If True, mesh will be hidden.
             backface_culling: If True, enable backface culling.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
 
         # Convert warp arrays to numpy

--- a/newton/_src/viewer/viewer_usd.py
+++ b/newton/_src/viewer/viewer_usd.py
@@ -215,6 +215,8 @@ class ViewerUSD(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         Create a USD mesh prototype from vertex and index data.
@@ -230,6 +232,10 @@ class ViewerUSD(ViewerBase):
             backface_culling: If True, enable backface culling.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
 
         # Convert warp arrays to numpy

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -502,6 +502,7 @@ class ViewerViser(ViewerBase):
         texture: np.ndarray | str | None = None,
         hidden: bool = False,
         backface_culling: bool = True,
+        color: tuple[float, float, float] | None = None,
     ):
         """
         Log a mesh to viser for visualization.
@@ -515,6 +516,8 @@ class ViewerViser(ViewerBase):
             texture: Texture path/URL or image array (H, W, C).
             hidden: Whether the mesh is hidden.
             backface_culling: Whether to enable backface culling.
+            color: Optional base color as an RGB tuple with values in
+                [0, 1]. Used when no texture is provided.
         """
         assert isinstance(points, wp.array)
         assert isinstance(indices, wp.array)
@@ -580,7 +583,7 @@ class ViewerViser(ViewerBase):
                 name=name,
                 vertices=points_np,
                 faces=indices_np,
-                color=(180, 180, 180),  # Default gray color
+                color=(180, 180, 180) if color is None else color,
                 wireframe=False,
                 side="double" if not backface_culling else "front",
             )

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -503,6 +503,8 @@ class ViewerViser(ViewerBase):
         hidden: bool = False,
         backface_culling: bool = True,
         color: tuple[float, float, float] | None = None,
+        roughness: float | None = None,
+        metallic: float | None = None,
     ):
         """
         Log a mesh to viser for visualization.
@@ -518,6 +520,10 @@ class ViewerViser(ViewerBase):
             backface_culling: Whether to enable backface culling.
             color: Optional base color as an RGB tuple with values in
                 [0, 1]. Used when no texture is provided.
+            roughness: Surface roughness in ``[0, 1]``. ``0`` is perfectly
+                smooth, ``1`` is fully rough.
+            metallic: Metallicity in ``[0, 1]``. ``0`` is dielectric, ``1``
+                is metal.
         """
         assert isinstance(points, wp.array)
         assert isinstance(indices, wp.array)


### PR DESCRIPTION
## Description

Extend `ViewerBase.log_mesh()` with three optional per-mesh material parameters: `color` (RGB base color used when no texture is supplied), `roughness`, and `metallic`. This lets callers tint or restyle individual meshes through the public viewer API without authoring per-vertex colors or building a texture.

The new parameters are wired through every viewer backend (`gl`, `usd`, `rerun`, `viser`, `file`, `null`); the GL backend honors the values via the existing PBR uniforms, while other backends accept the arguments for API parity.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## New feature / API change

```python
import newton

viewer = newton.viewer.ViewerGL()
viewer.log_mesh(
    "/world/widget",
    points=points,
    indices=indices,
    color=(0.85, 0.1, 0.1),
    roughness=0.3,
    metallic=1.0,
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesh logging now supports per-mesh RGB color tinting and per-mesh PBR overrides for roughness and metallic when logging meshes, enabling per-mesh appearance control without vertex colors.

* **Documentation**
  * Updated mesh logging docs and docstrings to describe the new color, roughness, and metallic parameters, their [0,1] ranges, and semantics.

* **Chores**
  * Preserved backward compatibility; cleaned up CHANGELOG formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->