### PR TITLE
MuJoCo Contact Scaling for Articulated Geoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix viewer crash with `imgui_bundle>=1.92.6` when editing colors by normalizing `color_edit3` input/output in `_edit_color3`
 - Show prismatic joints in the GL viewer when "Show Joints" is enabled
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
+- Fix `SolverMuJoCo` converting `shape_material_ke` / `shape_material_kd` without MuJoCo's q0 invweight scaling, so articulated shapes honor authored contact stiffness and damping after `notify_model_changed()`
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged
 - Fix `State.assign` not copying namespaced extended and custom state attributes 
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -251,6 +251,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
     geom_friction: wp.array2d[wp.vec3],
     geom_margin: wp.array2d[float],
     geom_gap: wp.array2d[float],
+    shape_ke: wp.array[float],
+    shape_kd: wp.array[float],
     # Newton contacts
     rigid_contact_count: wp.array[wp.int32],
     rigid_contact_shape0: wp.array[wp.int32],
@@ -399,6 +401,29 @@ def convert_newton_contacts_to_mjwarp_kernel(
             geoms,
             worldid,
         )
+
+        # Newton-authored contacts are already in force units, so keep the
+        # pre-existing unscaled material conversion here. The geom solrefs in
+        # mjw_model are q0-scaled for MuJoCo's native collision pipeline.
+        solref_a = convert_solref(shape_ke[shape_a], shape_kd[shape_a], 1.0, 1.0)
+        solref_b = convert_solref(shape_ke[shape_b], shape_kd[shape_b], 1.0, 1.0)
+        priority_a = geom_priority[geom_a]
+        priority_b = geom_priority[geom_b]
+        if priority_a > priority_b:
+            mix = 1.0
+        elif priority_b > priority_a:
+            mix = 0.0
+        else:
+            solmix_a = geom_solmix[worldid, geom_a]
+            solmix_b = geom_solmix[worldid, geom_b]
+            mix = safe_div(solmix_a, solmix_a + solmix_b)
+            mix = wp.where((solmix_a < MJ_MINVAL) and (solmix_b < MJ_MINVAL), 0.5, mix)
+            mix = wp.where((solmix_a < MJ_MINVAL) and (solmix_b >= MJ_MINVAL), 0.0, mix)
+            mix = wp.where((solmix_a >= MJ_MINVAL) and (solmix_b < MJ_MINVAL), 1.0, mix)
+        if solref_a.x > 0.0 and solref_b.x > 0.0:
+            solref = mix * solref_a + (1.0 - mix) * solref_b
+        else:
+            solref = wp.min(solref_a, solref_b)
 
         # Convert Newton per-contact stiffness/damping to MuJoCo solref
         # (timeconst, dampratio).  solimp is set to approximate a linear
