### PR TITLE
Fix floating URDF dummy roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
+- Add opt-in `collapse_massless_fixed_root` to URDF and MJCF importers to collapse massless fixed-root chains for maximal-coordinate solvers while preserving topology by default
 - Add USD parsing for `NewtonSiteAPI` to mark shapes as sites.
 
 ### Changed
@@ -142,7 +143,6 @@
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead
 - Fix `SolverMuJoCo` Newton-contact conversion to use geometry-surface contact anchors
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata
-- Fix floating URDF imports with massless fixed root links so XPBD treats the imported articulation as dynamic
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead
 - Fix `SolverMuJoCo` Newton-contact conversion to use geometry-surface contact anchors
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata
+- Fix floating URDF imports with massless fixed root links so XPBD treats the imported articulation as dynamic
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2277,6 +2277,7 @@ class ModelBuilder:
         joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
         bodies_follow_joint_ordering: bool = True,
         collapse_fixed_joints: bool = False,
+        collapse_massless_fixed_root: bool = False,
         mesh_maxhullvert: int | None = None,
         force_position_velocity_actuation: bool = False,
         override_root_xform: bool = False,
@@ -2370,6 +2371,7 @@ class ModelBuilder:
             joint_ordering: The ordering of the joints in the simulation. Can be either "bfs" or "dfs" for breadth-first or depth-first search, or ``None`` to keep joints in the order in which they appear in the URDF. Default is "dfs".
             bodies_follow_joint_ordering: If True, the bodies are added to the builder in the same order as the joints (parent then child body). Otherwise, bodies are added in the order they appear in the URDF. Default is True.
             collapse_fixed_joints: If True, fixed joints are removed and the respective bodies are merged.
+            collapse_massless_fixed_root: If True, collapse only the massless fixed-joint chain below an imported free root body. Ignored when ``collapse_fixed_joints`` is True.
             mesh_maxhullvert: Maximum vertices for convex hull approximation of meshes.
             force_position_velocity_actuation: If True and both position (stiffness) and velocity
                 (damping) gains are non-zero, joints use :attr:`~newton.JointTargetMode.POSITION_VELOCITY` actuation mode.
@@ -2397,6 +2399,7 @@ class ModelBuilder:
             joint_ordering=joint_ordering,
             bodies_follow_joint_ordering=bodies_follow_joint_ordering,
             collapse_fixed_joints=collapse_fixed_joints,
+            collapse_massless_fixed_root=collapse_massless_fixed_root,
             mesh_maxhullvert=mesh_maxhullvert,
             force_position_velocity_actuation=force_position_velocity_actuation,
             override_root_xform=override_root_xform,
@@ -2654,6 +2657,7 @@ class ModelBuilder:
         enable_self_collisions: bool = True,
         ignore_inertial_definitions: bool = False,
         collapse_fixed_joints: bool = False,
+        collapse_massless_fixed_root: bool = False,
         verbose: bool = False,
         skip_equality_constraints: bool = False,
         convert_3d_hinge_to_ball_joints: bool = False,
@@ -2759,6 +2763,7 @@ class ModelBuilder:
             enable_self_collisions: If True, self-collisions are enabled.
             ignore_inertial_definitions: If True, the inertial parameters defined in the MJCF are ignored and the inertia is calculated from the shape geometry.
             collapse_fixed_joints: If True, fixed joints are removed and the respective bodies are merged.
+            collapse_massless_fixed_root: If True, collapse only the massless fixed-joint chain below an imported free root body. Ignored when ``collapse_fixed_joints`` is True.
             verbose: If True, print additional information about parsing the MJCF.
             skip_equality_constraints: Whether <equality> tags should be parsed. If True, equality constraints are ignored.
             convert_3d_hinge_to_ball_joints: If True, series of three hinge joints are converted to a single ball joint. Default is False.
@@ -2799,6 +2804,7 @@ class ModelBuilder:
             enable_self_collisions=enable_self_collisions,
             ignore_inertial_definitions=ignore_inertial_definitions,
             collapse_fixed_joints=collapse_fixed_joints,
+            collapse_massless_fixed_root=collapse_massless_fixed_root,
             verbose=verbose,
             skip_equality_constraints=skip_equality_constraints,
             convert_3d_hinge_to_ball_joints=convert_3d_hinge_to_ball_joints,

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4838,16 +4838,16 @@ class ModelBuilder:
     def collapse_fixed_joints(
         self,
         verbose: bool = False,
-        joints_to_keep: list[str] | None = None,
-        joint_indices_to_keep: set[int] | None = None,
+        joints_to_keep: Sequence[str | int] | None = None,
     ) -> dict[str, Any]:
         """Removes fixed joints from the model and merges the bodies they connect. This is useful for simplifying the model for faster and more stable simulation.
 
         Args:
             verbose: If True, print additional information about the collapsed joints.
-            joints_to_keep: An optional list of joint labels to be excluded from the collapse process.
-            joint_indices_to_keep: An optional set of joint indices to be excluded from the collapse process.
+            joints_to_keep: An optional sequence of joint labels or original joint indices to be excluded from
+                the collapse process.
         """
+        joints_to_keep = set(joints_to_keep or ())
 
         body_data = {}
         body_children = {-1: []}
@@ -4958,7 +4958,6 @@ class ModelBuilder:
             nonlocal retained_joints
             nonlocal retained_bodies
             nonlocal body_data
