### PR TITLE
Cherry-pick 1.2 Release PRs onto release-1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Fix VRAM leak when resetting examples that allocate large GPU state (e.g. `diffsim_bear`)
 - Fix `SensorRaycast` and viewer picking ignoring `HFIELD` (heightfield) geometry
 - Fix `SensorTiledCamera` textured albedo output rendering flat colors when color and normal outputs are disabled
+- Fix URDF Collada visual meshes dropping diffuse texture bindings
 - Fix `contacts_rj45_plug` example crashing on reset
 - Fix `SolverMuJoCo` dependency version-mismatch warning being silently skipped when Newton is installed from a wheel
 - Fix `ViewerGL.log_image()` windows persisting across example-browser switches and failing to re-open on re-entry after manual close, by clearing the image logger in `ViewerGL.clear_model()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
+- Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead
 - Fix `SolverMuJoCo` Newton-contact conversion to use geometry-surface contact anchors
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Restrict `usd-core` to `<26.5` to avoid deprecation warnings introduced in 26.5
 - Require explicit `SensorTiledCamera` BVH lifecycle management instead of implicit camera maintenance: call `newton.geometry.build_bvh_shape()` / `build_bvh_particle()` once after setup, then `refit_bvh_shape()` / `refit_bvh_particle()` before rendering frames that change geometry
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections
+- Remove visual-only procedural terrain from `example_robot_anymal_c_walk`
 - Migrate all raycast logic to `geometry.raycast`, all raycast functions now return distance and normal information
 - Disable process reuse in the test runner on multi-GPU systems to prevent CUDA errors from cascading across test suites, keeping process reuse enabled on single-GPU systems for faster throughput
 - Default `python -m newton.examples` with no argument to launch `basic_pendulum`; use `--list` to print available examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - Update default environment map texture in GL viewer (source: https://polyhaven.com/a/brown_photostudio_02)
 - Remove the implicit-MPM rasterized collider's reliance on Warp's `warp.fem` module (behavior unchanged)
 - Replace the StVK VBD triangle membrane material with the stable Neo-Hookean form (Smith et al. 2018, adapted to 2D shells). The upstream two-constraint Rayleigh damping model is preserved unchanged
-- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.2`)
+- Bump `mujoco` and `mujoco-warp` dependencies to `~=3.8.0` (`mujoco-warp` requires `>=3.8.0.3`)
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -18,7 +18,7 @@
     "python -m pip install -U numpy",
     "python -m pip install -U warp-lang==1.13.0",
     "python -m pip install -U mujoco==3.8.0",
-    "python -m pip install -U mujoco-warp==3.8.0.2",
+    "python -m pip install -U mujoco-warp==3.8.0.3",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
     "in-dir={env_dir} python -m pip install {wheel_file}[dev]"
   ]

--- a/docs/_static/mermaid-nbsphinx.js
+++ b/docs/_static/mermaid-nbsphinx.js
@@ -12,6 +12,17 @@
     return document.querySelector("pre.mermaid:not([data-processed])") !== null;
   }
 
