### PR TITLE
Kamino - regularized FK

### DIFF
--- a/newton/_src/solvers/kamino/_src/linalg/blas.py
+++ b/newton/_src/solvers/kamino/_src/linalg/blas.py
@@ -957,15 +957,17 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
     def cwise_inverse_kernel(
         # Inputs
         x: wp.array2d[dtype],
+        offset: float32,
         dim: wp.array[wp.int32],
         mask: wp.array[wp.int32],
     ):
+        """Kernel computing x_i = 1 / (x_i + offset) for an array of scalars x_i"""
         mat_id, coeff_id = wp.tid()
 
         if mat_id >= mask.shape[0] or mask[mat_id] == 0 or coeff_id >= dim[mat_id]:
             return
 
-        x[mat_id, coeff_id] = 1.0 / x[mat_id, coeff_id]
+        x[mat_id, coeff_id] = 1.0 / (x[mat_id, coeff_id] + offset)
 
     return cwise_inverse_kernel
 
@@ -974,30 +976,43 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
 def blockwise_inverse_kernel_3_2d(
     # Inputs
     blocks: wp.array2d[wp.mat33f],
+    diag_offset: float32,
     dim: wp.array[wp.int32],
     mask: wp.array[wp.int32],
 ):
+    """Kernel computing B_i = (B_i + diag_offset * I)^-1 for an array of 3x3 blocks B_i"""
     mat_id, block_id = wp.tid()
 
     if mat_id >= mask.shape[0] or mask[mat_id] == 0 or 7 * block_id >= dim[mat_id]:
         return
 
-    blocks[mat_id, block_id] = wp.inverse(blocks[mat_id, block_id])
+    block = blocks[mat_id, block_id]
+    block[0, 0] += diag_offset
+    block[1, 1] += diag_offset
+    block[2, 2] += diag_offset
+    blocks[mat_id, block_id] = wp.inverse(block)
 
 
 @wp.kernel
 def blockwise_inverse_kernel_4_2d(
     # Inputs
     blocks: wp.array2d[wp.mat44f],
+    diag_offset: float32,
     dim: wp.array[wp.int32],
     mask: wp.array[wp.int32],
 ):
+    """Kernel computing B_i = (B_i + diag_offset * I)^-1 for an array of 4x4 blocks B_i"""
     mat_id, block_id = wp.tid()
 
     if mat_id >= mask.shape[0] or mask[mat_id] == 0 or 7 * block_id >= dim[mat_id]:
         return
 
-    blocks[mat_id, block_id] = wp.inverse(blocks[mat_id, block_id])
+    block = blocks[mat_id, block_id]
+    block[0, 0] += diag_offset
+    block[1, 1] += diag_offset
+    block[2, 2] += diag_offset
+    block[3, 3] += diag_offset
+    blocks[mat_id, block_id] = wp.inverse(block)
 
 
 @wp.kernel
@@ -1399,14 +1414,17 @@ def block_sparse_transpose_gemv(
         )
 
 
-def block_sparse_ATA_inv_diagonal_2d(A: BlockSparseMatrices, inv_diag: wp.array, matrix_mask: wp.array):
+def block_sparse_ATA_inv_diagonal_2d(
+    A: BlockSparseMatrices, inv_diag: wp.array, matrix_mask: wp.array, diag_offset: float32 = 0.0
+):
     """
-    Function computing the inverse of the diagonal of A^T * A given sparse matrix (stack) A.
+    Function computing the inverse of the diagonal of A^T * A + diag_offset * I, given sparse matrix (stack) A.
 
     Args:
         A (BlockSparseMatrices): Sparse matrices.
         inv_diag (wp.array): Stack of output vectors, expects shape (num_matrices, max_of_max_cols).
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
+        diag_offset (float32, optional): Scalar diagonal offset added to A^T * A (defaults to zero).
     """
     wp.launch(
         kernel=_make_masked_zero_kernel_2d(A.nzb_type.dtype),
@@ -1427,20 +1445,13 @@ def block_sparse_ATA_inv_diagonal_2d(A: BlockSparseMatrices, inv_diag: wp.array,
         ],
         device=A.device,
     )
-    int_size_bytes = 4  # Size of wp.int32 in bytes
-    cols = wp.array(
-        dtype=wp.int32,
-        shape=(A.num_matrices,),
-        ptr=A.dims.ptr + int_size_bytes,
-        strides=(2 * int_size_bytes,),
-        copy=False,
-    )
     wp.launch(
         kernel=_make_cwise_inverse_kernel_2d(A.nzb_dtype.dtype),
         dim=(A.num_matrices, A.max_of_max_dims[1]),
         inputs=[
             inv_diag,
-            cols,
+            diag_offset,
+            A.num_cols,
             matrix_mask,
         ],
         device=A.device,
@@ -1448,10 +1459,14 @@ def block_sparse_ATA_inv_diagonal_2d(A: BlockSparseMatrices, inv_diag: wp.array,
 
 
 def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
-    A: BlockSparseMatrices, inv_blocks_3: wp.array, inv_blocks_4: wp.array, matrix_mask: wp.array
+    A: BlockSparseMatrices,
+    inv_blocks_3: wp.array,
+    inv_blocks_4: wp.array,
+    matrix_mask: wp.array,
+    diag_offset: float32 = 0.0,
 ):
     """
-    Function computing the blockwise inverse of the diagonal of A^T * A given sparse matrix (stack) A,
+    Function computing the blockwise inverse of the diagonal of A^T * A + diag_offset * I given sparse matrix (stack) A,
     with alternating 3x3 and 4x4 blocks
     A must have block size 1x7
 
@@ -1459,6 +1474,7 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         A (BlockSparseMatrices): Sparse matrices.
         inv_blocks (wp.array): Stack of vectors of 3x3 blocks, expects shape (num_matrices, max_of_max_cols / 7).
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
+        diag_offset (float32, optional): Scalar diagonal offset added to A^T * A (defaults to zero).
     """
     wp.launch(
         _make_masked_zero_kernel_2d(wp.mat33f),
@@ -1500,20 +1516,13 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         ],
         device=A.device,
     )
