### PR TITLE
Backport #2797 to release 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead
+- Fix `SolverMuJoCo` Newton-contact conversion to use geometry-surface contact anchors
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -239,6 +239,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
     rigid_contact_point0: wp.array[wp.vec3],
     rigid_contact_point1: wp.array[wp.vec3],
     rigid_contact_normal: wp.array[wp.vec3],
+    rigid_contact_offset0: wp.array[wp.vec3],
+    rigid_contact_offset1: wp.array[wp.vec3],
     rigid_contact_margin0: wp.array[wp.float32],
     rigid_contact_margin1: wp.array[wp.float32],
     rigid_contact_stiffness: wp.array[wp.float32],
@@ -346,19 +348,18 @@ def convert_newton_contacts_to_mjwarp_kernel(
         if body_b >= 0:
             X_wb_b = body_q[body_b]
 
-        bx_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid])
-        bx_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid])
+        # Strip artificial shape margins from Newton offsets before computing MuJoCo's geometry-surface anchor.
+        offset_scale_a = safe_div(rigid_contact_margin0[tid] - shape_margin[shape_a], rigid_contact_margin0[tid])
+        offset_scale_b = safe_div(rigid_contact_margin1[tid] - shape_margin[shape_b], rigid_contact_margin1[tid])
+        offset_a = rigid_contact_offset0[tid] * offset_scale_a
+        offset_b = rigid_contact_offset1[tid] * offset_scale_b
 
-        # rigid_contact_margin0/1 = radius_eff + shape_margin per shape.
-        # Subtract shape_margin so dist is the surface-to-surface distance;
-        # shape_margin is handled by geom_margin (MuJoCo's includemargin).
-        radius_eff = (rigid_contact_margin0[tid] - shape_margin[shape_a]) + (
-            rigid_contact_margin1[tid] - shape_margin[shape_b]
-        )
+        point_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid] + offset_a)
+        point_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid] + offset_b)
 
         n = rigid_contact_normal[tid]
-        dist = wp.dot(n, bx_b - bx_a) - radius_eff
-        pos = 0.5 * (bx_a + bx_b)
+        dist = wp.dot(n, point_b - point_a)
+        pos = 0.5 * (point_a + point_b)
 
         frame = make_frame(n)
 
@@ -480,16 +481,17 @@ def convert_newton_contacts_to_mjwarp_kernel(
         if body_b >= 0:
             X_wb_b = body_q[body_b]
 
-        bx_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid])
-        bx_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid])
+        offset_scale_a = safe_div(rigid_contact_margin0[tid] - shape_margin[shape_a], rigid_contact_margin0[tid])
+        offset_scale_b = safe_div(rigid_contact_margin1[tid] - shape_margin[shape_b], rigid_contact_margin1[tid])
+        offset_a = rigid_contact_offset0[tid] * offset_scale_a
+        offset_b = rigid_contact_offset1[tid] * offset_scale_b
 
-        radius_eff = (rigid_contact_margin0[tid] - shape_margin[shape_a]) + (
-            rigid_contact_margin1[tid] - shape_margin[shape_b]
-        )
+        point_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid] + offset_a)
+        point_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid] + offset_b)
 
         n = rigid_contact_normal[tid]
-        contact_dist_out[cid] = wp.dot(n, bx_b - bx_a) - radius_eff
-        contact_pos_out[cid] = 0.5 * (bx_a + bx_b)
+        contact_dist_out[cid] = wp.dot(n, point_b - point_a)
+        contact_pos_out[cid] = 0.5 * (point_a + point_b)
 
         for i in range(contact_efc_address_out.shape[1]):
             contact_efc_address_out[cid, i] = -1

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -354,11 +354,17 @@ def convert_newton_contacts_to_mjwarp_kernel(
         offset_a = rigid_contact_offset0[tid] * offset_scale_a
         offset_b = rigid_contact_offset1[tid] * offset_scale_b
 
+        bx_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid])
+        bx_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid])
         point_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid] + offset_a)
         point_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid] + offset_b)
 
+        radius_eff = (rigid_contact_margin0[tid] - shape_margin[shape_a]) + (
+            rigid_contact_margin1[tid] - shape_margin[shape_b]
+        )
+
         n = rigid_contact_normal[tid]
-        dist = wp.dot(n, point_b - point_a)
+        dist = wp.dot(n, bx_b - bx_a) - radius_eff
         pos = 0.5 * (point_a + point_b)
 
         frame = make_frame(n)
