### PR TITLE
Document finite-value requirement for joint limits

### DIFF
--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -494,9 +494,9 @@ class Model:
         self.joint_enabled: wp.array[wp.bool] | None = None
         """Controls which joint is simulated (bodies become disconnected if False, supported by :class:`~newton.solvers.SolverXPBD`, :class:`~newton.solvers.SolverVBD`, and :class:`~newton.solvers.SolverSemiImplicit`), shape [joint_count], bool."""
         self.joint_limit_lower: wp.array[wp.float32] | None = None
-        """Joint lower position limits [m or rad, depending on joint type], shape [joint_dof_count], float."""
+        """Joint lower position limits [m or rad, depending on joint type], shape [joint_dof_count], float. Values must be finite; use ``-newton.MAXVAL`` to indicate no lower limit."""
         self.joint_limit_upper: wp.array[wp.float32] | None = None
-        """Joint upper position limits [m or rad, depending on joint type], shape [joint_dof_count], float."""
+        """Joint upper position limits [m or rad, depending on joint type], shape [joint_dof_count], float. Values must be finite; use ``newton.MAXVAL`` to indicate no upper limit."""
         self.joint_limit_ke: wp.array[wp.float32] | None = None
         """Joint position limit stiffness [N/m or N·m/rad, depending on joint type] (used by :class:`~newton.solvers.SolverSemiImplicit` and :class:`~newton.solvers.SolverFeatherstone`), shape [joint_dof_count], float."""
         self.joint_limit_kd: wp.array[wp.float32] | None = None


### PR DESCRIPTION
## Description

Document on `Model.joint_limit_lower` / `Model.joint_limit_upper` that the array values must be finite, and that `±newton.MAXVAL` is the runtime sentinel for "no limit". This mirrors the convention the builder already uses for unspecified limits but isn't currently surfaced anywhere a user updating the arrays at runtime would see.

The motivating issue (#2072) was a user writing `np.array([None], dtype=np.float32)` into `joint_limit_upper`, which silently lands as `NaN` and breaks any solver reading that value (caught visibly in MuJoCo, accidentally tolerated by Featherstone). `None` is only meaningful at build time, where the builder converts it to `±MAXVAL`; once the model is built the arrays are raw floats with no such conversion. This is the smallest change that closes the documentation gap on the array contract itself.

The MuJoCo `jnt_limited`-is-fixed-at-construction caveat from #2072 is a separate, solver-specific concern and is intentionally not in scope here.

Refs #2072

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Docstring-only change; no behavior change. Built docs locally to confirm rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved documentation for joint position limit parameters to clarify how to specify no limit conditions using sentinel values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->