### PR TITLE
Use Warp FEM at argument

### DIFF
--- a/newton/_src/solvers/implicit_mpm/render_grains.py
+++ b/newton/_src/solvers/implicit_mpm/render_grains.py
@@ -186,7 +186,7 @@ def update_render_grains(
 
     fem.interpolate(
         advect_grains,
-        quadrature=grain_pic,
+        at=grain_pic,
         values={
             "dt": dt,
             "positions": grain_pos,


### PR DESCRIPTION
## Description

Migrate the implicit-MPM render-grain interpolation call from Warp FEM's deprecated `quadrature=` argument to the preferred `at=` argument. This matches the current preferred API ahead of Warp's planned removal of the deprecated argument, without changing interpolation behavior.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

No changelog entry is included because this is not a user-facing behavior change.

## Test plan

```bash
uv run --extra examples -m newton.examples mpm_grain_rendering --viewer null --num-frames 2 --test --quiet --voxel-size 0.5
uvx pre-commit run --files newton/_src/solvers/implicit_mpm/render_grains.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected grain sampling parameter specification in the implicit MPM solver to ensure accurate grain interpolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2884)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->