@@ -486,11 +492,17 @@ def convert_newton_contacts_to_mjwarp_kernel(
         offset_a = rigid_contact_offset0[tid] * offset_scale_a
         offset_b = rigid_contact_offset1[tid] * offset_scale_b
 
+        bx_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid])
+        bx_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid])
         point_a = wp.transform_point(X_wb_a, rigid_contact_point0[tid] + offset_a)
         point_b = wp.transform_point(X_wb_b, rigid_contact_point1[tid] + offset_b)
 
+        radius_eff = (rigid_contact_margin0[tid] - shape_margin[shape_a]) + (
+            rigid_contact_margin1[tid] - shape_margin[shape_b]
+        )
+
         n = rigid_contact_normal[tid]
-        contact_dist_out[cid] = wp.dot(n, point_b - point_a)
+        contact_dist_out[cid] = wp.dot(n, bx_b - bx_a) - radius_eff
         contact_pos_out[cid] = 0.5 * (point_a + point_b)
 
         for i in range(contact_efc_address_out.shape[1]):

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3384,6 +3384,8 @@ class SolverMuJoCo(SolverBase):
                 contacts.rigid_contact_point0,
                 contacts.rigid_contact_point1,
                 contacts.rigid_contact_normal,
+                contacts.rigid_contact_offset0,
+                contacts.rigid_contact_offset1,
                 contacts.rigid_contact_margin0,
                 contacts.rigid_contact_margin1,
                 contacts.rigid_contact_stiffness,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -3928,6 +3928,56 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
             f"Sphere is floating above the plane. Final height: {final_height}",
         )
 
+    def test_sphere_rolls_without_slip_with_newton_contacts(self):
+        radius = 0.1
+        builder = newton.ModelBuilder(gravity=-9.81)
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.default_shape_cfg.ke = 1.0e5
+        builder.default_shape_cfg.kd = 2.0e3
+        builder.default_shape_cfg.mu = 1.0
+        builder.add_ground_plane()
+
+        shape_cfg = newton.ModelBuilder.ShapeConfig(density=1000.0, ke=1.0e5, kd=2.0e3, mu=1.0)
+        body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius), wp.quat_identity()))
+        builder.add_shape_sphere(body=body, radius=radius, cfg=shape_cfg)
+        model = builder.finalize()
+
+        try:
+            solver = SolverMuJoCo(
+                model,
+                use_mujoco_contacts=False,
+                use_mujoco_cpu=False,
+                solver="newton",
+                integrator="implicitfast",
+                cone="elliptic",
+                iterations=50,
+                ls_iterations=20,
+                nconmax=64,
+                njmax=256,
+            )
+        except ImportError as e:
+            self.skipTest(f"MuJoCo or deps not installed. Skipping test: {e}")
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = model.contacts()
+
+        joint_qd = state_0.joint_qd.numpy()
+        joint_qd[:] = 0.0
+        joint_qd[0] = 0.1
+        state_0.joint_qd.assign(joint_qd)
+        newton.eval_fk(model, state_0.joint_q, state_0.joint_qd, state_0)
+
+        for _ in range(240):
+            state_0.clear_forces()
+            model.collide(state_0, contacts)
+            solver.step(state_0, state_1, control, contacts, 1.0 / 240.0)
+            state_0, state_1 = state_1, state_0
+
+        body_qd = state_0.body_qd.numpy()[body]
+        self.assertAlmostEqual(float(body_qd[0]), float(body_qd[4] * radius), delta=5.0e-3)
+
     def test_efc_address_init(self):
         """efc_address is -1 for inactive contacts after Newton-to-mujoco_warp conversion.
 
@@ -4195,6 +4245,8 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
             "rigid_contact_point0",
             "rigid_contact_point1",
             "rigid_contact_normal",
+            "rigid_contact_offset0",
+            "rigid_contact_offset1",
             "rigid_contact_margin0",
             "rigid_contact_margin1",
             "rigid_contact_stiffness",


### PR DESCRIPTION
## Description

Backport #2797 to `release-1.2`.

This cherry-picks the SolverMuJoCo contact-anchor conversion fixes and the rolling sphere regression test from #2797 without pulling main branch history into the release branch.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_mujoco_solver.TestMuJoCoSolverNewtonContacts.test_sphere_rolls_without_slip_with_newton_contacts
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Convert Newton-generated contacts into SolverMuJoCo/mujoco_warp contacts.
2. Observe incorrect anchor/distance conversion behavior that can produce rolling-sphere slip.

**Minimal reproduction:**

See `TestMuJoCoSolverNewtonContacts.test_sphere_rolls_without_slip_with_newton_contacts` in `newton/tests/test_mujoco_solver.py`.