### PR TITLE
Updated cable y-junction example

### DIFF
--- a/newton/examples/cable/example_cable_y_junction.py
+++ b/newton/examples/cable/example_cable_y_junction.py
@@ -120,9 +120,14 @@ class Example:
 
         self.viewer.set_model(self.model)
 
-        # Set camera to be closer to the cable
+        if hasattr(self.viewer, "picking"):
+            pick_state = self.viewer.picking.pick_state.numpy()
+            pick_state[0]["pick_stiffness"] = 0.2
+            pick_state[0]["pick_damping"] = 0.0
+            self.viewer.picking.pick_state.assign(pick_state)
+
         self.viewer.set_camera(
-            pos=wp.vec3(6.0, 0.0, 1.5),
+            pos=wp.vec3(2.10, 0.0, z0 - 0.15),
             pitch=0.0,
             yaw=-180.0,
         )


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Minor camera/mouse tuning for cable y-junction example.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added picking behavior configuration to the cable Y junction example, enabling adjustable interaction parameters.

* **Improvements**
  * Refined camera positioning to provide an optimized viewing perspective of the Y junction structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->