### PR TITLE
Add guard against invalid block or tile size in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/linalg/conjugate.py
+++ b/newton/_src/solvers/kamino/_src/linalg/conjugate.py
@@ -628,7 +628,7 @@ class ConjugateSolver:
             wp.launch_tiled(
                 self.tiled_dot_kernel,
                 dim=(a.shape[0], self.n_worlds),
-                block_dim=min(256, self.dot_tile_size // 8),
+                block_dim=max(1, min(256, self.dot_tile_size // 8)),
                 inputs=[a, b, self.vio, active_dims, world_active],
                 outputs=[result],
                 device=self.device,

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -9,7 +9,6 @@ See the :mod:`newton._src.solvers.kamino._src.solvers.fk` module for a detailed 
 
 from __future__ import annotations
 
-import math
 import sys
 
 import numpy as np
@@ -28,6 +27,7 @@ from ...linalg.conjugate import BatchedLinearOperator, CGSolver
 from ...linalg.factorize.llt_blocked_semi_sparse import SemiSparseBlockCholeskySolverBatched
 from ...linalg.sparse_matrix import BlockDType, BlockSparseMatrices
 from ...linalg.sparse_operator import BlockSparseLinearOperators
+from ...utils.tile import get_block_dim, get_num_tiles, get_tile_size
 from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_classes
 from .kernels import (
     _apply_line_search_step,
@@ -973,7 +973,7 @@ class ForwardKinematicsSolver:
         wp.launch_tiled(
             self._eval_min_num_iterations_kernel,
             dim=(self.num_worlds, self.num_tiles_coords),
-            block_dim=get_block_size(self.tile_size_coords),
+            block_dim=get_block_dim(self.tile_size_coords),
             inputs=[
                 self.world_actuated_coord_offsets,
                 self.actuators_q_prev,
@@ -1105,7 +1105,7 @@ class ForwardKinematicsSolver:
             self._eval_max_constraint_kernel,
             dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, max_constraint],
-            block_dim=get_block_size(self.tile_size_cts_1d),
+            block_dim=get_block_dim(self.tile_size_cts_1d),
             device=self.device,
         )
 
@@ -1236,7 +1236,7 @@ class ForwardKinematicsSolver:
             self._eval_merit_function_kernel,
             dim=(self.num_worlds, self.num_tiles_cts_1d),
             inputs=[constraints, error],
-            block_dim=get_block_size(self.tile_size_cts_1d),
+            block_dim=get_block_dim(self.tile_size_cts_1d),
             device=self.device,
         )
 
@@ -1255,7 +1255,7 @@ class ForwardKinematicsSolver:
             self._eval_merit_function_gradient_kernel,
             dim=(self.num_worlds, self.num_tiles_vrs_1d),
             inputs=[step, grad, error_grad],
-            block_dim=get_block_size(self.tile_size_vrs_1d),
+            block_dim=get_block_dim(self.tile_size_vrs_1d),
             device=self.device,
         )
 
@@ -1898,23 +1898,6 @@ class ForwardKinematicsSolver:
 ###
 # Functions
 ###
-
-
-def get_tile_size(size: int, max_size: int = 2048):
-    """Rounds up size into a power-of-two tile size, clamping to the [1, max_size] range if needed."""
-    if size < 1:
-        return 1
-    return min(max_size, 2 ** math.ceil(math.log(size, 2)))
-
-
-def get_num_tiles(size: int, tile_size: int):
-    """Computes the number of tiles needed to cover an array of given size, with tiles of given size."""
-    return (size + tile_size - 1) // tile_size
-
-
-def get_block_size(tile_size: int, ratio: int = 8, min_size: int = 32, max_size: int = 256):
-    """Computes the block size as a fixed ratio of the tile size, clamped to a min-max range."""
-    return max(min_size, min(max_size, tile_size // ratio))
 
 
 def compute_fk_equivalence_classes(model: ModelKamino) -> list[list[int]]:

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -11,8 +11,6 @@ See the :mod:`newton._src.solvers.kamino.solvers.padmm` module for a detailed de
 
 from __future__ import annotations
 
-import math
-
 import warp as wp
 
 from ....config import PADMMSolverConfig
@@ -22,6 +20,7 @@ from ...core.size import SizeKamino
 from ...dynamics.dual import DualProblem
 from ...geometry.contacts import ContactsKamino
 from ...kinematics.limits import LimitsKamino
+from ...utils.tile import get_block_dim, get_tile_size
 from .kernels import (
     _apply_dual_preconditioner_to_solution,
     _apply_dual_preconditioner_to_state,
@@ -1198,11 +1197,8 @@ class PADMMSolver:
             problem (DualProblem): The dual forward dynamics problem to be solved.
         """
         # Compute infinity-norm of all residuals and check for convergence
-        if self._size.max_of_max_total_cts > 0:
-            tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
-        else:
-            tile_size = 1
-        block_dim = max(1, min(256, tile_size // 8))
+        tile_size = get_tile_size(self._size.max_of_max_total_cts)
+        block_dim = get_block_dim(tile_size, min_size=1)
         wp.launch_tiled(
             kernel=_make_compute_infnorm_residuals_kernel(
                 tile_size,
@@ -1242,11 +1238,8 @@ class PADMMSolver:
             problem (DualProblem): The dual forward dynamics problem to be solved.
         """
         # Compute infinity-norm of all residuals and check for convergence
-        if self._size.max_of_max_total_cts > 0:
-            tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
-        else:
-            tile_size = 1
-        block_dim = max(1, min(256, tile_size // 8))
+        tile_size = get_tile_size(self._size.max_of_max_total_cts)
+        block_dim = get_block_dim(tile_size, min_size=1)
         wp.launch_tiled(
             kernel=_make_compute_infnorm_residuals_accel_kernel(
                 tile_size,

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -1198,8 +1198,11 @@ class PADMMSolver:
             problem (DualProblem): The dual forward dynamics problem to be solved.
         """
         # Compute infinity-norm of all residuals and check for convergence
-        tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
-        block_dim = min(256, tile_size // 8)
+        if self._size.max_of_max_total_cts > 0:
+            tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
+        else:
+            tile_size = 1
+        block_dim = max(1, min(256, tile_size // 8))
         wp.launch_tiled(
             kernel=_make_compute_infnorm_residuals_kernel(
                 tile_size,
@@ -1239,8 +1242,11 @@ class PADMMSolver:
             problem (DualProblem): The dual forward dynamics problem to be solved.
         """
         # Compute infinity-norm of all residuals and check for convergence
-        tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
-        block_dim = min(256, tile_size // 8)
+        if self._size.max_of_max_total_cts > 0:
+            tile_size = min(2048, 2 ** math.ceil(math.log(self._size.max_of_max_total_cts, 2)))
+        else:
+            tile_size = 1
+        block_dim = max(1, min(256, tile_size // 8))
         wp.launch_tiled(
             kernel=_make_compute_infnorm_residuals_accel_kernel(
                 tile_size,

--- a/newton/_src/solvers/kamino/_src/utils/tile.py
+++ b/newton/_src/solvers/kamino/_src/utils/tile.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""KAMINO: Utilities: tile and block sizing helpers."""
+
+from __future__ import annotations
+
+import math
+
+__all__ = [
+    "get_block_dim",
+    "get_num_tiles",
+    "get_tile_size",
+]
+
+
+def get_tile_size(size: int, max_size: int = 2048) -> int:
+    """Return a power-of-two tile size that covers ``size``.
+
+    The tile size is the smallest power-of-two value greater than or equal to
+    ``size``, clamped to ``[1, max_size]``.
+
+    Args:
+        size: Number of elements to cover.
+        max_size: Maximum allowed tile size.
+
+    Returns:
+        A power-of-two tile size in ``[1, max_size]``.
+    """
+    if size < 1:
+        return 1
+    return min(max_size, 2 ** math.ceil(math.log(size, 2)))
+
+
+def get_num_tiles(size: int, tile_size: int) -> int:
+    """Return the number of tiles required to cover ``size`` elements.
+
+    Args:
+        size: Number of elements to cover.
+        tile_size: Number of elements per tile.
+
+    Returns:
+        Number of tiles needed so that ``num_tiles * tile_size >= size``.
+    """
+    return (size + tile_size - 1) // tile_size
+
+
+def get_block_dim(tile_size: int, ratio: int = 8, min_size: int = 32, max_size: int = 256) -> int:
+    """Return a launch block dimension derived from a tile size.
+
+    Computes ``tile_size // ratio`` and clamps the result to
+    ``[min_size, max_size]``.
+
+    Args:
+        tile_size: Tile size the kernel operates on.
+        ratio: Ratio between tile size and block dimension.
+        min_size: Minimum block size.
+        max_size: Maximum block size.
+
+    Returns:
+        A block dimension suitable for passing as ``block_dim`` to tiled launches.
+    """
+    return max(min_size, min(max_size, tile_size // ratio))

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -657,6 +657,32 @@ class TestPADMMSolver(unittest.TestCase):
             path = self.output_path / "test_07_padmm_solve_with_acceleration_and_container_warmstart.pdf"
             save_solver_info(solver=solver, path=str(path))
 
+    def test_10_padmm_solve_single_contact(self):
+        """
+        Tests the Proximal-ADMM (PADMM) solver with default config on the reference problem (no
+        constraints and limits) with a single contact.
+        """
+        # Create the test problem
+        test = TestSetup(builder_fn=basics.build_box_on_plane, max_world_contacts=1, device=self.default_device)
+
+        # Create the PADMM solver
+        solver = PADMMSolver(model=test.model)
+
+        # Solve the test problem
+        test.build()
+        solver.reset()
+        solver.coldstart()
+        solver.solve(problem=test.problem)
+
+        # Extract solver info
+        if self.savefig:
+            msg.notif("Generating solver info plots...")
+            path = self.output_path / "test_10_padmm_solve.pdf"
+            save_solver_info(solver=solver, path=str(path))
+
+        # Check solution
+        check_padmm_solution(self, test.model, test.problem, solver, verbose=self.verbose)
+
 
 ###
 # Test execution


### PR DESCRIPTION
## Description

This PR guards against some edges cases where kernel launch parameters (tile size and block size) that are computed from the problem size would be set to invalid values. Specifically, it guards against setting `block_dim=0` when there are too few constraints in a model.

Issues were detected for the kernel parameters in the ADMM solver, though just in case, a guard was also added to the conjugate solver, which could end up with `block_dim==0` if the tile size is smaller than 8 (which happens for `maxdims < 5`).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

1. Create a model with two bodies, each one with a sphere shape.
2. Instantiate a simulation with `SolverKamino` without any controls and contacts.
3. Run `step()` on the solver, which will run indefinitely if run on GPU.

**Minimal reproduction:**

```python
import newton
import warp as wp


def main() -> int:
    builder = newton.ModelBuilder(gravity=0.0)
    newton.solvers.SolverKamino.register_custom_attributes(builder)
    body_a = builder.add_body(
        xform=wp.transform(wp.vec3(-0.3, 0.0, 0.0), wp.quat_identity()),
        mass=1.0,
    )
    builder.add_shape_sphere(body_a, radius=0.1)
    body_b = builder.add_body(
        xform=wp.transform(wp.vec3(0.45, 0.0, 0.0), wp.quat_identity()),
        mass=1.0,
    )
    builder.add_shape_sphere(body_b, radius=0.1)
    model = builder.finalize()
    solver = newton.solvers.SolverKamino(model)

    print("Executing step...")
    state_0, state_1 = model.state(), model.state()

    solver.step(state_0, state_1, None, None, 0.01)

    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid GPU kernel launches by clamping tile/block sizes to safe minima, avoiding zero-dimension cases.
  * Improved convergence checks to use robust tile/block sizing so edge cases (e.g., minimal constraints) no longer cause invalid behavior.

* **Refactor**
  * Centralized tile/block sizing into shared helpers for consistent behavior across solvers.

* **Tests**
  * Added a unit test validating solver behavior with a single-contact configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->