### PR TITLE
Respect world_mask in SolverKamino joint state writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - Fix material-combination inconsistency in the Newton-to-`mujoco-warp` contact converter so combined friction / solref / solimp values match native MuJoCo
 - Fix `eq_objtype` mismatch for joint equality and mimic constraints in `SolverMuJoCo` so compiled models match native MuJoCo XML behavior
 - Fix implicit-MPM rheology solver launch-dim handling under `warp-lang` 1.13's templated `launch_bounds` (formerly produced out-of-bounds reads)
+- Fix `SolverKamino.reset` clobbering `q_j_p`, `q_j`, and `dq_j` for worlds outside `world_mask` when `joint_q`/`joint_u` targets were provided. The previous unmasked writes broke TWOPI revolute-joint angle unwrapping after partial-mask resets.
 
 ## [1.1.0] - 2026-04-13
 

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -213,7 +213,7 @@ def _reset_joint_state_of_select_worlds(
 @wp.kernel
 def _set_joint_state_of_select_worlds(
     # Inputs:
-    write_velocities: int32,
+    write_velocities: bool,
     world_mask: wp.array[int32],
     model_joint_wid: wp.array[int32],
     model_joint_coords_offset: wp.array[int32],
@@ -244,7 +244,7 @@ def _set_joint_state_of_select_worlds(
         dst_q_p[coords_offset + j] = v
 
     # Optionally write the joint's DoF velocities
-    if write_velocities != 0:
+    if write_velocities:
         dofs_offset = model_joint_dofs_offset[jid]
         num_dofs = model_joint_dofs_offset[jid + 1] - dofs_offset
         for j in range(num_dofs):
@@ -585,7 +585,7 @@ def set_joint_state_masked(
     either is ``None``, the velocity write is skipped and ``src_q`` / ``dst_q`` are
     passed as placeholders to satisfy the kernel signature.
     """
-    write_velocities = wp.int32(1) if (src_u is not None and dst_dq is not None) else wp.int32(0)
+    write_velocities = src_u is not None and dst_dq is not None
     _src_u = src_u if src_u is not None else src_q
     _dst_dq = dst_dq if dst_dq is not None else dst_q
     wp.launch(

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -210,6 +210,47 @@ def _reset_joint_state_of_select_worlds(
 
 
 @wp.kernel
+def _set_joint_state_of_select_worlds(
+    # Inputs:
+    world_mask: wp.array[int32],
+    model_joint_wid: wp.array[int32],
+    model_joint_coords_offset: wp.array[int32],
+    model_joint_dofs_offset: wp.array[int32],
+    src_q: wp.array[float32],
+    src_u: wp.array[float32],
+    write_velocities: int32,
+    # Outputs:
+    dst_q: wp.array[float32],
+    dst_q_p: wp.array[float32],
+    dst_dq: wp.array[float32],
+):
+    # Retrieve the joint index from the 1D thread index
+    jid = wp.tid()
+
+    # Retrieve the world index for this joint
+    wid = model_joint_wid[jid]
+
+    # Skip writing this joint's state if the world has not been marked for reset
+    if world_mask[wid] == 0:
+        return
+
+    # Write the joint's coordinate block to both `q` and `q_p` (TWOPI reference)
+    coords_offset = model_joint_coords_offset[jid]
+    num_coords = model_joint_coords_offset[jid + 1] - coords_offset
+    for j in range(num_coords):
+        v = src_q[coords_offset + j]
+        dst_q[coords_offset + j] = v
+        dst_q_p[coords_offset + j] = v
+
+    # Optionally write the joint's DoF velocities
+    if write_velocities != 0:
+        dofs_offset = model_joint_dofs_offset[jid]
+        num_dofs = model_joint_dofs_offset[jid + 1] - dofs_offset
+        for j in range(num_dofs):
+            dst_dq[dofs_offset + j] = src_u[dofs_offset + j]
+
+
+@wp.kernel
 def _reset_bodies_of_select_worlds(
     # Inputs:
     mask: wp.array[int32],
@@ -520,6 +561,48 @@ def reset_joint_constraint_reactions(
             model.joints.kinematic_cts_offset_total_cts,
             # Outputs:
             lambda_j,
+        ],
+        device=model.device,
+    )
+
+
+def _set_joint_state_masked(
+    model: ModelKamino,
+    world_mask: wp.array,
+    src_q: wp.array,
+    src_u: wp.array | None,
+    dst_q: wp.array,
+    dst_q_p: wp.array,
+    dst_dq: wp.array | None,
+):
+    """
+    Writes joint state into ``dst_q`` and ``dst_q_p`` from ``src_q``, and optionally
+    writes joint velocities into ``dst_dq`` from ``src_u``, for the worlds selected
+    by ``world_mask``. Joints whose world is masked out are left untouched.
+
+    Velocities are written only when both ``src_u`` and ``dst_dq`` are provided. When
+    either is ``None``, the velocity write is skipped and ``src_q`` / ``dst_q`` are
+    passed as placeholders to satisfy the kernel signature.
+    """
+    write_velocities = wp.int32(1) if (src_u is not None and dst_dq is not None) else wp.int32(0)
+    _src_u = src_u if src_u is not None else src_q
+    _dst_dq = dst_dq if dst_dq is not None else dst_q
+    wp.launch(
+        _set_joint_state_of_select_worlds,
+        dim=model.size.sum_of_num_joints,
+        inputs=[
+            # Inputs:
+            world_mask,
+            model.joints.wid,
+            model.joints.coords_offset,
+            model.joints.dofs_offset,
+            src_q,
+            _src_u,
+            write_velocities,
+            # Outputs:
+            dst_q,
+            dst_q_p,
+            _dst_dq,
         ],
         device=model.device,
     )

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -26,6 +26,7 @@ __all__ = [
     "reset_state_from_bodies_state",
     "reset_state_to_model_default",
     "reset_time",
+    "set_joint_state_masked",
 ]
 
 
@@ -212,13 +213,13 @@ def _reset_joint_state_of_select_worlds(
 @wp.kernel
 def _set_joint_state_of_select_worlds(
     # Inputs:
+    write_velocities: int32,
     world_mask: wp.array[int32],
     model_joint_wid: wp.array[int32],
     model_joint_coords_offset: wp.array[int32],
     model_joint_dofs_offset: wp.array[int32],
     src_q: wp.array[float32],
     src_u: wp.array[float32],
-    write_velocities: int32,
     # Outputs:
     dst_q: wp.array[float32],
     dst_q_p: wp.array[float32],
@@ -566,7 +567,7 @@ def reset_joint_constraint_reactions(
     )
 
 
-def _set_joint_state_masked(
+def set_joint_state_masked(
     model: ModelKamino,
     world_mask: wp.array,
     src_q: wp.array,
@@ -592,13 +593,13 @@ def _set_joint_state_masked(
         dim=model.size.sum_of_num_joints,
         inputs=[
             # Inputs:
+            write_velocities,
             world_mask,
             model.joints.wid,
             model.joints.coords_offset,
             model.joints.dofs_offset,
             src_q,
             _src_u,
-            write_velocities,
             # Outputs:
             dst_q,
             dst_q_p,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -48,13 +48,13 @@ from .kinematics.joints import (
 )
 from .kinematics.limits import LimitsKamino
 from .kinematics.resets import (
-    _set_joint_state_masked,
     reset_body_net_wrenches,
     reset_joint_constraint_reactions,
     reset_state_from_base_state,
     reset_state_from_bodies_state,
     reset_state_to_model_default,
     reset_time,
+    set_joint_state_masked,
 )
 from .linalg import ConjugateResidualSolver, IterativeSolver, LinearSolverNameToType
 from .solvers.fk import ForwardKinematicsSolver
@@ -859,7 +859,7 @@ class SolverKaminoImpl(SolverBase):
         # write ensures worlds outside `world_mask` keep their previous values (notably
         # `q_j_p`, the TWOPI angle-correction reference).
         if with_joint_targets:
-            _set_joint_state_masked(
+            set_joint_state_masked(
                 model=self._model,
                 world_mask=world_mask,
                 src_q=joint_q,
@@ -878,7 +878,7 @@ class SolverKaminoImpl(SolverBase):
                 joint_q=state_out.q_j,
                 joint_u=state_out.dq_j,
             )
-            _set_joint_state_masked(
+            set_joint_state_masked(
                 model=self._model,
                 world_mask=world_mask,
                 src_q=state_out.q_j,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -48,6 +48,7 @@ from .kinematics.joints import (
 )
 from .kinematics.limits import LimitsKamino
 from .kinematics.resets import (
+    _set_joint_state_masked,
     reset_body_net_wrenches,
     reset_joint_constraint_reactions,
     reset_state_from_base_state,
@@ -854,14 +855,20 @@ class SolverKaminoImpl(SolverBase):
         reset_body_net_wrenches(model=self._model, body_w=state_out.w_i, world_mask=world_mask)
         reset_joint_constraint_reactions(model=self._model, lambda_j=state_out.lambda_j, world_mask=world_mask)
 
-        # If joint targets were provided, copy them to the output state
+        # If joint targets were provided, write them to the output state. The mask-aware
+        # write ensures worlds outside `world_mask` keep their previous values (notably
+        # `q_j_p`, the TWOPI angle-correction reference).
         if with_joint_targets:
-            # Copy the joint states to the output state
-            wp.copy(state_out.q_j_p, joint_q)
-            wp.copy(state_out.q_j, joint_q)
-            if joint_u is not None:
-                wp.copy(state_out.dq_j, joint_u)
-        # Otherwise, extract the joint states from the actuators
+            _set_joint_state_masked(
+                model=self._model,
+                world_mask=world_mask,
+                src_q=joint_q,
+                src_u=joint_u,
+                dst_q=state_out.q_j,
+                dst_q_p=state_out.q_j_p,
+                dst_dq=state_out.dq_j,
+            )
+        # Otherwise, extract the joint states from the actuators and synchronize `q_j_p`
         else:
             extract_joints_state_from_actuators(
                 model=self._model,
@@ -871,7 +878,15 @@ class SolverKaminoImpl(SolverBase):
                 joint_q=state_out.q_j,
                 joint_u=state_out.dq_j,
             )
-            wp.copy(state_out.q_j_p, state_out.q_j)
+            _set_joint_state_masked(
+                model=self._model,
+                world_mask=world_mask,
+                src_q=state_out.q_j,
+                src_u=None,
+                dst_q=state_out.q_j,
+                dst_q_p=state_out.q_j_p,
+                dst_dq=None,
+            )
 
     def _reset_post_process(self, world_mask: wp.array | None = None):
         """

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -767,6 +767,11 @@ class TestSolverKaminoImpl(unittest.TestCase):
             show_progress=self.progress or self.verbose,
         )
 
+        # Snapshot pre-reset state to verify masked-out worlds are preserved
+        pre_reset_q_j = state_n.q_j.numpy().copy()
+        pre_reset_q_j_p = state_n.q_j_p.numpy().copy()
+        pre_reset_dq_j = state_n.dq_j.numpy().copy()
+
         # Reset selected worlds to the specified joint states
         solver.reset(
             state_out=state_n,
@@ -812,6 +817,23 @@ class TestSolverKaminoImpl(unittest.TestCase):
                     rtol=rtol,
                     atol=atol,
                     err_msg="\n`state_out.dq_j` does not match joint_u target\n",
+                )
+            else:
+                # Worlds outside the mask must keep their pre-reset values
+                np.testing.assert_array_equal(
+                    state_n.q_j.numpy()[coords_start : coords_start + num_world_coords],
+                    pre_reset_q_j[coords_start : coords_start + num_world_coords],
+                    err_msg="\n`state_out.q_j` was modified for an unmasked world\n",
+                )
+                np.testing.assert_array_equal(
+                    state_n.q_j_p.numpy()[coords_start : coords_start + num_world_coords],
+                    pre_reset_q_j_p[coords_start : coords_start + num_world_coords],
+                    err_msg="\n`state_out.q_j_p` was modified for an unmasked world\n",
+                )
+                np.testing.assert_array_equal(
+                    state_n.dq_j.numpy()[dofs_start : dofs_start + num_world_dofs],
+                    pre_reset_dq_j[dofs_start : dofs_start + num_world_dofs],
+                    err_msg="\n`state_out.dq_j` was modified for an unmasked world\n",
                 )
             coords_start += num_world_coords
             dofs_start += num_world_dofs
@@ -1010,6 +1032,11 @@ class TestSolverKaminoImpl(unittest.TestCase):
             show_progress=self.progress or self.verbose,
         )
 
+        # Snapshot pre-reset state to verify masked-out worlds are preserved
+        pre_reset_q_j = state_n.q_j.numpy().copy()
+        pre_reset_q_j_p = state_n.q_j_p.numpy().copy()
+        pre_reset_dq_j = state_n.dq_j.numpy().copy()
+
         # Reset all worlds to the specified joint states
         solver.reset(
             state_out=state_n,
@@ -1076,6 +1103,23 @@ class TestSolverKaminoImpl(unittest.TestCase):
                     rtol=rtol,
                     atol=atol,
                     err_msg="\n`state_out.dq_j` does not match joint_u target\n",
+                )
+            else:
+                # Worlds outside the mask must keep their pre-reset values
+                np.testing.assert_array_equal(
+                    state_n.q_j.numpy()[coords_start : coords_start + num_world_coords],
+                    pre_reset_q_j[coords_start : coords_start + num_world_coords],
+                    err_msg="\n`state_out.q_j` was modified for an unmasked world\n",
+                )
+                np.testing.assert_array_equal(
+                    state_n.q_j_p.numpy()[coords_start : coords_start + num_world_coords],
+                    pre_reset_q_j_p[coords_start : coords_start + num_world_coords],
+                    err_msg="\n`state_out.q_j_p` was modified for an unmasked world\n",
+                )
+                np.testing.assert_array_equal(
+                    state_n.dq_j.numpy()[dofs_start : dofs_start + num_world_dofs],
+                    pre_reset_dq_j[dofs_start : dofs_start + num_world_dofs],
+                    err_msg="\n`state_out.dq_j` was modified for an unmasked world\n",
                 )
             coords_start += num_world_coords
             dofs_start += num_world_dofs


### PR DESCRIPTION
## Description

`SolverKamino.reset(...)` accepts a `world_mask` parameter, and most operations inside `_reset_with_fk_solve` follow it. However, the function ended with four unmasked `wp.copy()` calls that overwrote `state_out.q_j`, `state_out.q_j_p`, and `state_out.dq_j` for all worlds regardless of the mask. This silently corrupted state for masked-out worlds, most notably `q_j_p`, the previous-coordinate cache used as the reference for revolute-joint TWOPI angle unwrapping. After a partial-mask reset, `q_j_p == q_j` for every world, which disables the angle correction on the next step and can cause revolute joints to glitch near pi.

This PR replaces the four unmasked copies with a single mask-aware kernel `_set_joint_state_of_select_worlds` that writes `q_j`, `q_j_p`, and (optionally) `dq_j` in one launch, gated per-joint on `world_mask[joint_wid]`. Joints whose world is masked out are left untouched. The kernel and its launcher `_set_joint_state_masked` are private helpers, so no new public API surface is added.

With this fix, `solver.reset(world_mask=zeros)` is a true per-world no-op.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- Extended `test_08_reset_to_joint_state` and `test_09_reset_to_actuator_state` to snapshot the pre-reset state and assert that worlds outside the mask retain their previous `q_j`, `q_j_p`, and `dq_j` values.
- Verified the regression test fails when the per-joint mask guard is removed (`AssertionError: state_out.q_j was modified for an unmasked world`) and passes when restored.
- All five reset tests (`test_05`–`test_09`) pass.
- `uvx pre-commit run -a` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Masked resets no longer overwrite joint state in worlds excluded by a partial mask, preserving unmasked joint values and restoring correct revolute-joint angle behavior after partial resets. Masking is now applied consistently during resets.

* **Tests**
  * Added tests that confirm worlds excluded by the mask remain unchanged during masked resets.

* **Changelog**
  * Added an unreleased entry documenting the masked-reset issue and its fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->