### PR TITLE
Fix Warp intersphinx URL to point to /stable/ (release-1.2)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytorch": ("https://pytorch.org/docs/stable", None),
-    "warp": ("https://nvidia.github.io/warp", None),
+    "warp": ("https://nvidia.github.io/warp/stable", None),
     "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }
 


### PR DESCRIPTION
Backport of #2811 to `release-1.2`.

The Warp docs recently moved to versioned hosting (`/stable/`, `/latest/`, `/vX.Y/`). The `objects.inv` file is now at `/stable/objects.inv` rather than the site root.

Without this fix, intersphinx cross-references to Warp APIs (e.g. `:class:\`warp.array\``) fail to resolve during the Sphinx build.

**Change:** `https://nvidia.github.io/warp` → `https://nvidia.github.io/warp/stable`