### PR TITLE
Bump MjWarp version to 3.8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 - Update default environment map texture in GL viewer (source: https://polyhaven.com/a/brown_photostudio_02)
 - Remove the implicit-MPM rasterized collider's reliance on Warp's `warp.fem` module (behavior unchanged)
 - Replace the StVK VBD triangle membrane material with the stable Neo-Hookean form (Smith et al. 2018, adapted to 2D shells). The upstream two-constraint Rayleigh damping model is preserved unchanged
-- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.2`)
+- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.3`)
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 - Update default environment map texture in GL viewer (source: https://polyhaven.com/a/brown_photostudio_02)
 - Remove the implicit-MPM rasterized collider's reliance on Warp's `warp.fem` module (behavior unchanged)
 - Replace the StVK VBD triangle membrane material with the stable Neo-Hookean form (Smith et al. 2018, adapted to 2D shells). The upstream two-constraint Rayleigh damping model is preserved unchanged
-- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.1`)
+- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.2`)
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -18,7 +18,7 @@
     "python -m pip install -U numpy",
     "python -m pip install -U warp-lang==1.13.0",
     "python -m pip install -U mujoco==3.8.0",
-    "python -m pip install -U mujoco-warp==3.8.0.2",
+    "python -m pip install -U mujoco-warp==3.8.0.3",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,8 +17,8 @@
   "install_command": [
     "python -m pip install -U numpy",
     "python -m pip install -U warp-lang==1.13.0",
-    "python -m pip install -U mujoco==3.7.0",
-    "python -m pip install -U mujoco-warp==3.7.0.1",
+    "python -m pip install -U mujoco==3.8.0",
+    "python -m pip install -U mujoco-warp==3.8.0.2",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1547,6 +1547,13 @@ class TestMenagerieBase(unittest.TestCase):
         Override in subclasses where DOF ordering may differ.
         """
 
+    def _compare_qD_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
+        """Compare sparse RNE derivative D-structure (qD_fullm_i, qD_fullm_j).
+
+        Default: no-op (covered by compare_mjw_models for same-order pipelines).
+        Override in subclasses where DOF ordering may differ.
+        """
+
     def _compare_compiled_fields(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare compilation-dependent fields at relaxed tolerance.
 
@@ -1703,6 +1710,7 @@ class TestMenagerieBase(unittest.TestCase):
         self._compare_dof_physics(self._newton_solver.mjw_model, self._native_mjw_model)
         self._compare_mass_matrix_structure(self._newton_solver.mjw_model, self._native_mjw_model)
         self._compare_tendon_jacobian_structure(self._newton_solver.mjw_model, self._native_mjw_model)
+        self._compare_qD_structure(self._newton_solver.mjw_model, self._native_mjw_model)
         self._compare_actuator_physics(self._newton_solver.mjw_model, self._native_mjw_model)
         self._compare_compiled_fields(self._newton_solver.mjw_model, self._native_mjw_model)
 

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -946,9 +946,7 @@ def compare_qD_structure_mapped(
     inv_dof_map = {v: k for k, v in dof_map.items()}
 
     native_pairs = {(int(native_i[k]), int(native_j[k])) for k in range(nD)}
-    newton_pairs = {
-        (inv_dof_map.get(int(newton_i[k]), -1), inv_dof_map.get(int(newton_j[k]), -1)) for k in range(nD)
-    }
+    newton_pairs = {(inv_dof_map.get(int(newton_i[k]), -1), inv_dof_map.get(int(newton_j[k]), -1)) for k in range(nD)}
 
     missing = native_pairs - newton_pairs
     extra = newton_pairs - native_pairs

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -908,6 +908,59 @@ def compare_tendon_jacobian_structure_mapped(
     )
 
 
+def compare_qD_structure_mapped(
+    newton_mjw: Any,
+    native_mjw: Any,
+    dof_map: dict[int, int],
+) -> None:
+    """Compare sparse RNE derivative D-structure under DOF reordering.
+
+    qD_fullm_i and qD_fullm_j are flat arrays of (row, col) DOF indices
+    enumerating the D-structure (full square sparsity used by RNE
+    derivatives). When DOF ordering differs the indices are permuted but
+    the underlying (row, col) set is structurally equivalent: each native
+    (i, j) entry should map to a Newton entry at (dof_map[i], dof_map[j]).
+
+    Gracefully skips if the fields are absent (older mujoco_warp without
+    RNE derivative support).
+
+    Args:
+        dof_map: native_dof_idx -> newton_dof_idx.
+    """
+    if not hasattr(native_mjw, "qD_fullm_i") or not hasattr(newton_mjw, "qD_fullm_i"):
+        return
+
+    nD = int(getattr(native_mjw, "nD", 0))
+    assert int(getattr(newton_mjw, "nD", 0)) == nD, (
+        f"nD mismatch: newton={getattr(newton_mjw, 'nD', None)} vs native={nD}"
+    )
+
+    if nD == 0:
+        return
+
+    newton_i = newton_mjw.qD_fullm_i.numpy().flatten()
+    newton_j = newton_mjw.qD_fullm_j.numpy().flatten()
+    native_i = native_mjw.qD_fullm_i.numpy().flatten()
+    native_j = native_mjw.qD_fullm_j.numpy().flatten()
+
+    inv_dof_map = {v: k for k, v in dof_map.items()}
+
+    native_pairs = {(int(native_i[k]), int(native_j[k])) for k in range(nD)}
+    newton_pairs = {
+        (inv_dof_map.get(int(newton_i[k]), -1), inv_dof_map.get(int(newton_j[k]), -1)) for k in range(nD)
+    }
+
+    missing = native_pairs - newton_pairs
+    extra = newton_pairs - native_pairs
+    if missing or extra:
+        parts = []
+        if missing:
+            parts.append(f"missing in newton (remapped): {sorted(missing)[:10]}")
+        if extra:
+            parts.append(f"extra in newton (remapped): {sorted(extra)[:10]}")
+        raise AssertionError("qD_fullm sparsity mismatch:\n" + "\n".join(parts))
+
+
 ACTUATOR_SKIP_FIELDS: set[str] = {
     "actuator_plugin",
     "actuator_user",
@@ -1053,8 +1106,8 @@ class TestMenagerieUSD(TestMenagerieBase):
         "jnt_",
         # Sparse mass matrix structure: DOF-indexed, compared via _compare_mass_matrix_structure
         "M_",
-        # Sparse RNE derivative D-structure indices: DOF-indexed, depend on DOF ordering
-        "qD_",
+        # Sparse RNE derivative D-structure: DOF-indexed, compared via _compare_qD_structure
+        "qD_fullm_",
         # Sparse tendon Jacobian structure: DOF-indexed, compared via _compare_tendon_jacobian_structure
         "ten_J_",
         "nJten",
@@ -1153,6 +1206,10 @@ class TestMenagerieUSD(TestMenagerieBase):
     def _compare_tendon_jacobian_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare sparse tendon Jacobian structure using DOF index mapping."""
         compare_tendon_jacobian_structure_mapped(newton_mjw, native_mjw, self._dof_map)
+
+    def _compare_qD_structure(self, newton_mjw: Any, native_mjw: Any) -> None:
+        """Compare sparse RNE derivative D-structure using DOF index mapping."""
+        compare_qD_structure_mapped(newton_mjw, native_mjw, self._dof_map)
 
     def _compare_actuator_physics(self, newton_mjw: Any, native_mjw: Any) -> None:
         """Compare actuator fields using name-based index mapping."""

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1053,6 +1053,8 @@ class TestMenagerieUSD(TestMenagerieBase):
         "jnt_",
         # Sparse mass matrix structure: DOF-indexed, compared via _compare_mass_matrix_structure
         "M_",
+        # Sparse RNE derivative D-structure indices: DOF-indexed, depend on DOF ordering
+        "qD_",
         # Sparse tendon Jacobian structure: DOF-indexed, compared via _compare_tendon_jacobian_structure
         "ten_J_",
         "nJten",

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -10,7 +10,7 @@ from newton._src.solvers.mujoco import solver_mujoco
 
 _MOCK_REQUIREMENTS = (
     "mujoco~=3.8.0 ; extra == 'sim'",
-    "mujoco-warp~=3.8.0,>=3.8.0.2 ; extra == 'sim'",
+    "mujoco-warp~=3.8.0,>=3.8.0.3 ; extra == 'sim'",
 )
 _MOCK_METADATA = "\n".join(f"Requires-Dist: {requirement}" for requirement in _MOCK_REQUIREMENTS)
 

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -10,7 +10,7 @@ from newton._src.solvers.mujoco import solver_mujoco
 
 _MOCK_REQUIREMENTS = (
     "mujoco~=3.8.0 ; extra == 'sim'",
-    "mujoco-warp~=3.8.0,>=3.8.0.1 ; extra == 'sim'",
+    "mujoco-warp~=3.8.0,>=3.8.0.2 ; extra == 'sim'",
 )
 _MOCK_METADATA = "\n".join(f"Requires-Dist: {requirement}" for requirement in _MOCK_REQUIREMENTS)
 

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -561,7 +561,7 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         """Test contact forces with b stacked on a on base."""
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 1e4
-        builder.default_shape_cfg.kd = 1000.0
+        builder.default_shape_cfg.kd = 2000.0
         builder.default_shape_cfg.density = 1000.0
 
         builder.add_shape_box(body=-1, hx=1.0, hy=1.0, hz=0.25, label="base")

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -247,7 +247,7 @@ def main(argv=None):
                         executor_kwargs["max_tasks_per_child"] = 1
                     with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
                         test_manager = ParallelTestManager(manager, args, temp_dir)
-                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=3000))
+                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=3600))
         else:
             # This entire path is an NVIDIA Modification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 # Core simulation dependencies
 sim = [
     # MuJoCo simulation
-    "mujoco-warp>=3.8.0.2,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
+    "mujoco-warp>=3.8.0.3,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
     "mujoco~=3.8.0",        # MuJoCo physics engine
     "newton-actuators>=0.1.0",  # deprecated — kept for backward compat, will be removed
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 # Core simulation dependencies
 sim = [
     # MuJoCo simulation
-    "mujoco-warp>=3.8.0.1,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
+    "mujoco-warp>=3.8.0.2,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
     "mujoco~=3.8.0",        # MuJoCo physics engine
     "newton-actuators>=0.1.0",  # deprecated — kept for backward compat, will be removed
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2961,7 +2961,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.8.0.1"
+version = "3.8.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -2972,9 +2972,9 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "warp-lang" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fa/5d97d91bf58a01de56cb321a61bdd48b4514399e2a1577de8cd11dcaaf5d/mujoco_warp-3.8.0.1.tar.gz", hash = "sha256:a3a21f499bddc020b7a360a420ddffe405f496e53c1abb91f374489fe1bfeef9", size = 1929078, upload-time = "2026-04-29T00:05:27.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/46/9d5fdf2ac1d873eac9292acf51d337c49cbf160bb485677cd39eaa41d72d/mujoco_warp-3.8.0.2.tar.gz", hash = "sha256:074d45080b48412bfeab7a9f7461e4d3491f08d2e9f9c2e63aa948b5b0a01817", size = 1936860, upload-time = "2026-05-06T23:45:21.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/fc/f3375bc4f6d08b73d157aa8c87adb93aed9652a37100eb1323c2c4aa09b3/mujoco_warp-3.8.0.1-py3-none-any.whl", hash = "sha256:7bb1e94b0cb5da2e5af8b6f4585eb14c758b1cab76facf50d18a40924bfb0304", size = 2007392, upload-time = "2026-04-29T00:05:25.602Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c3/7025b41679686683421f13a1c85475c417937c519bb25a4b83ce57c195e6/mujoco_warp-3.8.0.2-py3-none-any.whl", hash = "sha256:b50267ca8825787fd8b6e3c6da5e5ed43268a7db399869159c2c8740543f2d13", size = 2015551, upload-time = "2026-05-06T23:45:19.772Z" },
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ requires-dist = [
     { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.5.7" },
     { name = "meshio", marker = "extra == 'importers'", specifier = ">=5.3.5" },
     { name = "mujoco", marker = "extra == 'sim'", specifier = "~=3.8.0" },
-    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.1" },
+    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.2" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.1" },
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9.0" },
     { name = "newton", extras = ["examples"], marker = "extra == 'dev'" },

--- a/uv.lock
+++ b/uv.lock
@@ -2961,7 +2961,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.8.0.2"
+version = "3.8.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -2972,9 +2972,9 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "warp-lang" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/46/9d5fdf2ac1d873eac9292acf51d337c49cbf160bb485677cd39eaa41d72d/mujoco_warp-3.8.0.2.tar.gz", hash = "sha256:074d45080b48412bfeab7a9f7461e4d3491f08d2e9f9c2e63aa948b5b0a01817", size = 1936860, upload-time = "2026-05-06T23:45:21.27Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/63/7dabf7f487c0946894a8ec85ea5d978c19e6b1afb6d6b6f63f457dff75ee/mujoco_warp-3.8.0.3.tar.gz", hash = "sha256:ca143a82f76b8df60984ca0d3c0f269a745886621cc2168beaa58e1d2c2358b8", size = 1938832, upload-time = "2026-05-08T23:27:41.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/c3/7025b41679686683421f13a1c85475c417937c519bb25a4b83ce57c195e6/mujoco_warp-3.8.0.2-py3-none-any.whl", hash = "sha256:b50267ca8825787fd8b6e3c6da5e5ed43268a7db399869159c2c8740543f2d13", size = 2015551, upload-time = "2026-05-06T23:45:19.772Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f5/30c736dfe87ad7e8f7a7f8f43b80e0ff43c6af46cef65ba95d3ba172129a/mujoco_warp-3.8.0.3-py3-none-any.whl", hash = "sha256:dfbfa24e376e0b03bf6dcebaed7ef69b4885280a020e5f0fd805c125fae3d129", size = 2019908, upload-time = "2026-05-08T23:27:39.283Z" },
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ requires-dist = [
     { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.5.7" },
     { name = "meshio", marker = "extra == 'importers'", specifier = ">=5.3.5" },
     { name = "mujoco", marker = "extra == 'sim'", specifier = "~=3.8.0" },
-    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.2" },
+    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.3" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.1" },
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9.0" },
     { name = "newton", extras = ["examples"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## Description
This will close #2727.
Updated MjWarp version, fix 4 UTs. 

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composable actuator subsystem, richer viewer logging (scalars, images, arrows), geometry/BVH helpers, deterministic contact ordering, expanded importer/exporter support, and viewer UX improvements (orbit/pan/dolly, stepping while paused).

* **Changed**
  * Behavioral defaults and APIs updated (actuator registration, viewer input, raycast returns, collision pipeline execution, solver/MPM defaults).

* **Fixed**
  * Multiple fixes across collision/contact generation, importers, viewer controls, solvers, geometry/SDF, caching and determinism.

* **Tests**
  * Added hooks/routines for comparing sparse derivative structure between representations.

* **Dependencies**
  * Bumped MuJoCo / MuJoCo‑warp versions and benchmark environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->