### PR TITLE
Add macOS CI timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,14 +89,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            windows-latest,
-            macos-latest,
-          ]
+        # macOS unit tests regularly exceed the PR timeout, so keep them on
+        # post-merge branch pushes only. PR and merge queue runs still cover
+        # Linux, Linux ARM, and Windows.
+        os: ${{ fromJSON((github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))) && '["ubuntu-latest", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]' || '["ubuntu-latest", "ubuntu-24.04-arm", "windows-latest"]') }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.os == 'macos-latest' && 120 || 60 }}
     env:
       OS: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macOS unit tests regularly exceed the PR timeout, so keep them on
-        # post-merge branch pushes only. PR and merge queue runs still cover
-        # Linux, Linux ARM, and Windows.
-        os: ${{ fromJSON((github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))) && '["ubuntu-latest", "ubuntu-24.04-arm", "windows-latest", "macos-latest"]' || '["ubuntu-latest", "ubuntu-24.04-arm", "windows-latest"]') }}
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            macos-latest,
+          ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.os == 'macos-latest' && 120 || 60 }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,13 @@ jobs:
       - name: Run Tests
         env:
           PYTHONFAULTHANDLER: "1"
-        run: uv run --extra dev -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
+        run: >
+          uv run --extra dev -m newton.tests
+          --parallel-timeout ${{ matrix.os == 'macos-latest' && 6900 || 3300 }}
+          --no-cache-clear
+          --junit-report-xml rspec.xml
+          --coverage
+          --coverage-xml coverage.xml
       - name: Test Summary
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -131,6 +131,13 @@ def main(argv=None):
         help="Use multiprocessing instead of concurrent.futures.",
     )  # NVIDIA Modification
     group_parallel.add_argument(
+        "--parallel-timeout",
+        metavar="SECONDS",
+        type=int,
+        default=3600,
+        help="Timeout in seconds for collecting all parallel test results (default is 3600)",
+    )  # NVIDIA Modification
+    group_parallel.add_argument(
         "--serial-fallback",
         action="store_true",
         default=False,
@@ -160,6 +167,8 @@ def main(argv=None):
         "Useful for faster iteration and avoiding interference with parallel sessions.",
     )
     args = parser.parse_args(args=argv)
+    if args.parallel_timeout <= 0:
+        parser.error("--parallel-timeout must be greater than 0")
 
     if args.coverage_branch:
         args.coverage = args.coverage_branch
@@ -234,7 +243,13 @@ def main(argv=None):
                         initargs=(manager.Lock(), shared_index, args, temp_dir),
                     ) as pool:
                         test_manager = ParallelTestManager(manager, args, temp_dir)
-                        results = pool.map(test_manager.run_tests, test_suites)
+                        try:
+                            results = pool.map_async(test_manager.run_tests, test_suites).get(
+                                timeout=args.parallel_timeout
+                            )
+                        except multiprocessing.TimeoutError:
+                            pool.terminate()
+                            results = [_parallel_timeout_result(args.parallel_timeout)]
                 else:
                     # NVIDIA Modification added concurrent.futures
                     executor_kwargs = {
@@ -245,9 +260,21 @@ def main(argv=None):
                     }
                     if sys.version_info >= (3, 11) and (args.disable_process_pooling or wp.get_cuda_device_count() > 1):
                         executor_kwargs["max_tasks_per_child"] = 1
-                    with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
+                    executor = concurrent.futures.ProcessPoolExecutor(**executor_kwargs)
+                    try:
                         test_manager = ParallelTestManager(manager, args, temp_dir)
-                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=3600))
+                        results = list(executor.map(test_manager.run_tests, test_suites, timeout=args.parallel_timeout))
+                    except concurrent.futures.TimeoutError:
+                        _shutdown_executor_after_timeout(executor)
+                        executor = None
+                        results = [_parallel_timeout_result(args.parallel_timeout)]
+                    except Exception:
+                        _shutdown_executor_after_timeout(executor)
+                        executor = None
+                        raise
+                    finally:
+                        if executor is not None:
+                            executor.shutdown()
         else:
             # This entire path is an NVIDIA Modification
 
@@ -359,6 +386,35 @@ def _convert_select_pattern(pattern):
     if "*" not in pattern:
         return f"*{pattern}*"
     return pattern
+
+
+def _parallel_timeout_result(timeout_seconds):
+    message = f"Parallel test run exceeded timeout of {timeout_seconds} seconds"
+    details = f"{message} while waiting for worker results. Increase --parallel-timeout or reduce the test workload."
+    return (
+        1,
+        [message],
+        [],
+        0,
+        0,
+        0,
+        [("unittest_parallel", "parallel_timeout", float(timeout_seconds), "ERROR", message, details)],
+    )
+
+
+def _shutdown_executor_after_timeout(executor):
+    terminate_workers = getattr(executor, "terminate_workers", None)
+    if terminate_workers is not None:
+        terminate_workers()
+        return
+
+    # ProcessPoolExecutor has no public process-termination API before Python 3.14.
+    processes = list((getattr(executor, "_processes", None) or {}).values())
+    executor.shutdown(wait=False, cancel_futures=True)
+    for process in processes:
+        process.terminate()
+    for process in processes:
+        process.join(timeout=5)
 
 
 @contextmanager


### PR DESCRIPTION
## Description

Keep macOS unit tests in the CI matrix for pull requests, merge queue runs, and post-merge pushes as before, but give the macOS unit test job more time to finish.

This PR adds macOS-specific timeout headroom in `.github/workflows/ci.yml`:

- Set the `newton-unittests` job timeout to 120 minutes on `macos-latest` and 60 minutes elsewhere.
- Pass `--parallel-timeout 6900` on macOS and `--parallel-timeout 3300` elsewhere so the test runner can report a structured failure before GitHub Actions kills the job.
- Keep the static OS matrix, including `macos-latest`, instead of special-casing macOS out of PR or merge queue CI.

It also updates `newton/tests/thirdparty/unittest_parallel.py` to make the parallel result collection timeout configurable, validate that timeout, stop stalled worker processes, and emit a synthetic timeout error for JUnit reporting.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
git diff --check
uv run --extra dev -m newton.tests --help
uv run --extra dev -m newton.tests --parallel-timeout 1 --serial-fallback --no-cache-clear -p 'no_such_test_*.py'
uv run --extra dev -m newton.tests --parallel-timeout 0 --no-cache-clear -p 'no_such_test_*.py'  # expected parser error
uv run --extra dev -m newton.tests --parallel-timeout 1 --no-cache-clear -p 'no_such_test_*.py'
uv run --extra dev python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('yaml ok')"
SKIP=uv-lock uvx pre-commit run --files .github/workflows/ci.yml newton/tests/thirdparty/unittest_parallel.py
uvx pre-commit run -a
```
