### PR TITLE
docs: point warp intersphinx at /stable subpath

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytorch": ("https://pytorch.org/docs/stable", None),
-    "warp": ("https://nvidia.github.io/warp", None),
+    "warp": ("https://nvidia.github.io/warp/stable", None),
     "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }
 


### PR DESCRIPTION
## Summary

- Switch `intersphinx_mapping["warp"]` from `https://nvidia.github.io/warp` to `https://nvidia.github.io/warp/stable` in `docs/conf.py`.
- Unblocks every PR's `Build Sphinx documentation` job (currently failing under `sphinx-build -W` with a `404` on `https://nvidia.github.io/warp/objects.inv`).

## Why

Warp moved to multi-version docs. `https://nvidia.github.io/warp/` is now a `<meta http-equiv="refresh" content="0; url=stable/">` redirect rather than a docs root, so `objects.inv` is no longer at that bare URL. The actual inventories live one level down:

| URL | HTTP status |
|---|---|
| `https://nvidia.github.io/warp/objects.inv` | **404** |
| `https://nvidia.github.io/warp/stable/objects.inv` | **200** |
| `https://nvidia.github.io/warp/latest/objects.inv` | **200** |

`stable` (rather than `latest`) matches the Warp release pinned in `pyproject.toml` and keeps cross-references reproducible across builds.

Filed for context: #2809

## Test plan

- [x] `LC_ALL=C.UTF-8 LANG=C.UTF-8 uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html` → `build succeeded.`
- [x] `LC_ALL=C.UTF-8 LANG=C.UTF-8 uv run --extra docs --extra sim sphinx-build -j auto -W -b doctest docs docs/_build/doctest` → `build succeeded.` (82 tests, 0 failures)
- [x] On `main` without this change, the same `-W` html build fails with the 404 above; with this change it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation URLs to reference the stable documentation site for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->