### PR TITLE
Fix viewer particle active constant codegen

### DIFF
--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -784,7 +784,7 @@ def compute_hydro_contact_surface_lines(
     line_colors[tid * 3 + 2] = color
 
 
-PARTICLE_ACTIVE = wp.constant(wp.int32(newton.ParticleFlags.ACTIVE))
+PARTICLE_ACTIVE = wp.constant(wp.int32(int(newton.ParticleFlags.ACTIVE)))
 
 
 @wp.kernel


### PR DESCRIPTION
## Summary

Convert the viewer particle active flag constant through a plain Python integer before wrapping it as a Warp constant.

## Why

With warp-lang 1.12.1, the viewer kernel can emit ParticleFlags.ACTIVE into generated CUDA for build_active_particle_mask. NVRTC then fails compilation because ParticleFlags is not defined in CUDA.

Converting the IntEnum value to int first forces Warp to see a numeric constant and generate a valid literal.

## Validation

- Reproduced locally with python -m newton.examples basic_pendulum on an AWS DCV X display before the fix.
- Verified the patched checkout imports newton._src.viewer.kernels and resolves PARTICLE_ACTIVE to 1.
- Attempted pytest collection locally, but the environment failed during unrelated Kamino test collection imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type conversion issue for particle flag handling to ensure proper constant initialization and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->