### PR TITLE
Fix VRAM leak when resetting examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Fix MPR convergence failure on large and extreme-aspect-ratio mesh triangles by projecting the starting point onto the triangle nearest the convex center
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Fix `SensorRaycast` ignoring `PLANE` geometry
+- Fix VRAM leak when resetting examples that allocate large GPU state (e.g. `diffsim_bear`)
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -239,7 +239,11 @@ class _ExampleBrowser:
         return example, type(example)
 
     def reset(self, example_class):
-        """Reset the current example by re-creating it. Returns the new example or None."""
+        """Reset the current example by re-creating it. Returns the new example or None.
+
+        The caller must drop its reference to the old example before calling
+        this method.
+        """
         self._reset_requested = False
         self.viewer.clear_model()
         try:
@@ -280,6 +284,8 @@ def run(example, args):
             continue
 
         if browser is not None and browser._reset_requested:
+            example_class = type(example)
+            example = None
             example = browser.reset(example_class)
             continue
 

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -284,7 +284,6 @@ def run(example, args):
             continue
 
         if browser is not None and browser._reset_requested:
-            example_class = type(example)
             example = None
             example = browser.reset(example_class)
             continue

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -284,6 +284,8 @@ def run(example, args):
             continue
 
         if browser is not None and browser._reset_requested:
+            # Drop our reference so the old example is freed before reset()
+            # builds the replacement; otherwise both coexist in VRAM.
             example = None
             example = browser.reset(example_class)
             continue

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ast
+import gc
 import importlib
 import os
 import warnings
@@ -284,9 +285,12 @@ def run(example, args):
             continue
 
         if browser is not None and browser._reset_requested:
-            # Drop our reference so the old example is freed before reset()
-            # builds the replacement; otherwise both coexist in VRAM.
+            # Drop our reference and force cycle collection so the old
+            # example's destructors finish before reset() enters the new
+            # CUDA graph capture; otherwise late texture/array __del__
+            # calls could fire mid-capture and CUDA rejects them.
             example = None
+            gc.collect()
             example = browser.reset(example_class)
             continue
 

--- a/newton/examples/basic/example_basic_conveyor.py
+++ b/newton/examples/basic/example_basic_conveyor.py
@@ -433,5 +433,4 @@ if __name__ == "__main__":
         help="Conveyor tangential speed [m/s].",
     )
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_heightfield.py
+++ b/newton/examples/basic/example_basic_heightfield.py
@@ -135,5 +135,4 @@ if __name__ == "__main__":
         help="Solver type: xpbd (default, native collision) or mujoco",
     )
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_joints.py
+++ b/newton/examples/basic/example_basic_joints.py
@@ -292,6 +292,4 @@ if __name__ == "__main__":
     viewer._paused = True
 
     # Create viewer and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_pendulum.py
