### PR TITLE
Warn on stale MuJoCo dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `ViewerBase.log_arrows()` for arrow rendering (wide line + arrowhead) in the GL viewer with a dedicated geometry shader
 - Add frame-to-frame contact matching via `CollisionPipeline(contact_matching=...)` with modes `"latest"` (populates `contacts.rigid_contact_match_index`) and `"sticky"` (experimental; additionally replays previous-frame contact geometry on matched contacts — the sticky update strategy may change without warning). Optional `contact_report=True` exposes new/broken contact index lists on `Contacts`.
 - Add `enable_multiccd` parameter to `SolverMuJoCo` for multi-CCD contact generation (up to 4 contact points per geom pair)
+- Warn when `SolverMuJoCo` detects installed `mujoco` or `mujoco-warp` versions that do not satisfy `pyproject.toml` requirements
 - Support `<joint type="ball"/>` in the MJCF importer, and preserve authored damping, stiffness, and frictionloss when exporting ball joints to MuJoCo specs (previously silently dropped)
 - Add `ViewerViser.log_scalar()` for live scalar time-series plots via uPlot
 - Honor `UsdGeomImageable` visibility (including inherited `invisible`) on USD prims imported via `ModelBuilder.add_usd()`; visual shapes, gaussian splats, and collider shapes are imported with `ShapeFlags.VISIBLE` cleared when the prim is effectively invisible, while collision behavior is preserved

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import importlib.metadata as importlib_metadata
 import os
+import re
 import warnings
 from collections.abc import Iterable
 from enum import IntEnum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -90,6 +93,63 @@ else:
 
 AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
