### PR TITLE
Kamino - FK solver performance improvements

### DIFF
--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_semi_sparse.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_semi_sparse.py
@@ -426,20 +426,30 @@ class SemiSparseBlockCholeskySolverBatched:
         self,
         A: np.ndarray,  # 3D array (batch_size, n, n)
         A_reorder_size: np.ndarray,  # 1D array (batch_size)
+        eq_classes: list[list[int]] | None = None,
     ):
         """
         Captures sparsity pattern and computes fill-reducing ordering for batched matrices.
 
         Args:
-            A: Input SPD matrices of shape (batch_size, n, n), as float arrays or directly as binary 0/1 matrices
-            indicating the sparsity pattern (float arrays will be converted to binary automatically).
-            A_reorder_size: Per-batch size of top-left block to reorder for sparsity
+        A (np.ndarray):
+            Input SPD matrices as float arrays or directly as binary 0/1 matrices indicating the sparsity
+            pattern (float arrays are converted to binary automatically).
+            Shape of (batch_size, n, n); or of (num_classes, n, n) if eq_classes is provided.
+        A_reorder_size (np.ndarray):
+            Size of the active top-left block per matrix, to reorder for sparsity.
+            Shape of (batch_size,); or of (num_classes,) if eq_classes is provided.
+        eq_classes (list[list[int]], optional):
+            List of list of matrix indices (along the batch dimension) that form equivalence classes with
+            the same sparsity pattern.
+            If provided, only one sparsity pattern per class should be provided in `A`.
+            The computed ordering will then be broadcast to all matrices in each class.
 
         Computes Cuthill-McKee ordering on top-left block, analyzes symbolic Cholesky factorization,
         and stores tile-level sparsity patterns. Tiles beyond A_reorder_size are treated as dense.
         """
 
-        batch_size = A.shape[0]
+        batch_size = self.num_batches
 
         # Convert to binary
         A = to_binary_matrix(A)
@@ -450,25 +460,28 @@ class SemiSparseBlockCholeskySolverBatched:
         inverse_orderings = np.zeros((batch_size, self.max_num_equations), dtype=np.int32)
         L_tile_patterns = np.zeros((batch_size, self.num_tiles, self.num_tiles), dtype=np.int32)
 
-        # Process each batch independently
-        for batch_id in range(batch_size):
+        # Process each equivalence class independently
+        if eq_classes is None:
+            eq_classes = [[i] for i in range(batch_size)]
+        assert len(A) == len(eq_classes)
+        assert len(A_reorder_size) == len(eq_classes)
+        for class_id, eq_class in enumerate(eq_classes):
             # Call cuthill_mckee_ordering on the binary version of A and store both orderings
-            reorder_size = A_reorder_size[batch_id]
-            ordering = cuthill_mckee_ordering(A[batch_id, :reorder_size, :reorder_size])
+            reorder_size = A_reorder_size[class_id]
+            ordering = cuthill_mckee_ordering(A[class_id, :reorder_size, :reorder_size])
 
             # Append sequential indices for remaining rows/cols
             remaining_indices = np.arange(reorder_size, self.max_num_equations)
             ordering = np.concatenate([ordering, remaining_indices])
-            orderings[batch_id] = ordering
 
+            # Compute inverse ordering
             inverse_ordering = compute_inverse_ordering(ordering)
-            inverse_orderings[batch_id] = inverse_ordering
 
             # Reorder A and then extract the sparsity patterns
             if self.enable_reordering:
-                A_reordered = A[batch_id][ordering][:, ordering]
+                A_reordered = A[class_id][ordering][:, ordering]
             else:
-                A_reordered = A[batch_id]
+                A_reordered = A[class_id]
 
             L_tile_pattern_np = symbolic_cholesky_dense(A_reordered, self.block_size)
 
@@ -478,7 +491,11 @@ class SemiSparseBlockCholeskySolverBatched:
                 for j in range(min(i + 1, self.num_tiles)):  # Only set lower triangular part
                     L_tile_pattern_np[i, j] = 1
 
-            L_tile_patterns[batch_id] = L_tile_pattern_np
+            # Store ordering data for all ids in the equivalence class
+            for batch_id in eq_class:
+                orderings[batch_id] = ordering
+                inverse_orderings[batch_id] = inverse_ordering
+                L_tile_patterns[batch_id] = L_tile_pattern_np
 
         # Convert to warp arrays on the correct device
         self.ordering = wp.array(orderings, dtype=int, device=self.device)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -43,10 +43,11 @@ __all__ = [
     "_reset_state",
     "_reset_state_base_q",
     "_update_cg_tolerance_kernel",
+    "create_1d_tile_based_kernels",
+    "create_2d_tile_based_kernels",
     "create_eval_joint_constraints_jacobian_kernel",
     "create_eval_joint_constraints_kernel",
     "create_eval_joint_constraints_sparse_jacobian_kernel",
-    "create_tile_based_kernels",
     "read_quat_from_array",
 ]
 
