### PR TITLE
Add HDR color output to tiled camera sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add linear HDR color output support to `SensorTiledCamera` via `hdr_color_image`.
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
 - Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -204,9 +204,9 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
-        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         clear_data: ClearData | None = DEFAULT_CLEAR_DATA,
         refit_bvh: bool | None = None,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
     ):
         """Render output images for all worlds and cameras.
 
@@ -232,7 +232,6 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             shape_index_image: Output for per-pixel shape id. None to skip.
             normal_image: Output for surface normals. None to skip.
             albedo_image: Output for unshaded surface color. None to skip.
-            hdr_color_image: Output for linear HDR color. None to skip.
             clear_data: Values to clear output buffers with.
                 See :attr:`DEFAULT_CLEAR_DATA`, :attr:`GRAY_CLEAR_DATA`.
             refit_bvh: Refit the BVH before rendering. This is deprecated, use
@@ -241,6 +240,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
                 :func:`~newton.geometry.build_bvh_particle`, and
                 :func:`~newton.geometry.refit_bvh_particle` explicitly
                 before calling this method instead.
+            hdr_color_image: Output for linear HDR color. None to skip.
         """
 
         # TODO: Remove this deprecation behaviour in the next release.
@@ -281,8 +281,8 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             shape_index_image,
             normal_image,
             albedo_image,
-            hdr_color_image,
             clear_data=clear_data,