+++ b/newton/examples/basic/example_basic_pendulum.py
@@ -150,6 +150,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create viewer and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_plotting.py
+++ b/newton/examples/basic/example_basic_plotting.py
@@ -223,6 +223,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_shapes.py
+++ b/newton/examples/basic/example_basic_shapes.py
@@ -240,6 +240,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_urdf.py
+++ b/newton/examples/basic/example_basic_urdf.py
@@ -188,6 +188,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_basic_viewer.py
+++ b/newton/examples/basic/example_basic_viewer.py
@@ -229,5 +229,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create viewer and run
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/basic/example_replay_viewer.py
+++ b/newton/examples/basic/example_replay_viewer.py
@@ -220,6 +220,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cable/example_cable_bundle_hysteresis.py
+++ b/newton/examples/cable/example_cable_bundle_hysteresis.py
@@ -422,15 +422,15 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    # Create example and run
-    example = Example(
-        viewer,
+    newton.examples.run(
+        Example(
+            viewer,
+            args,
+            num_cables=7,
+            segments=args.segments,
+            with_dahl=not args.no_dahl and args.eps_max > 0.0 and args.tau > 0.0,
+            eps_max=args.eps_max,
+            tau=args.tau,
+        ),
         args,
-        num_cables=7,
-        segments=args.segments,
-        with_dahl=not args.no_dahl and args.eps_max > 0.0 and args.tau > 0.0,
-        eps_max=args.eps_max,
-        tau=args.tau,
     )
-
-    newton.examples.run(example, args)

--- a/newton/examples/cable/example_cable_pile.py
+++ b/newton/examples/cable/example_cable_pile.py
@@ -259,5 +259,4 @@ class Example:
 
 if __name__ == "__main__":
     viewer, args = newton.examples.init()
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cable/example_cable_twist.py
+++ b/newton/examples/cable/example_cable_twist.py
@@ -317,6 +317,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cable/example_cable_y_junction.py
+++ b/newton/examples/cable/example_cable_y_junction.py
@@ -214,5 +214,4 @@ class Example:
 
 if __name__ == "__main__":
     viewer, args = newton.examples.init()
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_bending.py
+++ b/newton/examples/cloth/example_cloth_bending.py
@@ -172,6 +172,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create viewer and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_franka.py
+++ b/newton/examples/cloth/example_cloth_franka.py
@@ -648,6 +648,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_h1.py
+++ b/newton/examples/cloth/example_cloth_h1.py
@@ -323,5 +323,4 @@ if __name__ == "__main__":
     parser = newton.examples.create_parser()
     parser.set_defaults(num_frames=601)
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_hanging.py
+++ b/newton/examples/cloth/example_cloth_hanging.py
@@ -223,13 +223,13 @@ if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init(parser)
 
-    # Create example and run
-    example = Example(
-        viewer=viewer,
-        args=args,
-        solver_type=args.solver,
-        height=args.height,
-        width=args.width,
+    newton.examples.run(
+        Example(
+            viewer=viewer,
+            args=args,
+            solver_type=args.solver,
+            height=args.height,
+            width=args.width,
+        ),
+        args,
     )
-
-    newton.examples.run(example, args)

--- a/newton/examples/cloth/example_cloth_poker_cards.py
+++ b/newton/examples/cloth/example_cloth_poker_cards.py
@@ -302,6 +302,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_rollers.py
+++ b/newton/examples/cloth/example_cloth_rollers.py
@@ -527,7 +527,4 @@ if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init(parser)
 
-    # Create example and run
-    example = Example(viewer=viewer, args=args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer=viewer, args=args), args)

--- a/newton/examples/cloth/example_cloth_style3d.py
+++ b/newton/examples/cloth/example_cloth_style3d.py
@@ -183,6 +183,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/cloth/example_cloth_twist.py
+++ b/newton/examples/cloth/example_cloth_twist.py
@@ -304,6 +304,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/contacts/example_brick_stacking.py
+++ b/newton/examples/contacts/example_brick_stacking.py
@@ -1043,5 +1043,4 @@ if __name__ == "__main__":
     parser = newton.examples.create_parser()
 
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/contacts/example_contacts_rj45_plug.py
+++ b/newton/examples/contacts/example_contacts_rj45_plug.py
@@ -514,5 +514,4 @@ class Example:
 
 if __name__ == "__main__":
     viewer, args = newton.examples.init()
-    example = Example(viewer)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer), args)

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -425,6 +425,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/contacts/example_nut_bolt_sdf.py
+++ b/newton/examples/contacts/example_nut_bolt_sdf.py
@@ -400,6 +400,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/contacts/example_pyramid.py
+++ b/newton/examples/contacts/example_pyramid.py
@@ -216,5 +216,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/diffsim/example_diffsim_ball.py
+++ b/newton/examples/diffsim/example_diffsim_ball.py
@@ -267,6 +267,9 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-    example.check_grad()
-    newton.examples.run(example, args)
+    def _build():
+        ex = Example(viewer, args)
+        ex.check_grad()
+        return ex
+
+    newton.examples.run(_build(), args)

--- a/newton/examples/diffsim/example_diffsim_bear.py
+++ b/newton/examples/diffsim/example_diffsim_bear.py
@@ -323,5 +323,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/diffsim/example_diffsim_cloth.py
+++ b/newton/examples/diffsim/example_diffsim_cloth.py
@@ -222,5 +222,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/diffsim/example_diffsim_drone.py
+++ b/newton/examples/diffsim/example_diffsim_drone.py
@@ -796,13 +796,13 @@ if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init(parser)
 
