### PR TITLE
Remove outdated limitations from docs

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -97,10 +97,6 @@ CPU-Only Limitations
 Newton can run on CPU (including macOS), but the following features require an
 NVIDIA GPU and are unavailable in CPU-only mode:
 
-- **SDF collision** — signed-distance-field computation requires CUDA
-  (``wp.Volume`` is GPU-only).
-- **Mesh-mesh contacts** — SDF-based mesh-mesh collision is silently skipped on CPU.
-- **Hydroelastic contacts** — depends on the SDF system.
 - **Tiled camera sensor** — GPU-accelerated raytraced rendering.
 - **Implicit MPM solver** — designed for GPU execution with CUDA graph support.
 - **Tile-based VBD solve** — uses GPU tile API; gracefully disabled on CPU.


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Remove outdated "cpu only" limitations from docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guide's CPU-only feature limitations documentation, removing references to SDF collision, mesh-mesh contacts, and hydroelastic contacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2842)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->