### PR TITLE
Fix `contacts_rj45_plug` Example Crashing On Reset (#2699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - Fix `SensorRaycast` ignoring `PLANE` geometry
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
+- Fix `contacts_rj45_plug` example crashing on reset
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix `collision_filter_parent` silently ignored on joints to world (`parent=-1`); now honored for all `add_joint_*` methods, with `add_joint_fixed(parent=-1, ...)` defaulting to filter child shapes against world-static shapes
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`

--- a/newton/examples/contacts/example_contacts_rj45_plug.py
+++ b/newton/examples/contacts/example_contacts_rj45_plug.py
@@ -220,7 +220,7 @@ def _load_cable_centerline(stage) -> tuple[wp.vec3, ...]:
 
 
 class Example:
-    def __init__(self, viewer):
+    def __init__(self, viewer, _args=None):
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0
@@ -514,5 +514,5 @@ class Example:
 
 if __name__ == "__main__":
     viewer, args = newton.examples.init()
-    example = Example(viewer)
+    example = Example(viewer, args)
     newton.examples.run(example, args)


### PR DESCRIPTION
## Description

This fixes the issue where clicking on the reset button for that example would crash wit hthe following error:

```
newton/examples/__init__.py:283: UserWarning: Failed to reset example: Example.__init__() takes 2 positional arguments but 3 were given
  example = browser.reset(example_class)
  ```

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)


## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

1. `uv run --extra examples -m newton.examples contacts_rj45_plug`
2. Click the Reset button


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the contacts RJ45 plug example that occurred during reset.

* **New Features**
  * Example now accepts optional runtime/command-line arguments and forwards them to its runner, enabling configurable example execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->