### PR TITLE
Fix albedo renders as flat grey when render_color=False on textured scenes (#2401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Fix `SensorRaycast` ignoring `PLANE` geometry
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
+- Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`
 - Fix `SolverMuJoCo.__init__` time scaling with `world_count × actuators_per_world` instead of `actuators_per_world` by vectorizing the template-world filter for site-targeted actuators

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -20,7 +20,7 @@ def create_kernel(
 ) -> wp.kernel:
     compute_lighting = lighting.create_compute_lighting_function(config, state)
 
-    if state.render_color or state.render_normal:
+    if state.render_color or state.render_normal or (state.render_albedo and config.enable_textures):
         raytrace_closest_hit = raytrace.create_closest_hit_function(config, state)
     else:
         raytrace_closest_hit = raytrace.create_closest_hit_depth_only_function(config, state)


### PR DESCRIPTION
## Summary
- Fix `SensorTiledCamera` albedo output for textured scenes when only albedo is requested.
- Ensure textured albedo rendering uses the full closest-hit raytrace path so texture sampling is available without color or normal outputs.
- Add an Unreleased changelog entry under Fixed.

## Test plan
- Not run; reviewed the targeted branch diff and changelog update.

Closes #2401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rendering issue in SensorTiledCamera when rendering textured albedo output while color and normal outputs are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->