-            nonlocal joints_to_keep
 
             joint = joint_data[(parent_body, child_body)]
             # Don't merge fixed joints if the child body is referenced in an equality constraint
@@ -4966,11 +4965,7 @@ class ModelBuilder:
             should_skip_merge = child_body in bodies_in_constraints and last_dynamic_body == -1
 
             # Don't merge fixed joints listed in joints_to_keep list
-            if joints_to_keep is None:
-                joints_to_keep = []
-            joint_in_keep_list = joint["label"] in joints_to_keep or (
-                joint_indices_to_keep is not None and joint["original_id"] in joint_indices_to_keep
-            )
+            joint_in_keep_list = joint["label"] in joints_to_keep or joint["original_id"] in joints_to_keep
 
             if should_skip_merge and joint["type"] == JointType.FIXED:
                 # Skip merging this fixed joint because the body is referenced in an equality constraint

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4829,12 +4829,18 @@ class ModelBuilder:
             plt.legend(loc="upper left", fontsize=6)
         plt.show()
 
-    def collapse_fixed_joints(self, verbose: bool = False, joints_to_keep: list[str] | None = None) -> dict[str, Any]:
+    def collapse_fixed_joints(
+        self,
+        verbose: bool = False,
+        joints_to_keep: list[str] | None = None,
+        joint_indices_to_keep: set[int] | None = None,
+    ) -> dict[str, Any]:
         """Removes fixed joints from the model and merges the bodies they connect. This is useful for simplifying the model for faster and more stable simulation.
 
         Args:
             verbose: If True, print additional information about the collapsed joints.
             joints_to_keep: An optional list of joint labels to be excluded from the collapse process.
+            joint_indices_to_keep: An optional set of joint indices to be excluded from the collapse process.
         """
 
         body_data = {}
@@ -4956,7 +4962,9 @@ class ModelBuilder:
             # Don't merge fixed joints listed in joints_to_keep list
             if joints_to_keep is None:
                 joints_to_keep = []