-    example = Example(
-        viewer,
-        args.verbose,
-        args.num_rollouts,
-        args.render_rollouts,
-        args.drone_path,
+    newton.examples.run(
+        Example(
+            viewer,
+            args.verbose,
+            args.num_rollouts,
+            args.render_rollouts,
+            args.drone_path,
+        ),
+        args,
     )
-
-    # Run example
-    newton.examples.run(example, args)

--- a/newton/examples/diffsim/example_diffsim_soft_body.py
+++ b/newton/examples/diffsim/example_diffsim_soft_body.py
@@ -379,5 +379,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/diffsim/example_diffsim_spring_cage.py
+++ b/newton/examples/diffsim/example_diffsim_spring_cage.py
@@ -287,5 +287,4 @@ if __name__ == "__main__":
     if isinstance(viewer, newton.viewer.ViewerGL):
         viewer.show_particles = True
 
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/ik/example_ik_cube_stacking.py
+++ b/newton/examples/ik/example_ik_cube_stacking.py
@@ -719,6 +719,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/ik/example_ik_custom.py
+++ b/newton/examples/ik/example_ik_custom.py
@@ -321,5 +321,4 @@ class Example:
 if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init()
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/ik/example_ik_franka.py
+++ b/newton/examples/ik/example_ik_franka.py
@@ -160,5 +160,4 @@ class Example:
 if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init()
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/ik/example_ik_h1.py
+++ b/newton/examples/ik/example_ik_h1.py
@@ -169,5 +169,4 @@ class Example:
 if __name__ == "__main__":
     # Parse arguments and initialize viewer
     viewer, args = newton.examples.init()
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/kamino/example_kamino_basic_dr_testmech.py
+++ b/newton/examples/kamino/example_kamino_basic_dr_testmech.py
@@ -134,5 +134,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/kamino/example_kamino_basic_fourbar.py
+++ b/newton/examples/kamino/example_kamino_basic_fourbar.py
@@ -178,5 +178,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/kamino/example_kamino_basic_heterogeneous.py
+++ b/newton/examples/kamino/example_kamino_basic_heterogeneous.py
@@ -165,5 +165,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/kamino/example_kamino_robot_anymal_d.py
+++ b/newton/examples/kamino/example_kamino_robot_anymal_d.py
@@ -171,5 +171,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/kamino/example_kamino_robot_dr_legs.py
+++ b/newton/examples/kamino/example_kamino_robot_dr_legs.py
@@ -170,5 +170,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_anymal.py
+++ b/newton/examples/mpm/example_mpm_anymal.py
@@ -344,5 +344,4 @@ if __name__ == "__main__":
         print("Error: This example requires a GPU device.")
         sys.exit(1)
 
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_beam_twist.py
+++ b/newton/examples/mpm/example_mpm_beam_twist.py
@@ -328,6 +328,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_grain_rendering.py
+++ b/newton/examples/mpm/example_mpm_grain_rendering.py
@@ -139,6 +139,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_granular.py
+++ b/newton/examples/mpm/example_mpm_granular.py
@@ -282,6 +282,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_multi_material.py
+++ b/newton/examples/mpm/example_mpm_multi_material.py
@@ -193,6 +193,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_snow_ball.py
+++ b/newton/examples/mpm/example_mpm_snow_ball.py
@@ -406,6 +406,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_twoway_coupling.py
+++ b/newton/examples/mpm/example_mpm_twoway_coupling.py
@@ -387,6 +387,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create example and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/mpm/example_mpm_viscous.py
+++ b/newton/examples/mpm/example_mpm_viscous.py
@@ -274,6 +274,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/multiphysics/example_softbody_dropping_to_cloth.py
+++ b/newton/examples/multiphysics/example_softbody_dropping_to_cloth.py
@@ -166,5 +166,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/multiphysics/example_softbody_gift.py
+++ b/newton/examples/multiphysics/example_softbody_gift.py
@@ -298,5 +298,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_allegro_hand.py
+++ b/newton/examples/robot/example_robot_allegro_hand.py
@@ -248,6 +248,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -362,6 +362,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_anymal_d.py
+++ b/newton/examples/robot/example_robot_anymal_d.py
@@ -171,6 +171,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_cartpole.py
+++ b/newton/examples/robot/example_robot_cartpole.py
@@ -201,6 +201,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_g1.py
+++ b/newton/examples/robot/example_robot_g1.py
@@ -166,6 +166,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_h1.py
+++ b/newton/examples/robot/example_robot_h1.py
@@ -158,6 +158,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_panda_hydro.py
+++ b/newton/examples/robot/example_robot_panda_hydro.py
@@ -539,6 +539,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -462,10 +462,10 @@ if __name__ == "__main__":
     else:
         policy_path = f"{asset_directory}/{robot_config.policy_path['mjw']}"
 
-    example = Example(viewer, robot_config, config, asset_directory, mjc_to_physx, physx_to_mjc)
-
-    # Use utility function to load policy and setup tensors
-    load_policy_and_setup_tensors(example, policy_path, config["num_dofs"], slice(7, None))
+    def _build():
+        ex = Example(viewer, robot_config, config, asset_directory, mjc_to_physx, physx_to_mjc)
+        load_policy_and_setup_tensors(ex, policy_path, config["num_dofs"], slice(7, None))
+        return ex
 
     # Run using standard example loop
-    newton.examples.run(example, args)
+    newton.examples.run(_build(), args)

--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -192,15 +192,57 @@ def find_physx_mjwarp_mapping(mjwarp_joint_names, physx_joint_names):
 
 
 class Example:
-    def __init__(
-        self,
-        viewer,
-        robot_config: RobotConfig,
-        config,
-        asset_directory: str,
-        mjc_to_physx: list[int],
-        physx_to_mjc: list[int],
-    ):
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument(
+            "--robot",
+            type=str,
+            default="g1_29dof",
+            choices=list(ROBOT_CONFIGS.keys()),
+            help="Robot name to load",
+        )
+        parser.add_argument(
+            "--physx",
+            action="store_true",
+            help="Run physX policy instead of MJWarp.",
+        )
+        return parser
+
+    def __init__(self, viewer, args):
+        # Resolve robot configuration, asset paths, and joint mapping from args.
+        # Done in __init__ (rather than at module level) so the example can be
+        # rebuilt by _ExampleBrowser.reset() with the same (viewer, args) call
+        # convention as every other example.
+        if args.robot not in ROBOT_CONFIGS:
+            raise ValueError(f"Unknown robot: {args.robot}. Available: {list(ROBOT_CONFIGS.keys())}")
+        robot_config = ROBOT_CONFIGS[args.robot]
+        print(f"[INFO] Selected robot: {args.robot}")
+
+        asset_directory = str(newton.utils.download_asset(robot_config.asset_dir))
+        print(f"[INFO] Asset directory: {asset_directory}")
+
+        yaml_file_path = f"{asset_directory}/{robot_config.yaml_path}"
+        with open(yaml_file_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        print(f"[INFO] Loaded config with {config['num_dofs']} DOFs")
+
+        mjc_to_physx = list(range(config["num_dofs"]))
+        physx_to_mjc = list(range(config["num_dofs"]))
+
+        if args.physx:
+            if "physx" not in robot_config.policy_path or "physx_joint_names" not in config:
+                physx_robots = [name for name, cfg in ROBOT_CONFIGS.items() if "physx" in cfg.policy_path]
+                raise ValueError(
+                    f"PhysX policy not available for robot '{args.robot}'. Robots with PhysX support: {physx_robots}"
+                )
+            policy_path = f"{asset_directory}/{robot_config.policy_path['physx']}"
+            mjc_to_physx, physx_to_mjc = find_physx_mjwarp_mapping(
+                config["mjw_joint_names"], config["physx_joint_names"]
+            )
+        else:
+            policy_path = f"{asset_directory}/{robot_config.policy_path['mjw']}"
+
         # Setup simulation parameters first
         fps = 200
         self.frame_dt = 1.0e0 / fps
@@ -304,6 +346,9 @@ class Example:
         self.joint_pos_initial = None
         self.act = None
         self.rearranged_act = None
+
+        # Load policy weights and prepare tensors used by step()
+        load_policy_and_setup_tensors(self, policy_path, config["num_dofs"], slice(7, None))
 
         # Call capture at the end
         self.capture()
@@ -410,62 +455,6 @@ class Example:
 
 
 if __name__ == "__main__":
-    # Create parser that inherits common arguments and adds
-    # example-specific ones
-    parser = newton.examples.create_parser()
-    parser.add_argument(
-        "--robot", type=str, default="g1_29dof", choices=list(ROBOT_CONFIGS.keys()), help="Robot name to load"
-    )
-    parser.add_argument("--physx", action="store_true", help="Run physX policy instead of MJWarp.")
-
-    # Parse arguments and initialize viewer
+    parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-
-    # Get robot configuration
-    if args.robot not in ROBOT_CONFIGS:
-        print(f"[ERROR] Unknown robot: {args.robot}")
-        print(f"[INFO] Available robots: {list(ROBOT_CONFIGS.keys())}")
-        exit(1)
-
-    robot_config = ROBOT_CONFIGS[args.robot]
-    print(f"[INFO] Selected robot: {args.robot}")
-
-    # Download assets from newton-assets repository
-    asset_directory = str(newton.utils.download_asset(robot_config.asset_dir))
-    print(f"[INFO] Asset directory: {asset_directory}")
-
-    # Load robot configuration from YAML file in the downloaded assets
-    yaml_file_path = f"{asset_directory}/{robot_config.yaml_path}"
-    try:
-        with open(yaml_file_path, encoding="utf-8") as f:
-            config = yaml.safe_load(f)
-    except FileNotFoundError:
-        print(f"[ERROR] Robot config file not found: {yaml_file_path}")
-        exit(1)
-    except yaml.YAMLError as e:
-        print(f"[ERROR] Error parsing YAML file: {e}")
-        exit(1)
-
-    print(f"[INFO] Loaded config with {config['num_dofs']} DOFs")
-
-    mjc_to_physx = list(range(config["num_dofs"]))
-    physx_to_mjc = list(range(config["num_dofs"]))
-
-    if args.physx:
-        if "physx" not in robot_config.policy_path or "physx_joint_names" not in config:
-            physx_robots = [name for name, cfg in ROBOT_CONFIGS.items() if "physx" in cfg.policy_path]
-            print(f"[ERROR] PhysX policy not available for robot '{args.robot}'.")
-            print(f"[INFO] Robots with PhysX support: {physx_robots}")
-            exit(1)
-        policy_path = f"{asset_directory}/{robot_config.policy_path['physx']}"
-        mjc_to_physx, physx_to_mjc = find_physx_mjwarp_mapping(config["mjw_joint_names"], config["physx_joint_names"])
-    else:
-        policy_path = f"{asset_directory}/{robot_config.policy_path['mjw']}"
-
-    def _build():
-        ex = Example(viewer, robot_config, config, asset_directory, mjc_to_physx, physx_to_mjc)
-        load_policy_and_setup_tensors(ex, policy_path, config["num_dofs"], slice(7, None))
-        return ex
-
-    # Run using standard example loop
-    newton.examples.run(_build(), args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/robot/example_robot_policy.py
+++ b/newton/examples/robot/example_robot_policy.py
@@ -192,23 +192,6 @@ def find_physx_mjwarp_mapping(mjwarp_joint_names, physx_joint_names):
 
 
 class Example:
-    @staticmethod
-    def create_parser():
-        parser = newton.examples.create_parser()
-        parser.add_argument(
-            "--robot",
-            type=str,
-            default="g1_29dof",
-            choices=list(ROBOT_CONFIGS.keys()),
-            help="Robot name to load",
-        )
-        parser.add_argument(
-            "--physx",
-            action="store_true",
-            help="Run physX policy instead of MJWarp.",
-        )
-        return parser
-
     def __init__(self, viewer, args):
         # Resolve robot configuration, asset paths, and joint mapping from args.
         # Done in __init__ (rather than at module level) so the example can be
@@ -452,6 +435,23 @@ class Example:
             "all bodies are above the ground",
             lambda q, qd: q[2] > 0.0,
         )
+
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument(
+            "--robot",
+            type=str,
+            default="g1_29dof",
+            choices=list(ROBOT_CONFIGS.keys()),
+            help="Robot name to load",
+        )
+        parser.add_argument(
+            "--physx",
+            action="store_true",
+            help="Run physX policy instead of MJWarp.",
+        )
+        return parser
 
 
 if __name__ == "__main__":

--- a/newton/examples/robot/example_robot_ur10.py
+++ b/newton/examples/robot/example_robot_ur10.py
@@ -207,6 +207,4 @@ if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/selection/example_selection_articulations.py
+++ b/newton/examples/selection/example_selection_articulations.py
@@ -311,6 +311,4 @@ if __name__ == "__main__":
 
         torch.set_default_device(args.device)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -238,6 +238,4 @@ if __name__ == "__main__":
 
         torch.set_default_device(args.device)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/selection/example_selection_materials.py
+++ b/newton/examples/selection/example_selection_materials.py
@@ -271,6 +271,4 @@ if __name__ == "__main__":
 
         torch.set_default_device(args.device)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/selection/example_selection_multiple.py
+++ b/newton/examples/selection/example_selection_multiple.py
@@ -289,6 +289,4 @@ if __name__ == "__main__":
 
         torch.set_default_device(args.device)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -216,6 +216,4 @@ if __name__ == "__main__":
 
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/sensors/example_sensor_imu.py
+++ b/newton/examples/sensors/example_sensor_imu.py
@@ -186,6 +186,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init()
 
     # Create viewer and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -401,6 +401,4 @@ if __name__ == "__main__":
     viewer, args = newton.examples.init(parser)
 
     # Create viewer and run
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/softbody/example_softbody_franka.py
+++ b/newton/examples/softbody/example_softbody_franka.py
@@ -397,6 +397,4 @@ if __name__ == "__main__":
     parser.set_defaults(num_frames=1000)
     viewer, args = newton.examples.init(parser)
 
-    example = Example(viewer, args)
-
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/softbody/example_softbody_hanging.py
+++ b/newton/examples/softbody/example_softbody_hanging.py
@@ -154,5 +154,4 @@ class Example:
 if __name__ == "__main__":
     parser = Example.create_parser()
     viewer, args = newton.examples.init(parser)
-    example = Example(viewer, args)
-    newton.examples.run(example, args)
+    newton.examples.run(Example(viewer, args), args)


### PR DESCRIPTION
## Description

Closes #2700.

`_ExampleBrowser.reset` rebuilds the current example by calling its constructor while the previous instance is still referenced — by `run()`'s local and, when the example file is invoked directly, by the script's `__main__` globals. Both old and new live in VRAM during `__init__`, peaking at 2× the example's footprint. For `diffsim_bear` (~6 GB of grad-enabled sim states + captured forward/backward CUDA graph), a single reset hits ~12 GB and the second reset OOMs on a 16 GB GPU.

Two changes:

1. `newton/examples/diffsim/example_diffsim_bear.py`: inline `Example(viewer, args)` into the `newton.examples.run(...)` call, so the example isn't bound at module level.
2. `newton/examples/__init__.py`: in `run()`'s reset branch, set the local `example = None` before calling `_ExampleBrowser.reset(example_class)`, so refcount-based collection actually runs.

The two changes together make the old example's destructors run before the new one starts allocating, so peak VRAM stays at 1×.

## Other examples with the same latent issue

The same `example = Example(viewer, args); newton.examples.run(example, args)` pattern appears in 63 other examples; they have the same latent leak but don't trip it because their per-instance VRAM is small. Happy to include all the other examples in this PR once the fix is confirmed by a reviewer. Distribution:

- `basic/`: 10
- `robot/`: 8
- `mpm/`: 8
- `cloth/`: 6
- `kamino/`: 5
- `contacts/`, `diffsim/`, `ik/`, `selection/`: 4 each
- `cable/`, `sensors/`: 3 each
- `multiphysics/`, `softbody/`: 2 each

The mechanical fix is identical in each: replace
```python
example = Example(viewer, args)
newton.examples.run(example, args)
```
with
```python
newton.examples.run(Example(viewer, args), args)
```

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Manual: with the GUI viewer, click Reset multiple times and watch `nvidia-smi`.

```bash
uv run --extra examples -m newton.examples diffsim_bear
```

Before fix: VRAM steps from ~6 GB → ~12 GB on first reset, OOM on a 16 GB GPU on the second. After fix: VRAM stays roughly flat across resets (verified across 5 consecutive resets on an RTX A6000, total drift < 150 MB).

## Bug fix

**Steps to reproduce:**

1. `uv run --extra examples -m newton.examples diffsim_bear`
2. Note initial process VRAM in `nvidia-smi` (~6 GB).
3. Click "Reset" in the top-left panel.
4. Observe VRAM jumps to ~12 GB.
5. Click "Reset" again — OOM on GPUs with ≤16 GB VRAM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a VRAM memory leak when resetting examples that allocate large GPU state.

* **Documentation**
  * Clarified reset guidance and changelog to instruct dropping old example references before re-creation.

* **Refactor**
  * Simplified many example startup entrypoints to inline instance creation for cleaner wiring; behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->