### PR TITLE
Anchor ViewerGL Plots window to bottom-right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
+- Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead
 - Fix `SolverMuJoCo` Newton-contact conversion to use geometry-surface contact anchors
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -2702,7 +2702,7 @@ class ViewerGL(ViewerBase):
             item_height + 60,
         )
         imgui.set_next_window_pos(
-            imgui.ImVec2(io.display_size[0] - window_width - 10, 10),
+            imgui.ImVec2(io.display_size[0] - window_width - 10, io.display_size[1] - window_height - 10),
             imgui.Cond_.appearing,
         )
         imgui.set_next_window_size(


### PR DESCRIPTION
## Description

The `Plots` ImGui window in `viewer_gl.py` opened at the top-right with `Cond_.appearing`, overlapping the `Performance Stats` overlay (also anchored top-right). This change moves the default position to the bottom-right so both panels are visible on a fresh run. `Cond_.appearing` is preserved, so user-dragged positions persisted in `imgui.ini` still take effect.

Closes #2817

Before:
<img width="1920" height="1113" alt="plot_before" src="https://github.com/user-attachments/assets/d51a8de2-f506-44d7-8d14-92c3101fd561" />


After fixing: 
<img width="1920" height="1113" alt="plot_after" src="https://github.com/user-attachments/assets/bb1ebc41-3d92-4f3f-9781-f10a5fd6f724" />

## Checklist

- [x] New or existing tests cover these changes (UI position only; no behavioral change — covered by existing example tests)
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run -m newton.examples sensor_contact      # Plots panel now bottom-right; stats overlay fully visible
uv run -m newton.examples basic_plotting
uv run -m newton.examples diffsim_bear
uv run -m newton.examples diffsim_drone
uv run -m newton.examples diffsim_ball
```

## Bug fix

**Steps to reproduce:**

1. Run any example that uses `viewer.log_scalar()` (e.g. `uv run -m newton.examples sensor_contact`).
2. Observe the `Plots` window in the top-right covering the lower rows of the `Performance Stats` overlay (Triangles / Edges / Tetrahedra / Unique Objects).

**Minimal reproduction:**

```python
import newton
# Any example calling viewer.log_scalar(...) with --viewer gl reproduces it.
# Affected examples:
#   newton/examples/basic/example_basic_plotting.py
#   newton/examples/sensors/example_sensor_contact.py
#   newton/examples/diffsim/example_diffsim_bear.py
#   newton/examples/diffsim/example_diffsim_drone.py
#   newton/examples/diffsim/example_diffsim_ball.py
```