### PR TITLE
Fix Collada textures in URDF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - Fix VRAM leak when resetting examples that allocate large GPU state (e.g. `diffsim_bear`)
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
+- Fix URDF Collada visual meshes dropping diffuse texture bindings
 - Fix `contacts_rj45_plug` example crashing on reset
 - Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel
 - Fix `ViewerGL.log_image()` windows persisting across example-browser switches and failing to re-open on re-entry after manual close, by clearing the image logger in `ViewerGL.clear_model()`

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -409,6 +409,11 @@ def _extract_trimesh_texture(visual_or_material, base_dir: str) -> np.ndarray | 
         if base_color_texture is not None:
             image = getattr(base_color_texture, "image", None)
             image_path = image_path or getattr(base_color_texture, "image_path", None)
+            if image is None:
+                if isinstance(base_color_texture, (str, os.PathLike)):
+                    image_path = image_path or os.fspath(base_color_texture)
+                else:
+                    image = base_color_texture
 
     if image is not None:
         try:
@@ -497,7 +502,7 @@ def load_meshes_from_file(
 
     def _parse_dae_material_colors(
         path: str,
-    ) -> tuple[list[str], dict[str, dict[str, float | tuple[float, float, float] | None]]]:
+    ) -> tuple[list[str], dict[str, dict[str, float | str | tuple[float, float, float] | None]]]:
         try:
             tree = ET.parse(path)
             root = tree.getroot()
