### PR TITLE
Better handling of `collision_filter_parent` in ModelBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
-- Fix `collision_filter_parent` being silently ignored on joints to world (`parent=-1`) for all `add_joint_*` methods; explicit values are now honored regardless of joint type, including when builders are composed with `add_builder()`. The default smart-resolves to `True` for `add_joint_fixed(parent=-1, ...)` (auto-filtering child-body shapes against world-static shapes such as a ground plane) and `False` otherwise
+- Fix `collision_filter_parent` silently ignored on joints to world (`parent=-1`); now honored for all `add_joint_*` methods, with `add_joint_fixed(parent=-1, ...)` defaulting to filter child shapes against world-static shapes
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`
 - Fix `SolverMuJoCo.__init__` time scaling with `world_count × actuators_per_world` instead of `actuators_per_world` by vectorizing the template-world filter for site-targeted actuators
 - Fix compressed tets in `evaluate_volumetric_neo_hookean_force_and_hessian` producing an indefinite Hessian by clamping the cofactor-derivative coefficient to `max(0, s)`, removing a contribution that could corrupt the VBD inner solve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,6 @@
 ### Deprecated
 
 - Deprecate and ignore `rigid_enable_dahl_friction` in `SolverVBD`; Dahl friction is now auto-detected from model attributes (`model.vbd.dahl_eps_max` / `model.vbd.dahl_tau`)
-
-### Deprecated
-
 - Deprecate `newton-actuators` package dependency; all actuator functionality is now built into `newton.actuators`. The dependency is kept for backward compatibility and will be removed in a future release; migrate imports from `newton_actuators` to `newton.actuators`
 
 ### Fixed
@@ -87,6 +84,7 @@
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
+- Fix `collision_filter_parent` being silently ignored on joints to world (`parent=-1`) for all `add_joint_*` methods; explicit values are now honored regardless of joint type, including when builders are composed with `add_builder()`. The default smart-resolves to `True` for `add_joint_fixed(parent=-1, ...)` (auto-filtering child-body shapes against world-static shapes such as a ground plane) and `False` otherwise
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`
 - Fix `SolverMuJoCo.__init__` time scaling with `world_count × actuators_per_world` instead of `actuators_per_world` by vectorizing the template-world filter for site-targeted actuators
 - Fix compressed tets in `evaluate_volumetric_neo_hookean_force_and_hessian` producing an indefinite Hessian by clamping the cofactor-derivative coefficient to `max(0, s)`, removing a contribution that could corrupt the VBD inner solve

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1058,10 +1058,15 @@ class ModelBuilder:
         # rigid joints
         self.joint_parent: list[int] = []
         """Parent body indices accumulated for :attr:`Model.joint_parent`."""
-        self.joint_parents: dict[int, list[int]] = {}
-        """Mapping from child body index to parent body indices used while composing articulations."""
-        self.joint_children: dict[int, list[int]] = {}
-        """Mapping from parent body index to child body indices used while composing articulations."""
+        self.joint_parents: dict[int, list[tuple[int, int]]] = {}
+        """Mapping from child body index to ``(parent_body, joint_idx)`` pairs — one entry per joint
+        attached to the child. Used while composing articulations and for shape-collision-filter lookup
+        (where the per-joint :attr:`joint_collision_filter_parent` flag is consulted)."""
+        self.joint_children: dict[int, list[tuple[int, int]]] = {}
+        """Mapping from parent body index to ``(child_body, joint_idx)`` pairs — one entry per joint.
+        Two joints between the same parent/child pair appear as two entries (no dedup), mirroring
+        :attr:`joint_parents` so the per-joint :attr:`joint_collision_filter_parent` flag can be
+        resolved correctly when shapes are added after the joints."""
         self.joint_child: list[int] = []
         """Child body indices accumulated for :attr:`Model.joint_child`."""
         self.joint_axis: list[Vec3] = []
@@ -1119,6 +1124,12 @@ class ModelBuilder:
 
         self.joint_enabled: list[bool] = []
         """Joint enabled flags accumulated for :attr:`Model.joint_enabled`."""
+
+        self.joint_collision_filter_parent: list[bool] = []
+        """Per-joint resolved value of the ``collision_filter_parent`` flag (sentinel ``None`` already
+        resolved via :meth:`_default_filter_parent`). Consulted by :meth:`_finalize_shape` so that the
+        explicit user choice is honored regardless of whether shapes are added before or after the
+        joint. Builder-only — not propagated to :class:`Model`."""
 
         self.joint_q_start: list[int] = []
         """Joint coordinate start indices accumulated for :attr:`Model.joint_q_start`."""
