### PR TITLE
Expose render_megakernel launch args in SensorTiledCamera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add linear HDR color output support to `SensorTiledCamera` via `hdr_color_image`.
+- Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
 - Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -207,6 +207,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         clear_data: ClearData | None = DEFAULT_CLEAR_DATA,
         refit_bvh: bool | None = None,
         hdr_color_image: wp.array4d[wp.vec3f] | None = None,
+        kernel_block_dim: int = 64,
     ):
         """Render output images for all worlds and cameras.
 
@@ -241,6 +242,8 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
                 :func:`~newton.geometry.refit_bvh_particle` explicitly
                 before calling this method instead.
             hdr_color_image: Output for linear HDR color. None to skip.
+            kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
+                for the render megakernel.
         """
 
         # TODO: Remove this deprecation behaviour in the next release.
@@ -283,6 +286,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             albedo_image,
             clear_data=clear_data,
             hdr_color_image=hdr_color_image,
+            kernel_block_dim=kernel_block_dim,
         )
 
     def compute_pinhole_camera_rays(

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -148,6 +148,7 @@ class RenderContext:
         albedo_image: wp.array4d[wp.uint32] | None = None,
         clear_data: RenderContext.ClearData | None = DEFAULT_CLEAR_DATA,
         hdr_color_image: wp.array4d[wp.vec3f] | None = None,
+        kernel_block_dim: int = 64,
     ):
         """Raytrace the scene into the provided output images.
 
@@ -178,6 +179,8 @@ class RenderContext:
             clear_data: Values used to clear output images before
                 rendering. Pass ``None`` to use :attr:`DEFAULT_CLEAR_DATA`.
             hdr_color_image: Output linear HDR color buffer.
+            kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
+                for the render megakernel.
         """
         if model.shape_count > 0 and model.bvh_shape_enabled is None:
             raise RuntimeError("build_bvh_shape() must be called before rendering shapes.")
@@ -335,6 +338,7 @@ class RenderContext:
                     hdr_color_image,
                 ],
                 device=self.device,
+                block_dim=kernel_block_dim,
             )
 
     @property


### PR DESCRIPTION
## Description

Adds `kernel_block_dim` to `SensorTiledCamera.update()` and forwards it through `RenderContext.render()` to the Warp ray-tracer `render_megakernel` launch:

- `kernel_block_dim: int = 64` is forwarded to `wp.launch(..., block_dim=...)`.
- The override is launch-time only; `RenderConfig` and the existing render-kernel cache key are unchanged.

## Checklist

- [x] Existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Existing tiled camera sensor tests

## New feature / API change

Callers can tune the render megakernel block dim per update call:

```python
sensor.update(
    state,
    camera_transforms,
    camera_rays,
    color_image=color_image,
    kernel_block_dim=64,
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-render kernel launch tuning added (block/thread and max-blocks controls) with defaults preserving prior behavior; launch config now affects kernel cache keys.
  * New KernelLaunchConfig type introduced and re-exported via the public utilities API.

* **Tests**
  * Added unit tests covering defaults, explicit launch configs, equality/hashing, and cache-key effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2673)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->