-    int_size_bytes = 4  # Size of wp.int32 in bytes
-    cols = wp.array(
-        dtype=wp.int32,
-        shape=(A.num_matrices,),
-        ptr=A.dims.ptr + int_size_bytes,
-        strides=(2 * int_size_bytes,),
-        copy=False,
-    )
     wp.launch(
         kernel=blockwise_inverse_kernel_3_2d,
         dim=inv_blocks_3.shape,
         inputs=[
             inv_blocks_3,
-            cols,
+            diag_offset,
+            A.num_cols,
             matrix_mask,
         ],
         device=A.device,
@@ -1523,7 +1532,8 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         dim=inv_blocks_4.shape,
         inputs=[
             inv_blocks_4,
-            cols,
+            diag_offset,
+            A.num_cols,
             matrix_mask,
         ],
         device=A.device,

--- a/newton/_src/solvers/kamino/_src/linalg/blas.py
+++ b/newton/_src/solvers/kamino/_src/linalg/blas.py
@@ -956,8 +956,8 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
     @wp.kernel
     def cwise_inverse_kernel(
         # Inputs
-        x: wp.array2d[dtype],
         offset: float32,
+        x: wp.array2d[dtype],
         dim: wp.array[wp.int32],
         mask: wp.array[wp.int32],
     ):
@@ -975,8 +975,8 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
 @wp.kernel
 def blockwise_inverse_kernel_3_2d(
     # Inputs
-    blocks: wp.array2d[wp.mat33f],
     diag_offset: float32,
+    blocks: wp.array2d[wp.mat33f],
     dim: wp.array[wp.int32],
     mask: wp.array[wp.int32],
 ):
@@ -996,8 +996,8 @@ def blockwise_inverse_kernel_3_2d(
 @wp.kernel
 def blockwise_inverse_kernel_4_2d(
     # Inputs
-    blocks: wp.array2d[wp.mat44f],
     diag_offset: float32,
+    blocks: wp.array2d[wp.mat44f],
     dim: wp.array[wp.int32],
     mask: wp.array[wp.int32],
 ):
@@ -1153,7 +1153,8 @@ def block_sparse_matvec(
         version; or shape (num_matrices, max_of_max_cols) for the 2D version.
         y (wp.array): Stack of output vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
         version; or shape (num_matrices, max_of_max_rows) for the 2D version.
-        matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
+        matrix_mask (wp.array): Per-matrix 0/1 flag for whether to perform the operation. Blocks of `y`, that
+        correspond to matrices for which the mask is `0`, are left unchanged.
     """
     if len(x.shape) == 1:
         wp.launch(
@@ -1216,7 +1217,8 @@ def block_sparse_transpose_matvec(
         version; or shape (num_matrices, max_of_max_rows) for the 2D version.
         x (wp.array): Stack of output vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
         version; or shape (num_matrices, max_of_max_cols) for the 2D version.
-        matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
+        matrix_mask (wp.array): Per-matrix 0/1 flag for whether to perform the operation. Blocks of `x`, that
+        correspond to matrices for which the mask is `0`, are left unchanged.
     """
     if len(x.shape) == 1:
         wp.launch(
@@ -1427,7 +1429,7 @@ def block_sparse_ATA_inv_diagonal_2d(
         diag_offset (float32, optional): Scalar diagonal offset added to A^T * A (defaults to zero).
     """
     wp.launch(
-        kernel=_make_masked_zero_kernel_2d(A.nzb_type.dtype),
+        kernel=_make_masked_zero_kernel_2d(A.nzb_dtype.dtype),
         dim=(A.num_matrices, A.max_of_max_dims[1]),
         inputs=[matrix_mask, inv_diag],
         device=A.device,
@@ -1449,8 +1451,8 @@ def block_sparse_ATA_inv_diagonal_2d(
         kernel=_make_cwise_inverse_kernel_2d(A.nzb_dtype.dtype),
         dim=(A.num_matrices, A.max_of_max_dims[1]),
         inputs=[
-            inv_diag,
             diag_offset,
+            inv_diag,
             A.num_cols,
             matrix_mask,
         ],
@@ -1520,8 +1522,8 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         kernel=blockwise_inverse_kernel_3_2d,
         dim=inv_blocks_3.shape,
         inputs=[
-            inv_blocks_3,
             diag_offset,
+            inv_blocks_3,
             A.num_cols,
             matrix_mask,
         ],
@@ -1531,8 +1533,8 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         kernel=blockwise_inverse_kernel_4_2d,
         dim=inv_blocks_4.shape,
         inputs=[
-            inv_blocks_4,
             diag_offset,
+            inv_blocks_4,
             A.num_cols,
             matrix_mask,
         ],

--- a/newton/_src/solvers/kamino/_src/linalg/blas.py
+++ b/newton/_src/solvers/kamino/_src/linalg/blas.py
@@ -118,6 +118,49 @@ def _mult_left_diag_matrix_with_vector(
 
 
 @functools.cache
+def _make_masked_zero_kernel_1d(dtype: Any):
+    """Factory method producing a kernel for masked zero_() operation on a flattened 2d array"""
+
+    @wp.kernel
+    def masked_zero_kernel_1d(
+        # Inputs:
+        segment_offset: wp.array[int32],
+        segment_size: wp.array[int32],
+        segment_mask: wp.array[int32],
+        # Outputs:
+        x: wp.array[dtype],
+    ):
+        """Kernel resetting to zero segments of input array, based on input mask."""
+        seg_id, coeff_id_loc = wp.tid()
+        if segment_mask[seg_id] == 0 or coeff_id_loc >= segment_size[seg_id]:
+            return
+        coeff_id = segment_offset[seg_id] + coeff_id_loc
+        x[coeff_id] = dtype(0.0)
+
+    return masked_zero_kernel_1d
+
+
+@functools.cache
+def _make_masked_zero_kernel_2d(dtype: Any):
+    """Factory method producing a kernel for masked zero_() operation on a 2d array"""
+
+    @wp.kernel
+    def masked_zero_kernel_2d(
+        # Inputs:
+        row_mask: wp.array[int32],
+        # Outputs:
+        x: wp.array2d[dtype],
+    ):
+        """Kernel resetting to zero rows of input array, based on input mask."""
+        row_id, coeff_id = wp.tid()
+        if row_mask[row_id] == 0:
+            return
+        x[row_id, coeff_id] = dtype(0.0)
+
+    return masked_zero_kernel_2d
+
+
+@functools.cache
 def _make_block_sparse_matvec_kernel(block_type: BlockDType):
     # Determine (static) block size for kernel.
     block_shape = block_type.shape
@@ -1097,9 +1140,13 @@ def block_sparse_matvec(
         version; or shape (num_matrices, max_of_max_rows) for the 2D version.
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
     """
-    y.zero_()
-
     if len(x.shape) == 1:
+        wp.launch(
+            kernel=_make_masked_zero_kernel_1d(A.nzb_dtype.dtype),
+            dim=(A.num_matrices, A.max_of_max_dims[0]),
+            inputs=[A.row_start, A.max_rows, matrix_mask, y],
+            device=A.device,
+        )
         wp.launch(
             kernel=_make_block_sparse_matvec_kernel(A.nzb_dtype),
             dim=(A.num_matrices, A.max_of_num_nzb),
@@ -1117,6 +1164,12 @@ def block_sparse_matvec(
             device=A.device,
         )
     else:
+        wp.launch(
+            kernel=_make_masked_zero_kernel_2d(A.nzb_dtype.dtype),
+            dim=(A.num_matrices, A.max_of_max_dims[0]),
+            inputs=[matrix_mask, y],
+            device=A.device,
+        )
         wp.launch(
             kernel=_make_block_sparse_matvec_kernel_2d(A.nzb_dtype),
             dim=(A.num_matrices, A.max_of_num_nzb),
@@ -1150,9 +1203,13 @@ def block_sparse_transpose_matvec(
         version; or shape (num_matrices, max_of_max_cols) for the 2D version.
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
     """
-    x.zero_()
-
     if len(x.shape) == 1:
+        wp.launch(
+            kernel=_make_masked_zero_kernel_1d(A.nzb_dtype.dtype),
+            dim=(A.num_matrices, A.max_of_max_dims[1]),
+            inputs=[A.col_start, A.max_cols, matrix_mask, x],
+            device=A.device,
+        )
         wp.launch(
             kernel=_make_block_sparse_transpose_matvec_kernel(A.nzb_dtype),
             dim=(A.num_matrices, A.max_of_num_nzb),
@@ -1170,6 +1227,12 @@ def block_sparse_transpose_matvec(
             device=A.device,
         )
     else:
+        wp.launch(
+            kernel=_make_masked_zero_kernel_2d(A.nzb_dtype.dtype),
+            dim=(A.num_matrices, A.max_of_max_dims[1]),
+            inputs=[matrix_mask, x],
+            device=A.device,
+        )
         wp.launch(
             kernel=_make_block_sparse_transpose_matvec_kernel_2d(A.nzb_dtype),
             dim=(A.num_matrices, A.max_of_num_nzb),
@@ -1345,7 +1408,12 @@ def block_sparse_ATA_inv_diagonal_2d(A: BlockSparseMatrices, inv_diag: wp.array,
         inv_diag (wp.array): Stack of output vectors, expects shape (num_matrices, max_of_max_cols).
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
     """
-    inv_diag.zero_()
+    wp.launch(
+        kernel=_make_masked_zero_kernel_2d(A.nzb_type.dtype),
+        dim=(A.num_matrices, A.max_of_max_dims[1]),
+        inputs=[matrix_mask, inv_diag],
+        device=A.device,
+    )
     wp.launch(
         kernel=_make_block_sparse_ATA_diagonal_kernel_2d(A.nzb_dtype),
         dim=(A.num_matrices, A.max_of_num_nzb),
@@ -1392,8 +1460,18 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
         inv_blocks (wp.array): Stack of vectors of 3x3 blocks, expects shape (num_matrices, max_of_max_cols / 7).
         matrix_mask (wp.array): Mask vector to skip matrices set to `0` in the mask.
     """
-    inv_blocks_3.zero_()
-    inv_blocks_4.zero_()
+    wp.launch(
+        _make_masked_zero_kernel_2d(wp.mat33f),
+        dim=(A.num_matrices, A.max_of_max_dims[1] // 7),
+        inputs=[matrix_mask, inv_blocks_3],
+        device=A.device,
+    )
+    wp.launch(
+        _make_masked_zero_kernel_2d(wp.mat44f),
+        dim=(A.num_matrices, A.max_of_max_dims[1] // 7),
+        inputs=[matrix_mask, inv_blocks_4],
+        device=A.device,
+    )
     inv_blocks_3_flat = wp.array(
         dtype=wp.float32,
         ptr=inv_blocks_3.ptr,

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
@@ -440,10 +440,25 @@ class BlockSparseMatrices:
         self.num_nzb.zero_()
         self.nzb_coords.zero_()
 
-    def zero(self):
-        """Sets all non-zero block data to zero."""
+    def zero(self, matrix_mask: wp.array | None = None):
+        """
+        Sets non-zero block data to zero, for all or a subset of the matrices.
+
+        Args:
+            matrix_mask (optional): Per-matrix 0-1 flag indicating if it should be set to zero.
+                                    If not provided, all matrices are set to zero.
+                                    Shape of ``(num_matrices,)`` and type :class:`int`.
+        """
         self._assert_is_finalized()
-        self.nzb_values.zero_()
+        if matrix_mask is not None:
+            wp.launch(
+                _make_masked_zero_kernel(self.nzb_dtype, self.index_dtype),
+                dim=(self.num_matrices, self.max_of_num_nzb),
+                inputs=[self.nzb_start, self.max_nzb, matrix_mask, self.nzb_values],
+                device=self.device,
+            )
+        else:
+            self.nzb_values.zero_()
 
     def assign(self, matrices: list[np.ndarray]):
         """
@@ -577,6 +592,31 @@ class BlockSparseMatrices:
         else:
             raise RuntimeError("Unsupported block shape for NumPy conversion.")
         return block_nrows, block_ncols
+
+
+###
+# Kernels
+###
+
+
+@functools.cache
+def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
+    @wp.kernel
+    def masked_zero_kernel(
+        # Inputs
+        nzb_start: wp.array[index_dtype],
+        max_nzb: wp.array[index_dtype],
+        matrix_mask: wp.array[int32],
+        # Outputs
+        nzb_values: wp.array[block_type.warp_type],
+    ):
+        mat_id, nzb_id_loc = wp.tid()
+        if matrix_mask[mat_id] == 0 or nzb_id_loc >= max_nzb[mat_id]:
+            return
+        nzb_id = nzb_start[mat_id] + nzb_id_loc
+        nzb_values[nzb_id] = block_type.warp_type(0.0)
+
+    return masked_zero_kernel
 
 
 ###

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -1531,7 +1531,6 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
     @wp.kernel
     def _eval_regularizer(
         # Inputs
-        num_bodies: wp.array[wp.int32],
         first_body_id: wp.array[wp.int32],
         reg_weight: wp.float32,
         bodies_q_flat: wp.array[wp.float32],
@@ -1544,7 +1543,6 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
         and adding it to the merit function value.
 
         Inputs:
-            num_bodies: Number of bodies per world.
             first_body_id: First body index per world.
             reg_weight: Regularizer weight.
             bodies_q_flat: Flattened array of current body poses.

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -30,6 +30,7 @@ from .types import FKJointDoFType
 ###
 
 __all__ = [
+    "_add_regularizer_to_diagonal",
     "_apply_line_search_step",
     "_correct_actuator_coords",
     "_eval_actuator_coords",
@@ -38,12 +39,14 @@ __all__ = [
     "_eval_incremental_target_actuator_coords",
     "_eval_linear_combination",
     "_eval_position_control_transformations",
+    "_eval_regularizer_gradient",
     "_eval_rhs",
     "_eval_stepped_state",
     "_eval_target_constraint_velocities",
     "_eval_unit_quaternion_constraints",
     "_eval_unit_quaternion_constraints_jacobian",
     "_eval_unit_quaternion_constraints_sparse_jacobian",
+    "_initialize_jacobian_update_masks",
     "_line_search_check",
     "_newton_check",
     "_reset_state",
@@ -509,9 +512,15 @@ def less_than_op(i: wp.int32, threshold: wp.int32) -> wp.int32:
 
 
 @wp.func
-def mul_mask(mask: wp.int32, value: wp.int32):
+def mul_mask_int(mask: wp.int32, value: wp.int32) -> wp.int32:
     """Return value if mask is positive, else 0"""
     return wp.where(mask > 0, value, 0)
+
+
+@wp.func
+def mul_mask_float(mask: wp.int32, value: wp.float32) -> wp.float32:
+    """Return value if mask is positive, else 0"""
+    return wp.where(mask > 0, value, 0.0)
 
 
 @cache
@@ -545,6 +554,8 @@ def create_eval_min_num_iterations_kernel(TILE_SIZE: int):
         world_offset = world_actuated_coord_offsets[wd_id]
         next_world_offset = world_actuated_coord_offsets[wd_id + 1]
         offset = world_offset + i * TILE_SIZE
+        if offset >= next_world_offset:
+            return  # Early return if tile is fully outside of the world's data
         q_prev = wp.tile_load(actuators_q_prev, shape=TILE_SIZE, offset=offset)
         q_next = wp.tile_load(actuators_q_next, shape=TILE_SIZE, offset=offset)
         delta = wp.tile_load(delta_q_max, shape=TILE_SIZE, offset=offset)
@@ -553,12 +564,42 @@ def create_eval_min_num_iterations_kernel(TILE_SIZE: int):
         min_it = wp.tile_map(min_iteration_op, q_prev, q_next, delta)
         if offset + TILE_SIZE > next_world_offset:  # Mask out values from next world if needed
             mask = wp.tile_map(less_than_op, wp.tile_arange(TILE_SIZE, dtype=wp.int32), next_world_offset - offset)
-            min_it = wp.tile_map(mul_mask, mask, min_it)
+            min_it = wp.tile_map(mul_mask_int, mask, min_it)
         min_it_max = wp.tile_max(min_it)[0]
         if tid == 0:
             wp.atomic_max(min_iterations, wd_id, min_it_max)
 
     return _eval_min_num_iterations
+
+
+@wp.kernel
+def _initialize_jacobian_update_masks(
+    # Inputs
+    newton_mask: wp.array[wp.int32],
+    min_iterations: wp.array[wp.int32],
+    # Outputs
+    jacobian_early_update_mask: wp.array[wp.int32],
+    jacobian_late_update_mask: wp.array[wp.int32],
+):
+    """
+    Kernel initializing the early/late Jacobian update masks for the first iteration, depending
+    on the minimum iterations per world (and therefore, of whether an incremental control update
+    will happen in the first iteration).
+
+    Inputs:
+        newton_mask: Flag indicating whether Gauss-Newton is still running per world.
+        min_iterations: Minimal number of Newton iterations per world.
+    Outputs:
+        jacobian_early_update_mask: Flag set to 1 in worlds needing an early Jacobian update.
+        jacobian_late_update_mask: Flag set to 1 in worlds needing a late Jacobian update.
+
+    """
+    wd_id = wp.tid()  # Get thread id (= world index)
+
+    newton_flag = newton_mask[wd_id]
+    min_it = min_iterations[wd_id]
+    jacobian_early_update_mask[wd_id] = int(newton_flag and min_it == 0)
+    jacobian_late_update_mask[wd_id] = int(newton_flag and min_it > 0)
 
 
 @wp.kernel
@@ -1408,12 +1449,12 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
 
 
 @cache
-def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32):
+def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int32, use_regularization: bool):
     """
     Generates and returns all kernels based on 1d tiles in this module, given the tile size to use along the constraints
     and variables (i.e. body poses) dimensions in the constraint vector, Jacobian, step vector etc.
 
-    These are _eval_max_constraint, _eval_merit_function, _eval_merit_function_gradient
+    These are _eval_max_residual, _eval_merit_function, _eval_regularizer, _eval_merit_function_gradient
     (returned in this order)
     """
 
@@ -1422,40 +1463,43 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
         """Calls wp.isnan and converts the result to int32"""
         return wp.int32(wp.isnan(x))
 
+    TILE_SIZE = TILE_SIZE_VRS if use_regularization else TILE_SIZE_CTS
+
     @wp.kernel
-    def _eval_max_constraint(
+    def _eval_max_residual(
         # Inputs
-        constraints: wp.array2d[wp.float32],
+        residual: wp.array2d[wp.float32],
         # Outputs
-        max_constraint: wp.array[wp.float32],
+        max_residual: wp.array[wp.float32],
     ):
         """
-        A kernel computing the max absolute constraint from the constraints vector, in each world.
+        A kernel computing the max absolute residual from the residual vector, in each world.
+        This is the constraint vector in the general case, but the gradient vector for the regularized case.
 
         Inputs:
-            constraints: Constraint vector per world
+            residual: Residual vector per world
         Outputs:
-            max_constraint: Max absolute constraint per world; must be zero-initialized
+            max_residual: Max absolute residual per world; must be zero-initialized
         """
         wd_id, i, tid = wp.tid()  # Thread indices (= world index, input tile index, thread index in block)
 
-        if wd_id < constraints.shape[0] and i * TILE_SIZE_CTS < constraints.shape[1]:
-            segment = wp.tile_load(constraints, shape=(1, TILE_SIZE_CTS), offset=(wd_id, i * TILE_SIZE_CTS))
+        if wd_id < residual.shape[0] and i * TILE_SIZE < residual.shape[1]:
+            segment = wp.tile_load(residual, shape=(1, TILE_SIZE), offset=(wd_id, i * TILE_SIZE))
             segment_max = wp.tile_max(wp.tile_map(wp.abs, segment))[0]
             segment_has_nan = wp.tile_max(wp.tile_map(_isnan, segment))[0]
 
             if tid == 0:
                 if segment_has_nan:
                     # Write NaN in max (non-atomically, as this will overwrite any non-NaN value)
-                    max_constraint[wd_id] = wp.nan
+                    max_residual[wd_id] = wp.nan
                 else:
                     # Atomically update the max, only if it is not yet NaN (in CUDA, the max() operation only
                     # considers non-NaN values, so the NaN value would get overwritten by a non-NaN otherwise)
                     while True:
-                        curr_val = max_constraint[wd_id]
+                        curr_val = max_residual[wd_id]
                         if wp.isnan(curr_val):
                             break
-                        check_val = wp.atomic_cas(max_constraint, wd_id, curr_val, wp.max(curr_val, segment_max))
+                        check_val = wp.atomic_cas(max_residual, wd_id, curr_val, wp.max(curr_val, segment_max))
                         if check_val == curr_val:
                             break
 
@@ -1485,6 +1529,50 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
                 wp.atomic_add(merit_function_val, wd_id, segment_error)
 
     @wp.kernel
+    def _eval_regularizer(
+        # Inputs
+        num_bodies: wp.array[wp.int32],
+        first_body_id: wp.array[wp.int32],
+        reg_weight: wp.float32,
+        bodies_q_flat: wp.array[wp.float32],
+        bodies_q_ref_flat: wp.array[wp.float32],
+        # Outputs
+        merit_function_val: wp.array[wp.float32],
+    ):
+        """
+        A kernel computing the least-squares regularizer reg_weight * ||s - s_ref||^2 in each world,
+        and adding it to the merit function value.
+
+        Inputs:
+            num_bodies: Number of bodies per world.
+            first_body_id: First body index per world.
+            reg_weight: Regularizer weight.
+            bodies_q_flat: Flattened array of current body poses.
+            bodies_q_ref_flat: Flattened array of reference body poses.
+        Outputs:
+            merit_function_val: Merit function value per world; must be zero-initialized
+        """
+        wd_id, i, tid = wp.tid()  # Thread indices (= world index, input tile index, thread index in block)
+
+        # Load data
+        offset = 7 * first_body_id[wd_id] + i * TILE_SIZE_VRS
+        next_world_start = 7 * first_body_id[wd_id + 1]
+        if offset >= next_world_start:
+            return  # Early return if tile is fully outside of this world's data
+        tile = wp.tile_load(bodies_q_flat, shape=TILE_SIZE_VRS, offset=offset)
+        tile_ref = wp.tile_load(bodies_q_ref_flat, shape=TILE_SIZE_VRS, offset=offset)
+
+        # Compute regularizer
+        reg_tile = tile - tile_ref
+        reg_tile = wp.tile_map(wp.mul, reg_tile, reg_tile)
+        if offset + TILE_SIZE_VRS > next_world_start:  # Mask out values from next world if needed
+            mask = wp.tile_map(less_than_op, wp.tile_arange(TILE_SIZE_VRS, dtype=wp.int32), next_world_start - offset)
+            reg_tile = wp.tile_map(mul_mask_float, mask, reg_tile)
+        reg = wp.tile_sum(reg_tile)[0]
+        if tid == 0:
+            wp.atomic_add(merit_function_val, wd_id, 0.5 * reg_weight * reg)
+
+    @wp.kernel
     def _eval_merit_function_gradient(
         # Inputs
         step: wp.array2d[wp.float32],
@@ -1512,7 +1600,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
             if tid == 0:
                 wp.atomic_add(merit_function_grad, wd_id, tile_dot_prod)
 
-    return _eval_max_constraint, _eval_merit_function, _eval_merit_function_gradient
+    return _eval_max_residual, _eval_merit_function, _eval_regularizer, _eval_merit_function_gradient
 
 
 @wp.kernel
@@ -1533,6 +1621,66 @@ def _eval_rhs(
     wd_id, state_id_loc = wp.tid()  # Thread indices (= world index, state index)
     if wd_id < grad.shape[0] and state_id_loc < grad.shape[1]:
         rhs[wd_id, state_id_loc] = -grad[wd_id, state_id_loc]
+
+
+@wp.kernel
+def _add_regularizer_to_diagonal(
+    # Inputs
+    reg_weight: wp.float32,
+    active_size: wp.array[wp.int32],
+    world_mask: wp.array[wp.int32],
+    # Outputs
+    A: wp.array3d[wp.float32],
+):
+    """
+    A kernel adding a multiple of the identity to the matrix of a linear system (to regularize it).
+
+    Inputs:
+        reg_weight: Regularization weight to add to diagonal coefficients.
+        active_size: Active size of the matrix in each world, from the top-left corner.
+        world_mask: Per-world flag to perform the computation (0 = skip).
+    Outputs:
+        A: Stack of system matrices (one per world) to regularize.
+    """
+    wd_id, row_id = wp.tid()  # Thread indices (= world index, row index)
+    if world_mask[wd_id] != 0 and row_id < active_size[wd_id]:
+        A[wd_id, row_id, row_id] = A[wd_id, row_id, row_id] + reg_weight
+
+
+@wp.kernel
+def _eval_regularizer_gradient(
+    # Inputs
+    num_bodies: wp.array[wp.int32],
+    first_body_id: wp.array[wp.int32],
+    reg_weight: wp.float32,
+    bodies_q_flat: wp.array[wp.float32],
+    bodies_q_ref_flat: wp.array[wp.float32],
+    world_mask: wp.array[wp.int32],
+    # Outputs
+    gradient: wp.array2d[wp.float32],
+):
+    """
+    A kernel evaluating the gradient of the least-squares regularizer on body poses, and adding it to the
+    overall gradient vector.
+
+    Inputs:
+        num_bodies: Number of bodies per world.
+        first_body_id: First body index per world.
+        reg_weight: Regularizer weight.
+        bodies_q_flat: Flattened array of current body poses.
+        bodies_q_ref_flat: Flattened array of reference body poses.
+        world_mask: Per-world flag to perform the computation (0 = skip).
+    Outputs:
+        gradient: Gradient vector, to which to add the regularizer gradient.
+    """
+    wd_id, state_id_loc = wp.tid()  # Get thread id (= world index, state index within world)
+
+    rb_id_loc = state_id_loc // 7
+    if world_mask[wd_id] == 0 or rb_id_loc >= num_bodies[wd_id]:
+        return
+    state_id = 7 * first_body_id[wd_id] + state_id_loc
+
+    gradient[wd_id, state_id_loc] += reg_weight * (bodies_q_flat[state_id] - bodies_q_ref_flat[state_id])
 
 
 @wp.kernel
@@ -1672,7 +1820,7 @@ def _line_search_check(
 @wp.kernel
 def _newton_check(
     # Inputs
-    max_constraint: wp.array[wp.float32],
+    max_residual: wp.array[wp.float32],
     tolerance: wp.array[wp.float32],
     iteration: wp.array[wp.int32],
     min_iterations: wp.array[wp.int32],
@@ -1682,14 +1830,19 @@ def _newton_check(
     newton_success: wp.array[wp.int32],
     newton_mask: wp.array[wp.int32],
     newton_loop_condition: wp.array[wp.int32],
+    jacobian_early_update_mask: wp.array[wp.int32],
+    jacobian_late_update_mask: wp.array[wp.int32],
 ):
     """
-    A kernel checking the convergence (max constraint vs tolerance) in each world, and updating the looping
+    A kernel checking the convergence (max residual vs tolerance) in each world, and updating the looping
     condition (zero if max iterations reached, or all worlds successful)
 
+    If provided (non-zero size), also updates masks keeping tracks of worlds where the Jacobian needs to be
+    updated before/after the controls (based on whether min iterations was already reached or not)
+
     Inputs
-        max_constraint: Max absolute constraint per world
-        tolerance: Tolerance on max constraint (size 1 array)
+        max_residual: Max absolute residual per world
+        tolerance: Tolerance on max residual (size 1 array)
         iteration: Iteration count, per world
         min_iterations: Min iterations per world (may be > 0 if incremental solve is enabled)
         max_iterations: Max iterations (size 1 array)
@@ -1698,17 +1851,19 @@ def _newton_check(
         newton_success: Convergence per world
         newton_mask: Flag to keep iterating per world
         newton_loop_condition: Loop condition; must be zero-initialized (size 1 array)
+        jacobian_early_update_mask: Optional mask, set to 1 in worlds needing an early Jacobian update
+        jacobian_late_update_mask: Optional mask, set to 1 in worlds needing a late Jacobian update
     """
     wd_id = wp.tid()  # Thread index (= world index)
-    if wd_id < max_constraint.shape[0] and newton_mask[wd_id] != 0:
+    if wd_id < max_residual.shape[0] and newton_mask[wd_id] != 0:
         iteration_prev = iteration[wd_id]  # Index of the iteration that just ran
         iteration_next = iteration_prev + 1  # Index of the iteration that is about to run
         min_iterations_wd = min_iterations[wd_id]
         iteration[wd_id] = iteration_next
         reached_min_it = iteration_prev >= min_iterations_wd
-        max_constraint_wd = max_constraint[wd_id]
-        is_finite = wp.isfinite(max_constraint_wd)
-        newton_success[wd_id] = int(is_finite and reached_min_it and max_constraint_wd <= tolerance[0])
+        max_residual_wd = max_residual[wd_id]
+        is_finite = wp.isfinite(max_residual_wd)
+        newton_success[wd_id] = int(is_finite and reached_min_it and max_residual_wd <= tolerance[0])
         newton_continue_world = int(
             iteration_next < max_iterations[0]
             and not newton_success[wd_id]
@@ -1716,6 +1871,10 @@ def _newton_check(
             and line_search_success[wd_id]  # Abort in case of line search failure
         )
         newton_mask[wd_id] = newton_continue_world
+        if jacobian_early_update_mask.shape[0] > 0:
+            jacobian_early_update_mask[wd_id] = int(newton_continue_world and iteration_next >= min_iterations_wd)
+        if jacobian_late_update_mask.shape[0] > 0:
+            jacobian_late_update_mask[wd_id] = int(newton_continue_world and iteration_next <= min_iterations_wd)
         wp.atomic_max(newton_loop_condition, 0, newton_continue_world)
 
 
@@ -1844,20 +2003,20 @@ def _eval_body_velocities(
 @wp.kernel
 def _update_cg_tolerance_kernel(
     # Input
-    max_constraint: wp.array[wp.float32],
+    max_residual: wp.array[wp.float32],
     world_mask: wp.array[wp.int32],
     # Output
     atol: wp.array[wp.float32],
     rtol: wp.array[wp.float32],
 ):
     """
-    A kernel heuristically adapting the CG tolerance based on the current constraint residual
+    A kernel heuristically adapting the CG tolerance based on the current constraint/gradient residual
     (starting with a loose tolerance, and tightening it as we converge)
     Note: needs to be refined, until then we are still using a fixed tolerance
     """
     wd_id = wp.tid()
     if wd_id >= world_mask.shape[0] or world_mask[wd_id] == 0:
         return
-    tol = wp.max(1e-8, wp.min(1e-5, 1e-3 * max_constraint[wd_id]))
+    tol = wp.max(1e-8, wp.min(1e-5, 1e-3 * max_residual[wd_id]))
     atol[wd_id] = tol
     rtol[wd_id] = tol

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -1268,7 +1268,7 @@ class ForwardKinematicsSolver:
         self,
         bodies_q: wp.array[wp.transformf],
         pos_control_transforms: wp.array[wp.transformf],
-        world_mask: wp.array[wp.bool],
+        world_mask: wp.array[wp.int32],
     ):
         """
         Convenience function updating the constraints Jacobian, given body poses and position-control
@@ -1282,7 +1282,7 @@ class ForwardKinematicsSolver:
 
     def _update_lhs(
         self,
-        world_mask: wp.array[wp.bool],
+        world_mask: wp.array[wp.int32],
     ):
         """
         Convenience function updating the system left-hand side (J^T * J + regularization, optionally),
@@ -1310,7 +1310,7 @@ class ForwardKinematicsSolver:
     def _update_gradient(
         self,
         bodies_q: wp.array[wp.transformf],
-        world_mask: wp.array[bool],
+        world_mask: wp.array[wp.int32],
     ):
         """
         Convenience function updating the objective gradient (J^T * constraints + regularization, optionally),
@@ -1349,6 +1349,7 @@ class ForwardKinematicsSolver:
                     world_mask,
                     self.grad,
                 ],
+                device=self.device,
             )
 
     def _eval_lhs_gemv(
@@ -1439,7 +1440,6 @@ class ForwardKinematicsSolver:
                 self._eval_regularizer_kernel,
                 dim=(self.num_worlds, self.num_tiles_vrs_1d),
                 inputs=[
-                    self.model.info.num_bodies,
                     self.first_body_id,
                     self.config.regularization_weight,
                     wp.array(
@@ -1510,7 +1510,7 @@ class ForwardKinematicsSolver:
         self._eval_kinematic_constraints(
             self.bodies_q_alpha, self.pos_control_transforms, self.line_search_mask, self.constraints
         )
-        self._eval_merit_function(self.constraints, self.val_alpha, bodies_q)
+        self._eval_merit_function(self.constraints, self.val_alpha, self.bodies_q_alpha)
 
         # Check decrease and update step
         self.line_search_loop_condition.zero_()

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -870,6 +870,9 @@ class ForwardKinematicsSolver:
             def _cg_gemv_flat(x, y, world_active, alpha, beta):
                 self._eval_lhs_gemv(x.reshape((n_wd, n_st)), y.reshape((n_wd, n_st)), world_active, alpha, beta)
 
+            def _cg_matvec_flat(x, y, world_active):
+                self._eval_lhs_matvec(x.reshape((n_wd, n_st)), y.reshape((n_wd, n_st)), world_active)
+
             cg_op = BatchedLinearOperator(
                 n_worlds=self.num_worlds,
                 max_dim=self.num_states_max,
@@ -877,6 +880,7 @@ class ForwardKinematicsSolver:
                 dtype=wp.float32,
                 device=self.device,
                 gemv_fn=_cg_gemv_flat,
+                matvec_fn=_cg_matvec_flat,
                 vio=cg_vio,
                 total_vec_size=cg_total_vec_size,
             )
@@ -1218,7 +1222,7 @@ class ForwardKinematicsSolver:
         and position-control transformations
         """
 
-        self.sparse_jacobian.zero()
+        self.sparse_jacobian.zero(world_mask)
 
         # Evaluate unit norm quaternion constraints Jacobian
         wp.launch(
@@ -1382,6 +1386,34 @@ class ForwardKinematicsSolver:
             inputs=[alpha, self.lhs_times_vector, beta, y, self.num_constraints, world_mask, y],
             device=self.device,
         )
+
+    def _eval_lhs_matvec(
+        self,
+        x: wp.array2d[wp.float32],
+        y: wp.array2d[wp.float32],
+        world_mask: wp.array[wp.int32],
+    ):
+        """
+        Internal evaluator for y = lhs * x, using the assembled sparse Jacobian J,
+        and with lhs = J^T * J (plus optionally the regularizer Hessian reg_weight * I)
+        """
+        self.sparse_jacobian_op.matvec(x, self.jacobian_times_vector, world_mask)
+        self.sparse_jacobian_op.matvec_transpose(self.jacobian_times_vector, y, world_mask)
+        if self.config.use_regularization:
+            wp.launch(
+                _eval_linear_combination,
+                dim=(self.num_worlds, self.num_states_max),
+                inputs=[
+                    1.0,
+                    y,
+                    self.config.regularization_weight,
+                    x,
+                    self.num_constraints,
+                    world_mask,
+                    y,
+                ],
+                device=self.device,
+            )
 
     def _eval_merit_function(
         self,
@@ -1548,12 +1580,16 @@ class ForwardKinematicsSolver:
 
         # Compute step (system solve)
         if self.config.use_sparsity:
+            offset = self.config.regularization_weight if self.config.use_regularization else 0.0
             if self._preconditioner_type == ForwardKinematicsSolver.PreconditionerType.JACOBI_DIAGONAL:
-                block_sparse_ATA_inv_diagonal_2d(self.sparse_jacobian, self.jacobian_diag_inv, self.newton_mask)
+                block_sparse_ATA_inv_diagonal_2d(
+                    self.sparse_jacobian, self.jacobian_diag_inv, self.newton_mask, diag_offset=offset
+                )
             elif self._preconditioner_type == ForwardKinematicsSolver.PreconditionerType.JACOBI_BLOCK_DIAGONAL:
                 block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
-                    self.sparse_jacobian, self.inv_blocks_3, self.inv_blocks_4, self.newton_mask
+                    self.sparse_jacobian, self.inv_blocks_3, self.inv_blocks_4, self.newton_mask, diag_offset=offset
                 )
+
             self.step.zero_()
             if self.config.use_adaptive_cg_tolerance:
                 self._update_cg_tolerance(self.max_residual, self.newton_mask)
@@ -1690,11 +1726,14 @@ class ForwardKinematicsSolver:
 
         # Compute body velocities (system solve)
         if self.config.use_sparsity:
+            offset = self.config.regularization_weight if self.config.use_regularization else 0.0
             if self._preconditioner_type == ForwardKinematicsSolver.PreconditionerType.JACOBI_DIAGONAL:
-                block_sparse_ATA_inv_diagonal_2d(self.sparse_jacobian, self.jacobian_diag_inv, world_mask)
+                block_sparse_ATA_inv_diagonal_2d(
+                    self.sparse_jacobian, self.jacobian_diag_inv, world_mask, diag_offset=offset
+                )
             elif self._preconditioner_type == ForwardKinematicsSolver.PreconditionerType.JACOBI_BLOCK_DIAGONAL:
                 block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
-                    self.sparse_jacobian, self.inv_blocks_3, self.inv_blocks_4, world_mask
+                    self.sparse_jacobian, self.inv_blocks_3, self.inv_blocks_4, world_mask, diag_offset=offset
                 )
             self.bodies_q_dot.zero_()
             self.cg_atol.fill_(1e-8)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -30,6 +30,7 @@ from ...linalg.sparse_operator import BlockSparseLinearOperators
 from ...utils.tile import get_block_dim, get_num_tiles, get_tile_size
 from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_classes
 from .kernels import (
+    _add_regularizer_to_diagonal,
     _apply_line_search_step,
     _correct_actuator_coords,
     _eval_actuator_coords,
@@ -38,12 +39,14 @@ from .kernels import (
     _eval_incremental_target_actuator_coords,
     _eval_linear_combination,
     _eval_position_control_transformations,
+    _eval_regularizer_gradient,
     _eval_rhs,
     _eval_stepped_state,
     _eval_target_constraint_velocities,
     _eval_unit_quaternion_constraints,
     _eval_unit_quaternion_constraints_jacobian,
     _eval_unit_quaternion_constraints_sparse_jacobian,
+    _initialize_jacobian_update_masks,
     _line_search_check,
     _newton_check,
     _reset_state,
@@ -578,6 +581,13 @@ class ForwardKinematicsSolver:
             self.newton_loop_condition = wp.array(dtype=wp.int32, shape=(1,))  # Loop condition
             self.newton_success = wp.array(dtype=wp.int32, shape=(self.num_worlds,))  # Convergence per world
             self.newton_mask = wp.array(dtype=wp.int32, shape=(self.num_worlds,))  # Flag to keep iterating per world
+            if self.config.use_regularization and self.config.use_incremental_solve:
+                # Flags to keep track of in what worlds Jacobians should be updated before/after controls
+                self.jacobian_early_update_mask = wp.array(dtype=wp.int32, shape=(self.num_worlds,))
+                self.jacobian_late_update_mask = wp.array(dtype=wp.int32, shape=(self.num_worlds,))
+            else:
+                self.jacobian_early_update_mask = wp.array(dtype=wp.int32, shape=0)
+                self.jacobian_late_update_mask = wp.array(dtype=wp.int32, shape=0)
             self.tolerance = wp.array(dtype=wp.float32, shape=(1,))  # Tolerance on max constraint
             self.tolerance.fill_(self.config.tolerance)
             self.actuators_q_next = wp.array(
@@ -594,6 +604,10 @@ class ForwardKinematicsSolver:
             self.pos_control_transforms = wp.array(
                 dtype=wp.transformf, shape=(self.num_joints_tot,)
             )  # Position-control transformations at joints
+            if self.config.use_regularization:
+                self.bodies_q_ref = wp.array(
+                    dtype=wp.transformf, shape=(self.model.size.sum_of_num_bodies,)
+                )  # Reference for regularizer
             self.constraints = wp.zeros(
                 dtype=wp.float32,
                 shape=(
@@ -601,7 +615,6 @@ class ForwardKinematicsSolver:
                     self.num_constraints_max,
                 ),
             )  # Constraints vector per world
-            self.max_constraint = wp.array(dtype=wp.float32, shape=(self.num_worlds,))  # Maximal constraint per world
             self.jacobian = wp.zeros(
                 dtype=wp.float32, shape=(self.num_worlds, self.num_constraints_max, self.num_states_max)
             )  # Constraints Jacobian per world
@@ -612,6 +625,9 @@ class ForwardKinematicsSolver:
             self.grad = wp.zeros(
                 dtype=wp.float32, shape=(self.num_worlds, self.num_states_max)
             )  # Merit function gradient w.r.t. state per world
+            self.max_residual = wp.array(
+                dtype=wp.float32, shape=(self.num_worlds,)
+            )  # Maximal constraint or gradient per world
             self.rhs = wp.zeros(
                 dtype=wp.float32, shape=(self.num_worlds, self.num_states_max)
             )  # Gauss-Newton right-hand side per world (=-grad)
@@ -652,10 +668,11 @@ class ForwardKinematicsSolver:
             self._eval_jacobian_T_constraints_kernel,
         ) = create_2d_tile_based_kernels(self.tile_size_cts_2d, self.tile_size_vrs_2d)
         (
-            self._eval_max_constraint_kernel,
+            self._eval_max_residual_kernel,
             self._eval_merit_function_kernel,
+            self._eval_regularizer_kernel,
             self._eval_merit_function_gradient_kernel,
-        ) = create_1d_tile_based_kernels(self.tile_size_cts_1d, self.tile_size_vrs_1d)
+        ) = create_1d_tile_based_kernels(self.tile_size_cts_1d, self.tile_size_vrs_1d, self.config.use_regularization)
         if self.config.use_incremental_solve:
             self._eval_min_num_iterations_kernel = create_eval_min_num_iterations_kernel(self.tile_size_coords)
 
@@ -696,6 +713,11 @@ class ForwardKinematicsSolver:
                 device=self.device,
             )
             sparsity_pattern_lhs = sparsity_pattern_lhs_wp.numpy().astype("int32")
+            if self.config.use_regularization:  # Account for diagonal perturbation in sparsity pattern
+                for class_id in range(num_classes):
+                    wd_id = classes[class_id][0]
+                    N = num_states[wd_id]
+                    np.fill_diagonal(sparsity_pattern_lhs[class_id, :N, :N], 1)
 
             # Initialize linear solver (semi-sparse LLT)
             self.linear_solver_llt = SemiSparseBlockCholeskySolverBatched(
@@ -984,6 +1006,20 @@ class ForwardKinematicsSolver:
             device=self.device,
         )
 
+        # Initialize Jacobian update masks
+        if self.config.use_regularization:
+            wp.launch(
+                _initialize_jacobian_update_masks,
+                dim=(self.num_worlds,),
+                inputs=[
+                    self.newton_mask,
+                    self.min_newton_iterations,
+                    self.jacobian_early_update_mask,
+                    self.jacobian_late_update_mask,
+                ],
+                device=self.device,
+            )
+
     def _eval_target_actuators_q(
         self,
         base_q_model: wp.array[wp.transformf],
@@ -1096,18 +1132,36 @@ class ForwardKinematicsSolver:
             device=self.device,
         )
 
-    def _eval_max_constraint(self, constraints: wp.array2d[wp.float32], max_constraint: wp.array[wp.float32]):
+    def _eval_max_residual(
+        self,
+        constraints: wp.array2d[wp.float32],
+        gradient: wp.array2d[wp.float32],
+        max_residual: wp.array[wp.float32],
+    ):
         """
-        Internal evaluator for the maximal absolute constraint, from the constraints vector, in each world
+        Internal evaluator for the maximal absolute residual in each world, from either the constraints
+        vector (by default) or the gradient vector (if regularization is enabled).
+
+        Indeed, if a regularizer is added to the constraints squared norm objective, we cannot expect
+        Gauss-Newton to converge to zero constraints anymore.
         """
-        max_constraint.zero_()
-        wp.launch_tiled(
-            self._eval_max_constraint_kernel,
-            dim=(self.num_worlds, self.num_tiles_cts_1d),
-            inputs=[constraints, max_constraint],
-            block_dim=get_block_dim(self.tile_size_cts_1d),
-            device=self.device,
-        )
+        max_residual.zero_()
+        if self.config.use_regularization:
+            wp.launch_tiled(
+                self._eval_max_residual_kernel,
+                dim=(self.num_worlds, self.num_tiles_vrs_1d),
+                inputs=[gradient, max_residual],
+                block_dim=get_block_dim(self.tile_size_vrs_1d),
+                device=self.device,
+            )
+        else:
+            wp.launch_tiled(
+                self._eval_max_residual_kernel,
+                dim=(self.num_worlds, self.num_tiles_cts_1d),
+                inputs=[constraints, max_residual],
+                block_dim=get_block_dim(self.tile_size_cts_1d),
+                device=self.device,
+            )
 
     def _eval_kinematic_constraints_jacobian(
         self,
@@ -1206,6 +1260,93 @@ class ForwardKinematicsSolver:
             device=self.device,
         )
 
+    def _update_jacobian(
+        self,
+        bodies_q: wp.array[wp.transformf],
+        pos_control_transforms: wp.array[wp.transformf],
+        world_mask: wp.array[wp.bool],
+    ):
+        """
+        Convenience function updating the constraints Jacobian, given body poses and position-control
+        transforms
+        Solver configuration (sparsity, regularization) are taken into account.
+        """
+        if self.config.use_sparsity:
+            self._assemble_sparse_jacobian(bodies_q, pos_control_transforms, world_mask)
+        else:
+            self._eval_kinematic_constraints_jacobian(bodies_q, pos_control_transforms, world_mask, self.jacobian)
+
+    def _update_lhs(
+        self,
+        world_mask: wp.array[wp.bool],
+    ):
+        """
+        Convenience function updating the system left-hand side (J^T * J + regularization, optionally),
+        using the lastly assembled Jacobian
+        Solver configuration (sparsity, regularization) are taken into account.
+        """
+        if self.config.use_sparsity:
+            return  # No lhs to assemble for the sparse case (represented implicitly as an operator)
+
+        wp.launch_tiled(
+            self._eval_jacobian_T_jacobian_kernel,
+            dim=(self.num_worlds, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
+            inputs=[self.jacobian, self.tile_sparsity_pattern, world_mask, self.lhs],
+            block_dim=32,
+            device=self.device,
+        )
+        if self.config.use_regularization:
+            wp.launch(
+                _add_regularizer_to_diagonal,
+                dim=(self.num_worlds, self.num_states_max),
+                inputs=[self.config.regularization_weight, self.num_states, world_mask, self.lhs],
+                device=self.device,
+            )
+
+    def _update_gradient(
+        self,
+        bodies_q: wp.array[wp.transformf],
+        world_mask: wp.array[bool],
+    ):
+        """
+        Convenience function updating the objective gradient (J^T * constraints + regularization, optionally),
+        given body poses and using the lastly assembled Jacobian and constraints.
+        Solver configuration (sparsity, regularization) are taken into account.
+        """
+        if self.config.use_sparsity:
+            self.sparse_jacobian_op.matvec_transpose(self.constraints, self.grad, world_mask)
+        else:
+            wp.launch_tiled(
+                self._eval_jacobian_T_constraints_kernel,
+                dim=(self.num_worlds, self.num_tiles_vrs_2d),
+                inputs=[self.jacobian, self.constraints, self.tile_sparsity_pattern, world_mask, self.grad],
+                block_dim=32,
+                device=self.device,
+            )
+
+        if self.config.use_regularization:
+            wp.launch(
+                _eval_regularizer_gradient,
+                dim=(self.num_worlds, self.num_states_max),
+                inputs=[
+                    self.model.info.num_bodies,
+                    self.first_body_id,
+                    self.config.regularization_weight,
+                    wp.array(
+                        ptr=bodies_q.ptr, dtype=wp.float32, shape=(self.num_states_tot,), device=self.device, copy=False
+                    ),
+                    wp.array(
+                        ptr=self.bodies_q_ref.ptr,
+                        dtype=wp.float32,
+                        shape=(self.num_states_tot,),
+                        device=self.device,
+                        copy=False,
+                    ),
+                    world_mask,
+                    self.grad,
+                ],
+            )
+
     def _eval_lhs_gemv(
         self,
         x: wp.array2d[wp.float32],
@@ -1215,10 +1356,26 @@ class ForwardKinematicsSolver:
         beta: wp.float32,
     ):
         """
-        Internal evaluator for y = alpha * J^T * J * x + beta * y, using the assembled sparse Jacobian J
+        Internal evaluator for y = alpha * lhs * x + beta * y, using the assembled sparse Jacobian J,
+        and with lhs = J^T * J (plus optionally the regularizer Hessian reg_weight * I)
         """
         self.sparse_jacobian_op.matvec(x, self.jacobian_times_vector, world_mask)
         self.sparse_jacobian_op.matvec_transpose(self.jacobian_times_vector, self.lhs_times_vector, world_mask)
+        if self.config.use_regularization:
+            wp.launch(
+                _eval_linear_combination,
+                dim=(self.num_worlds, self.num_states_max),
+                inputs=[
+                    1.0,
+                    self.lhs_times_vector,
+                    self.config.regularization_weight,
+                    x,
+                    self.num_constraints,
+                    world_mask,
+                    self.lhs_times_vector,
+                ],
+                device=self.device,
+            )
         wp.launch(
             _eval_linear_combination,
             dim=(self.num_worlds, self.num_states_max),
@@ -1226,19 +1383,48 @@ class ForwardKinematicsSolver:
             device=self.device,
         )
 
-    def _eval_merit_function(self, constraints: wp.array2d[wp.float32], error: wp.array[wp.float32]):
+    def _eval_merit_function(
+        self,
+        constraints: wp.array2d[wp.float32],
+        merit_function: wp.array[wp.float32],
+        bodies_q: wp.array[wp.transformf] | None = None,
+    ):
         """
-        Internal evaluator for the line search merit function, i.e. the least-squares error 1/2 * ||C||^2,
+        Internal evaluator for the line search merit function, i.e. the least-squares error
+        1/2 * ||C||^2, plus optionally the regularizer 1/2 * reg_weight * ||s - s_ref||^2,
         from the constraints vector C, in each world
         """
-        error.zero_()
+        merit_function.zero_()
         wp.launch_tiled(
             self._eval_merit_function_kernel,
             dim=(self.num_worlds, self.num_tiles_cts_1d),
-            inputs=[constraints, error],
+            inputs=[constraints, merit_function],
             block_dim=get_block_dim(self.tile_size_cts_1d),
             device=self.device,
         )
+        if self.config.use_regularization and bodies_q is not None:
+            wp.launch_tiled(
+                self._eval_regularizer_kernel,
+                dim=(self.num_worlds, self.num_tiles_vrs_1d),
+                inputs=[
+                    self.model.info.num_bodies,
+                    self.first_body_id,
+                    self.config.regularization_weight,
+                    wp.array(
+                        ptr=bodies_q.ptr, dtype=wp.float32, shape=(self.num_states_tot,), device=self.device, copy=False
+                    ),
+                    wp.array(
+                        ptr=self.bodies_q_ref.ptr,
+                        dtype=wp.float32,
+                        shape=(self.num_states_tot,),
+                        device=self.device,
+                        copy=False,
+                    ),
+                    merit_function,
+                ],
+                block_dim=get_block_dim(self.tile_size_vrs_1d),
+                device=self.device,
+            )
 
     def _eval_merit_function_gradient(
         self,
@@ -1248,7 +1434,8 @@ class ForwardKinematicsSolver:
     ):
         """
         Internal evaluator for the merit function gradient w.r.t. line search step size, from the step direction
-        and the gradient in state space (= dC_ds^T * C). This is simply the dot product between these two vectors.
+        and the gradient in state space (= dC_ds^T * C, plus optionally reg_weight * (s - s_ref)).
+        This is simply the dot product between these two vectors.
         """
         error_grad.zero_()
         wp.launch_tiled(
@@ -1291,7 +1478,7 @@ class ForwardKinematicsSolver:
         self._eval_kinematic_constraints(
             self.bodies_q_alpha, self.pos_control_transforms, self.line_search_mask, self.constraints
         )
-        self._eval_merit_function(self.constraints, self.val_alpha)
+        self._eval_merit_function(self.constraints, self.val_alpha, bodies_q)
 
         # Check decrease and update step
         self.line_search_loop_condition.zero_()
@@ -1318,7 +1505,7 @@ class ForwardKinematicsSolver:
         world_mask: wp.array[wp.int32],
     ):
         """
-        Internal function heuristically adapting the CG tolerance based on the current constraint residual
+        Internal function heuristically adapting the CG tolerance based on the current constraint/gradient residual
         (starting with a loose tolerance, and tightening it as we converge)
         Note: needs to be refined, until then we are still using a fixed tolerance
         """
@@ -1340,32 +1527,18 @@ class ForwardKinematicsSolver:
             self._eval_position_control_transformations(self.actuators_q_curr, self.pos_control_transforms)
             self._eval_kinematic_constraints(bodies_q, self.pos_control_transforms, self.newton_mask, self.constraints)
 
-        # Evaluate constraints Jacobian
-        if self.config.use_sparsity:
-            self._assemble_sparse_jacobian(bodies_q, self.pos_control_transforms, self.newton_mask)
-        else:
-            self._eval_kinematic_constraints_jacobian(
-                bodies_q, self.pos_control_transforms, self.newton_mask, self.jacobian
-            )
+        # Evaluate constraints Jacobian if needed
+        if not self.config.use_regularization:
+            self._update_jacobian(bodies_q, self.pos_control_transforms, self.newton_mask)
+        elif self.config.use_incremental_solve:
+            self._update_jacobian(bodies_q, self.pos_control_transforms, self.jacobian_late_update_mask)
 
         # Evaluate Gauss-Newton left-hand side (J^T * J) if needed, and right-hand side (-J^T * C)
-        if self.config.use_sparsity:
-            self.sparse_jacobian_op.matvec_transpose(self.constraints, self.grad, self.newton_mask)
-        else:
-            wp.launch_tiled(
-                self._eval_jacobian_T_jacobian_kernel,
-                dim=(self.num_worlds, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
-                inputs=[self.jacobian, self.tile_sparsity_pattern, self.newton_mask, self.lhs],
-                block_dim=32,
-                device=self.device,
-            )
-            wp.launch_tiled(
-                self._eval_jacobian_T_constraints_kernel,
-                dim=(self.num_worlds, self.num_tiles_vrs_2d),
-                inputs=[self.jacobian, self.constraints, self.tile_sparsity_pattern, self.newton_mask, self.grad],
-                block_dim=32,
-                device=self.device,
-            )
+        self._update_lhs(self.newton_mask)
+        if not self.config.use_regularization:
+            self._update_gradient(bodies_q, self.newton_mask)
+        elif self.config.use_incremental_solve:
+            self._update_gradient(bodies_q, self.jacobian_late_update_mask)
         wp.launch(
             _eval_rhs,
             dim=(self.num_worlds, self.num_states_max),
@@ -1383,7 +1556,7 @@ class ForwardKinematicsSolver:
                 )
             self.step.zero_()
             if self.config.use_adaptive_cg_tolerance:
-                self._update_cg_tolerance(self.max_constraint, self.newton_mask)
+                self._update_cg_tolerance(self.max_residual, self.newton_mask)
             else:
                 self.cg_atol.fill_(1e-8)
                 self.cg_rtol.fill_(1e-8)
@@ -1403,7 +1576,7 @@ class ForwardKinematicsSolver:
         self.line_search_success.zero_()
         wp.copy(self.line_search_mask, self.newton_mask)
         self.line_search_loop_condition.fill_(1)
-        self._eval_merit_function(self.constraints, self.val_0)
+        self._eval_merit_function(self.constraints, self.val_0, bodies_q)
         self._eval_merit_function_gradient(self.step, self.grad, self.grad_0)
         self.alpha.fill_(1.0)
         wp.capture_while(self.line_search_loop_condition, lambda: self._run_line_search_iteration(bodies_q))
@@ -1421,7 +1594,11 @@ class ForwardKinematicsSolver:
             ],
             device=self.device,
         )
-        self._eval_max_constraint(self.constraints, self.max_constraint)
+        if self.config.use_regularization:
+            mask = self.jacobian_early_update_mask if self.config.use_incremental_solve else self.newton_mask
+            self._update_jacobian(bodies_q, self.pos_control_transforms, mask)
+            self._update_gradient(bodies_q, mask)
+        self._eval_max_residual(self.constraints, self.grad, self.max_residual)
 
         # Check convergence
         self.newton_loop_condition.zero_()
@@ -1429,7 +1606,7 @@ class ForwardKinematicsSolver:
             _newton_check,
             dim=(self.num_worlds,),
             inputs=[
-                self.max_constraint,
+                self.max_residual,
                 self.tolerance,
                 self.newton_iteration,
                 self.min_newton_iterations,
@@ -1438,6 +1615,8 @@ class ForwardKinematicsSolver:
                 self.newton_success,
                 self.newton_mask,
                 self.newton_loop_condition,
+                self.jacobian_early_update_mask,
+                self.jacobian_late_update_mask,
             ],
             device=self.device,
         )
@@ -1493,22 +1672,14 @@ class ForwardKinematicsSolver:
         )
 
         # Update constraints Jacobian
-        if self.config.use_sparsity:
-            self._assemble_sparse_jacobian(bodies_q, pos_control_transforms, world_mask)
-        else:
-            self._eval_kinematic_constraints_jacobian(bodies_q, pos_control_transforms, world_mask, self.jacobian)
+        self._update_jacobian(bodies_q, pos_control_transforms, world_mask)
 
-        # Evaluate system left-hand side (J^T * J) if needed, and right-hand side (J^T * targets_cts_u)
+        # Evaluate system left-hand side (for the dense solver) and right-hand side
+        # These are J^T * J (+ regularizer Hessian), and J^T * targets_cts_u
+        self._update_lhs(world_mask)
         if self.config.use_sparsity:
             self.sparse_jacobian_op.matvec_transpose(self.target_cts_u, self.rhs, world_mask)
         else:
-            wp.launch_tiled(
-                self._eval_jacobian_T_jacobian_kernel,
-                dim=(self.num_worlds, self.num_tiles_vrs_2d, self.num_tiles_vrs_2d),
-                inputs=[self.jacobian, self.tile_sparsity_pattern, world_mask, self.lhs],
-                block_dim=32,
-                device=self.device,
-            )
             wp.launch_tiled(
                 self._eval_jacobian_T_constraints_kernel,
                 dim=(self.num_worlds, self.num_tiles_vrs_2d),
@@ -1753,6 +1924,10 @@ class ForwardKinematicsSolver:
             else:
                 self._reset_state_base_q(bodies_q, base_q, self.newton_mask)
 
+        # Optionally initialize the reference pose for the regularizer
+        if self.config.use_regularization:
+            wp.copy(self.bodies_q_ref, bodies_q)
+
         # Use default base state if not provided
         if base_q is None:
             base_q = self.base_q_default
@@ -1765,14 +1940,17 @@ class ForwardKinematicsSolver:
 
         # Evaluate constraints, and initialize loop condition (might not even need to loop)
         self._eval_kinematic_constraints(bodies_q, self.pos_control_transforms, self.newton_mask, self.constraints)
-        self._eval_max_constraint(self.constraints, self.max_constraint)
+        if self.config.use_regularization:  # Update Jacobian and gradient for stopping criterion
+            self._update_jacobian(bodies_q, self.pos_control_transforms, self.newton_mask)
+            self._update_gradient(bodies_q, self.newton_mask)
+        self._eval_max_residual(self.constraints, self.grad, self.max_residual)
         self.newton_loop_condition.zero_()
         wp.copy(self.line_search_success, self.newton_mask)  # To disregard line search success in initial Newton check
         wp.launch(
             _newton_check,
             dim=(self.num_worlds,),
             inputs=[
-                self.max_constraint,
+                self.max_residual,
                 self.tolerance,
                 self.newton_iteration,
                 self.min_newton_iterations,
@@ -1781,6 +1959,8 @@ class ForwardKinematicsSolver:
                 self.newton_success,
                 self.newton_mask,
                 self.newton_loop_condition,
+                self.jacobian_early_update_mask,
+                self.jacobian_late_update_mask,
             ],
             device=self.device,
         )
@@ -1881,18 +2061,16 @@ class ForwardKinematicsSolver:
         if verbose or return_status:
             success = self.newton_success.numpy().copy()
             iterations = self.newton_iteration.numpy().copy()
-            max_constraints = self.max_constraint.numpy().copy()
+            max_residual = self.max_residual.numpy().copy()
             num_active_worlds = self.num_worlds if world_mask is None else world_mask.numpy().sum()
             if verbose:
                 sys.__stdout__.write(f"Newton success for {success.sum()}/{num_active_worlds} worlds; ")
                 sys.__stdout__.write(f"num iterations={iterations.max()}; ")
-                sys.__stdout__.write(f"max constraint={max_constraints.max()}\n")
+                sys.__stdout__.write(f"max residual={max_residual.max()}\n")
 
         # Return solver status
         if return_status:
-            return ForwardKinematicsSolver.Status(
-                iterations=iterations, max_constraints=max_constraints, success=success
-            )
+            return ForwardKinematicsSolver.Status(iterations=iterations, max_residual=max_residual, success=success)
 
 
 ###

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -100,8 +100,10 @@ class ForwardKinematicsStatus:
     Shape `(num_worlds,)` and type :class:`np.int32`.
     """
 
-    max_constraints: np.ndarray(dtype=np.float32)
+    max_residual: np.ndarray(dtype=np.float32)
     """
-    Maximal absolute kinematic constraint residual at the final solution, per world.\n
+    Maximal absolute residual at the final solution, per world. In the general case, the residual vector
+    is the kinematic constraints vector; if regularization is enabled, it is the penalty gradient.
+
     Shape `(num_worlds,)` and type :class:`np.float32`.
     """

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -88,10 +88,10 @@ class ForwardKinematicsStatus:
     Shape `(num_worlds,)` and type :class:`np.int32`.
 
     Note that in some cases the solver may fail to converge within the maximum number
-    of iterations, but still produce a solution with a reasonable constraint residual.
-    In such cases, the success flag will be set to 0, but the `max_constraints` field
-    can be inspected to check the actual constraint residuals and determine if the
-    solution is acceptable for the intended application.
+    of iterations, but still produce a solution with a reasonable residual.
+    In such cases, the success flag will be set to 0, but the `max_residual` field
+    can be inspected to check the actual residuals and determine if the solution is acceptable
+    for the intended application.
     """
 
     iterations: np.ndarray(dtype=np.int32)

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -867,8 +867,13 @@ class ForwardKinematicsSolverConfig:
     Whether to regularize the FK problem by trying to preserve the rigid body poses with a small weight.
     This might result in constraint violations of the order of the regularization weight, but allows to
     tackle systems with solution sub-spaces, in particular underactuated systems.
+
+    Important note: the default tolerance of 1e-6 may not be reachable if regularization is enabled,
+    using 1e-5 instead is recommended in most cases.
+
     For systems that are only underactuated due to tie rods being free to rotate about their own axis,
     enabling `add_axis_joints` is recommended instead.
+
     Changes to this setting after the solver's initialization lead to undefined behavior.
     Defaults to `False`.
     """

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -862,6 +862,24 @@ class ForwardKinematicsSolverConfig:
     Defaults to `math.radians(10.0)`, i.e. 10 degrees.
     """
 
+    use_regularization: bool = False
+    """
+    Whether to regularize the FK problem by trying to preserve the rigid body poses with a small weight.
+    This might result in constraint violations of the order of the regularization weight, but allows to
+    tackle systems with solution sub-spaces, in particular underactuated systems.
+    For systems that are only underactuated due to tie rods being free to rotate about their own axis,
+    enabling `add_axis_joints` is recommended instead.
+    Changes to this setting after the solver's initialization lead to undefined behavior.
+    Defaults to `False`.
+    """
+
+    regularization_weight: float = 1e-5
+    """
+    Weight applied to the rigid body pose least-squares regularizer, if regularization is enabled.
+    Changes to this setting after the solver's initialization lead to undefined behavior.
+    Defaults to `1e-5`.
+    """
+
     @override
     @staticmethod
     def register_custom_attributes(builder: ModelBuilder) -> None:
@@ -918,6 +936,8 @@ class ForwardKinematicsSolverConfig:
             raise ValueError("`max_linear_incremental_step` must be positive.")
         if self.max_angular_incremental_step <= 0.0:
             raise ValueError("`max_angular_incremental_step` must be positive.")
+        if self.regularization_weight < 0.0:
+            raise ValueError("`regularization_weight` must be non-negative.")
 
     @override
     def __post_init__(self):

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -8,6 +8,7 @@ Unit tests for the ForwardKinematicsSolver class of Kamino, in `solvers/fk.py`.
 import copy
 import hashlib
 import unittest
+from functools import partial
 
 import numpy as np
 import warp as wp
@@ -321,6 +322,7 @@ def simulate_random_poses(
     rng: np.random._generator.Generator,
     use_graph: bool = False,
     verbose: bool = False,
+    **config_kwargs,
 ):
     # Generate random inputs
     base_q_np, actuators_q_np = generate_random_inputs_q(model, num_poses, max_base_q, max_actuators_q, rng)
@@ -335,11 +337,7 @@ def simulate_random_poses(
     residual_mask = compute_constraint_residual_mask(model)
 
     # Run forward kinematics on all random poses
-    config = ForwardKinematicsSolver.Config()
-    config.reset_state = True
-    config.use_sparsity = False  # Change for sparse/dense solver
-    config.preconditioner = "jacobi_block_diagonal"  # Change to test preconditioners
-    config.add_axis_joints = True  # Set to False to check that axis joints are needed for tie rod example
+    config = ForwardKinematicsSolver.Config(**config_kwargs)
     solver = ForwardKinematicsSolver(model, config)
     success_flags = []
     with wp.ScopedDevice(model.device):
@@ -350,7 +348,7 @@ def simulate_random_poses(
         base_u = wp.array(shape=(model.size.num_worlds), dtype=vec6f)
         actuators_u = wp.array(shape=(actuators_u_np.shape[1]), dtype=wp.float32)
     data = model.data(device=model.device)
-    epsilon = 1e-4
+    epsilon = 1e-3 if config.use_regularization else 1e-4
     for pose_id in range(num_poses):
         # Run FK solve and check convergence
         base_q.assign(base_q_np[pose_id])
@@ -438,13 +436,14 @@ class DRTestMechanismRandomPosesCheckForwardKinematics(unittest.TestCase):
         builder.set_base_joint("base")
         model = builder.finalize(device=self.default_device, requires_grad=False)
 
-        # Simulate random poses
+        # Generate helper function to simulate random poses
         num_poses = 30
         base_q_max = np.array(3 * [0.2] + 4 * [1.0])
         actuators_q_max = np.radians([360.0])
         base_u_max = np.array(3 * [0.1] + 3 * [0.5])
         actuators_u_max = np.array([0.5])
-        success = simulate_random_poses(
+        simulate_function = partial(
+            simulate_random_poses,
             model,
             num_poses,
             base_q_max,
@@ -452,9 +451,19 @@ class DRTestMechanismRandomPosesCheckForwardKinematics(unittest.TestCase):
             base_u_max,
             actuators_u_max,
             rng,
-            self.has_cuda,
-            self.verbose,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            tolerance=1e-6,
         )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
         self.assertTrue(success)
 
 
@@ -482,14 +491,15 @@ class DRLegsRandomPosesCheckForwardKinematics(unittest.TestCase):
         builder.set_base_body("pelvis")
         model = builder.finalize(device=self.default_device, requires_grad=False)
 
-        # Simulate random poses
+        # Generate helper function to simulate random poses
         num_poses = 30
         theta_max = np.radians(10.0)  # Angles too far from the initial pose lead to singularities
         base_q_max = np.array(3 * [0.2] + 4 * [1.0])
         actuators_q_max = np.array(model.size.sum_of_num_actuated_joint_coords * [theta_max])
         base_u_max = np.array(3 * [0.5] + 3 * [0.5])
         actuators_u_max = np.array(model.size.sum_of_num_actuated_joint_dofs * [0.5])
-        success = simulate_random_poses(
+        simulate_function = partial(
+            simulate_random_poses,
             model,
             num_poses,
             base_q_max,
@@ -497,9 +507,18 @@ class DRLegsRandomPosesCheckForwardKinematics(unittest.TestCase):
             base_u_max,
             actuators_u_max,
             rng,
-            self.has_cuda,
-            self.verbose,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            tolerance=1e-6,
         )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
         self.assertTrue(success)
 
 
@@ -531,7 +550,7 @@ class HeterogenousModelRandomPosesCheckForwardKinematics(unittest.TestCase):
         builder.add_builder(builder1)
         model = builder.finalize(device=self.default_device, requires_grad=False)
 
-        # Simulate random poses
+        # Generate helper function to simulate random poses
         num_poses = 30
         theta_max_test_mech = np.radians(360.0)
         theta_max_dr_legs = np.radians(10.0)
@@ -539,9 +558,28 @@ class HeterogenousModelRandomPosesCheckForwardKinematics(unittest.TestCase):
         actuators_q_max = np.array([theta_max_test_mech] + builder1.num_actuated_joint_coords * [theta_max_dr_legs])
         base_u_max = np.array(3 * [0.1] + 3 * [0.5] + 3 * [0.5] + 3 * [0.5])
         actuators_u_max = np.array(model.size.sum_of_num_actuated_joint_dofs * [0.5])
-        success = simulate_random_poses(
-            model, num_poses, base_q_max, actuators_q_max, base_u_max, actuators_u_max, rng, self.has_cuda, self.verbose
+        simulate_function = partial(
+            simulate_random_poses,
+            model,
+            num_poses,
+            base_q_max,
+            actuators_q_max,
+            base_u_max,
+            actuators_u_max,
+            rng,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            tolerance=1e-6,
         )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
         self.assertTrue(success)
 
 
@@ -566,16 +604,43 @@ class FourBarTieRodRandomPosesCheckForwardKinematics(unittest.TestCase):
         builder = make_homogeneous_builder(num_worlds=10, build_fn=create_four_bar_tie_rod)
         model = builder.finalize(device=self.default_device, requires_grad=False)
 
-        # Simulate random poses
+        # Generate helper function to simulate random poses
         num_poses = 30
         theta_max = np.radians(30.0)
         base_q_max = np.array(builder.num_worlds * (3 * [0.2] + 4 * [1.0]))
         actuators_q_max = np.array(builder.num_actuated_joint_coords * [theta_max])
         base_u_max = np.array(builder.num_worlds * (3 * [0.5] + 3 * [0.5]))
         actuators_u_max = np.array(model.size.sum_of_num_actuated_joint_dofs * [0.5])
-        success = simulate_random_poses(
-            model, num_poses, base_q_max, actuators_q_max, base_u_max, actuators_u_max, rng, self.has_cuda, self.verbose
+        simulate_function = partial(
+            simulate_random_poses,
+            model,
+            num_poses,
+            base_q_max,
+            actuators_q_max,
+            base_u_max,
+            actuators_u_max,
+            rng,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            preconditioner="jacobi_block_diagonal",
         )
+
+        # Simulate random poses, adding axis joints to handle tie rod (dense solver)
+        success = simulate_function(add_axis_joints=True, tolerance=1e-6, use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses, adding axis joints to handle tie rod (sparse solver)
+        success = simulate_function(add_axis_joints=True, tolerance=1e-6, use_sparsity=True)
+        self.assertTrue(success)
+
+        # Simulate random poses, using regularization to handle tie rod (dense solver)
+        success = simulate_function(add_axis_joints=False, use_regularization=True, tolerance=1e-5, use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses, using regularization to handle tie rod (sparse solver)
+        success = simulate_function(add_axis_joints=False, use_regularization=True, tolerance=1e-5, use_sparsity=True)
         self.assertTrue(success)
 
 


### PR DESCRIPTION
## Description

This adds an option to regularize the FK solve, allowing to solving ill-posed problems such as for underactuated systems by trying to keep body poses close to previous poses.
The small price to pay in exchange is not being able to solve directly the maximal constraint being below a tolerance (but the gradient of the quadratic constraint penalty + the regularizer). In practical scenarios the constraint violations still remain very small if the regularization weight is kept small.

A few additional changes had to be made to sparse matrix code as a result, as the case where the FK solver has regularization AND sparsity AND incremental solve enabled called for jacobian/left-hand-side/right-hand-side at different places in the Newton loop for different worlds (using two different complementary masks); but most sparse operations were resetting the full matrix/vector to zero even when a mask is provided, erasing the work done for the previous subset of worlds. The mask is now correctly taken into account by these operations.

Resolves vastsoun/newton#125

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

This was tested by expanding the unit test with a four-bar and a tie rod, showing that the regularizer can also be used as an alternative to axis joints to make the problem well-posed for this case. Additional validation was run on BDX with a floating base, validating that we get the same results as with our external CPU code for regularized FK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional regularization for the forward-kinematics solver with configurable weight, per-world regularizer evaluation, and Jacobian-update masks.

* **Bug Fixes**
  * Selective masked-zeroing that leaves inactive outputs unchanged and safer diagonal inversion with an adjustable diagonal offset to prevent invalid values.

* **Behavior Changes**
  * Solver convergence, tolerance, and status now use a "max_residual" metric; incremental Jacobian/gradient update timing adjusted.

* **Tests**
  * FK tests parameterized to exercise regularization, dense/sparse paths, and adjusted tolerances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2824)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->