-            joint_in_keep_list = joint["label"] in joints_to_keep
+            joint_in_keep_list = joint["label"] in joints_to_keep or (
+                joint_indices_to_keep is not None and joint["original_id"] in joint_indices_to_keep
+            )
 
             if should_skip_merge and joint["type"] == JointType.FIXED:
                 # Skip merging this fixed joint because the body is referenced in an equality constraint

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2801,10 +2801,4 @@ def parse_mjcf(
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()
     elif collapse_massless_fixed_root:
-        root_joint_indices = []
-        for i, (start_idx, _) in enumerate(root_body_boundaries):
-            end_idx = root_body_boundaries[i + 1][0] if i + 1 < len(root_body_boundaries) else len(joint_indices)
-            root_joints = joint_indices[start_idx:end_idx]
-            if root_joints:
-                root_joint_indices.append(root_joints[0])
-        collapse_massless_fixed_root_joints(builder, joint_indices, root_joint_indices)
+        collapse_massless_fixed_root_joints(builder, joint_indices)

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -24,6 +24,7 @@ from ..solvers.mujoco import SolverMuJoCo
 from ..usd.schemas import solref_to_stiffness_damping
 from .heightfield import load_heightfield_elevation
 from .import_utils import (
+    collapse_massless_fixed_root_joints,
     is_xml_content,
     parse_custom_attributes,
     sanitize_name,
@@ -169,6 +170,7 @@ def parse_mjcf(
     enable_self_collisions: bool = True,
     ignore_inertial_definitions: bool = False,
     collapse_fixed_joints: bool = False,
+    collapse_massless_fixed_root: bool = False,
     verbose: bool = False,
     skip_equality_constraints: bool = False,
     convert_3d_hinge_to_ball_joints: bool = False,
@@ -275,6 +277,7 @@ def parse_mjcf(
         enable_self_collisions: If True, self-collisions are enabled.
         ignore_inertial_definitions: If True, the inertial parameters defined in the MJCF are ignored and the inertia is calculated from the shape geometry.
         collapse_fixed_joints: If True, fixed joints are removed and the respective bodies are merged.
+        collapse_massless_fixed_root: If True, collapse only the massless fixed-joint chain below an imported free root body. Ignored when ``collapse_fixed_joints`` is True.
         verbose: If True, print additional information about parsing the MJCF.
         skip_equality_constraints: Whether <equality> tags should be parsed. If True, equality constraints are ignored.
         convert_3d_hinge_to_ball_joints: If True, series of three hinge joints are converted to a single ball joint. Default is False.
@@ -2797,3 +2800,11 @@ def parse_mjcf(
 
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()
+    elif collapse_massless_fixed_root:
+        root_joint_indices = []
+        for i, (start_idx, _) in enumerate(root_body_boundaries):
+            end_idx = root_body_boundaries[i + 1][0] if i + 1 < len(root_body_boundaries) else len(joint_indices)
+            root_joints = joint_indices[start_idx:end_idx]
+            if root_joints:
+                root_joint_indices.append(root_joints[0])
+        collapse_massless_fixed_root_joints(builder, joint_indices, root_joint_indices)

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -179,8 +179,6 @@ def parse_urdf(
     if override_root_xform and xform is None:
         raise ValueError("override_root_xform=True requires xform to be set")
 
-    import_start_joint_count = builder.joint_count
-
     if mesh_maxhullvert is None:
         mesh_maxhullvert = Mesh.MAX_HULL_VERTICES
 
@@ -885,7 +883,8 @@ def parse_urdf(
     # A massless dummy root connected to the physical base by fixed joints is
     # immovable in maximal-coordinate solvers. Collapse that fixed subtree so
     # the free root carries the imported mass and inertia.
-    massless_floating_fixed_root = (
+    auto_collapse_fixed_joint_indices: set[int] = set()
+    if (
         floating
         and base_parent == -1
         and builder.body_mass[root] <= 0.0
@@ -893,14 +892,33 @@ def parse_urdf(
             builder.joint_type[joint_idx] == JointType.FIXED and builder.joint_parent[joint_idx] == root
             for joint_idx in joint_indices
         )
-    )
+    ):
+        massless_root_chain_parents = {root}
+        while True:
+            added_joint = False
+            for joint_idx in joint_indices:
+                if joint_idx in auto_collapse_fixed_joint_indices:
+                    continue
+                if builder.joint_type[joint_idx] != JointType.FIXED:
+                    continue
+                if builder.joint_parent[joint_idx] not in massless_root_chain_parents:
+                    continue
+
+                auto_collapse_fixed_joint_indices.add(joint_idx)
+                child = builder.joint_child[joint_idx]
+                if child >= 0 and builder.body_mass[child] <= 0.0:
+                    massless_root_chain_parents.add(child)
+                added_joint = True
+
+            if not added_joint:
+                break
 
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()
-    elif massless_floating_fixed_root:
-        external_fixed_joints = {
+    elif auto_collapse_fixed_joint_indices:
+        fixed_joints_to_keep = {
             joint_idx
-            for joint_idx in range(import_start_joint_count)
-            if builder.joint_type[joint_idx] == JointType.FIXED
+            for joint_idx in range(builder.joint_count)
+            if builder.joint_type[joint_idx] == JointType.FIXED and joint_idx not in auto_collapse_fixed_joint_indices
         }
-        builder.collapse_fixed_joints(joint_indices_to_keep=external_fixed_joints)
+        builder.collapse_fixed_joints(joint_indices_to_keep=fixed_joints_to_keep)

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -17,7 +17,7 @@ from ..core import Axis, AxisType, quat_between_axes
 from ..core.types import Transform
 from ..geometry import Mesh
 from ..sim import ModelBuilder
-from ..sim.enums import JointTargetMode
+from ..sim.enums import JointTargetMode, JointType
 from ..sim.model import Model
 from .import_utils import parse_custom_attributes, sanitize_xml_content, should_show_collider
 from .mesh import load_meshes_from_file
@@ -178,6 +178,8 @@ def parse_urdf(
 
     if override_root_xform and xform is None:
         raise ValueError("override_root_xform=True requires xform to be set")
+
+    import_start_joint_count = builder.joint_count
 
     if mesh_maxhullvert is None:
         mesh_maxhullvert = Mesh.MAX_HULL_VERTICES
@@ -880,5 +882,25 @@ def parse_urdf(
             for j in range(i + 1, end_shape_count):
                 builder.add_shape_collision_filter_pair(i, j)
 
+    # A massless dummy root connected to the physical base by fixed joints is
+    # immovable in maximal-coordinate solvers. Collapse that fixed subtree so
+    # the free root carries the imported mass and inertia.
+    massless_floating_fixed_root = (
+        floating
+        and base_parent == -1
+        and builder.body_mass[root] <= 0.0
+        and any(
+            builder.joint_type[joint_idx] == JointType.FIXED and builder.joint_parent[joint_idx] == root
+            for joint_idx in joint_indices
+        )
+    )
+
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()
+    elif massless_floating_fixed_root:
+        external_fixed_joints = {
+            joint_idx
+            for joint_idx in range(import_start_joint_count)
+            if builder.joint_type[joint_idx] == JointType.FIXED
+        }
+        builder.collapse_fixed_joints(joint_indices_to_keep=external_fixed_joints)

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -17,9 +17,14 @@ from ..core import Axis, AxisType, quat_between_axes
 from ..core.types import Transform
 from ..geometry import Mesh
 from ..sim import ModelBuilder
-from ..sim.enums import JointTargetMode, JointType
+from ..sim.enums import JointTargetMode
 from ..sim.model import Model
-from .import_utils import parse_custom_attributes, sanitize_xml_content, should_show_collider
+from .import_utils import (
+    collapse_massless_fixed_root_joints,
+    parse_custom_attributes,
+    sanitize_xml_content,
+    should_show_collider,
+)
 from .mesh import load_meshes_from_file
 from .texture import load_texture
 from .topology import topological_sort
@@ -71,6 +76,7 @@ def parse_urdf(
     joint_ordering: Literal["bfs", "dfs"] | None = "dfs",
     bodies_follow_joint_ordering: bool = True,
     collapse_fixed_joints: bool = False,
+    collapse_massless_fixed_root: bool = False,
     mesh_maxhullvert: int | None = None,
     force_position_velocity_actuation: bool = False,
     override_root_xform: bool = False,
@@ -165,6 +171,7 @@ def parse_urdf(
         joint_ordering: The ordering of the joints in the simulation. Can be either "bfs" or "dfs" for breadth-first or depth-first search, or ``None`` to keep joints in the order in which they appear in the URDF. Default is "dfs".
         bodies_follow_joint_ordering: If True, the bodies are added to the builder in the same order as the joints (parent then child body). Otherwise, bodies are added in the order they appear in the URDF. Default is True.
         collapse_fixed_joints: If True, fixed joints are removed and the respective bodies are merged.
+        collapse_massless_fixed_root: If True, collapse only the massless fixed-joint chain below an imported free root body. Ignored when ``collapse_fixed_joints`` is True.
         mesh_maxhullvert: Maximum vertices for convex hull approximation of meshes.
         force_position_velocity_actuation: If True and both position (stiffness) and velocity
             (damping) gains are non-zero, joints use :attr:`~newton.JointTargetMode.POSITION_VELOCITY` actuation mode.
@@ -880,45 +887,7 @@ def parse_urdf(
             for j in range(i + 1, end_shape_count):
                 builder.add_shape_collision_filter_pair(i, j)
 
-    # A massless dummy root connected to the physical base by fixed joints is
-    # immovable in maximal-coordinate solvers. Collapse that fixed subtree so
-    # the free root carries the imported mass and inertia.
-    auto_collapse_fixed_joint_indices: set[int] = set()
-    if (
-        floating
-        and base_parent == -1
-        and builder.body_mass[root] <= 0.0
-        and any(
-            builder.joint_type[joint_idx] == JointType.FIXED and builder.joint_parent[joint_idx] == root
-            for joint_idx in joint_indices
-        )
-    ):
-        massless_root_chain_parents = {root}
-        while True:
-            added_joint = False
-            for joint_idx in joint_indices:
-                if joint_idx in auto_collapse_fixed_joint_indices:
-                    continue
-                if builder.joint_type[joint_idx] != JointType.FIXED:
-                    continue
-                if builder.joint_parent[joint_idx] not in massless_root_chain_parents:
-                    continue
-
-                auto_collapse_fixed_joint_indices.add(joint_idx)
-                child = builder.joint_child[joint_idx]
-                if child >= 0 and builder.body_mass[child] <= 0.0:
-                    massless_root_chain_parents.add(child)
-                added_joint = True
-
-            if not added_joint:
-                break
-
     if collapse_fixed_joints:
         builder.collapse_fixed_joints()
-    elif auto_collapse_fixed_joint_indices:
-        fixed_joints_to_keep = {
-            joint_idx
-            for joint_idx in range(builder.joint_count)
-            if builder.joint_type[joint_idx] == JointType.FIXED and joint_idx not in auto_collapse_fixed_joint_indices
-        }
-        builder.collapse_fixed_joints(joint_indices_to_keep=fixed_joints_to_keep)
+    elif collapse_massless_fixed_root:
+        collapse_massless_fixed_root_joints(builder, joint_indices)

--- a/newton/_src/utils/import_utils.py
+++ b/newton/_src/utils/import_utils.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import warp as wp
 
 from ..sim.builder import ModelBuilder
+from ..sim.enums import JointType
 
 
 def string_to_warp(value: str, warp_dtype: Any, default: Any = None) -> Any:
@@ -203,6 +204,69 @@ def should_show_collider(
     if force_show_colliders or parse_visuals_as_colliders:
         return True
     return not has_visual_shapes
+
+
+def collapse_massless_fixed_root_joints(
+    builder: ModelBuilder,
+    joint_indices: Sequence[int],
+    root_joint_indices: Sequence[int] | None = None,
+) -> None:
+    """Collapse massless fixed-root chains below imported free root joints.
+
+    Args:
+        builder: The :class:`ModelBuilder` containing the imported joints.
+        joint_indices: Joint indices created by the current import.
+        root_joint_indices: Optional subset of ``joint_indices`` that should be
+            considered articulation roots.
+    """
+    imported_joint_indices = set(joint_indices)
+    if root_joint_indices is None:
+        root_joint_indices = [
+            joint_idx
+            for joint_idx in joint_indices
+            if builder.joint_type[joint_idx] == JointType.FREE and builder.joint_parent[joint_idx] == -1
+        ]
+
+    fixed_joint_indices_to_collapse: set[int] = set()
+    for root_joint_idx in root_joint_indices:
+        if root_joint_idx not in imported_joint_indices:
+            continue
+        if builder.joint_type[root_joint_idx] != JointType.FREE or builder.joint_parent[root_joint_idx] != -1:
+            continue
+
+        root_body = builder.joint_child[root_joint_idx]
+        if root_body < 0 or builder.body_mass[root_body] > 0.0:
+            continue
+
+        massless_chain_parents = {root_body}
+        while True:
+            added_joint = False
+            for joint_idx in joint_indices:
+                if joint_idx in fixed_joint_indices_to_collapse:
+                    continue
+                if builder.joint_type[joint_idx] != JointType.FIXED:
+                    continue
+                if builder.joint_parent[joint_idx] not in massless_chain_parents:
+                    continue
+
+                fixed_joint_indices_to_collapse.add(joint_idx)
+                child = builder.joint_child[joint_idx]
+                if child >= 0 and builder.body_mass[child] <= 0.0:
+                    massless_chain_parents.add(child)
+                added_joint = True
+
+            if not added_joint:
+                break
+
+    if not fixed_joint_indices_to_collapse:
+        return
+
+    fixed_joint_indices_to_keep = {
+        joint_idx
+        for joint_idx in range(builder.joint_count)
+        if builder.joint_type[joint_idx] == JointType.FIXED and joint_idx not in fixed_joint_indices_to_collapse
+    }
+    builder.collapse_fixed_joints(joint_indices_to_keep=fixed_joint_indices_to_keep)
 
 
 def is_xml_content(source: str) -> bool:

--- a/newton/_src/utils/import_utils.py
+++ b/newton/_src/utils/import_utils.py
@@ -266,7 +266,7 @@ def collapse_massless_fixed_root_joints(
         for joint_idx in range(builder.joint_count)
         if builder.joint_type[joint_idx] == JointType.FIXED and joint_idx not in fixed_joint_indices_to_collapse
     }
-    builder.collapse_fixed_joints(joint_indices_to_keep=fixed_joint_indices_to_keep)
+    builder.collapse_fixed_joints(joints_to_keep=fixed_joint_indices_to_keep)
 
 
 def is_xml_content(source: str) -> bool:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -20,8 +20,102 @@ from newton._src.sim.builder import ShapeFlags
 from newton._src.utils.import_mjcf import _load_and_expand_mjcf
 from newton.solvers import SolverMuJoCo
 
+MASSLESS_FIXED_ROOT_MJCF = """
+<mujoco model="massless_fixed_root">
+    <worldbody>
+        <body name="base_link">
+            <freejoint name="floating_base"/>
+            <body name="chassis">
+                <inertial pos="0 0 0" mass="2.0" diaginertia="0.1 0.1 0.1"/>
+                <geom type="box" size="0.5 0.5 0.5"/>
+            </body>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_MJCF = """
+<mujoco model="massless_fixed_root_internal_fixed">
+    <worldbody>
+        <body name="base_link">
+            <freejoint name="floating_base"/>
+            <body name="chassis">
+                <inertial pos="0 0 0" mass="2.0" diaginertia="0.1 0.1 0.1"/>
+                <geom type="box" size="0.5 0.5 0.5"/>
+                <body name="sensor" pos="0 0 0.6">
+                    <inertial pos="0 0 0" mass="0.1" diaginertia="0.01 0.01 0.01"/>
+                    <geom type="sphere" size="0.1"/>
+                </body>
+            </body>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
 
 class TestImportMjcfBasic(unittest.TestCase):
+    def test_massless_fixed_root_default_preserves_topology(self):
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_MJCF)
+
+        self.assertEqual(builder.joint_count, 3)
+        self.assertTrue(any(label.endswith("/floating_base") for label in builder.joint_label))
+        self.assertTrue(any(label.endswith("/chassis/chassis_joint") for label in builder.joint_label))
+        self.assertTrue(any(label.endswith("/sensor/sensor_joint") for label in builder.joint_label))
+
+        root_joint = next(i for i, label in enumerate(builder.joint_label) if label.endswith("/floating_base"))
+        root_body = builder.joint_child[root_joint]
+        self.assertEqual(builder.joint_type[root_joint], newton.JointType.FREE)
+        self.assertEqual(builder.body_mass[root_body], 0.0)
+
+    def test_massless_fixed_root_opt_in_is_dynamic(self):
+        dt = 1.0 / 60.0
+        step_count = 5
+        expected_drop = 0.5 * 9.81 * (step_count * dt) ** 2
+        min_drop = 0.5 * expected_drop
+
+        for mjcf in [MASSLESS_FIXED_ROOT_MJCF, MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_MJCF]:
+            with self.subTest(mjcf=mjcf.splitlines()[1].strip()):
+                builder = newton.ModelBuilder()
+                builder.add_mjcf(mjcf, collapse_massless_fixed_root=True)
+
+                self.assertEqual(builder.joint_type[0], newton.JointType.FREE)
+                self.assertGreater(builder.body_mass[0], 0.0)
+
+                model = builder.finalize()
+                state_0 = model.state()
+                state_1 = model.state()
+                control = model.control()
+                contacts = model.contacts()
+                newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+
+                root_body = int(model.joint_child.numpy()[0])
+                start_z = float(state_0.body_q.numpy()[root_body][2])
+
+                solver = newton.solvers.SolverXPBD(model, iterations=2)
+                for _ in range(step_count):
+                    state_0.clear_forces()
+                    solver.step(state_0, state_1, control, contacts, dt)
+                    state_0, state_1 = state_1, state_0
+
+                end_z = float(state_0.body_q.numpy()[root_body][2])
+                self.assertGreaterEqual(start_z - end_z, min_drop)
+
+    def test_massless_fixed_root_opt_in_preserves_imported_internal_fixed_joints(self):
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_MJCF, collapse_massless_fixed_root=True)
+
+        self.assertEqual(builder.joint_count, 2)
+        self.assertTrue(any(label.endswith("/floating_base") for label in builder.joint_label))
+        self.assertFalse(any(label.endswith("/chassis/chassis_joint") for label in builder.joint_label))
+        self.assertTrue(any(label.endswith("/sensor/sensor_joint") for label in builder.joint_label))
+
+        root_joint = next(i for i, label in enumerate(builder.joint_label) if label.endswith("/floating_base"))
+        sensor_joint = next(i for i, label in enumerate(builder.joint_label) if label.endswith("/sensor/sensor_joint"))
+        self.assertGreater(builder.body_mass[builder.joint_child[root_joint]], 0.0)
+        self.assertEqual(builder.joint_type[root_joint], newton.JointType.FREE)
+        self.assertEqual(builder.joint_type[sensor_joint], newton.JointType.FIXED)
+
     def test_humanoid_mjcf(self):
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 123.0

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -541,6 +541,29 @@ class TestImportUrdfBasic(unittest.TestCase):
         end_z = float(state_0.body_q.numpy()[root_body][2])
         self.assertLess(end_z, start_z)
 
+    def test_floating_massless_fixed_root_preserves_existing_fixed_joints(self):
+        builder = newton.ModelBuilder()
+        root = builder.add_link(mass=1.0, label="pre_root")
+        child = builder.add_link(mass=1.0, label="pre_child")
+        root_joint = builder.add_joint_fixed(parent=-1, child=root, label="pre_world_fixed")
+        child_joint = builder.add_joint_fixed(parent=root, child=child, label="pre_child_fixed")
+        builder.add_articulation([root_joint, child_joint], label="pre_articulation")
+
+        builder.add_urdf(MASSLESS_FIXED_ROOT_URDF, floating=True, up_axis="Z")
+
+        self.assertEqual(builder.joint_count, 3)
+        self.assertIn("pre_world_fixed", builder.joint_label)
+        self.assertIn("pre_child_fixed", builder.joint_label)
+        self.assertIn("massless_fixed_root/floating_base", builder.joint_label)
+        self.assertNotIn("massless_fixed_root/base_to_chassis", builder.joint_label)
+
+        self.assertEqual(builder.joint_type[builder.joint_label.index("pre_world_fixed")], newton.JointType.FIXED)
+        self.assertEqual(builder.joint_type[builder.joint_label.index("pre_child_fixed")], newton.JointType.FIXED)
+        self.assertEqual(
+            builder.joint_type[builder.joint_label.index("massless_fixed_root/floating_base")],
+            newton.JointType.FREE,
+        )
+
     def test_cartpole_urdf(self):
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 123.0

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -230,6 +230,48 @@ MASSLESS_FIXED_ROOT_URDF = """
 </robot>
 """
 
+MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF = """
+<robot name="massless_fixed_root_internal_fixed">
+    <link name="base_link"/>
+    <link name="chassis">
+        <inertial>
+            <mass value="2.0"/>
+            <inertia ixx="0.1" ixy="0.0" ixz="0.0"
+                     iyy="0.1" iyz="0.0"
+                     izz="0.1"/>
+        </inertial>
+        <collision>
+            <geometry>
+                <box size="1.0 1.0 1.0"/>
+            </geometry>
+        </collision>
+    </link>
+    <link name="sensor">
+        <inertial>
+            <mass value="0.1"/>
+            <inertia ixx="0.01" ixy="0.0" ixz="0.0"
+                     iyy="0.01" iyz="0.0"
+                     izz="0.01"/>
+        </inertial>
+        <collision>
+            <geometry>
+                <sphere radius="0.1"/>
+            </geometry>
+        </collision>
+    </link>
+    <joint name="base_to_chassis" type="fixed">
+        <parent link="base_link"/>
+        <child link="chassis"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+    </joint>
+    <joint name="chassis_to_sensor" type="fixed">
+        <parent link="chassis"/>
+        <child link="sensor"/>
+        <origin xyz="0 0 0.6" rpy="0 0 0"/>
+    </joint>
+</robot>
+"""
+
 JOINT_TREE_URDF = """
 <robot name="joint_tree_test">
 <!-- Mixed ordering of links -->
@@ -562,6 +604,25 @@ class TestImportUrdfBasic(unittest.TestCase):
         self.assertEqual(
             builder.joint_type[builder.joint_label.index("massless_fixed_root/floating_base")],
             newton.JointType.FREE,
+        )
+
+    def test_floating_massless_fixed_root_preserves_imported_internal_fixed_joints(self):
+        builder = newton.ModelBuilder()
+        builder.add_urdf(MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF, floating=True, up_axis="Z")
+
+        self.assertEqual(builder.joint_count, 2)
+        self.assertIn("massless_fixed_root_internal_fixed/floating_base", builder.joint_label)
+        self.assertNotIn("massless_fixed_root_internal_fixed/base_to_chassis", builder.joint_label)
+        self.assertIn("massless_fixed_root_internal_fixed/chassis_to_sensor", builder.joint_label)
+
+        self.assertGreater(builder.body_mass[0], 0.0)
+        self.assertEqual(
+            builder.joint_type[builder.joint_label.index("massless_fixed_root_internal_fixed/floating_base")],
+            newton.JointType.FREE,
+        )
+        self.assertEqual(
+            builder.joint_type[builder.joint_label.index("massless_fixed_root_internal_fixed/chassis_to_sensor")],
+            newton.JointType.FIXED,
         )
 
     def test_cartpole_urdf(self):

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -557,31 +557,37 @@ class TestImportUrdfBasic(unittest.TestCase):
         assert_np_equal(builder.joint_effort_limit[-1], np.array([6.78]))
 
     def test_floating_massless_fixed_root_urdf_is_dynamic(self):
-        builder = newton.ModelBuilder()
-        builder.add_urdf(MASSLESS_FIXED_ROOT_URDF, floating=True, up_axis="Z")
+        dt = 1.0 / 60.0
+        step_count = 5
+        expected_drop = 0.5 * 9.81 * (step_count * dt) ** 2
+        min_drop = 0.5 * expected_drop
 
-        self.assertEqual(builder.joint_count, 1)
-        self.assertEqual(builder.joint_type[0], newton.JointType.FREE)
-        self.assertGreater(builder.body_mass[0], 0.0)
+        for urdf in [MASSLESS_FIXED_ROOT_URDF, MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF]:
+            with self.subTest(urdf=urdf.splitlines()[1].strip()):
+                builder = newton.ModelBuilder()
+                builder.add_urdf(urdf, floating=True, up_axis="Z")
 
-        model = builder.finalize()
-        state_0 = model.state()
-        state_1 = model.state()
-        control = model.control()
-        contacts = model.contacts()
-        newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+                self.assertEqual(builder.joint_type[0], newton.JointType.FREE)
+                self.assertGreater(builder.body_mass[0], 0.0)
 
-        root_body = int(model.joint_child.numpy()[0])
-        start_z = float(state_0.body_q.numpy()[root_body][2])
+                model = builder.finalize()
+                state_0 = model.state()
+                state_1 = model.state()
+                control = model.control()
+                contacts = model.contacts()
+                newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
 
-        solver = newton.solvers.SolverXPBD(model, iterations=2)
-        for _ in range(5):
-            state_0.clear_forces()
-            solver.step(state_0, state_1, control, contacts, 1.0 / 60.0)
-            state_0, state_1 = state_1, state_0
+                root_body = int(model.joint_child.numpy()[0])
+                start_z = float(state_0.body_q.numpy()[root_body][2])
 
-        end_z = float(state_0.body_q.numpy()[root_body][2])
-        self.assertLess(end_z, start_z)
+                solver = newton.solvers.SolverXPBD(model, iterations=2)
+                for _ in range(step_count):
+                    state_0.clear_forces()
+                    solver.step(state_0, state_1, control, contacts, dt)
+                    state_0, state_1 = state_1, state_0
+
+                end_z = float(state_0.body_q.numpy()[root_body][2])
+                self.assertGreaterEqual(start_z - end_z, min_drop)
 
     def test_floating_massless_fixed_root_preserves_existing_fixed_joints(self):
         builder = newton.ModelBuilder()

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -206,6 +206,30 @@ JOINT_URDF = """
 </robot>
 """
 
+MASSLESS_FIXED_ROOT_URDF = """
+<robot name="massless_fixed_root">
+    <link name="base_link"/>
+    <link name="chassis">
+        <inertial>
+            <mass value="2.0"/>
+            <inertia ixx="0.1" ixy="0.0" ixz="0.0"
+                     iyy="0.1" iyz="0.0"
+                     izz="0.1"/>
+        </inertial>
+        <collision>
+            <geometry>
+                <box size="1.0 1.0 1.0"/>
+            </geometry>
+        </collision>
+    </link>
+    <joint name="base_to_chassis" type="fixed">
+        <parent link="base_link"/>
+        <child link="chassis"/>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+    </joint>
+</robot>
+"""
+
 JOINT_TREE_URDF = """
 <robot name="joint_tree_test">
 <!-- Mixed ordering of links -->
@@ -489,6 +513,33 @@ class TestImportUrdfBasic(unittest.TestCase):
         assert_np_equal(builder.joint_limit_upper[-1], np.array([3.45]))
         assert_np_equal(builder.joint_axis[-1], np.array([0.0, 0.0, 1.0]))
         assert_np_equal(builder.joint_effort_limit[-1], np.array([6.78]))
+
+    def test_floating_massless_fixed_root_urdf_is_dynamic(self):
+        builder = newton.ModelBuilder()
+        builder.add_urdf(MASSLESS_FIXED_ROOT_URDF, floating=True, up_axis="Z")
+
+        self.assertEqual(builder.joint_count, 1)
+        self.assertEqual(builder.joint_type[0], newton.JointType.FREE)
+        self.assertGreater(builder.body_mass[0], 0.0)
+
+        model = builder.finalize()
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = model.contacts()
+        newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+
+        root_body = int(model.joint_child.numpy()[0])
+        start_z = float(state_0.body_q.numpy()[root_body][2])
+
+        solver = newton.solvers.SolverXPBD(model, iterations=2)
+        for _ in range(5):
+            state_0.clear_forces()
+            solver.step(state_0, state_1, control, contacts, 1.0 / 60.0)
+            state_0, state_1 = state_1, state_0
+
+        end_z = float(state_0.body_q.numpy()[root_body][2])
+        self.assertLess(end_z, start_z)
 
     def test_cartpole_urdf(self):
         builder = newton.ModelBuilder()

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -556,7 +556,21 @@ class TestImportUrdfBasic(unittest.TestCase):
         assert_np_equal(builder.joint_axis[-1], np.array([0.0, 0.0, 1.0]))
         assert_np_equal(builder.joint_effort_limit[-1], np.array([6.78]))
 
-    def test_floating_massless_fixed_root_urdf_is_dynamic(self):
+    def test_floating_massless_fixed_root_default_preserves_topology(self):
+        builder = newton.ModelBuilder()
+        builder.add_urdf(MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF, floating=True, up_axis="Z")
+
+        self.assertEqual(builder.joint_count, 3)
+        self.assertIn("massless_fixed_root_internal_fixed/floating_base", builder.joint_label)
+        self.assertIn("massless_fixed_root_internal_fixed/base_to_chassis", builder.joint_label)
+        self.assertIn("massless_fixed_root_internal_fixed/chassis_to_sensor", builder.joint_label)
+
+        root_joint = builder.joint_label.index("massless_fixed_root_internal_fixed/floating_base")
+        root_body = builder.joint_child[root_joint]
+        self.assertEqual(builder.joint_type[root_joint], newton.JointType.FREE)
+        self.assertEqual(builder.body_mass[root_body], 0.0)
+
+    def test_floating_massless_fixed_root_urdf_opt_in_is_dynamic(self):
         dt = 1.0 / 60.0
         step_count = 5
         expected_drop = 0.5 * 9.81 * (step_count * dt) ** 2
@@ -565,7 +579,7 @@ class TestImportUrdfBasic(unittest.TestCase):
         for urdf in [MASSLESS_FIXED_ROOT_URDF, MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF]:
             with self.subTest(urdf=urdf.splitlines()[1].strip()):
                 builder = newton.ModelBuilder()
-                builder.add_urdf(urdf, floating=True, up_axis="Z")
+                builder.add_urdf(urdf, floating=True, up_axis="Z", collapse_massless_fixed_root=True)
 
                 self.assertEqual(builder.joint_type[0], newton.JointType.FREE)
                 self.assertGreater(builder.body_mass[0], 0.0)
@@ -589,7 +603,7 @@ class TestImportUrdfBasic(unittest.TestCase):
                 end_z = float(state_0.body_q.numpy()[root_body][2])
                 self.assertGreaterEqual(start_z - end_z, min_drop)
 
-    def test_floating_massless_fixed_root_preserves_existing_fixed_joints(self):
+    def test_floating_massless_fixed_root_opt_in_preserves_existing_fixed_joints(self):
         builder = newton.ModelBuilder()
         root = builder.add_link(mass=1.0, label="pre_root")
         child = builder.add_link(mass=1.0, label="pre_child")
@@ -597,7 +611,7 @@ class TestImportUrdfBasic(unittest.TestCase):
         child_joint = builder.add_joint_fixed(parent=root, child=child, label="pre_child_fixed")
         builder.add_articulation([root_joint, child_joint], label="pre_articulation")
 
-        builder.add_urdf(MASSLESS_FIXED_ROOT_URDF, floating=True, up_axis="Z")
+        builder.add_urdf(MASSLESS_FIXED_ROOT_URDF, floating=True, up_axis="Z", collapse_massless_fixed_root=True)
 
         self.assertEqual(builder.joint_count, 3)
         self.assertIn("pre_world_fixed", builder.joint_label)
@@ -612,9 +626,14 @@ class TestImportUrdfBasic(unittest.TestCase):
             newton.JointType.FREE,
         )
 
-    def test_floating_massless_fixed_root_preserves_imported_internal_fixed_joints(self):
+    def test_floating_massless_fixed_root_opt_in_preserves_imported_internal_fixed_joints(self):
         builder = newton.ModelBuilder()
-        builder.add_urdf(MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF, floating=True, up_axis="Z")
+        builder.add_urdf(
+            MASSLESS_FIXED_ROOT_WITH_INTERNAL_FIXED_URDF,
+            floating=True,
+            up_axis="Z",
+            collapse_massless_fixed_root=True,
+        )
 
         self.assertEqual(builder.joint_count, 2)
         self.assertIn("massless_fixed_root_internal_fixed/floating_base", builder.joint_label)


### PR DESCRIPTION
## Description

Closes #2555.

Floating URDF imports can create a free root joint on a massless dummy root link that is fixed to the physical base link. XPBD then sees zero inverse mass for the root body and leaves the articulation immovable even when `floating=True`.

This changes URDF import to collapse that massless fixed root subtree for floating imports, while preserving fixed joints that existed before the import. It also adds a regression that verifies XPBD moves the imported model under gravity.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k floating_massless_fixed_root
uv run --extra dev -m newton.tests -k test_model.TestModelJoints.test_collapse_fixed_joints
uv run --extra dev -m newton.tests -k test_import_urdf.TestImportUrdfBasic
uv run --extra dev -m newton.tests -k test_import_urdf
uvx pre-commit run -a
```

Also verified the targeted regression in a Linux Docker CPU run:

```bash
uv run --extra dev -m newton.tests -k floating_massless_fixed_root
```

## Bug fix

**Steps to reproduce:**

1. Import a URDF whose root link is massless and fixed to the physical base link with `floating=True`.
2. Finalize the model and inspect the root body used by the free joint.
3. Step with `SolverXPBD` under gravity.
4. Without this PR, the root body has zero inverse mass and does not fall.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
builder.add_urdf("robot_with_massless_fixed_root.urdf", floating=True, up_axis="Z")
model = builder.finalize()

root_body = int(model.joint_child.numpy()[0])
print(model.body_inv_mass.numpy()[root_body])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in importer option to collapse massless fixed-root chains while preserving topology, enabling dynamic behavior for previously massless floating roots.

* **Bug Fixes**
  * Importer preserves existing internal and pre-existing fixed joints when collapsing massless fixed-root chains.

* **Tests**
  * Added tests verifying topology preservation and gravity-driven dynamic behavior when the opt-in collapse is used.

* **Documentation**
  * Changelog entry documenting the new opt-in option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->