### PR TITLE
Drop redundant jnt_solref backfill from Cassie test config

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2358,15 +2358,9 @@ class TestMenagerie_AgilityCassie(TestMenagerieMJCF):
     # while native keeps False when no actuatorfrcrange is specified. Flagged as
     # "no effect" in DEFAULT_MODEL_SKIP_FIELDS, but Cassie's closed-loop dynamics
     # show a measurable divergence without this backfill (qvel step 0 diff ~2e-5).
-    # jnt_solref: Newton's solref standard->direct conversion omits the dmax
-    # (solimp[0]) factor, so its stored direct-mode values are ~11% lower
-    # stiffness/damping than native's internal values for the same MJCF input
-    # (tracked in #2515). Cassie's closed-loop limit constraints amplify this
-    # into measurable qvel divergence; backfill until the conversion is fixed.
     backfill_fields = MODEL_BACKFILL_FIELDS + [  # noqa: RUF005
         "eq_data",
         "jnt_actfrclimited",
-        "jnt_solref",
     ]
     model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"eq_data"}
 


### PR DESCRIPTION
## Summary

- Drop `jnt_solref` from `TestMenagerie_AgilityCassie.backfill_fields` and remove the corresponding comment block. It was added in #2511 along with `eq_data` and `jnt_actfrclimited` based on the assumed solref bug from #2515 (since closed). Empirical isolation shows the `jnt_solref` portion of that backfill is not needed.

## Why it isn't needed

Newton's `solref_to_stiffness_damping` stores joint solref in direct mode as `(-1/(tc²·dr²), -2/tc)`. mjwarp's `_efc_row` decodes direct mode as `k = -solref[0] / dmax²`, `b = -solref[1] / dmax`, which produces the same physical `(k, b)` as native's standard-mode storage `(tc, dr)` evaluated as `k = 1/(dmax²·tc²·dr²)`, `b = 2/(dmax·tc)`. The dmax factor cancels symmetrically; there is no real solref divergence between Newton and native at the constraint update.

## Empirical isolation on Cassie (20-step dynamics, GPU)

| Backfill config | max\|qvel diff\| |
|---|---|
| All (eq_data + jnt_actfrclimited + jnt_solref) | 9.66e-06 |
| **eq_data + jnt_actfrclimited (this PR)** | **1.61e-05** ✓ passes 1e-4 |
| Only jnt_solref | 47.97 (broken) |
| Only eq_data | 5.08e-05 |
| Only jnt_actfrclimited | 47.97 (broken) |

The 9.66e-06 → 1.61e-05 change after dropping `jnt_solref` is well within the GPU non-determinism floor (~5e-6 observed native-vs-native variance) and well below the 1e-4 tolerance.

## Test plan

- [x] `uv run --extra dev -m newton.tests -k TestMenagerie_AgilityCassie` — `Ran 3 tests in 72s; OK (skipped=2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined MuJoCo model test configuration to improve precision in field backfill handling during model integration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->