+  function normalizeMermaidBlocks() {
+    const nodes = Array.from(document.querySelectorAll("pre.mermaid:not([data-processed])"));
+    for (const node of nodes) {
+      const text = node.textContent;
+      const normalizedText = text.trim();
+      if (text !== normalizedText) {
+        node.textContent = normalizedText;
+      }
+    }
+  }
+
   function loadMermaid() {
     if (window.mermaid) {
       return Promise.resolve(window.mermaid);
@@ -56,6 +67,12 @@
   }
 
   async function renderMermaidBlocks() {
+    normalizeMermaidBlocks();
+
+    if (typeof window.runMermaid === "function") {
+      return;
+    }
+
     if (!hasMermaidBlocks()) {
       return;
     }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Newton Physics
    :caption: API Reference
    
    api/newton
+   api/newton_actuators
    api/newton_geometry
    api/newton_ik
    api/newton_math

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -231,14 +231,14 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
     # correct shape and type, and copy the converted data into them.
     else:
         # Ensure that the output GravityModel has allocated arrays of the correct shape and type
-        if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count, 4):
+        if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.g_dir_acc` array does not have matching shape. Allocating a new array.")
-            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=vec4f)
+            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=vec4f, device=model_in.device)
         else:
             gravity_out.g_dir_acc.assign(g_dir_acc_np)
-        if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count, 4):
+        if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.vector` array does not have matching shape. Allocating a new array.")
-            gravity_out.vector = wp.array(vector_np, dtype=vec4f)
+            gravity_out.vector = wp.array(vector_np, dtype=vec4f, device=model_in.device)
         else:
             gravity_out.vector.assign(vector_np)
 

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -897,11 +897,11 @@ class DelassusOperator:
 
         # Update the allocation meta-data the specified constraint dimensions
         self._num_worlds = model.size.num_worlds
-        self._world_dims = maxdims
-        self._world_size = [maxdims[i] * maxdims[i] for i in range(self._num_worlds)]
-        self._model_maxdims = sum(self._world_dims)
-        self._model_maxsize = sum(self._world_size)
-        self._max_of_max_total_D_size = max(self._world_size)
+        self._world_maxdims = maxdims
+        self._world_maxsize = [maxdims[i] * maxdims[i] for i in range(self._num_worlds)]
+        self._model_maxdims = sum(self._world_maxdims)
+        self._model_maxsize = sum(self._world_maxsize)
+        self._max_of_max_total_D_size = max(self._world_maxsize) if self._world_maxsize else 0
 
         # Use the model's device
         self._device = model.device
@@ -911,7 +911,7 @@ class DelassusOperator:
         self._operator.info = DenseSquareMultiLinearInfo()
         self._operator.mat = wp.zeros(shape=(self._model_maxsize,), dtype=float32, device=self._device)
         if (model.info is not None) and (data.info is not None):
-            mat_offsets = [0] + [sum(self._world_size[:i]) for i in range(1, self._num_worlds + 1)]
+            mat_offsets = [0] + [sum(self._world_maxsize[:i]) for i in range(1, self._num_worlds + 1)]
             self._operator.info.assign(
                 maxdim=model.info.max_total_cts,
                 dim=data.info.num_total_cts,
@@ -985,7 +985,7 @@ class DelassusOperator:
         # Build the Delassus matrix parallelized over the upper triangle.
         # Aligns to warp size (32) to avoid partially-filled warps.
         if isinstance(jacobians, DenseSystemJacobians):
-            max_ncts = max(self._world_dims) if self._world_dims else 0
+            max_ncts = max(self._world_maxdims) if self._world_maxdims else 0
             upper_tri_size = max_ncts * (max_ncts + 1) // 2
             warp_size = 32
             upper_tri_size = ((upper_tri_size + warp_size - 1) // warp_size) * warp_size

--- a/newton/_src/utils/mesh.py
+++ b/newton/_src/utils/mesh.py
@@ -7,6 +7,7 @@ import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast, overload
+from urllib.parse import urlparse
 
 import numpy as np
 import warp as wp
@@ -409,6 +410,11 @@ def _extract_trimesh_texture(visual_or_material, base_dir: str) -> np.ndarray | 
         if base_color_texture is not None:
             image = getattr(base_color_texture, "image", None)
             image_path = image_path or getattr(base_color_texture, "image_path", None)
+            if image is None:
+                if isinstance(base_color_texture, (str, os.PathLike)):
+                    image_path = image_path or os.fspath(base_color_texture)
+                else:
+                    image = base_color_texture
 
     if image is not None:
         try:
@@ -497,7 +503,7 @@ def load_meshes_from_file(
 
     def _parse_dae_material_colors(
         path: str,
-    ) -> tuple[list[str], dict[str, dict[str, float | tuple[float, float, float] | None]]]:
+    ) -> tuple[list[str], dict[str, dict[str, float | str | tuple[float, float, float] | None]]]:
         try:
             tree = ET.parse(path)
             root = tree.getroot()
@@ -507,15 +513,64 @@ def load_meshes_from_file(
         def strip(tag: str) -> str:
             return tag.split("}", 1)[-1] if "}" in tag else tag
 
+        image_paths: dict[str, str] = {}
+        for image in root.iter():
+            if strip(image.tag) != "image":
+                continue
+            image_id = image.attrib.get("id")
+            image_name = image.attrib.get("name")
+            image_path = None
+            for child in image.iter():
+                if strip(child.tag) == "init_from" and child.text:
+                    image_path = child.text.strip()
+                    break
+            if image_path:
+                if image_id:
+                    image_paths[image_id] = image_path
+                if image_name:
+                    image_paths[image_name] = image_path
+
+        def resolve_dae_texture_path(texture_path: str | None) -> str | None:
+            if not texture_path:
+                return None
+            texture_path = image_paths.get(texture_path.lstrip("#"), texture_path)
+            parsed = urlparse(texture_path)
+            if parsed.scheme in {"file", "http", "https", "data"}:
+                return texture_path
+            if not os.path.isabs(texture_path):
+                texture_path = os.path.abspath(os.path.join(base_dir, texture_path))
+            return texture_path
+
         # Map effect id -> material properties
-        effect_props: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+        effect_props: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
         for effect in root.iter():
             if strip(effect.tag) != "effect":
                 continue
             effect_id = effect.attrib.get("id")
             if not effect_id:
                 continue
+            surface_images: dict[str, str] = {}
+            sampler_surfaces: dict[str, str] = {}
+            for newparam in effect.iter():
+                if strip(newparam.tag) != "newparam":
+                    continue
+                sid = newparam.attrib.get("sid")
+                if not sid:
+                    continue
+                for child in newparam:
+                    child_tag = strip(child.tag)
+                    if child_tag == "surface":
+                        for init in child.iter():
+                            if strip(init.tag) == "init_from" and init.text:
+                                surface_images[sid] = init.text.strip()
+                                break
+                    elif child_tag == "sampler2D":
+                        for source in child.iter():
+                            if strip(source.tag) == "source" and source.text:
+                                sampler_surfaces[sid] = source.text.strip()
+                                break
             diffuse_color = None
+            diffuse_texture = None
             specular_color = None
             specular_intensity = None
             shininess = None
@@ -530,9 +585,16 @@ def load_meshes_from_file(
                 for node in shader.iter():
                     tag = strip(node.tag)
                     if tag == "diffuse":
-                        for col in node.iter():
-                            if strip(col.tag) == "color" and col.text:
-                                values = [float(x) for x in col.text.strip().split()]
+                        for diffuse_node in node.iter():
+                            diffuse_tag = strip(diffuse_node.tag)
+                            if diffuse_tag == "texture":
+                                sampler_id = diffuse_node.attrib.get("texture")
+                                surface_id = sampler_surfaces.get(sampler_id, sampler_id)
+                                image_id = surface_images.get(surface_id, surface_id)
+                                diffuse_texture = resolve_dae_texture_path(image_id)
+                                break
+                            if diffuse_tag == "color" and diffuse_node.text:
+                                values = [float(x) for x in diffuse_node.text.strip().split()]
                                 if len(values) >= 3:
                                     # DAE diffuse colors are commonly authored in linear space.
                                     # Convert to sRGB for the viewer shader (which converts to linear).
@@ -567,7 +629,7 @@ def load_meshes_from_file(
                                     shininess = None
                                 break
                         continue
-                if diffuse_color is not None:
+                if diffuse_color is not None or diffuse_texture is not None:
                     break
             metallic = None
             if specular_color is not None:
@@ -579,15 +641,16 @@ def load_meshes_from_file(
                 if shininess > 1.0:
                     shininess = min(shininess / 128.0, 1.0)
                 roughness = float(np.clip(1.0 - shininess, 0.0, 1.0))
-            if diffuse_color is not None:
+            if diffuse_color is not None or diffuse_texture is not None:
                 effect_props[effect_id] = {
                     "color": diffuse_color,
+                    "texture": diffuse_texture,
                     "metallic": metallic,
                     "roughness": roughness,
                 }
 
         # Map material id/name -> material properties
-        material_colors: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+        material_colors: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
         for material in root.iter():
             if strip(material.tag) != "material":
                 continue
@@ -620,7 +683,7 @@ def load_meshes_from_file(
         return face_materials, material_colors
 
     dae_face_materials: list[str] = []
-    dae_material_colors: dict[str, dict[str, float | tuple[float, float, float] | None]] = {}
+    dae_material_colors: dict[str, dict[str, float | str | tuple[float, float, float] | None]] = {}
     if filename.lower().endswith(".dae"):
         dae_face_materials, dae_material_colors = _parse_dae_material_colors(filename)
 
@@ -667,6 +730,8 @@ def load_meshes_from_file(
             if sub_normals is None or force_smooth:
                 sub_normals = smooth_vertex_normals_by_position(sub_vertices, remapped_faces)
             sub_uvs = mesh_uvs[used] if mesh_uvs is not None else None
+            if mesh_texture is not None and mat_color is None:
+                mat_color = (1.0, 1.0, 1.0)
 
             meshes.append(
                 Mesh(
@@ -728,6 +793,7 @@ def load_meshes_from_file(
                 mat_color = mat_props.get("color")
                 mat_roughness = mat_props.get("roughness")
                 mat_metallic = mat_props.get("metallic")
+                mat_texture = mat_props.get("texture", texture)
                 add_mesh_from_faces(
                     mat_faces,
                     mat_color=mat_color,
@@ -736,7 +802,7 @@ def load_meshes_from_file(
                     mesh_vertices=vertices,
                     mesh_normals=normals,
                     mesh_uvs=uvs,
-                    mesh_texture=texture,
+                    mesh_texture=mat_texture,
                 )
             continue
 

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -2702,7 +2702,7 @@ class ViewerGL(ViewerBase):
             item_height + 60,
         )
         imgui.set_next_window_pos(
-            imgui.ImVec2(io.display_size[0] - window_width - 10, 10),
+            imgui.ImVec2(io.display_size[0] - window_width - 10, io.display_size[1] - window_height - 10),
             imgui.Cond_.appearing,
         )
         imgui.set_next_window_size(

--- a/newton/examples/robot/example_robot_anymal_c_walk.py
+++ b/newton/examples/robot/example_robot_anymal_c_walk.py
@@ -19,7 +19,7 @@ import warp as wp
 import newton
 import newton.examples
 import newton.utils
-from newton import GeoType, State
+from newton import State
 
 lab_to_mujoco = [0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11]
 mujoco_to_lab = [0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11]
@@ -74,7 +74,6 @@ class Example:
         self.viewer = viewer
         self.device = wp.get_device()
         self.torch_device = wp.device_to_torch(self.device)
-        self.is_test = args is not None and args.test
 
         builder = newton.ModelBuilder()
         newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
@@ -99,35 +98,6 @@ class Example:
             ignore_inertial_definitions=False,
         )
 
-        # Enlarge foot collision spheres to improve walking stability on uneven terrain.
-        # The URDF defines small spheres on the shank links; doubling their radius
-        # prevents the robot from stumbling on terrain features like waves and stairs.
-        for i in range(len(builder.shape_type)):
-            if builder.shape_type[i] == GeoType.SPHERE:
-                r = builder.shape_scale[i][0]
-                builder.shape_scale[i] = (r * 2.0, 0.0, 0.0)
-
-        # Generate procedural terrain for visual demonstration (but not during unit tests)
-        if not self.is_test:
-            terrain_mesh = newton.Mesh.create_terrain(
-                grid_size=(8, 3),  # 3x8 grid for forward walking
-                block_size=(3.0, 3.0),
-                terrain_types=["random_grid", "flat", "wave", "gap", "pyramid_stairs"],
-                terrain_params={
-                    "pyramid_stairs": {"step_width": 0.3, "step_height": 0.02, "platform_width": 0.6},
-                    "random_grid": {"grid_width": 0.3, "grid_height_range": (0, 0.02)},
-                    "wave": {"wave_amplitude": 0.1, "wave_frequency": 2.0},  # amplitude reduced from 0.15
-                },
-                seed=42,
-                compute_inertia=False,
-            )
-            terrain_offset = wp.transform(p=wp.vec3(-5, -2.0, 0.01), q=wp.quat_identity())
-            builder.add_shape_mesh(
-                body=-1,
-                mesh=terrain_mesh,
-                xform=terrain_offset,
-                cfg=newton.ModelBuilder.ShapeConfig(has_shape_collision=False),
-            )
         builder.add_ground_plane()
 
         self.sim_time = 0.0

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -3,7 +3,6 @@
 
 """Tests for Newton actuators."""
 
-import importlib.util
 import json
 import math
 import os
@@ -48,9 +47,8 @@ try:
 except ImportError:
     _HAS_LEGACY_ACTUATORS = False
 
-_HAS_TORCH = importlib.util.find_spec("torch") is not None
 
-if _HAS_TORCH:
+try:
     import torch as _torch
 
     class _LSTMNet(_torch.nn.Module):
@@ -68,6 +66,8 @@ if _HAS_TORCH:
         ) -> tuple[_torch.Tensor, tuple[_torch.Tensor, _torch.Tensor]]:
             out, (h, c) = self.lstm(x, hc)
             return self.dec(out[:, -1, :]), (h, c)
+except ImportError:
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -187,14 +187,24 @@ class TestControllerPID(unittest.TestCase):
             self.assertAlmostEqual(forces.numpy()[0], expected, places=4, msg=f"step {step_i}")
 
 
-@unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class TestControllerNeuralMLP(unittest.TestCase):
     """ControllerNeuralMLP — load via model_path, call compute() directly."""
 
     def setUp(self):
-        self.torch = _torch
+        # Mark the test as skipped if Torch is not installed but required
+        try:
+            import torch
+
+            if wp.get_device().is_cuda and not torch.cuda.is_available():
+                # Ensure torch has CUDA support
+                self.skipTest("Torch not compiled with CUDA support")
+
+        except Exception as e:
+            self.skipTest(f"{e}")
+
+        self.torch = torch
         self.device = wp.get_device()
-        self._torch_dev = _torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
+        self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
         self._tmp_dir = tempfile.mkdtemp()
 
     def _save_torchscript(self, net, filename="mlp.pt", metadata=None):
@@ -301,14 +311,24 @@ class TestControllerNeuralMLP(unittest.TestCase):
         self.assertAlmostEqual(forces.numpy()[0], 30.0, places=3, msg="bias=10 * effort_scale=3 -> 30")
 
 
-@unittest.skipUnless(_HAS_TORCH, "torch not installed")
 class TestControllerNeuralLSTM(unittest.TestCase):
     """ControllerNeuralLSTM — load via model_path, call compute() directly."""
 
     def setUp(self):
-        self.torch = _torch
+        # Mark the test as skipped if Torch is not installed but required
+        try:
+            import torch
+
+            if wp.get_device().is_cuda and not torch.cuda.is_available():
+                # Ensure torch has CUDA support
+                self.skipTest("Torch not compiled with CUDA support")
+
+        except Exception as e:
+            self.skipTest(f"{e}")
+
+        self.torch = torch
         self.device = wp.get_device()
-        self._torch_dev = _torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
+        self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
         self._tmp_dir = tempfile.mkdtemp()
 
     def _make_lstm(self, hidden=8, layers=1):
@@ -1482,7 +1502,7 @@ class TestDelayGraphCapture(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-@unittest.skipUnless(HAS_USD and _HAS_TORCH, "pxr or torch not installed")
+@unittest.skipUnless(HAS_USD, "pxr not installed")
 class TestNeuralActuatorUsdParsing(unittest.TestCase):
     """Verify ``parse_actuator_prim`` correctly handles neural controller
     prims with asset-typed ``newton:modelPath`` attributes.
@@ -1493,7 +1513,18 @@ class TestNeuralActuatorUsdParsing(unittest.TestCase):
     """
 
     def setUp(self):
-        self.torch = _torch
+        # Mark the test as skipped if Torch is not installed but required
+        try:
+            import torch
+
+            if wp.get_device().is_cuda and not torch.cuda.is_available():
+                # Ensure torch has CUDA support
+                self.skipTest("Torch not compiled with CUDA support")
+
+        except Exception as e:
+            self.skipTest(f"{e}")
+
+        self.torch = torch
         self._tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 import os
 import tempfile
 import unittest
@@ -62,6 +63,84 @@ f 4 7 8
 f 1 5 6
 f 1 6 2
 """
+
+TEXTURED_DAE = """<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset><unit name="meter" meter="1"/><up_axis>Z_UP</up_axis></asset>
+  <library_effects>
+    <effect id="mat-effect">
+      <profile_COMMON>
+        <newparam sid="tex-surface"><surface type="2D"><init_from>tex-image</init_from></surface></newparam>
+        <newparam sid="tex-sampler"><sampler2D><source>tex-surface</source></sampler2D></newparam>
+        <technique sid="common">
+          <lambert><diffuse><texture texture="tex-sampler" texcoord="UVMap"/></diffuse></lambert>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_images>
+    <image id="tex-image" name="tex-image"><init_from>texture.png</init_from></image>
+  </library_images>
+  <library_materials>
+    <material id="mat" name="mat"><instance_effect url="#mat-effect"/></material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="tri-mesh" name="tri">
+      <mesh>
+        <source id="tri-positions">
+          <float_array id="tri-positions-array" count="9">0 0 0 1 0 0 0 1 0</float_array>
+          <technique_common>
+            <accessor source="#tri-positions-array" count="3" stride="3">
+              <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="tri-normals">
+          <float_array id="tri-normals-array" count="9">0 0 1 0 0 1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#tri-normals-array" count="3" stride="3">
+              <param name="X" type="float"/><param name="Y" type="float"/><param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="tri-map">
+          <float_array id="tri-map-array" count="6">0 0 1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#tri-map-array" count="3" stride="2">
+              <param name="S" type="float"/><param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="tri-vertices"><input semantic="POSITION" source="#tri-positions"/></vertices>
+        <triangles material="mat" count="1">
+          <input semantic="VERTEX" source="#tri-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#tri-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#tri-map" offset="2" set="0"/>
+          <p>0 0 0 1 1 1 2 2 2</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="Scene">
+      <node id="tri">
+        <instance_geometry url="#tri-mesh">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="mat" target="#mat">
+                <bind_vertex_input semantic="UVMap" input_semantic="TEXCOORD" input_set="0"/>
+              </instance_material>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene><instance_visual_scene url="#Scene"/></scene>
+</COLLADA>
+"""
+
+TEXTURE_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 
 INERTIAL_URDF = """
 <robot name="inertial_test">
@@ -252,6 +331,66 @@ class TestImportUrdfBasic(unittest.TestCase):
                 assert_np_equal(builder.shape_transform[0][:], np.array([1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0]))
                 assert builder.shape_source[0].vertices.shape[0] == 8
                 assert builder.shape_source[0].indices.shape[0] == 3 * 12
+
+    def test_dae_visual_texture_urdf(self):
+        """Verify URDF visual meshes preserve Collada texture bindings."""
+        urdf = """
+<robot name="dae_texture_test">
+    <link name="base_link">
+        <visual>
+            <geometry><mesh filename="triangle.dae"/></geometry>
+        </visual>
+    </link>
+</robot>
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            (temp_path / "robot.urdf").write_text(urdf)
+            (temp_path / "triangle.dae").write_text(TEXTURED_DAE)
+            (temp_path / "texture.png").write_bytes(base64.b64decode(TEXTURE_PNG_BASE64))
+
+            builder = newton.ModelBuilder()
+            builder.add_urdf(str(temp_path / "robot.urdf"))
+
+            self.assertEqual(builder.shape_count, 1)
+            self.assertEqual(builder.shape_type[0], GeoType.MESH)
+            mesh = builder.shape_source[0]
+            self.assertIsNotNone(mesh.uvs)
+            self.assertIsNotNone(mesh.texture)
+            self.assertEqual(tuple(builder.shape_color[0]), (1.0, 1.0, 1.0))
+            texture = newton.utils.load_texture(mesh.texture)
+            self.assertIsNotNone(texture)
+            np.testing.assert_array_equal(texture[0, 0, :3], np.array([255, 0, 0], dtype=np.uint8))
+
+    def test_dae_visual_texture_uri_preserved(self):
+        """Verify URI-style Collada textures are not path-joined against the mesh directory."""
+        urdf = """
+<robot name="dae_texture_uri_test">
+    <link name="base_link">
+        <visual>
+            <geometry><mesh filename="triangle_uri.dae"/></geometry>
+        </visual>
+    </link>
+</robot>
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            texture_path = temp_path / "texture.png"
+            texture_uri = texture_path.resolve().as_uri()
+            dae_with_uri = TEXTURED_DAE.replace("texture.png", texture_uri)
+
+            (temp_path / "robot.urdf").write_text(urdf)
+            (temp_path / "triangle_uri.dae").write_text(dae_with_uri)
+            texture_path.write_bytes(base64.b64decode(TEXTURE_PNG_BASE64))
+
+            builder = newton.ModelBuilder()
+            builder.add_urdf(str(temp_path / "robot.urdf"))
+
+            self.assertEqual(builder.shape_count, 1)
+            self.assertEqual(builder.shape_type[0], GeoType.MESH)
+            mesh = builder.shape_source[0]
+            self.assertIsNotNone(mesh.texture)
+            self.assertEqual(mesh.texture, texture_uri)
 
     def test_inertial_params_urdf(self):
         builder = newton.ModelBuilder()

--- a/newton/tests/test_mujoco_version_check.py
+++ b/newton/tests/test_mujoco_version_check.py
@@ -10,7 +10,7 @@ from newton._src.solvers.mujoco import solver_mujoco
 
 _MOCK_REQUIREMENTS = (
     "mujoco~=3.8.0 ; extra == 'sim'",
-    "mujoco-warp~=3.8.0,>=3.8.0.2 ; extra == 'sim'",
+    "mujoco-warp~=3.8.0,>=3.8.0.3 ; extra == 'sim'",
 )
 _MOCK_METADATA = "\n".join(f"Requires-Dist: {requirement}" for requirement in _MOCK_REQUIREMENTS)
 

--- a/newton/tests/test_runtime_gravity.py
+++ b/newton/tests/test_runtime_gravity.py
@@ -7,7 +7,7 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.solvers import SolverSemiImplicit, SolverXPBD
+from newton.solvers import SolverKamino, SolverSemiImplicit, SolverXPBD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 
@@ -604,6 +604,7 @@ solvers_bodies = {
     "semi_implicit": SolverSemiImplicit,
     "mujoco_cpu": lambda model: newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=True, update_data_interval=0),
     "mujoco_warp": lambda model: newton.solvers.SolverMuJoCo(model, use_mujoco_cpu=False, update_data_interval=0),
+    "kamino": SolverKamino,
 }
 
 # Add tests for each device and solver combination

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 # Core simulation dependencies
 sim = [
     # MuJoCo simulation
-    "mujoco-warp>=3.8.0.2,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
+    "mujoco-warp>=3.8.0.3,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
     "mujoco~=3.8.0",        # MuJoCo physics engine
     "newton-actuators>=0.1.0",  # deprecated — kept for backward compat, will be removed
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1628,14 +1628,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -2111,7 +2111,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-server"
-version = "2.17.0"
+version = "2.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2134,9 +2134,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/ac/e040ec363d7b6b1f11304cc9f209dac4517ece5d5e01821366b924a64a50/jupyter_server-2.17.0.tar.gz", hash = "sha256:c38ea898566964c888b4772ae1ed58eca84592e88251d2cfc4d171f81f7e99d5", size = 731949, upload-time = "2025-08-21T14:42:54.042Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/80/a24767e6ca280f5a49525d987bf3e4d7552bf67c8be07e8ccf20271f8568/jupyter_server-2.17.0-py3-none-any.whl", hash = "sha256:e8cb9c7db4251f51ed307e329b81b72ccf2056ff82d50524debde1ee1870e13f", size = 388221, upload-time = "2025-08-21T14:42:52.034Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
 ]
 
 [[package]]
@@ -2842,14 +2842,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.2.0"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/55/d01f0c4b45ade6536c51170b9043db8b2ec6ddf4a35c7ea3f5f559ac935b/mistune-3.2.0.tar.gz", hash = "sha256:708487c8a8cdd99c9d90eb3ed4c3ed961246ff78ac82f03418f5183ab70e398a", size = 95467, upload-time = "2025-12-23T11:36:34.994Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/f7/4a5e785ec9fbd65146a27b6b70b6cdc161a66f2024e4b04ac06a67f5578b/mistune-3.2.0-py3-none-any.whl", hash = "sha256:febdc629a3c78616b94393c6580551e0e34cc289987ec6c35ed3f4be42d0eee1", size = 53598, upload-time = "2025-12-23T11:36:33.211Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2961,7 +2961,7 @@ wheels = [
 
 [[package]]
 name = "mujoco-warp"
-version = "3.8.0.2"
+version = "3.8.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -2972,9 +2972,9 @@ dependencies = [
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "warp-lang" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/46/9d5fdf2ac1d873eac9292acf51d337c49cbf160bb485677cd39eaa41d72d/mujoco_warp-3.8.0.2.tar.gz", hash = "sha256:074d45080b48412bfeab7a9f7461e4d3491f08d2e9f9c2e63aa948b5b0a01817", size = 1936860, upload-time = "2026-05-06T23:45:21.27Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/63/7dabf7f487c0946894a8ec85ea5d978c19e6b1afb6d6b6f63f457dff75ee/mujoco_warp-3.8.0.3.tar.gz", hash = "sha256:ca143a82f76b8df60984ca0d3c0f269a745886621cc2168beaa58e1d2c2358b8", size = 1938832, upload-time = "2026-05-08T23:27:41.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/c3/7025b41679686683421f13a1c85475c417937c519bb25a4b83ce57c195e6/mujoco_warp-3.8.0.2-py3-none-any.whl", hash = "sha256:b50267ca8825787fd8b6e3c6da5e5ed43268a7db399869159c2c8740543f2d13", size = 2015551, upload-time = "2026-05-06T23:45:19.772Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f5/30c736dfe87ad7e8f7a7f8f43b80e0ff43c6af46cef65ba95d3ba172129a/mujoco_warp-3.8.0.3-py3-none-any.whl", hash = "sha256:dfbfa24e376e0b03bf6dcebaed7ef69b4885280a020e5f0fd805c125fae3d129", size = 2019908, upload-time = "2026-05-08T23:27:39.283Z" },
 ]
 
 [[package]]
@@ -3504,7 +3504,7 @@ requires-dist = [
     { name = "jupyterlab", marker = "extra == 'notebook'", specifier = ">=4.5.7" },
     { name = "meshio", marker = "extra == 'importers'", specifier = ">=5.3.5" },
     { name = "mujoco", marker = "extra == 'sim'", specifier = "~=3.8.0" },
-    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.2" },
+    { name = "mujoco-warp", marker = "extra == 'sim'", specifier = "~=3.8.0,>=3.8.0.3" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=3.0.1" },
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9.0" },
     { name = "newton", extras = ["examples"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## Summary

Cherry-picks of PRs targeting the 1.2 release that landed on `main` after the last backport round.

## Cherry-picked PRs (chronological merge order)

- #2734 Refactor DelassusOperator attributes
- #2814 Update gitpython, mistune, jupyter-server versions
- #2818 Anchor ViewerGL Plots window to bottom-right
- #2828 Remove visual-only procedural terrain from \`example_robot_anymal_c_walk\`
- #2743 Fix Collada textures in URDF import
- #2827 Fix Mermaid docs rendering
- #2823 Fix device for gravity data allocation in Kamino
- #2815 Improve guard in actuator tests
- #2744 Bump MjWarp version to 3.8.0.3
- #2836 Add actuators API to docs sidebar

## Conflicts resolved

- #2744 (MjWarp bump): trivial `3.8.0.2` → `3.8.0.3` conflict in `asv.conf.json`, `pyproject.toml`, `uv.lock`, and `newton/tests/test_mujoco_version_check.py` — release-1.2 was at `3.8.0.2` from #2752; took the incoming side.

## Test plan

- [ ] CI passes on the release branch