### PR TITLE
Move the anynmal_d robot up to avoid initial penetration

### DIFF
--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -52,7 +52,7 @@ class Example:
             hide_collision_shapes=True,
         )
 
-        articulation_builder.joint_q[:3] = [0.0, 0.0, 0.62]
+        articulation_builder.joint_q[:3] = [0.0, 0.0, 0.68]
         if len(articulation_builder.joint_q) > 6:
             articulation_builder.joint_q[3:7] = [0.0, 0.0, 0.0, 1.0]
 


### PR DESCRIPTION
## Description
Closes #2679.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Bug fix

The `test_robot.example_robot_anymal_d_cpu` is failing when running with latest `mujoco_warp`.
This is caused by an initial penetration of the `anymal_d` feet that may or may not be resolved in the small amount of frame that the CPU test run.
We could also slightly increase the tolerance, but removing the initial penetration seems to be a better approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the initial robot starting position in the example configuration for improved pose initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->