### PR TITLE
Clamp warp-lang below 1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Bump `jupyterlab` lower bound to `>=4.5.7` to pick up the fix for CVE-2026-40171
 - Replace `ModelBuilder.add_actuator(actuator_class, input_indices=..., output_indices=..., **kwargs)` with `ModelBuilder.add_actuator(controller_class, index=..., clamping=[...], delay_steps=..., pos_index=..., **ctrl_kwargs)` where each call registers a single DOF
 - Change `ArticulationView.get_actuator_parameter(actuator, name)` and `set_actuator_parameter(actuator, name, values)` to require a `component` argument identifying the owning `Controller`, `Clamping`, or `Delay` instance: `get_actuator_parameter(actuator, actuator.controller, "kp")`
+- Bump `warp-lang` from `>=1.12.0` to `>=1.13.0,<1.14`; Warp 1.14 is excluded because it removes deprecated `warp.fem` arguments still used by implicit MPM grain rendering
 - Update default environment map texture in GL viewer (source: https://polyhaven.com/a/brown_photostudio_02)
 - Remove the implicit-MPM rasterized collider's reliance on Warp's `warp.fem` module (behavior unchanged)
 - Replace the StVK VBD triangle membrane material with the stable Neo-Hookean form (Smith et al. 2018, adapted to 2D shells). The upstream two-constraint Rayleigh damping model is preserved unchanged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.13.0",
+    "warp-lang>=1.13.0,<1.14",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3542,7 +3542,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.13.0" },
+    { name = "warp-lang", specifier = ">=1.13.0,<1.14" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 


### PR DESCRIPTION
## Description

Clamp `warp-lang` to `>=1.13.0,<1.14` for the 1.2 release and add a changelog entry for the dependency range.

Warp 1.14 removes the previously deprecated `quadrature` and `domain` arguments from `warp.fem.interpolate()`. Newton's implicit MPM grain rendering path still passes `quadrature=...`, so fresh installs could resolve Warp 1.14 and fail with:

```text
TypeError: interpolate() got an unexpected keyword argument 'quadrature'
```

This keeps 1.2 on the Warp 1.13 line until the MPM rendering code is migrated to the newer `at=` API.
