### PR TITLE
Parse ground meshes into ground planes during usd loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - Fix `State.assign` not copying namespaced extended and custom state attributes 
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
+- Fix `ModelBuilder.add_usd` failing to load static ground planes authored as a coplanar `UsdGeomMesh` with `PhysicsCollisionAPI` (the common Isaac Sim / PhysX `physics:approximation = "none"` ground-plane pattern). Such meshes are now imported as `GeoType.PLANE`, so volumetric solvers like `SolverMuJoCo` no longer fail with a Qhull error when building a degenerate convex hull. Coplanar meshes attached to a rigid body are unaffected and remain `GeoType.MESH`
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Fix `SensorRaycast` ignoring `PLANE` geometry

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -291,8 +291,10 @@ def parse_usd(
     # load shape defaults
     default_shape_density = builder.default_shape_cfg.density
 
-    # mapping from physics:approximation attribute (lower case) to remeshing method
+    # mapping from physics:approximation attribute (lower case) to remeshing method.
+    # ``"none"`` is recognised as a no-op (PhysX semantics: use the raw triangle mesh).
     approximation_to_remeshing_method = {
+        "none": None,
         "convexdecomposition": "coacd",
         "convexhull": "convex_hull",
         "boundingsphere": "bounding_sphere",
@@ -408,6 +410,32 @@ def parse_usd(
         mesh = usd.get_mesh(prim, load_uvs=load_uvs, load_normals=load_normals)
         mesh_cache[key] = mesh
         return mesh
+
+    def _detect_planar_mesh_axis(mesh: Mesh, scale: wp.vec3) -> Axis | None:
+        """Detect a coplanar mesh that should be treated as a plane collider.
+
+        Returns the local axis (in the mesh's frame) that is normal to the plane,
+        or ``None`` if the mesh is not coplanar along any local axis. Detection is
+        deliberately conservative: the mesh must lie in an axis-aligned plane in
+        its local frame, and the test is performed after applying ``scale``.
+        Common Isaac Sim / PhysX authoring uses a 4-vertex quad in the XY plane
+        with ``physics:approximation = "none"`` to express a static ground.
+        """
+        verts = np.asarray(mesh.vertices, dtype=np.float64)
+        if verts.size == 0:
+            return None
+        scaled = verts * np.array([float(scale[0]), float(scale[1]), float(scale[2])], dtype=np.float64)
+        extents = scaled.max(axis=0) - scaled.min(axis=0)
+        max_extent = float(extents.max())
+        if max_extent <= 0.0:
+            return None
+        # Relative tolerance against the largest extent; 1e-6 catches numerical
+        # noise while staying well below any author-relevant thickness.
+        flat_eps = max(1e-6 * max_extent, 1e-9)
+        flat_axes = [i for i in range(3) if extents[i] <= flat_eps]
+        if len(flat_axes) != 1:
+            return None
+        return (Axis.X, Axis.Y, Axis.Z)[flat_axes[0]]
 
     def _has_api_schema(prim: Usd.Prim, schema_name: str) -> bool:
         return bool(prim and prim.IsValid() and usd.has_applied_api_schema(prim, schema_name))
@@ -2747,24 +2775,48 @@ def parse_usd(
                         default=mesh_maxhullvert,
                         verbose=verbose,
                     )
-                    shape_id = builder.add_shape_mesh(
-                        scale=wp.vec3(*shape_spec.meshScale),
-                        mesh=mesh,
-                        **shape_params,
-                    )
-                    if not skip_mesh_approximation:
-                        approximation = usd.get_attribute(prim, "physics:approximation", None)
-                        if approximation is not None:
-                            remeshing_method = approximation_to_remeshing_method.get(approximation.lower(), None)
-                            if remeshing_method is None:
-                                if verbose:
-                                    print(
-                                        f"Warning: Unknown physics:approximation attribute '{approximation}' on shape at '{path}'."
-                                    )
-                            else:
-                                if remeshing_method not in remeshing_queue:
-                                    remeshing_queue[remeshing_method] = []
-                                remeshing_queue[remeshing_method].append(shape_id)
+                    mesh_scale = wp.vec3(*shape_spec.meshScale)
+                    # Static, axis-aligned coplanar Mesh colliders (e.g. a 4-vertex quad with
+                    # ``physics:approximation = "none"``) are a common Isaac Sim / PhysX way
+                    # to author a ground plane. Triangle-mesh collision degenerates to a
+                    # zero-volume convex hull in solvers like MuJoCo, so route it through
+                    # ``add_shape_plane`` instead.
+                    planar_axis = None
+                    if body_id == -1:
+                        planar_axis = _detect_planar_mesh_axis(mesh, mesh_scale)
+                    if planar_axis is not None:
+                        plane_params = dict(shape_params)
+                        if planar_axis != Axis.Z:
+                            xform = plane_params["xform"]
+                            plane_params["xform"] = wp.transform(
+                                xform.p, xform.q * quat_between_axes(Axis.Z, planar_axis)
+                            )
+                        shape_id = builder.add_shape_plane(
+                            **plane_params,
+                            width=0.0,
+                            length=0.0,
+                        )
+                    else:
+                        shape_id = builder.add_shape_mesh(
+                            scale=mesh_scale,
+                            mesh=mesh,
+                            **shape_params,
+                        )
+                        if not skip_mesh_approximation:
+                            approximation = usd.get_attribute(prim, "physics:approximation", None)
+                            if approximation is not None:
+                                approx_key = approximation.lower()
+                                if approx_key not in approximation_to_remeshing_method:
+                                    if verbose:
+                                        print(
+                                            f"Warning: Unknown physics:approximation attribute '{approximation}' on shape at '{path}'."
+                                        )
+                                else:
+                                    remeshing_method = approximation_to_remeshing_method[approx_key]
+                                    if remeshing_method is not None:
+                                        if remeshing_method not in remeshing_queue:
+                                            remeshing_queue[remeshing_method] = []
+                                        remeshing_queue[remeshing_method].append(shape_id)
 
                 elif key == UsdPhysics.ObjectType.PlaneShape:
                     # Warp uses +Z convention for planes

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -1534,6 +1534,93 @@ class TestImportUsdPhysics(unittest.TestCase):
         assert_np_equal(np.array(builder.shape_transform[3].p), np.array(tf.p), tol=1.0e-4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_planar_mesh_collider_imported_as_plane(self):
+        """A coplanar Mesh with PhysicsCollisionAPI and ``physics:approximation = "none"``
+        is the standard Isaac Sim / PhysX way to author a static ground plane. It must be
+        imported as ``GeoType.PLANE`` so volumetric solvers (e.g. MuJoCo, which would build
+        a degenerate convex hull) can consume the asset. Coplanar meshes attached to a
+        rigid body or oriented along non-Z axes are still handled correctly.
+        """
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        def add_quad(path, points, scale=(1.0, 1.0, 1.0)):
+            mesh = UsdGeom.Mesh.Define(stage, path)
+            mesh.CreateFaceVertexCountsAttr().Set([4])
+            mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 3, 2])
+            mesh.CreatePointsAttr().Set([Gf.Vec3f(*p) for p in points])
+            UsdGeom.Xformable(mesh).AddScaleOp().Set(Gf.Vec3f(*scale))
+            UsdPhysics.CollisionAPI.Apply(mesh.GetPrim())
+            mesh_api = UsdPhysics.MeshCollisionAPI.Apply(mesh.GetPrim())
+            mesh_api.CreateApproximationAttr().Set(UsdPhysics.Tokens.none)
+            return mesh.GetPrim()
+
+        # Static Z-coplanar quad (the H1-style ground plane).
+        add_quad(
+            "/World/PlaneZ",
+            [(-0.5, -0.5, 0.0), (0.5, -0.5, 0.0), (-0.5, 0.5, 0.0), (0.5, 0.5, 0.0)],
+            scale=(10.0, 10.0, 1.0),
+        )
+
+        # Static Y-coplanar quad (plane normal along local +Y).
+        add_quad(
+            "/World/PlaneY",
+            [(-0.5, 0.0, -0.5), (0.5, 0.0, -0.5), (-0.5, 0.0, 0.5), (0.5, 0.0, 0.5)],
+        )
+
+        # A coplanar quad attached to a rigid body must NOT be reinterpreted as a plane:
+        # the user authored a thin mesh collider and finite-plane semantics would change
+        # both collision behaviour and inertia accumulation.
+        body_xform = UsdGeom.Xform.Define(stage, "/World/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body_xform.GetPrim())
+        mass_api = UsdPhysics.MassAPI.Apply(body_xform.GetPrim())
+        mass_api.CreateMassAttr().Set(1.0)
+        add_quad(
+            "/World/Body/AttachedQuad",
+            [(-0.5, -0.5, 0.0), (0.5, -0.5, 0.0), (-0.5, 0.5, 0.0), (0.5, 0.5, 0.0)],
+        )
+
+        # A volumetric mesh with approximation="none" must remain a MESH (sanity check
+        # that planarity detection has not regressed standard triangle-mesh imports).
+        cube_mesh = newton.Mesh.create_box(
+            0.5, 0.5, 0.5, duplicate_vertices=False, compute_normals=False, compute_uvs=False, compute_inertia=False
+        )
+        cube_prim = UsdGeom.Mesh.Define(stage, "/World/CubeMesh")
+        cube_prim.CreateFaceVertexCountsAttr().Set([3] * (len(cube_mesh.indices) // 3))
+        cube_prim.CreateFaceVertexIndicesAttr().Set(cube_mesh.indices.tolist())
+        cube_prim.CreatePointsAttr().Set([Gf.Vec3f(*p) for p in cube_mesh.vertices.tolist()])
+        UsdPhysics.CollisionAPI.Apply(cube_prim.GetPrim())
+        UsdPhysics.MeshCollisionAPI.Apply(cube_prim.GetPrim()).CreateApproximationAttr().Set(UsdPhysics.Tokens.none)
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        shape_by_label = {builder.shape_label[i]: i for i in range(builder.shape_count)}
+
+        idx_z = shape_by_label["/World/PlaneZ"]
+        self.assertEqual(builder.shape_type[idx_z], newton.GeoType.PLANE)
+        self.assertEqual(builder.shape_body[idx_z], -1)
+
+        idx_y = shape_by_label["/World/PlaneY"]
+        self.assertEqual(builder.shape_type[idx_y], newton.GeoType.PLANE)
+        self.assertEqual(builder.shape_body[idx_y], -1)
+        # The axis correction must rotate the shape's local +Z onto the mesh-plane normal
+        # (local +Y for /World/PlaneY).
+        local_z = wp.quat_rotate(builder.shape_transform[idx_y].q, wp.vec3(0.0, 0.0, 1.0))
+        np.testing.assert_allclose(np.array(local_z), [0.0, 1.0, 0.0], atol=1e-6)
+
+        idx_attached = shape_by_label["/World/Body/AttachedQuad"]
+        self.assertEqual(builder.shape_type[idx_attached], newton.GeoType.MESH)
+        self.assertGreaterEqual(builder.shape_body[idx_attached], 0)
+
+        idx_cube = shape_by_label["/World/CubeMesh"]
+        self.assertEqual(builder.shape_type[idx_cube], newton.GeoType.MESH)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_visual_match_collision_shapes(self):
         builder = newton.ModelBuilder()
         builder.add_usd(newton.examples.get_asset("humanoid.usda"))


### PR DESCRIPTION
## Description

Fix for https://github.com/newton-physics/newton/issues/2668

`ModelBuilder.add_usd` failed to load static ground planes authored as a coplanar `UsdGeomMesh` with `PhysicsCollisionAPI` and `physics:approximation = "none"` (the standard Isaac Sim / PhysX ground-plane pattern). The mesh was added as `GeoType.MESH`, then `SolverMuJoCo` crashed with a Qhull error while building a degenerate convex hull from the flat quad.

The importer now detects axis-aligned coplanar `Mesh` colliders without a rigid body parent and routes them to `add_shape_plane`, with axis correction when the plane normal is along local X or Y. Coplanar meshes attached to a rigid body remain `GeoType.MESH` to preserve inertia accumulation and finite-plane semantics. `physics:approximation = "none"` is also recognised as a valid no-op, removing the spurious "Unknown" warning.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev python -m unittest newton.tests.test_import_usd
uv run --extra dev python -m unittest newton.tests.test_import_usd.TestImportUsdPhysics.test_planar_mesh_collider_imported_as_plane
```

The new regression test covers: Z-coplanar static quad → `PLANE`; Y-coplanar static quad → `PLANE` with axis correction; coplanar quad attached to a rigid body → stays `MESH`; volumetric mesh with `approximation="none"` → stays `MESH`. End-to-end verified by importing the H1 USDA from issue #2668 and constructing `SolverMuJoCo` without error.

## Bug fix

**Steps to reproduce:**

1. Import a USD stage containing a static ground authored as `def Mesh "Plane"` with `PhysicsCollisionAPI`, `PhysicsMeshCollisionAPI`, and `physics:approximation = "none"` (e.g. an Isaac Sim H1 scene).
2. Call `ModelBuilder.add_usd(...)`, finalize, and construct `SolverMuJoCo`.
3. Observe `ValueError: Error: qhull error` from `spec.add_mesh` because the 4-vertex coplanar quad has zero Z-extent.

**Minimal reproduction:**

```python
import warp as wp
import newton
import newton.solvers

builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
builder.add_usd("H1_flattened.usda", xform=wp.transform(wp.vec3(0, 0, 0)))
model = builder.finalize()
newton.solvers.SolverMuJoCo(model)  # ValueError: Error: qhull error (before this PR)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Static coplanar ground planes are now imported as plane geometry instead of mesh, preventing failures in volumetric solvers. Coplanar meshes attached to rigid bodies remain unchanged.

* **Tests**
  * Added regression test for planar mesh collider import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->