### PR TITLE
Kamino - Add incremental solve option to FK solver

### DIFF
--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -682,16 +682,18 @@ def compute_joint_pose_and_relative_motion(
 
     # Compute the pose of the joint frame via the Base body
     r_j_B = r_B_j + r_Bj
+    r_j_F = r_F_j + r_Fj
     p_j = wp.transformation(r_j_B, q_Bj, dtype=float32)
+    r_j = r_j_F - r_j_B
 
     # Compute the relative pose between the representations of joint frame w.r.t. the two bodies
     # NOTE: The pose is decomposed into a translation vector `j_r_j` and a rotation quaternion `j_q_j`
-    j_r_j = wp.quat_rotate_inv(q_Bj, r_F_j + r_Fj - r_j_B)
+    j_r_j = wp.quat_rotate_inv(q_Bj, r_j)
     j_q_j = wp.quat_inverse(q_Bj) * q_Fj
 
     # Compute the 6D relative twist vector between the representations of joint frame w.r.t. the two bodies
     # TODO: How can we simplify this expression and make it more efficient?
-    j_v_j = wp.quat_rotate_inv(q_Bj, v_F_j - v_B_j + wp.cross(omega_F_j, r_Fj) - wp.cross(omega_B_j, r_Bj))
+    j_v_j = wp.quat_rotate_inv(q_Bj, v_F_j - v_B_j + wp.cross(omega_F_j, r_Fj) - wp.cross(omega_B_j, r_Bj + r_j))
     j_omega_j = wp.quat_rotate_inv(q_Bj, omega_F_j - omega_B_j)
     j_u_j = screw(j_v_j, j_omega_j)
 

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -7,11 +7,13 @@ from functools import cache
 
 import warp as wp
 
-from ...core.joints import JointActuationType
+from ...core.joints import JointActuationType, JointDoFType
 from ...core.math import (
+    TWO_PI,
     G_of,
     quat_left_jacobian_inverse,
     quat_log,
+    squared_norm,
     unit_quat_apply,
     unit_quat_apply_jacobian,
     unit_quat_conj_apply,
@@ -19,6 +21,7 @@ from ...core.math import (
     unit_quat_conj_to_rotation_matrix,
 )
 from ...core.types import vec6f
+from ...kinematics.joints import get_joint_coords_mapping_function
 from ...linalg.sparse_matrix import BlockDType
 from .types import FKJointDoFType
 
@@ -28,8 +31,11 @@ from .types import FKJointDoFType
 
 __all__ = [
     "_apply_line_search_step",
+    "_correct_actuator_coords",
+    "_eval_actuator_coords",
     "_eval_body_velocities",
     "_eval_fk_actuated_dofs_or_coords",
+    "_eval_incremental_target_actuator_coords",
     "_eval_linear_combination",
     "_eval_position_control_transformations",
     "_eval_rhs",
@@ -48,6 +54,7 @@ __all__ = [
     "create_eval_joint_constraints_jacobian_kernel",
     "create_eval_joint_constraints_kernel",
     "create_eval_joint_constraints_sparse_jacobian_kernel",
+    "create_eval_min_num_iterations_kernel",
     "read_quat_from_array",
 ]
 
@@ -74,11 +81,14 @@ class block_type(BlockDType(dtype=wp.float32, shape=(7,)).warp_type):
 
 
 @wp.func
-def read_quat_from_array(array: wp.array[wp.float32], offset: int) -> wp.quatf:
+def read_quat_from_array(array: wp.array[wp.float32], offset: int, normalize: bool) -> wp.quatf:
     """
     Utility function to read a quaternion from a flat array
     """
-    return wp.quatf(array[offset], array[offset + 1], array[offset + 2], array[offset + 3])
+    q = wp.quatf(array[offset], array[offset + 1], array[offset + 2], array[offset + 3])
+    if normalize:
+        return wp.normalize(q)
+    return q
 
 
 ###
@@ -213,6 +223,331 @@ def _eval_fk_actuated_dofs_or_coords(
             fk_actuated_dofs[fk_dof_id] = model_base_dofs[base_dof_id]
 
 
+def _make_typed_joint_transform_to_coords_func(dof_type: JointDoFType):
+    """Factory returning a function extracting joint coords from joint transform, for a single joint type."""
+    num_coords = dof_type.num_coords
+
+    @wp.func
+    def _typed_joint_transform_to_coords(
+        pos_rel: wp.vec3f,
+        q_rel: wp.quatf,
+        offset: wp.int32,
+        output: wp.array[wp.float32],
+    ):
+        coords = wp.static(get_joint_coords_mapping_function(dof_type))(pos_rel, q_rel)
+        for i in range(num_coords):
+            output[offset + i] = coords[i]
+
+    return _typed_joint_transform_to_coords
+
+
+@wp.func
+def _joint_transform_to_coords(
+    dof_type: wp.int32,
+    pos_rel: wp.vec3f,
+    q_rel: wp.quatf,
+    offset: wp.int32,
+    output: wp.array[wp.float32],
+):
+    """Function extracting joint coordinates from the joint transform, and writing them out in an array."""
+    if dof_type == FKJointDoFType.CARTESIAN:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.CARTESIAN))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.CYLINDRICAL:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.CYLINDRICAL))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.FREE:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.FREE))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.PRISMATIC:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.PRISMATIC))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.REVOLUTE:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.REVOLUTE))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.SPHERICAL:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.SPHERICAL))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.UNIVERSAL:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.UNIVERSAL))(pos_rel, q_rel, offset, output)
+
+
+@wp.kernel
+def _eval_actuator_coords(
+    num_joints: wp.array[wp.int32],
+    first_joint_id: wp.array[wp.int32],
+    joints_dof_type: wp.array[wp.int32],
+    joints_bid_B: wp.array[wp.int32],
+    joints_bid_F: wp.array[wp.int32],
+    joints_X: wp.array[wp.mat33f],
+    joints_B_r_B: wp.array[wp.vec3f],
+    joints_F_r_F: wp.array[wp.vec3f],
+    bodies_q: wp.array[wp.transformf],
+    actuated_coord_offsets: wp.array[wp.int32],
+    actuators_q: wp.array[wp.float32],
+):
+    """
+    A kernel evaluating effective actuator coordinates based on body poses.
+
+    Inputs:
+        num_joints: Num joints per world.
+        first_joint_id: First joint id per world.
+        joints_dof_type: Joint dof type (i.e. revolute, spherical, ...).
+        joints_bid_B: Joint base body id.
+        joints_bid_F: Joint follower body id.
+        joints_X: Joint frame (local axes, valid both on base and follower).
+        joints_B_r_B: Joint local position on base body.
+        joints_F_r_F: Joint local position on follower body.
+        bodies_q: Body poses.
+        actuated_coord_offsets: Joint first actuated coordinate id, among all actuated coordinates in all worlds.
+    Outputs:
+        actuators_q: Actuator coordinates.
+    """
+    # Retrieve the thread index (= world index, joint index within world)
+    wd_id, jt_id_loc = wp.tid()
+
+    # Get global joint index
+    if jt_id_loc >= num_joints[wd_id]:
+        return
+    jt_id = first_joint_id[wd_id] + jt_id_loc
+
+    # Get joint actuated coords size and offset
+    coord_id = actuated_coord_offsets[jt_id]
+    num_coords = actuated_coord_offsets[jt_id + 1] - coord_id
+    if num_coords == 0:
+        return
+
+    # Get joint dof type, local positions and local orientation
+    dof_type = joints_dof_type[jt_id]
+    x_base = joints_B_r_B[jt_id]
+    x_follower = joints_F_r_F[jt_id]
+    q_X = wp.quat_from_matrix(joints_X[jt_id])
+
+    # Get base and follower transformations
+    base_id = joints_bid_B[jt_id]
+    if base_id < 0:
+        c_base = wp.vec3f(0.0, 0.0, 0.0)
+        q_base = wp.quatf(0.0, 0.0, 0.0, 1.0)
+    else:
+        c_base = wp.transform_get_translation(bodies_q[base_id])
+        q_base = wp.transform_get_rotation(bodies_q[base_id])
+    follower_id = joints_bid_F[jt_id]
+    c_follower = wp.transform_get_translation(bodies_q[follower_id])
+    q_follower = wp.transform_get_rotation(bodies_q[follower_id])
+
+    # Compute relative pose of follower body in joint frame of base body
+    pos_base = c_base + wp.quat_rotate(q_base, x_base)
+    pos_follower = c_follower + wp.quat_rotate(q_follower, x_follower)
+    ori_base_T = wp.quat_inverse(q_base * q_X)
+    ori_follower = q_follower * q_X
+    pos_rel = wp.quat_rotate(ori_base_T, pos_follower - pos_base)
+    q_rel = ori_base_T * ori_follower
+
+    # Extract joint coordinates from relative pose
+    _joint_transform_to_coords(dof_type, pos_rel, q_rel, coord_id, actuators_q)
+
+
+@wp.func
+def _correct_joint_angle(angle: wp.float32, angle_ref: wp.float32) -> wp.float32:
+    """Function adding multiples of 2 pi to an angle, so that it is the closest to a reference."""
+    return angle + wp.round((angle_ref - angle) / TWO_PI) * TWO_PI
+
+
+@wp.func
+def _correct_joint_quaternion(quat: wp.vec4f, quat_ref: wp.vec4f) -> wp.vec4f:
+    """Function flipping the sign of a quaternion if needed, so it is the closest to a reference."""
+    if squared_norm(quat + quat_ref) < squared_norm(quat - quat_ref):
+        return -quat
+    return quat
+
+
+@wp.kernel
+def _correct_actuator_coords(
+    # Inputs
+    actuated_coord_offsets: wp.array[wp.int32],
+    joints_dof_type: wp.array[wp.int32],
+    actuators_q_ref: wp.array[wp.float32],
+    # Outputs
+    actuators_q: wp.array[wp.float32],
+):
+    """
+    A kernel correcting actuator coordinates w.r.t. reference coordinates, ensuring that
+    angles are within +/- 2 pi of the reference, and quaternions are closer to the reference
+    than to its opposite.
+
+    Inputs:
+        actuated_coord_offsets: Joint first actuated coordinate id, among all actuated coordinates in all worlds.
+        joints_dof_type: Joint dof type (i.e. revolute, spherical, ...).
+        actuators_q_ref: Reference actuator coordinates.
+    Outputs:
+        actuators_q: Actuator coordinates to correct w.r.t. the reference.
+    """
+    # Retrieve the thread index (= joint index)
+    joint_id = wp.tid()
+
+    # Get joint actuated coords size and offset
+    coord_id = actuated_coord_offsets[joint_id]
+    num_coords = actuated_coord_offsets[joint_id + 1] - coord_id
+    if num_coords == 0:
+        return
+
+    # Apply correction based on DoFs
+    dof_type = joints_dof_type[joint_id]
+    if (
+        dof_type == FKJointDoFType.CARTESIAN or dof_type == FKJointDoFType.FIXED or dof_type == FKJointDoFType.PRISMATIC
+    ):  # No correction needed
+        return
+    elif dof_type == FKJointDoFType.CYLINDRICAL:  # Correct angle up to +/- 2 pi
+        angle = actuators_q[coord_id + 1]
+        angle_ref = actuators_q_ref[coord_id + 1]
+        actuators_q[coord_id + 1] = _correct_joint_angle(angle, angle_ref)
+    elif dof_type == FKJointDoFType.FREE:  # Correct quaternion up to sign
+        quat = wp.vec4f(
+            actuators_q[coord_id + 3], actuators_q[coord_id + 4], actuators_q[coord_id + 5], actuators_q[coord_id + 6]
+        )
+        quat_ref = wp.vec4f(
+            actuators_q_ref[coord_id + 3],
+            actuators_q_ref[coord_id + 4],
+            actuators_q_ref[coord_id + 5],
+            actuators_q_ref[coord_id + 6],
+        )
+        quat_corrected = _correct_joint_quaternion(quat, quat_ref)
+        for i in range(4):
+            actuators_q[coord_id + 3 + i] = quat_corrected[i]
+    elif dof_type == FKJointDoFType.REVOLUTE:  # Correct angle up to +/- 2 pi
+        angle = actuators_q[coord_id]
+        angle_ref = actuators_q_ref[coord_id]
+        actuators_q[coord_id] = _correct_joint_angle(angle, angle_ref)
+    elif dof_type == FKJointDoFType.SPHERICAL:  # Correct quaternion up to sign
+        quat = wp.vec4f(
+            actuators_q[coord_id], actuators_q[coord_id + 1], actuators_q[coord_id + 2], actuators_q[coord_id + 3]
+        )
+        quat_ref = wp.vec4f(
+            actuators_q_ref[coord_id],
+            actuators_q_ref[coord_id + 1],
+            actuators_q_ref[coord_id + 2],
+            actuators_q_ref[coord_id + 3],
+        )
+        quat_corrected = _correct_joint_quaternion(quat, quat_ref)
+        for i in range(4):
+            actuators_q[coord_id + i] = quat_corrected[i]
+    elif dof_type == FKJointDoFType.UNIVERSAL:  # Correct angles up to +/- 2 pi
+        angle = actuators_q[coord_id]
+        angle_ref = actuators_q_ref[coord_id]
+        actuators_q[coord_id] = _correct_joint_angle(angle, angle_ref)
+        angle = actuators_q[coord_id + 1]
+        angle_ref = actuators_q_ref[coord_id + 1]
+        actuators_q[coord_id + 1] = _correct_joint_angle(angle, angle_ref)
+    else:
+        assert False, "Unexpected actuator dof type"  # noqa: B011
+
+
+@wp.kernel
+def _eval_incremental_target_actuator_coords(
+    # Inputs
+    world_actuated_coord_offsets: wp.array[wp.int32],
+    actuators_q_prev: wp.array[wp.float32],
+    actuators_q_next: wp.array[wp.float32],
+    delta_q_max: wp.array[wp.float32],
+    iteration: wp.array[wp.int32],
+    world_mask: wp.array[wp.int32],
+    # Outputs
+    actuators_q_curr: wp.array[wp.float32],
+):
+    """
+    A kernel evaluating the actuator coordinates to solve for given the Newton iteration
+    number and the target actuator coordinates, by interpolating between initial and target
+    coordinates if necessary to avoid too large jumps per iteration.
+
+    Inputs:
+        world_actuated_coord_offsets: World first actuated coordinate id, among all actuated coordinates in all worlds.
+        actuators_q_prev: Previous actuator coordinates.
+        actuators_q_next: Next actuator coordinates (= target).
+        delta_q_max: Maximal allowed step per coordinate, for one Newton iteration.
+        iteration: Current Newton iteration per world.
+        world_mask: Per-world flag to perform the computation (0 = skip).
+    Outputs:
+        actuators_q_curr: Actuator coordinates to use as target for the current iteration (= incremental target).
+    """
+    # Retrieve the thread index (= world index, coordinate index in world)
+    wd_id, coord_id_loc = wp.tid()
+
+    # Early return based on world mask
+    if world_mask[wd_id] == 0:
+        return
+
+    # Read data
+    coord_id = world_actuated_coord_offsets[wd_id] + coord_id_loc
+    q_prev = actuators_q_prev[coord_id]
+    q_next = actuators_q_next[coord_id]
+    delta = delta_q_max[coord_id]
+    it = iteration[wd_id]
+
+    # Interpolate coordinate
+    sign = wp.where(q_prev > q_next, -1.0, 1.0)
+    actuators_q_curr[coord_id] = sign * wp.min(sign * q_prev + wp.float32(it + 1) * delta, sign * q_next)
+
+
+@wp.func
+def min_iteration_op(v0: wp.float32, v1: wp.float32, d: wp.float32) -> wp.int32:
+    """Function returning the floor of the absolute division of (v1 - v0) by d."""
+    eps = 1e-7  # Epsilon to ensure that we round down if |v1 - v0| = d
+    return wp.int32(wp.floor((wp.abs(v1 - v0) - eps) / d))
+
+
+@wp.func
+def less_than_op(i: wp.int32, threshold: wp.int32) -> wp.int32:
+    """Thresholding operation."""
+    return wp.where(i < threshold, 1, 0)
+
+
+@wp.func
+def mul_mask(mask: wp.int32, value: wp.int32):
+    """Return value if mask is positive, else 0"""
+    return wp.where(mask > 0, value, 0)
+
+
+@cache
+def create_eval_min_num_iterations_kernel(TILE_SIZE: int):
+    @wp.kernel
+    def _eval_min_num_iterations(
+        # Inputs
+        world_actuated_coord_offsets: wp.array[wp.int32],
+        actuators_q_prev: wp.array[wp.float32],
+        actuators_q_next: wp.array[wp.float32],
+        delta_q_max: wp.array[wp.float32],
+        # Outputs
+        min_iterations: wp.array[wp.int32],
+    ):
+        """
+        A kernel evaluating the minimal number of Newton iterations needed per world, for incremental steps
+        in actuator coordinates to have converged to the target coordinates.
+
+        Inputs:
+            world_actuated_coord_offsets: World first actuated coordinate id, among all actuated coordinates in all worlds.
+            actuators_q_prev: Previous actuator coordinates.
+            actuators_q_next: Next actuator coordinates (= target).
+            delta_q_max: Maximal allowed step per coordinate, for one Newton iteration.
+        Outputs:
+            min_iterations: Minimum iterations needed per world.
+        """
+        # Retrieve the thread index (= world index, input tile index, thread index in block)
+        wd_id, i, tid = wp.tid()
+
+        # Read data
+        world_offset = world_actuated_coord_offsets[wd_id]
+        next_world_offset = world_actuated_coord_offsets[wd_id + 1]
+        offset = world_offset + i * TILE_SIZE
+        q_prev = wp.tile_load(actuators_q_prev, shape=TILE_SIZE, offset=offset)
+        q_next = wp.tile_load(actuators_q_next, shape=TILE_SIZE, offset=offset)
+        delta = wp.tile_load(delta_q_max, shape=TILE_SIZE, offset=offset)
+
+        # Compute min iterations count per coordinate, and take the maximum per world
+        min_it = wp.tile_map(min_iteration_op, q_prev, q_next, delta)
+        if offset + TILE_SIZE > next_world_offset:  # Mask out values from next world if needed
+            mask = wp.tile_map(less_than_op, wp.tile_arange(TILE_SIZE, dtype=wp.int32), next_world_offset - offset)
+            min_it = wp.tile_map(mul_mask, mask, min_it)
+        min_it_max = wp.tile_max(min_it)[0]
+        if tid == 0:
+            wp.atomic_max(min_iterations, wd_id, min_it_max)
+
+    return _eval_min_num_iterations
+
+
 @wp.kernel
 def _eval_position_control_transformations(
     # Inputs
@@ -221,6 +556,7 @@ def _eval_position_control_transformations(
     actuated_coords_offset: wp.array[wp.int32],
     joints_X: wp.array[wp.mat33f],
     actuators_q: wp.array[wp.float32],
+    normalize_quaternions: wp.bool,
     # Outputs
     pos_control_transforms: wp.array[wp.transformf],
 ):
@@ -238,6 +574,7 @@ def _eval_position_control_transformations(
         actuated_coords_offset: Joint first actuated coordinate id, among all actuated coordinates in all worlds
         joints_X: Joint frame (local axes, valid both on base and follower)
         actuators_q: Actuated coordinates
+        normalize_quaternions: Whether to normalize quaternions in actuators_q (else unit length is assumed)
     Outputs:
         pos_control_transforms: Joint position-control transformation
     """
@@ -272,7 +609,7 @@ def _eval_position_control_transformations(
                 t[1] = actuators_q[offset_q_j + 1]
                 t[2] = actuators_q[offset_q_j + 2]
                 q_X = wp.quat_from_matrix(X)
-                q_loc = read_quat_from_array(actuators_q, offset_q_j + 3)
+                q_loc = read_quat_from_array(actuators_q, offset_q_j + 3, normalize_quaternions)
                 q = q_X * q_loc * wp.quat_inverse(q_X)
             elif dof_type_j == FKJointDoFType.PRISMATIC:
                 t[0] = actuators_q[offset_q_j]
@@ -280,7 +617,7 @@ def _eval_position_control_transformations(
                 q = wp.quat_from_axis_angle(wp.vec3f(X[0, 0], X[1, 0], X[2, 0]), actuators_q[offset_q_j])
             elif dof_type_j == FKJointDoFType.SPHERICAL:
                 q_X = wp.quat_from_matrix(X)
-                q_loc = read_quat_from_array(actuators_q, offset_q_j)
+                q_loc = read_quat_from_array(actuators_q, offset_q_j, normalize_quaternions)
                 q = q_X * q_loc * wp.quat_inverse(q_X)
             elif dof_type_j == FKJointDoFType.UNIVERSAL:
                 q_x = wp.quat_from_axis_angle(wp.vec3f(X[0, 0], X[1, 0], X[2, 0]), actuators_q[offset_q_j])
@@ -1325,6 +1662,7 @@ def _newton_check(
     max_constraint: wp.array[wp.float32],
     tolerance: wp.array[wp.float32],
     iteration: wp.array[wp.int32],
+    min_iterations: wp.array[wp.int32],
     max_iterations: wp.array[wp.int32],
     line_search_success: wp.array[wp.int32],
     # Outputs
@@ -1340,6 +1678,7 @@ def _newton_check(
         max_constraint: Max absolute constraint per world
         tolerance: Tolerance on max constraint (size 1 array)
         iteration: Iteration count, per world
+        min_iterations: Min iterations per world (may be > 0 if incremental solve is enabled)
         max_iterations: Max iterations (size 1 array)
         line_search_success: Per-world line search success flag
     Outputs
@@ -1349,12 +1688,16 @@ def _newton_check(
     """
     wd_id = wp.tid()  # Thread index (= world index)
     if wd_id < max_constraint.shape[0] and newton_mask[wd_id] != 0:
-        iteration[wd_id] += 1
+        iteration_prev = iteration[wd_id]  # Index of the iteration that just ran
+        iteration_next = iteration_prev + 1  # Index of the iteration that is about to run
+        min_iterations_wd = min_iterations[wd_id]
+        iteration[wd_id] = iteration_next
+        reached_min_it = iteration_prev >= min_iterations_wd
         max_constraint_wd = max_constraint[wd_id]
         is_finite = wp.isfinite(max_constraint_wd)
-        newton_success[wd_id] = int(is_finite and max_constraint_wd <= tolerance[0])
+        newton_success[wd_id] = int(is_finite and reached_min_it and max_constraint_wd <= tolerance[0])
         newton_continue_world = int(
-            iteration[wd_id] < max_iterations[0]
+            iteration_next < max_iterations[0]
             and not newton_success[wd_id]
             and is_finite  # Abort when encountering NaN / Inf values
             and line_search_success[wd_id]  # Abort in case of line search failure

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -483,6 +483,8 @@ def _eval_incremental_target_actuator_coords(
 
     # Read data
     coord_id = world_actuated_coord_offsets[wd_id] + coord_id_loc
+    if coord_id >= world_actuated_coord_offsets[wd_id + 1]:
+        return
     q_prev = actuators_q_prev[coord_id]
     q_next = actuators_q_next[coord_id]
     delta = delta_q_max[coord_id]

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -1803,7 +1803,7 @@ def _eval_body_velocities(
 ):
     """
     A kernel computing the body velocities (twists) from the time derivative of body poses,
-    computing in particular angular velocities omega = G(q)q_dot
+    computing in particular angular velocities omega = 2G(q)q_dot
 
     Inputs:
         num_bodies: Number of bodies per world

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -129,8 +129,10 @@ def _reset_state_base_q(
     # Inputs
     base_joint_id: wp.array[wp.int32],
     base_q: wp.array[wp.transformf],
+    joints_bid_F: wp.array[wp.int32],
     joints_X: wp.array[wp.mat33f],
     joints_B_r_B: wp.array[wp.vec3f],
+    joints_F_r_F: wp.array[wp.vec3f],
     num_bodies: wp.array[wp.int32],
     first_body_id: wp.array[wp.int32],
     bodies_q_0: wp.array[wp.transformf],
@@ -145,8 +147,10 @@ def _reset_state_base_q(
     Inputs:
         base_joint_id: Base joint id per world (-1 = None)
         base_q: Base body pose per world, in base joint coordinates
+        joints_bid_F: Joint follower body id
         joints_X: Joint frame (local axes, valid both on base and follower)
         joints_B_r_B: Joint local position on base body
+        joints_F_r_F: Joint local position on follower body
         num_bodies: Num bodies per world
         first_body_id: First body id per world
         bodies_q_0: Reference body poses
@@ -166,20 +170,27 @@ def _reset_state_base_q(
 
         # Read memory
         base_q_wd = base_q[wd_id]
+        bid_F = joints_bid_F[base_jt_id]
         X = joints_X[base_jt_id]
-        x = joints_B_r_B[base_jt_id]
+        x_B = joints_B_r_B[base_jt_id]
+        x_F = joints_F_r_F[base_jt_id]
+        body_q_F_0 = bodies_q_0[bid_F]
 
-        # Compute transformation that maps the reference pose of the base body (follower of the base joint)
-        # to the pose corresponding by base_q. Note: we make use of the fact that initial body orientations
-        # are the identity (a more complex formula would needed otherwise)
+        # Compute pose of the base body (follower of the base joint) given current joint coordinates
+        # Note: the relative transform from base to follower can be written
+        # t_jt = X^T * R_B^T * (c_F + R_F * x_F - c_B - R_B * x_B)
+        # q_jt = X^T * R_B^T * R_F * X
+        # We invert these equations, using R_B = I and c_B = 0 (base body = world)
         t_jt = wp.transform_get_translation(base_q_wd)
         q_jt = wp.transform_get_rotation(base_q_wd)
         q_X = wp.quat_from_matrix(X)
-        q_tot = q_X * q_jt * wp.quat_inverse(q_X)
-        t_tot = x - wp.quat_rotate(q_tot, x) + wp.quat_rotate(q_X, t_jt)
-        transform_tot = wp.transformf(t_tot, q_tot)
+        q_F = q_X * q_jt * wp.quat_inverse(q_X)
+        c_F = wp.quat_rotate(q_X, t_jt) - wp.quat_rotate(q_F, x_F) + x_B
+        body_q_F = wp.transformf(c_F, q_F)
 
-        # Apply to body pose
+        # Compute the transform that was applied to the base body relative to the base pose,
+        # and apply that transform to all rigid bodies
+        transform_tot = wp.transform_multiply(body_q_F, wp.transform_inverse(body_q_F_0))
         bodies_q[rb_id_tot] = wp.transform_multiply(transform_tot, body_q_0)
 
 

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -915,8 +915,10 @@ class ForwardKinematicsSolver:
             inputs=[
                 self.base_joint_id,
                 base_q,
+                self.joints_bid_F,
                 self.joints_X_j,
                 self.joints_B_r_Bj,
+                self.joints_F_r_Fj,
                 self.model.info.num_bodies,
                 self.first_body_id,
                 self.model.bodies.q_i_0,
@@ -1732,16 +1734,6 @@ class ForwardKinematicsSolver:
                 "run_fk_solve: actuators_u must be provided to solve for velocities (i.e. if bodies_u is provided)."
             )
 
-        # Use default base state if not provided
-        if base_q is None:
-            base_q = self.base_q_default
-        if bodies_u is not None and base_u is None:
-            base_u = self.base_u_default
-
-        # Compute target actuator coordinates and corresponding transforms
-        self._eval_target_actuators_q(base_q, actuators_q, self.actuators_q_next)
-        self._eval_position_control_transformations(self.actuators_q_next, self.pos_control_transforms)
-
         # Reset iteration count and success/continuation flags
         self.newton_iteration.fill_(-1)  # The initial Newton convergence check will increment this to zero
         self.newton_success.zero_()
@@ -1757,6 +1749,16 @@ class ForwardKinematicsSolver:
                 self._reset_state(bodies_q, self.newton_mask)
             else:
                 self._reset_state_base_q(bodies_q, base_q, self.newton_mask)
+
+        # Use default base state if not provided
+        if base_q is None:
+            base_q = self.base_q_default
+        if bodies_u is not None and base_u is None:
+            base_u = self.base_u_default
+
+        # Compute target actuator coordinates and corresponding transforms
+        self._eval_target_actuators_q(base_q, actuators_q, self.actuators_q_next)
+        self._eval_position_control_transformations(self.actuators_q_next, self.pos_control_transforms)
 
         # Evaluate constraints, and initialize loop condition (might not even need to loop)
         self._eval_kinematic_constraints(bodies_q, self.pos_control_transforms, self.newton_mask, self.constraints)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -31,8 +31,11 @@ from ...linalg.sparse_operator import BlockSparseLinearOperators
 from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_classes
 from .kernels import (
     _apply_line_search_step,
+    _correct_actuator_coords,
+    _eval_actuator_coords,
     _eval_body_velocities,
     _eval_fk_actuated_dofs_or_coords,
+    _eval_incremental_target_actuator_coords,
     _eval_linear_combination,
     _eval_position_control_transformations,
     _eval_rhs,
@@ -51,6 +54,7 @@ from .kernels import (
     create_eval_joint_constraints_jacobian_kernel,
     create_eval_joint_constraints_kernel,
     create_eval_joint_constraints_sparse_jacobian_kernel,
+    create_eval_min_num_iterations_kernel,
 )
 from .types import FKJointDoFType, ForwardKinematicsPreconditionerType, ForwardKinematicsStatus
 
@@ -366,6 +370,16 @@ class ForwardKinematicsSolver:
             ([0], joints_num_actuated_coords.cumsum())
         )  # First actuated coordinate offset per joint, among all actuated coordinates
         self.num_actuated_coords = actuated_coord_offsets[-1]
+        world_num_actuated_coords = np.array(
+            [
+                joints_num_actuated_coords[first_joint_id[wd_id] : first_joint_id[wd_id + 1]].sum()
+                for wd_id in range(self.num_worlds)
+            ]
+        )
+        world_actuated_coord_offsets = np.concatenate(([0], world_num_actuated_coords.cumsum()))
+        self.num_actuated_coords_max = np.max(world_num_actuated_coords)
+        if self.num_actuated_coords_max == 0:  # No actuated coordinates
+            self.config.use_incremental_solve = 0  # Turn off incremental solve (corner case in unit tests)
 
         # Retrieve / compute dimensions - Actuated dofs (FK model)
         joints_num_actuated_dofs = np.array(joints_num_actuated_dofs)  # Number of actuated dofs per joint
@@ -382,54 +396,53 @@ class ForwardKinematicsSolver:
             # Count constraints for first world in equivalence class
             wd_id = eq_class[0]
             ct_count = num_constraints[wd_id]
-            for jt_id_loc in range(num_joints[wd_id]):
-                jt_id_tot = first_joint_id[wd_id] + jt_id_loc  # Joint id among all joints
-                act_type = joints_act_type[jt_id_tot]
+            for jt_id in range(first_joint_id[wd_id], first_joint_id[wd_id + 1]):
+                act_type = joints_act_type[jt_id]
                 if act_type != JointActuationType.PASSIVE:  # Actuator: select all six constraints
                     for i in range(6):
-                        constraint_full_to_red_map[6 * jt_id_tot + i] = ct_count + i
+                        constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
                     ct_count += 6
                 else:
-                    dof_type = joints_dof_type[jt_id_tot]
+                    dof_type = joints_dof_type[jt_id]
                     if dof_type == FKJointDoFType.AXIS:
-                        constraint_full_to_red_map[6 * jt_id_tot + 3] = ct_count
+                        constraint_full_to_red_map[6 * jt_id + 3] = ct_count
                         ct_count += 1
                     elif dof_type == FKJointDoFType.CARTESIAN:
                         for i in range(3):
-                            constraint_full_to_red_map[6 * jt_id_tot + 3 + i] = ct_count + i
+                            constraint_full_to_red_map[6 * jt_id + 3 + i] = ct_count + i
                         ct_count += 3
                     elif dof_type == FKJointDoFType.CYLINDRICAL:
-                        constraint_full_to_red_map[6 * jt_id_tot + 1] = ct_count
-                        constraint_full_to_red_map[6 * jt_id_tot + 2] = ct_count + 1
-                        constraint_full_to_red_map[6 * jt_id_tot + 4] = ct_count + 2
-                        constraint_full_to_red_map[6 * jt_id_tot + 5] = ct_count + 3
+                        constraint_full_to_red_map[6 * jt_id + 1] = ct_count
+                        constraint_full_to_red_map[6 * jt_id + 2] = ct_count + 1
+                        constraint_full_to_red_map[6 * jt_id + 4] = ct_count + 2
+                        constraint_full_to_red_map[6 * jt_id + 5] = ct_count + 3
                         ct_count += 4
                     elif dof_type == FKJointDoFType.FIXED:
                         for i in range(6):
-                            constraint_full_to_red_map[6 * jt_id_tot + i] = ct_count + i
+                            constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
                         ct_count += 6
                     elif dof_type == FKJointDoFType.FREE:
                         pass
                     elif dof_type == FKJointDoFType.PRISMATIC:
-                        constraint_full_to_red_map[6 * jt_id_tot + 1] = ct_count
-                        constraint_full_to_red_map[6 * jt_id_tot + 2] = ct_count + 1
+                        constraint_full_to_red_map[6 * jt_id + 1] = ct_count
+                        constraint_full_to_red_map[6 * jt_id + 2] = ct_count + 1
                         for i in range(3):
-                            constraint_full_to_red_map[6 * jt_id_tot + 3 + i] = ct_count + 2 + i
+                            constraint_full_to_red_map[6 * jt_id + 3 + i] = ct_count + 2 + i
                         ct_count += 5
                     elif dof_type == FKJointDoFType.REVOLUTE:
                         for i in range(3):
-                            constraint_full_to_red_map[6 * jt_id_tot + i] = ct_count + i
-                        constraint_full_to_red_map[6 * jt_id_tot + 4] = ct_count + 3
-                        constraint_full_to_red_map[6 * jt_id_tot + 5] = ct_count + 4
+                            constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
+                        constraint_full_to_red_map[6 * jt_id + 4] = ct_count + 3
+                        constraint_full_to_red_map[6 * jt_id + 5] = ct_count + 4
                         ct_count += 5
                     elif dof_type == FKJointDoFType.SPHERICAL:
                         for i in range(3):
-                            constraint_full_to_red_map[6 * jt_id_tot + i] = ct_count + i
+                            constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
                         ct_count += 3
                     elif dof_type == FKJointDoFType.UNIVERSAL:
                         for i in range(3):
-                            constraint_full_to_red_map[6 * jt_id_tot + i] = ct_count + i
-                        constraint_full_to_red_map[6 * jt_id_tot + 5] = ct_count + 3
+                            constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
+                        constraint_full_to_red_map[6 * jt_id + 5] = ct_count + 3
                         ct_count += 4
                         has_universal_joints = True
                     else:
@@ -444,6 +457,53 @@ class ForwardKinematicsSolver:
                 num_constraints[wd_id_1] = num_constraints[wd_id]
         self.num_constraints_max = np.max(num_constraints)
 
+        # Initialize maximal step size per iteration in actuated coordinates
+        if self.config.use_incremental_solve:
+            delta_q_max = np.zeros(self.num_actuated_coords, dtype=np.float32)
+            max_step_linear = self.config.max_linear_incremental_step_meters
+            max_step_angular = np.radians(self.config.max_angular_incremental_step_degrees)
+            half_angle = 0.5 * min(max_step_angular, np.pi)
+            max_step_quat = max(np.sin(half_angle), 1.0 - np.cos(half_angle))
+            for eq_class in classes:
+                # Initialize delta_q_max for first world in equivalence class
+                wd_id = eq_class[0]
+                for jt_id in range(first_joint_id[wd_id], first_joint_id[wd_id + 1]):
+                    if joints_num_actuated_coords[jt_id] == 0:
+                        continue
+                    dof_type = joints_dof_type[jt_id]
+                    coord_id = actuated_coord_offsets[jt_id]
+                    if dof_type == FKJointDoFType.CARTESIAN:
+                        for i in range(3):
+                            delta_q_max[coord_id + i] = max_step_linear
+                    elif dof_type == FKJointDoFType.CYLINDRICAL:
+                        delta_q_max[coord_id] = max_step_linear
+                        delta_q_max[coord_id + 1] = max_step_angular
+                    elif dof_type == FKJointDoFType.FIXED:
+                        pass
+                    elif dof_type == FKJointDoFType.FREE:
+                        for i in range(3):
+                            delta_q_max[coord_id + i] = max_step_linear
+                        for i in range(4):
+                            delta_q_max[coord_id + 3 + i] = max_step_quat
+                    elif dof_type == FKJointDoFType.PRISMATIC:
+                        delta_q_max[coord_id] = max_step_linear
+                    elif dof_type == FKJointDoFType.REVOLUTE:
+                        delta_q_max[coord_id] = max_step_angular
+                    elif dof_type == FKJointDoFType.SPHERICAL:
+                        for i in range(4):
+                            delta_q_max[coord_id + i] = max_step_quat
+                    elif dof_type == FKJointDoFType.UNIVERSAL:
+                        delta_q_max[coord_id] = max_step_angular
+                        delta_q_max[coord_id + 1] = max_step_angular
+                    else:
+                        raise RuntimeError("Invalid joint dof type for an actuator")
+
+                # Copy delta_q_max for other worlds in equivalence class
+                for wd_id_1 in eq_class[1:]:
+                    delta_q_max[world_actuated_coord_offsets[wd_id_1] : world_actuated_coord_offsets[wd_id_1 + 1]] = (
+                        delta_q_max[world_actuated_coord_offsets[wd_id] : world_actuated_coord_offsets[wd_id + 1]]
+                    )
+
         # Retrieve / compute dimensions - Number of tiles (for kernels using Tile API)
         # For 1d reduction kernels, large tiles yield the best performance
         self.tile_size_cts_1d = min(2048, 2 ** math.ceil(math.log(self.num_constraints_max, 2)))
@@ -455,6 +515,10 @@ class ForwardKinematicsSolver:
         self.num_tiles_cts_2d = (self.num_constraints_max + self.tile_size_cts_2d - 1) // self.tile_size_cts_2d
         self.tile_size_vrs_2d = 16
         self.num_tiles_vrs_2d = (self.num_states_max + self.tile_size_vrs_2d - 1) // self.tile_size_vrs_2d
+        # For optional 1d reduction kernel over actuated coordinates
+        if self.config.use_incremental_solve:
+            self.tile_size_coords = min(2048, 2 ** math.ceil(math.log(self.num_actuated_coords_max, 2)))
+            self.num_tiles_coords = (self.num_actuated_coords_max + self.tile_size_coords - 1) // self.tile_size_coords
 
         # Data allocation or transfer from numpy to warp
         with wp.ScopedDevice(self.device):
@@ -464,6 +528,7 @@ class ForwardKinematicsSolver:
             self.first_joint_id = wp.from_numpy(first_joint_id, dtype=wp.int32)
             self.actuated_coord_offsets = wp.from_numpy(actuated_coord_offsets, dtype=wp.int32)
             self.actuated_coords_map = wp.from_numpy(np.array(actuated_coords_map), dtype=wp.int32)
+            self.world_actuated_coord_offsets = wp.from_numpy(world_actuated_coord_offsets, dtype=wp.int32)
             self.actuated_dof_offsets = wp.from_numpy(actuated_dof_offsets, dtype=wp.int32)
             self.actuated_dofs_map = wp.from_numpy(np.array(actuated_dofs_map), dtype=wp.int32)
             self.num_states = wp.from_numpy(num_states, dtype=wp.int32)
@@ -504,13 +569,24 @@ class ForwardKinematicsSolver:
             # Gauss-Newton
             self.max_newton_iterations = wp.array(dtype=wp.int32, shape=(1,))  # Max iterations
             self.max_newton_iterations.fill_(self.config.max_newton_iterations)
+            self.min_newton_iterations = wp.zeros(dtype=wp.int32, shape=(self.num_worlds,))  # Min iterations
             self.newton_iteration = wp.array(dtype=wp.int32, shape=(self.num_worlds,))  # Iteration count
             self.newton_loop_condition = wp.array(dtype=wp.int32, shape=(1,))  # Loop condition
             self.newton_success = wp.array(dtype=wp.int32, shape=(self.num_worlds,))  # Convergence per world
             self.newton_mask = wp.array(dtype=wp.int32, shape=(self.num_worlds,))  # Flag to keep iterating per world
             self.tolerance = wp.array(dtype=wp.float32, shape=(1,))  # Tolerance on max constraint
             self.tolerance.fill_(self.config.tolerance)
-            self.actuators_q = wp.array(dtype=wp.float32, shape=(self.num_actuated_coords,))  # Actuated coordinates
+            self.actuators_q_next = wp.array(
+                dtype=wp.float32, shape=(self.num_actuated_coords,)
+            )  # Actuated coordinates (target)
+            if self.config.use_incremental_solve:
+                self.actuators_q_prev = wp.array(
+                    dtype=wp.float32, shape=(self.num_actuated_coords,)
+                )  # Actuated coordinates (previous)
+                self.actuators_q_curr = wp.array(
+                    dtype=wp.float32, shape=(self.num_actuated_coords,)
+                )  # Actuated coordinates (incremental target)
+                self.delta_q_max = wp.from_numpy(delta_q_max, dtype=wp.float32)  # Maximal step in actuated coordinates
             self.pos_control_transforms = wp.array(
                 dtype=wp.transformf, shape=(self.num_joints_tot,)
             )  # Position-control transformations at joints
@@ -576,6 +652,8 @@ class ForwardKinematicsSolver:
             self._eval_merit_function_kernel,
             self._eval_merit_function_gradient_kernel,
         ) = create_1d_tile_based_kernels(self.tile_size_cts_1d, self.tile_size_vrs_1d)
+        if self.config.use_incremental_solve:
+            self._eval_min_num_iterations_kernel = create_eval_min_num_iterations_kernel(self.tile_size_coords)
 
         # Compute sparsity pattern and initialize linear solver for dense (semi-sparse) case
         if not self.config.use_sparsity:
@@ -848,31 +926,115 @@ class ForwardKinematicsSolver:
             device=self.device,
         )
 
-    def _eval_position_control_transformations(
+    def _initialize_incremental_solve(self, bodies_q: wp.array[wp.transformf]):
+        """
+        Internal function running all necessary precomputations for the incremental solve.
+        Assumes without check that data related to incremental solve is allocated, and min_newton_iterations
+        is pre-filled with zeros.
+        """
+        # Extract current actuator coordinates
+        wp.launch(
+            _eval_actuator_coords,
+            dim=(self.num_worlds, self.num_joints_max),
+            inputs=[
+                self.num_joints,
+                self.first_joint_id,
+                self.joints_dof_type,
+                self.joints_bid_B,
+                self.joints_bid_F,
+                self.joints_X_j,
+                self.joints_B_r_Bj,
+                self.joints_F_r_Fj,
+                bodies_q,
+                self.actuated_coord_offsets,
+                self.actuators_q_prev,
+            ],
+            device=self.device,
+        )
+        # Correct target actuator coordinates w.r.t. current
+        wp.launch(
+            _correct_actuator_coords,
+            dim=(self.num_joints_tot,),
+            inputs=[
+                self.actuated_coord_offsets,
+                self.joints_dof_type,
+                self.actuators_q_prev,
+                self.actuators_q_next,
+            ],
+            device=self.device,
+        )
+        # Compute necessary number of Newton steps, before the incremental target matches the true target
+        self.min_newton_iterations.zero_()
+        wp.launch_tiled(
+            self._eval_min_num_iterations_kernel,
+            dim=(self.num_worlds, self.num_tiles_coords),
+            block_dim=max(32, min(256, self.tile_size_coords // 8)),
+            inputs=[
+                self.world_actuated_coord_offsets,
+                self.actuators_q_prev,
+                self.actuators_q_next,
+                self.delta_q_max,
+                self.min_newton_iterations,
+            ],
+            device=self.device,
+        )
+
+    def _eval_target_actuators_q(
         self,
-        base_q: wp.array[wp.transformf],
-        actuators_q: wp.array[wp.float32],
-        pos_control_transforms: wp.array[wp.transformf],
+        base_q_model: wp.array[wp.transformf],
+        actuators_q_model: wp.array[wp.float32],
+        actuators_q_next: wp.array[wp.float32],
     ):
         """
-        Internal evaluator for position control transformations, from actuated & base coordinates of the main model.
+        Internal evaluator, converting actuator and base coordinates of the main model, to actuator
+        coordinates of the FK model.
         """
-        # Compute actuators_q of fk model with modified joints
         wp.launch(
             _eval_fk_actuated_dofs_or_coords,
             dim=(self.num_actuated_coords,),
             inputs=[
                 wp.array(
-                    ptr=base_q.ptr, dtype=wp.float32, shape=(7 * self.num_worlds,), device=self.device, copy=False
+                    ptr=base_q_model.ptr, dtype=wp.float32, shape=(7 * self.num_worlds,), device=self.device, copy=False
                 ),
-                actuators_q,
+                actuators_q_model,
                 self.actuated_coords_map,
-                self.actuators_q,
+                actuators_q_next,
             ],
             device=self.device,
         )
 
-        # Compute position control transformations
+    def _update_incremental_target_actuators_q(
+        self,
+        iteration: wp.array[wp.int32],
+        world_mask: wp.array[wp.int32],
+    ):
+        """
+        Internal evaluator, updating the incremental target for actuator coordinates by interpolating
+        between previous and next actuator coordinates, based on the current Newton iteration.
+        """
+        wp.launch(
+            _eval_incremental_target_actuator_coords,
+            dim=(self.num_worlds, self.num_actuated_coords_max),
+            inputs=[
+                self.world_actuated_coord_offsets,
+                self.actuators_q_prev,
+                self.actuators_q_next,
+                self.delta_q_max,
+                iteration,
+                world_mask,
+                self.actuators_q_curr,
+            ],
+            device=self.device,
+        )
+
+    def _eval_position_control_transformations(
+        self,
+        actuators_q: wp.array[wp.float32],
+        pos_control_transforms: wp.array[wp.transformf],
+    ):
+        """
+        Internal evaluator for position control transformations, from actuated coordinates of the FK model.
+        """
         wp.launch(
             _eval_position_control_transformations,
             dim=(self.num_joints_tot,),
@@ -881,7 +1043,8 @@ class ForwardKinematicsSolver:
                 self.joints_act_type,
                 self.actuated_coord_offsets,
                 self.joints_X_j,
-                self.actuators_q,
+                actuators_q,
+                self.config.use_incremental_solve,  # Incremental solve may result in non-unit quaternions
                 pos_control_transforms,
             ],
             device=self.device,
@@ -1166,6 +1329,12 @@ class ForwardKinematicsSolver:
         Internal function running one iteration of Gauss-Newton. Assumes the constraints vector to be already
         up-to-date (because we will already have checked convergence before the first loop iteration)
         """
+        # Update actuators_q and kinematic constraints, for incremental solve
+        if self.config.use_incremental_solve:
+            self._update_incremental_target_actuators_q(self.newton_iteration, self.newton_mask)
+            self._eval_position_control_transformations(self.actuators_q_curr, self.pos_control_transforms)
+            self._eval_kinematic_constraints(bodies_q, self.pos_control_transforms, self.newton_mask, self.constraints)
+
         # Evaluate constraints Jacobian
         if self.config.use_sparsity:
             self._assemble_sparse_jacobian(bodies_q, self.pos_control_transforms, self.newton_mask)
@@ -1258,6 +1427,7 @@ class ForwardKinematicsSolver:
                 self.max_constraint,
                 self.tolerance,
                 self.newton_iteration,
+                self.min_newton_iterations,
                 self.max_newton_iterations,
                 self.line_search_success,
                 self.newton_success,
@@ -1388,8 +1558,14 @@ class ForwardKinematicsSolver:
         if base_q is None:
             base_q = self.base_q_default
 
+        # Convert base_q, actuators_q from the main model to actuators_q for the FK model
+        actuators_q_fk = wp.array(dtype=wp.float32, shape=(self.num_actuated_coords,), device=self.device)
+        self._eval_target_actuators_q(base_q, actuators_q, actuators_q_fk)
+
+        # Evaluate position-control transformations
         pos_control_transforms = wp.array(dtype=wp.transformf, shape=(self.num_joints_tot,), device=self.device)
-        self._eval_position_control_transformations(base_q, actuators_q, pos_control_transforms)
+        self._eval_position_control_transformations(actuators_q_fk, pos_control_transforms)
+
         return pos_control_transforms
 
     def eval_kinematic_constraints(
@@ -1562,16 +1738,18 @@ class ForwardKinematicsSolver:
         if bodies_u is not None and base_u is None:
             base_u = self.base_u_default
 
-        # Compute position control transforms (independent of body poses, depends on controls only)
-        self._eval_position_control_transformations(base_q, actuators_q, self.pos_control_transforms)
+        # Compute target actuator coordinates and corresponding transforms
+        self._eval_target_actuators_q(base_q, actuators_q, self.actuators_q_next)
+        self._eval_position_control_transformations(self.actuators_q_next, self.pos_control_transforms)
 
         # Reset iteration count and success/continuation flags
-        self.newton_iteration.fill_(-1)  # The initial loop condition check will increment this to zero
+        self.newton_iteration.fill_(-1)  # The initial Newton convergence check will increment this to zero
         self.newton_success.zero_()
         if world_mask is not None:
             self.newton_mask.assign(world_mask)
         else:
             self.newton_mask.fill_(1)
+        self.min_newton_iterations.fill_(-1)  # To disregard min iterations in initial Newton check
 
         # Optionally reset state
         if self.config.reset_state:
@@ -1584,7 +1762,7 @@ class ForwardKinematicsSolver:
         self._eval_kinematic_constraints(bodies_q, self.pos_control_transforms, self.newton_mask, self.constraints)
         self._eval_max_constraint(self.constraints, self.max_constraint)
         self.newton_loop_condition.zero_()
-        wp.copy(self.line_search_success, self.newton_mask)  # Newton check will abort in case of line search failure
+        wp.copy(self.line_search_success, self.newton_mask)  # To disregard line search success in initial Newton check
         wp.launch(
             _newton_check,
             dim=(self.num_worlds,),
@@ -1592,6 +1770,7 @@ class ForwardKinematicsSolver:
                 self.max_constraint,
                 self.tolerance,
                 self.newton_iteration,
+                self.min_newton_iterations,
                 self.max_newton_iterations,
                 self.line_search_success,
                 self.newton_success,
@@ -1600,6 +1779,10 @@ class ForwardKinematicsSolver:
             ],
             device=self.device,
         )
+
+        # Initialize incremental solve
+        if self.config.use_incremental_solve:
+            wp.capture_if(self.newton_loop_condition, lambda: self._initialize_incremental_solve(bodies_q))
 
         # Main loop
         wp.capture_while(self.newton_loop_condition, lambda: self._run_newton_iteration(bodies_q))

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -155,6 +155,12 @@ class ForwardKinematicsSolver:
         if self.model is None:
             raise ValueError("ForwardKinematicsSolver: error, provided model is None.")
 
+        # Validate config
+        try:
+            self.config.validate()
+        except Exception as e:
+            raise RuntimeError("Solver configuration is invalid.") from e
+
         # Initialize device
         self.device = self.model.device
 
@@ -378,8 +384,6 @@ class ForwardKinematicsSolver:
         )
         world_actuated_coord_offsets = np.concatenate(([0], world_num_actuated_coords.cumsum()))
         self.num_actuated_coords_max = np.max(world_num_actuated_coords)
-        if self.num_actuated_coords_max == 0:  # No actuated coordinates
-            self.config.use_incremental_solve = 0  # Turn off incremental solve (corner case in unit tests)
 
         # Retrieve / compute dimensions - Actuated dofs (FK model)
         joints_num_actuated_dofs = np.array(joints_num_actuated_dofs)  # Number of actuated dofs per joint
@@ -460,8 +464,8 @@ class ForwardKinematicsSolver:
         # Initialize maximal step size per iteration in actuated coordinates
         if self.config.use_incremental_solve:
             delta_q_max = np.zeros(self.num_actuated_coords, dtype=np.float32)
-            max_step_linear = self.config.max_linear_incremental_step_meters
-            max_step_angular = np.radians(self.config.max_angular_incremental_step_degrees)
+            max_step_linear = self.config.max_linear_incremental_step
+            max_step_angular = self.config.max_angular_incremental_step
             half_angle = 0.5 * min(max_step_angular, np.pi)
             max_step_quat = max(np.sin(half_angle), 1.0 - np.cos(half_angle))
             for eq_class in classes:
@@ -506,19 +510,19 @@ class ForwardKinematicsSolver:
 
         # Retrieve / compute dimensions - Number of tiles (for kernels using Tile API)
         # For 1d reduction kernels, large tiles yield the best performance
-        self.tile_size_cts_1d = min(2048, 2 ** math.ceil(math.log(self.num_constraints_max, 2)))
-        self.num_tiles_cts_1d = (self.num_constraints_max + self.tile_size_cts_1d - 1) // self.tile_size_cts_1d
-        self.tile_size_vrs_1d = min(2048, 2 ** math.ceil(math.log(self.num_states_max, 2)))
-        self.num_tiles_vrs_1d = (self.num_states_max + self.tile_size_vrs_1d - 1) // self.tile_size_vrs_1d
+        self.tile_size_cts_1d = get_tile_size(self.num_constraints_max)
+        self.num_tiles_cts_1d = get_num_tiles(self.num_constraints_max, self.tile_size_cts_1d)
+        self.tile_size_vrs_1d = get_tile_size(self.num_states_max)
+        self.num_tiles_vrs_1d = get_num_tiles(self.num_states_max, self.tile_size_vrs_1d)
         # For 2d matrix product kernels, smaller 16x16 tiles give the best tradeoff (also for using sparsity)
         self.tile_size_cts_2d = 16
-        self.num_tiles_cts_2d = (self.num_constraints_max + self.tile_size_cts_2d - 1) // self.tile_size_cts_2d
+        self.num_tiles_cts_2d = get_num_tiles(self.num_constraints_max, self.tile_size_cts_2d)
         self.tile_size_vrs_2d = 16
-        self.num_tiles_vrs_2d = (self.num_states_max + self.tile_size_vrs_2d - 1) // self.tile_size_vrs_2d
+        self.num_tiles_vrs_2d = get_num_tiles(self.num_states_max, self.tile_size_vrs_2d)
         # For optional 1d reduction kernel over actuated coordinates
         if self.config.use_incremental_solve:
-            self.tile_size_coords = min(2048, 2 ** math.ceil(math.log(self.num_actuated_coords_max, 2)))
-            self.num_tiles_coords = (self.num_actuated_coords_max + self.tile_size_coords - 1) // self.tile_size_coords
+            self.tile_size_coords = get_tile_size(self.num_actuated_coords_max)
+            self.num_tiles_coords = get_num_tiles(self.num_actuated_coords_max, self.tile_size_coords)
 
         # Data allocation or transfer from numpy to warp
         with wp.ScopedDevice(self.device):
@@ -931,8 +935,7 @@ class ForwardKinematicsSolver:
     def _initialize_incremental_solve(self, bodies_q: wp.array[wp.transformf]):
         """
         Internal function running all necessary precomputations for the incremental solve.
-        Assumes without check that data related to incremental solve is allocated, and min_newton_iterations
-        is pre-filled with zeros.
+        Assumes without check that data related to incremental solve is allocated.
         """
         # Extract current actuator coordinates
         wp.launch(
@@ -970,7 +973,7 @@ class ForwardKinematicsSolver:
         wp.launch_tiled(
             self._eval_min_num_iterations_kernel,
             dim=(self.num_worlds, self.num_tiles_coords),
-            block_dim=max(32, min(256, self.tile_size_coords // 8)),
+            block_dim=get_block_size(self.tile_size_coords),
             inputs=[
                 self.world_actuated_coord_offsets,
                 self.actuators_q_prev,
@@ -1102,7 +1105,7 @@ class ForwardKinematicsSolver:
             self._eval_max_constraint_kernel,
             dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, max_constraint],
-            block_dim=max(32, min(256, self.tile_size_cts_1d // 8)),
+            block_dim=get_block_size(self.tile_size_cts_1d),
             device=self.device,
         )
 
@@ -1233,7 +1236,7 @@ class ForwardKinematicsSolver:
             self._eval_merit_function_kernel,
             dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, error],
-            block_dim=max(32, min(256, self.tile_size_cts_1d // 8)),
+            block_dim=get_block_size(self.tile_size_cts_1d),
             device=self.device,
         )
 
@@ -1252,7 +1255,7 @@ class ForwardKinematicsSolver:
             self._eval_merit_function_gradient_kernel,
             dim=(self.num_worlds, self.num_tiles_vrs_1d),
             inputs=[step, grad, error_grad],
-            block_dim=max(32, min(256, self.tile_size_vrs_1d // 8)),
+            block_dim=get_block_size(self.tile_size_vrs_1d),
             device=self.device,
         )
 
@@ -1895,6 +1898,23 @@ class ForwardKinematicsSolver:
 ###
 # Functions
 ###
+
+
+def get_tile_size(size: int, max_size: int = 2048):
+    """Rounds up size into a power-of-two tile size, clamping to the [1, max_size] range if needed."""
+    if size < 1:
+        return 1
+    return min(max_size, 2 ** math.ceil(math.log(size, 2)))
+
+
+def get_num_tiles(size: int, tile_size: int):
+    """Computes the number of tiles needed to cover an array of given size, with tiles of given size."""
+    return (size + tile_size - 1) // tile_size
+
+
+def get_block_size(tile_size: int, ratio: int = 8, min_size: int = 32, max_size: int = 256):
+    """Computes the block size as a fixed ratio of the tile size, clamped to a min-max range."""
+    return max(min_size, min(max_size, tile_size // ratio))
 
 
 def compute_fk_equivalence_classes(model: ModelKamino) -> list[list[int]]:

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -7,6 +7,7 @@ Defines configurations for :class:`SolverKamino`.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -845,20 +846,20 @@ class ForwardKinematicsSolverConfig:
     Defaults to `True`.
     """
 
-    max_linear_incremental_step_meters: float = 0.05
+    max_linear_incremental_step: float = 0.05
     """
     If incremental solve is enabled, maximal allowed step in linear actuator coordinates
     per solver iteration, in meters. A lower value results in more incremental steps.
     Changes to this setting after the solver's initialization will have no effect.
-    Defaults to `0.1`.
+    Defaults to `0.05`.
     """
 
-    max_angular_incremental_step_degrees: float = 10.0
+    max_angular_incremental_step: float = math.radians(10.0)
     """
     If incremental solve is enabled, maximal allowed step in angular actuator coordinates
-    per solver iteration, in degrees. A lower value results in more incremental steps.
+    per solver iteration, in radians. A lower value results in more incremental steps.
     Changes to this setting after the solver's initialization will have no effect.
-    Defaults to `10.0`.
+    Defaults to `math.radians(10.0)`, i.e. 10 degrees.
     """
 
     @override
@@ -913,10 +914,10 @@ class ForwardKinematicsSolverConfig:
             raise ValueError("`max_line_search_iterations` must be positive.")
         if self.tolerance <= 0.0:
             raise ValueError("`tolerance` must be positive.")
-        if self.max_linear_incremental_step_meters <= 0.0:
-            raise ValueError("`max_linear_incremental_step_meters` must be positive.")
-        if self.max_angular_incremental_step_degrees <= 0.0:
-            raise ValueError("`max_angular_incremental_step_degrees` must be positive.")
+        if self.max_linear_incremental_step <= 0.0:
+            raise ValueError("`max_linear_incremental_step` must be positive.")
+        if self.max_angular_incremental_step <= 0.0:
+            raise ValueError("`max_angular_incremental_step` must be positive.")
 
     @override
     def __post_init__(self):

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -837,6 +837,30 @@ class ForwardKinematicsSolverConfig:
     Defaults to `True`.
     """
 
+    use_incremental_solve: bool = True
+    """
+    Whether to automatically split large steps in actuator coordinates into smaller steps
+    in the FK solve, to improve the solver's robustness for a mild added cost.
+    Changes to this setting after the solver's initialization lead to undefined behavior.
+    Defaults to `True`.
+    """
+
+    max_linear_incremental_step_meters: float = 0.05
+    """
+    If incremental solve is enabled, maximal allowed step in linear actuator coordinates
+    per solver iteration, in meters. A lower value results in more incremental steps.
+    Changes to this setting after the solver's initialization will have no effect.
+    Defaults to `0.1`.
+    """
+
+    max_angular_incremental_step_degrees: float = 10.0
+    """
+    If incremental solve is enabled, maximal allowed step in angular actuator coordinates
+    per solver iteration, in degrees. A lower value results in more incremental steps.
+    Changes to this setting after the solver's initialization will have no effect.
+    Defaults to `10.0`.
+    """
+
     @override
     @staticmethod
     def register_custom_attributes(builder: ModelBuilder) -> None:
@@ -889,6 +913,10 @@ class ForwardKinematicsSolverConfig:
             raise ValueError("`max_line_search_iterations` must be positive.")
         if self.tolerance <= 0.0:
             raise ValueError("`tolerance` must be positive.")
+        if self.max_linear_incremental_step_meters <= 0.0:
+            raise ValueError("`max_linear_incremental_step_meters` must be positive.")
+        if self.max_angular_incremental_step_degrees <= 0.0:
+            raise ValueError("`max_angular_incremental_step_degrees` must be positive.")
 
     @override
     def __post_init__(self):

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -350,7 +350,7 @@ def simulate_random_poses(
         base_u = wp.array(shape=(model.size.num_worlds), dtype=vec6f)
         actuators_u = wp.array(shape=(actuators_u_np.shape[1]), dtype=wp.float32)
     data = model.data(device=model.device)
-    epsilon = 1e-2
+    epsilon = 1e-4
     for pose_id in range(num_poses):
         # Run FK solve and check convergence
         base_q.assign(base_q_np[pose_id])

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -137,17 +137,19 @@ def get_actuators_q_quaternion_first_ids(model: ModelKamino):
     return quat_ids
 
 
-def compute_actuated_coords_and_dofs_offsets(model: ModelKamino):
+def compute_actuated_coords_and_dofs_data(model: ModelKamino):
     """
     Helper function computing the offsets and sizes needed to extract actuated joint coordinates
-    and dofs from all joint coordinates/dofs
-    Returns actuated_coords_offsets, actuated_coords_sizes, actuated_dofs_offsets, actuated_dofs_sizes
+    and dofs from all joint coordinates/dofs, as well as the corresponding dof types.
+    Returns actuated_coords_offsets, actuated_coords_sizes, actuated_dofs_offsets, actuated_dofs_sizes,
+            actuator_dof_types
     """
-    # Retrieve joint coordinates/dofs sizes and offsets (offset arrays include a trailing total)
+    # Retrieve data for all joints (offset arrays include a trailing total)
     coord_offsets = model.joints.coords_offset.numpy()[:-1]
     joint_num_coords = model.joints.num_coords.numpy()
     dof_offsets = model.joints.dofs_offset.numpy()[:-1]
     joint_num_dofs = model.joints.num_dofs.numpy()
+    joint_dof_types = model.joints.dof_type.numpy()
 
     # Filter for actuators only
     joint_is_actuator = model.joints.act_type.numpy() != JointActuationType.PASSIVE
@@ -155,8 +157,42 @@ def compute_actuated_coords_and_dofs_offsets(model: ModelKamino):
     actuated_coords_sizes = joint_num_coords[joint_is_actuator]
     actuated_dof_offsets = dof_offsets[joint_is_actuator]
     actuated_dofs_sizes = joint_num_dofs[joint_is_actuator]
+    actuator_dof_types = joint_dof_types[joint_is_actuator]
 
-    return actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes
+    return actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes, actuator_dof_types
+
+
+def standardize_actuated_coords(
+    actuators_q: np.ndarray, actuated_coords_sizes: np.ndarray, actuator_dof_types: np.ndarray
+) -> np.ndarray:
+    """
+    Helper function converting actuator coordinates to their canonical, comparable form.
+    More specifically, angles are mapped to the [0, 2 * pi) range, and unit quaternions to their
+    representation with a positive real part.
+    """
+
+    def standardize_angle(angle):
+        return np.mod(angle, 2.0 * np.pi)
+
+    def standardize_quat(quat):
+        return -quat if quat[3] < 0.0 else quat
+
+    res = actuators_q.copy()
+    coord_id = 0
+    for i, dof_type in enumerate(actuator_dof_types):
+        if dof_type == JointDoFType.CYLINDRICAL:
+            res[coord_id + 1] = standardize_angle(res[coord_id + 1])
+        elif dof_type == JointDoFType.FREE:
+            res[coord_id + 3 : coord_id + 7] = standardize_quat(res[coord_id + 3 : coord_id + 7])
+        if dof_type == JointDoFType.REVOLUTE:
+            res[coord_id] = standardize_angle(res[coord_id])
+        elif dof_type == JointDoFType.SPHERICAL:
+            res[coord_id : coord_id + 4] = standardize_quat(res[coord_id : coord_id + 4])
+        if dof_type == JointDoFType.UNIVERSAL:
+            res[coord_id] = standardize_angle(res[coord_id])
+            res[coord_id + 1] = standardize_angle(res[coord_id + 1])
+        coord_id += actuated_coords_sizes[i]
+    return res
 
 
 def extract_segments(array, offsets, sizes):
@@ -179,8 +215,8 @@ def compute_constraint_residual_mask(model: ModelKamino):
     mask = np.array(model.size.sum_of_num_joint_cts * [True])
 
     # Exclude base joints
-    first_joint_ct_id = model.joints.cts_offset.numpy().copy()  # Cts offset per joint
-    num_joint_cts = model.joints.num_cts.numpy()  # Num cts per joint
+    first_joint_ct_id = model.joints.kinematic_cts_offset.numpy().copy()  # Cts offset per joint
+    num_joint_cts = model.joints.num_kinematic_cts.numpy()  # Num cts per joint
     base_joint_index = model.info.base_joint_index.numpy().tolist()
     for wd_id in range(model.size.num_worlds):
         if base_joint_index[wd_id] < 0:
@@ -291,8 +327,8 @@ def simulate_random_poses(
     base_u_np, actuators_u_np = generate_random_inputs_u(model, num_poses, max_base_u, max_actuators_u, rng)
 
     # Precompute offset arrays for extracting actuator coordinates/dofs
-    actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes = (
-        compute_actuated_coords_and_dofs_offsets(model)
+    actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes, actuator_dof_types = (
+        compute_actuated_coords_and_dofs_data(model)
     )
 
     # Precompute boolean mask for extracting relevant constraint residuals
@@ -349,7 +385,11 @@ def simulate_random_poses(
             print(f"Large constraint residual ({residual_ct_pos}) for pose {pose_id}")
             success_flags[-1] = False
         actuators_q_check = extract_segments(data.joints.q_j.numpy(), actuated_coord_offsets, actuated_coords_sizes)
-        residual_actuators_q = np.max(np.abs(actuators_q_check - actuators_q_np[pose_id]))
+        actuators_q_check = standardize_actuated_coords(actuators_q_check, actuated_coords_sizes, actuator_dof_types)
+        actuators_q_ref = standardize_actuated_coords(
+            actuators_q_np[pose_id], actuated_coords_sizes, actuator_dof_types
+        )
+        residual_actuators_q = np.max(np.abs(actuators_q_check - actuators_q_ref))
         if residual_actuators_q > epsilon:
             print(f"Large error on prescribed actuator coordinates ({residual_actuators_q}) for pose {pose_id}")
             success_flags[-1] = False
@@ -401,7 +441,7 @@ class DRTestMechanismRandomPosesCheckForwardKinematics(unittest.TestCase):
         # Simulate random poses
         num_poses = 30
         base_q_max = np.array(3 * [0.2] + 4 * [1.0])
-        actuators_q_max = np.radians([95.0])
+        actuators_q_max = np.radians([360.0])
         base_u_max = np.array(3 * [0.1] + 3 * [0.5])
         actuators_u_max = np.array([0.5])
         success = simulate_random_poses(
@@ -493,7 +533,7 @@ class HeterogenousModelRandomPosesCheckForwardKinematics(unittest.TestCase):
 
         # Simulate random poses
         num_poses = 30
-        theta_max_test_mech = np.radians(100.0)
+        theta_max_test_mech = np.radians(360.0)
         theta_max_dr_legs = np.radians(10.0)
         base_q_max = np.array(3 * [0.2] + 4 * [1.0] + 3 * [0.2] + 4 * [1.0])
         actuators_q_max = np.array([theta_max_test_mech] + builder1.num_actuated_joint_coords * [theta_max_dr_legs])
@@ -570,7 +610,7 @@ class HeterogenousModelSparseJacobianAssemblyCheck(unittest.TestCase):
         # Generate random poses
         num_poses = 30
         bodies_q_max = np.array(model.size.sum_of_num_bodies * [0.2, 0.2, 0.2, 1.0, 1.0, 1.0, 1.0])
-        theta_max_test_mech = np.radians(100.0)
+        theta_max_test_mech = np.radians(360.0)
         theta_max_dr_legs = np.radians(10.0)
         base_q_max = np.array(3 * [0.2] + 4 * [1.0] + 3 * [0.2] + 4 * [1.0])
         actuators_q_max = np.array([theta_max_test_mech] + builder1.num_actuated_joint_coords * [theta_max_dr_legs])


### PR DESCRIPTION
## Description

To increase the robustness of the FK solver, in particular resetting to poses that are far from the rest pose, this introduces the option to decompose large jumps in actuator coordinates into several intermediary steps, by updating the target actuator coordinates incrementally at every Newton iteration.

This PR also includes two related bug fixes (that prevented modified unit tests from passing):
- The kernel resetting from base pose (within FK, as initial guess) was not fully general (was assuming zero/identity initial actuator coordinates) which led up to the base offset being applied twice in the case of a base body (not of a base joint).
- The computation of joint relative velocity in kinematics/joints.py (for velocity-level residuals) was missing a term, so velocity-level residuals that should have been zero were not.

Resolves vastsoun/newton#319

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

This was tested on animatronic examples and was seen to improve the robustness significantly. The unit tests have also been altered to largely increase the sampling range of random poses, to demonstrate the added robustness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental actuator-coordinate solving with configurable linear/angular step limits and per-world minimum-iteration enforcement.
  * Support for incremental target actuator updates during solves.

* **Improvements**
  * Optional quaternion normalization and improved actuator-coordinate evaluation/correction (angle wrapping and quaternion sign canonicalization).
  * Adjusted body angular-velocity handling and stricter Newton convergence gating.

* **Tests**
  * FK tests updated with standardized actuator-coordinate canonicalization and tighter validation tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->