### PR TITLE
Update version mismatch check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `contacts_rj45_plug` example crashing on reset
+- Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel; the check now reads required versions via `importlib.metadata.requires` instead of `pyproject.toml`
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix `collision_filter_parent` silently ignored on joints to world (`parent=-1`); now honored for all `add_joint_*` methods, with `add_joint_fixed(parent=-1, ...)` defaulting to filter child shapes against world-static shapes
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `contacts_rj45_plug` example crashing on reset
-- Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel; the check now reads required versions via `importlib.metadata.requires` instead of `pyproject.toml`
+- Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix `collision_filter_parent` silently ignored on joints to world (`parent=-1`); now honored for all `add_joint_*` methods, with `add_joint_fixed(parent=-1, ...)` defaulting to filter child shapes against world-static shapes
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -105,11 +105,17 @@ def _required_specifier(package: str, requirements: Iterable[str]) -> str | None
 
 def _warn_if_mujoco_versions_mismatch(mujoco: Any, mujoco_warp: Any) -> None:
     try:
-        requirements = importlib_metadata.requires("newton")
+        metadata_text = importlib_metadata.distribution("newton").read_text("METADATA")
     except importlib_metadata.PackageNotFoundError:
         return
-    if requirements is None:
+    if metadata_text is None:
         return
+
+    requirements = [
+        line.removeprefix("Requires-Dist:").strip()
+        for line in metadata_text.splitlines()
+        if line.startswith("Requires-Dist:")
+    ]
 
     mismatches = []
     for package, module in (("mujoco", mujoco), ("mujoco-warp", mujoco_warp)):

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -96,8 +96,10 @@ AttributeFrequency = Model.AttributeFrequency
 
 def _required_specifier(package: str) -> str | None:
     try:
-        requirements = importlib_metadata.requires("newton") or ()
+        requirements = importlib_metadata.requires("newton")
     except importlib_metadata.PackageNotFoundError:
+        return None
+    if requirements is None:
         return None
 
     pattern = re.compile(rf"^{re.escape(package)}(?=[<>=!~])([^;]+)")

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -281,6 +281,7 @@ class SolverMuJoCo(SolverBase):
     # Class variables to cache the imported modules
     _mujoco = None
     _mujoco_warp = None
+    _versions_checked = False
     _convert_mjw_contacts_to_newton_kernel = None
 
     @classmethod
@@ -302,10 +303,12 @@ class SolverMuJoCo(SolverBase):
                 raise ImportError(
                     "MuJoCo backend not installed. Please refer to https://github.com/google-deepmind/mujoco_warp for installation instructions."
                 ) from e
-        try:
-            _warn_if_mujoco_versions_mismatch(cls._mujoco, cls._mujoco_warp)
-        except Exception:
-            pass
+        if not cls._versions_checked:
+            try:
+                _warn_if_mujoco_versions_mismatch(cls._mujoco, cls._mujoco_warp)
+            except Exception:
+                pass
+            cls._versions_checked = True
         return cls._mujoco, cls._mujoco_warp
 
     @staticmethod

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -9,7 +9,6 @@ import re
 import warnings
 from collections.abc import Iterable
 from enum import IntEnum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -95,22 +94,31 @@ AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
 
 
-def _warn_if_mujoco_versions_mismatch(mujoco: Any, mujoco_warp: Any) -> None:
+def _required_specifier(package: str) -> str | None:
     try:
-        pyproject_text = (Path(__file__).resolve().parents[4] / "pyproject.toml").read_text(encoding="utf-8")
-    except OSError:
-        return
+        requirements = importlib_metadata.requires("newton") or ()
+    except importlib_metadata.PackageNotFoundError:
+        return None
 
+    pattern = re.compile(rf"^{re.escape(package)}(?=[<>=!~])([^;]+)")
+    for requirement in requirements:
+        match = pattern.match(requirement)
+        if match:
+            return match.group(1).strip().replace(" ", "")
+    return None
+
+
+def _warn_if_mujoco_versions_mismatch(mujoco: Any, mujoco_warp: Any) -> None:
     mismatches = []
     for package, module in (("mujoco", mujoco), ("mujoco-warp", mujoco_warp)):
