### PR TITLE
Bump warp-lang to 1.13.0

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,10 +16,10 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.13.0rc1 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U warp-lang==1.13.0",
     "python -m pip install -U mujoco==3.7.0",
     "python -m pip install -U mujoco-warp==3.7.0.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
-    "in-dir={env_dir} python -m pip install --extra-index-url=https://pypi.nvidia.com/ {wheel_file}[dev]"
+    "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.13.0rc1",
+    "warp-lang>=1.13.0",
 ]
 
 [project.optional-dependencies]
@@ -145,7 +145,7 @@ conflicts = [
 ]
 
 [tool.uv.sources]
-warp-lang = { index = "nvidia" }
+# warp-lang = { index = "nvidia" }
 torch = [
     { index = "pytorch-cu128", extra = "torch-cu12" },
     { index = "pytorch-cu130", extra = "torch-cu13" },

--- a/uv.lock
+++ b/uv.lock
@@ -3110,7 +3110,7 @@ requires-dist = [
     { name = "usd-core", marker = "python_full_version < '3.14' and platform_machine != 'aarch64' and extra == 'importers'", specifier = ">=25.5,<26.5" },
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = ">=1.0.16" },
-    { name = "warp-lang", specifier = ">=1.13.0rc1", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.13.0" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -5908,17 +5908,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.13.0rc1"
-source = { registry = "https://pypi.nvidia.com/" }
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0rc1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e492e602eacf97d36f10233976f49537532f291e86cdff796fec827bbd6080fd" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0rc1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1c71f6c51616a1665c9f700119ab3536005b0fcbb0ebfe826fa1eab09177fdc4" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0rc1-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:8d3b15a4eaddc09686de77844906cc4daf7d8a06120ab708eb205e278441b986" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.13.0rc1-py3-none-win_amd64.whl", hash = "sha256:47ba281c2c3751a3699b8bba1d8edb462f76b2ffe650f44d16884ba18bc604f0" },
+    { url = "https://files.pythonhosted.org/packages/94/be/b79000cb5b551803416bc10c4fa43a37d31b48062683662a6c134d7452bc/warp_lang-1.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4375f572301991fe0fbf0af29fc84d76cd27d531432d6df8452b25088c21ea5a", size = 24584304, upload-time = "2026-05-04T04:30:03.621Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8e/b42f0ddeaca25251e5bbf7db6a89351a0722432ce075ebcdece9118e955a/warp_lang-1.13.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ac2479c70ad410d58deb088c2a64168792be588efc1bec22dc51f92238e8c8c3", size = 138337580, upload-time = "2026-05-04T04:30:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/53/19/87b3a3a1a5e07ad34a3886ec38e96b6865359fd17a2511e78e5430c6bace/warp_lang-1.13.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:476b54f0dcf6767f23305a328660a9a74d01e371b6b7c3d77e03e18b4a1bb1a5", size = 139812627, upload-time = "2026-05-04T04:31:03.731Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/79/e4117177b88df67d7967c993a2234a3888d0e388076652e1f2a50551f95a/warp_lang-1.13.0-py3-none-win_amd64.whl", hash = "sha256:47975ea07252d45a4d09d2d1a6cffc55002fa7fbde771c8dceb1baf4b32d4fb8", size = 121601324, upload-time = "2026-05-04T04:31:37.814Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Switch from the `1.13.0rc1` prerelease on `pypi.nvidia.com` to the `1.13.0` final on PyPI proper, now that it has been published. Drop the now-unneeded `--extra-index-url=https://pypi.nvidia.com/` from the asv wheel install step since warp-lang is the only dependency that previously required it.

The `[[tool.uv.index]] name = "nvidia"` block and the commented `warp-lang = { index = "nvidia" }` line in `pyproject.toml` are intentionally retained in case we want to point at a future dev/prerelease build from the NVIDIA index again.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- CI runs against the new `1.13.0` wheels resolved from PyPI.
- Locally verify `uv lock` is consistent and `uv sync --extra dev` resolves warp-lang 1.13.0 from `pypi.org/simple`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated warp-lang dependency from pre-release to stable version 1.13.0
  * Simplified dependency installation by removing custom package index configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->