### PR TITLE
Add actuators API to docs sidebar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Newton Physics
    :caption: API Reference
    
    api/newton
+   api/newton_actuators
    api/newton_geometry
    api/newton_ik
    api/newton_math


### PR DESCRIPTION
## Description

Adds the existing `docs/api/newton_actuators.rst` page to the top-level API Reference toctree in `docs/index.rst`, so the actuator API is discoverable from the documentation sidebar.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (N/A: docs navigation only)

## Test plan

```bash
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

Build succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Newton Actuators API reference to the documentation landing page, providing quick access to the API documentation from the index.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2836)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->