-        match = re.search(rf'^\s*"{re.escape(package)}(?=[<>=!~])([^";]+)', pyproject_text, re.MULTILINE)
+        specifier = _required_specifier(package)
         installed_version = _installed_version(package, module)
-        if match and installed_version and not _version_satisfies(installed_version, match.group(1)):
-            mismatches.append(f"{package}=={installed_version} (requires {match.group(1).replace(' ', '')})")
+        if specifier and installed_version and not _version_satisfies(installed_version, specifier):
+            mismatches.append(f"{package}=={installed_version} (requires {specifier})")
 
     if mismatches:
         warnings.warn(
-            "MuJoCo dependency version mismatch with pyproject.toml: "
+            "MuJoCo dependency version mismatch with Newton's declared requirements: "
             + "; ".join(mismatches)
             + '. Reinstall Newton dependencies, for example `uv pip install -e ".[examples]"`.',
             RuntimeWarning,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -94,14 +94,7 @@ AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
 
 
-def _required_specifier(package: str) -> str | None:
-    try:
-        requirements = importlib_metadata.requires("newton")
-    except importlib_metadata.PackageNotFoundError:
-        return None
-    if requirements is None:
-        return None
-
+def _required_specifier(package: str, requirements: Iterable[str]) -> str | None:
     pattern = re.compile(rf"^{re.escape(package)}(?=[<>=!~])([^;]+)")
     for requirement in requirements:
         match = pattern.match(requirement)
@@ -111,9 +104,16 @@ def _required_specifier(package: str) -> str | None:
 
 
 def _warn_if_mujoco_versions_mismatch(mujoco: Any, mujoco_warp: Any) -> None:
+    try:
+        requirements = importlib_metadata.requires("newton")
+    except importlib_metadata.PackageNotFoundError:
+        return
+    if requirements is None:
+        return
+
     mismatches = []
     for package, module in (("mujoco", mujoco), ("mujoco-warp", mujoco_warp)):
-        specifier = _required_specifier(package)
+        specifier = _required_specifier(package, requirements)
         installed_version = _installed_version(package, module)
         if specifier and installed_version and not _version_satisfies(installed_version, specifier):
             mismatches.append(f"{package}=={installed_version} (requires {specifier})")

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -84,6 +84,24 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         messages = [str(warning.message) for warning in caught]
         self.assertFalse(any("MuJoCo dependency version mismatch" in message for message in messages))
 
+    def test_required_specifier_returns_none(self):
+        cases = {
+            "metadata missing": mock.patch.object(
+                solver_mujoco.importlib_metadata,
+                "requires",
+                side_effect=solver_mujoco.importlib_metadata.PackageNotFoundError("newton"),
+            ),
+            "no requirements declared": mock.patch.object(
+                solver_mujoco.importlib_metadata, "requires", return_value=None
+            ),
+            "package not in requirements": mock.patch.object(
+                solver_mujoco.importlib_metadata, "requires", return_value=["warp-lang>=1.0"]
+            ),
+        }
+        for name, patch in cases.items():
+            with self.subTest(name), patch:
+                self.assertIsNone(solver_mujoco._required_specifier("mujoco"))
+
 
 def _matching_version(specifier: str) -> str:
     for pattern in (r">=\s*([0-9][^,;]*)", r"~=\s*([0-9][^,;]*)"):

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -4,24 +4,13 @@
 import types
 import unittest
 import warnings
-from pathlib import Path
 from unittest import mock
 
 from newton._src.solvers.mujoco import solver_mujoco
 
 
 def _mujoco_dependency_specs():
-    pyproject_text = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(encoding="utf-8")
-    specs = {}
-    for package in ("mujoco", "mujoco-warp"):
-        match = solver_mujoco.re.search(
-            rf'^\s*"{solver_mujoco.re.escape(package)}(?=[<>=!~])([^";]+)',
-            pyproject_text,
-            solver_mujoco.re.MULTILINE,
-        )
-        if match:
-            specs[package] = match.group(1).replace(" ", "")
-    return specs
+    return {package: solver_mujoco._required_specifier(package) for package in ("mujoco", "mujoco-warp")}
 
 
 class TestMuJoCoVersionCheck(unittest.TestCase):
@@ -30,13 +19,13 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         versions = {
             package: "0.0.0"
             for package, specifier in specs.items()
-            if not solver_mujoco._version_satisfies("0.0.0", specifier)
+            if specifier and not solver_mujoco._version_satisfies("0.0.0", specifier)
         }
 
         with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
             with self.assertWarnsRegex(
                 RuntimeWarning,
-                "pyproject.toml.*mujoco==0.0.0.*mujoco-warp==0.0.0",
+                r"MuJoCo dependency version mismatch.*mujoco==0\.0\.0.*mujoco-warp==0\.0\.0",
             ):
                 solver_mujoco._warn_if_mujoco_versions_mismatch(
                     types.SimpleNamespace(),
@@ -61,7 +50,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         versions = {
             package: "0.0.0"
             for package, specifier in specs.items()
-            if not solver_mujoco._version_satisfies("0.0.0", specifier)
+            if specifier and not solver_mujoco._version_satisfies("0.0.0", specifier)
         }
         previous_mujoco = solver_mujoco.SolverMuJoCo._mujoco
         previous_mujoco_warp = solver_mujoco.SolverMuJoCo._mujoco_warp
@@ -78,7 +67,11 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
             solver_mujoco.SolverMuJoCo._mujoco_warp = previous_mujoco_warp
 
     def test_accepts_versions_that_satisfy_pyproject(self):
-        versions = {package: _matching_version(specifier) for package, specifier in _mujoco_dependency_specs().items()}
+        versions = {
+            package: _matching_version(specifier)
+            for package, specifier in _mujoco_dependency_specs().items()
+            if specifier
+        }
 
         with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
             with warnings.catch_warnings(record=True) as caught:

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -8,12 +8,24 @@ from unittest import mock
 
 from newton._src.solvers.mujoco import solver_mujoco
 
+_MOCK_REQUIREMENTS = (
+    "mujoco~=3.8.0 ; extra == 'sim'",
+    "mujoco-warp~=3.8.0,>=3.8.0.1 ; extra == 'sim'",
+)
+
 
 def _mujoco_dependency_specs():
-    return {package: solver_mujoco._required_specifier(package) for package in ("mujoco", "mujoco-warp")}
+    return {
+        package: solver_mujoco._required_specifier(package, _MOCK_REQUIREMENTS) for package in ("mujoco", "mujoco-warp")
+    }
 
 
 class TestMuJoCoVersionCheck(unittest.TestCase):
+    def setUp(self):
+        patcher = mock.patch.object(solver_mujoco.importlib_metadata, "requires", return_value=list(_MOCK_REQUIREMENTS))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_warns_when_installed_versions_do_not_satisfy_pyproject(self):
         specs = _mujoco_dependency_specs()
         versions = {
@@ -86,21 +98,12 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
 
     def test_required_specifier_returns_none(self):
         cases = {
-            "metadata missing": mock.patch.object(
-                solver_mujoco.importlib_metadata,
-                "requires",
-                side_effect=solver_mujoco.importlib_metadata.PackageNotFoundError("newton"),
-            ),
-            "no requirements declared": mock.patch.object(
-                solver_mujoco.importlib_metadata, "requires", return_value=None
-            ),
-            "package not in requirements": mock.patch.object(
-                solver_mujoco.importlib_metadata, "requires", return_value=["warp-lang>=1.0"]
-            ),
+            "empty requirements": [],
+            "package not in requirements": ["warp-lang>=1.0"],
         }
-        for name, patch in cases.items():
-            with self.subTest(name), patch:
-                self.assertIsNone(solver_mujoco._required_specifier("mujoco"))
+        for name, requirements in cases.items():
+            with self.subTest(name):
+                self.assertIsNone(solver_mujoco._required_specifier("mujoco", requirements))
 
 
 def _matching_version(specifier: str) -> str:

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -36,7 +36,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
             if specifier and not solver_mujoco._version_satisfies("0.0.0", specifier)
         }
 
-        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.get):
             with self.assertWarnsRegex(
                 RuntimeWarning,
                 r"MuJoCo dependency version mismatch.*mujoco==0\.0\.0.*mujoco-warp==0\.0\.0",
@@ -52,7 +52,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         self.assertFalse(solver_mujoco._version_satisfies(mujoco_warp_bad_version, specs["mujoco-warp"]))
 
         versions = {"mujoco": _matching_version(specs["mujoco"]), "mujoco-warp": mujoco_warp_bad_version}
-        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.get):
             with self.assertWarnsRegex(RuntimeWarning, f"mujoco-warp=={mujoco_warp_bad_version}"):
                 solver_mujoco._warn_if_mujoco_versions_mismatch(
                     types.SimpleNamespace(),
@@ -75,7 +75,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
             solver_mujoco.SolverMuJoCo._mujoco_warp = types.SimpleNamespace()
             solver_mujoco.SolverMuJoCo._versions_checked = False
 
-            with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+            with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.get):
                 with self.assertWarnsRegex(RuntimeWarning, "MuJoCo dependency version mismatch"):
                     solver_mujoco.SolverMuJoCo.import_mujoco()
         finally:
@@ -90,7 +90,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
             if specifier
         }
 
