### PR TITLE
Fix MuJoCo D6 mixed-axis joint names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - Fix `ModelBuilder.finalize()` crashing with 3+ articulations after `collapse_fixed_joints()` reordered `articulation_start` and dropped per-articulation metadata
 - Fix Sphinx docs builds to auto-discover bundled ``pypandoc_binary`` pandoc so notebook tutorials build without manual PATH configuration
 - Fix `SolverStyle3D` initialization to precompute its fixed PD matrix from the finalized model
+- Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
 - Fix connect constraint anchor computation to account for joint reference positions when `SolverMuJoCo` is the chosen solver.
 - Fix joint-synthesized CONNECT constraint anchors not updating when `dof_ref` or `joint_X_p` changes at runtime via `notify_model_changed()`
 - Fix WELD constraint data corruption when a model contains both FIXED and revolute/ball loop joints

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5001,6 +5001,7 @@ class SolverMuJoCo(SolverBase):
                             actuator_count += 1
             elif j_type in supported_joint_types:
                 lin_axis_count, ang_axis_count = joint_dof_dim[j]
+                multi_axis_joint = lin_axis_count + ang_axis_count > 1
                 num_dofs += lin_axis_count + ang_axis_count
                 num_qpos += lin_axis_count + ang_axis_count
 
@@ -5053,7 +5054,7 @@ class SolverMuJoCo(SolverBase):
                         joint_params["ref"] = joint_ref[ai]
 
                     axname = name
-                    if lin_axis_count > 1 or ang_axis_count > 1:
+                    if multi_axis_joint:
                         axname += "_lin"
                     if lin_axis_count > 1:
                         axname += str(i)
@@ -5151,7 +5152,7 @@ class SolverMuJoCo(SolverBase):
                         joint_params["ref"] = np.rad2deg(joint_ref[ai])
 
                     axname = name
-                    if lin_axis_count > 1 or ang_axis_count > 1:
+                    if multi_axis_joint:
                         axname += "_ang"
                     if ang_axis_count > 1:
                         axname += str(i - lin_axis_count)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8288,6 +8288,27 @@ class TestMuJoCoSolverQpos0(unittest.TestCase):
 
 
 class TestMuJoCoSolverDuplicateBodyNames(unittest.TestCase):
+    def test_d6_single_linear_single_angular_joint_names_are_unique(self):
+        """D6 joints with one slide and one hinge axis emit unique MuJoCo joint names."""
+        builder = newton.ModelBuilder()
+        link = builder.add_link(mass=1.0, com=wp.vec3(0.0, 0.0, 0.0), inertia=wp.mat33(np.eye(3)))
+        joint = builder.add_joint_d6(
+            parent=-1,
+            child=link,
+            linear_axes=[newton.ModelBuilder.JointDofConfig(axis=newton.Axis.X)],
+            angular_axes=[newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Z)],
+        )
+        builder.add_articulation([joint])
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mujoco = SolverMuJoCo._mujoco
+        joint_names = [
+            mujoco.mj_id2name(solver.mj_model, mujoco.mjtObj.mjOBJ_JOINT, i) for i in range(solver.mj_model.njnt)
+        ]
+
+        self.assertEqual(joint_names, ["joint_1_lin", "joint_1_ang"])
+
     def test_body_actuator_with_duplicated_body_names(self):
         """Test that duplicated body names resolve correctly for BODY actuators."""
         mjcf = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Description

Fix `SolverMuJoCo` generated joint names for D6 joints that contain both a single linear axis and a single angular axis. These are exported as separate MuJoCo slide and hinge joints, so their generated names now include `_lin` and `_ang` suffixes to avoid duplicate MuJoCo joint names.

Closes #2854.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k TestMuJoCoSolverDuplicateBodyNames
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Build a model with a D6 joint containing one linear axis and one angular axis.
2. Finalize the model.
3. Construct `newton.solvers.SolverMuJoCo(model)`.
4. Without this PR, MuJoCo raises a duplicate joint name error for `joint_1`.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton
from newton.solvers import SolverMuJoCo

builder = newton.ModelBuilder()
link = builder.add_link(
    mass=1.0,
    com=wp.vec3(0.0, 0.0, 0.0),
    inertia=wp.mat33(np.eye(3)),
)
joint = builder.add_joint_d6(
    parent=-1,
    child=link,
    linear_axes=[newton.ModelBuilder.JointDofConfig(axis=newton.Axis.X)],
    angular_axes=[newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Z)],
)
builder.add_articulation([joint])
model = builder.finalize()

SolverMuJoCo(model, iterations=1, disable_contacts=True)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MuJoCo joint name duplication for multi-axis D6 joints, ensuring unique identification across linear and angular axes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2868)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->