+            hdr_color_image=hdr_color_image,
         )
 
     def compute_pinhole_camera_rays(

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -41,9 +41,10 @@ class _SensorTiledCameraMeta(type):
 class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     """Warp-based tiled camera sensor for raytraced rendering across multiple worlds.
 
-    Renders up to five image channels per (world, camera) pair:
+    Renders up to six image channels per (world, camera) pair:
 
     - **color** -- RGBA shaded image (``uint32``).
+    - **hdr_color** -- linear shaded RGB image (``vec3f``).
     - **depth** -- ray-hit distance [m] (``float32``); negative means no hit.
     - **normal** -- surface normal at hit point (``vec3f``).
     - **albedo** -- unshaded surface color (``uint32``).
@@ -203,6 +204,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         clear_data: ClearData | None = DEFAULT_CLEAR_DATA,
         refit_bvh: bool | None = None,
     ):
@@ -230,6 +232,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             shape_index_image: Output for per-pixel shape id. None to skip.
             normal_image: Output for surface normals. None to skip.
             albedo_image: Output for unshaded surface color. None to skip.
+            hdr_color_image: Output for linear HDR color. None to skip.
             clear_data: Values to clear output buffers with.
                 See :attr:`DEFAULT_CLEAR_DATA`, :attr:`GRAY_CLEAR_DATA`.
             refit_bvh: Refit the BVH before rendering. This is deprecated, use
@@ -278,6 +281,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             shape_index_image,
             normal_image,
             albedo_image,
+            hdr_color_image,
             clear_data=clear_data,
         )
 

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -20,7 +20,12 @@ def create_kernel(
 ) -> wp.kernel:
     compute_lighting = lighting.create_compute_lighting_function(config, state)
 
-    if state.render_color or state.render_normal or (state.render_albedo and config.enable_textures):
+    if (
+        state.render_color
+        or state.render_hdr_color
+        or state.render_normal
+        or (state.render_albedo and config.enable_textures)
+    ):
         raytrace_closest_hit = raytrace.create_closest_hit_function(config, state)
     else:
         raytrace_closest_hit = raytrace.create_closest_hit_depth_only_function(config, state)
@@ -76,6 +81,7 @@ def create_kernel(
         out_shape_index: wp.array[wp.uint32],
         out_normal: wp.array[wp.vec3f],
         out_albedo: wp.array[wp.uint32],
+        out_hdr_color: wp.array[wp.vec3f],
     ):
         tid = wp.tid()
 
@@ -136,6 +142,8 @@ def create_kernel(
                 out_color[out_index] = wp.uint32(wp.static(clear_data.clear_color))
             if wp.static(state.render_albedo):
                 out_albedo[out_index] = wp.uint32(wp.static(clear_data.clear_albedo))
+            if wp.static(state.render_hdr_color):
+                out_hdr_color[out_index] = wp.vec3f(0.0)
             if wp.static(state.render_depth):
                 out_depth[out_index] = wp.float32(wp.static(clear_data.clear_depth))
             if wp.static(state.render_normal):
@@ -157,7 +165,7 @@ def create_kernel(
         if wp.static(state.render_shape_index):
             out_shape_index[out_index] = closest_hit.shape_index
 
-        if not wp.static(state.render_color) and not wp.static(state.render_albedo):
+        if not wp.static(state.render_color) and not wp.static(state.render_albedo) and not wp.static(state.render_hdr_color):
             return
 
         is_gaussian = wp.bool(False)
@@ -196,7 +204,7 @@ def create_kernel(
         if wp.static(state.render_albedo):
             out_albedo[out_index] = tiling.pack_rgba_to_uint32(albedo_color, 1.0)
 
-        if not wp.static(state.render_color):
+        if not wp.static(state.render_color) and not wp.static(state.render_hdr_color):
             return
 
         shaded_color = closest_hit.color
@@ -243,6 +251,10 @@ def create_kernel(
                 )
                 shaded_color = shaded_color + albedo_color * light_contribution
 
-        out_color[out_index] = tiling.pack_rgba_to_uint32(shaded_color, 1.0)
+        if wp.static(state.render_hdr_color):
+            out_hdr_color[out_index] = shaded_color
+
+        if wp.static(state.render_color):
+            out_color[out_index] = tiling.pack_rgba_to_uint32(shaded_color, 1.0)
 
     return render_megakernel

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -165,7 +165,11 @@ def create_kernel(
         if wp.static(state.render_shape_index):
             out_shape_index[out_index] = closest_hit.shape_index
 
-        if not wp.static(state.render_color) and not wp.static(state.render_albedo) and not wp.static(state.render_hdr_color):
+        if (
+            not wp.static(state.render_color)
+            and not wp.static(state.render_albedo)
+            and not wp.static(state.render_hdr_color)
+        ):
             return
 
         is_gaussian = wp.bool(False)

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -146,8 +146,8 @@ class RenderContext:
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
-        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         clear_data: RenderContext.ClearData | None = DEFAULT_CLEAR_DATA,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
     ):
         """Raytrace the scene into the provided output images.
 
@@ -175,9 +175,9 @@ class RenderContext:
             shape_index_image: Output shape-index buffer.
             normal_image: Output world-space surface normals.
             albedo_image: Output albedo buffer (packed ``uint32``).
-            hdr_color_image: Output linear HDR color buffer.
             clear_data: Values used to clear output images before
                 rendering. Pass ``None`` to use :attr:`DEFAULT_CLEAR_DATA`.
+            hdr_color_image: Output linear HDR color buffer.
         """
         if model.shape_count > 0 and model.bvh_shape_enabled is None:
             raise RuntimeError("build_bvh_shape() must be called before rendering shapes.")

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -31,6 +31,7 @@ class RenderContext:
         render_shape_index: bool = False
         render_normal: bool = False
         render_albedo: bool = False
+        render_hdr_color: bool = False
 
     DEFAULT_CLEAR_DATA = ClearData()
 
@@ -145,6 +146,7 @@ class RenderContext:
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         clear_data: RenderContext.ClearData | None = DEFAULT_CLEAR_DATA,
     ):
         """Raytrace the scene into the provided output images.
@@ -173,6 +175,7 @@ class RenderContext:
             shape_index_image: Output shape-index buffer.
             normal_image: Output world-space surface normals.
             albedo_image: Output albedo buffer (packed ``uint32``).
+            hdr_color_image: Output linear HDR color buffer.
             clear_data: Values used to clear output images before
                 rendering. Pass ``None`` to use :attr:`DEFAULT_CLEAR_DATA`.
         """
@@ -211,6 +214,7 @@ class RenderContext:
             self.state.render_shape_index = shape_index_image is not None
             self.state.render_normal = normal_image is not None
             self.state.render_albedo = albedo_image is not None
+            self.state.render_hdr_color = hdr_color_image is not None
 
             assert camera_transforms.shape == (camera_count, self.world_count), (
                 f"camera_transforms size must match {camera_count} x {self.world_count}"
@@ -244,6 +248,10 @@ class RenderContext:
                 assert albedo_image.shape == (self.world_count, camera_count, height, width), (
                     f"albedo_image size must match {self.world_count} x {camera_count} x {height} x {width}"
                 )
+            if hdr_color_image is not None:
+                assert hdr_color_image.shape == (self.world_count, camera_count, height, width), (
+                    f"hdr_color_image size must match {self.world_count} x {camera_count} x {height} x {width}"
+                )
 
             if self.config.render_order == RenderOrder.TILED:
                 assert width % self.config.tile_width == 0, "render width must be a multiple of tile_width"
@@ -260,6 +268,8 @@ class RenderContext:
                 normal_image = normal_image.reshape(self.world_count * camera_count * width * height)
             if albedo_image is not None:
                 albedo_image = albedo_image.reshape(self.world_count * camera_count * width * height)
+            if hdr_color_image is not None:
+                hdr_color_image = hdr_color_image.reshape(self.world_count * camera_count * width * height)
 
             kernel_cache_key = hash((self.config, self.state, clear_data))
             render_kernel = self.kernel_cache.get(kernel_cache_key)
@@ -322,6 +332,7 @@ class RenderContext:
                     shape_index_image,
                     normal_image,
                     albedo_image,
+                    hdr_color_image,
                 ],
                 device=self.device,
             )
@@ -529,3 +540,16 @@ class RenderContext:
             stacklevel=2,
         )
         return self.utils.create_albedo_image_output(width, height, camera_count)
+
+    def create_hdr_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
+        """Create an output array for linear HDR color rendering.
+
+        .. deprecated:: 1.1
+            Use :meth:`SensorTiledCamera.utils.create_hdr_color_image_output`.
+        """
+        warnings.warn(
+            "RenderContext.create_hdr_color_image_output is deprecated, use SensorTiledCamera.utils.create_hdr_color_image_output instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.utils.create_hdr_color_image_output(width, height, camera_count)

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -362,6 +362,23 @@ class Utils:
             device=self.__render_context.device,
         )
 
+    def create_hdr_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
+        """Create a linear HDR color output array for :meth:`~SensorTiledCamera.update`.
+
+        Args:
+            width: Image width [px].
+            height: Image height [px].
+            camera_count: Number of cameras.
+
+        Returns:
+            Array of shape ``(world_count, camera_count, height, width)``, dtype ``vec3f``.
+        """
+        return wp.zeros(
+            (self.__render_context.world_count, camera_count, height, width),
+            dtype=wp.vec3f,
+            device=self.__render_context.device,
+        )
+
     def compute_pinhole_camera_rays(
         self, width: int, height: int, camera_fovs: float | list[float] | np.ndarray | wp.array[wp.float32]
     ) -> wp.array4d[wp.vec3f]:

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
 import math

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import unittest
 
 import numpy as np
 import warp as wp
@@ -39,23 +40,27 @@ def _render_tiny_color_and_hdr(model):
     return np.asarray(color_image.numpy(), dtype=np.uint32), np.asarray(hdr_color_image.numpy(), dtype=np.float32)
 
 
-def test_hdr_color_is_available_next_to_packed_color():
-    model = _build_single_sphere_model()
+class TestSensorTiledCameraHdrColor(unittest.TestCase):
+    def test_hdr_color_is_available_next_to_packed_color(self):
+        model = _build_single_sphere_model()
 
-    color, hdr_color = _render_tiny_color_and_hdr(model)
+        color, hdr_color = _render_tiny_color_and_hdr(model)
 
-    assert color.shape == (1, 1, 4, 4)
-    assert hdr_color.shape == (1, 1, 4, 4, 3)
-    assert color.dtype == np.uint32
-    assert hdr_color.dtype == np.float32
-    assert np.isfinite(hdr_color).all()
-    assert hdr_color.max() > 0.0
+        self.assertEqual(color.shape, (1, 1, 4, 4))
+        self.assertEqual(hdr_color.shape, (1, 1, 4, 4, 3))
+        self.assertEqual(color.dtype, np.uint32)
+        self.assertEqual(hdr_color.dtype, np.float32)
+        self.assertTrue(np.isfinite(hdr_color).all())
+        self.assertGreater(hdr_color.max(), 0.0)
+
+    def test_hdr_color_matches_linear_color_before_packing(self):
+        model = _build_single_sphere_model()
+
+        color, hdr_color = _render_tiny_color_and_hdr(model)
+        packed_rgb = color.view(np.uint8).reshape(*color.shape, 4)[..., :3].astype(np.float32) / 255.0
+
+        np.testing.assert_allclose(np.clip(hdr_color, 0.0, 1.0), packed_rgb, atol=1.0 / 255.0)
 
 
-def test_hdr_color_matches_linear_color_before_packing():
-    model = _build_single_sphere_model()
-
-    color, hdr_color = _render_tiny_color_and_hdr(model)
-    packed_rgb = color.view(np.uint8).reshape(*color.shape, 4)[..., :3].astype(np.float32) / 255.0
-
-    np.testing.assert_allclose(np.clip(hdr_color, 0.0, 1.0), packed_rgb, atol=1.0 / 255.0)
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.sensors import SensorTiledCamera
+
+
+def _build_single_sphere_model():
+    builder = newton.ModelBuilder()
+    body = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.0), q=wp.quat_identity()))
+    builder.add_shape_sphere(body, radius=1.0, color=(0.5, 0.5, 0.5))
+    return builder.finalize(device="cpu")
+
+
+def _render_tiny_color_and_hdr(model):
+    sensor = SensorTiledCamera(model=model)
+
+    camera_transforms = wp.array(
+        [[wp.transformf(wp.vec3f(3.0, 0.0, 0.0), wp.quatf(0.5, 0.5, 0.5, 0.5))]],
+        dtype=wp.transformf,
+        device="cpu",
+    )
+    camera_rays = sensor.utils.compute_pinhole_camera_rays(4, 4, math.radians(45.0))
+    color_image = sensor.utils.create_color_image_output(4, 4, 1)
+    hdr_color_image = sensor.utils.create_hdr_color_image_output(4, 4, 1)
+
+    sensor.update(
+        model.state(),
+        camera_transforms,
+        camera_rays,
+        color_image=color_image,
+        hdr_color_image=hdr_color_image,
+    )
+    return np.asarray(color_image.numpy(), dtype=np.uint32), np.asarray(hdr_color_image.numpy(), dtype=np.float32)
+
+
+def test_hdr_color_is_available_next_to_packed_color():
+    model = _build_single_sphere_model()
+
+    color, hdr_color = _render_tiny_color_and_hdr(model)
+
+    assert color.shape == (1, 1, 4, 4)
+    assert hdr_color.shape == (1, 1, 4, 4, 3)
+    assert color.dtype == np.uint32
+    assert hdr_color.dtype == np.float32
+    assert np.isfinite(hdr_color).all()
+    assert hdr_color.max() > 0.0
+
+
+def test_hdr_color_matches_linear_color_before_packing():
+    model = _build_single_sphere_model()
+
+    color, hdr_color = _render_tiny_color_and_hdr(model)
+    packed_rgb = color.view(np.uint8).reshape(*color.shape, 4)[..., :3].astype(np.float32) / 255.0
+
+    np.testing.assert_allclose(np.clip(hdr_color, 0.0, 1.0), packed_rgb, atol=1.0 / 255.0)

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -20,6 +20,7 @@ def _build_single_sphere_model():
 
 def _render_tiny_color_and_hdr(model):
     sensor = SensorTiledCamera(model=model)
+    state = model.state()
 
     camera_transforms = wp.array(
         [[wp.transformf(wp.vec3f(3.0, 0.0, 0.0), wp.quatf(0.5, 0.5, 0.5, 0.5))]],
@@ -30,8 +31,10 @@ def _render_tiny_color_and_hdr(model):
     color_image = sensor.utils.create_color_image_output(4, 4, 1)
     hdr_color_image = sensor.utils.create_hdr_color_image_output(4, 4, 1)
 
+    newton.geometry.build_bvh_shape(model, state)
+    newton.geometry.build_bvh_particle(model, state)
     sensor.update(
-        model.state(),
+        state,
         camera_transforms,
         camera_rays,
         color_image=color_image,


### PR DESCRIPTION
## Description

Adds linear HDR RGB output support to `SensorTiledCamera` via the new `hdr_color_image` output buffer. This lets downstream render pipelines consume scene-linear shaded color before LDR packing, while preserving the existing packed `color_image` output.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
uv run --extra dev -m newton.tests -p test_sensor_tiled_camera_hdr_color.py
uv run --extra dev -m newton.tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SensorTiledCamera can now produce linear HDR color (linear RGB) images alongside the existing packed color output for improved visual fidelity.

* **Tests**
  * Added unit tests confirming HDR output is produced, has correct shape/dtype, contains finite/non-zero values, and matches pre-packing linear RGB within tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->