@@ -2263,6 +2288,7 @@ def update_geom_properties_kernel(
     mjc_geom_to_newton_shape: wp.array2d[wp.int32],
     geom_bodyid: wp.array[int],
     body_invweight0: wp.array2d[wp.vec2],
+    shape_geom_solref: wp.array[wp.vec2],
     geom_type: wp.array[int],
     GEOM_TYPE_MESH: int,
     geom_dataid: wp.array2d[int],
@@ -2320,23 +2346,29 @@ def update_geom_properties_kernel(
         geom_solimp[world, geom_idx] = shape_geom_solimp[shape_idx]
         dmax = shape_geom_solimp[shape_idx][1]
 
-    # update geom_solref (timeconst, dampratio) using stiffness and damping
-    # we don't use the negative convention to support controlling the mixing of
-    # shapes' stiffnesses via solmix. MuJoCo's force-space conversion depends on
-    # the frozen q0 invweight0 factor and the geom's dmax impedance.
-    solref_scale = geom_solref_scale_factor(
-        world,
-        geom_idx,
-        geom_bodyid,
-        body_invweight0,
-        dmax,
-    )
-    geom_solref[world, geom_idx] = convert_solref(
-        shape_ke[shape_idx],
-        shape_kd[shape_idx],
-        solref_scale,
-        solref_scale,
-    )
+    # update geom_solref (timeconst, dampratio) using either authored MuJoCo
+    # solref or Newton stiffness and damping. Raw MuJoCo solrefs already live
+    # in MuJoCo solver units, while Newton materials need q0 invweight scaling.
+    if shape_geom_solref and (shape_geom_solref[shape_idx][0] != 0.0 or shape_geom_solref[shape_idx][1] != 0.0):
+        geom_solref[world, geom_idx] = shape_geom_solref[shape_idx]
+    else:
+        # We don't use the negative convention to support controlling the
+        # mixing of shapes' stiffnesses via solmix. MuJoCo's force-space
+        # conversion depends on the frozen q0 invweight0 factor and the geom's
+        # dmax impedance.
+        solref_scale = geom_solref_scale_factor(
+            world,
+            geom_idx,
+            geom_bodyid,
+            body_invweight0,
+            dmax,
+        )
+        geom_solref[world, geom_idx] = convert_solref(
+            shape_ke[shape_idx],
+            shape_kd[shape_idx],
+            solref_scale,
+            solref_scale,
+        )
 
     # update geom_solmix from custom attribute
     if shape_geom_solmix:

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -200,6 +200,27 @@ def convert_solref(ke: float, kd: float, d_width: float, d_r: float) -> wp.vec2:
 
 
 @wp.func
+def geom_solref_scale_factor(
+    world: int,
+    geom_idx: int,
+    geom_bodyid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
+    dmax: float,
+) -> float:
+    """Return the q0-based impedance scale for MuJoCo geom solref conversion."""
+    body_idx = geom_bodyid[geom_idx]
+    if body_idx < 0:
+        return 1.0
+
+    effective_body_idx = body_weldid[body_idx]
+    factor = body_invweight0[world, effective_body_idx][0] * (1.0 - dmax)
+    if factor > 0.0:
+        return factor
+    return 1.0
+
+
+@wp.func
 def quat_wxyz_to_xyzw(q: wp.quat) -> wp.quat:
     """Convert a quaternion from MuJoCo wxyz storage to Warp xyzw format."""
     return wp.quat(q[1], q[2], q[3], q[0])
@@ -2242,6 +2263,9 @@ def update_geom_properties_kernel(
     shape_size: wp.array[wp.vec3f],
     shape_transform: wp.array[wp.transform],
     mjc_geom_to_newton_shape: wp.array2d[wp.int32],
+    geom_bodyid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_invweight0: wp.array2d[wp.vec2],
     geom_type: wp.array[int],
     GEOM_TYPE_MESH: int,
     geom_dataid: wp.array2d[int],
@@ -2292,14 +2316,31 @@ def update_geom_properties_kernel(
     rolling = shape_mu_rolling[shape_idx]
     geom_friction[world, geom_idx] = wp.vec3f(mu, torsional, rolling)
 
-    # update geom_solref (timeconst, dampratio) using stiffness and damping
-    # we don't use the negative convention to support controlling the mixing of shapes' stiffnesses via solmix
-    # use approximation of d(0) = d(width) = 1
-    geom_solref[world, geom_idx] = convert_solref(shape_ke[shape_idx], shape_kd[shape_idx], 1.0, 1.0)
+    dmax = geom_solimp[world, geom_idx][1]
 
     # update geom_solimp from custom attribute
     if shape_geom_solimp:
         geom_solimp[world, geom_idx] = shape_geom_solimp[shape_idx]
+        dmax = shape_geom_solimp[shape_idx][1]
+
+    # update geom_solref (timeconst, dampratio) using stiffness and damping
+    # we don't use the negative convention to support controlling the mixing of
+    # shapes' stiffnesses via solmix. MuJoCo's force-space conversion depends on
+    # the frozen q0 invweight0 factor and the geom's dmax impedance.
+    solref_scale = geom_solref_scale_factor(
+        world,
+        geom_idx,
+        geom_bodyid,
+        body_weldid,
+        body_invweight0,
+        dmax,
+    )
+    geom_solref[world, geom_idx] = convert_solref(
+        shape_ke[shape_idx],
+        shape_kd[shape_idx],
+        solref_scale,
+        solref_scale,
+    )
 
     # update geom_solmix from custom attribute
     if shape_geom_solmix:

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -204,7 +204,6 @@ def geom_solref_scale_factor(
     world: int,
     geom_idx: int,
     geom_bodyid: wp.array[int],
-    body_weldid: wp.array[int],
     body_invweight0: wp.array2d[wp.vec2],
     dmax: float,
 ) -> float:
@@ -213,8 +212,7 @@ def geom_solref_scale_factor(
     if body_idx < 0:
         return 1.0
 
-    effective_body_idx = body_weldid[body_idx]
-    factor = body_invweight0[world, effective_body_idx][0] * (1.0 - dmax)
+    factor = body_invweight0[world, body_idx][0] * (1.0 - dmax)
     if factor > 0.0:
         return factor
     return 1.0
@@ -2264,7 +2262,6 @@ def update_geom_properties_kernel(
     shape_transform: wp.array[wp.transform],
     mjc_geom_to_newton_shape: wp.array2d[wp.int32],
     geom_bodyid: wp.array[int],
-    body_weldid: wp.array[int],
     body_invweight0: wp.array2d[wp.vec2],
     geom_type: wp.array[int],
     GEOM_TYPE_MESH: int,
@@ -2331,7 +2328,6 @@ def update_geom_properties_kernel(
         world,
         geom_idx,
         geom_bodyid,
-        body_weldid,
         body_invweight0,
         dmax,
     )

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2289,6 +2289,7 @@ def update_geom_properties_kernel(
     geom_bodyid: wp.array[int],
     body_invweight0: wp.array2d[wp.vec2],
     shape_geom_solref: wp.array[wp.vec2],
+    scale_material_solref: bool,
     geom_type: wp.array[int],
     GEOM_TYPE_MESH: int,
     geom_dataid: wp.array2d[int],
@@ -2356,13 +2357,15 @@ def update_geom_properties_kernel(
         # mixing of shapes' stiffnesses via solmix. MuJoCo's force-space
         # conversion depends on the frozen q0 invweight0 factor and the geom's
         # dmax impedance.
-        solref_scale = geom_solref_scale_factor(
-            world,
-            geom_idx,
-            geom_bodyid,
-            body_invweight0,
-            dmax,
-        )
+        solref_scale = 1.0
+        if scale_material_solref:
+            solref_scale = geom_solref_scale_factor(
+                world,
+                geom_idx,
+                geom_bodyid,
+                body_invweight0,
+                dmax,
+            )
         geom_solref[world, geom_idx] = convert_solref(
             shape_ke[shape_idx],
             shape_kd[shape_idx],

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -481,6 +481,18 @@ class SolverMuJoCo(SolverBase):
         )
         builder.add_custom_attribute(
             ModelBuilder.CustomAttribute(
+                name="geom_solref",
+                frequency=AttributeFrequency.SHAPE,
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.vec2,
+                default=wp.vec2(0.0, 0.0),
+                namespace="mujoco",
+                usd_attribute_name="mjc:solref",
+                mjcf_attribute_name="solref",
+            )
+        )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
                 name="limit_margin",
                 frequency=AttributeFrequency.JOINT_DOF,
                 assignment=AttributeAssignment.MODEL,
@@ -3154,6 +3166,8 @@ class SolverMuJoCo(SolverBase):
                 self.mjw_model.geom_friction,
                 self.mjw_model.geom_margin,
                 self.mjw_model.geom_gap,
+                model.shape_material_ke,
+                model.shape_material_kd,
                 # Newton contacts
                 contacts.rigid_contact_count,
                 contacts.rigid_contact_shape0,
@@ -4119,6 +4133,7 @@ class SolverMuJoCo(SolverBase):
         shape_priority = get_custom_attribute("geom_priority")
         shape_geom_solimp = get_custom_attribute("geom_solimp")
         shape_geom_solmix = get_custom_attribute("geom_solmix")
+        shape_geom_solref = get_custom_attribute("geom_solref")
         joint_dof_limit_margin = get_custom_attribute("limit_margin")
         joint_solimp_limit = get_custom_attribute("solimplimit")
         joint_dof_solref = get_custom_attribute("solreffriction")
@@ -4501,8 +4516,11 @@ class SolverMuJoCo(SolverBase):
                     rolling,
                 ]
 
-                # set solref from shape stiffness and damping
-                geom_params["solref"] = convert_solref(float(shape_ke[shape]), float(shape_kd[shape]), 1.0, 1.0)
+                # set solref from authored MuJoCo solref, or shape stiffness and damping
+                if shape_geom_solref is not None and np.any(shape_geom_solref[shape] != 0.0):
+                    geom_params["solref"] = shape_geom_solref[shape]
+                else:
+                    geom_params["solref"] = convert_solref(float(shape_ke[shape]), float(shape_kd[shape]), 1.0, 1.0)
 
                 if shape_condim is not None:
                     geom_params["condim"] = shape_condim[shape]
@@ -6387,6 +6405,7 @@ class SolverMuJoCo(SolverBase):
         mujoco_attrs = getattr(self.model, "mujoco", None)
         shape_geom_solimp = getattr(mujoco_attrs, "geom_solimp", None) if mujoco_attrs is not None else None
         shape_geom_solmix = getattr(mujoco_attrs, "geom_solmix", None) if mujoco_attrs is not None else None
+        shape_geom_solref = getattr(mujoco_attrs, "geom_solref", None) if mujoco_attrs is not None else None
         wp.launch(
             update_geom_properties_kernel,
             dim=(world_count, num_geoms),
@@ -6399,6 +6418,7 @@ class SolverMuJoCo(SolverBase):
                 self.mjc_geom_to_newton_shape,
                 self.mjw_model.geom_bodyid,
                 self.mjw_model.body_invweight0,
+                shape_geom_solref,
                 self.mjw_model.geom_type,
                 self._mujoco.mjtGeom.mjGEOM_MESH,
                 self.mjw_model.geom_dataid,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3220,25 +3220,27 @@ class SolverMuJoCo(SolverBase):
         need_const_fixed = False
         need_const_0 = False
         need_length_range = False
+        need_geom_update = False
 
         if flags & SolverNotifyFlags.BODY_INERTIAL_PROPERTIES:
             self._update_model_inertial_properties()
             need_const_fixed = True
             need_const_0 = True
+            need_geom_update = True
         if flags & SolverNotifyFlags.JOINT_PROPERTIES:
             self._update_joint_properties()
         if flags & SolverNotifyFlags.BODY_PROPERTIES:
             self._update_body_properties()
-            self._invalidate_contact_fast_path()
             need_const_0 = True
+            need_geom_update = True
         if flags & SolverNotifyFlags.JOINT_DOF_PROPERTIES:
             self._update_joint_dof_properties()
             need_const_0 = True
             need_length_range = True
+            need_geom_update = True
         if flags & SolverNotifyFlags.SHAPE_PROPERTIES:
-            self._update_geom_properties()
             self._update_pair_properties()
-            self._invalidate_contact_fast_path()
+            need_geom_update = True
         if flags & SolverNotifyFlags.MODEL_PROPERTIES:
             self._update_model_properties()
         if flags & SolverNotifyFlags.CONSTRAINT_PROPERTIES:
@@ -3302,6 +3304,12 @@ class SolverMuJoCo(SolverBase):
                         update_connect_constraint_anchor_rel_xform_at_ref_pose,
                         update_connect_constraint_anchors,
                     )
+
+        if need_geom_update:
+            self._update_geom_properties()
+            self._invalidate_contact_fast_path()
+            if self.use_mujoco_cpu:
+                self._sync_cpu_geom_properties()
 
     def _create_inverse_shape_mapping(self):
         """
@@ -6389,6 +6397,9 @@ class SolverMuJoCo(SolverBase):
                 self.model.shape_scale,
                 self.model.shape_transform,
                 self.mjc_geom_to_newton_shape,
+                self.mjw_model.geom_bodyid,
+                self.mjw_model.body_weldid,
+                self.mjw_model.body_invweight0,
                 self.mjw_model.geom_type,
                 self._mujoco.mjtGeom.mjGEOM_MESH,
                 self.mjw_model.geom_dataid,
@@ -6414,6 +6425,18 @@ class SolverMuJoCo(SolverBase):
             ],
             device=self.model.device,
         )
+
+    def _sync_cpu_geom_properties(self) -> None:
+        """Copy runtime-updated geom properties from MJWarp back to the CPU model."""
+        self.mj_model.geom_friction[:] = self.mjw_model.geom_friction.numpy()[0]
+        self.mj_model.geom_solref[:] = self.mjw_model.geom_solref.numpy()[0]
+        self.mj_model.geom_size[:] = self.mjw_model.geom_size.numpy()[0]
+        self.mj_model.geom_pos[:] = self.mjw_model.geom_pos.numpy()[0]
+        self.mj_model.geom_quat[:] = self.mjw_model.geom_quat.numpy()[0]
+        self.mj_model.geom_solimp[:] = self.mjw_model.geom_solimp.numpy()[0]
+        self.mj_model.geom_solmix[:] = self.mjw_model.geom_solmix.numpy()[0]
+        self.mj_model.geom_gap[:] = self.mjw_model.geom_gap.numpy()[0]
+        self.mj_model.geom_margin[:] = self.mjw_model.geom_margin.numpy()[0]
 
     def _update_pair_properties(self):
         """Update MuJoCo contact pair properties from Newton custom attributes.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3025,6 +3025,7 @@ class SolverMuJoCo(SolverBase):
         self._last_contact_generation: wp.array[wp.int32] | None = None
         self._last_nacon_count: wp.array[wp.int32] | None = None
         self._last_contacts_id: int | None = None
+        self._initializing_mujoco_model = False
 
         with wp.ScopedTimer("convert_model_to_mujoco", active=False):
             self._convert_to_mjc(
@@ -5545,7 +5546,11 @@ class SolverMuJoCo(SolverBase):
 
             # so far we have only defined the first world,
             # now complete the data from the Newton model
-            self.notify_model_changed(SolverNotifyFlags.ALL)
+            self._initializing_mujoco_model = True
+            try:
+                self.notify_model_changed(SolverNotifyFlags.ALL)
+            finally:
+                self._initializing_mujoco_model = False
 
     def _expand_model_fields(self, mj_model: MjWarpModel, nworld: int):
         if nworld == 1:
@@ -6406,6 +6411,7 @@ class SolverMuJoCo(SolverBase):
         shape_geom_solimp = getattr(mujoco_attrs, "geom_solimp", None) if mujoco_attrs is not None else None
         shape_geom_solmix = getattr(mujoco_attrs, "geom_solmix", None) if mujoco_attrs is not None else None
         shape_geom_solref = getattr(mujoco_attrs, "geom_solref", None) if mujoco_attrs is not None else None
+        scale_material_solref = not self._initializing_mujoco_model
         wp.launch(
             update_geom_properties_kernel,
             dim=(world_count, num_geoms),
@@ -6419,6 +6425,7 @@ class SolverMuJoCo(SolverBase):
                 self.mjw_model.geom_bodyid,
                 self.mjw_model.body_invweight0,
                 shape_geom_solref,
+                scale_material_solref,
                 self.mjw_model.geom_type,
                 self._mujoco.mjtGeom.mjGEOM_MESH,
                 self.mjw_model.geom_dataid,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -6398,7 +6398,6 @@ class SolverMuJoCo(SolverBase):
                 self.model.shape_transform,
                 self.mjc_geom_to_newton_shape,
                 self.mjw_model.geom_bodyid,
-                self.mjw_model.body_weldid,
                 self.mjw_model.body_invweight0,
                 self.mjw_model.geom_type,
                 self._mujoco.mjtGeom.mjGEOM_MESH,

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -690,6 +690,8 @@ def parse_mjcf(
                 shape_cfg.gap = mj_gap
 
             custom_attributes = parse_custom_attributes(geom_attrib, builder_custom_attr_shape, parsing_mode="mjcf")
+            if "mujoco:geom_solref" in builder.custom_attributes and "mujoco:geom_solref" not in custom_attributes:
+                custom_attributes["mujoco:geom_solref"] = parse_vec(geom_attrib, "solref", (0.02, 1.0))
             shape_label = f"{label_prefix}/{geom_name}" if label_prefix else geom_name
             shape_kwargs = {
                 "label": shape_label,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2124,6 +2124,33 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         dampratio = kd / 2.0 * np.sqrt(factor / ke)
         return timeconst, dampratio
 
+    def test_mjcf_geom_solref_round_trips_without_material_scaling(self):
+        """Verify MJCF-authored geom solref stays in MuJoCo solver units."""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(
+            """
+            <mujoco>
+                <worldbody>
+                    <body name="body">
+                        <freejoint/>
+                        <geom name="geom" type="sphere" size="0.1" solref="0.04 1.25"/>
+                    </body>
+                </worldbody>
+            </mujoco>
+            """,
+            up_axis="Z",
+        )
+
+        model = builder.finalize()
+        self.assertTrue(hasattr(model.mujoco, "geom_solref"))
+        np.testing.assert_allclose(model.mujoco.geom_solref.numpy()[0], [0.04, 1.25], rtol=0.0, atol=1e-6)
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        to_newton_shape = solver.mjc_geom_to_newton_shape.numpy()[0]
+        geom_idx = int(np.where(to_newton_shape == 0)[0][0])
+
+        np.testing.assert_allclose(solver.mjw_model.geom_solref.numpy()[0, geom_idx], [0.04, 1.25], rtol=0.0, atol=1e-6)
+
     def test_geom_solref_scaling_uses_geom_body_invweight_for_welded_child(self):
         """Verify welded child geoms use their own body invweight for solref scaling."""
         builder = newton.ModelBuilder()

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2102,6 +2102,8 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         geom_idx: int,
         ke: float,
         kd: float,
+        *,
+        scale: bool = True,
     ) -> tuple[float, float]:
         """Compute the expected MuJoCo solref for a Newton shape material."""
         if ke <= 0.0 or kd <= 0.0:
@@ -2113,7 +2115,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
 
         body_id = int(geom_bodyid[geom_idx])
         factor = 1.0
-        if body_id >= 0:
+        if scale and body_id >= 0:
             dmax = float(solver.mjw_model.geom_solimp.numpy()[world_idx, geom_idx][1])
             invweight0 = float(solver.mjw_model.body_invweight0.numpy()[world_idx, body_id][0])
             scaled_factor = invweight0 * (1.0 - dmax)
@@ -2284,7 +2286,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 # Compute expected solref based on Newton's conversion logic
                 ke = shape_ke[shape_idx]
                 kd = shape_kd[shape_idx]
-                expected_solref = self._expected_geom_solref(solver, world_idx, geom_idx, ke, kd)
+                expected_solref = self._expected_geom_solref(solver, world_idx, geom_idx, ke, kd, scale=False)
 
                 self.assertAlmostEqual(
                     float(actual_solref[0]),

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2095,6 +2095,40 @@ class TestMuJoCoSolverKinematicBodyProperties(unittest.TestCase):
 
 
 class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
+    @staticmethod
+    def _expected_geom_solref(
+        solver: SolverMuJoCo,
+        world_idx: int,
+        geom_idx: int,
+        ke: float,
+        kd: float,
+    ) -> tuple[float, float]:
+        """Compute the expected MuJoCo solref for a Newton shape material."""
+        if ke <= 0.0 or kd <= 0.0:
+            return 0.02, 1.0
+
+        geom_bodyid = np.asarray(solver.mjw_model.geom_bodyid.numpy())
+        body_weldid = np.asarray(solver.mjw_model.body_weldid.numpy())
+
+        if geom_bodyid.ndim > 1:
+            geom_bodyid = geom_bodyid[world_idx]
+        if body_weldid.ndim > 1:
+            body_weldid = body_weldid[world_idx]
+
+        body_id = int(geom_bodyid[geom_idx])
+        factor = 1.0
+        if body_id >= 0:
+            effective_body = int(body_weldid[body_id])
+            dmax = float(solver.mjw_model.geom_solimp.numpy()[world_idx, geom_idx][1])
+            invweight0 = float(solver.mjw_model.body_invweight0.numpy()[world_idx, effective_body][0])
+            scaled_factor = invweight0 * (1.0 - dmax)
+            if scaled_factor > 0.0:
+                factor = scaled_factor
+
+        timeconst = 2.0 / (kd * factor)
+        dampratio = kd / 2.0 * np.sqrt(factor / ke)
+        return timeconst, dampratio
+
     def test_geom_property_conversion(self):
         """
         Test that ALL Newton shape properties are correctly converted to MuJoCo geom properties.
@@ -2173,13 +2207,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 # Compute expected solref based on Newton's conversion logic
                 ke = shape_ke[shape_idx]
                 kd = shape_kd[shape_idx]
-
-                if ke > 0.0 and kd > 0.0:
-                    timeconst = 2.0 / kd
-                    dampratio = np.sqrt(1.0 / (timeconst * timeconst * ke))
-                    expected_solref = (timeconst, dampratio)
-                else:
-                    expected_solref = (0.02, 1.0)
+                expected_solref = self._expected_geom_solref(solver, world_idx, geom_idx, ke, kd)
 
                 self.assertAlmostEqual(
                     float(actual_solref[0]),
@@ -2375,13 +2403,7 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                 # Compute expected values based on new ke/kd using timeconst/dampratio conversion
                 ke = new_ke[shape_idx]
                 kd = new_kd[shape_idx]
-
-                if ke > 0.0 and kd > 0.0:
-                    timeconst = 2.0 / kd
-                    dampratio = np.sqrt(1.0 / (timeconst * timeconst * ke))
-                    expected_solref = (timeconst, dampratio)
-                else:
-                    expected_solref = (0.02, 1.0)
+                expected_solref = self._expected_geom_solref(solver, world_idx, geom_idx, ke, kd)
 
                 self.assertAlmostEqual(
                     float(updated_solref[world_idx, geom_idx][0]),

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2108,19 +2108,14 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
             return 0.02, 1.0
 
         geom_bodyid = np.asarray(solver.mjw_model.geom_bodyid.numpy())
-        body_weldid = np.asarray(solver.mjw_model.body_weldid.numpy())
-
         if geom_bodyid.ndim > 1:
             geom_bodyid = geom_bodyid[world_idx]
-        if body_weldid.ndim > 1:
-            body_weldid = body_weldid[world_idx]
 
         body_id = int(geom_bodyid[geom_idx])
         factor = 1.0
         if body_id >= 0:
-            effective_body = int(body_weldid[body_id])
             dmax = float(solver.mjw_model.geom_solimp.numpy()[world_idx, geom_idx][1])
-            invweight0 = float(solver.mjw_model.body_invweight0.numpy()[world_idx, effective_body][0])
+            invweight0 = float(solver.mjw_model.body_invweight0.numpy()[world_idx, body_id][0])
             scaled_factor = invweight0 * (1.0 - dmax)
             if scaled_factor > 0.0:
                 factor = scaled_factor
@@ -2128,6 +2123,61 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
         timeconst = 2.0 / (kd * factor)
         dampratio = kd / 2.0 * np.sqrt(factor / ke)
         return timeconst, dampratio
+
+    def test_geom_solref_scaling_uses_geom_body_invweight_for_welded_child(self):
+        """Verify welded child geoms use their own body invweight for solref scaling."""
+        builder = newton.ModelBuilder()
+        shape_cfg = newton.ModelBuilder.ShapeConfig(density=0.0, ke=1000.0, kd=10.0)
+
+        root = builder.add_link(mass=1.0, com=wp.vec3(0.0), inertia=wp.mat33(np.eye(3)), lock_inertia=True)
+        child = builder.add_link(
+            mass=5.0,
+            com=wp.vec3(0.0),
+            inertia=wp.mat33(np.eye(3) * 2.0),
+            lock_inertia=True,
+        )
+        builder.add_shape_box(root, hx=0.1, hy=0.1, hz=0.1, cfg=shape_cfg)
+        builder.add_shape_sphere(child, radius=0.1, cfg=shape_cfg)
+
+        root_joint = builder.add_joint_free(child=root)
+        child_joint = builder.add_joint_fixed(
+            parent=root,
+            child=child,
+            parent_xform=wp.transform(wp.vec3(0.75, 0.0, 0.0), wp.quat_identity()),
+            child_xform=wp.transform(),
+            collision_filter_parent=False,
+        )
+        builder.add_articulation([root_joint, child_joint])
+
+        model = builder.finalize()
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+
+        to_newton_shape = solver.mjc_geom_to_newton_shape.numpy()[0]
+        child_shape = int(np.where(model.shape_body.numpy() == child)[0][0])
+        child_geom = int(np.where(to_newton_shape == child_shape)[0][0])
+        child_body = int(solver.mjw_model.geom_bodyid.numpy()[child_geom])
+        weld_root_body = int(solver.mjw_model.body_weldid.numpy()[child_body])
+
+        self.assertNotEqual(child_body, weld_root_body)
+
+        dmax = float(solver.mjw_model.geom_solimp.numpy()[0, child_geom][1])
+        body_invweight0 = solver.mjw_model.body_invweight0.numpy()[0]
+        child_scale = float(body_invweight0[child_body][0]) * (1.0 - dmax)
+        weld_root_scale = float(body_invweight0[weld_root_body][0]) * (1.0 - dmax)
+        self.assertNotAlmostEqual(child_scale, weld_root_scale, places=6)
+
+        new_ke = model.shape_material_ke.numpy().copy()
+        new_kd = model.shape_material_kd.numpy().copy()
+        new_ke[child_shape] = 2000.0
+        new_kd[child_shape] = 20.0
+        model.shape_material_ke.assign(new_ke)
+        model.shape_material_kd.assign(new_kd)
+
+        solver.notify_model_changed(SolverNotifyFlags.SHAPE_PROPERTIES)
+
+        actual_solref = solver.mjw_model.geom_solref.numpy()[0, child_geom]
+        expected_solref = self._expected_geom_solref(solver, 0, child_geom, new_ke[child_shape], new_kd[child_shape])
+        np.testing.assert_allclose(actual_solref, expected_solref, rtol=1e-5, atol=1e-6)
 
     def test_geom_property_conversion(self):
         """


### PR DESCRIPTION
## Summary
Fixes geom solref conversion to honor MuJoCo q0 invweight scaling and sync runtime geom updates, so articulated shapes keep authored contact stiffness after updates.

## What changed
- Use geom body invweight for solref scaling
- Fix MuJoCo shape material solref scaling

Closes #2009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for authored per-geometry contact parameters (per-geom solref) and import fallback when provided in MJCF.

* **Bug Fixes**
  * Contact stiffness/damping for articulated shapes are preserved when models are refreshed; geometry updates are applied atomically to avoid transient inconsistencies.

* **Tests**
  * Added targeted tests verifying authored solref round-trip, welded-body scaling behavior, and runtime propagation of material parameter changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->