### PR TITLE
Fix Mermaid docs rendering

### DIFF
--- a/docs/_static/mermaid-nbsphinx.js
+++ b/docs/_static/mermaid-nbsphinx.js
@@ -12,6 +12,17 @@
     return document.querySelector("pre.mermaid:not([data-processed])") !== null;
   }
 
+  function normalizeMermaidBlocks() {
+    const nodes = Array.from(document.querySelectorAll("pre.mermaid:not([data-processed])"));
+    for (const node of nodes) {
+      const text = node.textContent;
+      const normalizedText = text.trim();
+      if (text !== normalizedText) {
+        node.textContent = normalizedText;
+      }
+    }
+  }
+
   function loadMermaid() {
     if (window.mermaid) {
       return Promise.resolve(window.mermaid);
@@ -56,6 +67,12 @@
   }
 
   async function renderMermaidBlocks() {
+    normalizeMermaidBlocks();
+
+    if (typeof window.runMermaid === "function") {
+      return;
+    }
+
     if (!hasMermaidBlocks()) {
       return;
     }


### PR DESCRIPTION
## Description

Fixes #2825.

Trim generated Mermaid `<pre>` block text before rendering so leading template whitespace is not passed to Mermaid as diagram syntax. When `sphinxcontrib-mermaid` is present, the local fallback renderer now steps aside after normalization, preserving the existing per-diagram green `forest` theme and avoiding double-rendering.

Changelog entry is not needed since I introduced this rendering bug within this release cycle in https://github.com/newton-physics/newton/pull/2694.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uvx pre-commit run -a
uv run --extra docs sphinx-build -b html docs docs\_build\html
```

Also verified locally in the browser on port 9119 that `guide/overview.html` and `api/newton_solvers.html` each render one Mermaid SVG, do not show `Syntax error in text`, and retain the Newton green theme.

## Bug fix

**Steps to reproduce:**

1. Build and serve the docs.
2. Open `guide/overview.html` or `api/newton_solvers.html`.
3. Observe the Mermaid block rendering `Syntax error in text` instead of the diagram.

**Minimal reproduction:**

```text
Open the affected generated Sphinx HTML page with the existing Mermaid diagram block.
```