### PR TITLE
Fix Warp intersphinx URL to point to /stable/

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytorch": ("https://pytorch.org/docs/stable", None),
-    "warp": ("https://nvidia.github.io/warp", None),
+    "warp": ("https://nvidia.github.io/warp/stable", None),
     "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }
 


### PR DESCRIPTION
The Warp docs recently moved to versioned hosting (`/stable/`, `/latest/`, `/vX.Y/`). The `objects.inv` file is now at `/stable/objects.inv` rather than the site root.

Without this fix, intersphinx cross-references to Warp APIs (e.g. `:class:\`warp.array\``) fail to resolve during the Sphinx build.

**Change:** `https://nvidia.github.io/warp` → `https://nvidia.github.io/warp/stable`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation references to point to stable NVIDIA Warp documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->