### PR TITLE
Fix collapsed URDF articulation starts (#2589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
+- Fix repeated URDF imports with fixed-joint collapse preserving articulation order.
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix repeated URDF imports with fixed-joint collapse preserving articulation order.
+- Fix repeated URDF imports with fixed-joint collapse preserving articulation order
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,7 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
-- Fix repeated URDF imports with fixed-joint collapse preserving articulation order.
-- Fix repeated URDF imports with fixed-joint collapse preserving articulation order
+- Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5131,23 +5131,57 @@ class ModelBuilder:
         # sort joints so they appear in the same order as before
         retained_joints.sort(key=lambda x: x["original_id"])
 
+        original_articulation_start = self.articulation_start[:]
+        original_articulation_label = self.articulation_label[:]
+        original_articulation_world = self.articulation_world[:]
+        original_joint_articulation = self.joint_articulation[:] if self.joint_articulation else []
+
         joint_remap = {}
+        articulation_first_joint: dict[int, int] = {}
         for i, joint in enumerate(retained_joints):
-            joint_remap[joint["original_id"]] = i
-        # update articulation_start
-        for i, old_i in enumerate(self.articulation_start):
-            start_i = old_i
-            while start_i not in joint_remap:
-                start_i += 1
-                if start_i >= self.joint_count:
-                    break
-            self.articulation_start[i] = joint_remap.get(start_i, start_i)
-        # remove empty articulation starts, i.e. where the start and end are the same
-        self.articulation_start = list(set(self.articulation_start))
+            old_joint_idx = joint["original_id"]
+            joint_remap[old_joint_idx] = i
+            if original_joint_articulation and old_joint_idx < len(original_joint_articulation):
+                old_articulation = original_joint_articulation[old_joint_idx]
+                if old_articulation >= 0 and old_articulation not in articulation_first_joint:
+                    articulation_first_joint[old_articulation] = i
+
+        # Update articulation starts from retained joints' original articulation
+        # ownership. This preserves articulation order while dropping empty
+        # articulations whose joints were fully collapsed away.
+        articulation_remap: dict[int, int] = {}
+        new_articulation_start: list[int] = []
+        new_articulation_label: list[str] = []
+        new_articulation_world: list[int] = []
+        for articulation_idx in range(len(original_articulation_start)):
+            if articulation_idx not in articulation_first_joint:
+                continue
+
+            articulation_remap[articulation_idx] = len(new_articulation_start)
+            new_articulation_start.append(articulation_first_joint[articulation_idx])
+            if articulation_idx < len(original_articulation_label):
+                new_articulation_label.append(original_articulation_label[articulation_idx])
+            else:
+                new_articulation_label.append(f"articulation_{articulation_idx}")
+            if articulation_idx < len(original_articulation_world):
+                new_articulation_world.append(original_articulation_world[articulation_idx])
+            else:
+                new_articulation_world.append(self.current_world)
+
+        self.articulation_start = new_articulation_start
+        self.articulation_label = new_articulation_label
+        self.articulation_world = new_articulation_world
+
+        for custom_attr in self.get_custom_attributes_by_frequency([Model.AttributeFrequency.ARTICULATION]):
+            if isinstance(custom_attr.values, dict):
+                custom_attr.values = {
+                    new_idx: custom_attr.values[old_idx]
+                    for old_idx, new_idx in articulation_remap.items()
+                    if old_idx in custom_attr.values
+                }
 
         # save original joint worlds and articulations before clearing
         original_ = self.joint_world[:] if self.joint_world else []
-        original_articulation = self.joint_articulation[:] if self.joint_articulation else []
 
         self.joint_label.clear()
         self.joint_type.clear()
@@ -5200,8 +5234,9 @@ class ModelBuilder:
                 # If no world was assigned, use default -1
                 self.joint_world.append(-1)
             # Rebuild joint articulation assignment
-            if original_articulation and joint["original_id"] < len(original_articulation):
-                self.joint_articulation.append(original_articulation[joint["original_id"]])
+            if original_joint_articulation and joint["original_id"] < len(original_joint_articulation):
+                old_articulation = original_joint_articulation[joint["original_id"]]
+                self.joint_articulation.append(articulation_remap.get(old_articulation, -1))
             else:
                 self.joint_articulation.append(-1)
             for axis in joint["axes"]:

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5172,6 +5172,17 @@ class ModelBuilder:
         self.articulation_label = new_articulation_label
         self.articulation_world = new_articulation_world
 
+        def remap_articulation_reference(value: Any) -> Any:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, int):
+                return articulation_remap.get(value, -1) if value >= 0 else value
+            if isinstance(value, list):
+                return [remap_articulation_reference(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(remap_articulation_reference(v) for v in value)
+            return value
+
         for custom_attr in self.get_custom_attributes_by_frequency([Model.AttributeFrequency.ARTICULATION]):
             if isinstance(custom_attr.values, dict):
                 custom_attr.values = {
@@ -5179,6 +5190,16 @@ class ModelBuilder:
                     for old_idx, new_idx in articulation_remap.items()
                     if old_idx in custom_attr.values
                 }
+
+        for custom_attr in self.custom_attributes.values():
+            if custom_attr.references != "articulation" or custom_attr.values is None:
+                continue
+            if isinstance(custom_attr.values, dict):
+                custom_attr.values = {
+                    entity_idx: remap_articulation_reference(value) for entity_idx, value in custom_attr.values.items()
+                }
+            else:
+                custom_attr.values = [remap_articulation_reference(value) for value in custom_attr.values]
 
         # save original joint worlds and articulations before clearing
         original_ = self.joint_world[:] if self.joint_world else []
@@ -5356,6 +5377,7 @@ class ModelBuilder:
         return {
             "body_remap": body_remap,
             "joint_remap": joint_remap,
+            "articulation_remap": articulation_remap,
             "body_merged_parent": body_merged_parent,
             "body_merged_transform": body_merged_transform,
             # TODO clean up this data

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5183,13 +5183,14 @@ class ModelBuilder:
                 return tuple(remap_articulation_reference(v) for v in value)
             return value
 
+        # ARTICULATION-frequency attributes use dict storage by construction
+        # (see CustomAttribute._create_empty_values_container).
         for custom_attr in self.get_custom_attributes_by_frequency([Model.AttributeFrequency.ARTICULATION]):
-            if isinstance(custom_attr.values, dict):
-                custom_attr.values = {
-                    new_idx: custom_attr.values[old_idx]
-                    for old_idx, new_idx in articulation_remap.items()
-                    if old_idx in custom_attr.values
-                }
+            custom_attr.values = {
+                new_idx: custom_attr.values[old_idx]
+                for old_idx, new_idx in articulation_remap.items()
+                if old_idx in custom_attr.values
+            }
 
         for custom_attr in self.custom_attributes.values():
             if custom_attr.references != "articulation" or custom_attr.values is None:

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5175,13 +5175,17 @@ class ModelBuilder:
         def remap_articulation_reference(value: Any) -> Any:
             if isinstance(value, bool):
                 return value
-            if isinstance(value, int):
-                return articulation_remap.get(value, -1) if value >= 0 else value
             if isinstance(value, list):
                 return [remap_articulation_reference(v) for v in value]
             if isinstance(value, tuple):
                 return tuple(remap_articulation_reference(v) for v in value)
-            return value
+            # Covers Python int as well as Warp scalar integer types (wp.int32 etc.),
+            # whose default `dtype(0)` instances are not Python ints.
+            try:
+                idx = int(value)
+            except (TypeError, ValueError):
+                return value
+            return articulation_remap.get(idx, -1) if idx >= 0 else value
 
         # ARTICULATION-frequency attributes use dict storage by construction
         # (see CustomAttribute._create_empty_values_container).

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3305,9 +3305,18 @@ def parse_usd(
         body_merged_parent = collapse_results["body_merged_parent"]
         body_merged_transform = collapse_results["body_merged_transform"]
         body_remap = collapse_results["body_remap"]
+        articulation_remap = collapse_results["articulation_remap"]
         # remap body ids in articulation bodies
-        for art_id, bodies in articulation_bodies.items():
-            articulation_bodies[art_id] = [body_remap[b] for b in bodies if b in body_remap]
+        articulation_bodies = {
+            articulation_remap[art_id]: [body_remap[b] for b in bodies if b in body_remap]
+            for art_id, bodies in articulation_bodies.items()
+            if art_id in articulation_remap
+        }
+        articulation_has_self_collision = {
+            articulation_remap[art_id]: enabled
+            for art_id, enabled in articulation_has_self_collision.items()
+            if art_id in articulation_remap
+        }
 
         for path, body_id in path_body_map.items():
             if body_id in body_remap:

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3305,18 +3305,6 @@ def parse_usd(
         body_merged_parent = collapse_results["body_merged_parent"]
         body_merged_transform = collapse_results["body_merged_transform"]
         body_remap = collapse_results["body_remap"]
-        articulation_remap = collapse_results["articulation_remap"]
-        # remap body ids in articulation bodies
-        articulation_bodies = {
-            articulation_remap[art_id]: [body_remap[b] for b in bodies if b in body_remap]
-            for art_id, bodies in articulation_bodies.items()
-            if art_id in articulation_remap
-        }
-        articulation_has_self_collision = {
-            articulation_remap[art_id]: enabled
-            for art_id, enabled in articulation_has_self_collision.items()
-            if art_id in articulation_remap
-        }
 
         for path, body_id in path_body_map.items():
             if body_id in body_remap:

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1140,6 +1140,50 @@ class TestImportUrdfComposition(unittest.TestCase):
         self.assertIn("gripper/gripper_base", builder.body_label)
         self.assertEqual(len(model.articulation_start.numpy()) - 1, 1)  # Single articulation
 
+    def test_repeated_collapse_fixed_joints_preserves_articulation_order(self):
+        """Test repeated URDF imports with fixed-joint collapse preserve articulation order."""
+        joint_count = 12
+        links = ['    <link name="base"/>', '    <link name="mount"/>']
+        links.extend(f'    <link name="link_{i}"/>' for i in range(joint_count))
+
+        joints = [
+            """    <joint name="fixed_mount" type="fixed">
+        <parent link="base"/>
+        <child link="mount"/>
+    </joint>"""
+        ]
+        parent = "mount"
+        for i in range(joint_count):
+            child = f"link_{i}"
+            joints.append(
+                f"""    <joint name="joint_{i}" type="revolute">
+        <parent link="{parent}"/>
+        <child link="{child}"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="-1" upper="1" effort="1" velocity="1"/>
+    </joint>"""
+            )
+            parent = child
+
+        robot_urdf = '<robot name="collapse_order">\n' + "\n".join(links + joints) + "\n</robot>\n"
+
+        builder = newton.ModelBuilder()
+        for i in range(3):
+            parse_urdf(
+                robot_urdf,
+                builder,
+                floating=True,
+                collapse_fixed_joints=True,
+                up_axis="Z",
+                xform=wp.transform(wp.vec3(float(i), 0.0, 0.0), wp.quat_identity()),
+            )
+
+        self.assertEqual(builder.articulation_start, [0, 13, 26])
+        model = builder.finalize()
+        self.assertEqual(model.articulation_count, 3)
+        self.assertEqual(model.joint_count, 39)
+        assert_np_equal(model.articulation_start.numpy(), np.array([0, 13, 26, 39], dtype=np.int32))
+
     def test_floating_true_with_parent_body_raises_error(self):
         """Test that floating=True with parent_body raises an error."""
         robot_urdf = """<?xml version="1.0"?>

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1186,6 +1186,9 @@ class TestImportUrdfComposition(unittest.TestCase):
         self.assertEqual(model.articulation_count, 3)
         self.assertEqual(model.joint_count, 39)
         assert_np_equal(model.articulation_start.numpy(), np.array([0, 13, 26, 39], dtype=np.int32))
+        self.assertEqual(model.articulation_label, ["collapse_order", "collapse_order", "collapse_order"])
+        assert_np_equal(model.articulation_world.numpy(), np.array([-1, -1, -1], dtype=np.int32))
+        assert_np_equal(model.joint_articulation.numpy(), np.array([0] * 13 + [1] * 13 + [2] * 13, dtype=np.int32))
 
     def test_floating_true_with_parent_body_raises_error(self):
         """Test that floating=True with parent_body raises an error."""

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1179,6 +1179,9 @@ class TestImportUrdfComposition(unittest.TestCase):
             )
 
         self.assertEqual(builder.articulation_start, [0, 13, 26])
+        self.assertEqual(builder.articulation_label, ["collapse_order", "collapse_order", "collapse_order"])
+        self.assertEqual(builder.articulation_world, [-1, -1, -1])
+        self.assertEqual(builder.joint_articulation, [0] * 13 + [1] * 13 + [2] * 13)
         model = builder.finalize()
         self.assertEqual(model.articulation_count, 3)
         self.assertEqual(model.joint_count, 39)

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -574,6 +574,9 @@ class TestModelJoints(unittest.TestCase):
         assert builder.joint_count == 2
         assert builder.articulation_count == 2
         assert builder.articulation_start == [0, 1]
+        assert builder.articulation_label == ["articulation_1", "articulation_2"]
+        assert builder.articulation_world == [-1, -1]
+        assert builder.joint_articulation == [0, 1]
         assert builder.joint_type == [newton.JointType.REVOLUTE, newton.JointType.FREE]
         assert builder.shape_count == 11
         assert builder.shape_body == [-1, -1, -1, -1, -1, -1, 0, 1, 1, 1, 1]

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -569,14 +569,37 @@ class TestModelJoints(unittest.TestCase):
         builder.add_articulation(all_joints)
         assert builder.articulation_count == 3  # Three articulations total
 
-        builder.collapse_fixed_joints()
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="articulation_name",
+                dtype=str,
+                frequency=newton.Model.AttributeFrequency.ARTICULATION,
+                default="",
+                values={0: "fixed", 1: "revolute", 2: "free"},
+            )
+        )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="articulation_ref",
+                dtype=wp.int32,
+                frequency=newton.Model.AttributeFrequency.ONCE,
+                references="articulation",
+                default=-1,
+                values={0: [1, (2, -1)]},
+            )
+        )
+
+        collapse_results = builder.collapse_fixed_joints()
 
         assert builder.joint_count == 2
         assert builder.articulation_count == 2
+        assert collapse_results["articulation_remap"] == {1: 0, 2: 1}
         assert builder.articulation_start == [0, 1]
         assert builder.articulation_label == ["articulation_1", "articulation_2"]
         assert builder.articulation_world == [-1, -1]
         assert builder.joint_articulation == [0, 1]
+        assert builder.custom_attributes["articulation_name"].values == {0: "revolute", 1: "free"}
+        assert builder.custom_attributes["articulation_ref"].values == {0: [0, (1, -1)]}
         assert builder.joint_type == [newton.JointType.REVOLUTE, newton.JointType.FREE]
         assert builder.shape_count == 11
         assert builder.shape_body == [-1, -1, -1, -1, -1, -1, 0, 1, 1, 1, 1]

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -588,6 +588,16 @@ class TestModelJoints(unittest.TestCase):
                 values={0: [1, (2, -1)]},
             )
         )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="articulation_ref_wp",
+                dtype=wp.int32,
+                frequency=newton.Model.AttributeFrequency.ONCE,
+                references="articulation",
+                default=wp.int32(-1),
+                values={0: [wp.int32(1), (wp.int32(2), wp.int32(-1))]},
+            )
+        )
 
         collapse_results = builder.collapse_fixed_joints()
 
@@ -600,6 +610,7 @@ class TestModelJoints(unittest.TestCase):
         assert builder.joint_articulation == [0, 1]
         assert builder.custom_attributes["articulation_name"].values == {0: "revolute", 1: "free"}
         assert builder.custom_attributes["articulation_ref"].values == {0: [0, (1, -1)]}
+        assert builder.custom_attributes["articulation_ref_wp"].values == {0: [0, (1, -1)]}
         assert builder.joint_type == [newton.JointType.REVOLUTE, newton.JointType.FREE]
         assert builder.shape_count == 11
         assert builder.shape_body == [-1, -1, -1, -1, -1, -1, 0, 1, 1, 1, 1]


### PR DESCRIPTION
## Description

Closes #2589.

`ModelBuilder.finalize()` crashes with `ValueError: articulation_start is not monotonically increasing` when 3 or more URDFs (e.g. ANYmal C) are imported into the same builder with `collapse_fixed_joints=True`.

The root cause is in `ModelBuilder.collapse_fixed_joints()`:

- After remapping joint indices, `self.articulation_start = list(set(...))` was used to drop empty articulations. `set()` is unordered, so for 3+ articulations the starts can come out scrambled (e.g. `[0, 26, 13]`), tripping the monotonicity check in `finalize()`.
- Even when ordering happened to survive, `articulation_label`, `articulation_world`, and `joint_articulation` were not kept aligned with the (potentially shrunken) `articulation_start`, so per-articulation metadata could be silently misattributed.

This PR rebuilds articulation bookkeeping in original order from the retained joints' articulation ownership, drops fully-collapsed empty articulations, and exposes an `articulation_remap` so external callers can update their own per-articulation side data.

This builds on the work started in #2616 by @devshahofficial — that PR is from a fork I cannot push to, so I am opening a fresh one with the same approach plus the two outstanding review comments addressed:

- [Drop the silent dict-only skip in the ARTICULATION custom-attribute remap](https://github.com/newton-physics/newton/pull/2616#discussion_r3164793320) and document that enum-frequency attributes always use dict storage by construction.
- [Remove the dead `articulation_bodies` / `articulation_has_self_collision` remap in `import_usd.py`](https://github.com/newton-physics/newton/pull/2616#discussion_r3164793357) — both maps are consumed during self-collision filter setup, before `collapse_fixed_joints()` runs, so the remap had no user-visible effect.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_import_urdf
uv run --extra dev -m newton.tests -k test_model.TestModelJoints.test_collapse_fixed_joints
uv run --extra dev -m newton.tests -k test_import_usd
uvx pre-commit run -a
```

Manual smoke check against the original issue repro: ANYmal C URDF imported three times with `collapse_fixed_joints=True` now finalizes with `model.articulation_start == [0, 13, 26, 39]` instead of crashing.

## Bug fix

**Steps to reproduce:**

1. Import the same multi-joint URDF (e.g. ANYmal C) three times into one `ModelBuilder` with `collapse_fixed_joints=True`.
2. Call `builder.finalize()`.
3. Without this PR, finalize raises `ValueError: articulation_start is not monotonically increasing: articulation_start[1]=26 > articulation_start[2]=13`.

**Minimal reproduction:**

See `test_repeated_collapse_fixed_joints_preserves_articulation_order` in `newton/tests/test_import_urdf.py` for the inline regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when finalizing models with 3+ articulations after simplifying fixed joints; articulation indices and per-articulation metadata are now remapped consistently.
  * Ensures custom per-articulation attributes are preserved and remapped correctly after simplification.

* **Tests**
  * Added regression tests to verify articulation ordering and attribute preservation across repeated simplifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->