+
+
+def _warn_if_mujoco_versions_mismatch(mujoco: Any, mujoco_warp: Any) -> None:
+    try:
+        pyproject_text = (Path(__file__).resolve().parents[4] / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    mismatches = []
+    for package, module in (("mujoco", mujoco), ("mujoco-warp", mujoco_warp)):
+        match = re.search(rf'^\s*"{re.escape(package)}(?=[<>=!~])([^";]+)', pyproject_text, re.MULTILINE)
+        installed_version = _installed_version(package, module)
+        if match and installed_version and not _version_satisfies(installed_version, match.group(1)):
+            mismatches.append(f"{package}=={installed_version} (requires {match.group(1).replace(' ', '')})")
+
+    if mismatches:
+        warnings.warn(
+            "MuJoCo dependency version mismatch with pyproject.toml: "
+            + "; ".join(mismatches)
+            + '. Reinstall Newton dependencies, for example `uv pip install -e ".[examples]"`.',
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+def _installed_version(package: str, module: Any) -> str | None:
+    try:
+        return importlib_metadata.version(package)
+    except importlib_metadata.PackageNotFoundError:
+        module_version = getattr(module, "__version__", None)
+        return str(module_version) if module_version is not None else None
+
+
+def _version_satisfies(installed_version: str, specifier: str) -> bool:
+    installed = _release(installed_version)
+    if not installed:
+        return True
+
+    for required_version in re.findall(r">=\s*([0-9][^,;]*)", specifier):
+        if _version_lt(installed, _release(required_version)):
+            return False
+    for required_version in re.findall(r"~=\s*([0-9][^,;]*)", specifier):
+        required = _release(required_version)
+        prefix_width = max(len(required) - 1, 1)
+        if _version_lt(installed, required) or installed[:prefix_width] != required[:prefix_width]:
+            return False
+    return True
+
+
+def _release(version: str) -> tuple[int, ...]:
+    match = re.match(r"\d+(?:\.\d+)*", version)
+    return tuple(int(component) for component in match.group(0).split(".")) if match else ()
+
+
+def _version_lt(left: tuple[int, ...], right: tuple[int, ...]) -> bool:
+    width = max(len(left), len(right))
+    return left + (0,) * (width - len(left)) < right + (0,) * (width - len(right))
 
 
 class SolverMuJoCo(SolverBase):
@@ -226,6 +286,10 @@ class SolverMuJoCo(SolverBase):
                 raise ImportError(
                     "MuJoCo backend not installed. Please refer to https://github.com/google-deepmind/mujoco_warp for installation instructions."
                 ) from e
+        try:
+            _warn_if_mujoco_versions_mismatch(cls._mujoco, cls._mujoco_warp)
+        except Exception:
+            pass
         return cls._mujoco, cls._mujoco_warp
 
     @staticmethod
@@ -251,7 +315,7 @@ class SolverMuJoCo(SolverBase):
     @staticmethod
     def _parse_named_int(value: str | int, mapping: dict[str, int], fallback_on_unknown: int | None = None) -> int:
         """Parse string-valued enums to int, otherwise return int(value)."""
-        if isinstance(value, (int, np.integer)):
+        if isinstance(value, int | np.integer):
             return int(value)
         lower_value = str(value).lower().strip()
         if lower_value in mapping:
@@ -983,7 +1047,7 @@ class SolverMuJoCo(SolverBase):
             """Parse MJCF/USD boolean values to bool."""
             if isinstance(value, bool):
                 return value
-            if isinstance(value, (int, np.integer)):
+            if isinstance(value, int | np.integer):
                 return bool(value)
             s = str(value).strip().lower()
             if s == "auto":

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import types
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+from newton._src.solvers.mujoco import solver_mujoco
+
+
+def _mujoco_dependency_specs():
+    pyproject_text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(encoding="utf-8")
+    specs = {}
+    for package in ("mujoco", "mujoco-warp"):
+        match = solver_mujoco.re.search(
+            rf'^\s*"{solver_mujoco.re.escape(package)}(?=[<>=!~])([^";]+)',
+            pyproject_text,
+            solver_mujoco.re.MULTILINE,
+        )
+        if match:
+            specs[package] = match.group(1).replace(" ", "")
+    return specs
+
+
+class TestMuJoCoVersionCheck(unittest.TestCase):
+    def test_warns_when_installed_versions_do_not_satisfy_pyproject(self):
+        specs = _mujoco_dependency_specs()
+        versions = {
+            package: "0.0.0"
+            for package, specifier in specs.items()
+            if not solver_mujoco._version_satisfies("0.0.0", specifier)
+        }
+
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+            with self.assertWarnsRegex(
+                RuntimeWarning,
+                "pyproject.toml.*mujoco==0.0.0.*mujoco-warp==0.0.0",
+            ):
+                solver_mujoco._warn_if_mujoco_versions_mismatch(
+                    types.SimpleNamespace(),
+                    types.SimpleNamespace(),
+                )
+
+    def test_warns_when_only_mujoco_warp_mismatches_pyproject(self):
+        specs = _mujoco_dependency_specs()
+        mujoco_warp_bad_version = "0.0.0"
+        self.assertFalse(solver_mujoco._version_satisfies(mujoco_warp_bad_version, specs["mujoco-warp"]))
+
+        versions = {"mujoco": _matching_version(specs["mujoco"]), "mujoco-warp": mujoco_warp_bad_version}
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+            with self.assertWarnsRegex(RuntimeWarning, f"mujoco-warp=={mujoco_warp_bad_version}"):
+                solver_mujoco._warn_if_mujoco_versions_mismatch(
+                    types.SimpleNamespace(),
+                    types.SimpleNamespace(),
+                )
+
+    def test_import_mujoco_warns_for_cached_mismatched_versions(self):
+        specs = _mujoco_dependency_specs()
+        versions = {
+            package: "0.0.0"
+            for package, specifier in specs.items()
+            if not solver_mujoco._version_satisfies("0.0.0", specifier)
+        }
+        previous_mujoco = solver_mujoco.SolverMuJoCo._mujoco
+        previous_mujoco_warp = solver_mujoco.SolverMuJoCo._mujoco_warp
+
+        try:
+            solver_mujoco.SolverMuJoCo._mujoco = types.SimpleNamespace()
+            solver_mujoco.SolverMuJoCo._mujoco_warp = types.SimpleNamespace()
+
+            with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+                with self.assertWarnsRegex(RuntimeWarning, "MuJoCo dependency version mismatch"):
+                    solver_mujoco.SolverMuJoCo.import_mujoco()
+        finally:
+            solver_mujoco.SolverMuJoCo._mujoco = previous_mujoco
+            solver_mujoco.SolverMuJoCo._mujoco_warp = previous_mujoco_warp
+
+    def test_accepts_versions_that_satisfy_pyproject(self):
+        versions = {package: _matching_version(specifier) for package, specifier in _mujoco_dependency_specs().items()}
+
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                solver_mujoco._warn_if_mujoco_versions_mismatch(
+                    types.SimpleNamespace(),
+                    types.SimpleNamespace(),
+                )
+
+        messages = [str(warning.message) for warning in caught]
+        self.assertFalse(any("MuJoCo dependency version mismatch" in message for message in messages))
+
+
+def _matching_version(specifier: str) -> str:
+    for pattern in (r">=\s*([0-9][^,;]*)", r"~=\s*([0-9][^,;]*)"):
+        match = solver_mujoco.re.search(pattern, specifier)
+        if match:
+            return match.group(1)
+    return "0.0.0"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Warn during `SolverMuJoCo` dependency import when the installed `mujoco` or `mujoco-warp` versions do not satisfy the requirements declared in `pyproject.toml`.

This catches stale editable-install environments like the one discussed in #2582, where Newton code has been updated but MuJoCo dependencies were not reinstalled. The check is warning-only and does not prevent solver initialization.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_mujoco_version_check
uv run --extra dev ruff check newton/_src/solvers/mujoco/solver_mujoco.py newton/tests/test_mujoco_version_check.py
uv run --extra dev ruff format --check newton/_src/solvers/mujoco/solver_mujoco.py newton/tests/test_mujoco_version_check.py
uv run --extra dev python -c "import warnings; from importlib.metadata import version; from newton.solvers import SolverMuJoCo; print('mujoco', version('mujoco')); print('mujoco-warp', version('mujoco-warp')); warnings.simplefilter('error', RuntimeWarning); SolverMuJoCo.import_mujoco(); print('import ok')"
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Install Newton in editable mode with an older `mujoco` / `mujoco-warp` set.
2. Pull a newer Newton revision whose `pyproject.toml` requires newer MuJoCo packages.
3. Run a MuJoCo-backed scene without reinstalling dependencies.
4. Observe confusing runtime behavior from stale MuJoCo package versions.

**Minimal reproduction:**

```python
import newton
from newton.solvers import SolverMuJoCo

builder = newton.ModelBuilder()
model = builder.finalize()
solver = SolverMuJoCo(model)
```

With this change, initialization emits a `RuntimeWarning` when the installed MuJoCo package versions do not satisfy `pyproject.toml`.

## New feature / API change

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime version validation for `mujoco` and `mujoco-warp` dependencies with warning notifications when installed versions don't satisfy project requirements.

* **Tests**
  * Added comprehensive test suite for dependency version checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->