### PR TITLE
Move collapse_fixed_joints() to be at solver level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Add Kamino-specific simulation examples in `newton/examples/kamino`
 - Add per-mesh `color` override to `ViewerBase.log_mesh()` for tinting individual meshes without authoring per-vertex colors
 - Add per-mesh `roughness` and `metallic` PBR overrides to `ViewerBase.log_mesh()`
+- Add solver-level fixed-joint merging to ``SolverXPBD`` and ``SolverSemiImplicit`` via ``collapse_fixed_joints=True`` (the default); the original ``Model`` body hierarchy is preserved so USD-path-to-body-index mappings remain valid, while merged-child inertia is accumulated into survivor bodies for improved numerical stability
+
 
 ### Changed
 

--- a/docs/concepts/mass_inertia.rst
+++ b/docs/concepts/mass_inertia.rst
@@ -220,6 +220,13 @@ The following checks are applied in order:
    :meth:`~newton.ModelBuilder.collapse_fixed_joints` merges mass and inertia
    across collapsed bodies *before* validation runs.
 
+   The solver-level equivalent (``collapse_fixed_joints=True`` on
+   :class:`~newton.solvers.SolverXPBD` and
+   :class:`~newton.solvers.SolverSemiImplicit`) accumulates inertia at solver
+   construction time, *after* :meth:`~newton.ModelBuilder.finalize` has already
+   validated individual body inertias.  The original
+   :class:`~newton.Model` body hierarchy is preserved.
+
 
 .. _Shape inertia reference:
 

--- a/newton/_src/solvers/_fixed_joint_merger.py
+++ b/newton/_src/solvers/_fixed_joint_merger.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 
 import warp as wp
 
-from ..geometry.inertia import transform_inertia
 from ..sim import BodyFlags, JointType
 from ..sim.model import Model
 
@@ -25,19 +24,19 @@ class FixedJointMergeInfo:
     has_merges: bool
     survivor_of: list[int]
     relative_xform_of: list[wp.transform]