@@ -870,13 +871,13 @@ def create_eval_joint_constraints_sparse_jacobian_kernel(has_universal_joints: b
 
 
 @cache
-def create_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
+def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
     """
-    Generates and returns all tile-based kernels in this module, given the tile size to use along the constraints
+    Generates and returns all kernels based on 2d tiles in this module, given the tile size to use along the constraints
     and variables (i.e. body poses) dimensions in the constraint vector, Jacobian, step vector etc.
 
-    These are _eval_pattern_T_pattern, _eval_max_constraint, _eval_jacobian_T_jacobian, eval_jacobian_T_constraints,
-    _eval_merit_function, _eval_merit_function_gradient (returned in this order)
+    These are _eval_pattern_T_pattern, _eval_jacobian_T_jacobian, eval_jacobian_T_constraints
+    (returned in this order)
     """
 
     @wp.func
@@ -937,6 +938,135 @@ def create_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
             tile_out_3d_clipped = wp.tile_map(clip_to_one, tile_out_3d)
             wp.tile_store(pattern_T_pattern, tile_out_3d_clipped, offset=(wd_id, i * TILE_SIZE_VRS, j * TILE_SIZE_VRS))
 
+    @wp.kernel
+    def _eval_jacobian_T_jacobian(
+        # Inputs
+        constraints_jacobian: wp.array3d[wp.float32],
+        tile_sparsity_pattern: wp.array3d[wp.int32],
+        world_mask: wp.array[wp.int32],
+        # Outputs
+        jacobian_T_jacobian: wp.array3d[wp.float32],
+    ):
+        """
+        A kernel computing the matrix product J^T * J given the Jacobian J, in each world
+
+        Inputs:
+            constraints_jacobian: Constraint Jacobian per world
+            tile_sparsity_pattern: Per-tile sparsity pattern of the Jacobian (0 = tile is fully zero)
+            world_mask: Per-world flag to perform the computation (0 = skip)
+        Outputs:
+            jacobian_T_jacobian: Jacobian^T * Jacobian per world
+        """
+        wd_id, i, j = wp.tid()  # Thread indices (= world index, output tile indices)
+
+        if (
+            wd_id < jacobian_T_jacobian.shape[0]
+            and world_mask[wd_id] != 0
+            and i * TILE_SIZE_VRS < jacobian_T_jacobian.shape[1]
+            and j * TILE_SIZE_VRS < jacobian_T_jacobian.shape[2]
+        ):
+            tile_out = wp.tile_zeros(shape=(TILE_SIZE_VRS, TILE_SIZE_VRS), dtype=wp.float32)
+
+            num_cts = constraints_jacobian.shape[1]
+            num_tiles_K = (num_cts + TILE_SIZE_CTS - 1) // TILE_SIZE_CTS  # Equivalent to ceil(num_cts / TILE_SIZE_CTS)
+
+            for k in range(num_tiles_K):
+                if tile_sparsity_pattern[wd_id, k, i] == 0 or tile_sparsity_pattern[wd_id, k, j] == 0:
+                    continue
+                tile_i_3d = wp.tile_load(
+                    constraints_jacobian,
+                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
+                    offset=(wd_id, k * TILE_SIZE_CTS, i * TILE_SIZE_VRS),
+                )
+                tile_i = wp.tile_reshape(tile_i_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
+                tile_i_T = wp.tile_transpose(tile_i)
+                tile_j_3d = wp.tile_load(
+                    constraints_jacobian,
+                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
+                    offset=(wd_id, k * TILE_SIZE_CTS, j * TILE_SIZE_VRS),
+                )
+                tile_j = wp.tile_reshape(tile_j_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
+                wp.tile_matmul(tile_i_T, tile_j, tile_out)
+
+            tile_out_3d = wp.tile_reshape(tile_out, (1, TILE_SIZE_VRS, TILE_SIZE_VRS))
+            wp.tile_store(jacobian_T_jacobian, tile_out_3d, offset=(wd_id, i * TILE_SIZE_VRS, j * TILE_SIZE_VRS))
+
+    @wp.kernel
+    def _eval_jacobian_T_constraints(
+        # Inputs
+        constraints_jacobian: wp.array3d[wp.float32],
+        constraints: wp.array2d[wp.float32],
+        tile_sparsity_pattern: wp.array3d[wp.int32],
+        world_mask: wp.array[wp.int32],
+        # Outputs
+        jacobian_T_constraints: wp.array2d[wp.float32],
+    ):
+        """
+        A kernel computing the matrix product J^T * C given the Jacobian J and the constraints vector C, in each world
+
+        Inputs:
+            constraints_jacobian: Constraint Jacobian per world
+            constraints: Constraint vector per world
+            tile_sparsity_pattern: Per-tile sparsity pattern of the Jacobian (0 = tile is fully zero)
+            world_mask: Per-world flag to perform the computation (0 = skip)
+        Outputs:
+            jacobian_T_constraints: Jacobian^T * Constraints per world
+        """
+        wd_id, i = wp.tid()  # Thread indices (= world index, output tile index)
+
+        if (
+            wd_id < jacobian_T_constraints.shape[0]
+            and world_mask[wd_id] != 0
+            and i * TILE_SIZE_VRS < jacobian_T_constraints.shape[1]
+        ):
+            segment_out = wp.tile_zeros(shape=(TILE_SIZE_VRS, 1), dtype=wp.float32)
+
+            num_cts = constraints_jacobian.shape[1]
+            num_tiles_K = (num_cts + TILE_SIZE_CTS - 1) // TILE_SIZE_CTS  # Equivalent to ceil(num_cts / TILE_SIZE_CTS)
+
+            for k in range(num_tiles_K):
+                if tile_sparsity_pattern[wd_id, k, i] == 0:
+                    continue
+                tile_i_3d = wp.tile_load(
+                    constraints_jacobian,
+                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
+                    offset=(wd_id, k * TILE_SIZE_CTS, i * TILE_SIZE_VRS),
+                )
+                tile_i = wp.tile_reshape(tile_i_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
+                tile_i_T = wp.tile_transpose(tile_i)
+                segment_k_2d = wp.tile_load(constraints, shape=(1, TILE_SIZE_CTS), offset=(wd_id, k * TILE_SIZE_CTS))
+                segment_k = wp.tile_reshape(segment_k_2d, (TILE_SIZE_CTS, 1))  # Technically still 2d...
+                wp.tile_matmul(tile_i_T, segment_k, segment_out)
+
+            segment_out_2d = wp.tile_reshape(
+                segment_out,
+                (
+                    1,
+                    TILE_SIZE_VRS,
+                ),
+            )
+            wp.tile_store(
+                jacobian_T_constraints,
+                segment_out_2d,
+                offset=(
+                    wd_id,
+                    i * TILE_SIZE_VRS,
+                ),
+            )
+
+    return _eval_pattern_T_pattern, _eval_jacobian_T_jacobian, _eval_jacobian_T_constraints
+
+
+@cache
+def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
+    """
+    Generates and returns all kernels based on 1d tiles in this module, given the tile size to use along the constraints
+    and variables (i.e. body poses) dimensions in the constraint vector, Jacobian, step vector etc.
+
+    These are _eval_max_constraint, _eval_merit_function, _eval_merit_function_gradient
+    (returned in this order)
+    """
+
     @wp.func
     def _isnan(x: wp.float32) -> wp.int32:
         """Calls wp.isnan and converts the result to int32"""
@@ -978,114 +1108,6 @@ def create_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
                         check_val = wp.atomic_cas(max_constraint, wd_id, curr_val, wp.max(curr_val, segment_max))
                         if check_val == curr_val:
                             break
-
-    @wp.kernel
-    def _eval_jacobian_T_jacobian(
-        # Inputs
-        constraints_jacobian: wp.array3d[wp.float32],
-        world_mask: wp.array[wp.int32],
-        # Outputs
-        jacobian_T_jacobian: wp.array3d[wp.float32],
-    ):
-        """
-        A kernel computing the matrix product J^T * J given the Jacobian J, in each world
-
-        Inputs:
-            constraints_jacobian: Constraint Jacobian per world
-            world_mask: Per-world flag to perform the computation (0 = skip)
-        Outputs:
-            jacobian_T_jacobian: Jacobian^T * Jacobian per world
-        """
-        wd_id, i, j = wp.tid()  # Thread indices (= world index, output tile indices)
-
-        if (
-            wd_id < jacobian_T_jacobian.shape[0]
-            and world_mask[wd_id] != 0
-            and i * TILE_SIZE_VRS < jacobian_T_jacobian.shape[1]
-            and j * TILE_SIZE_VRS < jacobian_T_jacobian.shape[2]
-        ):
-            tile_out = wp.tile_zeros(shape=(TILE_SIZE_VRS, TILE_SIZE_VRS), dtype=wp.float32)
-
-            num_cts = constraints_jacobian.shape[1]
-            num_tiles_K = (num_cts + TILE_SIZE_CTS - 1) // TILE_SIZE_CTS  # Equivalent to ceil(num_cts / TILE_SIZE_CTS)
-
-            for k in range(num_tiles_K):
-                tile_i_3d = wp.tile_load(
-                    constraints_jacobian,
-                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
-                    offset=(wd_id, k * TILE_SIZE_CTS, i * TILE_SIZE_VRS),
-                )
-                tile_i = wp.tile_reshape(tile_i_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
-                tile_i_T = wp.tile_transpose(tile_i)
-                tile_j_3d = wp.tile_load(
-                    constraints_jacobian,
-                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
-                    offset=(wd_id, k * TILE_SIZE_CTS, j * TILE_SIZE_VRS),
-                )
-                tile_j = wp.tile_reshape(tile_j_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
-                wp.tile_matmul(tile_i_T, tile_j, tile_out)
-
-            tile_out_3d = wp.tile_reshape(tile_out, (1, TILE_SIZE_VRS, TILE_SIZE_VRS))
-            wp.tile_store(jacobian_T_jacobian, tile_out_3d, offset=(wd_id, i * TILE_SIZE_VRS, j * TILE_SIZE_VRS))
-
-    @wp.kernel
-    def _eval_jacobian_T_constraints(
-        # Inputs
-        constraints_jacobian: wp.array3d[wp.float32],
-        constraints: wp.array2d[wp.float32],
-        world_mask: wp.array[wp.int32],
-        # Outputs
-        jacobian_T_constraints: wp.array2d[wp.float32],
-    ):
-        """
-        A kernel computing the matrix product J^T * C given the Jacobian J and the constraints vector C, in each world
-
-        Inputs:
-            constraints_jacobian: Constraint Jacobian per world
-            constraints: Constraint vector per world
-            world_mask: Per-world flag to perform the computation (0 = skip)
-        Outputs:
-            jacobian_T_constraints: Jacobian^T * Constraints per world
-        """
-        wd_id, i = wp.tid()  # Thread indices (= world index, output tile index)
-
-        if (
-            wd_id < jacobian_T_constraints.shape[0]
-            and world_mask[wd_id] != 0
-            and i * TILE_SIZE_VRS < jacobian_T_constraints.shape[1]
-        ):
-            segment_out = wp.tile_zeros(shape=(TILE_SIZE_VRS, 1), dtype=wp.float32)
-
-            num_cts = constraints_jacobian.shape[1]
-            num_tiles_K = (num_cts + TILE_SIZE_CTS - 1) // TILE_SIZE_CTS  # Equivalent to ceil(num_cts / TILE_SIZE_CTS)
-
-            for k in range(num_tiles_K):
-                tile_i_3d = wp.tile_load(
-                    constraints_jacobian,
-                    shape=(1, TILE_SIZE_CTS, TILE_SIZE_VRS),
-                    offset=(wd_id, k * TILE_SIZE_CTS, i * TILE_SIZE_VRS),
-                )
-                tile_i = wp.tile_reshape(tile_i_3d, (TILE_SIZE_CTS, TILE_SIZE_VRS))
-                tile_i_T = wp.tile_transpose(tile_i)
-                segment_k_2d = wp.tile_load(constraints, shape=(1, TILE_SIZE_CTS), offset=(wd_id, k * TILE_SIZE_CTS))
-                segment_k = wp.tile_reshape(segment_k_2d, (TILE_SIZE_CTS, 1))  # Technically still 2d...
-                wp.tile_matmul(tile_i_T, segment_k, segment_out)
-
-            segment_out_2d = wp.tile_reshape(
-                segment_out,
-                (
-                    1,
-                    TILE_SIZE_VRS,
-                ),
-            )
-            wp.tile_store(
-                jacobian_T_constraints,
-                segment_out_2d,
-                offset=(
-                    wd_id,
-                    i * TILE_SIZE_VRS,
-                ),
-            )
 
     @wp.kernel
     def _eval_merit_function(
@@ -1140,14 +1162,7 @@ def create_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
             if tid == 0:
                 wp.atomic_add(merit_function_grad, wd_id, tile_dot_prod)
 
-    return (
-        _eval_pattern_T_pattern,
-        _eval_max_constraint,
-        _eval_jacobian_T_jacobian,
-        _eval_jacobian_T_constraints,
-        _eval_merit_function,
-        _eval_merit_function_gradient,
-    )
+    return _eval_max_constraint, _eval_merit_function, _eval_merit_function_gradient
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -1329,7 +1329,7 @@ class ForwardKinematicsSolver:
         else:
             wp.launch_tiled(
                 self._eval_jacobian_T_jacobian_kernel,
-                dim=(self.num_worlds, self.num_tiles_cts_2d, self.num_tiles_cts_2d),
+                dim=(self.num_worlds, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
                 inputs=[self.jacobian, self.tile_sparsity_pattern, world_mask, self.lhs],
                 block_dim=32,
                 device=self.device,

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -27,6 +27,7 @@ from ...linalg.conjugate import BatchedLinearOperator, CGSolver
 from ...linalg.factorize.llt_blocked_semi_sparse import SemiSparseBlockCholeskySolverBatched
 from ...linalg.sparse_matrix import BlockDType, BlockSparseMatrices
 from ...linalg.sparse_operator import BlockSparseLinearOperators
+from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_classes
 from .kernels import (
     _apply_line_search_step,
     _eval_body_velocities,
@@ -174,6 +175,10 @@ class ForwardKinematicsSolver:
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
         actuated_coord_offsets_prev = self.model.joints.actuated_coords_offset.numpy().copy()
         actuated_dof_offsets_prev = self.model.joints.actuated_dofs_offset.numpy().copy()
+
+        # Determine which worlds are equivalent for FK (at least discrete data)
+        classes = compute_fk_equivalence_classes(self.model)
+        num_classes = len(classes)
 
         # Create a copy of the model's joints with added joints as needed:
         # - actuated free joints to reset the base position/orientation
@@ -371,7 +376,9 @@ class ForwardKinematicsSolver:
         num_constraints = num_bodies.copy()  # Number of kinematic constraints per world (unit quat. + joints)
         has_universal_joints = False  # Whether the model has a least one passive universal joint
         constraint_full_to_red_map = np.full(6 * self.num_joints_tot, -1, dtype=np.int32)
-        for wd_id in range(self.num_worlds):
+        for eq_class in classes:
+            # Count constraints for first world in equivalence class
+            wd_id = eq_class[0]
             ct_count = num_constraints[wd_id]
             for jt_id_loc in range(num_joints[wd_id]):
                 jt_id_tot = first_joint_id[wd_id] + jt_id_loc  # Joint id among all joints
@@ -426,6 +433,13 @@ class ForwardKinematicsSolver:
                     else:
                         raise RuntimeError("Unknown joint dof type")
             num_constraints[wd_id] = ct_count
+
+            # Copy constraints counts/map data for other worlds in equivalence class
+            for wd_id_1 in eq_class[1:]:
+                constraint_full_to_red_map[6 * first_joint_id[wd_id_1] : 6 * first_joint_id[wd_id_1 + 1]] = (
+                    constraint_full_to_red_map[6 * first_joint_id[wd_id] : 6 * first_joint_id[wd_id + 1]]
+                )
+                num_constraints[wd_id_1] = num_constraints[wd_id]
         self.num_constraints_max = np.max(num_constraints)
 
         # Retrieve / compute dimensions - Number of tiles (for kernels using Tile API)
@@ -556,10 +570,11 @@ class ForwardKinematicsSolver:
         # Compute sparsity pattern and initialize linear solver for dense (semi-sparse) case
         if not self.config.use_sparsity:
             # Jacobian sparsity pattern
-            sparsity_pattern = np.zeros((self.num_worlds, self.num_constraints_max, self.num_states_max), dtype=int)
-            for wd_id in range(self.num_worlds):
+            sparsity_pattern = np.zeros((num_classes, self.num_constraints_max, self.num_states_max), dtype=int)
+            for class_id in range(num_classes):
+                wd_id = classes[class_id][0]  # Compute sparsity pattern for first world in equivalence class
                 for rb_id_loc in range(num_bodies[wd_id]):
-                    sparsity_pattern[wd_id, rb_id_loc, 7 * rb_id_loc + 3 : 7 * rb_id_loc + 7] = 1
+                    sparsity_pattern[class_id, rb_id_loc, 7 * rb_id_loc + 3 : 7 * rb_id_loc + 7] = 1
                 for jt_id_loc in range(num_joints[wd_id]):
                     jt_id_tot = first_joint_id[wd_id] + jt_id_loc
                     base_id_tot = joints_bid_B[jt_id_tot]
@@ -571,19 +586,19 @@ class ForwardKinematicsSolver:
                         for i in range(3):
                             ct_offset = constraint_full_to_red_map[6 * jt_id_tot + i]  # ith translation constraint
                             if ct_offset >= 0:
-                                sparsity_pattern[wd_id, ct_offset, state_offset : state_offset + 7] = 1
+                                sparsity_pattern[class_id, ct_offset, state_offset : state_offset + 7] = 1
                             ct_offset = constraint_full_to_red_map[6 * jt_id_tot + 3 + i]  # ith rotation constraint
                             if ct_offset >= 0:
-                                sparsity_pattern[wd_id, ct_offset, state_offset + 3 : state_offset + 7] = 1
+                                sparsity_pattern[class_id, ct_offset, state_offset + 3 : state_offset + 7] = 1
 
             # Jacobian^T * Jacobian sparsity pattern
             sparsity_pattern_wp = wp.from_numpy(sparsity_pattern, dtype=wp.float32, device=self.device)
             sparsity_pattern_lhs_wp = wp.zeros(
-                dtype=wp.float32, shape=(self.num_worlds, self.num_states_max, self.num_states_max), device=self.device
+                dtype=wp.float32, shape=(num_classes, self.num_states_max, self.num_states_max), device=self.device
             )
             wp.launch_tiled(
                 self._eval_pattern_T_pattern_kernel,
-                dim=(self.num_worlds, self.num_tiles_states, self.num_tiles_states),
+                dim=(num_classes, self.num_tiles_states, self.num_tiles_states),
                 inputs=[sparsity_pattern_wp, sparsity_pattern_lhs_wp],
                 block_dim=64,
                 device=self.device,
@@ -598,7 +613,8 @@ class ForwardKinematicsSolver:
                 device=self.device,
                 enable_reordering=True,
             )
-            self.linear_solver_llt.capture_sparsity_pattern(sparsity_pattern_lhs, num_states)
+            num_states_per_class = np.array([num_states[eq_class[0]] for eq_class in classes])
+            self.linear_solver_llt.capture_sparsity_pattern(sparsity_pattern_lhs, num_states_per_class, classes)
 
         # Compute sparsity pattern and initialize linear solver for sparse case
         if self.config.use_sparsity:
@@ -1663,3 +1679,63 @@ class ForwardKinematicsSolver:
             return ForwardKinematicsSolver.Status(
                 iterations=iterations, max_constraints=max_constraints, success=success
             )
+
+
+###
+# Functions
+###
+
+
+def compute_fk_equivalence_classes(model: ModelKamino) -> list[list[int]]:
+    """Groups world that are equivalent for FK discrete information"""
+    sig_num_bodies = DiscreteSignature(num_worlds=model.size.num_worlds, data=model.info.num_bodies)
+    sig_joint_act_type = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.joints.act_type,
+        world_offset=model.info.joints_offset,
+        world_size=model.info.num_joints,
+    )
+    sig_joint_dof_type = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.joints.dof_type,
+        world_offset=model.info.joints_offset,
+        world_size=model.info.num_joints,
+    )
+    sig_joint_bid_B = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.joints.bid_B,
+        world_offset=model.info.joints_offset,
+        world_size=model.info.num_joints,
+        world_delta=model.info.bodies_offset,
+        ignore_negative=True,
+    )
+    sig_joint_bid_F = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.joints.bid_F,
+        world_offset=model.info.joints_offset,
+        world_size=model.info.num_joints,
+        world_delta=model.info.bodies_offset,
+    )
+    sig_base_body = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.info.base_body_index,
+        world_delta=model.info.bodies_offset,
+        ignore_negative=True,
+    )
+    sig_base_joint = DiscreteSignature(
+        num_worlds=model.size.num_worlds,
+        data=model.info.base_joint_index,
+        world_delta=model.info.joints_offset,
+        ignore_negative=True,
+    )
+    return compute_equivalence_classes(
+        [
+            sig_num_bodies,
+            sig_joint_act_type,
+            sig_joint_dof_type,
+            sig_joint_bid_B,
+            sig_joint_bid_F,
+            sig_base_body,
+            sig_base_joint,
+        ]
+    )

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -9,6 +9,7 @@ See the :mod:`newton._src.solvers.kamino._src.solvers.fk` module for a detailed 
 
 from __future__ import annotations
 
+import math
 import sys
 
 import numpy as np
@@ -45,10 +46,11 @@ from .kernels import (
     _reset_state,
     _reset_state_base_q,
     _update_cg_tolerance_kernel,
+    create_1d_tile_based_kernels,
+    create_2d_tile_based_kernels,
     create_eval_joint_constraints_jacobian_kernel,
     create_eval_joint_constraints_kernel,
     create_eval_joint_constraints_sparse_jacobian_kernel,
-    create_tile_based_kernels,
 )
 from .types import FKJointDoFType, ForwardKinematicsPreconditionerType, ForwardKinematicsStatus
 
@@ -443,10 +445,16 @@ class ForwardKinematicsSolver:
         self.num_constraints_max = np.max(num_constraints)
 
         # Retrieve / compute dimensions - Number of tiles (for kernels using Tile API)
-        self.num_tiles_constraints = (
-            self.num_constraints_max + self.config.TILE_SIZE_CTS - 1
-        ) // self.config.TILE_SIZE_CTS
-        self.num_tiles_states = (self.num_states_max + self.config.TILE_SIZE_VRS - 1) // self.config.TILE_SIZE_VRS
+        # For 1d reduction kernels, large tiles yield the best performance
+        self.tile_size_cts_1d = min(2048, 2 ** math.ceil(math.log(self.num_constraints_max, 2)))
+        self.num_tiles_cts_1d = (self.num_constraints_max + self.tile_size_cts_1d - 1) // self.tile_size_cts_1d
+        self.tile_size_vrs_1d = min(2048, 2 ** math.ceil(math.log(self.num_states_max, 2)))
+        self.num_tiles_vrs_1d = (self.num_states_max + self.tile_size_vrs_1d - 1) // self.tile_size_vrs_1d
+        # For 2d matrix product kernels, smaller 16x16 tiles give the best tradeoff (also for using sparsity)
+        self.tile_size_cts_2d = 16
+        self.num_tiles_cts_2d = (self.num_constraints_max + self.tile_size_cts_2d - 1) // self.tile_size_cts_2d
+        self.tile_size_vrs_2d = 16
+        self.num_tiles_vrs_2d = (self.num_states_max + self.tile_size_vrs_2d - 1) // self.tile_size_vrs_2d
 
         # Data allocation or transfer from numpy to warp
         with wp.ScopedDevice(self.device):
@@ -560,12 +568,14 @@ class ForwardKinematicsSolver:
         )
         (
             self._eval_pattern_T_pattern_kernel,
-            self._eval_max_constraint_kernel,
             self._eval_jacobian_T_jacobian_kernel,
             self._eval_jacobian_T_constraints_kernel,
+        ) = create_2d_tile_based_kernels(self.tile_size_cts_2d, self.tile_size_vrs_2d)
+        (
+            self._eval_max_constraint_kernel,
             self._eval_merit_function_kernel,
             self._eval_merit_function_gradient_kernel,
-        ) = create_tile_based_kernels(self.config.TILE_SIZE_CTS, self.config.TILE_SIZE_VRS)
+        ) = create_1d_tile_based_kernels(self.tile_size_cts_1d, self.tile_size_vrs_1d)
 
         # Compute sparsity pattern and initialize linear solver for dense (semi-sparse) case
         if not self.config.use_sparsity:
@@ -598,9 +608,9 @@ class ForwardKinematicsSolver:
             )
             wp.launch_tiled(
                 self._eval_pattern_T_pattern_kernel,
-                dim=(num_classes, self.num_tiles_states, self.num_tiles_states),
+                dim=(num_classes, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
                 inputs=[sparsity_pattern_wp, sparsity_pattern_lhs_wp],
-                block_dim=64,
+                block_dim=32,
                 device=self.device,
             )
             sparsity_pattern_lhs = sparsity_pattern_lhs_wp.numpy().astype("int32")
@@ -615,6 +625,22 @@ class ForwardKinematicsSolver:
             )
             num_states_per_class = np.array([num_states[eq_class[0]] for eq_class in classes])
             self.linear_solver_llt.capture_sparsity_pattern(sparsity_pattern_lhs, num_states_per_class, classes)
+
+            # Compute tile-level Jacobian sparsity pattern, to skip zero tiles in tile-based matrix products
+            tile_sparsity_pattern_np = np.zeros(
+                (self.num_worlds, self.num_tiles_cts_2d, self.num_tiles_vrs_2d), dtype=np.int32
+            )
+            for class_id, eq_class in enumerate(classes):
+                pattern = np.zeros((self.num_tiles_cts_2d, self.num_tiles_vrs_2d), dtype=np.int32)
+                for i in range(self.num_constraints_max):
+                    for j in range(self.num_states_max):
+                        if sparsity_pattern[class_id, i, j] != 0:
+                            tile_row = i // self.tile_size_cts_2d
+                            tile_col = j // self.tile_size_vrs_2d
+                            pattern[tile_row, tile_col] = 1
+                for wd_id in eq_class:
+                    tile_sparsity_pattern_np[wd_id] = pattern
+            self.tile_sparsity_pattern = wp.from_numpy(tile_sparsity_pattern_np, dtype=wp.int32, device=self.device)
 
         # Compute sparsity pattern and initialize linear solver for sparse case
         if self.config.use_sparsity:
@@ -909,9 +935,9 @@ class ForwardKinematicsSolver:
         max_constraint.zero_()
         wp.launch_tiled(
             self._eval_max_constraint_kernel,
-            dim=(self.num_worlds, self.num_tiles_constraints),
+            dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, max_constraint],
-            block_dim=64,
+            block_dim=max(32, min(256, self.tile_size_cts_1d // 8)),
             device=self.device,
         )
 
@@ -1040,9 +1066,9 @@ class ForwardKinematicsSolver:
         error.zero_()
         wp.launch_tiled(
             self._eval_merit_function_kernel,
-            dim=(self.num_worlds, self.num_tiles_constraints),
+            dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, error],
-            block_dim=64,
+            block_dim=max(32, min(256, self.tile_size_cts_1d // 8)),
             device=self.device,
         )
 
@@ -1059,9 +1085,9 @@ class ForwardKinematicsSolver:
         error_grad.zero_()
         wp.launch_tiled(
             self._eval_merit_function_gradient_kernel,
-            dim=(self.num_worlds, self.num_tiles_states),
+            dim=(self.num_worlds, self.num_tiles_vrs_1d),
             inputs=[step, grad, error_grad],
-            block_dim=64,
+            block_dim=max(32, min(256, self.tile_size_vrs_1d // 8)),
             device=self.device,
         )
 
@@ -1154,16 +1180,16 @@ class ForwardKinematicsSolver:
         else:
             wp.launch_tiled(
                 self._eval_jacobian_T_jacobian_kernel,
-                dim=(self.num_worlds, self.num_tiles_states, self.num_tiles_states),
-                inputs=[self.jacobian, self.newton_mask, self.lhs],
-                block_dim=64,
+                dim=(self.num_worlds, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
+                inputs=[self.jacobian, self.tile_sparsity_pattern, self.newton_mask, self.lhs],
+                block_dim=32,
                 device=self.device,
             )
             wp.launch_tiled(
                 self._eval_jacobian_T_constraints_kernel,
-                dim=(self.num_worlds, self.num_tiles_states),
-                inputs=[self.jacobian, self.constraints, self.newton_mask, self.grad],
-                block_dim=64,
+                dim=(self.num_worlds, self.num_tiles_vrs_2d),
+                inputs=[self.jacobian, self.constraints, self.tile_sparsity_pattern, self.newton_mask, self.grad],
+                block_dim=32,
                 device=self.device,
             )
         wp.launch(
@@ -1303,16 +1329,16 @@ class ForwardKinematicsSolver:
         else:
             wp.launch_tiled(
                 self._eval_jacobian_T_jacobian_kernel,
-                dim=(self.num_worlds, self.num_tiles_states, self.num_tiles_states),
-                inputs=[self.jacobian, world_mask, self.lhs],
-                block_dim=64,
+                dim=(self.num_worlds, self.num_tiles_cts_2d, self.num_tiles_cts_2d),
+                inputs=[self.jacobian, self.tile_sparsity_pattern, world_mask, self.lhs],
+                block_dim=32,
                 device=self.device,
             )
             wp.launch_tiled(
                 self._eval_jacobian_T_constraints_kernel,
-                dim=(self.num_worlds, self.num_tiles_states),
-                inputs=[self.jacobian, self.target_cts_u, world_mask, self.rhs],
-                block_dim=64,
+                dim=(self.num_worlds, self.num_tiles_vrs_2d),
+                inputs=[self.jacobian, self.target_cts_u, self.tile_sparsity_pattern, world_mask, self.rhs],
+                block_dim=32,
                 device=self.device,
             )
 

--- a/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
+++ b/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provides utilities to efficiently compare discrete information across worlds."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import warp as wp
+
+from ..core.types import int32, uint64
+
+###
+# Module interface
+###
+
+__all__ = ["DiscreteSignature", "compute_equivalence_classes"]
+
+
+###
+# Module configs
+###
+
+wp.set_module_options({"enable_backward": False})
+
+
+###
+# Types
+###
+
+
+@dataclass
+class DiscreteSignature:
+    """
+    Class representing a per-world discrete signature, such as the number of bodies per world, the
+    joint types per world etc.
+
+    Can be a single integer per world, or more generally a per-world segment in an integer data array.
+    Two worlds are equivalent w.r.t. this signature iff their segments match (in size and contents).
+
+    To be able to compare values of the form per-world constant + within-world index (e.g., follower body
+    id per joint), a "delta" value to subtract per world can be specified (e.g., first body index per world).
+    """
+
+    num_worlds: int
+    """Number of worlds"""
+
+    data: wp.array
+    """Flat data array, with type int32, concatenating a signature block for each world"""
+
+    world_offset: wp.array | None = None
+    """
+    Per-world offset of the signature block into `data`, with shape (num_worlds) and type int32.
+    Optional if data has exactly one entry per world.
+    """
+
+    world_size: wp.array | None = None
+    """
+    Per-world size of the signature block into `data`, with shape (num_worlds) and type int32.
+    Optional if data has exactly one entry per world.
+    """
+
+    world_delta: wp.array | None = None
+    """
+    Optional per-world delta to subtract from signature values before comparison, with shape (num_worlds)
+    and type int32.
+    If provided, two signature coefficients are considered equivalent if coeff1 - delta1 = coeff2 - delta2.
+    """
+
+    ignore_negative: bool = False
+    """
+    If True, all negative values (before subtracting delta, if applicable) will be treated as equivalent
+    (e.g. to allow handling data with sentinel -1 values).
+    """
+
+    def __post_init__(self):
+        assert self.num_worlds > 0
+
+        if self.world_offset is None:
+            assert self.data.size == self.num_worlds, (
+                "world_offset is optional only if data has exactly one entry per world"
+            )
+            self.world_offset = wp.array(range(self.num_worlds), device=self.data.device, dtype=wp.int32)
+        else:
+            assert self.world_offset.size == self.num_worlds or self.world_offset.size == self.num_worlds + 1, (
+                "invalid size for world_offset"
+            )
+
+        if self.world_size is None:
+            assert self.data.size == self.num_worlds, (
+                "world_size is optional only if data has exactly one entry per world"
+            )
+            self.world_size = wp.ones(shape=self.num_worlds, device=self.data.device, dtype=wp.int32)
+        else:
+            assert self.world_size.size == self.num_worlds, "invalid size for world_size"
+
+        if self.world_delta is None:
+            self.world_delta = wp.zeros(shape=self.num_worlds, device=self.data.device, dtype=wp.int32)
+        else:
+            assert self.world_delta.size == self.num_worlds or self.world_delta.size == self.num_worlds + 1, (
+                "invalid size for world_delta"
+            )
+
+
+###
+# Kernels
+###
+
+
+@wp.func
+def comparison_value(value: int32, delta: int32, ignore_negative: wp.bool):
+    if ignore_negative and value < 0:
+        return -1
+    return value - delta
+
+
+@wp.kernel
+def equivalence_mask_kernel(
+    data: wp.array[int32],
+    world_offset: wp.array[int32],
+    world_size: wp.array[int32],
+    world_delta: wp.array[int32],
+    ignore_negative: wp.bool,
+    world_ref_index: wp.array[int32],
+    world_equivalence_mask: wp.array[wp.bool],
+):
+    """Updates a mask indicating whether the signature of each world matches the one of the reference world"""
+    wid = wp.tid()  # Retrieve world index
+
+    # Early return if we already know that the world is not equivalent to the reference
+    if not world_equivalence_mask[wid]:
+        return
+
+    # Get index of reference world to compare against
+    ref_id = world_ref_index[wid]
+    if ref_id < 0:
+        return
+
+    # Read offsets, deltas and size (we assume here the signature size to match with the reference)
+    offset_w = world_offset[wid]
+    offset_ref = world_offset[ref_id]
+    delta_w = world_delta[wid]
+    delta_ref = world_delta[ref_id]
+    size = world_size[wid]
+    assert world_size[ref_id] == size
+
+    # Compare data segments for world and reference
+    for i in range(size):
+        value_w = comparison_value(data[offset_w + i], delta_w, ignore_negative)
+        value_ref = comparison_value(data[offset_ref + i], delta_ref, ignore_negative)
+        if value_w != value_ref:
+            world_equivalence_mask[wid] = False
+            return
+
+
+@wp.kernel
+def hash_kernel(
+    data: wp.array[int32],
+    world_offset: wp.array[int32],
+    world_size: wp.array[int32],
+    world_delta: wp.array[int32],
+    ignore_negative: wp.bool,
+    world_class_index: wp.array[int32],
+    world_hash: wp.array[uint64],
+):
+    """Updates a per-world hash based on the signature, for worlds that don't have a class yet"""
+    wid = wp.tid()  # Retrieve world index
+
+    # Early return if a class id is already assigned to this world
+    class_id = world_class_index[wid]
+    if class_id >= 0:
+        return
+
+    # Read offset size and delta
+    offset = world_offset[wid]
+    size = world_size[wid]
+    delta = world_delta[wid]
+
+    # Combine hash of data segments for world with current hash
+    h = world_hash[wid]
+    prime = wp.uint64(1099511628211)
+    for i in range(size):
+        val = wp.uint64(comparison_value(data[offset + i], delta, ignore_negative))
+        h = h ^ val
+        h = h * prime
+    world_hash[wid] = h
+
+
+###
+# Functions
+###
+
+
+def compute_equivalence_classes(signatures: Iterable[DiscreteSignature]) -> list[list[int]]:
+    """
+    For a collection of discrete per-world signatures, splits the worlds into equivalence classes
+    within which all signatures are identical.
+
+    Returns:
+        Equivalence classes, as a list of lists of world indices (each sorted in ascending order).
+    """
+
+    # Helper listing ids per class, from a class id per world
+    def class_ids_to_classes(class_ids, num_classes):
+        classes = [[] for _ in range(num_classes)]
+        for i in range(len(class_ids)):
+            classes[class_ids[i]].append(i)
+        return classes
+
+    # Dimensions
+    num_worlds = next(iter(signatures)).num_worlds
+    assert all(sig.num_worlds == num_worlds for sig in signatures)
+    device = next(iter(signatures)).data.device
+
+    # Initialize class labels
+    class_ids = [-1 for i in range(num_worlds)]
+    next_class = 0
+
+    # Group all worlds by sizes
+    sizes_np = [sig.world_size.numpy() for sig in signatures]
+    num_signatures = len(sizes_np)
+    world_groups = {}
+    world_ref = [-1 for i in range(num_worlds)]  # Reference per group (first world in each group)
+    for i in range(num_worlds):
+        world_sizes = tuple(sizes_np[sig_id][i] for sig_id in range(num_signatures))
+        try:
+            indices, ref = world_groups[world_sizes]
+            indices.append(i)
+            world_ref[i] = ref
+        except KeyError:
+            world_groups[world_sizes] = [i], i
+    world_ref_wp = wp.array(world_ref, dtype=wp.int32, device=device)
+
+    # Run greedy exact comparison within each size group, against the group reference
+    # (leading to early exit for homogenous worlds)
+    eq_mask_wp = wp.ones(shape=num_worlds, dtype=wp.bool, device=device)
+    for sig in signatures:
+        wp.launch(
+            equivalence_mask_kernel,
+            dim=num_worlds,
+            inputs=[
+                sig.data,
+                sig.world_offset,
+                sig.world_size,
+                sig.world_delta,
+                sig.ignore_negative,
+                world_ref_wp,
+                eq_mask_wp,
+            ],
+            device=device,
+        )
+
+    # Assign class label to all worlds that match the reference in their group
+    eq_mask_np = eq_mask_wp.numpy()
+    leftover_groups = []
+    for indices, _ in world_groups.values():
+        non_matching = []
+        for index in indices:
+            if eq_mask_np[index]:
+                class_ids[index] = next_class
+            else:
+                non_matching.append(index)
+        next_class += 1
+        if len(non_matching) > 0:
+            leftover_groups.append(non_matching)
+    if len(leftover_groups) == 0:
+        return class_ids_to_classes(class_ids, next_class)
+
+    # Hash signatures of remaining worlds
+    class_ids_wp = wp.array(class_ids, dtype=wp.int32, device=device)
+    hashes_wp = wp.full(shape=num_worlds, value=1469598103934665603, dtype=wp.uint64, device=device)
+    for sig in signatures:
+        wp.launch(
+            hash_kernel,
+            dim=num_worlds,
+            inputs=[
+                sig.data,
+                sig.world_offset,
+                sig.world_size,
+                sig.world_delta,
+                sig.ignore_negative,
+                class_ids_wp,
+                hashes_wp,
+            ],
+            device=device,
+        )
+
+    # Group remaining worlds by hash
+    hashes_np = hashes_wp.numpy()
+    world_groups = {}
+    world_ref = [-1 for i in range(num_worlds)]
+    for group_id, group in enumerate(leftover_groups):
+        for i in group:
+            try:
+                indices, ref = world_groups[(group_id, hashes_np[i])]
+                indices.append(i)
+                world_ref[i] = ref
+            except KeyError:
+                world_groups[(group_id, hashes_np[i])] = [i], i
+
+    while len(world_groups) > 0:
+        # Run greedy exact comparison within each hash group
+        world_ref_wp.assign(world_ref)
+        eq_mask_wp.fill_(True)
+        for sig in signatures:
+            wp.launch(
+                equivalence_mask_kernel,
+                dim=num_worlds,
+                inputs=[
+                    sig.data,
+                    sig.world_offset,
+                    sig.world_size,
+                    sig.world_delta,
+                    sig.ignore_negative,
+                    world_ref_wp,
+                    eq_mask_wp,
+                ],
+                device=device,
+            )
+
+        # Assign class label to all worlds that match the reference in their group
+        eq_mask_np = eq_mask_wp.numpy()
+        new_groups = {}
+        world_ref = [-1 for i in range(num_worlds)]
+        for old_indices, old_ref in world_groups.values():
+            for index in old_indices:
+                if eq_mask_np[index]:
+                    class_ids[index] = next_class
+                else:
+                    try:
+                        indices, ref = new_groups[old_ref]
+                        indices.append(index)
+                        world_ref[index] = ref
+                    except KeyError:
+                        new_groups[old_ref] = [index], index
+            next_class += 1
+        world_groups = new_groups
+
+    return class_ids_to_classes(class_ids, next_class)

--- a/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
+++ b/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
@@ -201,6 +201,10 @@ def compute_equivalence_classes(signatures: Iterable[DiscreteSignature]) -> list
     Returns:
         Equivalence classes, as a list of lists of world indices (each sorted in ascending order).
     """
+    # Convert input to list
+    signatures = list(signatures)
+    if len(signatures) == 0:
+        raise ValueError("`signatures` cannot be empty.")
 
     # Helper listing ids per class, from a class id per world
     def class_ids_to_classes(class_ids, num_classes):
@@ -210,19 +214,19 @@ def compute_equivalence_classes(signatures: Iterable[DiscreteSignature]) -> list
         return classes
 
     # Dimensions
-    num_worlds = next(iter(signatures)).num_worlds
+    num_worlds = signatures[0].num_worlds
     assert all(sig.num_worlds == num_worlds for sig in signatures)
-    device = next(iter(signatures)).data.device
+    device = signatures[0].data.device
 
     # Initialize class labels
-    class_ids = [-1 for i in range(num_worlds)]
+    class_ids = [-1 for _ in range(num_worlds)]
     next_class = 0
 
     # Group all worlds by sizes
     sizes_np = [sig.world_size.numpy() for sig in signatures]
     num_signatures = len(sizes_np)
     world_groups = {}
-    world_ref = [-1 for i in range(num_worlds)]  # Reference per group (first world in each group)
+    world_ref = [-1 for _ in range(num_worlds)]  # Reference per group (first world in each group)
     for i in range(num_worlds):
         world_sizes = tuple(sizes_np[sig_id][i] for sig_id in range(num_signatures))
         try:
@@ -290,7 +294,7 @@ def compute_equivalence_classes(signatures: Iterable[DiscreteSignature]) -> list
     # Group remaining worlds by hash
     hashes_np = hashes_wp.numpy()
     world_groups = {}
-    world_ref = [-1 for i in range(num_worlds)]
+    world_ref = [-1 for _ in range(num_worlds)]
     for group_id, group in enumerate(leftover_groups):
         for i in group:
             try:
@@ -323,7 +327,7 @@ def compute_equivalence_classes(signatures: Iterable[DiscreteSignature]) -> list
         # Assign class label to all worlds that match the reference in their group
         eq_mask_np = eq_mask_wp.numpy()
         new_groups = {}
-        world_ref = [-1 for i in range(num_worlds)]
+        world_ref = [-1 for _ in range(num_worlds)]
         for old_indices, old_ref in world_groups.values():
             for index in old_indices:
                 if eq_mask_np[index]:

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -807,20 +807,6 @@ class ForwardKinematicsSolverConfig:
     Defaults to `1e-6`.
     """
 
-    TILE_SIZE_CTS: int = 8
-    """
-    Tile size for kernels along the dimension of kinematic constraints.
-    Changes to this setting after the solver's initialization will have no effect.
-    Defaults to `8`.
-    """
-
-    TILE_SIZE_VRS: int = 8
-    """
-    Tile size for kernels along the dimension of rigid body pose variables.
-    Changes to this setting after the solver's initialization will have no effect.
-    Defaults to `8`.
-    """
-
     use_sparsity: bool = False
     """
     Whether to use sparse Jacobian and solver; otherwise, dense versions are used.
@@ -903,10 +889,6 @@ class ForwardKinematicsSolverConfig:
             raise ValueError("`max_line_search_iterations` must be positive.")
         if self.tolerance <= 0.0:
             raise ValueError("`tolerance` must be positive.")
-        if self.TILE_SIZE_CTS <= 0:
-            raise ValueError("`TILE_SIZE_CTS` must be positive.")
-        if self.TILE_SIZE_VRS <= 0:
-            raise ValueError("`TILE_SIZE_VRS` must be positive.")
 
     @override
     def __post_init__(self):

--- a/newton/_src/solvers/kamino/tests/test_utils_world_equivalence.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_world_equivalence.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the equivalence classes computation utility for discrete information of Kamino"""
+
+import unittest
+
+import warp as wp
+
+from newton._src.solvers.kamino._src.utils.world_equivalence import DiscreteSignature, compute_equivalence_classes
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+###
+# Tests
+###
+
+
+class TestEquivalenceClasses(unittest.TestCase):
+    def setUp(self):
+        # Configs
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.default_device = wp.get_device(test_context.device)
+
+    def tearDown(self):
+        self.default_device = None
+
+    def test_01_discrete_signature_equivalence(self):
+        # Create some discrete signatures
+        with wp.ScopedDevice(self.default_device):
+            sig_0 = DiscreteSignature(
+                num_worlds=6,
+                data=wp.array([1, 2, 1, 1, 2, 1, 0, 3, 0, 3, 1, 1, 2, 1, 0, 3, 1], dtype=wp.int32),
+                world_offset=wp.array([0, 3, 6, 8, 11, 14], dtype=wp.int32),
+                world_size=wp.array([3, 3, 2, 3, 3, 3], dtype=wp.int32),
+            )
+            # Splits per world as: 1, 2, 1 | 1, 2, 1 | 0, 3 | 0, 3, 1 | 1, 2, 1 | 0, 3, 1
+
+            sig_1 = DiscreteSignature(
+                num_worlds=6,
+                data=wp.array([1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10], dtype=wp.int32),
+                world_offset=wp.array([0, 2, 4, 6, 8, 10], dtype=wp.int32),
+                world_size=wp.array([2, 2, 2, 2, 2, 2], dtype=wp.int32),
+                world_delta=wp.array([0, 2, 4, 6, 8, 10], dtype=wp.int32),
+            )
+            # After subtracting delta: 1, 0 | 1, 0 | 1, 0 | 1, 0 | 1, 0 | 1, 0
+
+            sig_2 = DiscreteSignature(
+                num_worlds=6,
+                data=wp.array([11, 12, 11, 11, 11, 11], dtype=wp.int32),
+            )
+
+        # Compute and check equivalence classes for various combinations of these signatures
+
+        # Signature 0 only, expected classes (up to order): 0, 1, 4 | 2 | 3, 5
+        classes_0 = compute_equivalence_classes([sig_0])
+        self.assertEqual(len(classes_0), 3)
+        self.assertTrue([0, 1, 4] in classes_0)
+        self.assertTrue([2] in classes_0)
+        self.assertTrue([3, 5] in classes_0)
+
+        # Signature 1 only, single class expected
+        classes_1 = compute_equivalence_classes([sig_1])
+        self.assertEqual(classes_1, [[0, 1, 2, 3, 4, 5]])
+
+        # Signature 2 only, expected classes (up to order): 0, 2, 3, 4, 5 | 1
+        classes_2 = compute_equivalence_classes([sig_2])
+        self.assertEqual(len(classes_2), 2)
+        self.assertTrue([0, 2, 3, 4, 5] in classes_2)
+        self.assertTrue([1] in classes_2)
+
+        # Signatures 0 and 1, expected classes (up to order): 0, 1, 4 | 2 | 3, 5
+        classes_01 = compute_equivalence_classes([sig_0, sig_1])
+        self.assertEqual(len(classes_01), 3)
+        self.assertTrue([0, 1, 4] in classes_01)
+        self.assertTrue([2] in classes_01)
+        self.assertTrue([3, 5] in classes_01)
+
+        # Signatures 1 and 2, expected classes (up to order): 0, 2, 3, 4, 5 | 1
+        classes_12 = compute_equivalence_classes([sig_1, sig_2])
+        self.assertEqual(len(classes_12), 2)
+        self.assertTrue([0, 2, 3, 4, 5] in classes_12)
+        self.assertTrue([1] in classes_12)
+
+        # Signatures 2 and 0, expected classes (up to order): 0, 4 | 1 | 2 | 3, 5
+        classes_20 = compute_equivalence_classes([sig_2, sig_0])
+        self.assertEqual(len(classes_20), 4)
+        self.assertTrue([0, 4] in classes_20)
+        self.assertTrue([1] in classes_20)
+        self.assertTrue([2] in classes_20)
+        self.assertTrue([3, 5] in classes_20)
+
+        # All 3 signatures, expected classes (up to order): 0, 4 | 1 | 2 | 3, 5
+        classes_012 = compute_equivalence_classes([sig_0, sig_1, sig_2])
+        self.assertEqual(len(classes_012), 4)
+        self.assertTrue([0, 4] in classes_012)
+        self.assertTrue([1] in classes_012)
+        self.assertTrue([2] in classes_012)
+        self.assertTrue([3, 5] in classes_012)
+
+
+###
+# Test execution
+###
+
+if __name__ == "__main__":
+    # Test setup
+    setup_tests()
+
+    # Run all tests
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

This improves the performance of the FK solver, both the CPU precomputation (in particular, sparsity pattern generation and symbolic factorization) and the GPU runtime.

For precomputations, utilities are added that group worlds into equivalence classes with respect to discrete FK structure (i.e. worlds with the same joint types between the same bodies are equivalent in terms of matrix sparsity pattern). Then all precomputations that depend on discrete information only are done only once per class, leading to severe performance improvements on large models / large world counts (with speedup basically proportional to the number of identical worlds).

For general runtime, the tile-based kernels have been optimized. The kernels with 2d tiles computing matrix-matrix or matrix-vector products with the jacobians now skip tiles that are known to be zero. The tile sizes and block sizes have also been optimized.

Resolves vastsoun/newton#314

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

On an example used as benchmark (middle-scale animatronic character on 1024 worlds and randomized poses), this yields an overall 3x speedup for the FK solve time, and a speedup roughly proportional to the number of identical worlds for the precomputations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Equivalence-class grouping for worlds and a compute_fk_equivalence_classes helper.
  * New 1D/2D tile kernel factories and a per-class tile_sparsity_pattern to skip zero tiles.
  * capture_sparsity_pattern supports per-equivalence-class ordering and broadcasts results across class members.

* **Improvements**
  * Per-class reuse of sparsity and factorization ordering to reduce redundant work.
  * Removed global TILE_SIZE_CTS/TILE_SIZE_VRS config fields.

* **Tests**
  * Added unit tests for world-equivalence grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->