### PR TITLE
Fix graphability of delayed actuator

### DIFF
--- a/newton/_src/actuators/delay.py
+++ b/newton/_src/actuators/delay.py
@@ -16,22 +16,25 @@ def _delay_buffer_state_kernel(
     feedforward_global: wp.array[float],
     pos_indices: wp.array[wp.uint32],
     vel_indices: wp.array[wp.uint32],
-    copy_idx: int,
-    write_idx: int,
     buf_depth: int,
     current_buffer_pos: wp.array2d[float],
     current_buffer_vel: wp.array2d[float],
     current_buffer_act: wp.array2d[float],
     current_num_pushes: wp.array[int],
+    current_write_idx: wp.array[int],
     next_buffer_pos: wp.array2d[float],
     next_buffer_vel: wp.array2d[float],
     next_buffer_act: wp.array2d[float],
     next_num_pushes: wp.array[int],
+    next_write_idx: wp.array[int],
 ):
-    """Update delay circular buffer: copy previous entry, write new entry, increment push count."""
+    """Update delay circular buffer: copy previous entry, write new entry, advance write pointer."""
     i = wp.tid()
     pos_idx = pos_indices[i]
     vel_idx = vel_indices[i]
+
+    copy_idx = current_write_idx[0]
+    write_idx = (copy_idx + 1) % buf_depth
 
     next_buffer_pos[copy_idx, i] = current_buffer_pos[copy_idx, i]
     next_buffer_vel[copy_idx, i] = current_buffer_vel[copy_idx, i]
