### PR TITLE
Expose BVH constructor in ModelBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add user-defined pressure laws to hydroelastic SDF contact via `HydroelasticSDF.Config.pressure_func` (a `@wp.func` mapping `(signed_depth, shape_idx, data) -> pressure`) and `pressure_data` (a `@wp.struct` carrying per-shape state). The contact patch is the iso-pressure surface `p_a == p_b`; the default linear law `pressure = -kh * signed_depth` is preserved when no callback is supplied.
 - Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` for applying the checkerboard texture to selected shapes.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
+- Add `ModelBuilder.BvhConfig` for selecting Warp BVH constructors during model finalization for mesh, Gaussian, and shape BVHs.
 
 ### Changed
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.15.0.dev20260612 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.15.0.dev20260626 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.8.1",
     "python -m pip install -U mujoco-warp==3.8.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -1433,13 +1433,19 @@ class Mesh:
         self._cached_hash = None
 
     # construct simulation ready buffers from points
-    def finalize(self, device: Devicelike = None, requires_grad: bool = False) -> wp.uint64:
+    def finalize(
+        self,
+        device: Devicelike = None,
+        requires_grad: bool = False,
+        bvh_constructor: str | None = None,
+    ) -> wp.uint64:
         """
         Construct a simulation-ready Warp Mesh object from the mesh data and return its ID.
 
         Args:
             device: Device on which to allocate mesh buffers.
             requires_grad: If True, mesh points and velocities are allocated with gradient tracking.
+            bvh_constructor: Optional Warp mesh BVH constructor backend. If ``None``, Warp's default is used.
 
         Returns:
             The ID of the simulation-ready Warp Mesh.
@@ -1449,7 +1455,7 @@ class Mesh:
             vel = wp.zeros_like(pos)
             indices = wp.array(self.indices, dtype=wp.int32)
 
-            self.mesh = wp.Mesh(points=pos, velocities=vel, indices=indices)
+            self.mesh = wp.Mesh(points=pos, velocities=vel, indices=indices, bvh_constructor=bvh_constructor)
             return self.mesh.id
 
     def compute_convex_hull(self, replace: bool = False) -> "Mesh":
@@ -2379,11 +2385,12 @@ class Gaussian:
 
     # ---- Finalize (GPU upload) -----------------------------------------------
 
-    def finalize(self, device: Devicelike = None) -> Data:
+    def finalize(self, device: Devicelike = None, bvh_constructor: str | None = None) -> Data:
         """Upload Gaussian data to the GPU as Warp arrays.
 
         Args:
             device: Device on which to allocate buffers.
+            bvh_constructor: Optional Warp BVH constructor backend. If ``None``, Warp's default is used.
 
         Returns:
             Gaussian.Data struct containing the Warp arrays.
@@ -2412,7 +2419,7 @@ class Gaussian:
                 inputs=[self.warp_data, lowers, uppers],
             )
 
-            self.warp_bvh = wp.Bvh(lowers, uppers)
+            self.warp_bvh = wp.Bvh(lowers, uppers, constructor=bvh_constructor)
             self.warp_data.bvh_id = self.warp_bvh.id
         return self.warp_data
 

--- a/newton/_src/geometry/types.py
+++ b/newton/_src/geometry/types.py
@@ -12,6 +12,7 @@ import numpy as np
 import warp as wp
 
 from ..core.types import Axis, Devicelike, Vec2, Vec3, override
+from ..utils.deprecation import deprecate_nonkeyword_arguments
 from ..utils.texture import compute_texture_hash
 
 if TYPE_CHECKING:
@@ -1433,9 +1434,11 @@ class Mesh:
         self._cached_hash = None
 
     # construct simulation ready buffers from points
+    @deprecate_nonkeyword_arguments
     def finalize(
         self,
         device: Devicelike = None,
+        *,
         requires_grad: bool = False,
         bvh_constructor: str | None = None,
     ) -> wp.uint64:
@@ -2385,7 +2388,7 @@ class Gaussian:
 
     # ---- Finalize (GPU upload) -----------------------------------------------
 
-    def finalize(self, device: Devicelike = None, bvh_constructor: str | None = None) -> Data:
+    def finalize(self, device: Devicelike = None, *, bvh_constructor: str | None = None) -> Data:
         """Upload Gaussian data to the GPU as Warp arrays.
 
         Args:

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -257,6 +257,19 @@ class ModelBuilder:
         delay_args: list[dict[str, Any]]  # Per-actuator delay params (empty if no delay)
         clamping_args: list[list[dict[str, Any]]]  # Per-actuator per-clamping array params
 
+    @dataclass
+    class BvhConfig:
+        """Default BVH construction settings used during model finalization."""
+
+        mesh_constructor: str | None = None
+        """Warp mesh BVH constructor backend. If ``None``, Warp's default is used."""
+
+        gaussian_constructor: str | None = None
+        """Warp Gaussian BVH constructor backend. If ``None``, Warp's default is used."""
+
+        shape_constructor: str | None = None
+        """Warp model shape BVH constructor backend. If ``None``, Warp's default is used."""
+
     @dataclass(kw_only=True)
     class ShapeConfig:
         """
@@ -867,6 +880,9 @@ class ModelBuilder:
         """Number of worlds accumulated for :attr:`Model.world_count`."""
 
         # region defaults
+        self.default_bvh_cfg = ModelBuilder.BvhConfig()
+        """Default BVH construction configuration used during model finalization."""
+
         self.default_shape_cfg = ModelBuilder.ShapeConfig()
         """Default shape configuration used when shape-creation methods are called with ``cfg=None``.
         Update this object before adding shapes to set default contact/material properties."""
@@ -10588,17 +10604,25 @@ class ModelBuilder:
                             ground_z=geo.min_z,
                             compute_inertia=False,
                         )
-                        finalized_geos[geo_hash] = hf_geo.finalize(device=device)
+                        finalized_geos[geo_hash] = hf_geo.finalize(
+                            device=device,
+                            bvh_constructor=self.default_bvh_cfg.mesh_constructor,
+                        )
                         # keep mesh alive for the model's lifetime
                         heightfield_meshes.append(hf_geo.mesh)
                     geo_sources.append(finalized_geos[geo_hash])
                 elif geo:
                     if geo_hash not in finalized_geos:
                         if isinstance(geo, Mesh):
-                            finalized_geos[geo_hash] = geo.finalize(device=device)
+                            finalized_geos[geo_hash] = geo.finalize(
+                                device=device,
+                                bvh_constructor=self.default_bvh_cfg.mesh_constructor,
+                            )
                         elif isinstance(geo, Gaussian):
                             finalized_geos[geo_hash] = len(gaussians)
-                            gaussians.append(geo.finalize(device=device))
+                            gaussians.append(
+                                geo.finalize(device=device, bvh_constructor=self.default_bvh_cfg.gaussian_constructor)
+                            )
                         else:
                             finalized_geos[geo_hash] = geo.finalize()
                     geo_sources.append(finalized_geos[geo_hash])
@@ -11492,7 +11516,7 @@ class ModelBuilder:
             # Add custom attributes onto the model (with lazy evaluation)
             # Early return if no custom attributes exist to avoid overhead
             if not self.custom_attributes:
-                m.bvh_build_shapes(m)
+                m.bvh_build_shapes(m, bvh_constructor=self.default_bvh_cfg.shape_constructor)
                 m.bvh_build_particles(m)
                 return m
 
@@ -11599,7 +11623,7 @@ class ModelBuilder:
                 result = custom_attr.build_array(count, device=device, requires_grad=requires_grad)
                 m.add_attribute(custom_attr.name, result, freq_key, custom_attr.assignment, custom_attr.namespace)
 
-            m.bvh_build_shapes(m)
+            m.bvh_build_shapes(m, bvh_constructor=self.default_bvh_cfg.shape_constructor)
             m.bvh_build_particles(m)
             return m
 

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -221,6 +221,57 @@ class TestModelBuilderDeprecations(unittest.TestCase):
             newton.use_coord_layout_targets = prev_flag
 
 
+class TestModelBuilderBvhConstructor(unittest.TestCase):
+    def test_model_builder_forwards_bvh_constructors(self):
+        builder = ModelBuilder()
+        builder.default_bvh_cfg.mesh_constructor = "cubql"
+        builder.default_bvh_cfg.gaussian_constructor = "sah"
+        builder.default_bvh_cfg.shape_constructor = "lbvh"
+
+        mesh = newton.Mesh(
+            vertices=np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.int32),
+            compute_inertia=False,
+        )
+        gaussian = newton.Gaussian(positions=np.zeros((1, 3), dtype=np.float32))
+        builder.add_shape_mesh(body=-1, mesh=mesh)
+        builder.add_shape_gaussian(body=-1, gaussian=gaussian)
+
+        with (
+            mock.patch("newton._src.geometry.types.wp.Mesh") as wp_mesh,
+            mock.patch.object(
+                newton.Gaussian, "finalize", autospec=True, return_value=newton.Gaussian.Data()
+            ) as finalize,
+            mock.patch.object(newton.Model, "bvh_build_shapes", autospec=True) as build_shapes,
+            mock.patch.object(newton.Model, "bvh_build_particles", autospec=True),
+        ):
+            wp_mesh.return_value.id = 123
+            model = builder.finalize(device="cpu")
+
+        wp_mesh.assert_called_once()
+        self.assertEqual(wp_mesh.call_args.kwargs["bvh_constructor"], "cubql")
+        finalize.assert_called_once_with(gaussian, device="cpu", bvh_constructor="sah")
+        build_shapes.assert_called_once_with(model, model, bvh_constructor="lbvh")
+
+    def test_gaussian_finalize_forwards_bvh_constructor_to_warp_bvh(self):
+        gaussian = newton.Gaussian(
+            positions=np.zeros((1, 3), dtype=np.float32),
+            rotations=np.array([[0.0, 0.0, 0.0, 1.0]], dtype=np.float32),
+            scales=np.ones((1, 3), dtype=np.float32),
+            opacities=np.ones(1, dtype=np.float32),
+            sh_coeffs=np.ones((1, 3), dtype=np.float32),
+        )
+
+        with (
+            mock.patch("newton._src.geometry.types.wp.launch"),
+            mock.patch("newton._src.geometry.types.wp.Bvh") as wp_bvh,
+        ):
+            wp_bvh.return_value.id = 456
+            gaussian.finalize(device="cpu", bvh_constructor="sah")
+
+        self.assertEqual(wp_bvh.call_args.kwargs["constructor"], "sah")
+
+
 class TestModelMesh(unittest.TestCase):
     def test_add_triangles(self):
         rng = np.random.default_rng(123)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.14.0",
+    "warp-lang>=1.15.0.dev20260626",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3900,7 +3900,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.14.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.15.0.dev20260626", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "rtx", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -7174,17 +7174,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.15.0.dev20260612"
+version = "1.15.0.dev20260626"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260612-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9ff409ef0143116869f2987d802f610b9d10c797e030d59e1bca049db1d2bfc7" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260612-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f17a22f2b8b4b8767386f6ab592e7af7125ceeb017150407d13bd792307d4616" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260612-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:c41ab515b1429b0042d29105c493c8b9d5139c08c5faf3bb12b53c735338e1a7" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260612-py3-none-win_amd64.whl", hash = "sha256:42b16713e1f6984bacab9997e0ab617a1d307bebdb081c22fc8b7c4ad8617fd5" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260626-py3-none-macosx_11_0_arm64.whl", hash = "sha256:351cb3e0679767f29a7d1fd639537fe40f66fe9f29355d4d19c5cbde8959916d" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260626-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:e43f8eedb80300bd4e024a50d2bf9b5177bb16a838d936f1d4a0a2499cf531e2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260626-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:d87dc2f286372cbb2c1c66857e7b9ee62a9d485ecf01b193349ecb6f5b4d938c" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.15.0.dev20260626-py3-none-win_amd64.whl", hash = "sha256:81b2328cc5bfafc70776cad651d99d28d280d3f544bd5e555400d1d379528de4" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Adds `ModelBuilder.BvhConfig` so callers can choose Warp BVH constructors during model finalization. The new `builder.default_bvh_cfg` controls:

- `mesh_constructor`: forwarded to `wp.Mesh(..., bvh_constructor=...)` for mesh geometry, including meshes created from heightfields.
- `gaussian_constructor`: forwarded to `wp.Bvh(..., constructor=...)` when finalizing Gaussian geometry.
- `shape_constructor`: forwarded to `Model.bvh_build_shapes(..., bvh_constructor=...)` for the model shape broadphase BVH.

All fields default to `None`, so existing behavior continues to use Warp's default constructors unless a caller opts in.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k TestModelBuilderBvhConstructor
uv run python docs/generate_api.py
git diff --check
```

## New feature / API change

```python
import newton

builder = newton.ModelBuilder()

# Leave as None to preserve Warp's default constructor for that BVH.
builder.default_bvh_cfg.mesh_constructor = "cubql"
builder.default_bvh_cfg.gaussian_constructor = "sah"
builder.default_bvh_cfg.shape_constructor = "lbvh"

model = builder.finalize()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable BVH construction backends during model finalization, with separate options for mesh, Gaussian, and shape BVHs.
  * `Mesh.finalize` and `Gaussian.finalize` now support an optional BVH constructor override, and `requires_grad` is keyword-only for `Mesh`.
* **Tests**
  * Added coverage to verify BVH constructor settings are correctly forwarded through model finalization, including direct Warp BVH creation.
* **Documentation**
  * Updated `CHANGELOG.md` with the new BVH configuration option.
* **Chores**
  * Bumped the Warp dependency to a newer dev build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->