### PR TITLE
Document BrokenProcessPool workaround in dev guide

### DIFF
--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -140,6 +140,19 @@ in a serial manner with ``--serial-fallback``.
 
 Pass ``--help`` to either run method below to see all available flags.
 
+.. note::
+
+    If a test run aborts with ``concurrent.futures.process.BrokenProcessPool``,
+    a worker process crashed (out-of-memory, segfault, or similar). The runner
+    parallelizes across ``min(cpu_count, 8)`` workers by default; on
+    memory-constrained machines this can saturate RAM and kill a worker.
+    Retry with fewer workers via ``--jobs`` (or ``--serial-fallback`` for a
+    single process):
+
+    .. code-block:: console
+
+        python -m newton.tests --jobs 4
+
 .. tab-set::
     :sync-group: env
 


### PR DESCRIPTION
## Description

Add a short note to the *Running the tests* section of the development
guide explaining that `concurrent.futures.process.BrokenProcessPool`
indicates a worker crash (OOM, segfault, etc.) and pointing developers
at `--jobs N` / `--serial-fallback` as the first remedy on memory-
constrained machines.

Background: a 90-day scan of GPU CI runs (split at the
[#2262](https://github.com/newton-physics/newton/pull/2262) merge)
showed the CI rate dropped from 36/3819 (0.94%) pre-fix to 0/1624
post-fix, but developers occasionally still hit `BrokenProcessPool`
locally on lower-RAM machines. Discussed in
[#1847](https://github.com/newton-physics/newton/issues/1847).

Closes #1847.

## Checklist

- [x] New or existing tests cover these changes (docs-only)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change) — N/A, no behavior change

## Test plan

Docs-only change. Verified locally:

```
uvx pre-commit run -a
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive troubleshooting guide for test failures caused by crashed worker processes resulting from resource constraints. Includes specific instructions for reducing test parallelism via command-line configuration options and provides concrete examples for executing test suites with fewer parallel workers to improve system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->