### PR TITLE
Restore PyTorch intersphinx to stable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
-    "pytorch": ("https://docs.pytorch.org/docs/2.10", None),
+    "pytorch": ("https://pytorch.org/docs/stable", None),
     "warp": ("https://nvidia.github.io/warp", None),
     "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }


### PR DESCRIPTION
## Description

The upstream issue (pytorch/pytorch#182007) has been resolved via pytorch/docs#85, which restores `objects.inv` to the `stable` alias.

This reverts the temporary pin to `/docs/2.10/` introduced in #2660.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PyTorch documentation reference to use the stable version instead of a pinned release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->