### PR TITLE
Pin PyTorch docs intersphinx version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
-    "pytorch": ("https://docs.pytorch.org/docs/stable", None),
+    "pytorch": ("https://docs.pytorch.org/docs/2.10", None),
     "warp": ("https://nvidia.github.io/warp", None),
     "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }


### PR DESCRIPTION
## Description

Pin the PyTorch intersphinx mapping to the resolved PyTorch 2.10 docs instead of the broken `stable` alias. The `stable` HTML alias exists, but `https://docs.pytorch.org/docs/stable/objects.inv` currently returns 404 and fails the docs build under `-W`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
git diff --exit-code docs/api/
uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Build the docs with `sphinx-build -W`.
2. Sphinx tries to load `https://docs.pytorch.org/docs/stable/objects.inv`.
3. The inventory request returns 404, and `-W` turns the warning into a build failure.

**Minimal reproduction:**

```bash
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PyTorch documentation reference links to target a specific version for improved consistency in external documentation integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->