@@ -1252,6 +1263,14 @@ class ModelBuilder:
             shape_b: Second shape index
         """
         self.shape_collision_filter_pairs.append((min(shape_a, shape_b), max(shape_a, shape_b)))
+
+    @staticmethod
+    def _default_filter_parent(joint_type: JointType, parent: int) -> bool:
+        """Default value of ``collision_filter_parent``: ``False`` when the joint connects to world
+        and is not ``FIXED``; ``True`` otherwise."""
+        if parent == -1:
+            return joint_type == JointType.FIXED
+        return True
 
     def add_custom_attribute(self, attribute: CustomAttribute) -> None:
         """
@@ -3055,6 +3074,7 @@ class ModelBuilder:
 
         start_body_idx = self.body_count
         start_shape_idx = self.shape_count
+        existing_world_shapes = tuple(self.body_shapes[-1])
         for s, b in enumerate(builder.shape_body):
             if b > -1:
                 new_b = b + start_body_idx
@@ -3100,16 +3120,17 @@ class ModelBuilder:
             self.joint_child.extend(new_children)
 
             # Update parent/child lookups
-            for p, c in zip(new_parents, new_children, strict=True):
+            for i, (p, c) in enumerate(zip(new_parents, new_children, strict=True)):
+                new_joint_idx = start_joint_idx + i
                 if c not in self.joint_parents:
-                    self.joint_parents[c] = [p]
+                    self.joint_parents[c] = [(p, new_joint_idx)]
                 else:
-                    self.joint_parents[c].append(p)
+                    self.joint_parents[c].append((p, new_joint_idx))
 
                 if p not in self.joint_children:
-                    self.joint_children[p] = [c]
-                elif c not in self.joint_children[p]:
-                    self.joint_children[p].append(c)
+                    self.joint_children[p] = [(c, new_joint_idx)]
+                else:
+                    self.joint_children[p].append((c, new_joint_idx))
 
             self.joint_q_start.extend([c + self.joint_coord_count for c in builder.joint_q_start])
             self.joint_qd_start.extend([c + self.joint_dof_count for c in builder.joint_qd_start])
@@ -3128,6 +3149,25 @@ class ModelBuilder:
         self.shape_collision_filter_pairs.extend(
             [(i + start_shape_idx, j + start_shape_idx) for i, j in builder.shape_collision_filter_pairs]
         )
+
+        if existing_world_shapes:
+            # Source-local filter pairs were copied above. Add the cross-builder
+            # pairs between destination world shapes and copied bodies whose
+            # joints request parent collision filtering.
+            for i, parent in enumerate(builder.joint_parent):
+                if parent != -1 or not builder.joint_collision_filter_parent[i]:
+                    continue
+
+                child = builder.joint_child[i]
+                for child_shape in builder.body_shapes[child]:
+                    if not builder.shape_flags[child_shape] & ShapeFlags.COLLIDE_SHAPES:
+                        continue
+
+                    copied_child_shape = child_shape + start_shape_idx
+                    for world_shape in existing_world_shapes:
+                        if not self.shape_flags[world_shape] & ShapeFlags.COLLIDE_SHAPES:
+                            continue
+                        self.add_shape_collision_filter_pair(world_shape, copied_child_shape)
 
         # Handle world assignments
         # For particles
@@ -3234,6 +3274,7 @@ class ModelBuilder:
             "body_qd",
             "joint_type",
             "joint_enabled",
+            "joint_collision_filter_parent",
             "joint_X_c",
             "joint_armature",
             "joint_axis",
@@ -3718,7 +3759,7 @@ class ModelBuilder:
         label: str | None = None,
         parent_xform: Transform | None = None,
         child_xform: Transform | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
     ) -> int:
@@ -3738,7 +3779,7 @@ class ModelBuilder:
                 If None, the identity transform is used.
             child_xform: The transform from the child body frame to the joint child anchor frame.
                 If None, the identity transform is used.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the joint connects to world and is not ``FIXED``; ``True`` otherwise.
             enabled: Whether the joint is enabled (not considered by :class:`SolverFeatherstone`).
             custom_attributes: Dictionary of custom attribute keys (see :attr:`CustomAttribute.key`) to values. Note that custom attributes with frequency :attr:`Model.AttributeFrequency.JOINT_DOF` or :attr:`Model.AttributeFrequency.JOINT_COORD` can be provided as: (1) lists with length equal to the joint's DOF or coordinate count, (2) dicts mapping DOF/coordinate indices to values, or (3) a single scalar value that is broadcast to all DOFs/coordinates of the joint. For joints with zero DOFs (e.g., fixed joints), JOINT_DOF attributes are silently skipped. Custom attributes with frequency :attr:`Model.AttributeFrequency.JOINT` require a single value to be defined.
 
