### PR TITLE
Fix device for gravity data allocation in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -231,14 +231,14 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
     # correct shape and type, and copy the converted data into them.
     else:
         # Ensure that the output GravityModel has allocated arrays of the correct shape and type
-        if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count, 4):
+        if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.g_dir_acc` array does not have matching shape. Allocating a new array.")
-            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=vec4f)
+            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=vec4f, device=model_in.device)
         else:
             gravity_out.g_dir_acc.assign(g_dir_acc_np)
-        if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count, 4):
+        if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.vector` array does not have matching shape. Allocating a new array.")
-            gravity_out.vector = wp.array(vector_np, dtype=vec4f)
+            gravity_out.vector = wp.array(vector_np, dtype=vec4f, device=model_in.device)
         else:
             gravity_out.vector.assign(vector_np)
 

--- a/newton/tests/test_runtime_gravity.py
+++ b/newton/tests/test_runtime_gravity.py
@@ -7,7 +7,7 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.solvers import SolverSemiImplicit, SolverXPBD
+from newton.solvers import SolverKamino, SolverSemiImplicit, SolverXPBD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 
@@ -604,6 +604,7 @@ solvers_bodies = {
     "semi_implicit": SolverSemiImplicit,
     "mujoco_cpu": lambda model: newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=True, update_data_interval=0),
     "mujoco_warp": lambda model: newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=False, update_data_interval=0),
+    "kamino": SolverKamino,
 }
 
 # Add tests for each device and solver combination


### PR DESCRIPTION
## Description

When converting gravity from a Newton model to Kamino's gravity data structure, a specific code path failed to allocate new warp arrays on the same device the model data lives, instead allocating it on the default device. This specific case generally happens when an existing gravity data structure is updated, e.g., as a reaction to the solver being notified about an update to the gravity values.

At the same time, an issue with the size check of the existing array was addressed. The issue lead to a new array being allocated with every change, even if the size was compatible with the new gravity data.

To simplify the testing and in anticipation of the test migration, I added Kamino to the existing Newton gravity tests, instead of creating a new test in Kamino.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_runtime_gravity
```

## Bug fix

**Steps to reproduce:**

1. Add Kamino to `test_runtime_gravity.py`
2. Run `uv run --extra dev -m newton.tests -k test_runtime_gravity`
3. The CPU-based test for Kamino will fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Gravity runtime tests now include the Kamino solver, increasing solver coverage.

* **Bug Fixes**
  * Fixed device-aware allocation for gravity model data to ensure correct behavior across compute devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->