### PR TITLE
Use particle flag `newton.ParticleFlags.ACTIVE` directly in viewer kernel

### DIFF
--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -784,16 +784,13 @@ def compute_hydro_contact_surface_lines(
     line_colors[tid * 3 + 2] = color
 
 
-PARTICLE_ACTIVE = wp.constant(wp.int32(newton.ParticleFlags.ACTIVE))
-
-
 @wp.kernel
 def build_active_particle_mask(
     flags: wp.array[wp.int32],
     mask: wp.array[wp.int32],
 ):
     i = wp.tid()
-    if (flags[i] & PARTICLE_ACTIVE) != wp.int32(0):
+    if (flags[i] & newton.ParticleFlags.ACTIVE) != wp.int32(0):
         mask[i] = wp.int32(1)
     else:
         mask[i] = wp.int32(0)


### PR DESCRIPTION
﻿## Description

Remove the viewer-local `PARTICLE_ACTIVE` Warp constant and use `newton.ParticleFlags.ACTIVE` directly in `build_active_particle_mask`.

This matches the pattern already used by other Newton Warp kernels. It also supersedes #2676: that PR added an `int(...)` workaround for a reported Warp 1.12.1 CUDA codegen issue, but current `main` requires `warp-lang>=1.13.0rc1`, and direct enum use now compiles and passes the focused viewer particle flag tests.

No changelog entry is included because this is an internal viewer kernel cleanup with no user-facing behavior change.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_viewer_particle_flags
```

Also verified a direct CUDA launch of `build_active_particle_mask` on `cuda:0`, producing mask `[1, 0, 1]` for active/inactive/active particle flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved particle activation testing logic for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->