@@ -3749,6 +3790,9 @@ class ModelBuilder:
             linear_axes = []
         if angular_axes is None:
             angular_axes = []
+
+        if collision_filter_parent is None:
+            collision_filter_parent = self._default_filter_parent(joint_type, parent)
 
         if parent_xform is None:
             parent_xform = wp.transform()
@@ -3778,21 +3822,23 @@ class ModelBuilder:
             )
 
         self.joint_type.append(joint_type)
+        joint_idx = self.joint_count - 1
         self.joint_parent.append(parent)
         if child not in self.joint_parents:
-            self.joint_parents[child] = [parent]
+            self.joint_parents[child] = [(parent, joint_idx)]
         else:
-            self.joint_parents[child].append(parent)
+            self.joint_parents[child].append((parent, joint_idx))
         if parent not in self.joint_children:
-            self.joint_children[parent] = [child]
-        elif child not in self.joint_children[parent]:
-            self.joint_children[parent].append(child)
+            self.joint_children[parent] = [(child, joint_idx)]
+        else:
+            self.joint_children[parent].append((child, joint_idx))
         self.joint_child.append(child)
         self.joint_X_p.append(parent_xform)
         self.joint_X_c.append(child_xform)
         self.joint_label.append(label or f"joint_{self.joint_count}")
         self.joint_dof_dim.append((len(linear_axes), len(angular_axes)))
         self.joint_enabled.append(enabled)
+        self.joint_collision_filter_parent.append(collision_filter_parent)
         self.joint_world.append(self.current_world)
         self.joint_articulation.append(-1)
 
@@ -3858,7 +3904,7 @@ class ModelBuilder:
         self.joint_coord_count += coord_count
         self.joint_constraint_count += cts_count
 
-        if collision_filter_parent and parent > -1:
+        if collision_filter_parent:
             for child_shape in self.body_shapes[child]:
                 if not self.shape_flags[child_shape] & ShapeFlags.COLLIDE_SHAPES:
                     continue
@@ -3899,7 +3945,7 @@ class ModelBuilder:
         friction: float | None = None,
         actuator_mode: JointTargetMode | None = None,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
         **kwargs,
@@ -3927,7 +3973,7 @@ class ModelBuilder:
             velocity_limit: Maximum velocity the joint axis can achieve. If None, the default value from ``ModelBuilder.default_joint_cfg.velocity_limit`` is used.
             friction: Friction coefficient for the joint axis. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -3992,7 +4038,7 @@ class ModelBuilder:
         friction: float | None = None,
         actuator_mode: JointTargetMode | None = None,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
     ) -> int:
@@ -4019,7 +4065,7 @@ class ModelBuilder:
             velocity_limit: Maximum velocity the joint axis can achieve. If None, the default value from ``ModelBuilder.default_joint_cfg.velocity_limit`` is used.
             friction: Friction coefficient for the joint axis. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4071,7 +4117,7 @@ class ModelBuilder:
         armature: float | None = None,
         friction: float | None = None,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
         actuator_mode: JointTargetMode | None = None,
@@ -4086,7 +4132,7 @@ class ModelBuilder:
             armature: Artificial inertia added around the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.armature`` is used.
             friction: Friction coefficient for the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
             actuator_mode: The actuator mode for this joint's DOFs. If None, defaults to NONE.
@@ -4142,7 +4188,7 @@ class ModelBuilder:
         parent_xform: Transform | None = None,
         child_xform: Transform | None = None,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
     ) -> int:
@@ -4155,7 +4201,7 @@ class ModelBuilder:
             parent_xform: The transform of the joint in the parent body's local frame.
             child_xform: The transform of the joint in the child body's local frame.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``True``.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT frequency attributes.
 
@@ -4188,7 +4234,7 @@ class ModelBuilder:
         child_xform: Transform | None = None,
         parent: int = -1,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
     ) -> int:
@@ -4202,7 +4248,7 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             parent: The index of the parent body (-1 by default to use the world frame, e.g. to make the child body and its children a floating-base mechanism).
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4245,7 +4291,7 @@ class ModelBuilder:
         child_xform: Transform | None = None,
         min_distance: float = -1.0,
         max_distance: float = 1.0,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
     ) -> int:
@@ -4259,7 +4305,7 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             min_distance: The minimum distance between the bodies (no limit if negative).
             max_distance: The maximum distance between the bodies (no limit if negative).
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4305,7 +4351,7 @@ class ModelBuilder:
         label: str | None = None,
         parent_xform: Transform | None = None,
         child_xform: Transform | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
         **kwargs,