@@ -507,15 +512,61 @@ def load_meshes_from_file(
         def strip(tag: str) -> str:
             return tag.split("}", 1)[-1] if "}" in tag else tag
 
+        image_paths: dict[str, str] = {}
+        for image in root.iter():
+            if strip(image.tag) != "image":
+                continue
+            image_id = image.attrib.get("id")
+            image_name = image.attrib.get("name")
+            image_path = None
+            for child in image.iter():
+                if strip(child.tag) == "init_from" and child.text:
+                    image_path = child.text.strip()
+                    break
+            if image_path:
+                if image_id:
+                    image_paths[image_id] = image_path
+                if image_name:
+                    image_paths[image_name] = image_path
+
+        def resolve_dae_texture_path(texture_path: str | None) -> str | None:
+            if not texture_path:
+                return None
+            texture_path = image_paths.get(texture_path, texture_path)
+            if not os.path.isabs(texture_path):
+                texture_path = os.path.abspath(os.path.join(base_dir, texture_path))
+            return texture_path
+
         # Map effect id -> material properties
-        effect_props: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+        effect_props: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
         for effect in root.iter():
             if strip(effect.tag) != "effect":
                 continue
             effect_id = effect.attrib.get("id")
             if not effect_id:
                 continue
+            surface_images: dict[str, str] = {}
+            sampler_surfaces: dict[str, str] = {}
+            for newparam in effect.iter():
+                if strip(newparam.tag) != "newparam":
+                    continue
+                sid = newparam.attrib.get("sid")
+                if not sid:
+                    continue
+                for child in newparam:
+                    child_tag = strip(child.tag)
+                    if child_tag == "surface":
+                        for init in child.iter():
+                            if strip(init.tag) == "init_from" and init.text:
+                                surface_images[sid] = init.text.strip()
+                                break
+                    elif child_tag == "sampler2D":
+                        for source in child.iter():
+                            if strip(source.tag) == "source" and source.text:
+                                sampler_surfaces[sid] = source.text.strip()
+                                break
             diffuse_color = None
+            diffuse_texture = None
             specular_color = None
             specular_intensity = None
             shininess = None
@@ -530,9 +581,16 @@ def load_meshes_from_file(
                 for node in shader.iter():
                     tag = strip(node.tag)
                     if tag == "diffuse":
-                        for col in node.iter():
-                            if strip(col.tag) == "color" and col.text:
-                                values = [float(x) for x in col.text.strip().split()]
+                        for diffuse_node in node.iter():
+                            diffuse_tag = strip(diffuse_node.tag)
+                            if diffuse_tag == "texture":
+                                sampler_id = diffuse_node.attrib.get("texture")
+                                surface_id = sampler_surfaces.get(sampler_id, sampler_id)
+                                image_id = surface_images.get(surface_id, surface_id)
+                                diffuse_texture = resolve_dae_texture_path(image_id)
+                                break
+                            if diffuse_tag == "color" and diffuse_node.text:
+                                values = [float(x) for x in diffuse_node.text.strip().split()]
                                 if len(values) >= 3:
                                     # DAE diffuse colors are commonly authored in linear space.
                                     # Convert to sRGB for the viewer shader (which converts to linear).
@@ -567,7 +625,7 @@ def load_meshes_from_file(
                                     shininess = None
                                 break
                         continue
-                if diffuse_color is not None:
+                if diffuse_color is not None or diffuse_texture is not None:
                     break
             metallic = None
             if specular_color is not None:
@@ -579,15 +637,16 @@ def load_meshes_from_file(
                 if shininess > 1.0:
                     shininess = min(shininess / 128.0, 1.0)
                 roughness = float(np.clip(1.0 - shininess, 0.0, 1.0))
-            if diffuse_color is not None:
+            if diffuse_color is not None or diffuse_texture is not None:
                 effect_props[effect_id] = {
                     "color": diffuse_color,
+                    "texture": diffuse_texture,
                     "metallic": metallic,
                     "roughness": roughness,
                 }
 
         # Map material id/name -> material properties
-        material_colors: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+        material_colors: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
         for material in root.iter():
             if strip(material.tag) != "material":
                 continue
@@ -620,7 +679,7 @@ def load_meshes_from_file(
         return face_materials, material_colors
 
     dae_face_materials: list[str] = []
-    dae_material_colors: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+    dae_material_colors: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
     if filename.lower().endswith(".dae"):
         dae_face_materials, dae_material_colors = _parse_dae_material_colors(filename)
 
@@ -667,6 +726,8 @@ def load_meshes_from_file(
             if sub_normals is None or force_smooth:
                 sub_normals = smooth_vertex_normals_by_position(sub_vertices, remapped_faces)
             sub_uvs = mesh_uvs[used] if mesh_uvs is not None else None
+            if mesh_texture is not None and mat_color is None:
+                mat_color = (1.0, 1.0, 1.0)
 
             meshes.append(
                 Mesh(
@@ -728,6 +789,7 @@ def load_meshes_from_file(
                 mat_color = mat_props.get("color")
                 mat_roughness = mat_props.get("roughness")
                 mat_metallic = mat_props.get("metallic")
+                mat_texture = mat_props.get("texture", texture)
                 add_mesh_from_faces(
                     mat_faces,
                     mat_color=mat_color,
@@ -736,7 +798,7 @@ def load_meshes_from_file(
                     mesh_vertices=vertices,
                     mesh_normals=normals,
                     mesh_uvs=uvs,
-                    mesh_texture=texture,
+                    mesh_texture=mat_texture,
                 )
             continue
 

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast, overload
+from urllib.parse import urlparse
 
 import numpy as np
 import warp as wp
@@ -532,7 +533,10 @@ def load_meshes_from_file(
         def resolve_dae_texture_path(texture_path: str | None) -> str | None:
             if not texture_path:
                 return None
-            texture_path = image_paths.get(texture_path, texture_path)
+            texture_path = image_paths.get(texture_path.lstrip("#"), texture_path)
+            parsed = urlparse(texture_path)
+            if parsed.scheme in {"file", "http", "https", "data"}:
+                return texture_path
             if not os.path.isabs(texture_path):
                 texture_path = os.path.abspath(os.path.join(base_dir, texture_path))
             return texture_path

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -362,6 +362,36 @@ class TestImportUrdfBasic(unittest.TestCase):
             self.assertIsNotNone(texture)
             np.testing.assert_array_equal(texture[0, 0, :3], np.array([255, 0, 0], dtype=np.uint8))
 
+    def test_dae_visual_texture_uri_preserved(self):
+        """Verify URI-style Collada textures are not path-joined against the mesh directory."""
+        urdf = """
+<robot name="dae_texture_uri_test">
+    <link name="base_link">
+        <visual>
+            <geometry><mesh filename="triangle_uri.dae"/></geometry>
+        </visual>
+    </link>
+</robot>
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            texture_path = temp_path / "texture.png"
+            texture_uri = texture_path.resolve().as_uri()
+            dae_with_uri = TEXTURED_DAE.replace("texture.png", texture_uri)
+
+            (temp_path / "robot.urdf").write_text(urdf)
+            (temp_path / "triangle_uri.dae").write_text(dae_with_uri)
+            texture_path.write_bytes(base64.b64decode(TEXTURE_PNG_BASE64))
+
+            builder = newton.ModelBuilder()
+            builder.add_urdf(str(temp_path / "robot.urdf"))
+
+            self.assertEqual(builder.shape_count, 1)
+            self.assertEqual(builder.shape_type[0], GeoType.MESH)
+            mesh = builder.shape_source[0]
+            self.assertIsNotNone(mesh.texture)
+            self.assertEqual(mesh.texture, texture_uri)
+
     def test_inertial_params_urdf(self):
         builder = newton.ModelBuilder()
         parse_urdf(INERTIAL_URDF, builder, ignore_inertial_definitions=False)

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import os
 import tempfile
 import unittest
@@ -62,6 +63,84 @@ f 4 7 8
 f 1 5 6
 f 1 6 2
 """
+
+TEXTURED_DAE = """<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset><unit name="meter" meter="1"/><up_axis>Z_UP</up_axis></asset>
+  <library_effects>
+    <effect id="mat-effect">
+      <profile_COMMON>
+        <newparam sid="tex-surface"><surface type="2D"><init_from>tex-image</init_from></surface></newparam>
+        <newparam sid="tex-sampler"><sampler2D><source>tex-surface</source></sampler2D></newparam>
+        <technique sid="common">
+          <lambert><diffuse><texture texture="tex-sampler" texcoord="UVMap"/></diffuse></lambert>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_images>
+    <image id="tex-image" name="tex-image"><init_from>texture.png</init_from></image>
+  </library_images>
+  <library_materials>
+    <material id="mat" name="mat"><instance_effect url="#mat-effect"/></material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="tri-mesh" name="tri">
+      <mesh>
+        <source id="tri-positions">
+          <float_array id="tri-positions-array" count="9">0 0 0 1 0 0 0 1 0</float_array>
+          <technique_common>
+            <accessor source="#tri-positions-array" count="3" stride="3">
+              <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="tri-normals">
+          <float_array id="tri-normals-array" count="9">0 0 1 0 0 1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#tri-normals-array" count="3" stride="3">
+              <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="tri-map">
+          <float_array id="tri-map-array" count="6">0 0 1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#tri-map-array" count="3" stride="2">
+              <param name="S" type="float"/><param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="tri-vertices"><input semantic="POSITION" source="#tri-positions"/></vertices>
+        <triangles material="mat" count="1">
+          <input semantic="VERTEX" source="#tri-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#tri-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#tri-map" offset="2" set="0"/>
+          <p>0 0 0 1 1 1 2 2 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="Scene">
+      <node id="tri">
+        <instance_geometry url="#tri-mesh">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="mat" target="#mat">
+                <bind_vertex_input semantic="UVMap" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#Scene"/></scene>
+</COLLADA>
+"""
+
+TEXTURE_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 
 INERTIAL_URDF = """
 <robot name="inertial_test">
@@ -252,6 +331,36 @@ class TestImportUrdfBasic(unittest.TestCase):
                 assert_np_equal(builder.shape_transform[0][:], np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0]))
                 assert builder.shape_source[0].vertices.shape[0] == 8
                 assert builder.shape_source[0].indices.shape[0] == 3 * 12
+
+    def test_dae_visual_texture_urdf(self):
+        """Verify URDF visual meshes preserve Collada texture bindings."""
+        urdf = """
+<robot name="dae_texture_test">
+    <link name="base_link">
+        <visual>
+            <geometry><mesh filename="triangle.dae"/></geometry>
+        </visual>
+    </link>
+</robot>
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            (temp_path / "robot.urdf").write_text(urdf)
+            (temp_path / "triangle.dae").write_text(TEXTURED_DAE)
+            (temp_path / "texture.png").write_bytes(base64.b64decode(TEXTURE_PNG_BASE64))
+
+            builder = newton.ModelBuilder()
+            builder.add_urdf(str(temp_path / "robot.urdf"))
+
+            self.assertEqual(builder.shape_count, 1)
+            self.assertEqual(builder.shape_type[0], GeoType.MESH)
+            mesh = builder.shape_source[0]
+            self.assertIsNotNone(mesh.uvs)
+            self.assertIsNotNone(mesh.texture)
+            self.assertEqual(tuple(builder.shape_color[0]), (1.0, 1.0, 1.0))
+            texture = newton.utils.load_texture(mesh.texture)
+            self.assertIsNotNone(texture)
+            np.testing.assert_array_equal(texture[0, 0, :3], np.array([255, 0, 0], dtype=np.uint8))
 
     def test_inertial_params_urdf(self):
         builder = newton.ModelBuilder()


### PR DESCRIPTION
Resolve diffuse texture bindings from Collada materials when URDF visual meshes are loaded through trimesh fallback paths. Preserve texture colors by using white base color for textured meshes without an authored color, and add a regression covering textured DAE import.

This fixes the rendering of the Anymal C from `example_robot_anymal_c_walk.py` to show the correct textures:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/c9f7c827-3f07-44e7-9211-3240f4bd1a53" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diffuse textures being lost when importing URDF models with Collada visual meshes; texture bindings are now correctly preserved during import.

* **Documentation**
  * Comprehensive changelog updates documenting new features and enhancements across actuators, rendering, physics simulation, collision detection, geometry utilities, and model import/export systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->