### PR TITLE
Backport #2748 and #2800 to release 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0
+- Bump `newton-usd-schemas` to `>=0.2.0` introducing new experimental actuator schemas & re-aligning friction defaults
 - Restrict `usd-core` to `<26.5` to avoid deprecation warnings introduced in 26.5
 - Require explicit `SensorTiledCamera` BVH lifecycle management instead of implicit camera maintenance: call `newton.geometry.build_bvh_shape()` / `build_bvh_particle()` once after setup, then `refit_bvh_shape()` / `refit_bvh_particle()` before rendering frames that change geometry
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections

--- a/newton/examples/basic/example_basic_joints.py
+++ b/newton/examples/basic/example_basic_joints.py
@@ -125,6 +125,7 @@ class Example:
             child_xform=wp.transform(p=wp.vec3(0.0, 0.0, +cuboid_hz), q=wp.quat_identity()),
             limit_lower=-0.3,
             limit_upper=0.3,
+            limit_kd=1.0e-1,
             label="prismatic_a_b",
         )
         # Create articulation from joints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.2.0rc1",
+    "newton-usd-schemas>=0.2.0",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -3515,7 +3515,7 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
     { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.2.0rc1" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.2.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
     { name = "pillow", marker = "extra == 'examples'", specifier = ">=11.3.0" },
@@ -3562,11 +3562,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.2.0rc1"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/9c/3802a082abb48b389e4b58c274257f5a723217585a3ea5552778674e1683/newton_usd_schemas-0.2.0rc1.tar.gz", hash = "sha256:1f8f6a8034f7e9a83ad25ddbd3314392e7db8f6f0f0e51a4af35771454bbfbbe", size = 69315, upload-time = "2026-04-22T21:29:35.564Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/9c/5a40c3fd86975172e01d46872e3f0b2c08409e22bdcac9d75e1e814f2e71/newton_usd_schemas-0.2.0.tar.gz", hash = "sha256:b483a029e54f4a7b06d3156c47860e3e8b77e33e3ee4c4fd525c335d74f898a0", size = 69375, upload-time = "2026-05-07T17:53:51.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/ec/0fa46947d6582431c2e1d9f1203e954181bc4f499862e1c7330d26b6e4d4/newton_usd_schemas-0.2.0rc1-py3-none-any.whl", hash = "sha256:4a94d955d6988b93010f5a722414bbe8ec6488d3c2dc10630e94142648c5fba9", size = 15583, upload-time = "2026-04-22T21:29:33.988Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7c/79ff957c828116966894268a749eccf455e4d11f08ef66ea681084c3faaa/newton_usd_schemas-0.2.0-py3-none-any.whl", hash = "sha256:b6402affb6cdc59b0a237994ee5196cc1b43f04f766e527b7e6ef061c0719acf", size = 15551, upload-time = "2026-05-07T17:53:50.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Backport #2748 and #2800 to `release-1.2`.

This PR cherry-picks:

- #2748: Add `limit_kd` damping to the `basic_joints` example prismatic joint.
- #2800: Bump `newton-usd-schemas` to v0.2.0, refresh `uv.lock`, and update the changelog.

The cherry-picks are applied directly onto `release-1.2` without pulling main branch history into the release branch.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv lock --check
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_basic.example_basic_joints
```

## Bug fix

#2748 fixes the `basic_joints` example behavior by damping the prismatic joint limit. #2800 is a dependency/version backport.

**Steps to reproduce:**

Run the `basic_joints` example tests on the release branch before #2748.

**Minimal reproduction:**

```bash
uv run --extra dev -m newton.tests -k test_basic.example_basic_joints
```

## New feature / API change

```python
import newton

# Enables use of newton-usd-schemas >=0.2.0 on release-1.2.
```