-        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
+        with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.get):
             with warnings.catch_warnings(record=True) as caught:
                 warnings.simplefilter("always")
                 solver_mujoco._warn_if_mujoco_versions_mismatch(
@@ -116,7 +116,7 @@ def _matching_version(specifier: str) -> str:
         match = solver_mujoco.re.search(pattern, specifier)
         if match:
             return match.group(1)
-    return "0.0.0"
+    raise ValueError(f"_matching_version cannot derive a satisfying version from specifier {specifier!r}")
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -12,6 +12,7 @@ _MOCK_REQUIREMENTS = (
     "mujoco~=3.8.0 ; extra == 'sim'",
     "mujoco-warp~=3.8.0,>=3.8.0.1 ; extra == 'sim'",
 )
+_MOCK_METADATA = "\n".join(f"Requires-Dist: {requirement}" for requirement in _MOCK_REQUIREMENTS)
 
 
 def _mujoco_dependency_specs():
@@ -22,7 +23,8 @@ def _mujoco_dependency_specs():
 
 class TestMuJoCoVersionCheck(unittest.TestCase):
     def setUp(self):
-        patcher = mock.patch.object(solver_mujoco.importlib_metadata, "requires", return_value=list(_MOCK_REQUIREMENTS))
+        mock_dist = types.SimpleNamespace(read_text=lambda name: _MOCK_METADATA)
+        patcher = mock.patch.object(solver_mujoco.importlib_metadata, "distribution", return_value=mock_dist)
         patcher.start()
         self.addCleanup(patcher.stop)
 

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -68,10 +68,12 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         }
         previous_mujoco = solver_mujoco.SolverMuJoCo._mujoco
         previous_mujoco_warp = solver_mujoco.SolverMuJoCo._mujoco_warp