@@ -4321,7 +4367,7 @@ class ModelBuilder:
             parent_xform: The transform from the parent body frame to the joint parent anchor frame.
             child_xform: The transform from the child body frame to the joint child anchor frame.
             armature: Artificial inertia added around the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.armature`` is used.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4360,7 +4406,7 @@ class ModelBuilder:
         bend_stiffness: float | None = None,
         bend_damping: float | None = None,
         label: str | None = None,
-        collision_filter_parent: bool = True,
+        collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
         **kwargs,
@@ -4393,7 +4439,7 @@ class ModelBuilder:
                 this is a dimensionless (Rayleigh-style) coefficient. If None,
                 defaults to 0.0.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD
                 frequency attributes.
@@ -4877,6 +4923,7 @@ class ModelBuilder:
                 "parent_xform": wp.transform_expand(self.joint_X_p[i]),
                 "child_xform": wp.transform_expand(self.joint_X_c[i]),
                 "enabled": self.joint_enabled[i],
+                "collision_filter_parent": self.joint_collision_filter_parent[i],
                 "axes": [],
                 "axis_dim": self.joint_dof_dim[i],
                 "parent": parent,
@@ -5160,6 +5207,7 @@ class ModelBuilder:
         self.joint_qd_start.clear()
         self.joint_cts_start.clear()
         self.joint_enabled.clear()
+        self.joint_collision_filter_parent.clear()
         self.joint_armature.clear()
         self.joint_X_p.clear()
         self.joint_X_c.clear()
@@ -5190,6 +5238,7 @@ class ModelBuilder:
             self.joint_cts.extend(joint["cts"])
             self.joint_armature.extend(joint["armature"])
             self.joint_enabled.append(joint["enabled"])
+            self.joint_collision_filter_parent.append(joint["collision_filter_parent"])
             self.joint_X_p.append(joint["parent_xform"])
             self.joint_X_c.append(joint["child_xform"])
             self.joint_dof_dim.append(joint["axis_dim"])
@@ -5307,16 +5356,16 @@ class ModelBuilder:
         # Rebuild parent/child lookups
         self.joint_parents.clear()
         self.joint_children.clear()
-        for p, c in zip(self.joint_parent, self.joint_child, strict=True):
+        for i, (p, c) in enumerate(zip(self.joint_parent, self.joint_child, strict=True)):
             if c not in self.joint_parents:
-                self.joint_parents[c] = [p]
+                self.joint_parents[c] = [(p, i)]
             else:
-                self.joint_parents[c].append(p)
+                self.joint_parents[c].append((p, i))
 
             if p not in self.joint_children:
-                self.joint_children[p] = [c]
-            elif c not in self.joint_children[p]:
-                self.joint_children[p].append(c)
+                self.joint_children[p] = [(c, i)]
+            else:
+                self.joint_children[p].append((c, i))
 
         return {
             "body_remap": body_remap,
@@ -5499,14 +5548,15 @@ class ModelBuilder:
         self.shape_sdf_max_resolution.append(cfg.sdf_max_resolution)
         self.shape_sdf_texture_format.append(cfg.sdf_texture_format)
 
-        if cfg.has_shape_collision and cfg.collision_filter_parent and body > -1 and body in self.joint_parents:
-            for parent_body in self.joint_parents[body]:
-                if parent_body > -1:
-                    for parent_shape in self.body_shapes[parent_body]:
-                        self.add_shape_collision_filter_pair(parent_shape, shape)
-
-        if cfg.has_shape_collision and cfg.collision_filter_parent and body > -1 and body in self.joint_children:
-            for child_body in self.joint_children[body]:
+        if cfg.has_shape_collision and cfg.collision_filter_parent:
+            for parent_body, joint_idx in self.joint_parents.get(body, ()):
+                if not self.joint_collision_filter_parent[joint_idx]:
+                    continue
+                for parent_shape in self.body_shapes[parent_body]:
+                    self.add_shape_collision_filter_pair(parent_shape, shape)
+            for child_body, joint_idx in self.joint_children.get(body, ()):
+                if not self.joint_collision_filter_parent[joint_idx]:
+                    continue
                 for child_shape in self.body_shapes[child_body]:
                     self.add_shape_collision_filter_pair(shape, child_shape)
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -1059,14 +1059,9 @@ class ModelBuilder:
         self.joint_parent: list[int] = []
         """Parent body indices accumulated for :attr:`Model.joint_parent`."""
         self.joint_parents: dict[int, list[tuple[int, int]]] = {}
-        """Mapping from child body index to ``(parent_body, joint_idx)`` pairs — one entry per joint
-        attached to the child. Used while composing articulations and for shape-collision-filter lookup
-        (where the per-joint :attr:`joint_collision_filter_parent` flag is consulted)."""
+        """Mapping from child body index to ``(parent_body, joint_idx)`` pairs (one per joint, no dedup)."""
         self.joint_children: dict[int, list[tuple[int, int]]] = {}
-        """Mapping from parent body index to ``(child_body, joint_idx)`` pairs — one entry per joint.
-        Two joints between the same parent/child pair appear as two entries (no dedup), mirroring
-        :attr:`joint_parents` so the per-joint :attr:`joint_collision_filter_parent` flag can be
-        resolved correctly when shapes are added after the joints."""
+        """Mapping from parent body index to ``(child_body, joint_idx)`` pairs (one per joint, no dedup)."""
         self.joint_child: list[int] = []
         """Child body indices accumulated for :attr:`Model.joint_child`."""
         self.joint_axis: list[Vec3] = []
@@ -1126,10 +1121,7 @@ class ModelBuilder:
         """Joint enabled flags accumulated for :attr:`Model.joint_enabled`."""
 
         self.joint_collision_filter_parent: list[bool] = []
-        """Per-joint resolved value of the ``collision_filter_parent`` flag (sentinel ``None`` already
-        resolved via :meth:`_default_filter_parent`). Consulted by :meth:`_finalize_shape` so that the
-        explicit user choice is honored regardless of whether shapes are added before or after the
-        joint. Builder-only — not propagated to :class:`Model`."""
+        """Per-joint resolved ``collision_filter_parent`` flag. Builder-only."""
 
         self.joint_q_start: list[int] = []
         """Joint coordinate start indices accumulated for :attr:`Model.joint_q_start`."""
@@ -1266,8 +1258,7 @@ class ModelBuilder:
 
     @staticmethod
     def _default_filter_parent(joint_type: JointType, parent: int) -> bool:
-        """Default value of ``collision_filter_parent``: ``False`` when the joint connects to world
-        and is not ``FIXED``; ``True`` otherwise."""
+        """Default ``collision_filter_parent``: ``False`` for non-fixed joints to world; ``True`` otherwise."""
         if parent == -1:
             return joint_type == JointType.FIXED
         return True
@@ -3074,7 +3065,6 @@ class ModelBuilder:
 
         start_body_idx = self.body_count
         start_shape_idx = self.shape_count
-        existing_world_shapes = tuple(self.body_shapes[-1])
         for s, b in enumerate(builder.shape_body):
             if b > -1:
                 new_b = b + start_body_idx
@@ -3149,25 +3139,6 @@ class ModelBuilder:
         self.shape_collision_filter_pairs.extend(
             [(i + start_shape_idx, j + start_shape_idx) for i, j in builder.shape_collision_filter_pairs]
         )
-
-        if existing_world_shapes:
-            # Source-local filter pairs were copied above. Add the cross-builder
-            # pairs between destination world shapes and copied bodies whose
-            # joints request parent collision filtering.
-            for i, parent in enumerate(builder.joint_parent):
-                if parent != -1 or not builder.joint_collision_filter_parent[i]:
-                    continue
-
-                child = builder.joint_child[i]
-                for child_shape in builder.body_shapes[child]:
-                    if not builder.shape_flags[child_shape] & ShapeFlags.COLLIDE_SHAPES:
-                        continue
-
-                    copied_child_shape = child_shape + start_shape_idx
-                    for world_shape in existing_world_shapes:
-                        if not self.shape_flags[world_shape] & ShapeFlags.COLLIDE_SHAPES:
-                            continue
-                        self.add_shape_collision_filter_pair(world_shape, copied_child_shape)
 
         # Handle world assignments
         # For particles
@@ -3779,7 +3750,7 @@ class ModelBuilder:
                 If None, the identity transform is used.
             child_xform: The transform from the child body frame to the joint child anchor frame.
                 If None, the identity transform is used.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the joint connects to world and is not ``FIXED``; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for non-fixed joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled (not considered by :class:`SolverFeatherstone`).
             custom_attributes: Dictionary of custom attribute keys (see :attr:`CustomAttribute.key`) to values. Note that custom attributes with frequency :attr:`Model.AttributeFrequency.JOINT_DOF` or :attr:`Model.AttributeFrequency.JOINT_COORD` can be provided as: (1) lists with length equal to the joint's DOF or coordinate count, (2) dicts mapping DOF/coordinate indices to values, or (3) a single scalar value that is broadcast to all DOFs/coordinates of the joint. For joints with zero DOFs (e.g., fixed joints), JOINT_DOF attributes are silently skipped. Custom attributes with frequency :attr:`Model.AttributeFrequency.JOINT` require a single value to be defined.
 
@@ -3973,7 +3944,7 @@ class ModelBuilder:
             velocity_limit: Maximum velocity the joint axis can achieve. If None, the default value from ``ModelBuilder.default_joint_cfg.velocity_limit`` is used.
             friction: Friction coefficient for the joint axis. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4065,7 +4036,7 @@ class ModelBuilder:
             velocity_limit: Maximum velocity the joint axis can achieve. If None, the default value from ``ModelBuilder.default_joint_cfg.velocity_limit`` is used.
             friction: Friction coefficient for the joint axis. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4132,7 +4103,7 @@ class ModelBuilder:
             armature: Artificial inertia added around the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.armature`` is used.
             friction: Friction coefficient for the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.friction`` is used.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
             actuator_mode: The actuator mode for this joint's DOFs. If None, defaults to NONE.
@@ -4248,7 +4219,7 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             parent: The index of the parent body (-1 by default to use the world frame, e.g. to make the child body and its children a floating-base mechanism).
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4305,7 +4276,7 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             min_distance: The minimum distance between the bodies (no limit if negative).
             max_distance: The maximum distance between the bodies (no limit if negative).
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4367,7 +4338,7 @@ class ModelBuilder:
             parent_xform: The transform from the parent body frame to the joint parent anchor frame.
             child_xform: The transform from the child body frame to the joint child anchor frame.
             armature: Artificial inertia added around the joint axes. If None, the default value from ``ModelBuilder.default_joint_cfg.armature`` is used.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
 
@@ -4439,7 +4410,7 @@ class ModelBuilder:
                 this is a dimensionless (Rayleigh-style) coefficient. If None,
                 defaults to 0.0.
             label: The label of the joint.
-            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` when the parent is world; ``True`` otherwise.
+            collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD
                 frequency attributes.

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -500,7 +500,7 @@ class TestModelMesh(unittest.TestCase):
 
         def joint_first():
             b = ModelBuilder()
-            body = b.add_body()
+            body = b.add_link()
             b.add_joint_fixed(parent=-1, child=body)
             mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
             ground_shape = b.add_ground_plane()
@@ -509,14 +509,14 @@ class TestModelMesh(unittest.TestCase):
         def world_shape_first():
             b = ModelBuilder()
             ground_shape = b.add_ground_plane()
-            body = b.add_body()
+            body = b.add_link()
             b.add_joint_fixed(parent=-1, child=body)
             mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
             return b, mesh_shape, ground_shape
 
         def body_shape_first():
             b = ModelBuilder()
-            body = b.add_body()
+            body = b.add_link()
             mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
             b.add_joint_fixed(parent=-1, child=body)
             ground_shape = b.add_ground_plane()
@@ -537,7 +537,7 @@ class TestModelMesh(unittest.TestCase):
         world shapes — they need to be able to land on the ground."""
 
         builder = ModelBuilder()
-        body = builder.add_body()
+        body = builder.add_link()
         builder.add_joint_free(parent=-1, child=body)
         base_shape = builder.add_shape_sphere(body=body, radius=0.5)
         ground_shape = builder.add_ground_plane()
@@ -550,7 +550,7 @@ class TestModelMesh(unittest.TestCase):
         geometry (e.g. a pendulum hitting the ground)."""
 
         builder = ModelBuilder()
-        body = builder.add_body()
+        body = builder.add_link()
         builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z)
         body_shape = builder.add_shape_sphere(body=body, radius=0.5)
         ground_shape = builder.add_ground_plane()
@@ -563,7 +563,7 @@ class TestModelMesh(unittest.TestCase):
         joint-creation time."""
 
         builder = ModelBuilder()
-        body = builder.add_body()
+        body = builder.add_link()
         body_shape = builder.add_shape_sphere(body=body, radius=0.5)
         ground_shape = builder.add_ground_plane()
         builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z, collision_filter_parent=True)
@@ -575,8 +575,8 @@ class TestModelMesh(unittest.TestCase):
         default, matching the legacy behavior for joints between real bodies."""
 
         builder = ModelBuilder()
-        parent = builder.add_body()
-        child = builder.add_body()
+        parent = builder.add_link()
+        child = builder.add_link()
         parent_shape = builder.add_shape_sphere(body=parent, radius=0.5)
         child_shape = builder.add_shape_sphere(body=child, radius=0.5)
         builder.add_joint_free(parent=parent, child=child)
@@ -588,7 +588,7 @@ class TestModelMesh(unittest.TestCase):
         when shapes already exist on both sides at joint-creation time."""
 
         builder = ModelBuilder()
-        body = builder.add_body()
+        body = builder.add_link()
         mesh_shape = builder.add_shape_sphere(body=body, radius=0.5)
         ground_shape = builder.add_ground_plane()
         builder.add_joint_fixed(parent=-1, child=body, collision_filter_parent=False)

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -532,23 +532,6 @@ class TestModelMesh(unittest.TestCase):
                 pair = (min(mesh_shape, ground_shape), max(mesh_shape, ground_shape))
                 self.assertEqual(builder.shape_collision_filter_pairs.count(pair), 1)
 
-    def test_collision_filter_fixed_to_world_add_builder(self):
-        """Merging a fixed-to-world builder should filter against existing world shapes."""
-
-        fixed_base_builder = ModelBuilder()
-        body = fixed_base_builder.add_body()
-        fixed_base_builder.add_joint_fixed(parent=-1, child=body)
-        base_shape = fixed_base_builder.add_shape_sphere(body=body, radius=0.5)
-
-        scene = ModelBuilder()
-        ground_shape = scene.add_ground_plane()
-        start_shape_idx = scene.shape_count
-        scene.add_builder(fixed_base_builder)
-
-        copied_base_shape = start_shape_idx + base_shape
-        pair = (min(copied_base_shape, ground_shape), max(copied_base_shape, ground_shape))
-        self.assertEqual(scene.shape_collision_filter_pairs.count(pair), 1)
-
     def test_collision_filter_floating_base_not_filtered(self):
         """Floating-base bodies (FREE joint to world) must NOT be filtered against
         world shapes — they need to be able to land on the ground."""

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -493,6 +493,125 @@ class TestModelMesh(unittest.TestCase):
         self.assertIn((shape0, shape2), model.shape_collision_filter_pairs)
         self.assertIn((shape1, shape2), model.shape_collision_filter_pairs)
 
+    def test_collision_filter_fixed_to_world(self):
+        """Bodies fixed to world via add_joint_fixed(parent=-1) should auto-filter
+        their shapes against world-static shapes regardless of construction order
+        (issue #2201)."""
+
+        def joint_first():
+            b = ModelBuilder()
+            body = b.add_body()
+            b.add_joint_fixed(parent=-1, child=body)
+            mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
+            ground_shape = b.add_ground_plane()
+            return b, mesh_shape, ground_shape
+
+        def world_shape_first():
+            b = ModelBuilder()
+            ground_shape = b.add_ground_plane()
+            body = b.add_body()
+            b.add_joint_fixed(parent=-1, child=body)
+            mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
+            return b, mesh_shape, ground_shape
+
+        def body_shape_first():
+            b = ModelBuilder()
+            body = b.add_body()
+            mesh_shape = b.add_shape_sphere(body=body, radius=0.5)
+            b.add_joint_fixed(parent=-1, child=body)
+            ground_shape = b.add_ground_plane()
+            return b, mesh_shape, ground_shape
+
+        for case_name, build in (
+            ("joint before shapes", joint_first),
+            ("world shape before joint", world_shape_first),
+            ("body shape before joint", body_shape_first),
+        ):
+            with self.subTest(case=case_name):
+                builder, mesh_shape, ground_shape = build()
+                pair = (min(mesh_shape, ground_shape), max(mesh_shape, ground_shape))
+                self.assertEqual(builder.shape_collision_filter_pairs.count(pair), 1)
+
+    def test_collision_filter_fixed_to_world_add_builder(self):
+        """Merging a fixed-to-world builder should filter against existing world shapes."""
+
+        fixed_base_builder = ModelBuilder()
+        body = fixed_base_builder.add_body()
+        fixed_base_builder.add_joint_fixed(parent=-1, child=body)
+        base_shape = fixed_base_builder.add_shape_sphere(body=body, radius=0.5)
+
+        scene = ModelBuilder()
+        ground_shape = scene.add_ground_plane()
+        start_shape_idx = scene.shape_count
+        scene.add_builder(fixed_base_builder)
+
+        copied_base_shape = start_shape_idx + base_shape
+        pair = (min(copied_base_shape, ground_shape), max(copied_base_shape, ground_shape))
+        self.assertEqual(scene.shape_collision_filter_pairs.count(pair), 1)
+
+    def test_collision_filter_floating_base_not_filtered(self):
+        """Floating-base bodies (FREE joint to world) must NOT be filtered against
+        world shapes — they need to be able to land on the ground."""
+
+        builder = ModelBuilder()
+        body = builder.add_body()
+        builder.add_joint_free(parent=-1, child=body)
+        base_shape = builder.add_shape_sphere(body=body, radius=0.5)
+        ground_shape = builder.add_ground_plane()
+        pair = (min(base_shape, ground_shape), max(base_shape, ground_shape))
+        self.assertNotIn(pair, builder.shape_collision_filter_pairs)
+
+    def test_collision_filter_revolute_to_world_default(self):
+        """A revolute (non-fixed) joint to world does NOT auto-filter child shapes
+        against world shapes — the child needs to be able to collide with world
+        geometry (e.g. a pendulum hitting the ground)."""
+
+        builder = ModelBuilder()
+        body = builder.add_body()
+        builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z)
+        body_shape = builder.add_shape_sphere(body=body, radius=0.5)
+        ground_shape = builder.add_ground_plane()
+        pair = (min(body_shape, ground_shape), max(body_shape, ground_shape))
+        self.assertNotIn(pair, builder.shape_collision_filter_pairs)
+
+    def test_collision_filter_revolute_to_world_explicit(self):
+        """Explicit collision_filter_parent=True is honored even for a non-fixed
+        joint to world (overrides the smart default) when shapes exist at
+        joint-creation time."""
+
+        builder = ModelBuilder()
+        body = builder.add_body()
+        body_shape = builder.add_shape_sphere(body=body, radius=0.5)
+        ground_shape = builder.add_ground_plane()
+        builder.add_joint_revolute(parent=-1, child=body, axis=newton.Axis.Z, collision_filter_parent=True)
+        pair = (min(body_shape, ground_shape), max(body_shape, ground_shape))
+        self.assertEqual(builder.shape_collision_filter_pairs.count(pair), 1)
+
+    def test_collision_filter_free_with_real_parent_default_filtered(self):
+        """A free joint between two real bodies auto-filters parent/child shape pairs by
+        default, matching the legacy behavior for joints between real bodies."""
+
+        builder = ModelBuilder()
+        parent = builder.add_body()
+        child = builder.add_body()
+        parent_shape = builder.add_shape_sphere(body=parent, radius=0.5)
+        child_shape = builder.add_shape_sphere(body=child, radius=0.5)
+        builder.add_joint_free(parent=parent, child=child)
+        pair = (min(parent_shape, child_shape), max(parent_shape, child_shape))
+        self.assertEqual(builder.shape_collision_filter_pairs.count(pair), 1)
+
+    def test_collision_filter_fixed_to_world_opt_out(self):
+        """collision_filter_parent=False on the joint suppresses the auto-filter
+        when shapes already exist on both sides at joint-creation time."""
+
+        builder = ModelBuilder()
+        body = builder.add_body()
+        mesh_shape = builder.add_shape_sphere(body=body, radius=0.5)
+        ground_shape = builder.add_ground_plane()
+        builder.add_joint_fixed(parent=-1, child=body, collision_filter_parent=False)
+        pair = (min(mesh_shape, ground_shape), max(mesh_shape, ground_shape))
+        self.assertNotIn(pair, builder.shape_collision_filter_pairs)
+
     def test_validate_structure_invalid_shape_body(self):
         """Test that _validate_structure catches invalid shape_body references."""
         builder = ModelBuilder()


### PR DESCRIPTION
## Description

Fixes collision_filter_parent being silently ignored on joints whose parent is the world (parent=-1). Explicit values are
now honored, and add_joint_fixed(parent=-1, ...) now defaults to auto-filtering child-body shapes against world-static shapes (e.g. ground plane) (#2201).

The default for collision_filter_parent is now resolved per joint type:
- True for FIXED joints to world (filter applies — body is welded to world geometry)
- False for non-FIXED joints to world (no filter — floating bases and articulated links must collide with the ground)
- True otherwise (legacy behavior between two real bodies, unchanged)

Explicit True/False values now flow through whether shapes are added before or after the joint, via a new builder-side
joint_collision_filter_parent list consulted by add_shape.
## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

Steps to reproduce (without this PR):

1. Build a body fixed to world via `add_joint_fixed(parent=-1, child=body, collision_filter_parent=True)`.
2. Add a shape to the body and a ground plane.
3. Observe that the body's shape collides with the ground plane even though the body is rigidly welded to world.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Joint-to-world collision filtering now behaves consistently; parent-child filtering for joints is honored for all joint creation methods, and fixed-to-world joints create the expected filter against world/static shapes.

* **Changes**
  * Joint creation accepts an "unspecified" option that resolves sensible defaults: fixed joints default to filtering, other world-connected joints default to not filtering.

* **Tests**
  * Added unit tests covering defaults and explicit opt-in/opt-out behavior for world-connected joints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->