### PR TITLE
Fix vbd contact offset handling for friction anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@
 - Fix `eq_objtype` mismatch for joint equality and mimic constraints in `SolverMuJoCo` so compiled models match native MuJoCo XML behavior
 - Fix implicit-MPM rheology solver launch-dim handling under `warp-lang` 1.13's templated `launch_bounds` (formerly produced out-of-bounds reads)
 - Fix `SolverKamino.reset` clobbering `q_j_p`, `q_j`, and `dq_j` for worlds outside `world_mask` when `joint_q`/`joint_u` targets were provided. The previous unmasked writes broke TWOPI revolute-joint angle unwrapping after partial-mask resets.
+- Fix rigid-rigid friction in `SolverVBD` for contacts with nonzero `rigid_contact_offset0/rigid_contact_offset1`.
 
 ## [1.1.0] - 2026-04-13
 

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -580,6 +580,8 @@ def evaluate_rigid_contact_from_collision(
     body_com: wp.array[wp.vec3],
     contact_point_a_local: wp.vec3,
     contact_point_b_local: wp.vec3,
+    contact_offset_a_local: wp.vec3,
+    contact_offset_b_local: wp.vec3,
     contact_normal: wp.vec3,
     penetration_depth: float,
     contact_ke: float,
@@ -598,6 +600,11 @@ def evaluate_rigid_contact_from_collision(
     The tangential constraint is the relative tangential displacement from body_q_prev to body_q,
     which correctly captures kinematic body motion.
     Soft contacts: velocity-based IPC friction with scalar penalty.
+
+    The friction anchor lives on the contact surface, computed as
+    ``contact_point_local + contact_offset_local``. Some narrow-phase contact points
+    lie on a shape skeleton, with the radial extent stored in ``contact_offset``.
+    Tangential slip must use the offset anchor so rigid rotation moves the contact point.
 
     Returns:
         10-tuple: (force_a, torque_a, H_ll_a, H_al_a, H_aa_a,
@@ -643,10 +650,15 @@ def evaluate_rigid_contact_from_collision(
     x_com_a_now = wp.transform_point(X_wa, body_a_com_local)
     x_com_b_now = wp.transform_point(X_wb, body_b_com_local)
 
-    x_c_a_now = wp.transform_point(X_wa, contact_point_a_local)
-    x_c_b_now = wp.transform_point(X_wb, contact_point_b_local)
-    x_c_a_prev = wp.transform_point(X_wa_prev, contact_point_a_local)
-    x_c_b_prev = wp.transform_point(X_wb_prev, contact_point_b_local)
+    # Friction anchor on the contact surface. The offset is body-local, so the same material
+    # point is tracked across all inner-solver iterations within a step. This is required for
+    # the ALM tangent multiplier to accumulate consistently.
+    anchor_a_local = contact_point_a_local + contact_offset_a_local
+    anchor_b_local = contact_point_b_local + contact_offset_b_local
+    x_c_a_now = wp.transform_point(X_wa, anchor_a_local)
+    x_c_b_now = wp.transform_point(X_wb, anchor_b_local)
+    x_c_a_prev = wp.transform_point(X_wa_prev, anchor_a_local)
+    x_c_b_prev = wp.transform_point(X_wb_prev, anchor_b_local)
 
     n_outer = wp.outer(contact_normal, contact_normal)
 
@@ -2476,6 +2488,8 @@ def accumulate_body_body_contacts_per_body(
     rigid_contact_shape1: wp.array[int],
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
     rigid_contact_margin0: wp.array[float],
     rigid_contact_margin1: wp.array[float],
@@ -2533,7 +2547,11 @@ def accumulate_body_body_contacts_per_body(
 
         cp0_local = rigid_contact_point0[contact_idx]
         cp1_local = rigid_contact_point1[contact_idx]
+        cp0_offset_local = rigid_contact_offset0[contact_idx]
+        cp1_offset_local = rigid_contact_offset1[contact_idx]
         contact_normal = rigid_contact_normal[contact_idx]
+        # Normal C_n uses the unprojected (skeleton) points: ``thickness`` already accounts
+        # for the radial extent, so adding the offset here would double-count it.
         cp0_world = wp.transform_point(body_q[b0], cp0_local) if b0 >= 0 else cp0_local
         cp1_world = wp.transform_point(body_q[b1], cp1_local) if b1 >= 0 else cp1_local
         thickness = rigid_contact_margin0[contact_idx] + rigid_contact_margin1[contact_idx]
@@ -2587,6 +2605,8 @@ def accumulate_body_body_contacts_per_body(
             body_com,
             cp0_local,
             cp1_local,
+            cp0_offset_local,
+            cp1_offset_local,
             contact_normal,
             C_eff,
             k,
@@ -2631,6 +2651,8 @@ def compute_rigid_contact_forces(
     rigid_contact_shape1: wp.array[int],
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
     rigid_contact_margin0: wp.array[float],
     rigid_contact_margin1: wp.array[float],
@@ -2685,12 +2707,20 @@ def compute_rigid_contact_forces(
 
     cp0_local = rigid_contact_point0[contact_idx]
     cp1_local = rigid_contact_point1[contact_idx]
+    cp0_offset_local = rigid_contact_offset0[contact_idx]
+    cp1_offset_local = rigid_contact_offset1[contact_idx]
     contact_normal = rigid_contact_normal[contact_idx]
 
+    # Normal C_n uses the unprojected (skeleton) points: ``thickness`` already accounts
+    # for the radial extent, so adding the offset here would double-count it.
     cp0_world = wp.transform_point(body_q[b0], cp0_local) if b0 >= 0 else cp0_local
     cp1_world = wp.transform_point(body_q[b1], cp1_local) if b1 >= 0 else cp1_local
-    out_point0_world[contact_idx] = cp0_world
-    out_point1_world[contact_idx] = cp1_world
+    out_point0_world[contact_idx] = (
+        wp.transform_point(body_q[b0], cp0_local + cp0_offset_local) if b0 >= 0 else cp0_local + cp0_offset_local
+    )
+    out_point1_world[contact_idx] = (
+        wp.transform_point(body_q[b1], cp1_local + cp1_offset_local) if b1 >= 0 else cp1_local + cp1_offset_local
+    )
 
     thickness = rigid_contact_margin0[contact_idx] + rigid_contact_margin1[contact_idx]
     d = cp1_world - cp0_world
@@ -2739,6 +2769,8 @@ def compute_rigid_contact_forces(
         body_com,
         cp0_local,
         cp1_local,
+        cp0_offset_local,
+        cp1_offset_local,
         contact_normal,
         C_eff,
         k,
@@ -3567,6 +3599,8 @@ def update_duals_body_body_contacts(
     rigid_contact_shape1: wp.array[int],
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
     rigid_contact_margin0: wp.array[float],
     rigid_contact_margin1: wp.array[float],
@@ -3608,20 +3642,30 @@ def update_duals_body_body_contacts(
 
     cp0_local = rigid_contact_point0[idx]
     cp1_local = rigid_contact_point1[idx]
+    # Friction anchor on the contact surface; see evaluate_rigid_contact_from_collision.
+    # The skeleton points (p0/p1) drive the normal C_n term so that ``thickness`` accounts
+    # for the radial extent without double-counting; the surface anchors (a0/a1) drive the
+    # tangential rel_disp so that spin about a body's symmetry axis registers as slip.
+    anchor0_local = cp0_local + rigid_contact_offset0[idx]
+    anchor1_local = cp1_local + rigid_contact_offset1[idx]
 
     if body_id_0 >= 0:
         p0_world = wp.transform_point(body_q[body_id_0], cp0_local)
-        p0_prev = wp.transform_point(body_q_prev[body_id_0], cp0_local)
+        a0_world = wp.transform_point(body_q[body_id_0], anchor0_local)
+        a0_prev = wp.transform_point(body_q_prev[body_id_0], anchor0_local)
     else:
         p0_world = cp0_local
-        p0_prev = cp0_local
+        a0_world = anchor0_local
+        a0_prev = anchor0_local
 
     if body_id_1 >= 0:
         p1_world = wp.transform_point(body_q[body_id_1], cp1_local)
-        p1_prev = wp.transform_point(body_q_prev[body_id_1], cp1_local)
+        a1_world = wp.transform_point(body_q[body_id_1], anchor1_local)
+        a1_prev = wp.transform_point(body_q_prev[body_id_1], anchor1_local)
     else:
         p1_world = cp1_local
-        p1_prev = cp1_local
+        a1_world = anchor1_local
+        a1_prev = anchor1_local
 
     n = rigid_contact_normal[idx]
     d = p1_world - p0_world
@@ -3644,7 +3688,7 @@ def update_duals_body_body_contacts(
         lam_n_old = wp.dot(lam_vec, n)
         lam_n_new = wp.max(lam_n_old + k * C_stab_n, 0.0)
 
-        rel_disp = (p0_world - p0_prev) - (p1_world - p1_prev)
+        rel_disp = (a0_world - a0_prev) - (a1_world - a1_prev)
         tangential_disp = rel_disp - n * wp.dot(n, rel_disp)
         C0_t_vec = C0_vec - n * C0_n
         lam_t_old = lam_vec - n * lam_n_old

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -601,11 +601,6 @@ def evaluate_rigid_contact_from_collision(
     which correctly captures kinematic body motion.
     Soft contacts: velocity-based IPC friction with scalar penalty.
 
-    The friction anchor lives on the contact surface, computed as
-    ``contact_point_local + contact_offset_local``. Some narrow-phase contact points
-    lie on a shape skeleton, with the radial extent stored in ``contact_offset``.
-    Tangential slip must use the offset anchor so rigid rotation moves the contact point.
-
     Returns:
         10-tuple: (force_a, torque_a, H_ll_a, H_al_a, H_aa_a,
                    force_b, torque_b, H_ll_b, H_al_b, H_aa_b)
@@ -650,9 +645,6 @@ def evaluate_rigid_contact_from_collision(
     x_com_a_now = wp.transform_point(X_wa, body_a_com_local)
     x_com_b_now = wp.transform_point(X_wb, body_b_com_local)
 
-    # Friction anchor on the contact surface. The offset is body-local, so the same material
-    # point is tracked across all inner-solver iterations within a step. This is required for
-    # the ALM tangent multiplier to accumulate consistently.
     anchor_a_local = contact_point_a_local + contact_offset_a_local
     anchor_b_local = contact_point_b_local + contact_offset_b_local
     x_c_a_now = wp.transform_point(X_wa, anchor_a_local)
@@ -3642,10 +3634,6 @@ def update_duals_body_body_contacts(
 
     cp0_local = rigid_contact_point0[idx]
     cp1_local = rigid_contact_point1[idx]
-    # Friction anchor on the contact surface; see evaluate_rigid_contact_from_collision.
-    # The skeleton points (p0/p1) drive the normal C_n term so that ``thickness`` accounts
-    # for the radial extent without double-counting; the surface anchors (a0/a1) drive the
-    # tangential rel_disp so that spin about a body's symmetry axis registers as slip.
     anchor0_local = cp0_local + rigid_contact_offset0[idx]
     anchor1_local = cp1_local + rigid_contact_offset1[idx]
 

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -2234,6 +2234,8 @@ def step_body_body_contact_C0_lambda(
     rigid_contact_shape1: wp.array[int],
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
     rigid_contact_margin0: wp.array[float],
     rigid_contact_margin1: wp.array[float],
@@ -2272,12 +2274,24 @@ def step_body_body_contact_C0_lambda(
         b1 = shape_body[s1] if s1 >= 0 else -1
         p0 = rigid_contact_point0[i]
         p1 = rigid_contact_point1[i]
+        anchor0_local = p0 + rigid_contact_offset0[i]
+        anchor1_local = p1 + rigid_contact_offset1[i]
         n = rigid_contact_normal[i]
+        # Normal: thickness already accounts for the radial extent, so use
+        # the unprojected skeleton points (matches update_duals_body_body_contacts).
         cp0 = wp.transform_point(body_q[b0], p0) if b0 >= 0 else p0
         cp1 = wp.transform_point(body_q[b1], p1) if b1 >= 0 else p1
         thickness = rigid_contact_margin0[i] + rigid_contact_margin1[i]
         d = cp1 - cp0
-        contact_C0[i] = n * thickness - d
+        C0_n = thickness - wp.dot(n, d)
+        # Tangential: use surface anchors so spin about a body's symmetry axis
+        # registers in the frozen tangential offset, matching tangential_disp
+        # in update_duals_body_body_contacts.
+        a0 = wp.transform_point(body_q[b0], anchor0_local) if b0 >= 0 else anchor0_local
+        a1 = wp.transform_point(body_q[b1], anchor1_local) if b1 >= 0 else anchor1_local
+        d_surf = a1 - a0
+        C0_t = -(d_surf - n * wp.dot(n, d_surf))
+        contact_C0[i] = n * C0_n + C0_t
 
 
 @wp.kernel

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -68,6 +68,8 @@ class RigidContactHistory:
     penalty_k: wp.array[float]
     point0: wp.array[wp.vec3]
     point1: wp.array[wp.vec3]
+    offset0: wp.array[wp.vec3]
+    offset1: wp.array[wp.vec3]
     normal: wp.array[wp.vec3]
 
 
@@ -2128,6 +2130,8 @@ def init_body_body_contacts_avbd(
     # In/out: replayed only for matched hard contacts that were sticking.
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     # Outputs
     contact_penalty_k: wp.array[float],
     contact_lambda: wp.array[wp.vec3],
@@ -2141,8 +2145,8 @@ def init_body_body_contacts_avbd(
     penalty_k, and stick-anchor points when the previous matched contact stuck.
     For soft contacts: restores penalty_k only; lambda stays zero because the
     soft path is penalty-only.
-    Sticky hard contacts may overwrite rigid_contact_point0/1 in place with the
-    previously saved contact anchors.
+    Sticky hard contacts may overwrite rigid_contact_point0/1 and
+    rigid_contact_offset0/1 in place with the previously saved contact anchors.
     C0 and decay are handled by step_body_body_contact_C0_lambda.
 
     match_index[i] addresses saved contact rows from the last snapshot.
@@ -2182,10 +2186,14 @@ def init_body_body_contacts_avbd(
             contact_lambda[i] = n_new * lam_n + lam_t_new
 
             stick_flag = history.stick_flag[slot]
-            # Replay saved points only for contacts whose saved state was sticking.
+            # Replay saved points and offsets only for contacts whose saved
+            # state was sticking. Point and offset must move together; the
+            # surface anchor is ``point + offset``.
             if stick_flag == _STICK_FLAG_ANCHOR or stick_flag == _STICK_FLAG_DEADZONE:
                 rigid_contact_point0[i] = history.point0[slot]
                 rigid_contact_point1[i] = history.point1[slot]
+                rigid_contact_offset0[i] = history.offset0[slot]
+                rigid_contact_offset1[i] = history.offset1[slot]
         else:
             contact_lambda[i] = wp.vec3(0.0)
     else:
@@ -2198,6 +2206,8 @@ def snapshot_body_body_contact_history(
     rigid_contact_count: wp.array[int],
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
     contact_lambda: wp.array[wp.vec3],
     contact_stick_flag: wp.array[wp.int32],
@@ -2208,6 +2218,8 @@ def snapshot_body_body_contact_history(
     prev_penalty_k: wp.array[float],
     prev_point0: wp.array[wp.vec3],
     prev_point1: wp.array[wp.vec3],
+    prev_offset0: wp.array[wp.vec3],
+    prev_offset1: wp.array[wp.vec3],
     prev_normal: wp.array[wp.vec3],
 ):
     """Snapshot converged contact state by contact row.
@@ -2224,6 +2236,8 @@ def snapshot_body_body_contact_history(
     prev_penalty_k[i] = contact_penalty_k[i]
     prev_point0[i] = rigid_contact_point0[i]
     prev_point1[i] = rigid_contact_point1[i]
+    prev_offset0[i] = rigid_contact_offset0[i]
+    prev_offset1[i] = rigid_contact_offset1[i]
     prev_normal[i] = rigid_contact_normal[i]
 
 

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -1904,6 +1904,8 @@ class SolverVBD(SolverBase):
                         contacts.rigid_contact_shape1,
                         contacts.rigid_contact_point0,
                         contacts.rigid_contact_point1,
+                        contacts.rigid_contact_offset0,
+                        contacts.rigid_contact_offset1,
                         contacts.rigid_contact_normal,
                         contacts.rigid_contact_margin0,
                         contacts.rigid_contact_margin1,

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -692,6 +692,8 @@ class SolverVBD(SolverBase):
             self._prev_contact_penalty_k = None
             self._prev_contact_point0 = None
             self._prev_contact_point1 = None
+            self._prev_contact_offset0 = None
+            self._prev_contact_offset1 = None
             self._prev_contact_normal = None
 
             # Joint augmented-Lagrangian state (vec3, per-joint, bilateral)
@@ -802,6 +804,8 @@ class SolverVBD(SolverBase):
         self._prev_contact_penalty_k = wp.zeros(cap, dtype=float, device=self.device)
         self._prev_contact_point0 = wp.zeros(cap, dtype=wp.vec3, device=self.device)
         self._prev_contact_point1 = wp.zeros(cap, dtype=wp.vec3, device=self.device)
+        self._prev_contact_offset0 = wp.zeros(cap, dtype=wp.vec3, device=self.device)
+        self._prev_contact_offset1 = wp.zeros(cap, dtype=wp.vec3, device=self.device)
         self._prev_contact_normal = wp.zeros(cap, dtype=wp.vec3, device=self.device)
 
     def _raise_if_capturing_resize(self, name: str, current: int, required: int) -> None:
@@ -1618,6 +1622,8 @@ class SolverVBD(SolverBase):
                 contacts.rigid_contact_count,
                 contacts.rigid_contact_point0,
                 contacts.rigid_contact_point1,
+                contacts.rigid_contact_offset0,
+                contacts.rigid_contact_offset1,
                 contacts.rigid_contact_normal,
                 self.body_body_contact_lambda,
                 self.body_body_contact_stick_flag,
@@ -1629,6 +1635,8 @@ class SolverVBD(SolverBase):
                 self._prev_contact_penalty_k,
                 self._prev_contact_point0,
                 self._prev_contact_point1,
+                self._prev_contact_offset0,
+                self._prev_contact_offset1,
                 self._prev_contact_normal,
             ],
             device=self.device,
@@ -1835,6 +1843,8 @@ class SolverVBD(SolverBase):
                         history.penalty_k = self._prev_contact_penalty_k
                         history.point0 = self._prev_contact_point0
                         history.point1 = self._prev_contact_point1
+                        history.offset0 = self._prev_contact_offset0
+                        history.offset1 = self._prev_contact_offset1
                         history.normal = self._prev_contact_normal
 
                         wp.launch(
@@ -1856,6 +1866,8 @@ class SolverVBD(SolverBase):
                             outputs=[
                                 contacts.rigid_contact_point0,
                                 contacts.rigid_contact_point1,
+                                contacts.rigid_contact_offset0,
+                                contacts.rigid_contact_offset1,
                                 self.body_body_contact_penalty_k,
                                 self.body_body_contact_lambda,
                                 self.body_body_contact_material_kd,

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -211,7 +211,7 @@ class SolverVBD(SolverBase):
         particle_rest_shape_contact_exclusion_radius: float = 0.0,
         particle_external_vertex_contact_filtering_map: dict | None = None,
         particle_external_edge_contact_filtering_map: dict | None = None,
-        # Rigid body parameters — AVBD hyperparameters
+        # Rigid body parameters - AVBD hyperparameters
         rigid_avbd_alpha: float = 0.95,  # C0 stabilization strength (C_stab = C - alpha * C0)
         rigid_avbd_joint_alpha: float | None = None,  # Joint alpha override; None uses rigid_avbd_alpha
         rigid_avbd_contact_alpha: float | None = None,  # Body-body contact alpha; None selects default
@@ -2414,6 +2414,8 @@ class SolverVBD(SolverBase):
                         contacts.rigid_contact_shape1,
                         contacts.rigid_contact_point0,
                         contacts.rigid_contact_point1,
+                        contacts.rigid_contact_offset0,
+                        contacts.rigid_contact_offset1,
                         contacts.rigid_contact_normal,
                         contacts.rigid_contact_margin0,
                         contacts.rigid_contact_margin1,
@@ -2499,6 +2501,8 @@ class SolverVBD(SolverBase):
                     contacts.rigid_contact_shape1,
                     contacts.rigid_contact_point0,
                     contacts.rigid_contact_point1,
+                    contacts.rigid_contact_offset0,
+                    contacts.rigid_contact_offset1,
                     contacts.rigid_contact_normal,
                     contacts.rigid_contact_margin0,
                     contacts.rigid_contact_margin1,
@@ -2679,6 +2683,8 @@ class SolverVBD(SolverBase):
                 contacts.rigid_contact_shape1,
                 contacts.rigid_contact_point0,
                 contacts.rigid_contact_point1,
+                contacts.rigid_contact_offset0,
+                contacts.rigid_contact_offset1,
                 contacts.rigid_contact_normal,
                 contacts.rigid_contact_margin0,
                 contacts.rigid_contact_margin1,

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -3252,7 +3252,10 @@ def _cable_kinematic_gripper_picks_capsule_impl(test: unittest.TestCase, device)
 
     fps = 60.0
     frame_dt = 1.0 / fps
-    sim_substeps = 2
+    # AVBD friction tracking under the surface-anchor moment arm needs either
+    # dt ≲ 4 ms (substeps ≥ 4) or rigid_avbd_contact_alpha ≲ 0.5; both stay
+    # well inside the 1 cm tolerance below.
+    sim_substeps = 4
     sim_dt = frame_dt / sim_substeps
 
     # Record initial pose

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -3,6 +3,7 @@
 
 """Tests for the VBD solver."""
 
+import math
 import unittest
 
 import numpy as np
@@ -22,6 +23,23 @@ from newton._src.solvers.vbd.rigid_vbd_kernels import (
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 devices = get_test_devices()
+
+
+def _quat_rotate_np(q, v):
+    q_vec = np.asarray(q[:3], dtype=np.float64)
+    v = np.asarray(v, dtype=np.float64)
+    t = 2.0 * np.cross(q_vec, v)
+    return v + float(q[3]) * t + np.cross(q_vec, t)
+
+
+def _transform_point_np(xform, point):
+    return np.asarray(xform[:3], dtype=np.float64) + _quat_rotate_np(xform[3:], point)
+
+
+def _transform_contact_point_np(body_q, body_id, local_point):
+    if body_id < 0:
+        return np.asarray(local_point, dtype=np.float64)
+    return _transform_point_np(body_q[body_id], local_point)
 
 
 @wp.kernel
@@ -479,6 +497,8 @@ def _rigid_contact_stick_flags_require_cone_and_small_residual(test, device):
         shape1 = wp.array([1, 2, 3, 4], dtype=int, device=device)
         point0 = wp.zeros(4, dtype=wp.vec3, device=device)
         point1 = wp.zeros(4, dtype=wp.vec3, device=device)
+        offset0 = wp.zeros(4, dtype=wp.vec3, device=device)
+        offset1 = wp.zeros(4, dtype=wp.vec3, device=device)
         normal = wp.array([[0.0, 0.0, 1.0]] * 4, dtype=wp.vec3, device=device)
         margin0 = wp.array([0.05, 0.05, 0.05, 0.05], dtype=float, device=device)
         margin1 = wp.array([0.05, 0.05, 0.05, 0.05], dtype=float, device=device)
@@ -514,6 +534,8 @@ def _rigid_contact_stick_flags_require_cone_and_small_residual(test, device):
                 shape1,
                 point0,
                 point1,
+                offset0,
+                offset1,
                 normal,
                 margin0,
                 margin1,
@@ -557,6 +579,8 @@ def _rigid_contact_stick_flags_require_cone_and_small_residual(test, device):
                 shape1,
                 point0,
                 point1,
+                offset0,
+                offset1,
                 normal,
                 margin0,
                 margin1,
@@ -577,6 +601,120 @@ def _rigid_contact_stick_flags_require_cone_and_small_residual(test, device):
         )
 
         np.testing.assert_array_equal(stick_flag.numpy(), [0, 0, 0, 0])
+
+
+def _capsule_axial_spin_dissipates_via_friction(test, device):
+    """An axially-spinning capsule on its side must dissipate spin via Coulomb friction.
+
+    Lays a capsule on the ground (long axis along world X), gives it pure angular
+    velocity about that axis (no linear velocity), and checks that translational
+    friction couples the spin to lateral motion: angular velocity decays and the
+    capsule translates in -Y.
+    """
+    radius = 0.3
+    half_height = 0.7
+    omega_init = 5.0  # rad/s about world X (capsule's long axis)
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.ke = 1.0e6
+    builder.default_shape_cfg.kd = 1.0e1
+    builder.default_shape_cfg.mu = 0.5
+    builder.add_ground_plane()
+
+    half = 0.5 * (math.pi / 2)
+    q_side = wp.quat(0.0, math.sin(half), 0.0, math.cos(half))
+    body = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, radius), q=q_side))
+    builder.add_shape_capsule(body, radius=radius, half_height=half_height)
+    builder.color()
+
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+        solver = newton.solvers.SolverVBD(model, iterations=10)
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = model.contacts()
+
+        init_qd = state_0.body_qd.numpy().copy()
+        init_qd[0] = [0.0, 0.0, 0.0, omega_init, 0.0, 0.0]
+        state_0.body_qd = wp.array(init_qd, dtype=wp.spatial_vector)
+
+        sim_dt = 1.0e-3
+        for _ in range(500):
+            state_0.clear_forces()
+            model.collide(state_0, contacts)
+            solver.step(state_0, state_1, control, contacts, sim_dt)
+            state_0, state_1 = state_1, state_0
+
+        qd = state_0.body_qd.numpy()[0]
+
+    v_y = float(qd[1])
+    omega_x = float(qd[3])
+
+    test.assertLess(v_y, -0.1, f"capsule failed to translate under axial spin (v_y={v_y:.4f}, omega_x={omega_x:.4f})")
+    test.assertLess(omega_x, 4.0, f"axial spin failed to dissipate (omega_x={omega_x:.4f}, v_y={v_y:.4f})")
+
+
+def _collect_rigid_contact_forces_reports_surface_points(test, device):
+    """Rigid contact force reporting returns the same surface anchors used by the solve."""
+    radius = 0.3
+
+    builder = newton.ModelBuilder()
+    builder.default_shape_cfg.ke = 1.0e6
+    builder.default_shape_cfg.kd = 1.0e1
+    builder.default_shape_cfg.mu = 0.5
+    builder.add_ground_plane()
+    body = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.95 * radius), q=wp.quat_identity()))
+    builder.add_shape_sphere(body, radius=radius)
+    builder.color()
+
+    with wp.ScopedDevice(device):
+        model = builder.finalize()
+        model.set_gravity((0.0, 0.0, 0.0))
+        solver = newton.solvers.SolverVBD(model, iterations=2)
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = model.contacts()
+
+        model.collide(state_0, contacts)
+        body_q_prev_snapshot = wp.clone(solver.body_q_prev)
+        solver.step(state_0, state_1, control, contacts, 1.0e-3)
+
+        c_b0, c_b1, c_p0w, c_p1w, _c_force, c_count = solver.collect_rigid_contact_forces(
+            state_1.body_q, body_q_prev_snapshot, contacts, 1.0e-3
+        )
+
+        count = int(c_count.numpy()[0])
+        body_q_np = state_1.body_q.numpy()
+        body0_np = c_b0.numpy()
+        body1_np = c_b1.numpy()
+        reported0_np = c_p0w.numpy()
+        reported1_np = c_p1w.numpy()
+        point0_np = contacts.rigid_contact_point0.numpy()
+        point1_np = contacts.rigid_contact_point1.numpy()
+        offset0_np = contacts.rigid_contact_offset0.numpy()
+        offset1_np = contacts.rigid_contact_offset1.numpy()
+
+    test.assertGreater(count, 0, msg="Expected at least one sphere-ground rigid contact")
+    max_offset = np.max(
+        np.concatenate(
+            [
+                np.linalg.norm(offset0_np[:count], axis=1),
+                np.linalg.norm(offset1_np[:count], axis=1),
+            ]
+        )
+    )
+    test.assertGreater(max_offset, 1.0e-4, msg="Test requires a contact with a non-zero surface offset")
+
+    expected0 = np.empty((count, 3), dtype=np.float64)
+    expected1 = np.empty((count, 3), dtype=np.float64)
+    for i in range(count):
+        expected0[i] = _transform_contact_point_np(body_q_np, int(body0_np[i]), point0_np[i] + offset0_np[i])
+        expected1[i] = _transform_contact_point_np(body_q_np, int(body1_np[i]), point1_np[i] + offset1_np[i])
+
+    np.testing.assert_allclose(reported0_np[:count], expected0, atol=1.0e-5)
+    np.testing.assert_allclose(reported1_np[:count], expected1, atol=1.0e-5)
 
 
 class TestSolverVBD(unittest.TestCase):
@@ -629,6 +767,18 @@ add_function_test(
     TestSolverVBD,
     "test_rigid_contact_stick_flags_require_cone_and_small_residual",
     _rigid_contact_stick_flags_require_cone_and_small_residual,
+    devices=devices,
+)
+add_function_test(
+    TestSolverVBD,
+    "test_capsule_axial_spin_dissipates_via_friction",
+    _capsule_axial_spin_dissipates_via_friction,
+    devices=devices,
+)
+add_function_test(
+    TestSolverVBD,
+    "test_collect_rigid_contact_forces_reports_surface_points",
+    _collect_rigid_contact_forces_reports_surface_points,
     devices=devices,
 )
 

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -208,8 +208,20 @@ def _rigid_contact_history_restore_from_match_index(test, device):
             dtype=np.float32,
         )
         point1_in = point0_in + np.array([0.0, 0.0, 1.0], dtype=np.float32)
+        offset0_in = np.array(
+            [
+                [0.0, 0.0, 0.1],
+                [0.0, 0.0, 0.2],
+                [0.0, 0.0, 0.3],
+                [0.0, 0.0, 0.4],
+            ],
+            dtype=np.float32,
+        )
+        offset1_in = -offset0_in
         point0 = wp.array(point0_in, dtype=wp.vec3, device=device)
         point1 = wp.array(point1_in, dtype=wp.vec3, device=device)
+        offset0 = wp.array(offset0_in, dtype=wp.vec3, device=device)
+        offset1 = wp.array(offset1_in, dtype=wp.vec3, device=device)
         normal = wp.array([[0.0, 0.0, 1.0]] * 4, dtype=wp.vec3, device=device)
 
         shape_ke = wp.array([100.0, 200.0], dtype=float, device=device)
@@ -223,6 +235,8 @@ def _rigid_contact_history_restore_from_match_index(test, device):
         history.penalty_k = wp.array([20.0, 30.0, 40.0], dtype=float, device=device)
         history.point0 = wp.array([[20.0, 0.0, 0.0], [21.0, 0.0, 0.0], [22.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         history.point1 = wp.array([[20.0, 0.0, 1.0], [21.0, 0.0, 1.0], [22.0, 0.0, 1.0]], dtype=wp.vec3, device=device)
+        history.offset0 = wp.array([[0.0, 0.0, 0.5], [0.0, 0.0, 0.6], [0.0, 0.0, 0.7]], dtype=wp.vec3, device=device)
+        history.offset1 = wp.array([[0.0, 0.0, -0.5], [0.0, 0.0, -0.6], [0.0, 0.0, -0.7]], dtype=wp.vec3, device=device)
         history.normal = wp.array([[0.0, 0.0, 1.0]] * 3, dtype=wp.vec3, device=device)
 
         penalty_k = wp.zeros(4, dtype=float, device=device)
@@ -250,6 +264,8 @@ def _rigid_contact_history_restore_from_match_index(test, device):
             outputs=[
                 point0,
                 point1,
+                offset0,
+                offset1,
                 penalty_k,
                 lam,
                 material_kd,
@@ -267,24 +283,38 @@ def _rigid_contact_history_restore_from_match_index(test, device):
 
         point0_out = point0.numpy()
         point1_out = point1.numpy()
+        offset0_out = offset0.numpy()
+        offset1_out = offset1.numpy()
         np.testing.assert_allclose(point0_out[0], [22.0, 0.0, 0.0])
         np.testing.assert_allclose(point1_out[0], [22.0, 0.0, 1.0])
+        np.testing.assert_allclose(offset0_out[0], [0.0, 0.0, 0.7])
+        np.testing.assert_allclose(offset1_out[0], [0.0, 0.0, -0.7])
         np.testing.assert_allclose(point0_out[2], point0_in[2])
         np.testing.assert_allclose(point1_out[2], point1_in[2])
         np.testing.assert_allclose(point0_out[1], point0_in[1])
         np.testing.assert_allclose(point0_out[3], point0_in[3])
+        np.testing.assert_allclose(offset0_out[1], offset0_in[1])
+        np.testing.assert_allclose(offset0_out[2], offset0_in[2])
+        np.testing.assert_allclose(offset0_out[3], offset0_in[3])
+        np.testing.assert_allclose(offset1_out[1], offset1_in[1])
+        np.testing.assert_allclose(offset1_out[2], offset1_in[2])
+        np.testing.assert_allclose(offset1_out[3], offset1_in[3])
 
 
 def _rigid_contact_history_soft_restores_penalty_only(test, device):
-    """Soft contacts restore penalty state only; saved lambda and anchors stay unused."""
+    """Soft contacts restore penalty state only; saved lambda, points, and offsets stay unused."""
     with wp.ScopedDevice(device):
         contact_count = wp.array([1], dtype=int, device=device)
         shape0 = wp.array([0], dtype=int, device=device)
         shape1 = wp.array([1], dtype=int, device=device)
         point0_in = np.array([[10.0, 0.0, 0.0]], dtype=np.float32)
         point1_in = np.array([[10.0, 0.0, 1.0]], dtype=np.float32)
+        offset0_in = np.array([[0.0, 0.0, 0.1]], dtype=np.float32)
+        offset1_in = np.array([[0.0, 0.0, -0.1]], dtype=np.float32)
         point0 = wp.array(point0_in, dtype=wp.vec3, device=device)
         point1 = wp.array(point1_in, dtype=wp.vec3, device=device)
+        offset0 = wp.array(offset0_in, dtype=wp.vec3, device=device)
+        offset1 = wp.array(offset1_in, dtype=wp.vec3, device=device)
         normal = wp.array([[0.0, 0.0, 1.0]], dtype=wp.vec3, device=device)
 
         history = RigidContactHistory()
@@ -293,6 +323,8 @@ def _rigid_contact_history_soft_restores_penalty_only(test, device):
         history.penalty_k = wp.array([40.0], dtype=float, device=device)
         history.point0 = wp.array([[20.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         history.point1 = wp.array([[20.0, 0.0, 1.0]], dtype=wp.vec3, device=device)
+        history.offset0 = wp.array([[0.0, 0.0, 0.5]], dtype=wp.vec3, device=device)
+        history.offset1 = wp.array([[0.0, 0.0, -0.5]], dtype=wp.vec3, device=device)
         history.normal = wp.array([[0.0, 0.0, 1.0]], dtype=wp.vec3, device=device)
 
         penalty_k = wp.zeros(1, dtype=float, device=device)
@@ -320,6 +352,8 @@ def _rigid_contact_history_soft_restores_penalty_only(test, device):
             outputs=[
                 point0,
                 point1,
+                offset0,
+                offset1,
                 penalty_k,
                 lam,
                 material_kd,
@@ -333,6 +367,8 @@ def _rigid_contact_history_soft_restores_penalty_only(test, device):
         np.testing.assert_allclose(lam.numpy(), [[0.0, 0.0, 0.0]])
         np.testing.assert_allclose(point0.numpy(), point0_in)
         np.testing.assert_allclose(point1.numpy(), point1_in)
+        np.testing.assert_allclose(offset0.numpy(), offset0_in)
+        np.testing.assert_allclose(offset1.numpy(), offset1_in)
 
 
 def _joint_angular_dual_projects_free_axis_lambda(test, device):
@@ -458,6 +494,8 @@ def _rigid_contact_history_snapshot_copies_active_rows(test, device):
         contact_count = wp.array([2], dtype=int, device=device)
         point0 = wp.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         point1 = wp.array([[1.0, 0.0, 1.0], [2.0, 0.0, 1.0], [3.0, 0.0, 1.0]], dtype=wp.vec3, device=device)
+        offset0 = wp.array([[0.0, 0.0, 0.1], [0.0, 0.0, 0.2], [0.0, 0.0, 0.3]], dtype=wp.vec3, device=device)
+        offset1 = wp.array([[0.0, 0.0, -0.1], [0.0, 0.0, -0.2], [0.0, 0.0, -0.3]], dtype=wp.vec3, device=device)
         normal = wp.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         lam = wp.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=wp.vec3, device=device)
         stick = wp.array([1, 2, 3], dtype=wp.int32, device=device)
@@ -468,13 +506,24 @@ def _rigid_contact_history_snapshot_copies_active_rows(test, device):
         prev_penalty = wp.zeros(3, dtype=float, device=device)
         prev_point0 = wp.zeros(3, dtype=wp.vec3, device=device)
         prev_point1 = wp.zeros(3, dtype=wp.vec3, device=device)
+        prev_offset0 = wp.zeros(3, dtype=wp.vec3, device=device)
+        prev_offset1 = wp.zeros(3, dtype=wp.vec3, device=device)
         prev_normal = wp.zeros(3, dtype=wp.vec3, device=device)
 
         wp.launch(
             snapshot_body_body_contact_history,
             dim=3,
-            inputs=[contact_count, point0, point1, normal, lam, stick, penalty],
-            outputs=[prev_lambda, prev_stick, prev_penalty, prev_point0, prev_point1, prev_normal],
+            inputs=[contact_count, point0, point1, offset0, offset1, normal, lam, stick, penalty],
+            outputs=[
+                prev_lambda,
+                prev_stick,
+                prev_penalty,
+                prev_point0,
+                prev_point1,
+                prev_offset0,
+                prev_offset1,
+                prev_normal,
+            ],
             device=device,
         )
 
@@ -483,8 +532,12 @@ def _rigid_contact_history_snapshot_copies_active_rows(test, device):
         np.testing.assert_allclose(prev_penalty.numpy()[:2], [10.0, 20.0])
         np.testing.assert_allclose(prev_point0.numpy()[:2], point0.numpy()[:2])
         np.testing.assert_allclose(prev_point1.numpy()[:2], point1.numpy()[:2])
+        np.testing.assert_allclose(prev_offset0.numpy()[:2], offset0.numpy()[:2])
+        np.testing.assert_allclose(prev_offset1.numpy()[:2], offset1.numpy()[:2])
         np.testing.assert_allclose(prev_normal.numpy()[:2], normal.numpy()[:2])
         np.testing.assert_allclose(prev_lambda.numpy()[2], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(prev_offset0.numpy()[2], [0.0, 0.0, 0.0])
+        np.testing.assert_allclose(prev_offset1.numpy()[2], [0.0, 0.0, 0.0])
         test.assertEqual(prev_stick.numpy()[2], 0)
         test.assertEqual(prev_penalty.numpy()[2], 0.0)
 


### PR DESCRIPTION
## Description

Fix VBD rigid-rigid friction to use the contact surface anchor (`rigid_contact_point + rigid_contact_offset`) when measuring tangential slip.


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_collect_rigid_contact_forces_reports_surface_points
uv run --extra dev -m newton.tests -k test_solver_vbd
```

## Bug fix

**Steps to reproduce:**

1. Create a VBD capsule lying on its side on the ground.
2. Give it axial angular velocity with no initial linear velocity.
3. Step the simulation with rigid contact friction enabled.
4. Without this fix, tangential slip is evaluated at the skeleton contact point, so axial spin does not dissipate correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rigid-body contacts now carry per-contact surface anchor offsets end-to-end, preserving them across warm-start/snapshots and using anchors for tangential displacement/friction while keeping normals based on geometry.

* **Tests**
  * Added regression tests for contact surface-point reporting and frictional dissipation of axial spin; updated existing contact-history tests to validate offset behavior.

* **Documentation**
  * Changelog updated noting the rigid-rigid friction fix for per-contact offsets.

* **Chores**
  * Increased kinematic gripper substeps for more stable friction tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->