### PR TITLE
Preserve ViewerGL state across compatible model switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix MJCF worldbody static geoms bypassing the visual/collider class filter, so `parse_visuals=False` drops visual-class geoms attached directly to `<worldbody>` too. (#3030)
 - Fix `cable_cross_slide_table` example stability so the cable-driven table reliably tracks its rectangular path and catches drift during regression runs.
 - Fix URDF `package://` mesh fallback resolution without `resolve-robotics-uri-py` so package names only match full path components instead of unrelated directory-name substrings
+- Fix `ViewerGL.set_model()` resetting headless/interactive camera and wind state when switching between models that use the same up-axis. (#2658)
 
 ### Removed
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -529,7 +529,16 @@ class ViewerGL(ViewerBase):
 
         Args:
             model: The Newton model instance.
+
+        Note:
+            Switching between models with the same up-axis preserves the
+            existing camera state. Wind settings are preserved across
+            non-``None`` model switches because they are independent of the
+            model up-axis.
         """
+        prev_camera = self.camera
+        prev_wind = self.wind
+
         super().set_model(model)
 
         # ``ViewerBase.set_model`` may have switched ``self.device`` to the
@@ -598,6 +607,19 @@ class ViewerGL(ViewerBase):
 
         fb_w, fb_h = self.renderer.window.get_framebuffer_size()
         self.camera = Camera(width=fb_w, height=fb_h, up_axis=model.up_axis if model else "Z")
+
+        if prev_camera is not None and model is not None and prev_camera.up_axis == self.camera.up_axis:
+            # Reuse the compatible camera so future Camera fields survive model switches too.
+            prev_camera.update_screen_size(fb_w, fb_h)
+            self.camera = prev_camera
+
+        if prev_wind is not None and model is not None:
+            # Wind parameters are model-agnostic, so keep them across model swaps.
+            self.wind.time = prev_wind.time
+            self.wind.period = prev_wind.period
+            self.wind.amplitude = prev_wind.amplitude
+            self.wind.frequency = prev_wind.frequency
+            self.wind.direction = prev_wind.direction
 
     def _build_packed_vbo_arrays(self):
         """Build write-index + output arrays for batched shape transform computation.

--- a/newton/tests/test_viewer_camera.py
+++ b/newton/tests/test_viewer_camera.py
@@ -5,8 +5,11 @@ import math
 import unittest
 
 import numpy as np
+import warp as wp
 
+import newton
 from newton._src.viewer.camera import Camera
+from newton.viewer import ViewerGL
 
 
 def _as_np(value):
@@ -116,6 +119,95 @@ class TestViewerCameraOrbit(unittest.TestCase):
         camera.dolly(-0.5)
 
         self.assertGreater(camera.pivot_distance, distance_after_dolly_in)
+
+
+def _build_viewer_model(z: float, up_axis: newton.Axis = newton.Axis.Z) -> newton.Model:
+    builder = newton.ModelBuilder(up_axis=up_axis)
+    body = builder.add_body(
+        xform=wp.transform(wp.vec3(0.0, 0.0, z), wp.quat_identity()),
+        mass=1.0,
+        inertia=wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+    )
+    builder.add_shape_box(body=body, hx=0.5, hy=0.5, hz=0.5)
+    return builder.finalize()
+
+
+@unittest.skipUnless(wp.is_cuda_available(), "ViewerGL model-switch test requires CUDA")
+class TestViewerGLSetModelState(unittest.TestCase):
+    def test_set_model_preserves_camera_and_wind_for_same_up_axis(self):
+        model_a = _build_viewer_model(1.0)
+        model_b = _build_viewer_model(2.0)
+
+        try:
+            viewer = ViewerGL(headless=True)
+        except Exception as exc:
+            self.skipTest(f"ViewerGL not available: {exc}")
+            return
+
+        try:
+            viewer.set_model(model_a)
+            viewer.camera.near = 0.123
+            viewer.camera.far = 456.0
+            viewer.camera.fov = 33.0
+            viewer.camera.pos = viewer.camera._as_vec3((3.0, 4.0, 5.0))
+            viewer.camera.yaw = 37.0
+            viewer.camera.pitch = -12.0
+            viewer.camera.set_pivot((1.0, 2.0, 3.0))
+            viewer.wind.time = 2.5
+            viewer.wind.period = 9.0
+            viewer.wind.amplitude = 5.0
+            viewer.wind.frequency = 7.0
+            viewer.wind.direction = (0.0, 1.0, 0.0)
+
+            viewer.set_model(model_b)
+
+            self.assertAlmostEqual(viewer.camera.near, 0.123)
+            self.assertAlmostEqual(viewer.camera.far, 456.0)
+            self.assertAlmostEqual(viewer.camera.fov, 33.0)
+            _assert_vec_close(self, viewer.camera.pos, (3.0, 4.0, 5.0))
+            self.assertAlmostEqual(viewer.camera.yaw, 37.0)
+            self.assertAlmostEqual(viewer.camera.pitch, -12.0)
+            _assert_vec_close(self, viewer.camera.pivot, (1.0, 2.0, 3.0))
+            self.assertAlmostEqual(viewer.wind.time, 2.5)
+            self.assertAlmostEqual(viewer.wind.period, 9.0)
+            self.assertAlmostEqual(viewer.wind.amplitude, 5.0)
+            self.assertAlmostEqual(viewer.wind.frequency, 7.0)
+            _assert_vec_close(self, viewer.wind.direction, (0.0, 1.0, 0.0))
+        finally:
+            viewer.close()
+
+    def test_set_model_resets_camera_for_different_up_axis(self):
+        model_a = _build_viewer_model(1.0, up_axis=newton.Axis.Z)
+        model_b = _build_viewer_model(2.0, up_axis=newton.Axis.Y)
+
+        try:
+            viewer = ViewerGL(headless=True)
+        except Exception as exc:
+            self.skipTest(f"ViewerGL not available: {exc}")
+            return
+
+        try:
+            viewer.set_model(model_a)
+            viewer.camera.near = 0.123
+            viewer.camera.far = 456.0
+            viewer.camera.fov = 33.0
+            viewer.camera.pos = viewer.camera._as_vec3((3.0, 4.0, 5.0))
+            viewer.camera.yaw = 37.0
+            viewer.camera.pitch = -12.0
+            viewer.camera.set_pivot((1.0, 2.0, 3.0))
+            viewer.wind.amplitude = 5.0
+
+            viewer.set_model(model_b)
+
+            self.assertAlmostEqual(viewer.camera.near, 0.01)
+            self.assertAlmostEqual(viewer.camera.far, 1000.0)
+            self.assertAlmostEqual(viewer.camera.fov, 45.0)
+            _assert_vec_close(self, viewer.camera.pos, (0.0, 2.0, 10.0))
+            self.assertAlmostEqual(viewer.camera.yaw, -180.0)
+            self.assertAlmostEqual(viewer.camera.pitch, 0.0)
+            self.assertAlmostEqual(viewer.wind.amplitude, 5.0)
+        finally:
+            viewer.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Preserve `ViewerGL` camera and wind state when switching between models that use the same `up_axis`.

`ViewerGL.set_model()` needs to rebuild model-dependent viewer state, but it was also recreating `Camera` and `Wind` unconditionally. That discarded interactive/headless viewer state such as camera position, yaw, pitch, pivot, and configured wind parameters during otherwise compatible model switches.

This change restores prior camera state when the old and new models share the same `up_axis`, while still rebuilding the default camera when the axis changes. It also preserves wind parameters across model switches.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m unittest newton.tests.test_viewer_camera.TestViewerGLSetModelState.test_set_model_preserves_camera_and_wind_for_same_up_axis
uv run --extra dev -m unittest newton.tests.test_viewer_camera
uv run --extra dev pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create a `ViewerGL(headless=True)` instance.
2. Load one model, then set custom camera position/yaw/pitch/pivot and wind parameters.
3. Call `viewer.set_model()` with another model that uses the same `up_axis`.
4. Observe that the old behavior resets the camera and wind state to defaults.

**Minimal reproduction:**

```python
import warp as wp
import newton
from newton.viewer import ViewerGL


def build_model(z: float) -> newton.Model:
    builder = newton.ModelBuilder()
    body = builder.add_body(
        xform=wp.transform(wp.vec3(0.0, 0.0, z), wp.quat_identity()),
        mass=1.0,
        inertia=wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
    )
    builder.add_shape_box(body=body, hx=0.5, hy=0.5, hz=0.5)
    return builder.finalize()


viewer = ViewerGL(headless=True)
try:
    viewer.set_model(build_model(1.0))
    viewer.camera.pos = viewer.camera._as_vec3((3.0, 4.0, 5.0))
    viewer.camera.yaw = 37.0
    viewer.camera.pitch = -12.0
    viewer.camera.set_pivot((1.0, 2.0, 3.0))
    viewer.wind.amplitude = 5.0
    viewer.wind.frequency = 7.0

    viewer.set_model(build_model(2.0))

    print(tuple(float(x) for x in viewer.camera.pos))
    print(viewer.camera.yaw, viewer.camera.pitch)
    print(tuple(float(x) for x in viewer.camera.pivot))
    print(viewer.wind.amplitude, viewer.wind.frequency)
finally:
    viewer.close()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Camera state (position/orientation/pivot and view settings) and wind simulation parameters are now preserved when switching between models that share the same up-axis.
  * When switching to a model with a different up-axis, the camera is reset to defaults as expected.
* **Tests**
  * Added unit coverage to verify state preservation and correct reset behavior across model changes.
* **Documentation**
  * Updated the changelog with an “Unreleased → Fixed” entry for this issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->