### PR TITLE
Fix log_image windows leaking across example browser switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
 - Fix `contacts_rj45_plug` example crashing on reset
 - Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel
+- Fix `ViewerGL.log_image()` windows persisting across example-browser switches and failing to re-open on re-entry after manual close, by clearing the image logger in `ViewerGL.clear_model()`
 - Fix `ModelBuilder.add_shape_heightfield` `scale` being ignored by narrow-phase collision and raycast
 - Fix `collision_filter_parent` silently ignored on joints to world (`parent=-1`); now honored for all `add_joint_*` methods, with `add_joint_fixed(parent=-1, ...)` defaulting to filter child shapes against world-static shapes
 - Fix multi-world `qfrc_actuator` conversion using the wrong body center of mass for worlds with `worldid > 0`

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -492,6 +492,13 @@ class ViewerGL(ViewerBase):
         self._array_dirty.clear()
         self._clear_array_textures()
 
+        # Drop image-logger entries so example-switch removes any image
+        # windows the previous example opened, and a re-entry into the same
+        # example creates a fresh entry (re-triggering the auto-select that
+        # opens the window after the user manually closed it).
+        if getattr(self, "_image_logger", None) is not None:
+            self._image_logger.clear()
+
         super().clear_model()
 
     @override

--- a/newton/tests/test_viewer_image_logger_class.py
+++ b/newton/tests/test_viewer_image_logger_class.py
@@ -322,5 +322,51 @@ class TestImageLoggerEnsurePboRollback(unittest.TestCase):
         self.assertEqual(len(self.fake_gl.deleted_buffers), 1)
 
 
+class TestViewerGLClearModelClearsImageLogger(unittest.TestCase):
+    """Regression test for issue #2731: example-browser switching must not
+    leave stale image-logger entries behind.
+
+    Two symptoms originally observed in the GUI:
+      1) The image window opened by the previous example stayed visible after
+         switching to one that does not call ``log_image``.
+      2) Closing that window manually and re-entering the camera example did
+         not re-open it (because logger entries from the prior run survived,
+         so the auto-select branch in ``ImageLogger.log`` was skipped).
+    Both stem from ``ViewerGL.clear_model`` not clearing the image logger.
+    """
+
+    def test_clear_model_clears_image_logger(self):
+        try:
+            import newton.viewer  # noqa: PLC0415
+
+            viewer = newton.viewer.ViewerGL(headless=True)
+        except Exception as exc:
+            self.skipTest(f"ViewerGL not available: {exc}")
+            return
+
+        try:
+            viewer.log_image("color", np.zeros((4, 4), dtype=np.uint8))
+            logger = viewer._image_logger
+            self.assertIn("color", logger._images)
+            self.assertEqual(logger._selected, "color")
+
+            # Simulate user closing the image window (the X button maps to
+            # this internally in ImageLogger.draw).
+            logger._selected = None
+
+            viewer.clear_model()
+
+            self.assertEqual(logger._images, {})
+            self.assertIsNone(logger._selected)
+
+            # Re-logging the same name after clear_model must auto-select
+            # again so the window re-opens, matching the behavior on first
+            # entry into a camera example.
+            viewer.log_image("color", np.zeros((4, 4), dtype=np.uint8))
+            self.assertEqual(logger._selected, "color")
+        finally:
+            viewer.close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

`ViewerGL.clear_model()` resets every model-dependent GL resource (objects,
lines, scalar buffers, array textures, side/free UI callbacks, etc.) but never
clears the image logger. The per-name texture/PBO entries and the `_selected`
field carry over between examples in the example browser, producing the two
behaviors reported in #2731:

1. The image window opened by the previous example stays visible after
   switching to one that does not call `log_image`.
2. Closing the window manually (which sets `_selected = None`) and re-entering
   the camera example does not reopen it: `ImageLogger.log` only auto-selects
   when *creating* a new entry, and the surviving `color` / `depth` / etc.
   entries skip that branch, leaving `_selected` at `None`.

Clearing the image logger inside `ViewerGL.clear_model()` discards the stale
GL resources on switch and lets the auto-select branch fire on re-entry.
Guarded with `getattr(...) is not None` because `clear_model()` is called
from `super().__init__()` before the logger is constructed.

Closes #2731

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Regression test confirmed to fail without the fix and pass with it:

```
uv run --extra dev -m newton.tests -k test_clear_model_clears_image_logger
```

Full image-logger suite still passes:

```
uv run --extra dev -m newton.tests -k test_viewer_image_logger
```

Example browser smoke test for the camera example (switch + reset):

```
uv run python newton/tests/test_example_browser.py "sensor_tiled_camera" --frames 2
```

## Bug fix

**Steps to reproduce (without this PR):**

1. `python -m newton.examples sensor_tiled_camera`
2. In the GL viewer's example browser, switch to any non-camera example.
   - Bug: the camera image window remains visible.
3. Close the camera image window via its `X` button, then switch to a
   non-camera example, then back to `sensor_tiled_camera`.
   - Bug: the image window does not reopen.

With this PR, switching examples removes the camera window and re-entering
the camera example reopens it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image logger windows persisting or failing to re-open when switching examples by ensuring image logger state is cleared.

* **Tests**
  * Added a regression test to verify the image logger is cleared and that re-logging the same image restores selection.

* **Documentation**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->