-    survivor_indices_gpu: wp.array
-    relative_xforms_gpu: wp.array
-    merged_body_inv_mass_gpu: wp.array
-    merged_body_inv_inertia_gpu: wp.array
-    merged_body_mass_gpu: wp.array
-    merged_body_inertia_gpu: wp.array
-    merged_body_com_gpu: wp.array
-    joint_enabled_effective_gpu: wp.array
-    joint_parent_effective_gpu: wp.array
-    joint_child_effective_gpu: wp.array
-    joint_X_p_effective_gpu: wp.array
-    joint_X_c_effective_gpu: wp.array
-    shape_body_effective_gpu: wp.array
+    survivor_indices_gpu: wp.array[wp.int32]
+    relative_xforms_gpu: wp.array[wp.transform]
+    merged_body_inv_mass_gpu: wp.array[float]
+    merged_body_inv_inertia_gpu: wp.array[wp.mat33]
+    merged_body_mass_gpu: wp.array[float]
+    merged_body_inertia_gpu: wp.array[wp.mat33]
+    merged_body_com_gpu: wp.array[wp.vec3]
+    joint_enabled_effective_gpu: wp.array[wp.bool]
+    joint_parent_effective_gpu: wp.array[wp.int32]
+    joint_child_effective_gpu: wp.array[wp.int32]
+    joint_X_p_effective_gpu: wp.array[wp.transform]
+    joint_X_c_effective_gpu: wp.array[wp.transform]
+    shape_body_effective_gpu: wp.array[wp.int32]
 
 
 def compute_fixed_joint_merge(
@@ -146,22 +145,21 @@ def compute_fixed_joint_merge(
                 relative_xform_of[child_body] = incoming_xform
 
                 sv = survivor_of[last_dynamic_body]
-                child_m = float(body_mass_np[child_body])
-                child_com = wp.transform_point(incoming_xform, wp.vec3(*body_com_np[child_body]))
-                child_inertia = wp.mat33(*body_inertia_np[child_body].flatten())
-                child_inertia_transformed = transform_inertia(
-                    child_m, child_inertia, incoming_xform.p, incoming_xform.q
+                new_m, new_com, new_I = _accumulate_child_into_survivor(
+                    merged_mass[sv],
+                    merged_com[sv],
+                    merged_inertia[sv],
+                    float(body_mass_np[child_body]),
+                    wp.vec3(*body_com_np[child_body]),
+                    wp.mat33(*body_inertia_np[child_body].flatten()),
+                    incoming_xform,
                 )
-
-                sv_m = merged_mass[sv]
-                sv_com = merged_com[sv]
-                new_m = sv_m + child_m
-                merged_inertia[sv] = merged_inertia[sv] + child_inertia_transformed
                 merged_mass[sv] = new_m
+                merged_com[sv] = new_com
+                merged_inertia[sv] = new_I
                 if new_m > 0.0:
-                    merged_com[sv] = (child_m * child_com + sv_m * sv_com) * (1.0 / new_m)
                     merged_inv_mass[sv] = 1.0 / new_m
-                    merged_inv_inertia[sv] = _safe_inv_mat33(merged_inertia[sv], new_m)
+                    merged_inv_inertia[sv] = _safe_inv_mat33(new_I, new_m)
                 # Child is absorbed; zero its effective inverse mass/inertia.
                 merged_inv_mass[child_body] = 0.0
                 merged_inv_inertia[child_body] = wp.mat33(0.0)
@@ -262,6 +260,47 @@ def _safe_inv_mat33(m: wp.mat33, mass: float) -> wp.mat33:
     return wp.inverse(m)
 
 
+_I3 = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+
+def _shift_inertia(inertia: wp.mat33, mass: float, offset: wp.vec3) -> wp.mat33:
+    """Shift an inertia tensor by ``offset`` via the parallel-axis theorem."""
+    return inertia + mass * (wp.dot(offset, offset) * _I3 - wp.outer(offset, offset))
+
+
+def _accumulate_child_into_survivor(
+    sv_m: float,
+    sv_com: wp.vec3,
+    sv_I: wp.mat33,
+    child_m: float,
+    child_com_local: wp.vec3,
+    child_I_local: wp.mat33,
+    incoming_xform: wp.transform,
+):
+    """Fuse a child body into the survivor.
+
+    Returns ``(mass, com, inertia)`` in the survivor's body frame, with
+    ``inertia`` parallel-axis-shifted to be expressed about the new combined
+    COM (Newton's convention for ``body_inertia``).
+    """
+    com_c_in_sv = wp.transform_point(incoming_xform, child_com_local)
+    new_m = sv_m + child_m
+    if new_m <= 0.0:
+        return new_m, sv_com, sv_I
+    new_com = (sv_m * sv_com + child_m * com_c_in_sv) * (1.0 / new_m)
+
+    # Survivor's existing inertia (about old sv_com) shifted to new_com.
+    sv_I_at_new = _shift_inertia(sv_I, sv_m, sv_com - new_com)
+
+    # Rotate child's inertia into survivor frame, then shift from child COM
+    # (in survivor frame) to new_com.
+    R = wp.quat_to_matrix(incoming_xform.q)
+    child_I_in_sv = R @ child_I_local @ wp.transpose(R)
+    child_I_at_new = _shift_inertia(child_I_in_sv, child_m, com_c_in_sv - new_com)
+
+    return new_m, new_com, sv_I_at_new + child_I_at_new
+
+
 @wp.kernel
 def _propagate_merged_body_poses(
     survivor_indices: wp.array[wp.int32],
@@ -280,18 +319,24 @@ def _propagate_merged_body_velocities(
     survivor_indices: wp.array[wp.int32],
     body_q: wp.array[wp.transform],
     relative_xforms: wp.array[wp.transform],
+    body_com_original: wp.array[wp.vec3],
+    merged_body_com: wp.array[wp.vec3],
     body_qd: wp.array[wp.spatial_vector],
 ):
     """Propagate survivor spatial velocity to each merged child."""
-    # Newton convention: spatial_vector(linear, angular).
+    # body_qd stores linear velocity at COM (Newton convention), so the
+    # lever arm must be the COM-to-COM offset in world, not body-origin to
+    # body-origin.  spatial_vector layout is (linear, angular).
     tid = wp.tid()
     s = survivor_indices[tid]
     if s != tid:
         tw = body_qd[s]
         v = wp.spatial_top(tw)
         w = wp.spatial_bottom(tw)
-        r_local = relative_xforms[tid].p
-        r_world = wp.transform_vector(body_q[s], r_local)
+        com_s_world = wp.transform_point(body_q[s], merged_body_com[s])
+        child_q_world = body_q[s] * relative_xforms[tid]
+        com_c_world = wp.transform_point(child_q_world, body_com_original[tid])
+        r_world = com_c_world - com_s_world
         body_qd[tid] = wp.spatial_vector(v + wp.cross(w, r_world), w)
 
 

--- a/newton/_src/solvers/_fixed_joint_merger.py
+++ b/newton/_src/solvers/_fixed_joint_merger.py
@@ -3,8 +3,8 @@
 
 """Solver-level fixed-joint merger utility.
 
-Computes merge metadata from a finalized :class:`~newton.Model` and provides
-Warp kernels to propagate merged-body poses/velocities after each solver step.
+Produces an effective-index layer that routes shapes, joints, and body forces
+onto surviving bodies without modifying the :class:`~newton.Model`.
 """
 
 from __future__ import annotations
@@ -20,50 +20,11 @@ from ..sim.model import Model
 
 @dataclass
 class FixedJointMergeInfo:
-    """Describes which bodies are collapsed at the solver level.
-
-    Computed once at solver construction from the finalized :class:`~newton.Model`.
-    All GPU arrays are allocated on the same device as the model.
-
-    Attributes:
-        has_merges: True iff at least one FIXED joint was collapsed.
-        survivor_of: Per-body survivor index, shape [body_count].
-            ``survivor_of[b] == b`` for bodies that are not merged children.
-        relative_xform_of: Per-body transform from the survivor frame to body
-            ``b``'s frame [m, unitless quat], shape [body_count].
-            Identity transform for survivors.
-        merged_body_mass: Per-body accumulated mass [kg], shape [body_count].
-            Survivor bodies hold the sum of their own mass plus all merged
-            children; merged children retain their original mass (it is not
-            used in dynamics since their effective inv_mass is zeroed).
-        merged_body_inertia: Per-body accumulated inertia tensor [kg·m²],
-            shape [body_count].
-        merged_body_inv_mass: Per-body effective inverse mass [1/kg],
-            shape [body_count].  0 for merged children and for zero-mass bodies.
-        merged_body_inv_inertia: Per-body effective inverse inertia [1/(kg·m²)],
-            shape [body_count].  Zero matrix for merged children.
-        merged_body_com: Per-body accumulated center of mass [m],
-            shape [body_count].  Mass-weighted average for survivors.
-        joint_enabled_effective: Per-joint effective enabled flag,
-            shape [joint_count].  False for FIXED joints that were collapsed.
-        survivor_indices_gpu: GPU int32 array, shape [body_count].
-        relative_xforms_gpu: GPU transform array, shape [body_count].
-        merged_body_inv_mass_gpu: GPU float array, shape [body_count].
-        merged_body_inv_inertia_gpu: GPU mat33 array, shape [body_count].
-        merged_body_mass_gpu: GPU float array, shape [body_count].
-        merged_body_inertia_gpu: GPU mat33 array, shape [body_count].
-        merged_body_com_gpu: GPU vec3 array, shape [body_count].
-    """
+    """Solver-level merge metadata for collapsed FIXED joints."""
 
     has_merges: bool
     survivor_of: list[int]
     relative_xform_of: list[wp.transform]
-    merged_body_mass: list[float]
-    merged_body_inertia: list[wp.mat33]
-    merged_body_inv_mass: list[float]
-    merged_body_inv_inertia: list[wp.mat33]
-    merged_body_com: list[wp.vec3]
-    joint_enabled_effective: list[bool]
     survivor_indices_gpu: wp.array
     relative_xforms_gpu: wp.array
     merged_body_inv_mass_gpu: wp.array
@@ -71,6 +32,12 @@ class FixedJointMergeInfo:
     merged_body_mass_gpu: wp.array
     merged_body_inertia_gpu: wp.array
     merged_body_com_gpu: wp.array
+    joint_enabled_effective_gpu: wp.array
+    joint_parent_effective_gpu: wp.array
+    joint_child_effective_gpu: wp.array
+    joint_X_p_effective_gpu: wp.array
+    joint_X_c_effective_gpu: wp.array
+    shape_body_effective_gpu: wp.array
 
 
 def compute_fixed_joint_merge(
@@ -79,18 +46,12 @@ def compute_fixed_joint_merge(
 ) -> FixedJointMergeInfo | None:
     """Compute solver-level fixed-joint merge metadata from a finalized model.
 
-    Reproduces the same DFS algorithm used by
-    :meth:`~newton.ModelBuilder.collapse_fixed_joints` but reads from the
-    finalized :class:`~newton.Model` arrays instead of the builder's Python
-    lists.  The model is never modified.
-
     Args:
-        model: The finalized model to analyse.
-        joints_to_keep: Optional list of joint labels to exempt from collapsing.
+        model: The finalized model to analyse. Never modified.
+        joints_to_keep: Joint labels to exempt from collapsing.
 
     Returns:
-        :class:`FixedJointMergeInfo` when at least one FIXED joint is
-        collapsed, or ``None`` when no merging is needed.
+        Merge metadata, or ``None`` when no FIXED joints are collapsed.
     """
     if joints_to_keep is None:
         joints_to_keep = []
@@ -106,12 +67,17 @@ def compute_fixed_joint_merge(
     joint_parent_np = model.joint_parent.numpy()
     joint_child_np = model.joint_child.numpy()
     joint_enabled_np = model.joint_enabled.numpy()
-    joint_X_p_np = model.joint_X_p.numpy()  # shape [joint_count, 7]
-    joint_X_c_np = model.joint_X_c.numpy()  # shape [joint_count, 7]
+    joint_X_p_np = model.joint_X_p.numpy()
+    joint_X_c_np = model.joint_X_c.numpy()
     body_inv_mass_np = model.body_inv_mass.numpy()
-    body_inertia_np = model.body_inertia.numpy()  # shape [body_count, 3, 3]
-    body_com_np = model.body_com.numpy()  # shape [body_count, 3]
+    body_inertia_np = model.body_inertia.numpy()
+    body_com_np = model.body_com.numpy()
     body_mass_np = model.body_mass.numpy()
+    body_flags_np = model.body_flags.numpy()
+
+    def _is_kinematic(b: int) -> bool:
+        return b >= 0 and bool(int(body_flags_np[b]) & int(BodyFlags.KINEMATIC))
+
     # Collect constraint bodies to avoid merging into world.
     bodies_in_constraints: set[int] = set()
     if model.equality_constraint_count > 0 and model.equality_constraint_body1 is not None:
@@ -120,7 +86,7 @@ def compute_fixed_joint_merge(
         bodies_in_constraints.update(int(x) for x in b1 if x >= 0)
         bodies_in_constraints.update(int(x) for x in b2 if x >= 0)
 
-    # Build body → children adjacency (joint index included for lookup).
+    # Build body → children adjacency.
     body_children: dict[int, list[int]] = {-1: []}
     joint_of: dict[tuple[int, int], int] = {}
     for i in range(body_count):
@@ -131,48 +97,54 @@ def compute_fixed_joint_merge(
         body_children[p].append(c)
         joint_of[(p, c)] = j
 
-    # Sort children so traversal order matches body index order.
     for children in body_children.values():
         children.sort()
 
-    # Initialise per-body working state.
     survivor_of: list[int] = list(range(body_count))
     relative_xform_of: list[wp.transform] = [wp.transform() for _ in range(body_count)]
 
-    merged_body_mass: list[float] = [float(body_mass_np[b]) for b in range(body_count)]
-    merged_body_inertia: list[wp.mat33] = [wp.mat33(*body_inertia_np[b].flatten()) for b in range(body_count)]
-    merged_body_inv_mass: list[float] = [float(body_inv_mass_np[b]) for b in range(body_count)]
-    merged_body_inv_inertia: list[wp.mat33] = [
+    merged_mass: list[float] = [float(body_mass_np[b]) for b in range(body_count)]
+    merged_inertia: list[wp.mat33] = [wp.mat33(*body_inertia_np[b].flatten()) for b in range(body_count)]
+    merged_inv_mass: list[float] = [float(body_inv_mass_np[b]) for b in range(body_count)]
+    merged_inv_inertia: list[wp.mat33] = [
         _safe_inv_mat33(wp.mat33(*body_inertia_np[b].flatten()), float(body_mass_np[b])) for b in range(body_count)
     ]
-    merged_body_com: list[wp.vec3] = [wp.vec3(*body_com_np[b]) for b in range(body_count)]
+    merged_com: list[wp.vec3] = [wp.vec3(*body_com_np[b]) for b in range(body_count)]
 
-    joint_enabled_effective: list[bool] = [bool(joint_enabled_np[j]) for j in range(joint_count)]
+    # Inherit model.joint_enabled so user-disabled joints stay disabled.
+    joint_enabled_eff: list[bool] = [bool(joint_enabled_np[j]) for j in range(joint_count)]
 
     visited: list[bool] = [False] * body_count
 
     def dfs(parent_body: int, child_body: int, incoming_xform: wp.transform, last_dynamic_body: int) -> None:
         j = joint_of[(parent_body, child_body)]
         jtype = int(joint_type_np[j])
+        joint_is_enabled = bool(joint_enabled_np[j])
         should_skip_merge = child_body in bodies_in_constraints and last_dynamic_body == -1
+        # Treat kinematic survivors like world: never absorb a dynamic body
+        # into one, since that would erase the joint reaction observable on
+        # state.body_parent_f.
+        survivor_is_kinematic = _is_kinematic(last_dynamic_body)
         joint_in_keep_list = model.joint_label[j] in joints_to_keep
 
-        if jtype == JointType.FIXED and not should_skip_merge and not joint_in_keep_list:
-            # Accumulate this fixed joint's transform.
+        if (
+            jtype == JointType.FIXED
+            and joint_is_enabled
+            and not should_skip_merge
+            and not survivor_is_kinematic
+            and not joint_in_keep_list
+        ):
             X_p = _np_row_to_transform(joint_X_p_np[j])
             X_c = _np_row_to_transform(joint_X_c_np[j])
             joint_xform = X_p * wp.transform_inverse(X_c)
             incoming_xform = incoming_xform * joint_xform
 
-            # Mark joint as collapsed.
-            joint_enabled_effective[j] = False
+            joint_enabled_eff[j] = False
 
             if last_dynamic_body >= 0:
-                # Record which survivor this body belongs to.
                 survivor_of[child_body] = survivor_of[last_dynamic_body]
                 relative_xform_of[child_body] = incoming_xform
 
-                # Accumulate mass, COM and inertia into the survivor.
                 sv = survivor_of[last_dynamic_body]
                 child_m = float(body_mass_np[child_body])
                 child_com = wp.transform_point(incoming_xform, wp.vec3(*body_com_np[child_body]))
@@ -181,20 +153,19 @@ def compute_fixed_joint_merge(
                     child_m, child_inertia, incoming_xform.p, incoming_xform.q
                 )
 
-                sv_m = merged_body_mass[sv]
-                sv_com = merged_body_com[sv]
+                sv_m = merged_mass[sv]
+                sv_com = merged_com[sv]
                 new_m = sv_m + child_m
-                merged_body_inertia[sv] = merged_body_inertia[sv] + child_inertia_transformed
-                merged_body_mass[sv] = new_m
+                merged_inertia[sv] = merged_inertia[sv] + child_inertia_transformed
+                merged_mass[sv] = new_m
                 if new_m > 0.0:
-                    merged_body_com[sv] = (child_m * child_com + sv_m * sv_com) * (1.0 / new_m)
-                    merged_body_inv_mass[sv] = 1.0 / new_m
-                    merged_body_inv_inertia[sv] = _safe_inv_mat33(merged_body_inertia[sv], new_m)
-                # Merged children: zeroed so they don't accumulate contact deltas.
-                merged_body_inv_mass[child_body] = 0.0
-                merged_body_inv_inertia[child_body] = wp.mat33(0.0)
+                    merged_com[sv] = (child_m * child_com + sv_m * sv_com) * (1.0 / new_m)
+                    merged_inv_mass[sv] = 1.0 / new_m
+                    merged_inv_inertia[sv] = _safe_inv_mat33(merged_inertia[sv], new_m)
+                # Child is absorbed; zero its effective inverse mass/inertia.
+                merged_inv_mass[child_body] = 0.0
+                merged_inv_inertia[child_body] = wp.mat33(0.0)
         else:
-            # Non-fixed (or exempted fixed) joint: child is its own survivor.
             last_dynamic_body = child_body
             incoming_xform = wp.transform()
 
@@ -203,12 +174,11 @@ def compute_fixed_joint_merge(
             if not visited[next_child]:
                 dfs(child_body, next_child, incoming_xform, last_dynamic_body)
 
-    # Traverse from world root.
     for root in body_children[-1]:
         if not visited[root]:
             dfs(-1, root, wp.transform(), -1)
 
-    # Handle bodies not reachable from world (disconnected subtrees).
+    # Disconnected subtrees that don't reach world.
     children_in_joints = {c for p, cs in body_children.items() if p >= 0 for c in cs}
     for b in range(body_count):
         if visited[b]:
@@ -224,39 +194,57 @@ def compute_fixed_joint_merge(
     if not has_merges:
         return None
 
-    # Allocate GPU arrays.
-    dev = model.device
-    survivor_indices_gpu = wp.array(survivor_of, dtype=wp.int32, device=dev)
-    relative_xforms_gpu = wp.array(relative_xform_of, dtype=wp.transform, device=dev)
-    merged_body_inv_mass_gpu = wp.array(merged_body_inv_mass, dtype=wp.float32, device=dev)
-    merged_body_inv_inertia_gpu = wp.array(merged_body_inv_inertia, dtype=wp.mat33, device=dev)
-    merged_body_mass_gpu = wp.array(merged_body_mass, dtype=wp.float32, device=dev)
-    merged_body_inertia_gpu = wp.array(merged_body_inertia, dtype=wp.mat33, device=dev)
-    merged_body_com_gpu = wp.array(merged_body_com, dtype=wp.vec3, device=dev)
+    # Effective-index layer: remap shapes/joints onto survivors so kernels
+    # don't have to chase indirections.  Anchors are pre-multiplied by the
+    # parent/child's relative_xform to land in the survivor's frame.
+    joint_parent_eff: list[int] = [int(joint_parent_np[j]) for j in range(joint_count)]
+    joint_child_eff: list[int] = [int(joint_child_np[j]) for j in range(joint_count)]
+    joint_X_p_eff: list[wp.transform] = [_np_row_to_transform(joint_X_p_np[j]) for j in range(joint_count)]
+    joint_X_c_eff: list[wp.transform] = [_np_row_to_transform(joint_X_c_np[j]) for j in range(joint_count)]
+    for j in range(joint_count):
+        p = joint_parent_eff[j]
+        c = joint_child_eff[j]
+        if p >= 0 and survivor_of[p] != p:
+            joint_X_p_eff[j] = relative_xform_of[p] * joint_X_p_eff[j]
+            joint_parent_eff[j] = survivor_of[p]
+        if c >= 0 and survivor_of[c] != c:
+            joint_X_c_eff[j] = relative_xform_of[c] * joint_X_c_eff[j]
+            joint_child_eff[j] = survivor_of[c]
 
+    shape_count = model.shape_count
+    if shape_count > 0 and model.shape_body is not None:
+        shape_body_np = model.shape_body.numpy()
+        shape_body_eff: list[int] = [int(b) for b in shape_body_np]
+        for s in range(shape_count):
+            b = shape_body_eff[s]
+            if b >= 0 and survivor_of[b] != b:
+                shape_body_eff[s] = survivor_of[b]
+    else:
+        shape_body_eff = []
+
+    dev = model.device
     return FixedJointMergeInfo(
         has_merges=has_merges,
         survivor_of=survivor_of,
         relative_xform_of=relative_xform_of,
-        merged_body_mass=merged_body_mass,
-        merged_body_inertia=merged_body_inertia,
-        merged_body_inv_mass=merged_body_inv_mass,
-        merged_body_inv_inertia=merged_body_inv_inertia,
-        merged_body_com=merged_body_com,
-        joint_enabled_effective=joint_enabled_effective,
-        survivor_indices_gpu=survivor_indices_gpu,
-        relative_xforms_gpu=relative_xforms_gpu,
-        merged_body_inv_mass_gpu=merged_body_inv_mass_gpu,
-        merged_body_inv_inertia_gpu=merged_body_inv_inertia_gpu,
-        merged_body_mass_gpu=merged_body_mass_gpu,
-        merged_body_inertia_gpu=merged_body_inertia_gpu,
-        merged_body_com_gpu=merged_body_com_gpu,
+        survivor_indices_gpu=wp.array(survivor_of, dtype=wp.int32, device=dev),
+        relative_xforms_gpu=wp.array(relative_xform_of, dtype=wp.transform, device=dev),
+        merged_body_inv_mass_gpu=wp.array(merged_inv_mass, dtype=wp.float32, device=dev),
+        merged_body_inv_inertia_gpu=wp.array(merged_inv_inertia, dtype=wp.mat33, device=dev),
+        merged_body_mass_gpu=wp.array(merged_mass, dtype=wp.float32, device=dev),
+        merged_body_inertia_gpu=wp.array(merged_inertia, dtype=wp.mat33, device=dev),
+        merged_body_com_gpu=wp.array(merged_com, dtype=wp.vec3, device=dev),
+        joint_enabled_effective_gpu=wp.array(joint_enabled_eff, dtype=wp.bool, device=dev),
+        joint_parent_effective_gpu=wp.array(joint_parent_eff, dtype=wp.int32, device=dev),
+        joint_child_effective_gpu=wp.array(joint_child_eff, dtype=wp.int32, device=dev),
+        joint_X_p_effective_gpu=wp.array(joint_X_p_eff, dtype=wp.transform, device=dev),
+        joint_X_c_effective_gpu=wp.array(joint_X_c_eff, dtype=wp.transform, device=dev),
+        shape_body_effective_gpu=(
+            wp.array(shape_body_eff, dtype=wp.int32, device=dev)
+            if shape_body_eff
+            else wp.empty(0, dtype=wp.int32, device=dev)
+        ),
     )
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _np_row_to_transform(row) -> wp.transform:
@@ -274,24 +262,13 @@ def _safe_inv_mat33(m: wp.mat33, mass: float) -> wp.mat33:
     return wp.inverse(m)
 
 
-# ---------------------------------------------------------------------------
-# Warp kernels (called from SolverBase)
-# ---------------------------------------------------------------------------
-
-
 @wp.kernel
 def _propagate_merged_body_poses(
     survivor_indices: wp.array[wp.int32],
     relative_xforms: wp.array[wp.transform],
     body_q: wp.array[wp.transform],
 ):
-    """Scatter survivor pose into each merged child's body_q slot.
-
-    Survivors are left untouched (their thread is a no-op).  Each merged child
-    gets ``body_q[child] = body_q[survivor] * relative_xform[child]``.
-    There is no write-aliasing: each thread writes exactly its own slot, and
-    survivor indices are always distinct from child indices by construction.
-    """
+    """Scatter survivor pose into each merged child's body_q slot."""
     tid = wp.tid()
     s = survivor_indices[tid]
     if s != tid:
@@ -305,22 +282,45 @@ def _propagate_merged_body_velocities(
     relative_xforms: wp.array[wp.transform],
     body_qd: wp.array[wp.spatial_vector],
 ):
-    """Propagate the survivor's spatial velocity to each merged child.
-
-    Uses the rigid-body formula:
-    ``v_child = v_survivor + omega_survivor x r``
-    where ``r`` is the offset from the survivor's COM to the child's frame
-    origin in world space.
-    """
+    """Propagate survivor spatial velocity to each merged child."""
+    # Newton convention: spatial_vector(linear, angular).
     tid = wp.tid()
     s = survivor_indices[tid]
     if s != tid:
         tw = body_qd[s]
-        w = wp.spatial_top(tw)  # angular velocity
-        v = wp.spatial_bottom(tw)  # linear velocity at survivor COM
+        v = wp.spatial_top(tw)
+        w = wp.spatial_bottom(tw)
         r_local = relative_xforms[tid].p
         r_world = wp.transform_vector(body_q[s], r_local)
-        body_qd[tid] = wp.spatial_vector(w, v + wp.cross(w, r_world))
+        body_qd[tid] = wp.spatial_vector(v + wp.cross(w, r_world), w)
+
+
+@wp.kernel
+def _scatter_body_forces_to_survivors(
+    survivor_indices: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    body_com: wp.array[wp.vec3],
+    relative_xforms: wp.array[wp.transform],
+    body_f: wp.array[wp.spatial_vector],
+):
+    """Move merged-child body_f onto the survivor and zero the child slot."""
+    tid = wp.tid()
+    s = survivor_indices[tid]
+    if s == tid:
+        return
+    fc = body_f[tid]
+    f_lin = wp.spatial_top(fc)
+    f_ang = wp.spatial_bottom(fc)
+    sv_q = body_q[s]
+    com_s_world = wp.transform_point(sv_q, body_com[s])
+    # Child body_q may be stale here (propagation runs at end-of-step), so
+    # reconstruct child COM through the rigid relation.
+    rel = relative_xforms[tid]
+    child_q = sv_q * rel
+    com_c_world = wp.transform_point(child_q, body_com[tid])
+    r_world = com_c_world - com_s_world
+    wp.atomic_add(body_f, s, wp.spatial_vector(f_lin, f_ang + wp.cross(r_world, f_lin)))
+    body_f[tid] = wp.spatial_vector(wp.vec3(0.0), wp.vec3(0.0))
 
 
 @wp.kernel
@@ -332,12 +332,7 @@ def _update_effective_inv_mass_inertia_merged(
     eff_inv_mass: wp.array[float],
     eff_inv_inertia: wp.array[wp.mat33],
 ):
-    """Compute effective inverse mass/inertia with merged-body accumulation.
-
-    Kinematic bodies and merged children both get zero effective mass so they
-    do not accumulate contact deltas.  Survivor bodies use their accumulated
-    inverse mass/inertia from the merge computation.
-    """
+    """Effective inverse mass/inertia, zeroed for kinematic and merged-child bodies."""
     tid = wp.tid()
     zero_mat = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     if (body_flags[tid] & BodyFlags.KINEMATIC) != 0 or survivor_indices[tid] != tid:

--- a/newton/_src/solvers/_fixed_joint_merger.py
+++ b/newton/_src/solvers/_fixed_joint_merger.py
@@ -61,7 +61,6 @@ def compute_fixed_joint_merge(
     if body_count == 0 or joint_count == 0:
         return None
 
-    # Pull everything to CPU once.
     joint_type_np = model.joint_type.numpy()
     joint_parent_np = model.joint_parent.numpy()
     joint_child_np = model.joint_child.numpy()
@@ -77,7 +76,7 @@ def compute_fixed_joint_merge(
     def _is_kinematic(b: int) -> bool:
         return b >= 0 and bool(int(body_flags_np[b]) & int(BodyFlags.KINEMATIC))
 
-    # Collect constraint bodies to avoid merging into world.
+    # Bodies referenced by equality constraints — never merge.
     bodies_in_constraints: set[int] = set()
     if model.equality_constraint_count > 0 and model.equality_constraint_body1 is not None:
         b1 = model.equality_constraint_body1.numpy()
@@ -85,7 +84,6 @@ def compute_fixed_joint_merge(
         bodies_in_constraints.update(int(x) for x in b1 if x >= 0)
         bodies_in_constraints.update(int(x) for x in b2 if x >= 0)
 
-    # Build body → children adjacency.
     body_children: dict[int, list[int]] = {-1: []}
     joint_of: dict[tuple[int, int], int] = {}
     for i in range(body_count):
@@ -119,10 +117,9 @@ def compute_fixed_joint_merge(
         j = joint_of[(parent_body, child_body)]
         jtype = int(joint_type_np[j])
         joint_is_enabled = bool(joint_enabled_np[j])
-        should_skip_merge = child_body in bodies_in_constraints and last_dynamic_body == -1
-        # Treat kinematic survivors like world: never absorb a dynamic body
-        # into one, since that would erase the joint reaction observable on
-        # state.body_parent_f.
+        # Equality constraints index by body and aren't remapped; never absorb.
+        should_skip_merge = child_body in bodies_in_constraints
+        # Kinematic survivors are treated like world: don't absorb dynamic bodies into them.
         survivor_is_kinematic = _is_kinematic(last_dynamic_body)
         joint_in_keep_list = model.joint_label[j] in joints_to_keep
 
@@ -160,7 +157,6 @@ def compute_fixed_joint_merge(
                 if new_m > 0.0:
                     merged_inv_mass[sv] = 1.0 / new_m
                     merged_inv_inertia[sv] = _safe_inv_mat33(new_I, new_m)
-                # Child is absorbed; zero its effective inverse mass/inertia.
                 merged_inv_mass[child_body] = 0.0
                 merged_inv_inertia[child_body] = wp.mat33(0.0)
         else:
@@ -192,9 +188,7 @@ def compute_fixed_joint_merge(
     if not has_merges:
         return None
 
-    # Effective-index layer: remap shapes/joints onto survivors so kernels
-    # don't have to chase indirections.  Anchors are pre-multiplied by the
-    # parent/child's relative_xform to land in the survivor's frame.
+    # Effective-index layer: anchors pre-multiplied so they land in the survivor's frame.
     joint_parent_eff: list[int] = [int(joint_parent_np[j]) for j in range(joint_count)]
     joint_child_eff: list[int] = [int(joint_child_np[j]) for j in range(joint_count)]
     joint_X_p_eff: list[wp.transform] = [_np_row_to_transform(joint_X_p_np[j]) for j in range(joint_count)]
@@ -289,11 +283,8 @@ def _accumulate_child_into_survivor(
         return new_m, sv_com, sv_I
     new_com = (sv_m * sv_com + child_m * com_c_in_sv) * (1.0 / new_m)
 
-    # Survivor's existing inertia (about old sv_com) shifted to new_com.
+    # Shift both sides to the new combined COM so the sum is consistent.
     sv_I_at_new = _shift_inertia(sv_I, sv_m, sv_com - new_com)
-
-    # Rotate child's inertia into survivor frame, then shift from child COM
-    # (in survivor frame) to new_com.
     R = wp.quat_to_matrix(incoming_xform.q)
     child_I_in_sv = R @ child_I_local @ wp.transpose(R)
     child_I_at_new = _shift_inertia(child_I_in_sv, child_m, com_c_in_sv - new_com)
@@ -324,9 +315,7 @@ def _propagate_merged_body_velocities(
     body_qd: wp.array[wp.spatial_vector],
 ):
     """Propagate survivor spatial velocity to each merged child."""
-    # body_qd stores linear velocity at COM (Newton convention), so the
-    # lever arm must be the COM-to-COM offset in world, not body-origin to
-    # body-origin.  spatial_vector layout is (linear, angular).
+    # body_qd is (linear-at-COM, angular); lever arm is the COM-to-COM world offset.
     tid = wp.tid()
     s = survivor_indices[tid]
     if s != tid:
@@ -358,8 +347,7 @@ def _scatter_body_forces_to_survivors(
     f_ang = wp.spatial_bottom(fc)
     sv_q = body_q[s]
     com_s_world = wp.transform_point(sv_q, body_com[s])
-    # Child body_q may be stale here (propagation runs at end-of-step), so
-    # reconstruct child COM through the rigid relation.
+    # Child body_q may be stale (propagation runs at end-of-step); rebuild via the rigid relation.
     rel = relative_xforms[tid]
     child_q = sv_q * rel
     com_c_world = wp.transform_point(child_q, body_com[tid])

--- a/newton/_src/solvers/_fixed_joint_merger.py
+++ b/newton/_src/solvers/_fixed_joint_merger.py
@@ -1,0 +1,348 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Solver-level fixed-joint merger utility.
+
+Computes merge metadata from a finalized :class:`~newton.Model` and provides
+Warp kernels to propagate merged-body poses/velocities after each solver step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import warp as wp
+
+from ..geometry.inertia import transform_inertia
+from ..sim import BodyFlags, JointType
+from ..sim.model import Model
+
+
+@dataclass
+class FixedJointMergeInfo:
+    """Describes which bodies are collapsed at the solver level.
+
+    Computed once at solver construction from the finalized :class:`~newton.Model`.
+    All GPU arrays are allocated on the same device as the model.
+
+    Attributes:
+        has_merges: True iff at least one FIXED joint was collapsed.
+        survivor_of: Per-body survivor index, shape [body_count].
+            ``survivor_of[b] == b`` for bodies that are not merged children.
+        relative_xform_of: Per-body transform from the survivor frame to body
+            ``b``'s frame [m, unitless quat], shape [body_count].
+            Identity transform for survivors.
+        merged_body_mass: Per-body accumulated mass [kg], shape [body_count].
+            Survivor bodies hold the sum of their own mass plus all merged
+            children; merged children retain their original mass (it is not
+            used in dynamics since their effective inv_mass is zeroed).
+        merged_body_inertia: Per-body accumulated inertia tensor [kg·m²],
+            shape [body_count].
+        merged_body_inv_mass: Per-body effective inverse mass [1/kg],
+            shape [body_count].  0 for merged children and for zero-mass bodies.
+        merged_body_inv_inertia: Per-body effective inverse inertia [1/(kg·m²)],
+            shape [body_count].  Zero matrix for merged children.
+        merged_body_com: Per-body accumulated center of mass [m],
+            shape [body_count].  Mass-weighted average for survivors.
+        joint_enabled_effective: Per-joint effective enabled flag,
+            shape [joint_count].  False for FIXED joints that were collapsed.
+        survivor_indices_gpu: GPU int32 array, shape [body_count].
+        relative_xforms_gpu: GPU transform array, shape [body_count].
+        merged_body_inv_mass_gpu: GPU float array, shape [body_count].
+        merged_body_inv_inertia_gpu: GPU mat33 array, shape [body_count].
+        merged_body_mass_gpu: GPU float array, shape [body_count].
+        merged_body_inertia_gpu: GPU mat33 array, shape [body_count].
+        merged_body_com_gpu: GPU vec3 array, shape [body_count].
+    """
+
+    has_merges: bool
+    survivor_of: list[int]
+    relative_xform_of: list[wp.transform]
+    merged_body_mass: list[float]
+    merged_body_inertia: list[wp.mat33]
+    merged_body_inv_mass: list[float]
+    merged_body_inv_inertia: list[wp.mat33]
+    merged_body_com: list[wp.vec3]
+    joint_enabled_effective: list[bool]
+    survivor_indices_gpu: wp.array
+    relative_xforms_gpu: wp.array
+    merged_body_inv_mass_gpu: wp.array
+    merged_body_inv_inertia_gpu: wp.array
+    merged_body_mass_gpu: wp.array
+    merged_body_inertia_gpu: wp.array
+    merged_body_com_gpu: wp.array
+
+
+def compute_fixed_joint_merge(
+    model: Model,
+    joints_to_keep: list[str] | None = None,
+) -> FixedJointMergeInfo | None:
+    """Compute solver-level fixed-joint merge metadata from a finalized model.
+
+    Reproduces the same DFS algorithm used by
+    :meth:`~newton.ModelBuilder.collapse_fixed_joints` but reads from the
+    finalized :class:`~newton.Model` arrays instead of the builder's Python
+    lists.  The model is never modified.
+
+    Args:
+        model: The finalized model to analyse.
+        joints_to_keep: Optional list of joint labels to exempt from collapsing.
+
+    Returns:
+        :class:`FixedJointMergeInfo` when at least one FIXED joint is
+        collapsed, or ``None`` when no merging is needed.
+    """
+    if joints_to_keep is None:
+        joints_to_keep = []
+
+    body_count = model.body_count
+    joint_count = model.joint_count
+
+    if body_count == 0 or joint_count == 0:
+        return None
+
+    # Pull everything to CPU once.
+    joint_type_np = model.joint_type.numpy()
+    joint_parent_np = model.joint_parent.numpy()
+    joint_child_np = model.joint_child.numpy()
+    joint_enabled_np = model.joint_enabled.numpy()
+    joint_X_p_np = model.joint_X_p.numpy()  # shape [joint_count, 7]
+    joint_X_c_np = model.joint_X_c.numpy()  # shape [joint_count, 7]
+    body_inv_mass_np = model.body_inv_mass.numpy()
+    body_inertia_np = model.body_inertia.numpy()  # shape [body_count, 3, 3]
+    body_com_np = model.body_com.numpy()  # shape [body_count, 3]
+    body_mass_np = model.body_mass.numpy()
+    # Collect constraint bodies to avoid merging into world.
+    bodies_in_constraints: set[int] = set()
+    if model.equality_constraint_count > 0 and model.equality_constraint_body1 is not None:
+        b1 = model.equality_constraint_body1.numpy()
+        b2 = model.equality_constraint_body2.numpy()
+        bodies_in_constraints.update(int(x) for x in b1 if x >= 0)
+        bodies_in_constraints.update(int(x) for x in b2 if x >= 0)
+
+    # Build body → children adjacency (joint index included for lookup).
+    body_children: dict[int, list[int]] = {-1: []}
+    joint_of: dict[tuple[int, int], int] = {}
+    for i in range(body_count):
+        body_children[i] = []
+    for j in range(joint_count):
+        p = int(joint_parent_np[j])
+        c = int(joint_child_np[j])
+        body_children[p].append(c)
+        joint_of[(p, c)] = j
+
+    # Sort children so traversal order matches body index order.
+    for children in body_children.values():
+        children.sort()
+
+    # Initialise per-body working state.
+    survivor_of: list[int] = list(range(body_count))
+    relative_xform_of: list[wp.transform] = [wp.transform() for _ in range(body_count)]
+
+    merged_body_mass: list[float] = [float(body_mass_np[b]) for b in range(body_count)]
+    merged_body_inertia: list[wp.mat33] = [wp.mat33(*body_inertia_np[b].flatten()) for b in range(body_count)]
+    merged_body_inv_mass: list[float] = [float(body_inv_mass_np[b]) for b in range(body_count)]
+    merged_body_inv_inertia: list[wp.mat33] = [
+        _safe_inv_mat33(wp.mat33(*body_inertia_np[b].flatten()), float(body_mass_np[b])) for b in range(body_count)
+    ]
+    merged_body_com: list[wp.vec3] = [wp.vec3(*body_com_np[b]) for b in range(body_count)]
+
+    joint_enabled_effective: list[bool] = [bool(joint_enabled_np[j]) for j in range(joint_count)]
+
+    visited: list[bool] = [False] * body_count
+
+    def dfs(parent_body: int, child_body: int, incoming_xform: wp.transform, last_dynamic_body: int) -> None:
+        j = joint_of[(parent_body, child_body)]
+        jtype = int(joint_type_np[j])
+        should_skip_merge = child_body in bodies_in_constraints and last_dynamic_body == -1
+        joint_in_keep_list = model.joint_label[j] in joints_to_keep
+
+        if jtype == JointType.FIXED and not should_skip_merge and not joint_in_keep_list:
+            # Accumulate this fixed joint's transform.
+            X_p = _np_row_to_transform(joint_X_p_np[j])
+            X_c = _np_row_to_transform(joint_X_c_np[j])
+            joint_xform = X_p * wp.transform_inverse(X_c)
+            incoming_xform = incoming_xform * joint_xform
+
+            # Mark joint as collapsed.
+            joint_enabled_effective[j] = False
+
+            if last_dynamic_body >= 0:
+                # Record which survivor this body belongs to.
+                survivor_of[child_body] = survivor_of[last_dynamic_body]
+                relative_xform_of[child_body] = incoming_xform
+
+                # Accumulate mass, COM and inertia into the survivor.
+                sv = survivor_of[last_dynamic_body]
+                child_m = float(body_mass_np[child_body])
+                child_com = wp.transform_point(incoming_xform, wp.vec3(*body_com_np[child_body]))
+                child_inertia = wp.mat33(*body_inertia_np[child_body].flatten())
+                child_inertia_transformed = transform_inertia(
+                    child_m, child_inertia, incoming_xform.p, incoming_xform.q
+                )
+
+                sv_m = merged_body_mass[sv]
+                sv_com = merged_body_com[sv]
+                new_m = sv_m + child_m
+                merged_body_inertia[sv] = merged_body_inertia[sv] + child_inertia_transformed
+                merged_body_mass[sv] = new_m
+                if new_m > 0.0:
+                    merged_body_com[sv] = (child_m * child_com + sv_m * sv_com) * (1.0 / new_m)
+                    merged_body_inv_mass[sv] = 1.0 / new_m
+                    merged_body_inv_inertia[sv] = _safe_inv_mat33(merged_body_inertia[sv], new_m)
+                # Merged children: zeroed so they don't accumulate contact deltas.
+                merged_body_inv_mass[child_body] = 0.0
+                merged_body_inv_inertia[child_body] = wp.mat33(0.0)
+        else:
+            # Non-fixed (or exempted fixed) joint: child is its own survivor.
+            last_dynamic_body = child_body
+            incoming_xform = wp.transform()
+
+        visited[child_body] = True
+        for next_child in body_children.get(child_body, []):
+            if not visited[next_child]:
+                dfs(child_body, next_child, incoming_xform, last_dynamic_body)
+
+    # Traverse from world root.
+    for root in body_children[-1]:
+        if not visited[root]:
+            dfs(-1, root, wp.transform(), -1)
+
+    # Handle bodies not reachable from world (disconnected subtrees).
+    children_in_joints = {c for p, cs in body_children.items() if p >= 0 for c in cs}
+    for b in range(body_count):
+        if visited[b]:
+            continue
+        if b in children_in_joints:
+            continue
+        visited[b] = True
+        for child in body_children.get(b, []):
+            if not visited[child]:
+                dfs(b, child, wp.transform(), b)
+
+    has_merges = any(survivor_of[b] != b for b in range(body_count))
+    if not has_merges:
+        return None
+
+    # Allocate GPU arrays.
+    dev = model.device
+    survivor_indices_gpu = wp.array(survivor_of, dtype=wp.int32, device=dev)
+    relative_xforms_gpu = wp.array(relative_xform_of, dtype=wp.transform, device=dev)
+    merged_body_inv_mass_gpu = wp.array(merged_body_inv_mass, dtype=wp.float32, device=dev)
+    merged_body_inv_inertia_gpu = wp.array(merged_body_inv_inertia, dtype=wp.mat33, device=dev)
+    merged_body_mass_gpu = wp.array(merged_body_mass, dtype=wp.float32, device=dev)
+    merged_body_inertia_gpu = wp.array(merged_body_inertia, dtype=wp.mat33, device=dev)
+    merged_body_com_gpu = wp.array(merged_body_com, dtype=wp.vec3, device=dev)
+
+    return FixedJointMergeInfo(
+        has_merges=has_merges,
+        survivor_of=survivor_of,
+        relative_xform_of=relative_xform_of,
+        merged_body_mass=merged_body_mass,
+        merged_body_inertia=merged_body_inertia,
+        merged_body_inv_mass=merged_body_inv_mass,
+        merged_body_inv_inertia=merged_body_inv_inertia,
+        merged_body_com=merged_body_com,
+        joint_enabled_effective=joint_enabled_effective,
+        survivor_indices_gpu=survivor_indices_gpu,
+        relative_xforms_gpu=relative_xforms_gpu,
+        merged_body_inv_mass_gpu=merged_body_inv_mass_gpu,
+        merged_body_inv_inertia_gpu=merged_body_inv_inertia_gpu,
+        merged_body_mass_gpu=merged_body_mass_gpu,
+        merged_body_inertia_gpu=merged_body_inertia_gpu,
+        merged_body_com_gpu=merged_body_com_gpu,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _np_row_to_transform(row) -> wp.transform:
+    """Reconstruct a wp.transform from a 7-element float32 numpy row [p, q]."""
+    return wp.transform(
+        wp.vec3(float(row[0]), float(row[1]), float(row[2])),
+        wp.quat(float(row[3]), float(row[4]), float(row[5]), float(row[6])),
+    )
+
+
+def _safe_inv_mat33(m: wp.mat33, mass: float) -> wp.mat33:
+    """Return the inverse of m, or a zero matrix when mass is zero."""
+    if mass <= 0.0:
+        return wp.mat33(0.0)
+    return wp.inverse(m)
+
+
+# ---------------------------------------------------------------------------
+# Warp kernels (called from SolverBase)
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def _propagate_merged_body_poses(
+    survivor_indices: wp.array[wp.int32],
+    relative_xforms: wp.array[wp.transform],
+    body_q: wp.array[wp.transform],
+):
+    """Scatter survivor pose into each merged child's body_q slot.
+
+    Survivors are left untouched (their thread is a no-op).  Each merged child
+    gets ``body_q[child] = body_q[survivor] * relative_xform[child]``.
+    There is no write-aliasing: each thread writes exactly its own slot, and
+    survivor indices are always distinct from child indices by construction.
+    """
+    tid = wp.tid()
+    s = survivor_indices[tid]
+    if s != tid:
+        body_q[tid] = body_q[s] * relative_xforms[tid]
+
+
+@wp.kernel
+def _propagate_merged_body_velocities(
+    survivor_indices: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    relative_xforms: wp.array[wp.transform],
+    body_qd: wp.array[wp.spatial_vector],
+):
+    """Propagate the survivor's spatial velocity to each merged child.
+
+    Uses the rigid-body formula:
+    ``v_child = v_survivor + omega_survivor x r``
+    where ``r`` is the offset from the survivor's COM to the child's frame
+    origin in world space.
+    """
+    tid = wp.tid()
+    s = survivor_indices[tid]
+    if s != tid:
+        tw = body_qd[s]
+        w = wp.spatial_top(tw)  # angular velocity
+        v = wp.spatial_bottom(tw)  # linear velocity at survivor COM
+        r_local = relative_xforms[tid].p
+        r_world = wp.transform_vector(body_q[s], r_local)
+        body_qd[tid] = wp.spatial_vector(w, v + wp.cross(w, r_world))
+
+
+@wp.kernel
+def _update_effective_inv_mass_inertia_merged(
+    body_flags: wp.array[wp.int32],
+    survivor_indices: wp.array[wp.int32],
+    merged_inv_mass: wp.array[float],
+    merged_inv_inertia: wp.array[wp.mat33],
+    eff_inv_mass: wp.array[float],
+    eff_inv_inertia: wp.array[wp.mat33],
+):
+    """Compute effective inverse mass/inertia with merged-body accumulation.
+
+    Kinematic bodies and merged children both get zero effective mass so they
+    do not accumulate contact deltas.  Survivor bodies use their accumulated
+    inverse mass/inertia from the merge computation.
+    """
+    tid = wp.tid()
+    zero_mat = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    if (body_flags[tid] & BodyFlags.KINEMATIC) != 0 or survivor_indices[tid] != tid:
+        eff_inv_mass[tid] = float(0.0)
+        eff_inv_inertia[tid] = zero_mat
+    else:
+        eff_inv_mass[tid] = merged_inv_mass[tid]
+        eff_inv_inertia[tid] = merged_inv_inertia[tid]

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -507,12 +507,12 @@ def eval_body_joint_forces(
     body_f: wp.array,
     joint_attach_ke: float,
     joint_attach_kd: float,
-    joint_enabled_override: wp.array | None = None,
-    body_com_override: wp.array | None = None,
-    joint_parent_override: wp.array | None = None,
-    joint_child_override: wp.array | None = None,
-    joint_X_p_override: wp.array | None = None,
-    joint_X_c_override: wp.array | None = None,
+    joint_enabled_override: wp.array[wp.bool] | None = None,
+    body_com_override: wp.array[wp.vec3] | None = None,
+    joint_parent_override: wp.array[wp.int32] | None = None,
+    joint_child_override: wp.array[wp.int32] | None = None,
+    joint_X_p_override: wp.array[wp.transform] | None = None,
+    joint_X_c_override: wp.array[wp.transform] | None = None,
 ):
     """Compute and accumulate joint forces into ``body_f``.
 

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -509,6 +509,21 @@ def eval_body_joint_forces(
     joint_attach_kd: float,
     joint_enabled_override: wp.array | None = None,
 ):
+    """Compute and accumulate joint forces into ``body_f``.
+
+    Args:
+        model: The simulation model.
+        state: Current simulation state providing body poses and velocities.
+        control: Control inputs providing joint targets and feedforward forces.
+        body_f: Output spatial force array [N, N·m], shape [body_count].
+            Forces are accumulated with atomic adds.
+        joint_attach_ke: Joint attachment spring stiffness [N/m].
+        joint_attach_kd: Joint attachment spring damping [N·s/m].
+        joint_enabled_override: Optional per-joint enabled flags to use
+            instead of :attr:`~newton.Model.joint_enabled`.  Pass the solver's
+            ``joint_enabled_effective`` array when fixed-joint collapsing is
+            active so that merged FIXED joints do not generate constraint forces.
+    """
     if model.joint_count:
         wp.launch(
             kernel=eval_body_joints,

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -501,7 +501,13 @@ def eval_body_joints(
 
 
 def eval_body_joint_forces(
-    model: Model, state: State, control: Control, body_f: wp.array, joint_attach_ke: float, joint_attach_kd: float
+    model: Model,
+    state: State,
+    control: Control,
+    body_f: wp.array,
+    joint_attach_ke: float,
+    joint_attach_kd: float,
+    joint_enabled_override: wp.array | None = None,
 ):
     if model.joint_count:
         wp.launch(
@@ -513,7 +519,7 @@ def eval_body_joint_forces(
                 model.body_com,
                 model.joint_qd_start,
                 model.joint_type,
-                model.joint_enabled,
+                joint_enabled_override if joint_enabled_override is not None else model.joint_enabled,
                 model.joint_child,
                 model.joint_parent,
                 model.joint_X_p,

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -508,21 +508,27 @@ def eval_body_joint_forces(
     joint_attach_ke: float,
     joint_attach_kd: float,
     joint_enabled_override: wp.array | None = None,
+    body_com_override: wp.array | None = None,
+    joint_parent_override: wp.array | None = None,
+    joint_child_override: wp.array | None = None,
+    joint_X_p_override: wp.array | None = None,
+    joint_X_c_override: wp.array | None = None,
 ):
     """Compute and accumulate joint forces into ``body_f``.
 
     Args:
         model: The simulation model.
-        state: Current simulation state providing body poses and velocities.
+        state: Current simulation state.
         control: Control inputs providing joint targets and feedforward forces.
-        body_f: Output spatial force array [N, N·m], shape [body_count].
-            Forces are accumulated with atomic adds.
-        joint_attach_ke: Joint attachment spring stiffness [N/m].
-        joint_attach_kd: Joint attachment spring damping [N·s/m].
-        joint_enabled_override: Optional per-joint enabled flags to use
-            instead of :attr:`~newton.Model.joint_enabled`.  Pass the solver's
-            ``joint_enabled_effective`` array when fixed-joint collapsing is
-            active so that merged FIXED joints do not generate constraint forces.
+        body_f: Output spatial force array, accumulated via atomic adds.
+        joint_attach_ke: Joint attachment spring stiffness.
+        joint_attach_kd: Joint attachment spring damping.
+        joint_enabled_override: Optional override for :attr:`~newton.Model.joint_enabled`.
+        body_com_override: Optional override for :attr:`~newton.Model.body_com`.
+        joint_parent_override: Optional override for :attr:`~newton.Model.joint_parent`.
+        joint_child_override: Optional override for :attr:`~newton.Model.joint_child`.
+        joint_X_p_override: Optional override for :attr:`~newton.Model.joint_X_p`.
+        joint_X_c_override: Optional override for :attr:`~newton.Model.joint_X_c`.
     """
     if model.joint_count:
         wp.launch(
@@ -531,14 +537,14 @@ def eval_body_joint_forces(
             inputs=[
                 state.body_q,
                 state.body_qd,
-                model.body_com,
+                body_com_override if body_com_override is not None else model.body_com,
                 model.joint_qd_start,
                 model.joint_type,
                 joint_enabled_override if joint_enabled_override is not None else model.joint_enabled,
-                model.joint_child,
-                model.joint_parent,
-                model.joint_X_p,
-                model.joint_X_c,
+                joint_child_override if joint_child_override is not None else model.joint_child,
+                joint_parent_override if joint_parent_override is not None else model.joint_parent,
+                joint_X_p_override if joint_X_p_override is not None else model.joint_X_p,
+                joint_X_c_override if joint_X_c_override is not None else model.joint_X_c,
                 model.joint_axis,
                 model.joint_dof_dim,
                 control.joint_f,

--- a/newton/_src/solvers/semi_implicit/kernels_contact.py
+++ b/newton/_src/solvers/semi_implicit/kernels_contact.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import warp as wp
 
 from ...geometry import ParticleFlags
@@ -604,9 +606,9 @@ def eval_body_contact_forces(
     contacts: Contacts | None,
     friction_smoothing: float = 1.0,
     force_in_world_frame: bool = False,
-    body_f_out: wp.array | None = None,
-    body_com_override: wp.array | None = None,
-    shape_body_override: wp.array | None = None,
+    body_f_out: wp.array[wp.spatial_vector] | None = None,
+    body_com_override: wp.array[wp.vec3] | None = None,
+    shape_body_override: wp.array[wp.int32] | None = None,
 ):
     """Compute and accumulate rigid contact forces into ``body_f_out``.
 
@@ -656,8 +658,8 @@ def eval_particle_body_contact_forces(
     particle_f: wp.array,
     body_f: wp.array,
     body_f_in_world_frame: bool = False,
-    body_com_override: wp.array | None = None,
-    shape_body_override: wp.array | None = None,
+    body_com_override: wp.array[wp.vec3] | None = None,
+    shape_body_override: wp.array[wp.int32] | None = None,
 ):
     """Compute particle-shape soft contact forces.
 

--- a/newton/_src/solvers/semi_implicit/kernels_contact.py
+++ b/newton/_src/solvers/semi_implicit/kernels_contact.py
@@ -605,7 +605,15 @@ def eval_body_contact_forces(
     friction_smoothing: float = 1.0,
     force_in_world_frame: bool = False,
     body_f_out: wp.array | None = None,
+    body_com_override: wp.array | None = None,
+    shape_body_override: wp.array | None = None,
 ):
+    """Compute and accumulate rigid contact forces into ``body_f_out``.
+
+    Args:
+        body_com_override: Optional override for :attr:`~newton.Model.body_com`.
+        shape_body_override: Optional override for :attr:`~newton.Model.shape_body`.
+    """
     if contacts is not None and contacts.rigid_contact_max:
         if body_f_out is None:
             body_f_out = state.body_f
@@ -615,13 +623,13 @@ def eval_body_contact_forces(
             inputs=[
                 state.body_q,
                 state.body_qd,
-                model.body_com,
+                body_com_override if body_com_override is not None else model.body_com,
                 model.shape_material_ke,
                 model.shape_material_kd,
                 model.shape_material_kf,
                 model.shape_material_ka,
                 model.shape_material_mu,
-                model.shape_body,
+                shape_body_override if shape_body_override is not None else model.shape_body,
                 contacts.rigid_contact_count,
                 contacts.rigid_contact_point0,
                 contacts.rigid_contact_point1,
@@ -648,7 +656,15 @@ def eval_particle_body_contact_forces(
     particle_f: wp.array,
     body_f: wp.array,
     body_f_in_world_frame: bool = False,
+    body_com_override: wp.array | None = None,
+    shape_body_override: wp.array | None = None,
 ):
+    """Compute particle-shape soft contact forces.
+
+    Args:
+        body_com_override: Optional override for :attr:`~newton.Model.body_com`.
+        shape_body_override: Optional override for :attr:`~newton.Model.shape_body`.
+    """
     if contacts is not None and contacts.soft_contact_max:
         wp.launch(
             kernel=eval_particle_body_contact,
@@ -660,8 +676,8 @@ def eval_particle_body_contact_forces(
                 state.body_qd,
                 model.particle_radius,
                 model.particle_flags,
-                model.body_com,
-                model.shape_body,
+                body_com_override if body_com_override is not None else model.body_com,
+                shape_body_override if shape_body_override is not None else model.shape_body,
                 model.shape_material_ke,
                 model.shape_material_kd,
                 model.shape_material_kf,

--- a/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
+++ b/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
@@ -71,29 +71,25 @@ class SolverSemiImplicit(SolverBase):
     def __init__(
         self,
         model: Model,
-        collapse_fixed_joints: bool = True,
-        joints_to_keep: list[str] | None = None,
         angular_damping: float = 0.05,
         friction_smoothing: float = 1.0,
         joint_attach_ke: float = 1.0e4,
         joint_attach_kd: float = 1.0e2,
         enable_tri_contact: bool = True,
+        *,
+        collapse_fixed_joints: bool = True,
+        joints_to_keep: list[str] | None = None,
     ):
         """
         Args:
             model: The model to be simulated.
-            collapse_fixed_joints: When ``True`` (the default), FIXED joints
-                are internally merged at the solver level for improved stability
-                and efficiency.  The original :class:`~newton.Model` body
-                hierarchy is preserved — only the solver's internal shadow
-                arrays reflect the merge.
-            joints_to_keep: Optional list of joint labels to exempt from
-                collapsing when ``collapse_fixed_joints`` is ``True``.
             angular_damping: Angular damping factor to be used in rigid body integration. Defaults to 0.05.
             friction_smoothing: Huber norm delta used for friction velocity normalization (see :func:`warp.norm_huber() <warp._src.lang.norm_huber>`). Defaults to 1.0.
             joint_attach_ke: Joint attachment spring stiffness. Defaults to 1.0e4.
             joint_attach_kd: Joint attachment spring damping. Defaults to 1.0e2.
             enable_tri_contact: Enable triangle contact. Defaults to True.
+            collapse_fixed_joints: Internally merge FIXED joints for stability and efficiency. Defaults to True.
+            joints_to_keep: Joint labels to exempt from ``collapse_fixed_joints``.
         """
         super().__init__(model=model)
         self.angular_damping = angular_damping
@@ -103,13 +99,13 @@ class SolverSemiImplicit(SolverBase):
         self.enable_tri_contact = enable_tri_contact
 
         self._joints_to_keep = joints_to_keep
+        # Always allocate so a later merges→no-merges notify can refresh safely.
+        self._init_kinematic_state()
         merge_info = (
             compute_fixed_joint_merge(model, joints_to_keep=joints_to_keep)
             if collapse_fixed_joints and model.body_count and model.joint_count
             else None
         )
-        if merge_info is not None:
-            self._init_kinematic_state()
         self._init_fixed_joint_merge(merge_info)
 
     @override
@@ -161,10 +157,20 @@ class SolverSemiImplicit(SolverBase):
             if control is None:
                 control = model.control(clone_variables=False)
 
+            _mi = getattr(self, "_merge_info", None)
             body_f_work = body_f
-            if body_f is not None and model.joint_count and control.joint_f is not None:
-                # Avoid accumulating joint_f into the persistent state body_f buffer.
+            # Clone body_f when joint forces, contact forces, or the merged-child
+            # scatter would otherwise leak into the user's state buffer.
+            needs_clone = body_f is not None and (
+                (model.joint_count and control.joint_f is not None)
+                or (contacts is not None and contacts.rigid_contact_max)
+                or _mi is not None
+            )
+            if needs_clone:
                 body_f_work = wp.clone(body_f)
+
+            if _mi is not None:
+                self._scatter_merged_body_forces(state_in, body_f_work)
 
             # damped springs
             eval_spring_forces(model, state_in, particle_f)
@@ -179,7 +185,6 @@ class SolverSemiImplicit(SolverBase):
             eval_tetrahedra_forces(model, state_in, control, particle_f)
 
             # body joints
-            _mi = getattr(self, "_merge_info", None)
             eval_body_joint_forces(
                 model,
                 state_in,
@@ -188,6 +193,11 @@ class SolverSemiImplicit(SolverBase):
                 self.joint_attach_ke,
                 self.joint_attach_kd,
                 joint_enabled_override=self.joint_enabled_effective if _mi is not None else None,
+                body_com_override=_mi.merged_body_com_gpu if _mi is not None else None,
+                joint_parent_override=_mi.joint_parent_effective_gpu if _mi is not None else None,
+                joint_child_override=_mi.joint_child_effective_gpu if _mi is not None else None,
+                joint_X_p_override=_mi.joint_X_p_effective_gpu if _mi is not None else None,
+                joint_X_c_override=_mi.joint_X_c_effective_gpu if _mi is not None else None,
             )
 
             # muscles
@@ -203,17 +213,29 @@ class SolverSemiImplicit(SolverBase):
 
             # body contacts
             eval_body_contact_forces(
-                model, state_in, contacts, friction_smoothing=self.friction_smoothing, body_f_out=body_f_work
+                model,
+                state_in,
+                contacts,
+                friction_smoothing=self.friction_smoothing,
+                body_f_out=body_f_work,
+                body_com_override=_mi.merged_body_com_gpu if _mi is not None else None,
+                shape_body_override=_mi.shape_body_effective_gpu if _mi is not None else None,
             )
 
             # particle shape contact
             eval_particle_body_contact_forces(
-                model, state_in, contacts, particle_f, body_f_work, body_f_in_world_frame=False
+                model,
+                state_in,
+                contacts,
+                particle_f,
+                body_f_work,
+                body_f_in_world_frame=False,
+                body_com_override=_mi.merged_body_com_gpu if _mi is not None else None,
+                shape_body_override=_mi.shape_body_effective_gpu if _mi is not None else None,
             )
 
             self.integrate_particles(model, state_in, state_out, dt)
 
-            _mi = getattr(self, "_merge_info", None)
             _int_kwargs = (
                 {
                     "body_com": _mi.merged_body_com_gpu,

--- a/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
+++ b/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
@@ -98,6 +98,7 @@ class SolverSemiImplicit(SolverBase):
         self.joint_attach_kd = joint_attach_kd
         self.enable_tri_contact = enable_tri_contact
 
+        self._collapse_fixed_joints = collapse_fixed_joints
         self._joints_to_keep = joints_to_keep
         # Always allocate so a later merges→no-merges notify can refresh safely.
         self._init_kinematic_state()
@@ -110,10 +111,13 @@ class SolverSemiImplicit(SolverBase):
 
     @override
     def notify_model_changed(self, flags: int) -> None:
-        if getattr(self, "_merge_info", None) is None:
-            return
-        if flags & SolverNotifyFlags.BODY_INERTIAL_PROPERTIES:
-            self._recompute_merged_inertial_properties()
+        merge_relevant = (
+            SolverNotifyFlags.BODY_INERTIAL_PROPERTIES
+            | SolverNotifyFlags.BODY_PROPERTIES
+            | SolverNotifyFlags.JOINT_PROPERTIES
+        )
+        if flags & merge_relevant:
+            self._recompute_merge_info()
 
     @override
     def step(

--- a/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
+++ b/newton/_src/solvers/semi_implicit/solver_semi_implicit.py
@@ -5,6 +5,8 @@ import warp as wp
 
 from ...core.types import override
 from ...sim import Contacts, Control, Model, State
+from .._fixed_joint_merger import compute_fixed_joint_merge
+from ..flags import SolverNotifyFlags
 from ..solver import SolverBase
 from .kernels_body import (
     eval_body_joint_forces,
@@ -69,6 +71,8 @@ class SolverSemiImplicit(SolverBase):
     def __init__(
         self,
         model: Model,
+        collapse_fixed_joints: bool = True,
+        joints_to_keep: list[str] | None = None,
         angular_damping: float = 0.05,
         friction_smoothing: float = 1.0,
         joint_attach_ke: float = 1.0e4,
@@ -78,6 +82,13 @@ class SolverSemiImplicit(SolverBase):
         """
         Args:
             model: The model to be simulated.
+            collapse_fixed_joints: When ``True`` (the default), FIXED joints
+                are internally merged at the solver level for improved stability
+                and efficiency.  The original :class:`~newton.Model` body
+                hierarchy is preserved — only the solver's internal shadow
+                arrays reflect the merge.
+            joints_to_keep: Optional list of joint labels to exempt from
+                collapsing when ``collapse_fixed_joints`` is ``True``.
             angular_damping: Angular damping factor to be used in rigid body integration. Defaults to 0.05.
             friction_smoothing: Huber norm delta used for friction velocity normalization (see :func:`warp.norm_huber() <warp._src.lang.norm_huber>`). Defaults to 1.0.
             joint_attach_ke: Joint attachment spring stiffness. Defaults to 1.0e4.
@@ -90,6 +101,23 @@ class SolverSemiImplicit(SolverBase):
         self.joint_attach_ke = joint_attach_ke
         self.joint_attach_kd = joint_attach_kd
         self.enable_tri_contact = enable_tri_contact
+
+        self._joints_to_keep = joints_to_keep
+        merge_info = (
+            compute_fixed_joint_merge(model, joints_to_keep=joints_to_keep)
+            if collapse_fixed_joints and model.body_count and model.joint_count
+            else None
+        )
+        if merge_info is not None:
+            self._init_kinematic_state()
+        self._init_fixed_joint_merge(merge_info)
+
+    @override
+    def notify_model_changed(self, flags: int) -> None:
+        if getattr(self, "_merge_info", None) is None:
+            return
+        if flags & SolverNotifyFlags.BODY_INERTIAL_PROPERTIES:
+            self._recompute_merged_inertial_properties()
 
     @override
     def step(
@@ -151,7 +179,16 @@ class SolverSemiImplicit(SolverBase):
             eval_tetrahedra_forces(model, state_in, control, particle_f)
 
             # body joints
-            eval_body_joint_forces(model, state_in, control, body_f_work, self.joint_attach_ke, self.joint_attach_kd)
+            _mi = getattr(self, "_merge_info", None)
+            eval_body_joint_forces(
+                model,
+                state_in,
+                control,
+                body_f_work,
+                self.joint_attach_ke,
+                self.joint_attach_kd,
+                joint_enabled_override=self.joint_enabled_effective if _mi is not None else None,
+            )
 
             # muscles
             if False:
@@ -176,10 +213,25 @@ class SolverSemiImplicit(SolverBase):
 
             self.integrate_particles(model, state_in, state_out, dt)
 
+            _mi = getattr(self, "_merge_info", None)
+            _int_kwargs = (
+                {
+                    "body_com": _mi.merged_body_com_gpu,
+                    "body_mass": _mi.merged_body_mass_gpu,
+                    "body_inertia": _mi.merged_body_inertia_gpu,
+                    "body_inv_mass": _mi.merged_body_inv_mass_gpu,
+                    "body_inv_inertia": _mi.merged_body_inv_inertia_gpu,
+                }
+                if _mi is not None
+                else {}
+            )
             if body_f_work is body_f:
-                self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping)
+                self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping, **_int_kwargs)
             else:
                 body_f_prev = state_in.body_f
                 state_in.body_f = body_f_work
-                self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping)
+                self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping, **_int_kwargs)
                 state_in.body_f = body_f_prev
+
+            if model.body_count:
+                self._propagate_merged_body_poses_and_velocities(state_out)

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -258,8 +258,13 @@ class SolverBase:
         if model.body_count and hasattr(self, "body_inv_mass_effective"):
             self._refresh_kinematic_state()
 
-    def _recompute_merged_inertial_properties(self) -> None:
-        """Re-run the merge analysis after model inertial properties change."""
+    def _recompute_merge_info(self) -> None:
+        """Re-run the merge analysis after model inputs change."""
+        # Honor the constructor opt-out: don't resurrect merging if the user
+        # built the solver with collapse_fixed_joints=False.
+        if not getattr(self, "_collapse_fixed_joints", True):
+            self._refresh_kinematic_state()
+            return
         joints_to_keep = getattr(self, "_joints_to_keep", None)
         new_info = compute_fixed_joint_merge(self.model, joints_to_keep=joints_to_keep)
         if new_info is None:
@@ -312,6 +317,8 @@ class SolverBase:
                 merge_info.survivor_indices_gpu,
                 state_out.body_q,
                 merge_info.relative_xforms_gpu,
+                model.body_com,
+                merge_info.merged_body_com_gpu,
                 state_out.body_qd,
             ],
             device=model.device,

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import warp as wp
 
 from ..geometry import ParticleFlags
@@ -274,7 +276,7 @@ class SolverBase:
             self.joint_enabled_effective = new_info.joint_enabled_effective_gpu
         self._refresh_kinematic_state()
 
-    def _scatter_merged_body_forces(self, state_in: State, body_f: wp.array | None) -> None:
+    def _scatter_merged_body_forces(self, state_in: State, body_f: wp.array[wp.spatial_vector] | None) -> None:
         """Move external body_f written to merged-child slots onto their survivors."""
         merge_info: FixedJointMergeInfo | None = getattr(self, "_merge_info", None)
         if merge_info is None or body_f is None:
@@ -330,11 +332,11 @@ class SolverBase:
         state_out: State,
         dt: float,
         angular_damping: float = 0.0,
-        body_com: wp.array | None = None,
-        body_mass: wp.array | None = None,
-        body_inertia: wp.array | None = None,
-        body_inv_mass: wp.array | None = None,
-        body_inv_inertia: wp.array | None = None,
+        body_com: wp.array[wp.vec3] | None = None,
+        body_mass: wp.array[float] | None = None,
+        body_inertia: wp.array[wp.mat33] | None = None,
+        body_inv_mass: wp.array[float] | None = None,
+        body_inv_inertia: wp.array[wp.mat33] | None = None,
     ) -> None:
         """Integrate the rigid bodies of the model.
 

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -260,8 +260,7 @@ class SolverBase:
 
     def _recompute_merge_info(self) -> None:
         """Re-run the merge analysis after model inputs change."""
-        # Honor the constructor opt-out: don't resurrect merging if the user
-        # built the solver with collapse_fixed_joints=False.
+        # Don't resurrect merging if the user opted out at construction.
         if not getattr(self, "_collapse_fixed_joints", True):
             self._refresh_kinematic_state()
             return

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -9,6 +9,7 @@ from ._fixed_joint_merger import (
     FixedJointMergeInfo,
     _propagate_merged_body_poses,
     _propagate_merged_body_velocities,
+    _scatter_body_forces_to_survivors,
     _update_effective_inv_mass_inertia_merged,
     compute_fixed_joint_merge,
 )
@@ -246,67 +247,50 @@ class SolverBase:
             )
 
     def _init_fixed_joint_merge(self, merge_info: FixedJointMergeInfo | None) -> None:
-        """Initialise shadow arrays for solver-level fixed-joint merging.
-
-        Must be called after :meth:`_init_kinematic_state` when merging is
-        requested.  Sets :attr:`joint_enabled_effective` either to a shadow
-        GPU array (with collapsed FIXED joints disabled) or to the model's own
-        :attr:`~newton.Model.joint_enabled` array when there is nothing to merge.
-
-        Args:
-            merge_info: Merge metadata from
-                :func:`~newton.solvers._fixed_joint_merger.compute_fixed_joint_merge`,
-                or ``None`` when no FIXED joints were collapsed.
-        """
+        """Install merge metadata and seed effective arrays."""
         model = self.model
         if merge_info is None or not merge_info.has_merges:
             self._merge_info = None
             self.joint_enabled_effective = model.joint_enabled
             return
         self._merge_info = merge_info
-        self.joint_enabled_effective = wp.array(merge_info.joint_enabled_effective, dtype=wp.bool, device=model.device)
-        # Refresh effective arrays now that merge_info is set.
+        self.joint_enabled_effective = merge_info.joint_enabled_effective_gpu
         if model.body_count and hasattr(self, "body_inv_mass_effective"):
             self._refresh_kinematic_state()
 
     def _recompute_merged_inertial_properties(self) -> None:
-        """Re-run the merge analysis and refresh GPU shadow arrays.
-
-        Called from :meth:`notify_model_changed` when
-        ``SolverNotifyFlags.BODY_INERTIAL_PROPERTIES`` is set and fixed-joint
-        merging is active.  Re-reads ``model.body_inv_mass`` etc. (which the
-        user has updated), recomputes accumulated values, and writes them into
-        the existing GPU arrays without reallocating.
-
-        Handles the topology change where all fixed joints become exempt (e.g.
-        all are now in ``joints_to_keep``): in that case ``_merge_info`` is
-        cleared and ``joint_enabled_effective`` is reset to ``model.joint_enabled``
-        so stale merged effective-mass data is no longer applied.
-        """
+        """Re-run the merge analysis after model inertial properties change."""
         joints_to_keep = getattr(self, "_joints_to_keep", None)
         new_info = compute_fixed_joint_merge(self.model, joints_to_keep=joints_to_keep)
         if new_info is None:
             self._merge_info = None
             self.joint_enabled_effective = self.model.joint_enabled
-        elif self._merge_info is not None:
-            self._merge_info.merged_body_inv_mass_gpu.assign(new_info.merged_body_inv_mass_gpu)
-            self._merge_info.merged_body_inv_inertia_gpu.assign(new_info.merged_body_inv_inertia_gpu)
-            self._merge_info.merged_body_mass_gpu.assign(new_info.merged_body_mass_gpu)
-            self._merge_info.merged_body_inertia_gpu.assign(new_info.merged_body_inertia_gpu)
-            self._merge_info.merged_body_com_gpu.assign(new_info.merged_body_com_gpu)
+        else:
+            self._merge_info = new_info
+            self.joint_enabled_effective = new_info.joint_enabled_effective_gpu
         self._refresh_kinematic_state()
 
+    def _scatter_merged_body_forces(self, state_in: State, body_f: wp.array | None) -> None:
+        """Move external body_f written to merged-child slots onto their survivors."""
+        merge_info: FixedJointMergeInfo | None = getattr(self, "_merge_info", None)
+        if merge_info is None or body_f is None:
+            return
+        model = self.model
+        wp.launch(
+            kernel=_scatter_body_forces_to_survivors,
+            dim=model.body_count,
+            inputs=[
+                merge_info.survivor_indices_gpu,
+                state_in.body_q,
+                merge_info.merged_body_com_gpu,
+                merge_info.relative_xforms_gpu,
+                body_f,
+            ],
+            device=model.device,
+        )
+
     def _propagate_merged_body_poses_and_velocities(self, state_out: State) -> None:
-        """Scatter survivor pose and velocity into each merged child's slots.
-
-        Must be called at the very end of :meth:`step`, after all constraint
-        iterations and after :meth:`copy_kinematic_body_state`, so the
-        survivor's final corrected pose is propagated to merged children.
-
-        Args:
-            state_out: The output state whose ``body_q`` and ``body_qd``
-                arrays are updated in-place.
-        """
+        """Scatter survivor pose and velocity into each merged child's slots."""
         merge_info: FixedJointMergeInfo | None = getattr(self, "_merge_info", None)
         if merge_info is None:
             return
@@ -354,12 +338,11 @@ class SolverBase:
             state_out: The output state.
             dt: The time step (typically in seconds).
             angular_damping: Angular damping factor. Defaults to 0.0.
-            body_com: Override for ``model.body_com`` [m]. Pass the solver's
-                merged COM array when fixed-joint collapsing is active.
-            body_mass: Override for ``model.body_mass`` [kg].
-            body_inertia: Override for ``model.body_inertia`` [kg·m²].
-            body_inv_mass: Override for ``model.body_inv_mass`` [1/kg].
-            body_inv_inertia: Override for ``model.body_inv_inertia`` [1/(kg·m²)].
+            body_com: Override for ``model.body_com``. Used by fixed-joint collapsing.
+            body_mass: Override for ``model.body_mass``.
+            body_inertia: Override for ``model.body_inertia``.
+            body_inv_mass: Override for ``model.body_inv_mass``.
+            body_inv_inertia: Override for ``model.body_inv_inertia``.
         """
         if model.body_count:
             wp.launch(

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -277,10 +277,18 @@ class SolverBase:
         merging is active.  Re-reads ``model.body_inv_mass`` etc. (which the
         user has updated), recomputes accumulated values, and writes them into
         the existing GPU arrays without reallocating.
+
+        Handles the topology change where all fixed joints become exempt (e.g.
+        all are now in ``joints_to_keep``): in that case ``_merge_info`` is
+        cleared and ``joint_enabled_effective`` is reset to ``model.joint_enabled``
+        so stale merged effective-mass data is no longer applied.
         """
         joints_to_keep = getattr(self, "_joints_to_keep", None)
         new_info = compute_fixed_joint_merge(self.model, joints_to_keep=joints_to_keep)
-        if new_info is not None and self._merge_info is not None:
+        if new_info is None:
+            self._merge_info = None
+            self.joint_enabled_effective = self.model.joint_enabled
+        elif self._merge_info is not None:
             self._merge_info.merged_body_inv_mass_gpu.assign(new_info.merged_body_inv_mass_gpu)
             self._merge_info.merged_body_inv_inertia_gpu.assign(new_info.merged_body_inv_inertia_gpu)
             self._merge_info.merged_body_mass_gpu.assign(new_info.merged_body_mass_gpu)

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -5,6 +5,13 @@ import warp as wp
 
 from ..geometry import ParticleFlags
 from ..sim import BodyFlags, Contacts, Control, Model, ModelBuilder, State
+from ._fixed_joint_merger import (
+    FixedJointMergeInfo,
+    _propagate_merged_body_poses,
+    _propagate_merged_body_velocities,
+    _update_effective_inv_mass_inertia_merged,
+    compute_fixed_joint_merge,
+)
 
 
 @wp.kernel
@@ -205,9 +212,26 @@ class SolverBase:
             self._refresh_kinematic_state()
 
     def _refresh_kinematic_state(self):
-        """Update effective arrays from model, zeroing kinematic bodies."""
+        """Update effective arrays from model, zeroing kinematic and merged-child bodies."""
         model = self.model
-        if model.body_count:
+        if not model.body_count:
+            return
+        merge_info: FixedJointMergeInfo | None = getattr(self, "_merge_info", None)
+        if merge_info is not None:
+            wp.launch(
+                kernel=_update_effective_inv_mass_inertia_merged,
+                dim=model.body_count,
+                inputs=[
+                    model.body_flags,
+                    merge_info.survivor_indices_gpu,
+                    merge_info.merged_body_inv_mass_gpu,
+                    merge_info.merged_body_inv_inertia_gpu,
+                    self.body_inv_mass_effective,
+                    self.body_inv_inertia_effective,
+                ],
+                device=model.device,
+            )
+        else:
             wp.launch(
                 kernel=_update_effective_inv_mass_inertia,
                 dim=model.body_count,
@@ -221,6 +245,86 @@ class SolverBase:
                 device=model.device,
             )
 
+    def _init_fixed_joint_merge(self, merge_info: FixedJointMergeInfo | None) -> None:
+        """Initialise shadow arrays for solver-level fixed-joint merging.
+
+        Must be called after :meth:`_init_kinematic_state` when merging is
+        requested.  Sets :attr:`joint_enabled_effective` either to a shadow
+        GPU array (with collapsed FIXED joints disabled) or to the model's own
+        :attr:`~newton.Model.joint_enabled` array when there is nothing to merge.
+
+        Args:
+            merge_info: Merge metadata from
+                :func:`~newton.solvers._fixed_joint_merger.compute_fixed_joint_merge`,
+                or ``None`` when no FIXED joints were collapsed.
+        """
+        model = self.model
+        if merge_info is None or not merge_info.has_merges:
+            self._merge_info = None
+            self.joint_enabled_effective = model.joint_enabled
+            return
+        self._merge_info = merge_info
+        self.joint_enabled_effective = wp.array(merge_info.joint_enabled_effective, dtype=wp.bool, device=model.device)
+        # Refresh effective arrays now that merge_info is set.
+        if model.body_count and hasattr(self, "body_inv_mass_effective"):
+            self._refresh_kinematic_state()
+
+    def _recompute_merged_inertial_properties(self) -> None:
+        """Re-run the merge analysis and refresh GPU shadow arrays.
+
+        Called from :meth:`notify_model_changed` when
+        ``SolverNotifyFlags.BODY_INERTIAL_PROPERTIES`` is set and fixed-joint
+        merging is active.  Re-reads ``model.body_inv_mass`` etc. (which the
+        user has updated), recomputes accumulated values, and writes them into
+        the existing GPU arrays without reallocating.
+        """
+        joints_to_keep = getattr(self, "_joints_to_keep", None)
+        new_info = compute_fixed_joint_merge(self.model, joints_to_keep=joints_to_keep)
+        if new_info is not None and self._merge_info is not None:
+            self._merge_info.merged_body_inv_mass_gpu.assign(new_info.merged_body_inv_mass_gpu)
+            self._merge_info.merged_body_inv_inertia_gpu.assign(new_info.merged_body_inv_inertia_gpu)
+            self._merge_info.merged_body_mass_gpu.assign(new_info.merged_body_mass_gpu)
+            self._merge_info.merged_body_inertia_gpu.assign(new_info.merged_body_inertia_gpu)
+            self._merge_info.merged_body_com_gpu.assign(new_info.merged_body_com_gpu)
+        self._refresh_kinematic_state()
+
+    def _propagate_merged_body_poses_and_velocities(self, state_out: State) -> None:
+        """Scatter survivor pose and velocity into each merged child's slots.
+
+        Must be called at the very end of :meth:`step`, after all constraint
+        iterations and after :meth:`copy_kinematic_body_state`, so the
+        survivor's final corrected pose is propagated to merged children.
+
+        Args:
+            state_out: The output state whose ``body_q`` and ``body_qd``
+                arrays are updated in-place.
+        """
+        merge_info: FixedJointMergeInfo | None = getattr(self, "_merge_info", None)
+        if merge_info is None:
+            return
+        model = self.model
+        wp.launch(
+            kernel=_propagate_merged_body_poses,
+            dim=model.body_count,
+            inputs=[
+                merge_info.survivor_indices_gpu,
+                merge_info.relative_xforms_gpu,
+                state_out.body_q,
+            ],
+            device=model.device,
+        )
+        wp.launch(
+            kernel=_propagate_merged_body_velocities,
+            dim=model.body_count,
+            inputs=[
+                merge_info.survivor_indices_gpu,
+                state_out.body_q,
+                merge_info.relative_xforms_gpu,
+                state_out.body_qd,
+            ],
+            device=model.device,
+        )
+
     def integrate_bodies(
         self,
         model: Model,
@@ -228,17 +332,26 @@ class SolverBase:
         state_out: State,
         dt: float,
         angular_damping: float = 0.0,
+        body_com: wp.array | None = None,
+        body_mass: wp.array | None = None,
+        body_inertia: wp.array | None = None,
+        body_inv_mass: wp.array | None = None,
+        body_inv_inertia: wp.array | None = None,
     ) -> None:
-        """
-        Integrate the rigid bodies of the model.
+        """Integrate the rigid bodies of the model.
 
         Args:
-            model (Model): The model to integrate.
-            state_in (State): The input state.
-            state_out (State): The output state.
-            dt (float): The time step (typically in seconds).
-            angular_damping (float, optional): The angular damping factor.
-                Defaults to 0.0.
+            model: The model to integrate.
+            state_in: The input state.
+            state_out: The output state.
+            dt: The time step (typically in seconds).
+            angular_damping: Angular damping factor. Defaults to 0.0.
+            body_com: Override for ``model.body_com`` [m]. Pass the solver's
+                merged COM array when fixed-joint collapsing is active.
+            body_mass: Override for ``model.body_mass`` [kg].
+            body_inertia: Override for ``model.body_inertia`` [kg·m²].
+            body_inv_mass: Override for ``model.body_inv_mass`` [1/kg].
+            body_inv_inertia: Override for ``model.body_inv_inertia`` [1/(kg·m²)].
         """
         if model.body_count:
             wp.launch(
@@ -248,11 +361,11 @@ class SolverBase:
                     state_in.body_q,
                     state_in.body_qd,
                     state_in.body_f,
-                    model.body_com,
-                    model.body_mass,
-                    model.body_inertia,
-                    model.body_inv_mass,
-                    model.body_inv_inertia,
+                    body_com if body_com is not None else model.body_com,
+                    body_mass if body_mass is not None else model.body_mass,
+                    body_inertia if body_inertia is not None else model.body_inertia,
+                    body_inv_mass if body_inv_mass is not None else model.body_inv_mass,
+                    body_inv_inertia if body_inv_inertia is not None else model.body_inv_inertia,
                     model.body_flags,
                     model.body_world,
                     model.gravity,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -5,6 +5,7 @@ import warp as wp
 
 from ...core.types import override
 from ...sim import Contacts, Control, Model, State
+from .._fixed_joint_merger import compute_fixed_joint_merge
 from ..flags import SolverNotifyFlags
 from ..solver import SolverBase
 from .kernels import (
@@ -95,6 +96,8 @@ class SolverXPBD(SolverBase):
     def __init__(
         self,
         model: Model,
+        collapse_fixed_joints: bool = True,
+        joints_to_keep: list[str] | None = None,
         iterations: int = 2,
         soft_body_relaxation: float = 0.9,
         soft_contact_relaxation: float = 0.9,
@@ -127,7 +130,15 @@ class SolverXPBD(SolverBase):
 
         self.compute_body_velocity_from_position_delta = False
 
+        self._joints_to_keep = joints_to_keep
         self._init_kinematic_state()
+
+        merge_info = (
+            compute_fixed_joint_merge(model, joints_to_keep=joints_to_keep)
+            if collapse_fixed_joints and model.body_count and model.joint_count
+            else None
+        )
+        self._init_fixed_joint_merge(merge_info)
 
         # helper variables to track constraint resolution vars
         self._particle_delta_counter = 0
@@ -141,7 +152,10 @@ class SolverXPBD(SolverBase):
     @override
     def notify_model_changed(self, flags: int) -> None:
         if flags & (SolverNotifyFlags.BODY_PROPERTIES | SolverNotifyFlags.BODY_INERTIAL_PROPERTIES):
-            self._refresh_kinematic_state()
+            if getattr(self, "_merge_info", None) is not None and (flags & SolverNotifyFlags.BODY_INERTIAL_PROPERTIES):
+                self._recompute_merged_inertial_properties()
+            else:
+                self._refresh_kinematic_state()
 
     def copy_kinematic_body_state(self, model: Model, state_in: State, state_out: State):
         if model.body_count == 0:
@@ -339,7 +353,7 @@ class SolverXPBD(SolverBase):
                             state_in.body_q,
                             model.body_com,
                             model.joint_type,
-                            model.joint_enabled,
+                            self.joint_enabled_effective,
                             model.joint_parent,
                             model.joint_child,
                             model.joint_X_p,
@@ -353,12 +367,24 @@ class SolverXPBD(SolverBase):
                         device=model.device,
                     )
 
+                _mi = getattr(self, "_merge_info", None)
+                _int_kwargs = (
+                    {
+                        "body_com": _mi.merged_body_com_gpu,
+                        "body_mass": _mi.merged_body_mass_gpu,
+                        "body_inertia": _mi.merged_body_inertia_gpu,
+                        "body_inv_mass": _mi.merged_body_inv_mass_gpu,
+                        "body_inv_inertia": _mi.merged_body_inv_inertia_gpu,
+                    }
+                    if _mi is not None
+                    else {}
+                )
                 if body_f_tmp is state_in.body_f:
-                    self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping)
+                    self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping, **_int_kwargs)
                 else:
                     body_f_prev = state_in.body_f
                     state_in.body_f = body_f_tmp
-                    self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping)
+                    self.integrate_bodies(model, state_in, state_out, dt, self.angular_damping, **_int_kwargs)
                     state_in.body_f = body_f_prev
 
             spring_constraint_lambdas = None
@@ -593,17 +619,18 @@ class SolverXPBD(SolverBase):
                         else:
                             body_deltas.zero_()
 
+                        _mi = getattr(self, "_merge_info", None)
                         wp.launch(
                             kernel=solve_body_joints,
                             dim=model.joint_count,
                             inputs=[
                                 body_q,
                                 body_qd,
-                                model.body_com,
+                                _mi.merged_body_com_gpu if _mi is not None else model.body_com,
                                 self.body_inv_mass_effective,
                                 self.body_inv_inertia_effective,
                                 model.joint_type,
-                                model.joint_enabled,
+                                self.joint_enabled_effective,
                                 model.joint_parent,
                                 model.joint_child,
                                 model.joint_X_p,
@@ -762,6 +789,7 @@ class SolverXPBD(SolverBase):
 
             if model.body_count:
                 self.copy_kinematic_body_state(model, state_in, state_out)
+                self._propagate_merged_body_poses_and_velocities(state_out)
 
     @override
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -171,8 +171,7 @@ class SolverXPBD(SolverBase):
 
     @override
     def notify_model_changed(self, flags: int) -> None:
-        # Any change to merger inputs (body inertial props, kinematic flags,
-        # joint enablement, or joint anchors) can invalidate the merge map.
+        # Any change to merger inputs may invalidate the cached merge map.
         merge_relevant = (
             SolverNotifyFlags.BODY_INERTIAL_PROPERTIES
             | SolverNotifyFlags.BODY_PROPERTIES
@@ -368,8 +367,7 @@ class SolverXPBD(SolverBase):
                 body_deltas = wp.empty_like(state_out.body_qd)
 
                 _mi = getattr(self, "_merge_info", None)
-                # Clone state_in.body_f when joint forces or the merged-child
-                # scatter would otherwise leak into the user's state buffer.
+                # Clone before mutating so we don't leak into state_in.body_f.
                 body_f_tmp = state_in.body_f
                 if model.joint_count or _mi is not None:
                     body_f_tmp = wp.clone(state_in.body_f)

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -96,8 +96,6 @@ class SolverXPBD(SolverBase):
     def __init__(
         self,
         model: Model,
-        collapse_fixed_joints: bool = True,
-        joints_to_keep: list[str] | None = None,
         iterations: int = 2,
         soft_body_relaxation: float = 0.9,
         soft_contact_relaxation: float = 0.9,
@@ -109,17 +107,13 @@ class SolverXPBD(SolverBase):
         rigid_contact_con_weighting: bool = True,
         angular_damping: float = 0.0,
         enable_restitution: bool = False,
+        *,
+        collapse_fixed_joints: bool = True,
+        joints_to_keep: list[str] | None = None,
     ):
         """
         Args:
             model: The model to be simulated.
-            collapse_fixed_joints: When ``True`` (the default), FIXED joints
-                are internally merged at the solver level for improved stability
-                and efficiency.  The original :class:`~newton.Model` body
-                hierarchy is preserved — only the solver's internal shadow
-                arrays reflect the merge.
-            joints_to_keep: Optional list of joint labels to exempt from
-                collapsing when ``collapse_fixed_joints`` is ``True``.
             iterations: Number of constraint solver iterations per step. Defaults to 2.
             soft_body_relaxation: Relaxation factor for soft body constraints. Defaults to 0.9.
             soft_contact_relaxation: Relaxation factor for soft contact constraints. Defaults to 0.9.
@@ -132,6 +126,8 @@ class SolverXPBD(SolverBase):
                 for improved stacking convergence. Defaults to True.
             angular_damping: Angular damping factor for rigid body integration. Defaults to 0.0.
             enable_restitution: Enable restitution (bouncing) at contacts. Defaults to False.
+            collapse_fixed_joints: Internally merge FIXED joints for stability and efficiency. Defaults to True.
+            joints_to_keep: Joint labels to exempt from ``collapse_fixed_joints``.
         """
         super().__init__(model=model)
         self.iterations = iterations
@@ -365,22 +361,27 @@ class SolverXPBD(SolverBase):
 
                 body_deltas = wp.empty_like(state_out.body_qd)
 
+                _mi = getattr(self, "_merge_info", None)
+                # Clone state_in.body_f when joint forces or the merged-child
+                # scatter would otherwise leak into the user's state buffer.
                 body_f_tmp = state_in.body_f
-                if model.joint_count:
-                    # Avoid accumulating joint_f into the persistent state body_f buffer.
+                if model.joint_count or _mi is not None:
                     body_f_tmp = wp.clone(state_in.body_f)
+                if _mi is not None:
+                    self._scatter_merged_body_forces(state_in, body_f_tmp)
+                if model.joint_count:
                     wp.launch(
                         kernel=apply_joint_forces,
                         dim=model.joint_count,
                         inputs=[
                             state_in.body_q,
-                            model.body_com,
+                            _mi.merged_body_com_gpu if _mi is not None else model.body_com,
                             model.joint_type,
                             self.joint_enabled_effective,
-                            model.joint_parent,
-                            model.joint_child,
-                            model.joint_X_p,
-                            model.joint_X_c,
+                            _mi.joint_parent_effective_gpu if _mi is not None else model.joint_parent,
+                            _mi.joint_child_effective_gpu if _mi is not None else model.joint_child,
+                            _mi.joint_X_p_effective_gpu if _mi is not None else model.joint_X_p,
+                            _mi.joint_X_c_effective_gpu if _mi is not None else model.joint_X_c,
                             model.joint_qd_start,
                             model.joint_dof_dim,
                             model.joint_axis,
@@ -390,7 +391,6 @@ class SolverXPBD(SolverBase):
                         device=model.device,
                     )
 
-                _mi = getattr(self, "_merge_info", None)
                 _int_kwargs = (
                     {
                         "body_com": _mi.merged_body_com_gpu,
@@ -433,6 +433,7 @@ class SolverXPBD(SolverBase):
 
                         # particle-rigid body contacts (besides ground plane)
                         if model.shape_count:
+                            _mi = getattr(self, "_merge_info", None)
                             wp.launch(
                                 kernel=solve_particle_shape_contacts,
                                 dim=contacts.soft_contact_max,
@@ -444,10 +445,10 @@ class SolverXPBD(SolverBase):
                                     model.particle_flags,
                                     body_q,
                                     body_qd,
-                                    model.body_com,
+                                    _mi.merged_body_com_gpu if _mi is not None else model.body_com,
                                     self.body_inv_mass_effective,
                                     self.body_inv_inertia_effective,
-                                    model.shape_body,
+                                    _mi.shape_body_effective_gpu if _mi is not None else model.shape_body,
                                     model.shape_material_mu,
                                     model.soft_contact_mu,
                                     model.particle_adhesion,
@@ -565,6 +566,9 @@ class SolverXPBD(SolverBase):
                         if contact_impulse_iter is not None:
                             contact_impulse_iter.zero_()
 
+                        _mi = getattr(self, "_merge_info", None)
+                        _shape_body = _mi.shape_body_effective_gpu if _mi is not None else model.shape_body
+                        _body_com = _mi.merged_body_com_gpu if _mi is not None else model.body_com
                         wp.launch(
                             kernel=solve_body_contact_positions,
                             dim=contacts.rigid_contact_max,
@@ -572,10 +576,10 @@ class SolverXPBD(SolverBase):
                                 body_q,
                                 body_qd,
                                 model.body_flags,
-                                model.body_com,
+                                _body_com,
                                 self.body_inv_mass_effective,
                                 self.body_inv_inertia_effective,
-                                model.shape_body,
+                                _shape_body,
                                 contacts.rigid_contact_count,
                                 contacts.rigid_contact_point0,
                                 contacts.rigid_contact_point1,
@@ -609,7 +613,7 @@ class SolverXPBD(SolverBase):
                                     contact_impulse_iter,
                                     contacts.rigid_contact_shape0,
                                     contacts.rigid_contact_shape1,
-                                    model.shape_body,
+                                    _shape_body,
                                     rigid_contact_inv_weight,
                                 ],
                                 outputs=[contact_impulse],
@@ -654,10 +658,10 @@ class SolverXPBD(SolverBase):
                                 self.body_inv_inertia_effective,
                                 model.joint_type,
                                 self.joint_enabled_effective,
-                                model.joint_parent,
-                                model.joint_child,
-                                model.joint_X_p,
-                                model.joint_X_c,
+                                _mi.joint_parent_effective_gpu if _mi is not None else model.joint_parent,
+                                _mi.joint_child_effective_gpu if _mi is not None else model.joint_child,
+                                _mi.joint_X_p_effective_gpu if _mi is not None else model.joint_X_p,
+                                _mi.joint_X_c_effective_gpu if _mi is not None else model.joint_X_c,
                                 model.joint_limit_lower,
                                 model.joint_limit_upper,
                                 model.joint_qd_start,
@@ -690,14 +694,15 @@ class SolverXPBD(SolverBase):
             if state_out.body_parent_f is not None:
                 state_out.body_parent_f.zero_()
                 if joint_impulse is not None:
+                    _mi = getattr(self, "_merge_info", None)
                     wp.launch(
                         kernel=convert_joint_impulse_to_parent_f,
                         dim=model.joint_count,
                         inputs=[
                             joint_impulse,
-                            model.joint_enabled,
+                            self.joint_enabled_effective,
                             model.joint_type,
-                            model.joint_child,
+                            _mi.joint_child_effective_gpu if _mi is not None else model.joint_child,
                             dt,
                         ],
                         outputs=[state_out.body_parent_f],
@@ -733,6 +738,9 @@ class SolverXPBD(SolverBase):
                 )
 
             if self.enable_restitution and contacts is not None:
+                _mi = getattr(self, "_merge_info", None)
+                _shape_body = _mi.shape_body_effective_gpu if _mi is not None else model.shape_body
+                _body_com = _mi.merged_body_com_gpu if _mi is not None else model.body_com
                 if model.particle_count:
                     wp.launch(
                         kernel=apply_particle_shape_restitution,
@@ -747,8 +755,8 @@ class SolverXPBD(SolverBase):
                             body_q_init,
                             body_qd,
                             body_qd_init,
-                            model.body_com,
-                            model.shape_body,
+                            _body_com,
+                            _shape_body,
                             model.particle_adhesion,
                             model.soft_contact_restitution,
                             contacts.soft_contact_count,
@@ -774,11 +782,11 @@ class SolverXPBD(SolverBase):
                             state_out.body_qd,
                             body_q_init,
                             body_qd_init,
-                            model.body_com,
+                            _body_com,
                             self.body_inv_mass_effective,
                             self.body_inv_inertia_effective,
                             model.body_world,
-                            model.shape_body,
+                            _shape_body,
                             contacts.rigid_contact_count,
                             contacts.rigid_contact_normal,
                             contacts.rigid_contact_shape0,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -149,6 +149,7 @@ class SolverXPBD(SolverBase):
 
         self.compute_body_velocity_from_position_delta = False
 
+        self._collapse_fixed_joints = collapse_fixed_joints
         self._joints_to_keep = joints_to_keep
         self._init_kinematic_state()
 
@@ -170,11 +171,15 @@ class SolverXPBD(SolverBase):
 
     @override
     def notify_model_changed(self, flags: int) -> None:
-        if flags & (SolverNotifyFlags.BODY_PROPERTIES | SolverNotifyFlags.BODY_INERTIAL_PROPERTIES):
-            if getattr(self, "_merge_info", None) is not None and (flags & SolverNotifyFlags.BODY_INERTIAL_PROPERTIES):
-                self._recompute_merged_inertial_properties()
-            else:
-                self._refresh_kinematic_state()
+        # Any change to merger inputs (body inertial props, kinematic flags,
+        # joint enablement, or joint anchors) can invalidate the merge map.
+        merge_relevant = (
+            SolverNotifyFlags.BODY_INERTIAL_PROPERTIES
+            | SolverNotifyFlags.BODY_PROPERTIES
+            | SolverNotifyFlags.JOINT_PROPERTIES
+        )
+        if flags & merge_relevant:
+            self._recompute_merge_info()
 
     def copy_kinematic_body_state(self, model: Model, state_in: State, state_out: State):
         if model.body_count == 0:
@@ -262,14 +267,15 @@ class SolverXPBD(SolverBase):
                     new_body_qd = state_out.body_qd
                 self._body_delta_counter = 1 - self._body_delta_counter
 
+            _mi = getattr(self, "_merge_info", None)
             wp.launch(
                 kernel=apply_body_deltas,
                 dim=model.body_count,
                 inputs=[
                     body_q,
                     body_qd,
-                    model.body_com,
-                    model.body_inertia,
+                    _mi.merged_body_com_gpu if _mi is not None else model.body_com,
+                    _mi.merged_body_inertia_gpu if _mi is not None else model.body_inertia,
                     self.body_inv_mass_effective,
                     self.body_inv_inertia_effective,
                     body_deltas,
@@ -729,10 +735,16 @@ class SolverXPBD(SolverBase):
                     out_body_qd = state_out.body_qd
 
                 # update body velocities
+                _mi = getattr(self, "_merge_info", None)
                 wp.launch(
                     kernel=update_body_velocities,
                     dim=model.body_count,
-                    inputs=[state_out.body_q, body_q_init, model.body_com, dt],
+                    inputs=[
+                        state_out.body_q,
+                        body_q_init,
+                        _mi.merged_body_com_gpu if _mi is not None else model.body_com,
+                        dt,
+                    ],
                     outputs=[out_body_qd],
                     device=model.device,
                 )

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -110,6 +110,29 @@ class SolverXPBD(SolverBase):
         angular_damping: float = 0.0,
         enable_restitution: bool = False,
     ):
+        """
+        Args:
+            model: The model to be simulated.
+            collapse_fixed_joints: When ``True`` (the default), FIXED joints
+                are internally merged at the solver level for improved stability
+                and efficiency.  The original :class:`~newton.Model` body
+                hierarchy is preserved — only the solver's internal shadow
+                arrays reflect the merge.
+            joints_to_keep: Optional list of joint labels to exempt from
+                collapsing when ``collapse_fixed_joints`` is ``True``.
+            iterations: Number of constraint solver iterations per step. Defaults to 2.
+            soft_body_relaxation: Relaxation factor for soft body constraints. Defaults to 0.9.
+            soft_contact_relaxation: Relaxation factor for soft contact constraints. Defaults to 0.9.
+            joint_linear_relaxation: Relaxation factor for linear joint constraints. Defaults to 0.7.
+            joint_angular_relaxation: Relaxation factor for angular joint constraints. Defaults to 0.4.
+            joint_linear_compliance: Compliance for linear joint constraints [m/N]. Defaults to 0.0.
+            joint_angular_compliance: Compliance for angular joint constraints [rad/N·m]. Defaults to 0.0.
+            rigid_contact_relaxation: Relaxation factor for rigid body contact constraints. Defaults to 0.8.
+            rigid_contact_con_weighting: Divide positional correction by active contact count per body
+                for improved stacking convergence. Defaults to True.
+            angular_damping: Angular damping factor for rigid body integration. Defaults to 0.0.
+            enable_restitution: Enable restitution (bouncing) at contacts. Defaults to False.
+        """
         super().__init__(model=model)
         self.iterations = iterations
 

--- a/newton/tests/test_fixed_joint_merger.py
+++ b/newton/tests/test_fixed_joint_merger.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for solver-level fixed-joint merging.
+
+Covers:
+- compute_fixed_joint_merge analysis (CPU-only, no device loop)
+- SolverXPBD and SolverSemiImplicit integration (device loop via add_function_test)
+"""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton import ModelBuilder
+from newton._src.solvers._fixed_joint_merger import compute_fixed_joint_merge
+from newton.solvers import SolverNotifyFlags, SolverSemiImplicit, SolverXPBD
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+_DEFAULT_OFFSET = wp.vec3(0, 1, 0)
+
+
+def _make_two_body_fixed(device, mass0=1.0, mass1=2.0, offset=_DEFAULT_OFFSET):
+    """Return a model with body0-(FREE)->world and body0-(FIXED)->body1."""
+    b = ModelBuilder(gravity=0.0)
+    b0 = b.add_body(mass=mass0)
+    b1 = b.add_body(mass=mass1, xform=wp.transform(offset, wp.quat_identity()))
+    b.add_joint_free(b0)
+    b.add_joint_fixed(b0, b1, parent_xform=wp.transform(offset, wp.quat_identity()))
+    return b.finalize(device=device), b0, b1
+
+
+# ---------------------------------------------------------------------------
+# CPU-only analysis tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFixedJointMerge(unittest.TestCase):
+    def test_no_fixed_joints_returns_none(self):
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=1.0)
+        b.add_joint_free(b0)
+        b.add_joint_revolute(b0, b1, axis=newton.Axis.Y)
+        model = b.finalize(device="cpu")
+        result = compute_fixed_joint_merge(model)
+        self.assertIsNone(result)
+
+    def test_no_bodies_returns_none(self):
+        b = ModelBuilder(gravity=0.0)
+        model = b.finalize(device="cpu")
+        result = compute_fixed_joint_merge(model)
+        self.assertIsNone(result)
+
+    def test_single_fixed_joint_merge(self):
+        model, b0, b1 = _make_two_body_fixed("cpu")
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        self.assertTrue(info.has_merges)
+        # b1 merges into b0
+        self.assertEqual(info.survivor_of[b0], b0)
+        self.assertEqual(info.survivor_of[b1], b0)
+        # b0 gets combined mass
+        combined = 1.0 + 2.0
+        self.assertAlmostEqual(info.merged_body_mass[b0], combined, places=5)
+        self.assertAlmostEqual(info.merged_body_inv_mass[b0], 1.0 / combined, places=5)
+        # b1 is zeroed
+        self.assertAlmostEqual(info.merged_body_inv_mass[b1], 0.0, places=10)
+
+    def test_chained_fixed_joints(self):
+        """A-(FREE)->world, A-(FIXED)->B, B-(FIXED)->C: B and C both merge into A."""
+        b = ModelBuilder(gravity=0.0)
+        bA = b.add_body(mass=1.0)
+        bB = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        bC = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 2, 0), wp.quat_identity()))
+        b.add_joint_free(bA)
+        b.add_joint_fixed(bA, bB, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_fixed(bB, bC, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        self.assertEqual(info.survivor_of[bA], bA)
+        self.assertEqual(info.survivor_of[bB], bA)
+        self.assertEqual(info.survivor_of[bC], bA)
+        self.assertAlmostEqual(info.merged_body_mass[bA], 3.0, places=5)
+        self.assertAlmostEqual(info.merged_body_inv_mass[bB], 0.0, places=10)
+        self.assertAlmostEqual(info.merged_body_inv_mass[bC], 0.0, places=10)
+
+    def test_joints_to_keep_exempts_joint(self):
+        """joints_to_keep preserves the named FIXED joint."""
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=2.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()), label="keep_me")
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model, joints_to_keep=["keep_me"])
+        # No merges should happen since the only fixed joint is in keep list.
+        self.assertIsNone(info)
+
+    def test_accumulated_inv_mass_correctness(self):
+        """Two 1-kg bodies: merged inv_mass = 0.5."""
+        model, b0, _b1 = _make_two_body_fixed("cpu", mass0=1.0, mass1=1.0)
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        self.assertAlmostEqual(info.merged_body_inv_mass[b0], 0.5, places=5)
+
+    def test_gpu_arrays_allocated_on_correct_device(self):
+        """GPU arrays in FixedJointMergeInfo land on model.device."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        for arr in [
+            info.survivor_indices_gpu,
+            info.relative_xforms_gpu,
+            info.merged_body_inv_mass_gpu,
+            info.merged_body_inv_inertia_gpu,
+        ]:
+            self.assertEqual(arr.device, model.device)
+
+    def test_collapse_false_disables_merge_in_xpbd(self):
+        """collapse_fixed_joints=False leaves _merge_info as None."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        solver = SolverXPBD(model, collapse_fixed_joints=False)
+        self.assertIsNone(solver._merge_info)
+        # joint_enabled_effective should be the model array itself
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+    def test_collapse_false_disables_merge_in_semi_implicit(self):
+        """collapse_fixed_joints=False leaves _merge_info as None in SemiImplicit."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        solver = SolverSemiImplicit(model, collapse_fixed_joints=False)
+        self.assertIsNone(solver._merge_info)
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+
+# ---------------------------------------------------------------------------
+# Device tests for XPBD
+# ---------------------------------------------------------------------------
+
+
+class TestSolverXPBDFixedJointCollapse(unittest.TestCase):
+    pass
+
+
+def test_xpbd_merged_child_pose_follows_survivor(test, device):
+    """After N steps body_q[child] equals body_q[survivor] * relative_xform."""
+    offset = wp.vec3(0.0, 1.5, 0.0)
+    model, b0, b1 = _make_two_body_fixed(device, mass0=1.0, mass1=1.0, offset=offset)
+    solver = SolverXPBD(model)
+    mi = solver._merge_info
+    test.assertIsNotNone(mi)
+
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+    contacts = model.contacts()
+
+    for _ in range(5):
+        model.collide(state0, contacts)
+        solver.step(state0, state1, None, contacts, 1.0 / 60.0)
+        state0, state1 = state1, state0
+
+    body_q_np = state0.body_q.numpy()
+    rel_xform = mi.relative_xform_of[b1]
+    survivor_q = wp.transform(*body_q_np[b0])
+    expected = survivor_q * rel_xform
+    actual = wp.transform(*body_q_np[b1])
+    for i in range(7):
+        test.assertAlmostEqual(float(actual[i]), float(expected[i]), places=4)
+
+
+def test_xpbd_no_nans_in_state(test, device):
+    """All body_q/body_qd entries are finite after stepping."""
+    model, _, _ = _make_two_body_fixed(device)
+    solver = SolverXPBD(model)
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+    contacts = model.contacts()
+
+    for _ in range(10):
+        model.collide(state0, contacts)
+        solver.step(state0, state1, None, contacts, 1.0 / 60.0)
+        state0, state1 = state1, state0
+
+    test.assertTrue(np.all(np.isfinite(state0.body_q.numpy())), "body_q contains non-finite values")
+    test.assertTrue(np.all(np.isfinite(state0.body_qd.numpy())), "body_qd contains non-finite values")
+
+
+def test_xpbd_notify_model_changed_refreshes_merge(test, device):
+    """Updating body mass then calling notify_model_changed updates merged inv_mass."""
+    model, b0, b1 = _make_two_body_fixed(device, mass0=1.0, mass1=1.0)
+    solver = SolverXPBD(model)
+    test.assertIsNotNone(solver._merge_info)
+
+    # Combined mass was 2.0 → inv_mass = 0.5
+    old_inv = solver._merge_info.merged_body_inv_mass_gpu.numpy()[b0]
+    test.assertAlmostEqual(float(old_inv), 0.5, places=4)
+
+    # Update model mass for b1 to 3.0
+    new_mass = model.body_mass.numpy()
+    new_mass[b1] = 3.0
+    model.body_mass.assign(new_mass)
+    new_inv_mass = model.body_inv_mass.numpy()
+    new_inv_mass[b1] = 1.0 / 3.0
+    model.body_inv_mass.assign(new_inv_mass)
+
+    solver.notify_model_changed(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
+
+    # Combined mass is now 1.0 + 3.0 = 4.0 → inv_mass = 0.25
+    new_inv = solver._merge_info.merged_body_inv_mass_gpu.numpy()[b0]
+    test.assertAlmostEqual(float(new_inv), 0.25, places=4)
+
+
+add_function_test(
+    TestSolverXPBDFixedJointCollapse,
+    "test_merged_child_pose_follows_survivor",
+    test_xpbd_merged_child_pose_follows_survivor,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverXPBDFixedJointCollapse, "test_no_nans_in_state", test_xpbd_no_nans_in_state, devices=get_test_devices()
+)
+add_function_test(
+    TestSolverXPBDFixedJointCollapse,
+    "test_notify_model_changed_refreshes_merge",
+    test_xpbd_notify_model_changed_refreshes_merge,
+    devices=get_test_devices(),
+)
+
+
+# ---------------------------------------------------------------------------
+# Device tests for SemiImplicit
+# ---------------------------------------------------------------------------
+
+
+class TestSolverSemiImplicitFixedJointCollapse(unittest.TestCase):
+    pass
+
+
+def test_semi_merged_child_pose_follows_survivor(test, device):
+    """After N steps body_q[child] equals body_q[survivor] * relative_xform."""
+    offset = wp.vec3(0.0, 1.5, 0.0)
+    model, b0, b1 = _make_two_body_fixed(device, mass0=1.0, mass1=1.0, offset=offset)
+    solver = SolverSemiImplicit(model)
+    mi = solver._merge_info
+    test.assertIsNotNone(mi)
+
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+
+    for _ in range(5):
+        solver.step(state0, state1, None, None, 1.0 / 60.0)
+        state0, state1 = state1, state0
+
+    body_q_np = state0.body_q.numpy()
+    rel_xform = mi.relative_xform_of[b1]
+    survivor_q = wp.transform(*body_q_np[b0])
+    expected = survivor_q * rel_xform
+    actual = wp.transform(*body_q_np[b1])
+    for i in range(7):
+        test.assertAlmostEqual(float(actual[i]), float(expected[i]), places=4)
+
+
+def test_semi_no_nans_in_state(test, device):
+    """All body_q/body_qd entries are finite after stepping."""
+    model, _, _ = _make_two_body_fixed(device)
+    solver = SolverSemiImplicit(model)
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+
+    for _ in range(10):
+        solver.step(state0, state1, None, None, 1.0 / 60.0)
+        state0, state1 = state1, state0
+
+    test.assertTrue(np.all(np.isfinite(state0.body_q.numpy())), "body_q contains non-finite values")
+    test.assertTrue(np.all(np.isfinite(state0.body_qd.numpy())), "body_qd contains non-finite values")
+
+
+add_function_test(
+    TestSolverSemiImplicitFixedJointCollapse,
+    "test_merged_child_pose_follows_survivor",
+    test_semi_merged_child_pose_follows_survivor,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverSemiImplicitFixedJointCollapse,
+    "test_no_nans_in_state",
+    test_semi_no_nans_in_state,
+    devices=get_test_devices(),
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_fixed_joint_merger.py
+++ b/newton/tests/test_fixed_joint_merger.py
@@ -18,7 +18,10 @@ import warp as wp
 
 import newton
 from newton import ModelBuilder
-from newton._src.solvers._fixed_joint_merger import compute_fixed_joint_merge
+from newton._src.solvers._fixed_joint_merger import (
+    _propagate_merged_body_velocities,
+    compute_fixed_joint_merge,
+)
 from newton.solvers import SolverNotifyFlags, SolverSemiImplicit, SolverXPBD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
@@ -290,6 +293,38 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         # No merges should happen — the dynamic child must stay as its own body.
         self.assertIsNone(info)
 
+    def test_merged_inertia_is_about_combined_com(self):
+        """Merged inertia must be expressed about the new combined COM.
+
+        Two equal-mass bodies separated along Y by ``L`` must produce a merged
+        tensor whose ``Ixx``/``Izz`` exceed ``Iyy`` by exactly ``m * L^2 / 2``
+        (the parallel-axis contribution of two point-masses at ``±L/2`` from
+        the combined COM along Y). The earlier accumulator returned the
+        survivor-origin-frame value ``m * L^2``, so this test catches it.
+        """
+        L = 2.0
+        m = 1.0
+        ident = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=m, inertia=ident)
+        b1 = b.add_body(mass=m, xform=wp.transform(wp.vec3(0, L, 0), wp.quat_identity()), inertia=ident)
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, L, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+
+        merged_com = info.merged_body_com_gpu.numpy()[b0]
+        merged_I = info.merged_body_inertia_gpu.numpy()[b0]
+        self.assertAlmostEqual(float(merged_com[1]), L / 2.0, places=5)
+
+        # Diagonal cross-term must be m*L^2/2, not m*L^2.
+        cross_xx = float(merged_I[0, 0]) - float(merged_I[1, 1])
+        cross_zz = float(merged_I[2, 2]) - float(merged_I[1, 1])
+        self.assertAlmostEqual(cross_xx, m * L * L / 2.0, places=4)
+        self.assertAlmostEqual(cross_zz, m * L * L / 2.0, places=4)
+
     def test_disabled_fixed_joint_keeps_joint_enabled_effective_false(self):
         """A model-level disabled FIXED joint must remain disabled in joint_enabled_effective."""
         # Use chain A-FIXED-B-FIXED-C, disable the first FIXED joint.  The DFS
@@ -313,6 +348,111 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         eff = info.joint_enabled_effective_gpu.numpy()
         # Disabled joint stays disabled in effective layer.
         self.assertFalse(bool(eff[j_ab]))
+
+    def test_velocity_propagation_uses_com_offset(self):
+        """Propagation must use COM-to-COM offset, not body-origin offset.
+
+        Build a setup where the two are measurably different (heavier child
+        shifts the combined COM far from the survivor's body origin), give the
+        survivor pure angular velocity, run the propagation kernel, and verify
+        body_qd[child].linear == omega x (com_child_world - com_survivor_world).
+        Using the body-origin offset would yield a different number.
+        """
+        device = "cpu"
+        L = 2.0
+        sv_mass = 1.0
+        child_mass = 4.0
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=sv_mass)
+        b1 = b.add_body(mass=child_mass, xform=wp.transform(wp.vec3(0, L, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, L, 0), wp.quat_identity()))
+        model = b.finalize(device=device)
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+
+        # Survivor at world identity, pure angular velocity about Z.
+        omega_z = 0.5
+        body_q = wp.array(
+            [wp.transform_identity(), wp.transform_identity()],
+            dtype=wp.transform,
+            device=device,
+        )
+        body_qd = wp.array(
+            [
+                wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, omega_z),
+                wp.spatial_vector(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+            ],
+            dtype=wp.spatial_vector,
+            device=device,
+        )
+
+        wp.launch(
+            kernel=_propagate_merged_body_velocities,
+            dim=model.body_count,
+            inputs=[
+                info.survivor_indices_gpu,
+                body_q,
+                info.relative_xforms_gpu,
+                model.body_com,
+                info.merged_body_com_gpu,
+                body_qd,
+            ],
+            device=device,
+        )
+
+        merged_com = info.merged_body_com_gpu.numpy()[b0]
+        # Survivor identity transform → world COMs equal local COMs.
+        com_s_world = np.array(merged_com)
+        com_c_world = np.array([0.0, L, 0.0])  # child body_com is zero, body origin at +L Y
+        r_world = com_c_world - com_s_world
+        omega_vec = np.array([0.0, 0.0, omega_z])
+        expected_v = np.cross(omega_vec, r_world)
+
+        actual_qd = body_qd.numpy()[b1]
+        for i in range(3):
+            self.assertAlmostEqual(float(actual_qd[i]), float(expected_v[i]), places=5)
+        # Angular velocity must equal survivor's exactly.
+        for i in range(3):
+            self.assertAlmostEqual(float(actual_qd[3 + i]), float(omega_vec[i]), places=6)
+
+    def test_collapse_false_survives_notify(self):
+        """A solver built with collapse_fixed_joints=False stays opted out across notifies."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        solver = SolverXPBD(model, collapse_fixed_joints=False)
+        self.assertIsNone(solver._merge_info)
+        solver.notify_model_changed(SolverNotifyFlags.JOINT_PROPERTIES)
+        # Must not silently re-enable merging.
+        self.assertIsNone(solver._merge_info)
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+    def test_notify_joint_properties_recomputes_merge(self):
+        """Changing joint_enabled and notifying with JOINT_PROPERTIES must refresh the merge.
+
+        Previously only ``BODY_INERTIAL_PROPERTIES`` triggered a recompute, so a
+        caller that disabled a FIXED joint and notified with the conceptually
+        correct flag would still get the stale collapsed topology.
+        """
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        j = b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+
+        solver = SolverXPBD(model)
+        self.assertIsNotNone(solver._merge_info)
+
+        # Disable the only FIXED joint and notify with JOINT_PROPERTIES.
+        je = model.joint_enabled.numpy()
+        je[j] = False
+        model.joint_enabled.assign(je)
+        solver.notify_model_changed(SolverNotifyFlags.JOINT_PROPERTIES)
+
+        # Topology now has no collapsible FIXED joint → merge cleared.
+        self.assertIsNone(solver._merge_info)
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
 
 
 # ---------------------------------------------------------------------------
@@ -462,10 +602,59 @@ def test_xpbd_downstream_revolute_joint_works(test, device):
     test.assertTrue(np.all(np.isfinite(state0.body_qd.numpy())))
 
 
+def test_xpbd_com_shifted_cluster_rigid_attachment(test, device):
+    """End-to-end rigid attachment for a cluster whose merged COM is far from sv body origin.
+
+    Uses a 4 times heavier child so the combined COM shifts strongly off the
+    survivor's body origin. Exercises (1) inertia recentered to combined COM,
+    (2) velocity propagation via COM-to-COM offset, (3) ``_apply_body_deltas``
+    using merged ``body_com``/``body_inertia``. Asserts the merged child stays
+    rigidly bonded to the survivor through gravity and contact-free integration.
+    """
+    offset = wp.vec3(0.0, 1.0, 0.0)
+    b = ModelBuilder(gravity=-9.81, up_axis=newton.Axis.Z)
+    sv = b.add_body(mass=1.0)
+    ch = b.add_body(mass=4.0, xform=wp.transform(offset, wp.quat_identity()))
+    b.add_joint_free(sv)
+    b.add_joint_fixed(sv, ch, parent_xform=wp.transform(offset, wp.quat_identity()))
+    model = b.finalize(device=device)
+
+    solver = SolverXPBD(model)
+    mi = solver._merge_info
+    test.assertIsNotNone(mi)
+
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+    contacts = model.contacts()
+
+    for _ in range(20):
+        model.collide(state0, contacts)
+        solver.step(state0, state1, None, contacts, 1.0 / 120.0)
+        state0, state1 = state1, state0
+
+    body_q_np = state0.body_q.numpy()
+    body_qd_np = state0.body_qd.numpy()
+    test.assertTrue(np.all(np.isfinite(body_q_np)))
+    test.assertTrue(np.all(np.isfinite(body_qd_np)))
+
+    # Rigid bond: child pose must equal survivor pose composed with relative xform.
+    rel = mi.relative_xform_of[ch]
+    expected = wp.transform(*body_q_np[sv]) * rel
+    actual = wp.transform(*body_q_np[ch])
+    for i in range(7):
+        test.assertAlmostEqual(float(actual[i]), float(expected[i]), places=4)
+
+
 add_function_test(
     TestSolverXPBDFixedJointCollapse,
     "test_merged_child_pose_follows_survivor",
     test_xpbd_merged_child_pose_follows_survivor,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverXPBDFixedJointCollapse,
+    "test_com_shifted_cluster_rigid_attachment",
+    test_xpbd_com_shifted_cluster_rigid_attachment,
     devices=get_test_devices(),
 )
 add_function_test(

--- a/newton/tests/test_fixed_joint_merger.py
+++ b/newton/tests/test_fixed_joint_merger.py
@@ -137,6 +137,43 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertIsNone(solver._merge_info)
         self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
 
+    def test_notify_merges_to_no_merges_clears_merge_info_xpbd(self):
+        """Topology change from merges to no merges clears stale _merge_info."""
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=2.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()), label="the_joint")
+        model = b.finalize(device="cpu")
+
+        solver = SolverXPBD(model)
+        self.assertIsNotNone(solver._merge_info)
+
+        # Now exempt the only fixed joint — should collapse to no merges.
+        solver._joints_to_keep = ["the_joint"]
+        solver.notify_model_changed(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
+
+        self.assertIsNone(solver._merge_info)
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+    def test_notify_merges_to_no_merges_clears_merge_info_semi_implicit(self):
+        """Topology change from merges to no merges clears stale _merge_info in SemiImplicit."""
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=2.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()), label="the_joint")
+        model = b.finalize(device="cpu")
+
+        solver = SolverSemiImplicit(model)
+        self.assertIsNotNone(solver._merge_info)
+
+        solver._joints_to_keep = ["the_joint"]
+        solver.notify_model_changed(SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)
+
+        self.assertIsNone(solver._merge_info)
+        self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
 
 # ---------------------------------------------------------------------------
 # Device tests for XPBD

--- a/newton/tests/test_fixed_joint_merger.py
+++ b/newton/tests/test_fixed_joint_merger.py
@@ -6,6 +6,9 @@
 Covers:
 - compute_fixed_joint_merge analysis (CPU-only, no device loop)
 - SolverXPBD and SolverSemiImplicit integration (device loop via add_function_test)
+- effective-index layer (shape_body, joint_parent/child, joint_X_p/X_c)
+- body_f scatter from merged children to survivor
+- disabled-fixed-joint handling
 """
 
 import unittest
@@ -64,10 +67,12 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertEqual(info.survivor_of[b1], b0)
         # b0 gets combined mass
         combined = 1.0 + 2.0
-        self.assertAlmostEqual(info.merged_body_mass[b0], combined, places=5)
-        self.assertAlmostEqual(info.merged_body_inv_mass[b0], 1.0 / combined, places=5)
+        merged_mass = info.merged_body_mass_gpu.numpy()
+        merged_inv_mass = info.merged_body_inv_mass_gpu.numpy()
+        self.assertAlmostEqual(float(merged_mass[b0]), combined, places=5)
+        self.assertAlmostEqual(float(merged_inv_mass[b0]), 1.0 / combined, places=5)
         # b1 is zeroed
-        self.assertAlmostEqual(info.merged_body_inv_mass[b1], 0.0, places=10)
+        self.assertAlmostEqual(float(merged_inv_mass[b1]), 0.0, places=10)
 
     def test_chained_fixed_joints(self):
         """A-(FREE)->world, A-(FIXED)->B, B-(FIXED)->C: B and C both merge into A."""
@@ -85,9 +90,11 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertEqual(info.survivor_of[bA], bA)
         self.assertEqual(info.survivor_of[bB], bA)
         self.assertEqual(info.survivor_of[bC], bA)
-        self.assertAlmostEqual(info.merged_body_mass[bA], 3.0, places=5)
-        self.assertAlmostEqual(info.merged_body_inv_mass[bB], 0.0, places=10)
-        self.assertAlmostEqual(info.merged_body_inv_mass[bC], 0.0, places=10)
+        merged_mass = info.merged_body_mass_gpu.numpy()
+        merged_inv_mass = info.merged_body_inv_mass_gpu.numpy()
+        self.assertAlmostEqual(float(merged_mass[bA]), 3.0, places=5)
+        self.assertAlmostEqual(float(merged_inv_mass[bB]), 0.0, places=10)
+        self.assertAlmostEqual(float(merged_inv_mass[bC]), 0.0, places=10)
 
     def test_joints_to_keep_exempts_joint(self):
         """joints_to_keep preserves the named FIXED joint."""
@@ -102,12 +109,30 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         # No merges should happen since the only fixed joint is in keep list.
         self.assertIsNone(info)
 
+    def test_disabled_fixed_joint_not_collapsed(self):
+        """A FIXED joint with joint_enabled=False must not collapse its child."""
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=2.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        j = b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+        # Disable the FIXED joint after finalize.
+        je = model.joint_enabled.numpy()
+        je[j] = False
+        model.joint_enabled.assign(je)
+
+        info = compute_fixed_joint_merge(model)
+        # Disabled fixed joint should leave the topology unchanged → no merges.
+        self.assertIsNone(info)
+
     def test_accumulated_inv_mass_correctness(self):
         """Two 1-kg bodies: merged inv_mass = 0.5."""
         model, b0, _b1 = _make_two_body_fixed("cpu", mass0=1.0, mass1=1.0)
         info = compute_fixed_joint_merge(model)
         self.assertIsNotNone(info)
-        self.assertAlmostEqual(info.merged_body_inv_mass[b0], 0.5, places=5)
+        merged_inv_mass = info.merged_body_inv_mass_gpu.numpy()
+        self.assertAlmostEqual(float(merged_inv_mass[b0]), 0.5, places=5)
 
     def test_gpu_arrays_allocated_on_correct_device(self):
         """GPU arrays in FixedJointMergeInfo land on model.device."""
@@ -119,6 +144,11 @@ class TestComputeFixedJointMerge(unittest.TestCase):
             info.relative_xforms_gpu,
             info.merged_body_inv_mass_gpu,
             info.merged_body_inv_inertia_gpu,
+            info.joint_enabled_effective_gpu,
+            info.joint_parent_effective_gpu,
+            info.joint_child_effective_gpu,
+            info.joint_X_p_effective_gpu,
+            info.joint_X_c_effective_gpu,
         ]:
             self.assertEqual(arr.device, model.device)
 
@@ -136,6 +166,18 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         solver = SolverSemiImplicit(model, collapse_fixed_joints=False)
         self.assertIsNone(solver._merge_info)
         self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+    def test_constructor_positional_args_unchanged_xpbd(self):
+        """Old positional callers like SolverXPBD(model, 4) still bind iterations correctly."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        solver = SolverXPBD(model, 4)
+        self.assertEqual(solver.iterations, 4)
+
+    def test_constructor_positional_args_unchanged_semi_implicit(self):
+        """Old positional callers like SolverSemiImplicit(model, 0.1) bind angular_damping correctly."""
+        model, _, _ = _make_two_body_fixed("cpu")
+        solver = SolverSemiImplicit(model, 0.1)
+        self.assertAlmostEqual(solver.angular_damping, 0.1)
 
     def test_notify_merges_to_no_merges_clears_merge_info_xpbd(self):
         """Topology change from merges to no merges clears stale _merge_info."""
@@ -173,6 +215,104 @@ class TestComputeFixedJointMerge(unittest.TestCase):
 
         self.assertIsNone(solver._merge_info)
         self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
+
+    def test_effective_shape_body_remaps_to_survivor(self):
+        """Shapes attached to merged children must resolve to the survivor's body slot."""
+        b = ModelBuilder(gravity=0.0)
+        b0 = b.add_body(mass=1.0)
+        b1 = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_free(b0)
+        b.add_joint_fixed(b0, b1, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        # One shape on each body.
+        b.add_shape_sphere(b0, radius=0.1)
+        s_on_child = b.add_shape_sphere(b1, radius=0.1)
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        shape_body_eff = info.shape_body_effective_gpu.numpy()
+        # Shape on the merged child b1 should now resolve to b0 (the survivor).
+        self.assertEqual(int(shape_body_eff[s_on_child]), b0)
+
+    def test_effective_downstream_joint_anchors_remapped(self):
+        """A joint downstream of a merged subtree gets parent remapped to the survivor."""
+        # Topology: A-(FREE)->world, A-(FIXED)->B, B-(REVOLUTE)->C
+        # B merges into A; the revolute joint's parent should point at A and its
+        # parent anchor should be expressed in A's frame.
+        b = ModelBuilder(gravity=0.0)
+        bA = b.add_body(mass=1.0)
+        bB = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        bC = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(1, 1, 0), wp.quat_identity()))
+        b.add_joint_free(bA)
+        b.add_joint_fixed(bA, bB, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        # Anchor on B's frame: simple identity-translated anchor.
+        rev = b.add_joint_revolute(
+            bB,
+            bC,
+            axis=newton.Axis.Z,
+            parent_xform=wp.transform(wp.vec3(1, 0, 0), wp.quat_identity()),
+        )
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        parent_eff = info.joint_parent_effective_gpu.numpy()
+        # Revolute parent must have been remapped from B → A.
+        self.assertEqual(int(parent_eff[rev]), bA)
+        # And the anchor for the revolute should now be expressed relative to A.
+        # We can verify by reconstructing: anchor_in_A = relative_xform_of[B] * joint_X_p[rev]
+        rel_B = info.relative_xform_of[bB]
+        Xp_orig = wp.transform(*model.joint_X_p.numpy()[rev])
+        expected = rel_B * Xp_orig
+        Xp_eff = info.joint_X_p_effective_gpu.numpy()[rev]
+        actual = wp.transform(*Xp_eff)
+        for i in range(7):
+            self.assertAlmostEqual(float(actual[i]), float(expected[i]), places=5)
+
+    def test_fixed_joint_to_kinematic_parent_not_collapsed(self):
+        """A dynamic body fixed to a kinematic parent must not be merged.
+
+        Collapsing such a joint would absorb the dynamic body into a kinematic
+        survivor, hiding the constraint reaction users observe via
+        ``state.body_parent_f``.  The merger must treat kinematic bodies the
+        way it treats world (i.e. don't merge into them).
+        """
+        b = ModelBuilder(gravity=0.0)
+        # Kinematic root (no inbound joint to world).
+        kp = b.add_body(mass=1.0)
+        b.body_flags[kp] = int(newton.BodyFlags.KINEMATIC)
+        # Dynamic child rigidly attached.
+        dc = b.add_body(mass=2.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_fixed(kp, dc, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        # No merges should happen — the dynamic child must stay as its own body.
+        self.assertIsNone(info)
+
+    def test_disabled_fixed_joint_keeps_joint_enabled_effective_false(self):
+        """A model-level disabled FIXED joint must remain disabled in joint_enabled_effective."""
+        # Use chain A-FIXED-B-FIXED-C, disable the first FIXED joint.  The DFS
+        # would then bail out of merging at the disabled joint, but the effective
+        # enabled flag must still mirror the model's disabled flag so the
+        # downstream solver doesn't try to enforce it as a constraint either.
+        b = ModelBuilder(gravity=0.0)
+        bA = b.add_body(mass=1.0)
+        bB = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        bC = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 2, 0), wp.quat_identity()))
+        b.add_joint_free(bA)
+        j_ab = b.add_joint_fixed(bA, bB, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_fixed(bB, bC, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        model = b.finalize(device="cpu")
+        je = model.joint_enabled.numpy()
+        je[j_ab] = False
+        model.joint_enabled.assign(je)
+
+        info = compute_fixed_joint_merge(model)
+        self.assertIsNotNone(info)
+        eff = info.joint_enabled_effective_gpu.numpy()
+        # Disabled joint stays disabled in effective layer.
+        self.assertFalse(bool(eff[j_ab]))
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +392,76 @@ def test_xpbd_notify_model_changed_refreshes_merge(test, device):
     test.assertAlmostEqual(float(new_inv), 0.25, places=4)
 
 
+def test_xpbd_external_force_on_merged_child_moves_survivor(test, device):
+    """A force written to state.body_f[merged_child] must move the survivor.
+
+    Without the body_f scatter, the force would be silently dropped because
+    the merged child has zero effective inverse mass.
+    """
+    offset = wp.vec3(0.0, 1.0, 0.0)
+    model, b0, b1 = _make_two_body_fixed(device, mass0=1.0, mass1=1.0, offset=offset)
+    solver = SolverXPBD(model)
+    test.assertIsNotNone(solver._merge_info)
+
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+
+    # Apply a +X force on the merged child; survivor should accelerate in +X.
+    bf = state0.body_f.numpy()
+    bf[b1] = [10.0, 0.0, 0.0, 0.0, 0.0, 0.0]  # [linear, angular]
+    state0.body_f.assign(bf)
+
+    initial_pos_x = float(state0.body_q.numpy()[b0][0])
+
+    # No contacts; just integrate.
+    contacts = model.contacts()
+    solver.step(state0, state1, None, contacts, 1.0 / 60.0)
+
+    final_pos_x = float(state1.body_q.numpy()[b0][0])
+    test.assertGreater(
+        final_pos_x - initial_pos_x,
+        0.0,
+        f"survivor body did not move under force applied to merged child (Δx = {final_pos_x - initial_pos_x})",
+    )
+
+
+def test_xpbd_downstream_revolute_joint_works(test, device):
+    """A revolute joint downstream of a merged FIXED chain must still rotate.
+
+    Topology: A-(FREE)->world, A-(FIXED)->B, B-(REVOLUTE)->C.
+    B merges into A; the revolute's effective parent points at A.  Verifies
+    the simulation runs and produces finite state for several steps under
+    gravity, exercising the joint with a remapped parent + remapped anchor.
+    """
+    b = ModelBuilder(gravity=-9.81)
+    bA = b.add_body(mass=1.0)
+    bB = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+    bC = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(1, 1, 0), wp.quat_identity()))
+    b.add_joint_free(bA)
+    b.add_joint_fixed(bA, bB, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+    b.add_joint_revolute(
+        bB,
+        bC,
+        axis=newton.Axis.Z,
+        parent_xform=wp.transform(wp.vec3(1, 0, 0), wp.quat_identity()),
+    )
+    model = b.finalize(device=device)
+
+    solver = SolverXPBD(model)
+    test.assertIsNotNone(solver._merge_info)
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+    contacts = model.contacts()
+
+    for _ in range(10):
+        model.collide(state0, contacts)
+        solver.step(state0, state1, None, contacts, 1.0 / 60.0)
+        state0, state1 = state1, state0
+
+    test.assertTrue(np.all(np.isfinite(state0.body_q.numpy())))
+    test.assertTrue(np.all(np.isfinite(state0.body_qd.numpy())))
+
+
 add_function_test(
     TestSolverXPBDFixedJointCollapse,
     "test_merged_child_pose_follows_survivor",
@@ -265,6 +475,18 @@ add_function_test(
     TestSolverXPBDFixedJointCollapse,
     "test_notify_model_changed_refreshes_merge",
     test_xpbd_notify_model_changed_refreshes_merge,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverXPBDFixedJointCollapse,
+    "test_external_force_on_merged_child_moves_survivor",
+    test_xpbd_external_force_on_merged_child_moves_survivor,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverXPBDFixedJointCollapse,
+    "test_downstream_revolute_joint_works",
+    test_xpbd_downstream_revolute_joint_works,
     devices=get_test_devices(),
 )
 
@@ -317,6 +539,30 @@ def test_semi_no_nans_in_state(test, device):
     test.assertTrue(np.all(np.isfinite(state0.body_qd.numpy())), "body_qd contains non-finite values")
 
 
+def test_semi_external_force_on_merged_child_moves_survivor(test, device):
+    """Same scatter contract as XPBD: force on merged child must drive the survivor."""
+    offset = wp.vec3(0.0, 1.0, 0.0)
+    model, b0, b1 = _make_two_body_fixed(device, mass0=1.0, mass1=1.0, offset=offset)
+    solver = SolverSemiImplicit(model)
+    test.assertIsNotNone(solver._merge_info)
+
+    state0, state1 = model.state(), model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
+
+    bf = state0.body_f.numpy()
+    bf[b1] = [10.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    state0.body_f.assign(bf)
+
+    initial_pos_x = float(state0.body_q.numpy()[b0][0])
+    solver.step(state0, state1, None, None, 1.0 / 60.0)
+    final_pos_x = float(state1.body_q.numpy()[b0][0])
+    test.assertGreater(
+        final_pos_x - initial_pos_x,
+        0.0,
+        f"survivor body did not move under force applied to merged child (Δx = {final_pos_x - initial_pos_x})",
+    )
+
+
 add_function_test(
     TestSolverSemiImplicitFixedJointCollapse,
     "test_merged_child_pose_follows_survivor",
@@ -327,6 +573,12 @@ add_function_test(
     TestSolverSemiImplicitFixedJointCollapse,
     "test_no_nans_in_state",
     test_semi_no_nans_in_state,
+    devices=get_test_devices(),
+)
+add_function_test(
+    TestSolverSemiImplicitFixedJointCollapse,
+    "test_external_force_on_merged_child_moves_survivor",
+    test_semi_external_force_on_merged_child_moves_survivor,
     devices=get_test_devices(),
 )
 

--- a/newton/tests/test_fixed_joint_merger.py
+++ b/newton/tests/test_fixed_joint_merger.py
@@ -273,13 +273,7 @@ class TestComputeFixedJointMerge(unittest.TestCase):
             self.assertAlmostEqual(float(actual[i]), float(expected[i]), places=5)
 
     def test_fixed_joint_to_kinematic_parent_not_collapsed(self):
-        """A dynamic body fixed to a kinematic parent must not be merged.
-
-        Collapsing such a joint would absorb the dynamic body into a kinematic
-        survivor, hiding the constraint reaction users observe via
-        ``state.body_parent_f``.  The merger must treat kinematic bodies the
-        way it treats world (i.e. don't merge into them).
-        """
+        """A dynamic body fixed to a kinematic parent must not be merged."""
         b = ModelBuilder(gravity=0.0)
         # Kinematic root (no inbound joint to world).
         kp = b.add_body(mass=1.0)
@@ -294,14 +288,7 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertIsNone(info)
 
     def test_merged_inertia_is_about_combined_com(self):
-        """Merged inertia must be expressed about the new combined COM.
-
-        Two equal-mass bodies separated along Y by ``L`` must produce a merged
-        tensor whose ``Ixx``/``Izz`` exceed ``Iyy`` by exactly ``m * L^2 / 2``
-        (the parallel-axis contribution of two point-masses at ``±L/2`` from
-        the combined COM along Y). The earlier accumulator returned the
-        survivor-origin-frame value ``m * L^2``, so this test catches it.
-        """
+        """Merged inertia must be expressed about the new combined COM (parallel-axis identity)."""
         L = 2.0
         m = 1.0
         ident = wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
@@ -324,6 +311,26 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         cross_zz = float(merged_I[2, 2]) - float(merged_I[1, 1])
         self.assertAlmostEqual(cross_xx, m * L * L / 2.0, places=4)
         self.assertAlmostEqual(cross_zz, m * L * L / 2.0, places=4)
+
+    def test_constraint_body_nested_under_dynamic_not_merged(self):
+        """A body in an equality constraint must not be merged, even when nested under a dynamic ancestor."""
+        b = ModelBuilder(gravity=0.0)
+        bA = b.add_body(mass=1.0)
+        bB = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        bC = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 2, 0), wp.quat_identity()))
+        bD = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(2, 0, 0), wp.quat_identity()))
+        b.add_joint_free(bA)
+        b.add_joint_free(bD)
+        # FIXED chain: A -(FIXED)-> B -(FIXED)-> C, with C in an equality.
+        b.add_joint_fixed(bA, bB, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_joint_fixed(bB, bC, parent_xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))
+        b.add_equality_constraint_connect(body1=bC, body2=bD, anchor=wp.vec3(0.0))
+        model = b.finalize(device="cpu")
+
+        info = compute_fixed_joint_merge(model)
+        # bC participates in an equality constraint and must stay its own body.
+        if info is not None:
+            self.assertEqual(info.survivor_of[bC], bC)
 
     def test_disabled_fixed_joint_keeps_joint_enabled_effective_false(self):
         """A model-level disabled FIXED joint must remain disabled in joint_enabled_effective."""
@@ -350,14 +357,7 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertFalse(bool(eff[j_ab]))
 
     def test_velocity_propagation_uses_com_offset(self):
-        """Propagation must use COM-to-COM offset, not body-origin offset.
-
-        Build a setup where the two are measurably different (heavier child
-        shifts the combined COM far from the survivor's body origin), give the
-        survivor pure angular velocity, run the propagation kernel, and verify
-        body_qd[child].linear == omega x (com_child_world - com_survivor_world).
-        Using the body-origin offset would yield a different number.
-        """
+        """Velocity propagation must use the COM-to-COM offset, not the body-origin offset."""
         device = "cpu"
         L = 2.0
         sv_mass = 1.0
@@ -428,12 +428,7 @@ class TestComputeFixedJointMerge(unittest.TestCase):
         self.assertIs(solver.joint_enabled_effective, model.joint_enabled)
 
     def test_notify_joint_properties_recomputes_merge(self):
-        """Changing joint_enabled and notifying with JOINT_PROPERTIES must refresh the merge.
-
-        Previously only ``BODY_INERTIAL_PROPERTIES`` triggered a recompute, so a
-        caller that disabled a FIXED joint and notified with the conceptually
-        correct flag would still get the stale collapsed topology.
-        """
+        """notify_model_changed(JOINT_PROPERTIES) must refresh the cached merge."""
         b = ModelBuilder(gravity=0.0)
         b0 = b.add_body(mass=1.0)
         b1 = b.add_body(mass=1.0, xform=wp.transform(wp.vec3(0, 1, 0), wp.quat_identity()))


### PR DESCRIPTION
## Description

Addresses issue #164 

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

unit test: test_fixed_joint_merger.py specifically tests that the changes made in this PR appropriately address the goal


## New feature / API change

```
import warp as wp
import newton

# Build a robot with bodies connected by FIXED joints (e.g. a rigid tool
# attached to a wrist link). The original body hierarchy is preserved in Model
# — all body indices remain valid for USD path mapping, contact sensors, etc.
builder = newton.ModelBuilder()
base   = builder.add_body(mass=1.0)
tool   = builder.add_body(mass=0.5, xform=wp.transform(wp.vec3(0, 0.2, 0), wp.quat_identity()))
builder.add_joint_free(base)
builder.add_joint_fixed(base, tool,
                         parent_xform=wp.transform(wp.vec3(0, 0.2, 0), wp.quat_identity()))
model = builder.finalize(device="cuda")

# By default (collapse_fixed_joints=True), the solver merges the FIXED joint
# internally for improved stability and efficiency. The Model is untouched —
# model.body_count is still 2 and body indices are unchanged.
solver = newton.solvers.SolverXPBD(model)         # collapse_fixed_joints=True by default
# solver = newton.solvers.SolverSemiImplicit(model)  # same on SemiImplicit

# Opt out to keep the original per-body dynamics:
# solver = newton.solvers.SolverXPBD(model, collapse_fixed_joints=False)

# Exempt specific joints from collapsing (e.g. a joint that drives animation):
# solver = newton.solvers.SolverXPBD(model, joints_to_keep=["wrist_fixed"])

state_0, state_1 = model.state(), model.state()
newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
contacts = model.contacts()

for _ in range(100):
    state_0.clear_forces()
    model.collide(state_0, contacts)
    solver.step(state_0, state_1, None, contacts, dt=1.0 / 120.0)
    state_0, state_1 = state_1, state_0

# Both body indices remain valid — state reflects the correct pose for every body.
print(state_0.body_q.numpy()[base])   # base body pose
print(state_0.body_q.numpy()[tool])   # tool pose, propagated from base

# When body inertial properties change at runtime, notify the solver to
# recompute the merged mass/inertia:
solver.notify_model_changed(newton.solvers.SolverNotifyFlags.BODY_INERTIAL_PROPERTIES)

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solvers (XPBD and Semi‑Implicit) now collapse enabled fixed joints by default, preserving model body hierarchy while accumulating merged inertial properties; option to disable or exempt specific joints. Force, contact, and joint evaluation paths accept merged-property overrides so simulations remain stable and consistent.

* **Tests**
  * Added CPU/GPU unit and integration tests covering merge correctness, force scattering, pose/velocity propagation, stability, and model-change handling.

* **Documentation**
  * Updated mass/inertia docs and CHANGELOG to describe solver-level fixed‑joint collapsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->