+        previous_versions_checked = solver_mujoco.SolverMuJoCo._versions_checked
 
         try:
             solver_mujoco.SolverMuJoCo._mujoco = types.SimpleNamespace()
             solver_mujoco.SolverMuJoCo._mujoco_warp = types.SimpleNamespace()
+            solver_mujoco.SolverMuJoCo._versions_checked = False
 
             with mock.patch.object(solver_mujoco.importlib_metadata, "version", side_effect=versions.__getitem__):
                 with self.assertWarnsRegex(RuntimeWarning, "MuJoCo dependency version mismatch"):
@@ -79,6 +81,7 @@ class TestMuJoCoVersionCheck(unittest.TestCase):
         finally:
             solver_mujoco.SolverMuJoCo._mujoco = previous_mujoco
             solver_mujoco.SolverMuJoCo._mujoco_warp = previous_mujoco_warp
+            solver_mujoco.SolverMuJoCo._versions_checked = previous_versions_checked
 
     def test_accepts_versions_that_satisfy_pyproject(self):
         versions = {


### PR DESCRIPTION
## Description
Closes #2719.
Use the package metadata to check `mujoco` and `mujoco_warp` package version instead of relying on the `pyproject `file.
This should make sure that the test are passing when running from the PyPi package.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MuJoCo dependency mismatches are now detected reliably at backend import; warnings report conflicting versions and suggest reinstalling dependencies.

* **Tests**
  * Tests updated to derive checks from declared dependency specifiers and cover absent/empty specifier cases.

* **Changelog**
  * Added an Unreleased → Fixed entry documenting the dependency compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->