@@ -47,12 +50,15 @@ def _delay_buffer_state_kernel(
 
     next_num_pushes[i] = wp.min(current_num_pushes[i] + 1, buf_depth)
 
+    if i == 0:
+        next_write_idx[0] = write_idx
+
 
 @wp.kernel
 def _delay_read_kernel(
     delays: wp.array[int],
     num_pushes: wp.array[int],
-    write_idx: int,
+    write_idx_arr: wp.array[int],
     buf_depth: int,
     buffer_pos: wp.array2d[float],
     buffer_vel: wp.array2d[float],
@@ -79,6 +85,7 @@ def _delay_read_kernel(
             act = current_act[vel_idx]
         out_act[i] = act
     else:
+        write_idx = write_idx_arr[0]
         lag = wp.min(delays[i] - 1, n - 1)
         read_idx = (write_idx - lag + buf_depth) % buf_depth
         out_pos[i] = buffer_pos[read_idx, i]
@@ -133,8 +140,8 @@ class Delay:
         """Delayed feedforward inputs [N or N·m], shape (buf_depth, N)."""
         num_pushes: wp.array[int] | None = None
         """Per-DOF count of writes since last reset, shape (N,)."""
-        write_idx: int = 0
-        """Current write position in the circular buffer."""
+        write_idx: wp.array[int] | None = None
+        """Current write position in the circular buffer, shape (1,). Device-side for graph capture."""
 
         def reset(self, mask: wp.array[wp.bool] | None = None) -> None:
             """Reset delay buffer state.
@@ -149,7 +156,7 @@ class Delay:
                 self.buffer_vel.zero_()
                 self.buffer_act.zero_()
                 self.num_pushes.zero_()
-                self.write_idx = self.buffer_pos.shape[0] - 1
+                self.write_idx.fill_(self.buffer_pos.shape[0] - 1)
             else:
                 rows = self.buffer_pos.shape[0]
                 n = len(mask)
@@ -227,12 +234,13 @@ class Delay:
             Freshly allocated :class:`Delay.State`.
         """
         rg = self._requires_grad
+        write_idx_arr = wp.full(1, self.buf_depth - 1, dtype=int, device=device)
         return Delay.State(
             buffer_pos=wp.zeros((self.buf_depth, num_actuators), dtype=wp.float32, device=device, requires_grad=rg),
             buffer_vel=wp.zeros((self.buf_depth, num_actuators), dtype=wp.float32, device=device, requires_grad=rg),
             buffer_act=wp.zeros((self.buf_depth, num_actuators), dtype=wp.float32, device=device, requires_grad=rg),
             num_pushes=wp.zeros(num_actuators, dtype=int, device=device),
-            write_idx=self.buf_depth - 1,
+            write_idx=write_idx_arr,
         )
 
     def get_delayed_targets(
@@ -269,7 +277,7 @@ class Delay:
             inputs=[
                 self.delay_steps,
                 current_state.num_pushes,
-                current_state.write_idx,
+                current_state.write_idx,  # device-side array (1,)
                 self.buf_depth,
                 current_state.buffer_pos,
                 current_state.buffer_vel,
@@ -309,9 +317,6 @@ class Delay:
         if next_state is None:
             return
 
-        copy_idx = current_state.write_idx
-        write_idx = (current_state.write_idx + 1) % self.buf_depth
-
         wp.launch(
             kernel=_delay_buffer_state_kernel,
             dim=self._num_actuators,
@@ -321,21 +326,19 @@ class Delay:
                 feedforward,
                 pos_indices,
                 vel_indices,
-                copy_idx,
-                write_idx,
                 self.buf_depth,
                 current_state.buffer_pos,
                 current_state.buffer_vel,
                 current_state.buffer_act,
                 current_state.num_pushes,
+                current_state.write_idx,
             ],
             outputs=[
                 next_state.buffer_pos,
                 next_state.buffer_vel,
                 next_state.buffer_act,
                 next_state.num_pushes,
+                next_state.write_idx,
             ],
             device=self._device,
         )
-
-        next_state.write_idx = write_idx

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -1403,7 +1403,10 @@ class TestDelayGraphCapture(unittest.TestCase):
         builder.add_articulation([joint])
         dof = builder.joint_qd_start[joint]
         builder.add_actuator(
-            ControllerPD, index=dof, kp=200.0, kd=10.0,
+            ControllerPD,
+            index=dof,
+            kp=200.0,
+            kd=10.0,
             delay_steps=max_delay,
             clamping=[(ClampingMaxEffort, {"max_effort": 500.0})],
         )
@@ -1446,9 +1449,7 @@ class TestDelayGraphCapture(unittest.TestCase):
         # --- Graph ---
         solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g = _setup()
         wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
-        s0_g, s1_g, act_a_g, act_b_g = _loop(
-            solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g, max_delay
-        )
+        s0_g, s1_g, act_a_g, act_b_g = _loop(solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g, max_delay)
         sub_dt = dt / K
         with wp.ScopedCapture(device=device) as capture:
             for _ in range(N):
@@ -1469,7 +1470,9 @@ class TestDelayGraphCapture(unittest.TestCase):
 
         for ci in range(len(cycle_targets)):
             np.testing.assert_allclose(
-                graph_results[ci], eager_results[ci], rtol=1e-4,
+                graph_results[ci],
+                eager_results[ci],
+                rtol=1e-4,
                 err_msg=f"Cycle {ci}: graph should match eager with device-side write_idx",
             )
 

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -1418,40 +1418,43 @@ class TestDelayGraphCapture(unittest.TestCase):
             ctrl = model.control()
             newton.eval_fk(model, s0.joint_q, s0.joint_qd, s0)
             act = model.actuators[0]
-            return solver, s0, s1, ctrl, act, [act.state(), act.state()]
+            act_a, act_b = act.state(), act.state()
+            return solver, s0, s1, ctrl, act, act_a, act_b
 
-        def _loop(solver, s0, s1, ctrl, act, astates, n, offset):
+        def _loop(solver, s0, s1, ctrl, act, act_a, act_b, n):
             sub_dt = dt / K
-            for i in range(n):
-                idx = offset + i
+            for _ in range(n):
                 ctrl.joint_f.zero_()
-                act.step(s0, ctrl, astates[idx % 2], astates[(idx + 1) % 2], dt=dt)
+                act.step(s0, ctrl, act_a, act_b, dt=dt)
+                act_a, act_b = act_b, act_a
                 for _ in range(K):
                     s0.clear_forces()
                     solver.step(s0, s1, ctrl, None, sub_dt)
                     s0, s1 = s1, s0
-            return s0, s1
+            return s0, s1, act_a, act_b
 
         # --- Eager ---
-        solver, s0, s1, ctrl, act, astates = _setup()
+        solver, s0, s1, ctrl, act, act_a, act_b = _setup()
         wp.copy(ctrl.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
-        s0, s1 = _loop(solver, s0, s1, ctrl, act, astates, max_delay, 0)
+        s0, s1, act_a, act_b = _loop(solver, s0, s1, ctrl, act, act_a, act_b, max_delay)
         eager_results = []
-        for ci, tgt in enumerate(cycle_targets):
+        for tgt in cycle_targets:
             wp.copy(ctrl.joint_target_pos, wp.full(ndof, tgt, dtype=wp.float32, device=device))
-            s0, s1 = _loop(solver, s0, s1, ctrl, act, astates, N, max_delay + ci * N)
+            s0, s1, act_a, act_b = _loop(solver, s0, s1, ctrl, act, act_a, act_b, N)
             eager_results.append(s0.joint_q.numpy().copy())
 
         # --- Graph ---
-        solver_g, s0_g, s1_g, ctrl_g, act_g, ast_g = _setup()
+        solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g = _setup()
         wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
-        s0_g, s1_g = _loop(solver_g, s0_g, s1_g, ctrl_g, act_g, ast_g, max_delay, 0)
+        s0_g, s1_g, act_a_g, act_b_g = _loop(
+            solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g, max_delay
+        )
         sub_dt = dt / K
         with wp.ScopedCapture(device=device) as capture:
-            for i in range(N):
-                idx = max_delay + i
+            for _ in range(N):
                 ctrl_g.joint_f.zero_()
-                act_g.step(s0_g, ctrl_g, ast_g[idx % 2], ast_g[(idx + 1) % 2], dt=dt)
+                act_g.step(s0_g, ctrl_g, act_a_g, act_b_g, dt=dt)
+                act_a_g, act_b_g = act_b_g, act_a_g
                 for _ in range(K):
                     s0_g.clear_forces()
                     solver_g.step(s0_g, s1_g, ctrl_g, None, sub_dt)

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -412,7 +412,7 @@ class TestDelay(unittest.TestCase):
         self.assertEqual(ds.buffer_pos.shape, (max_delay, n))
         self.assertEqual(ds.buffer_vel.shape, (max_delay, n))
         self.assertEqual(ds.buffer_act.shape, (max_delay, n))
-        self.assertEqual(ds.write_idx, max_delay - 1)
+        self.assertEqual(ds.write_idx.numpy()[0], max_delay - 1)
         np.testing.assert_array_equal(ds.num_pushes.numpy(), [0, 0])
 
     def test_latency_behavior(self):
@@ -1261,7 +1261,7 @@ class TestStateReset(unittest.TestCase):
         np.testing.assert_array_equal(state.buffer_pos.numpy(), np.zeros((max_delay, n)))
         np.testing.assert_array_equal(state.buffer_vel.numpy(), np.zeros((max_delay, n)))
         np.testing.assert_array_equal(state.buffer_act.numpy(), np.zeros((max_delay, n)))
-        self.assertEqual(state.write_idx, max_delay - 1)
+        self.assertEqual(state.write_idx.numpy()[0], max_delay - 1)
 
     def test_pid_masked_reset(self):
         """PID integral accumulator: masked reset zeros selected DOFs only."""
@@ -1359,6 +1359,116 @@ class TestStateReset(unittest.TestCase):
             state_0.controller_state.integral.numpy()[0], 0.0, places=6, msg="env 0 integral should be reset"
         )
         self.assertGreater(state_0.controller_state.integral.numpy()[1], 0.0, msg="env 1 integral should be untouched")
+
+
+# ---------------------------------------------------------------------------
+# 7b. CUDA graph capture — end-to-end with Newton solver + delayed actuator
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    wp.get_device().is_cuda and wp.is_mempool_enabled(wp.get_device()),
+    "CUDA graph capture requires CUDA device with memory pools",
+)
+class TestDelayGraphCapture(unittest.TestCase):
+    """Verify delayed actuator is graph-safe with device-side write_idx.
+
+    Captures N actuator + K physics substeps as a CUDA graph and replays
+    with varying targets. With N even and N % buf_depth != 0, the test
+    confirms graph replay matches eager execution — proving the write
+    pointer advances correctly on-device during replay.
+    """
+
+    def test_delay_graph_n_not_multiple_matches_eager(self):
+        """N=2, buf_depth=5: graph matches eager across multiple cycles.
+
+        This configuration (N < buf_depth, N % buf_depth != 0) previously
+        failed when write_idx was a host-side scalar baked into the graph.
+        With device-side write_idx the kernel advances the pointer on-GPU,
+        making graph replay correct for any even N.
+        """
+        max_delay = 5
+        N = 2  # 2 % 5 != 0, N < buf_depth, N is even
+        K = 2
+        dt = 0.02
+        warmup_target = 0.0
+        cycle_targets = [2.0, -3.0, 5.0, -1.0]
+
+        # Build a single-DOF revolute pendulum with delayed PD actuator
+        builder = newton.ModelBuilder()
+        builder.default_shape_cfg.density = 1000.0
+        link = builder.add_link()
+        joint = builder.add_joint_revolute(parent=-1, child=link, axis=newton.Axis.Z)
+        builder.add_shape_sphere(body=link, radius=0.1)
+        builder.add_articulation([joint])
+        dof = builder.joint_qd_start[joint]
+        builder.add_actuator(
+            ControllerPD, index=dof, kp=200.0, kd=10.0,
+            delay_steps=max_delay,
+            clamping=[(ClampingMaxEffort, {"max_effort": 500.0})],
+        )
+        model = builder.finalize()
+        device = model.device
+        ndof = model.joint_coord_count
+
+        def _setup():
+            solver = newton.solvers.SolverMuJoCo(model, iterations=4, ls_iterations=4)
+            s0 = model.state()
+            s1 = model.state()
+            ctrl = model.control()
+            newton.eval_fk(model, s0.joint_q, s0.joint_qd, s0)
+            act = model.actuators[0]
+            return solver, s0, s1, ctrl, act, [act.state(), act.state()]
+
+        def _loop(solver, s0, s1, ctrl, act, astates, n, offset):
+            sub_dt = dt / K
+            for i in range(n):
+                idx = offset + i
+                ctrl.joint_f.zero_()
+                act.step(s0, ctrl, astates[idx % 2], astates[(idx + 1) % 2], dt=dt)
+                for _ in range(K):
+                    s0.clear_forces()
+                    solver.step(s0, s1, ctrl, None, sub_dt)
+                    s0, s1 = s1, s0
+            return s0, s1
+
+        # --- Eager ---
+        solver, s0, s1, ctrl, act, astates = _setup()
+        wp.copy(ctrl.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
+        s0, s1 = _loop(solver, s0, s1, ctrl, act, astates, max_delay, 0)
+        eager_results = []
+        for ci, tgt in enumerate(cycle_targets):
+            wp.copy(ctrl.joint_target_pos, wp.full(ndof, tgt, dtype=wp.float32, device=device))
+            s0, s1 = _loop(solver, s0, s1, ctrl, act, astates, N, max_delay + ci * N)
+            eager_results.append(s0.joint_q.numpy().copy())
+
+        # --- Graph ---
+        solver_g, s0_g, s1_g, ctrl_g, act_g, ast_g = _setup()
+        wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
+        s0_g, s1_g = _loop(solver_g, s0_g, s1_g, ctrl_g, act_g, ast_g, max_delay, 0)
+        sub_dt = dt / K
+        with wp.ScopedCapture(device=device) as capture:
+            for i in range(N):
+                idx = max_delay + i
+                ctrl_g.joint_f.zero_()
+                act_g.step(s0_g, ctrl_g, ast_g[idx % 2], ast_g[(idx + 1) % 2], dt=dt)
+                for _ in range(K):
+                    s0_g.clear_forces()
+                    solver_g.step(s0_g, s1_g, ctrl_g, None, sub_dt)
+                    s0_g, s1_g = s1_g, s0_g
+        graph = capture.graph
+
+        graph_results = []
+        for tgt in cycle_targets:
+            wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, tgt, dtype=wp.float32, device=device))
+            wp.capture_launch(graph)
+            graph_results.append(s0_g.joint_q.numpy().copy())
+
+        for ci in range(len(cycle_targets)):
+            np.testing.assert_allclose(
+                graph_results[ci], eager_results[ci], rtol=1e-4,
+                err_msg=f"Cycle {ci}: graph should match eager with device-side write_idx",
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Improved delay buffer implementation for more robust and reliable actuator timing and state handling.

* **Tests**
  - Added CUDA graph capture integration tests for the delay actuator to ensure replayed simulations match eager execution across multiple control cycles and buffer configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->