### PR TITLE
Add ignore_paths check to actuators parsing

### DIFF
--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3477,6 +3477,9 @@ def parse_usd(
         if idx < len(builder.joint_q_start)
     }
     for prim in Usd.PrimRange(stage.GetPrimAtPath(root_path)):
+        prim_path = str(prim.GetPath())
+        if any(re.match(pattern, prim_path) for pattern in ignore_paths):
+            continue
         parsed = parse_actuator_prim(prim)
         if parsed is None:
             continue

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -735,8 +735,6 @@ class TestActuatorBuilder(unittest.TestCase):
         """Actuator prims matched by ignore_paths are not registered."""
         test_dir = os.path.dirname(__file__)
         usd_path = os.path.join(test_dir, "assets", "actuator_test.usda")
-        if not os.path.exists(usd_path):
-            self.skipTest(f"Test USD file not found: {usd_path}")
 
         builder = newton.ModelBuilder()
         result = parse_usd(builder, usd_path, ignore_paths=[".*Joint1Actuator"])

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -731,6 +731,22 @@ class TestActuatorBuilder(unittest.TestCase):
         self.assertEqual(parsed.controller_class, ControllerPD)
 
     @unittest.skipUnless(HAS_USD, "pxr not installed")
+    def test_from_usd_ignore_paths(self):
+        """Actuator prims matched by ignore_paths are not registered."""
+        test_dir = os.path.dirname(__file__)
+        usd_path = os.path.join(test_dir, "assets", "actuator_test.usda")
+        if not os.path.exists(usd_path):
+            self.skipTest(f"Test USD file not found: {usd_path}")
+
+        builder = newton.ModelBuilder()
+        result = parse_usd(builder, usd_path, ignore_paths=[".*Joint1Actuator"])
+        self.assertEqual(result["actuator_count"], 1)
+
+        builder2 = newton.ModelBuilder()
+        result2 = parse_usd(builder2, usd_path, ignore_paths=[".*Actuator"])
+        self.assertEqual(result2["actuator_count"], 0)
+
+    @unittest.skipUnless(HAS_USD, "pxr not installed")
     def test_from_usd_schema_plugin_not_loaded(self):
         """parse_actuator_prim works when the USD schema plugin is not registered.
 


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Actuator import now respects configured ignore-patterns, skipping matching entries during USD import to prevent validation errors and unintended actuator registration.

* **Tests**
  * Added a unit test confirming ignore-patterns prevent matching actuator entries from being registered while non-matching entries remain processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->