### PR TITLE
Backport #2747 to release 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@
 - Fix MPR/GJK reporting wrong contacts for `CONVEX_MESH` shapes whose authoring origin lies outside the hull, and tighten heightfield-vs-convex midphase to use the convex's local AABB instead of an origin-centered bounding sphere
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Fix `SensorRaycast` ignoring `PLANE` geometry
-- Fix `nut_bolt_hydro` example threading regression (some nuts pinned in static friction) by re-running collision per substep so contact normals stay aligned with the rotating helix; also stop the example from re-allocating the `Contacts` buffer every frame, which broke CUDA graph capture (#2702)
+- Fix `nut_bolt_hydro` example threading regression where some nuts were pinned in static friction; nuts now thread reliably down the bolt under both MuJoCo and XPBD solvers (#2702)
 - Fix VRAM leak when resetting examples that allocate large GPU state (e.g. `diffsim_bear`)
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add linear HDR color output support to `SensorTiledCamera` via `hdr_color_image`.
+- Add `HydroelasticSDF.Config.mc_edge_clamp` to expose the marching-cubes edge-interpolation clamp that controls how strongly contact-surface vertices are pulled off cube corners; default is `0.0` (no clamp) to favor faithful contact-surface dynamics. Larger values (recommended close to zero) prevent vertex collapse at SDF ridges at the cost of biasing the surface, which can dampen threading-style contacts (#2702)
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
 - Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add linear HDR color output support to `SensorTiledCamera` via `hdr_color_image`.
 - Add `HydroelasticSDF.Config.mc_edge_clamp` to expose the marching-cubes edge-interpolation clamp that controls how strongly contact-surface vertices are pulled off cube corners; default is `0.0` (no clamp) to favor faithful contact-surface dynamics. Larger values (recommended close to zero) prevent vertex collapse at SDF ridges at the cost of biasing the surface, which can dampen threading-style contacts (#2702)
+- Add `HydroelasticSDF.Config.mc_edge_clamp_min` to expose the marching-cubes edge-interpolation clamp; default `0.02` matches the previous hard-coded value. Set to `0.0` to disable the clamp and recover faithful contact-surface dynamics for threading-style scenarios (#2702)
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
 - Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 ### Added
 
 - Add linear HDR color output support to `SensorTiledCamera` via `hdr_color_image`.
-- Add `HydroelasticSDF.Config.mc_edge_clamp` to expose the marching-cubes edge-interpolation clamp that controls how strongly contact-surface vertices are pulled off cube corners; default is `0.0` (no clamp) to favor faithful contact-surface dynamics. Larger values (recommended close to zero) prevent vertex collapse at SDF ridges at the cost of biasing the surface, which can dampen threading-style contacts (#2702)
-- Add `HydroelasticSDF.Config.mc_edge_clamp_min` to expose the marching-cubes edge-interpolation clamp; default `0.02` matches the previous hard-coded value. Set to `0.0` to disable the clamp and recover faithful contact-surface dynamics for threading-style scenarios (#2702)
 - Add composable actuator subsystem with pluggable `Controller` (`ControllerPD`, `ControllerPID`, `ControllerNeuralMLP`, `ControllerNeuralLSTM`), `Clamping` (`ClampingMaxEffort`, `ClampingDCMotor`, `ClampingPositionBased`), and `Delay` components; supports per-DOF delays, CUDA graph capture, and masked environment reset
 - Add heatmap rendering for scalar arrays logged through `ViewerGL.log_array()`
 - Add Blender-style orbit, pan, and dolly controls to the GL viewer using middle-mouse drag combinations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `TRIANGLE_PRISM` support-function type for heightfield triangles, extruding 1 m along the heightfield's local -Z so GJK/MPR naturally resolves shapes on the back side
 - Add `ViewerGL.log_scalar()` for live scalar time-series plots in the viewer
 - Add `Mesh.is_watertight` property (cached) that reports whether every geometric edge is shared by exactly two triangles
+- Add `HydroelasticSDF.Config.mc_edge_clamp_min` to expose the marching-cubes edge-interpolation clamp; default `0.02` matches the previous hard-coded value. Set to `0.0` to disable the clamp and recover faithful contact-surface dynamics for threading-style scenarios (#2702)
 - Add `deterministic` flag to `CollisionPipeline` and `NarrowPhase` for GPU-thread-scheduling-independent contact ordering via radix sort and deterministic fingerprint tiebreaking in contact reduction
 - Add fast parity-based SDF construction path for watertight meshes in `SDF.create_from_mesh`, using `wp.mesh_query_point_sign_parity` instead of winding numbers; selected via the new `sign_method` argument (`"auto"` — the default — picks parity when `Mesh.is_watertight` is true, or `"parity"` / `"winding"` to force either strategy)
 - Add `Viewer.log_image()` for displaying single or batched images in `ViewerGL`; other backends inherit a no-op. Also add `SensorTiledCamera.utils.to_rgba_from_color()`, `to_rgba_from_normal()`, `to_rgba_from_depth()`, and `to_rgba_from_shape_index()` (hash palette or caller-provided RGB lookup) adapters producing output consumable by `log_image()`.
@@ -107,6 +108,7 @@
 - Fix MPR/GJK reporting wrong contacts for `CONVEX_MESH` shapes whose authoring origin lies outside the hull, and tighten heightfield-vs-convex midphase to use the convex's local AABB instead of an origin-centered bounding sphere
 - Fix O(W²·S²) memory explosion in `CollisionPipeline` shape-pair buffer allocation for NXN and SAP broad phase modes by computing per-world pair counts instead of a global N²
 - Fix `SensorRaycast` ignoring `PLANE` geometry
+- Fix `nut_bolt_hydro` example threading regression (some nuts pinned in static friction) by re-running collision per substep so contact normals stay aligned with the rotating helix; also stop the example from re-allocating the `Contacts` buffer every frame, which broke CUDA graph capture (#2702)
 - Fix VRAM leak when resetting examples that allocate large GPU state (e.g. `diffsim_bear`)
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled

--- a/newton/_src/geometry/sdf_hydroelastic.py
+++ b/newton/_src/geometry/sdf_hydroelastic.py
@@ -57,8 +57,6 @@ from .contact_reduction_hydroelastic import (
 from .hashtable import hashtable_find_or_insert
 from .sdf_mc import (
     MC_DEGENERATE_N_SQ_EPS,
-    MC_EDGE_CLAMP_MAX,
-    MC_EDGE_CLAMP_MIN,
     MC_EDGE_VAL_DIFF_EPS,
     get_mc_tables,
     get_triangle_fraction,
@@ -114,6 +112,8 @@ def mc_calc_face_texture(
     x_id: wp.int32,
     y_id: wp.int32,
     z_id: wp.int32,
+    edge_clamp_min: wp.float32,
+    edge_clamp_max: wp.float32,
 ) -> tuple[float, wp.vec3, wp.vec3, float, wp.mat33f]:
     """Extract a triangle face from a marching cubes voxel using texture SDF.
 
@@ -123,6 +123,10 @@ def mc_calc_face_texture(
     just enough to classify touching-surface vertices as penetrating.  The
     resulting phantom force is negligible (< 0.1 % of typical contact forces)
     but prevents zero-area contacts at exactly-touching surfaces.
+
+    ``edge_clamp_min`` / ``edge_clamp_max`` clamp the edge-interpolation
+    parameter ``t`` to ``[edge_clamp_min, edge_clamp_max]``.  Pass
+    ``(0.0, 1.0)`` to disable.  See :attr:`HydroelasticSDF.Config.mc_edge_clamp`.
     """
     thickness = sdf_a.voxel_radius * 1.0e-4
 
@@ -147,7 +151,7 @@ def mc_calc_face_texture(
             # both shapes share the same nearest face).  Without the clamp,
             # t close to 0 or 1 places multiple vertices at the same corner,
             # producing degenerate (zero-area) triangles.
-            t = wp.clamp((0.0 - val_0) / val_diff, wp.static(MC_EDGE_CLAMP_MIN), wp.static(MC_EDGE_CLAMP_MAX))
+            t = wp.clamp((0.0 - val_0) / val_diff, edge_clamp_min, edge_clamp_max)
         p = p_0 + t * (p_1 - p_0)
         vol_idx = p + int_to_vec3f(x_id, y_id, z_id)
         local_pos = sdf_a.sdf_box_lower + wp.cw_mul(vol_idx, sdf_a.voxel_size)
@@ -271,6 +275,18 @@ class HydroelasticSDF:
         Only active when reduce_contacts is True."""
         margin_contact_area: float = 1e-2
         """Contact area used for non-penetrating contacts at the margin."""
+        mc_edge_clamp: float = 0.0
+        """Symmetric clamp on the marching-cubes edge interpolation parameter
+        (``t`` clamped to ``[mc_edge_clamp, 1 - mc_edge_clamp]``).
+
+        Range: ``[0.0, 0.5]``.
+
+        ``0.0`` (default) disables clamping and yields the most faithful
+        contact-surface dynamics. Larger values prevent vertex collapse at
+        SDF ridge boundaries (where multiple triangle vertices would
+        otherwise land on the same cube corner) at the cost of biasing
+        contact-surface vertices off the true zero-isosurface; values close
+        to zero are recommended."""
 
     @dataclass
     class ContactSurfaceData:
@@ -403,6 +419,7 @@ class HydroelasticSDF:
             self.generate_contacts_kernel = get_generate_contacts_kernel(
                 output_vertices=self.config.output_contact_surface,
                 pre_prune=self.config.reduce_contacts and self.config.pre_prune_contacts,
+                mc_edge_clamp=self.config.mc_edge_clamp,
             )
 
             if self.config.reduce_contacts:
@@ -1384,6 +1401,7 @@ def get_decode_contacts_kernel(margin_contact_area: float = 1e-4, writer_func: A
 def get_generate_contacts_kernel(
     output_vertices: bool,
     pre_prune: bool = False,
+    mc_edge_clamp: float = 0.0,
 ):
     """Create kernel for hydroelastic contact generation.
 
@@ -1406,10 +1424,15 @@ def get_generate_contacts_kernel(
     Args:
         output_vertices: Whether to output contact surface vertices for visualization.
         pre_prune: Whether to perform local-first face compaction.
+        mc_edge_clamp: Symmetric clamp applied to the marching-cubes edge
+            interpolation parameter; see :attr:`HydroelasticSDF.Config.mc_edge_clamp`.
 
     Returns:
         generate_contacts_kernel: Warp kernel for contact generation.
     """
+
+    edge_clamp_min = wp.float32(mc_edge_clamp)
+    edge_clamp_max = wp.float32(1.0 - mc_edge_clamp)
 
     @wp.kernel(enable_backward=False)
     def generate_contacts_kernel(
@@ -1538,6 +1561,8 @@ def get_generate_contacts_kernel(
                     x_id,
                     y_id,
                     z_id,
+                    wp.static(edge_clamp_min),
+                    wp.static(edge_clamp_max),
                 )
                 if area <= 0.0:
                     continue

--- a/newton/_src/geometry/sdf_hydroelastic.py
+++ b/newton/_src/geometry/sdf_hydroelastic.py
@@ -280,13 +280,12 @@ class HydroelasticSDF:
         """Lower bound for the marching-cubes edge interpolation parameter
         (``t`` clamped to ``[mc_edge_clamp_min, 1 - mc_edge_clamp_min]``).
 
-        Range: ``[0.0, 0.5]``.  The default of ``0.02`` matches the behavior
-        introduced in #2424 and prevents vertex collapse at SDF ridge
-        boundaries (where multiple triangle vertices would otherwise land on
-        the same cube corner).  Set to ``0.0`` for the most faithful
-        contact-surface dynamics — recommended for threading-style scenarios
-        like ``nut_bolt_hydro`` where the surface bias measurably damps the
-        contact response (#2702)."""
+        Range: ``[0.0, 0.5]``.  The default of ``0.02`` prevents vertex
+        collapse at SDF ridge boundaries, where multiple triangle vertices
+        would otherwise land on the same cube corner.  Set to ``0.0`` for
+        the most faithful contact-surface dynamics — recommended for
+        threading-style scenarios like ``nut_bolt_hydro`` where the surface
+        bias measurably damps the contact response."""
 
         def __post_init__(self):
             # NaN fails both bounds (NaN comparisons return False) and lands here too.

--- a/newton/_src/geometry/sdf_hydroelastic.py
+++ b/newton/_src/geometry/sdf_hydroelastic.py
@@ -126,7 +126,8 @@ def mc_calc_face_texture(
 
     ``edge_clamp_min`` / ``edge_clamp_max`` clamp the edge-interpolation
     parameter ``t`` to ``[edge_clamp_min, edge_clamp_max]``.  Pass
-    ``(0.0, 1.0)`` to disable.  See :attr:`HydroelasticSDF.Config.mc_edge_clamp`.
+    ``(0.0, 1.0)`` to disable.  See
+    :attr:`HydroelasticSDF.Config.mc_edge_clamp_min`.
     """
     thickness = sdf_a.voxel_radius * 1.0e-4
 
@@ -275,18 +276,24 @@ class HydroelasticSDF:
         Only active when reduce_contacts is True."""
         margin_contact_area: float = 1e-2
         """Contact area used for non-penetrating contacts at the margin."""
-        mc_edge_clamp: float = 0.0
-        """Symmetric clamp on the marching-cubes edge interpolation parameter
-        (``t`` clamped to ``[mc_edge_clamp, 1 - mc_edge_clamp]``).
+        mc_edge_clamp_min: float = 0.02
+        """Lower bound for the marching-cubes edge interpolation parameter
+        (``t`` clamped to ``[mc_edge_clamp_min, 1 - mc_edge_clamp_min]``).
 
-        Range: ``[0.0, 0.5]``.
+        Range: ``[0.0, 0.5]``.  The default of ``0.02`` matches the behavior
+        introduced in #2424 and prevents vertex collapse at SDF ridge
+        boundaries (where multiple triangle vertices would otherwise land on
+        the same cube corner).  Set to ``0.0`` for the most faithful
+        contact-surface dynamics — recommended for threading-style scenarios
+        like ``nut_bolt_hydro`` where the surface bias measurably damps the
+        contact response (#2702)."""
 
-        ``0.0`` (default) disables clamping and yields the most faithful
-        contact-surface dynamics. Larger values prevent vertex collapse at
-        SDF ridge boundaries (where multiple triangle vertices would
-        otherwise land on the same cube corner) at the cost of biasing
-        contact-surface vertices off the true zero-isosurface; values close
-        to zero are recommended."""
+        def __post_init__(self):
+            # NaN fails both bounds (NaN comparisons return False) and lands here too.
+            if not (0.0 <= float(self.mc_edge_clamp_min) <= 0.5):
+                raise ValueError(
+                    f"HydroelasticSDF.Config.mc_edge_clamp_min must be in [0.0, 0.5], got {self.mc_edge_clamp_min}"
+                )
 
     @dataclass
     class ContactSurfaceData:
@@ -419,7 +426,7 @@ class HydroelasticSDF:
             self.generate_contacts_kernel = get_generate_contacts_kernel(
                 output_vertices=self.config.output_contact_surface,
                 pre_prune=self.config.reduce_contacts and self.config.pre_prune_contacts,
-                mc_edge_clamp=self.config.mc_edge_clamp,
+                mc_edge_clamp_min=self.config.mc_edge_clamp_min,
             )
 
             if self.config.reduce_contacts:
@@ -1401,7 +1408,7 @@ def get_decode_contacts_kernel(margin_contact_area: float = 1e-4, writer_func: A
 def get_generate_contacts_kernel(
     output_vertices: bool,
     pre_prune: bool = False,
-    mc_edge_clamp: float = 0.0,
+    mc_edge_clamp_min: float = 0.02,
 ):
     """Create kernel for hydroelastic contact generation.
 
@@ -1424,15 +1431,16 @@ def get_generate_contacts_kernel(
     Args:
         output_vertices: Whether to output contact surface vertices for visualization.
         pre_prune: Whether to perform local-first face compaction.
-        mc_edge_clamp: Symmetric clamp applied to the marching-cubes edge
-            interpolation parameter; see :attr:`HydroelasticSDF.Config.mc_edge_clamp`.
+        mc_edge_clamp_min: Lower bound for the marching-cubes edge
+            interpolation parameter; see
+            :attr:`HydroelasticSDF.Config.mc_edge_clamp_min`.
 
     Returns:
         generate_contacts_kernel: Warp kernel for contact generation.
     """
 
-    edge_clamp_min = wp.float32(mc_edge_clamp)
-    edge_clamp_max = wp.float32(1.0 - mc_edge_clamp)
+    edge_clamp_min = float(mc_edge_clamp_min)
+    edge_clamp_max = float(1.0 - mc_edge_clamp_min)
 
     @wp.kernel(enable_backward=False)
     def generate_contacts_kernel(

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -24,7 +24,7 @@ ASSEMBLY_STR = "m20_loose"
 ISAACGYM_ENVS_REPO_URL = "https://github.com/isaac-sim/IsaacGymEnvs.git"
 ISAACGYM_NUT_BOLT_FOLDER = "assets/factory/mesh/factory_nut_bolt"
 
-SDF_MAX_RESOLUTION = 256
+SDF_MAX_RESOLUTION = 128
 SDF_NARROW_BAND_RANGE = (-0.005, 0.005)
 
 SHAPE_CFG = newton.ModelBuilder.ShapeConfig(

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -166,7 +166,7 @@ class Example:
         # M20 helix are sensitive to the contact-surface vertex bias the clamp
         # introduces (see #2702).
         sdf_hydroelastic_config = HydroelasticSDF.Config(
-            mc_edge_clamp=0.0,
+            mc_edge_clamp_min=0.0,
         )
 
         self.collision_pipeline = newton.CollisionPipeline(
@@ -207,7 +207,8 @@ class Example:
 
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
-        self.contacts = self.model.collide(self.state_0, collision_pipeline=self.collision_pipeline)
+        self.contacts = self.collision_pipeline.contacts()
+        self.collision_pipeline.collide(self.state_0, self.contacts)
 
         self.viewer.set_model(self.model)
 
@@ -295,7 +296,7 @@ class Example:
         for _ in range(self.sim_substeps):
             # Re-run collision detection every substep so contact normals
             # stay aligned with the threading rotation (#2702).
-            self.contacts = self.model.collide(self.state_0, collision_pipeline=self.collision_pipeline)
+            self.collision_pipeline.collide(self.state_0, self.contacts)
             self.state_0.clear_forces()
 
             self.viewer.apply_forces(self.state_0)

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -116,8 +116,8 @@ class Example:
         self.fps = 120
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0
-        self.sim_substeps = 6
-        self.collide_every = 3 if args.solver == "mujoco" else 1  # re-collide every K substeps
+        self.sim_substeps = 4
+        self.collide_every = 2 if args.solver == "mujoco" else 1  # re-collide every K substeps
         self.sim_dt = self.frame_dt / self.sim_substeps
 
         self.world_count = args.world_count

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -292,8 +292,10 @@ class Example:
             self.graph = None
 
     def simulate(self):
-        self.contacts = self.model.collide(self.state_0, collision_pipeline=self.collision_pipeline)
         for _ in range(self.sim_substeps):
+            # Re-run collision detection every substep so contact normals
+            # stay aligned with the threading rotation (#2702).
+            self.contacts = self.model.collide(self.state_0, collision_pipeline=self.collision_pipeline)
             self.state_0.clear_forces()
 
             self.viewer.apply_forces(self.state_0)

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -16,6 +16,7 @@ import warp as wp
 
 import newton
 import newton.examples
+from newton.geometry import HydroelasticSDF
 
 # Assembly type for the nut and bolt
 ASSEMBLY_STR = "m20_loose"
@@ -161,11 +162,19 @@ class Example:
 
         self.model = main_scene.finalize()
 
+        # Disable the marching-cubes edge clamp — threading dynamics on the
+        # M20 helix are sensitive to the contact-surface vertex bias the clamp
+        # introduces (see #2702).
+        sdf_hydroelastic_config = HydroelasticSDF.Config(
+            mc_edge_clamp=0.0,
+        )
+
         self.collision_pipeline = newton.CollisionPipeline(
             self.model,
             reduce_contacts=True,
             rigid_contact_max=self.rigid_contact_max,
             broad_phase=self.broad_phase_mode,
+            sdf_hydroelastic_config=sdf_hydroelastic_config,
         )
 
         # Create solver based on user choice

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -165,7 +165,7 @@ class Example:
 
         # Disable the marching-cubes edge clamp — threading dynamics on the
         # M20 helix are sensitive to the contact-surface vertex bias the clamp
-        # introduces (see #2702).
+        # introduces.
         sdf_hydroelastic_config = HydroelasticSDF.Config(
             mc_edge_clamp_min=0.0,
         )

--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -116,7 +116,8 @@ class Example:
         self.fps = 120
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0
-        self.sim_substeps = 5
+        self.sim_substeps = 6
+        self.collide_every = 3 if args.solver == "mujoco" else 1  # re-collide every K substeps
         self.sim_dt = self.frame_dt / self.sim_substeps
 
         self.world_count = args.world_count
@@ -140,7 +141,7 @@ class Example:
 
         # Maximum number of rigid contacts to allocate (limits memory usage)
         # None = auto-calculate (can be very large), or set explicit limit (e.g., 1_000_000)
-        self.rigid_contact_max = 100000
+        self.rigid_contact_max = 40_000
 
         # Broad phase mode: NXN (O(N²)), SAP (O(N log N)), EXPLICIT (precomputed pairs)
         self.broad_phase_mode = "sap"
@@ -293,10 +294,11 @@ class Example:
             self.graph = None
 
     def simulate(self):
-        for _ in range(self.sim_substeps):
-            # Re-run collision detection every substep so contact normals
-            # stay aligned with the threading rotation (#2702).
-            self.collision_pipeline.collide(self.state_0, self.contacts)
+        for sub in range(self.sim_substeps):
+            # Refresh contacts every K substeps so contact normals stay
+            # aligned with the threading rotation.
+            if sub % self.collide_every == 0:
+                self.collision_pipeline.collide(self.state_0, self.contacts)
             self.state_0.clear_forces()
 
             self.viewer.apply_forces(self.state_0)

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1245,6 +1245,10 @@ def test_no_degenerate_triangles_deep_penetration(test, device):
     of degenerate (zero-area) triangles that arise from vertex collapse at
     SDF ridge boundaries.
 
+    The edge-interpolation clamp (:attr:`HydroelasticSDF.Config.mc_edge_clamp`)
+    is the mechanism that prevents these vertex collapses, so this test is
+    only meaningful when ``mc_edge_clamp`` is non-zero.
+
     Args:
         test: Unittest-style assertion helper.
         device: Warp device under test.
@@ -1294,6 +1298,7 @@ def test_no_degenerate_triangles_deep_penetration(test, device):
             reduce_contacts=False,
             buffer_mult_iso=4,
             buffer_mult_contact=4,
+            mc_edge_clamp=0.02,
         )
         collision_pipeline = newton.CollisionPipeline(
             model,

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1411,53 +1411,57 @@ def _build_two_box_hydro_pipeline(device, mc_edge_clamp_min: float):
     return pipeline, model
 
 
-def _canonical_contact_surface_signature(cs):
-    """Return an order-invariant signature of a contact surface for equality checks.
+def _contact_surface_aggregates(cs):
+    """Return order-invariant scalar aggregates summarizing a contact surface.
 
-    Returns ``(num_faces, sorted_flattened_vertex_components)``.  The contact
-    writer uses ``wp.atomic_add`` to assign output slots, so two builds with
-    identical inputs may produce vertices in different orders but with the
-    same set of values; sorting all vertex components together cancels any
-    ordering noise.
+    Returns ``(face_count, total_triangle_area, sum_of_vertex_norms)``.  All
+    three are commutative reductions, so they are insensitive to the
+    ``wp.atomic_add`` ordering the contact writer uses to assign output
+    slots; comparing them across configs avoids false negatives from
+    atomic-ordering noise without depending on bit-exact reproducibility.
     """
     n = int(cs.face_contact_count.numpy()[0])
     if n == 0:
-        return 0, np.empty(0, dtype=np.float32)
-    components = cs.contact_surface_point.numpy()[: n * 3].reshape(-1).astype(np.float64)
-    return n, np.sort(components)
+        return 0, 0.0, 0.0
+    verts = cs.contact_surface_point.numpy()[: n * 3].astype(np.float64).reshape(-1, 3)
+    e1 = verts[1::3] - verts[0::3]
+    e2 = verts[2::3] - verts[0::3]
+    total_area = 0.5 * float(np.linalg.norm(np.cross(e1, e2), axis=1).sum())
+    vertex_norm_sum = float(np.linalg.norm(verts, axis=1).sum())
+    return n, total_area, vertex_norm_sum
 
 
 def test_mc_edge_clamp_min_changes_contact_surface(test, device):
     """Verify ``mc_edge_clamp_min`` actually flows through to vertex placement.
 
-    Builds the same two-box scene three times: twice with ``mc_edge_clamp_min=0.02``
-    (same-args control to confirm the build is order-invariantly deterministic)
-    and once with ``mc_edge_clamp_min=0.0``.  Asserts that the two same-args runs
-    produce identical canonical signatures, then asserts the differing-args run
-    produces a different signature.  The control rules out atomic-ordering
-    false positives — without it, swapping the clamp for a no-op constant in
-    the kernel would still pass CI.
+    Builds the same two-box scene with ``mc_edge_clamp_min=0.02`` and with
+    ``mc_edge_clamp_min=0.0`` and asserts that at least one of three
+    order-invariant scalar aggregates (face count, total triangle area, sum
+    of vertex norms) differs by more than a relative tolerance.  A kernel
+    that ignored the parameter would produce identical aggregates and fail
+    the test.
     """
-    pipe_a, _model_a = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
-    pipe_b, _model_b = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
-    pipe_diff, _model_diff = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.0)
+    pipe_clamped, _model_clamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
+    pipe_unclamped, _model_unclamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.0)
 
-    n_a, sig_a = _canonical_contact_surface_signature(pipe_a.hydroelastic_sdf.get_contact_surface())
-    n_b, sig_b = _canonical_contact_surface_signature(pipe_b.hydroelastic_sdf.get_contact_surface())
-    n_diff, sig_diff = _canonical_contact_surface_signature(pipe_diff.hydroelastic_sdf.get_contact_surface())
+    n_c, area_c, norm_c = _contact_surface_aggregates(pipe_clamped.hydroelastic_sdf.get_contact_surface())
+    n_u, area_u, norm_u = _contact_surface_aggregates(pipe_unclamped.hydroelastic_sdf.get_contact_surface())
 
-    test.assertGreater(n_a, 0, "Expected non-empty contact surface for the baseline build")
-    test.assertEqual(n_a, n_b, "Same-args builds produced different face counts — non-deterministic build")
-    np.testing.assert_allclose(
-        sig_a,
-        sig_b,
-        atol=1e-6,
-        rtol=0.0,
-        err_msg="Same-args builds produced different vertex sets — non-deterministic build",
+    test.assertGreater(n_c, 0, "Expected non-empty contact surface for the clamped build")
+    test.assertGreater(n_u, 0, "Expected non-empty contact surface for the unclamped build")
+
+    rel_tol = 1e-3
+    differs = (
+        n_c != n_u
+        or abs(area_c - area_u) / max(area_c, area_u, 1e-12) > rel_tol
+        or abs(norm_c - norm_u) / max(norm_c, norm_u, 1e-12) > rel_tol
     )
-
-    differs = (n_a != n_diff) or not np.allclose(sig_a, sig_diff, atol=1e-6, rtol=0.0)
-    test.assertTrue(differs, "Changing mc_edge_clamp_min did not change the contact surface")
+    test.assertTrue(
+        differs,
+        f"mc_edge_clamp_min did not change the contact surface: "
+        f"n=({n_c},{n_u}) area=({area_c:.6f},{area_u:.6f}) "
+        f"norm_sum=({norm_c:.6f},{norm_u:.6f})",
+    )
 
 
 add_function_test(

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1245,9 +1245,10 @@ def test_no_degenerate_triangles_deep_penetration(test, device):
     of degenerate (zero-area) triangles that arise from vertex collapse at
     SDF ridge boundaries.
 
-    The edge-interpolation clamp (:attr:`HydroelasticSDF.Config.mc_edge_clamp`)
-    is the mechanism that prevents these vertex collapses, so this test is
-    only meaningful when ``mc_edge_clamp`` is non-zero.
+    The edge-interpolation clamp
+    (:attr:`HydroelasticSDF.Config.mc_edge_clamp_min`) is the mechanism that
+    prevents these vertex collapses, so this test is only meaningful when
+    ``mc_edge_clamp_min`` is non-zero.
 
     Args:
         test: Unittest-style assertion helper.
@@ -1298,7 +1299,7 @@ def test_no_degenerate_triangles_deep_penetration(test, device):
             reduce_contacts=False,
             buffer_mult_iso=4,
             buffer_mult_contact=4,
-            mc_edge_clamp=0.02,
+            mc_edge_clamp_min=0.02,
         )
         collision_pipeline = newton.CollisionPipeline(
             model,
@@ -1342,6 +1343,99 @@ add_function_test(
     TestHydroelastic,
     "test_no_degenerate_triangles_deep_penetration",
     test_no_degenerate_triangles_deep_penetration,
+    devices=cuda_devices,
+    check_output=False,
+)
+
+
+def _build_two_box_hydro_pipeline(device, mc_edge_clamp_min: float):
+    """Build a deeply-overlapping two-box hydroelastic scene and return the populated contact surface."""
+    box_half = 0.1
+    narrow_band = box_half * 0.2
+    contact_gap = box_half * 0.2
+
+    cfg = newton.ModelBuilder.ShapeConfig(
+        mu=0.5,
+        kh=1e10,
+        sdf_max_resolution=64,
+        is_hydroelastic=True,
+        sdf_narrow_band_range=(-narrow_band, narrow_band),
+        gap=contact_gap,
+    )
+    builder = newton.ModelBuilder()
+    body_a = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, box_half), wp.quat_identity()))
+    builder.add_shape_box(body=body_a, hx=box_half, hy=box_half, hz=box_half, cfg=cfg)
+    overlap = 0.10
+    z_b = box_half + 2.0 * box_half - overlap
+    body_b = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, z_b), wp.quat_identity()))
+    builder.add_shape_box(body=body_b, hx=box_half, hy=box_half, hz=box_half, cfg=cfg)
+    model = builder.finalize(device=device)
+    state = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+    hydro_config = HydroelasticSDF.Config(
+        output_contact_surface=True,
+        reduce_contacts=False,
+        buffer_mult_iso=4,
+        buffer_mult_contact=4,
+        mc_edge_clamp_min=mc_edge_clamp_min,
+    )
+    pipeline = newton.CollisionPipeline(
+        model,
+        rigid_contact_max=100000,
+        broad_phase="explicit",
+        sdf_hydroelastic_config=hydro_config,
+    )
+    contacts = pipeline.contacts()
+    pipeline.collide(state, contacts)
+    return pipeline.hydroelastic_sdf.get_contact_surface()
+
+
+def test_mc_edge_clamp_min_changes_contact_surface(test, device):
+    """Verify ``mc_edge_clamp_min`` actually flows through to vertex placement.
+
+    Builds the same scene twice with different clamp values and asserts that
+    the resulting vertex positions differ. Without this guard, swapping the
+    clamp for a no-op constant in the kernel would still pass CI.
+    """
+    cs_clamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
+    cs_unclamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.0)
+    n_clamped = int(cs_clamped.face_contact_count.numpy()[0])
+    n_unclamped = int(cs_unclamped.face_contact_count.numpy()[0])
+    test.assertGreater(n_clamped, 0)
+    test.assertGreater(n_unclamped, 0)
+
+    n = min(n_clamped, n_unclamped)
+    v_clamped = cs_clamped.contact_surface_point.numpy()[: n * 3].reshape(n, 3, 3)
+    v_unclamped = cs_unclamped.contact_surface_point.numpy()[: n * 3].reshape(n, 3, 3)
+    test.assertGreater(
+        float(np.linalg.norm(v_clamped - v_unclamped)),
+        0.0,
+        "mc_edge_clamp_min did not change vertex positions",
+    )
+
+
+add_function_test(
+    TestHydroelastic,
+    "test_mc_edge_clamp_min_changes_contact_surface",
+    test_mc_edge_clamp_min_changes_contact_surface,
+    devices=cuda_devices,
+    check_output=False,
+)
+
+
+def test_mc_edge_clamp_min_rejects_out_of_range(test, device):
+    """``HydroelasticSDF.Config.mc_edge_clamp_min`` must be in ``[0.0, 0.5]``."""
+    del device  # validation runs at Config construction; no device needed
+    for bad_value in (-0.1, 0.51, float("nan")):
+        with test.assertRaises(ValueError, msg=f"Should reject mc_edge_clamp_min={bad_value}"):
+            HydroelasticSDF.Config(mc_edge_clamp_min=bad_value)
+
+
+add_function_test(
+    TestHydroelastic,
+    "test_mc_edge_clamp_min_rejects_out_of_range",
+    test_mc_edge_clamp_min_rejects_out_of_range,
     devices=cuda_devices,
     check_output=False,
 )

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -1064,6 +1064,21 @@ def test_mujoco_hydroelastic_penetration_depth(test, device):
 
 
 class TestHydroelastic(unittest.TestCase):
+    def test_mc_edge_clamp_min_validation(self):
+        """``HydroelasticSDF.Config.mc_edge_clamp_min`` validates its range at construction.
+
+        The validator runs in ``Config.__post_init__`` and is host-side only,
+        so this test is device-independent and runs even on CPU-only CI.
+        """
+        # In-range values, including the boundaries, must construct cleanly.
+        for good_value in (0.0, 0.02, 0.5):
+            HydroelasticSDF.Config(mc_edge_clamp_min=good_value)
+
+        # Out-of-range values, including NaN, must raise ``ValueError``.
+        for bad_value in (-0.1, 0.51, float("nan")):
+            with self.assertRaises(ValueError, msg=f"Should reject mc_edge_clamp_min={bad_value}"):
+                HydroelasticSDF.Config(mc_edge_clamp_min=bad_value)
+
     @unittest.skip("Visual debugging - run manually to view simulation")
     def test_view_stacked_primitive_cubes(self):
         """View stacked primitive cubes simulation with hydroelastic contacts."""
@@ -1349,7 +1364,12 @@ add_function_test(
 
 
 def _build_two_box_hydro_pipeline(device, mc_edge_clamp_min: float):
-    """Build a deeply-overlapping two-box hydroelastic scene and return the populated contact surface."""
+    """Build a deeply-overlapping two-box hydroelastic scene and return the live pipeline.
+
+    The pipeline (and its model) are kept alive by the caller so that the
+    Warp arrays referenced by the contact surface remain valid until
+    ``.numpy()`` reads have completed.
+    """
     box_half = 0.1
     narrow_band = box_half * 0.2
     contact_gap = box_half * 0.2
@@ -1388,54 +1408,62 @@ def _build_two_box_hydro_pipeline(device, mc_edge_clamp_min: float):
     )
     contacts = pipeline.contacts()
     pipeline.collide(state, contacts)
-    return pipeline.hydroelastic_sdf.get_contact_surface()
+    return pipeline, model
+
+
+def _canonical_contact_surface_signature(cs):
+    """Return an order-invariant signature of a contact surface for equality checks.
+
+    Returns ``(num_faces, sorted_flattened_vertex_components)``.  The contact
+    writer uses ``wp.atomic_add`` to assign output slots, so two builds with
+    identical inputs may produce vertices in different orders but with the
+    same set of values; sorting all vertex components together cancels any
+    ordering noise.
+    """
+    n = int(cs.face_contact_count.numpy()[0])
+    if n == 0:
+        return 0, np.empty(0, dtype=np.float32)
+    components = cs.contact_surface_point.numpy()[: n * 3].reshape(-1).astype(np.float64)
+    return n, np.sort(components)
 
 
 def test_mc_edge_clamp_min_changes_contact_surface(test, device):
     """Verify ``mc_edge_clamp_min`` actually flows through to vertex placement.
 
-    Builds the same scene twice with different clamp values and asserts that
-    the resulting vertex positions differ. Without this guard, swapping the
-    clamp for a no-op constant in the kernel would still pass CI.
+    Builds the same two-box scene three times: twice with ``mc_edge_clamp_min=0.02``
+    (same-args control to confirm the build is order-invariantly deterministic)
+    and once with ``mc_edge_clamp_min=0.0``.  Asserts that the two same-args runs
+    produce identical canonical signatures, then asserts the differing-args run
+    produces a different signature.  The control rules out atomic-ordering
+    false positives — without it, swapping the clamp for a no-op constant in
+    the kernel would still pass CI.
     """
-    cs_clamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
-    cs_unclamped = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.0)
-    n_clamped = int(cs_clamped.face_contact_count.numpy()[0])
-    n_unclamped = int(cs_unclamped.face_contact_count.numpy()[0])
-    test.assertGreater(n_clamped, 0)
-    test.assertGreater(n_unclamped, 0)
+    pipe_a, _model_a = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
+    pipe_b, _model_b = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.02)
+    pipe_diff, _model_diff = _build_two_box_hydro_pipeline(device, mc_edge_clamp_min=0.0)
 
-    n = min(n_clamped, n_unclamped)
-    v_clamped = cs_clamped.contact_surface_point.numpy()[: n * 3].reshape(n, 3, 3)
-    v_unclamped = cs_unclamped.contact_surface_point.numpy()[: n * 3].reshape(n, 3, 3)
-    test.assertGreater(
-        float(np.linalg.norm(v_clamped - v_unclamped)),
-        0.0,
-        "mc_edge_clamp_min did not change vertex positions",
+    n_a, sig_a = _canonical_contact_surface_signature(pipe_a.hydroelastic_sdf.get_contact_surface())
+    n_b, sig_b = _canonical_contact_surface_signature(pipe_b.hydroelastic_sdf.get_contact_surface())
+    n_diff, sig_diff = _canonical_contact_surface_signature(pipe_diff.hydroelastic_sdf.get_contact_surface())
+
+    test.assertGreater(n_a, 0, "Expected non-empty contact surface for the baseline build")
+    test.assertEqual(n_a, n_b, "Same-args builds produced different face counts — non-deterministic build")
+    np.testing.assert_allclose(
+        sig_a,
+        sig_b,
+        atol=1e-6,
+        rtol=0.0,
+        err_msg="Same-args builds produced different vertex sets — non-deterministic build",
     )
+
+    differs = (n_a != n_diff) or not np.allclose(sig_a, sig_diff, atol=1e-6, rtol=0.0)
+    test.assertTrue(differs, "Changing mc_edge_clamp_min did not change the contact surface")
 
 
 add_function_test(
     TestHydroelastic,
     "test_mc_edge_clamp_min_changes_contact_surface",
     test_mc_edge_clamp_min_changes_contact_surface,
-    devices=cuda_devices,
-    check_output=False,
-)
-
-
-def test_mc_edge_clamp_min_rejects_out_of_range(test, device):
-    """``HydroelasticSDF.Config.mc_edge_clamp_min`` must be in ``[0.0, 0.5]``."""
-    del device  # validation runs at Config construction; no device needed
-    for bad_value in (-0.1, 0.51, float("nan")):
-        with test.assertRaises(ValueError, msg=f"Should reject mc_edge_clamp_min={bad_value}"):
-            HydroelasticSDF.Config(mc_edge_clamp_min=bad_value)
-
-
-add_function_test(
-    TestHydroelastic,
-    "test_mc_edge_clamp_min_rejects_out_of_range",
-    test_mc_edge_clamp_min_rejects_out_of_range,
     devices=cuda_devices,
     check_output=False,
 )


### PR DESCRIPTION
## Description

Backports #2747 onto `release-1.2`.

This cherry-picks the hydroelastic marching-cubes clamp configuration and the `nut_bolt_hydro` threading fix into the release branch without merging unrelated `main` history. It also brings over the focused hydroelastic regression coverage and release changelog entries.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_mc_edge_clamp_min
uvx pre-commit run -a
git diff --check origin/release-1.2..HEAD
```

## Bug fix

**Steps to reproduce:**

1. Run the `nut_bolt_hydro` example on `release-1.2` without this backport.
2. Observe that hydroelastic contacts may leave the threading stuck/pinned during the nut/bolt interaction.
3. Compare against this PR, where contact generation cadence and SDF resolution tuning keep the example progressing.

**Minimal reproduction:**

```python
from newton.geometry import HydroelasticSDF

# The new tests cover both host-side validation and observable contact-surface behavior.
HydroelasticSDF.Config(mc_edge_clamp_min=0.02)
```

## New feature / API change

```python
from newton.geometry import HydroelasticSDF

sdf_config = HydroelasticSDF.Config(mc_edge_clamp_min=0.02)
```