### PR TITLE
Vectorize SolverMuJoCo init site-actuator scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`
+- Fix `SolverMuJoCo.__init__` time scaling with `world_count × actuators_per_world` instead of `actuators_per_world` by vectorizing the template-world filter for site-targeted actuators
 - Fix compressed tets in `evaluate_volumetric_neo_hookean_force_and_hessian` producing an indefinite Hessian by clamping the cofactor-derivative coefficient to `max(0, s)`, removing a contribution that could corrupt the VBD inner solve
 - Fix SDF hydroelastic broadphase scatter kernel using a grid-stride loop with binary search instead of per-pair thread launch
 - Fix box support-map sign flips from quaternion rotation noise (~1e-14) producing invalid GJK/MPR contacts for face-touching boxes with non-trivial base rotations

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -4378,36 +4378,41 @@ class SolverMuJoCo(SolverBase):
         # Collect shapes required by actuators targeting sites so they are not
         # skipped when include_sites=False.  USD actuators may still carry
         # sentinel trnid/trntype at this point (resolved later from
-        # actuator_target_label), so check labels first.
+        # actuator_target_label), so check labels too.
+        # Restrict everything to the template world so cost is O(per-world
+        # size) instead of O(world_count * per-world size), which dominated
+        # solver init for large world counts.
         actuator_required_shapes: set[int] = set()
         if mujoco_attrs is not None:
             _act_trntype = getattr(mujoco_attrs, "actuator_trntype", None)
             _act_trnid = getattr(mujoco_attrs, "actuator_trnid", None)
             _act_target_label = getattr(mujoco_attrs, "actuator_target_label", None)
             _act_world = getattr(mujoco_attrs, "actuator_world", None)
-            site_shape_by_label = {
-                label: idx
-                for idx, label in enumerate(model.shape_label)
-                if (shape_flags[idx] & ShapeFlags.SITE) and idx in selected_shapes_set
-            }
+            template_site_mask = (shape_flags[selected_shapes] & int(ShapeFlags.SITE)) != 0
+            template_site_indices = selected_shapes[template_site_mask]
+            site_shape_by_label = {model.shape_label[int(idx)]: int(idx) for idx in template_site_indices}
             if _act_trntype is not None and _act_trnid is not None:
                 act_trntype_np = _act_trntype.numpy()
                 act_trnid_np = _act_trnid.numpy()
-                act_world_np = _act_world.numpy() if _act_world is not None else None
-                for ai in range(len(act_trntype_np)):
-                    if act_world_np is not None:
-                        aw = int(act_world_np[ai])
-                        if aw != first_world and aw >= 0:
-                            continue
-                    # Try label-based resolution first (covers USD deferred targets)
-                    idx = -1
-                    if isinstance(_act_target_label, list) and ai < len(_act_target_label):
-                        idx = site_shape_by_label.get(_act_target_label[ai], -1)
-                    # Fall back to trnid for MJCF/direct site actuators
-                    if idx < 0 and int(act_trntype_np[ai]) == int(SolverMuJoCo.TrnType.SITE):
-                        idx = int(act_trnid_np[ai, 0])
-                    if idx >= 0:
-                        actuator_required_shapes.add(idx)
+                if _act_world is not None:
+                    act_world_np = _act_world.numpy()
+                    template_mask = (act_world_np == first_world) | (act_world_np < 0)
+                else:
+                    template_mask = np.ones(len(act_trntype_np), dtype=bool)
+                # Vectorized: every template-world actuator with trntype==SITE
+                # contributes its trnid as a required shape.
+                site_trntype_mask = template_mask & (act_trntype_np == int(SolverMuJoCo.TrnType.SITE))
+                trnid_targets = act_trnid_np[site_trntype_mask, 0]
+                actuator_required_shapes.update(trnid_targets[trnid_targets >= 0].tolist())
+                # Vectorized: USD-deferred actuators reference sites by label.
+                # Intersect template-world target labels with the site label
+                # dict instead of iterating over every actuator.
+                if isinstance(_act_target_label, list) and site_shape_by_label:
+                    template_indices = np.flatnonzero(template_mask).tolist()
+                    label_count = len(_act_target_label)
+                    template_target_labels = {_act_target_label[ai] for ai in template_indices if ai < label_count}
+                    for label in template_target_labels & site_shape_by_label.keys():
+                        actuator_required_shapes.add(site_shape_by_label[label])
 
         required_shapes = tendon_required_shapes | actuator_required_shapes
 


### PR DESCRIPTION
## Description

Fix a solver-init regression introduced in #2220 (site-targeted actuator support) where `SolverMuJoCo.__init__` time scales with `world_count * per-world size`. Visible across all dashboard runners on `setup.bench_model.KpiInitializeSolver` ([asv regressions](https://newton-physics.github.io/newton-asv/#regressions)).

The new code did two Python-level passes during init:

- A dict comprehension over the entire replicated `model.shape_label` (~400k entries for `ant` x 8192) to build `site_shape_by_label`.
- A loop over every entry of `actuator_trntype.numpy()` (~170k for `humanoid` x 8192) just to filter to the template world before resolving site targets.

Both are restricted to the template world here: `site_shape_by_label` is built from `selected_shapes`, the per-actuator loop is replaced by a vectorized `np.flatnonzero` on `actuator_world` plus a numpy mask for trnid targets, and the USD-deferred label path becomes a label-set intersection. Cost is back to O(per-world size).

### Timings (RTX PRO 6000, `KpiInitializeSolver`, world_count=8192, median of 3 measured runs)

| variant | `ant` | `humanoid` |
|---|---|---|
| `488e5e002` (last good, pre-#2220) | 0.264s | 0.661s |
| `main` (regressed) | 0.542s | 0.826s |
| this PR | **0.260s** | **0.601s** |

### Behavior note

The original code preferred label resolution and skipped trnid for the same actuator if the label matched. The vectorized version unions both paths. For well-formed actuators label and trnid agree, so the result is identical. In the pathological case of disagreement, the vectorized version retains both shapes; this is harmless because `actuator_required_shapes` is purely a "do not drop these shapes" set, never used to pick which shape an actuator targets.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

\`\`\`
uv run --extra dev -m newton.tests -k test_mujoco_general_actuators
\`\`\`

All 22 tests pass on the patched code. Solver-init perf was measured with a script that mirrors `KpiInitializeSolver` on `ant` and `humanoid` at 8192 worlds against three commits (last-good, current main, and this PR) on the same machine.

## Bug fix

**Steps to reproduce:**

1. Run \`KpiInitializeSolver\` on any commit at or after #2220 (e.g. via the asv dashboard) with \`world_count=8192\`.
2. Compare against any commit before #2220.
3. Observe ~50-120% slower solver init across `humanoid`, `g1`, `cartpole`, and `ant`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed time scaling calculation in MuJoCo solver initialization where actuator counts were incorrectly computed

* **Performance Improvements**
  * Optimized actuator-target detection during MuJoCo solver initialization to reduce computational overhead and improve startup performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->