### PR TITLE
Bump JupyterLab for CVE-2026-40171

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ docs = [
 notebook = [
     "newton[examples]",
     "rerun-sdk[notebook]>=0.27.1; python_version < '3.14'",
-    "jupyterlab>=4.4.10",
+    "jupyterlab>=4.5.7",
 ]
 
 [tool.uv.build-backend]

--- a/uv.lock
+++ b/uv.lock
@@ -1893,7 +1893,7 @@ wheels = [
 
 [[package]]
 name = "jupyterlab"
-version = "4.5.6"
+version = "4.5.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-lru" },
@@ -1911,9 +1911,9 @@ dependencies = [
     { name = "tornado" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/d5/730628e03fff2e8a8e8ccdaedde1489ab1309f9a4fa2536248884e30b7c7/jupyterlab-4.5.6.tar.gz", hash = "sha256:642fe2cfe7f0f5922a8a558ba7a0d246c7bc133b708dfe43f7b3a826d163cf42", size = 23970670, upload-time = "2026-03-11T14:17:04.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/22/8440ec827762146e7cdecf04335bd348795899d29dc6ae82238707353a2c/jupyterlab-4.5.7.tar.gz", hash = "sha256:55a9822c4754da305f41e113452c68383e214dcf96de760146af89ce5d5117b0", size = 23992763, upload-time = "2026-04-29T16:43:51.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/1b/dad6fdcc658ed7af26fdf3841e7394072c9549a8b896c381ab49dd11e2d9/jupyterlab-4.5.6-py3-none-any.whl", hash = "sha256:d6b3dac883aa4d9993348e0f8e95b24624f75099aed64eab6a4351a9cdd1e580", size = 12447124, upload-time = "2026-03-11T14:17:00.229Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/537b8f7d80e799af19af35fb3ddfc970b951088a13c57dd9387dcfbb7f61/jupyterlab-4.5.7-py3-none-any.whl", hash = "sha256:fba4cb0e2c44a52859669d8c98b45de029d5e515f8407bf8534d2a8fc5f0964d", size = 12450123, upload-time = "2026-04-29T16:43:46.639Z" },
 ]
 
 [[package]]
@@ -3067,7 +3067,7 @@ requires-dist = [
     { name = "gitpython", marker = "extra == 'examples'", specifier = ">=3.1.47" },
     { name = "imgui-bundle", marker = "extra == 'examples'", specifier = ">=1.92.0" },
     { name = "ipykernel", marker = "extra == 'docs'", specifier = ">=6.0.0,<7.0.0" },
-    { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.4.10" },
+    { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.5.7" },
     { name = "meshio", marker = "extra == 'importers'", specifier = ">=5.3.5" },
     { name = "mujoco", marker = "python_full_version < '3.14' and extra == 'sim'", specifier = "~=3.8.0" },
     { name = "mujoco-warp", marker = "python_full_version < '3.14' and extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.1" },


### PR DESCRIPTION
## Description

Raise the `notebook` extra's `jupyterlab` minimum from `>=4.4.10` to `>=4.5.7` and refresh `uv.lock` from `jupyterlab 4.5.6` to `4.5.7`.

This addresses Dependabot alert 23 for GHSA-rch3-82jr-f9w9 / CVE-2026-40171, where the patched JupyterLab release is 4.5.7.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not needed: dependency security floor/lock update only)

## Test plan

```bash
uv lock --check
uv run --extra notebook python -c "import jupyterlab; print(jupyterlab.__version__)"
uvx pre-commit run -a
uv run --extra docs --extra notebook --extra sim env NEWTON_SPHINX_BUILD=1 jupyter nbconvert --to notebook --execute docs/tutorials/00_introduction.ipynb --ExecutePreprocessor.timeout=3600 --output-dir=/tmp --output=newton_introduction_executed.ipynb
```

The version check prints `4.5.7`.

## Bug fix

**Steps to reproduce:**

1. Resolve the `notebook` extra without this PR.
2. Observe `uv.lock` selects `jupyterlab 4.5.6`, which is covered by Dependabot alert 23.
3. Apply this PR and observe the lock resolves to patched `jupyterlab 4.5.7`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of JupyterLab from 4.4.10 to 4.5.7 for the notebook optional dependency group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->