### PR TITLE
Remove visual-only procedural terrain from `example_robot_anymal_c_walk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Restrict `usd-core` to `<26.5` to avoid deprecation warnings introduced in 26.5
 - Require explicit `SensorTiledCamera` BVH lifecycle management instead of implicit camera maintenance: call `newton.geometry.build_bvh_shape()` / `build_bvh_particle()` once after setup, then `refit_bvh_shape()` / `refit_bvh_particle()` before rendering frames that change geometry
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections
+- Remove visual-only procedural terrain from `example_robot_anymal_c_walk`
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
 - Disable process reuse in the test runner on multi-GPU systems to prevent CUDA errors from cascading across test suites, keeping process reuse enabled on single-GPU systems for faster throughput
 - Default `python -m newton.examples` with no argument to launch `basic_pendulum`; use `--list` to print available examples

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -19,7 +19,7 @@ import warp as wp
 import newton
 import newton.examples
 import newton.utils
-from newton import GeoType, State
+from newton import State
 
 lab_to_mujoco = [0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11]
 mujoco_to_lab = [0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11]
@@ -74,7 +74,6 @@ class Example:
         self.viewer = viewer
         self.device = wp.get_device()
         self.torch_device = wp.device_to_torch(self.device)
-        self.is_test = args is not None and args.test
 
         builder = newton.ModelBuilder()
         newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
@@ -99,35 +98,6 @@ class Example:
             ignore_inertial_definitions=False,
         )
 
-        # Enlarge foot collision spheres to improve walking stability on uneven terrain.
-        # The URDF defines small spheres on the shank links; doubling their radius
-        # prevents the robot from stumbling on terrain features like waves and stairs.
-        for i in range(len(builder.shape_type)):
-            if builder.shape_type[i] == GeoType.SPHERE:
-                r = builder.shape_scale[i][0]
-                builder.shape_scale[i] = (r * 2.0, 0.0, 0.0)
-
-        # Generate procedural terrain for visual demonstration (but not during unit tests)
-        if not self.is_test:
-            terrain_mesh = newton.Mesh.create_terrain(
-                grid_size=(8, 3),  # 3x8 grid for forward walking
-                block_size=(3.0, 3.0),
-                terrain_types=["random_grid", "flat", "wave", "gap", "pyramid_stairs"],
-                terrain_params={
-                    "pyramid_stairs": {"step_width": 0.3, "step_height": 0.02, "platform_width": 0.6},
-                    "random_grid": {"grid_width": 0.3, "grid_height_range": (0, 0.02)},
-                    "wave": {"wave_amplitude": 0.1, "wave_frequency": 2.0},  # amplitude reduced from 0.15
-                },
-                seed=42,
-                compute_inertia=False,
-            )
-            terrain_offset = wp.transform(p=wp.vec3(-5, -2.0, 0.01), q=wp.quat_identity())
-            builder.add_shape_mesh(
-                body=-1,
-                mesh=terrain_mesh,
-                xform=terrain_offset,
-                cfg=newton.ModelBuilder.ShapeConfig(has_shape_collision=False),
-            )
         builder.add_ground_plane()
 
         self.sim_time = 0.0


### PR DESCRIPTION
## Description

This PR removes the procedurally generated terrain mesh from the `example_robot_anymal_c_walk` example.
Rationale:
- The current mesh is visual-only and does not have collision enabled. Since the robot tracks a flat ground plane, the visual mismatch is confusing.
- The terrain's current profile is too flat to serve as a meaningful "rough terrain" demonstration.

resolves #2819

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Simplified the robot walking example by removing procedural terrain generation and collision sphere modifications, now using a straightforward ground plane setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->