### PR TITLE
Update Warp logging compatibility

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.14.0.dev20260511 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.14.0.dev20260514 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.8.1",
     "python -m pip install -U mujoco-warp==3.8.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,10 +202,11 @@ from typing import Any
 import numpy as np
 import warp as wp
 import newton
+from newton._warp_config import set_warp_quiet
 
 warnings.filterwarnings("ignore")
 
-wp.config.quiet = True
+set_warp_quiet()
 wp.init()
 """
 

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -10,6 +10,8 @@ from typing import Literal
 import numpy as np
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ..sim import Contacts, Model, State
 from ..utils.selection import match_labels
 
@@ -359,7 +361,7 @@ class SensorContact:
                 against shape labels, or list of patterns where any one matches.
             measure_total: If True (default), :attr:`total_force` and :attr:`total_force_friction` are allocated.
                 If False, both are None.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
             request_contact_attributes: If True (default), transparently request the extended contact attribute
                 ``force`` from the model.
             include_total: Deprecated. Use ``measure_total`` instead.
@@ -379,7 +381,7 @@ class SensorContact:
             raise ValueError("At most one of `counterpart_bodies` and `counterpart_shapes` may be specified.")
 
         self.device = model.device
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else warp_verbose_enabled()
 
         # request contact force attribute
         if request_contact_attributes:

--- a/newton/_src/sensors/sensor_frame_transform.py
+++ b/newton/_src/sensors/sensor_frame_transform.py
@@ -5,6 +5,8 @@
 
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ..geometry import ShapeFlags
 from ..sim.model import Model
 from ..sim.state import State
@@ -134,13 +136,13 @@ class SensorFrameTransform:
             reference_sites: List of site indices, single pattern to match against
                 site labels, or list of patterns where any one matches. Must expand
                 to one site or the same number as ``shapes``.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
 
         Raises:
             ValueError: If arguments are invalid or no labels match.
         """
         self.model = model
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else warp_verbose_enabled()
 
         # Resolve label patterns to indices
         original_shapes = shapes

--- a/newton/_src/sensors/sensor_imu.py
+++ b/newton/_src/sensors/sensor_imu.py
@@ -5,6 +5,8 @@
 
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ..geometry.flags import ShapeFlags
 from ..sim.model import Model
 from ..sim.state import State
@@ -128,7 +130,7 @@ class SensorIMU:
             model: The model to use.
             sites: List of site indices, single pattern to match against site
                 labels, or list of patterns where any one matches.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
             request_state_attributes: If True (default), transparently request the extended state attribute ``body_qdd`` from the model.
                 If False, ``model`` is not modified and the attribute must be requested elsewhere before calling ``model.state()``.
         Raises:
@@ -136,7 +138,7 @@ class SensorIMU:
         """
 
         self.model = model
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else warp_verbose_enabled()
 
         original_sites = sites
         sites = match_labels(model.shape_label, sites)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 import numpy as np
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ..actuators.clamping.clamping_max_effort import ClampingMaxEffort
 from ..actuators.controllers.controller_pd import ControllerPD
 from ..actuators.controllers.controller_pid import ControllerPID
@@ -4829,12 +4831,12 @@ class ModelBuilder:
         plt.show()
 
     def collapse_fixed_joints(
-        self, verbose: bool = wp.config.verbose, joints_to_keep: list[str] | None = None
+        self, verbose: bool = warp_verbose_enabled(), joints_to_keep: list[str] | None = None
     ) -> dict[str, Any]:
         """Removes fixed joints from the model and merges the bodies they connect. This is useful for simplifying the model for faster and more stable simulation.
 
         Args:
-            verbose: If True, print additional information about the collapsed joints. Defaults to the value of `wp.config.verbose`.
+            verbose: If True, print additional information about the collapsed joints. Defaults to Warp debug logging.
             joints_to_keep: An optional list of joint labels to be excluded from the collapse process.
         """
 

--- a/newton/_src/sim/graph_coloring.py
+++ b/newton/_src/sim/graph_coloring.py
@@ -8,6 +8,8 @@ from typing import Literal
 import numpy as np
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 
 class ColoringAlgorithm(Enum):
     MCS = 0
@@ -344,7 +346,7 @@ def color_graph(
             particle_colors.__ctype__(),
         )
 
-        if max_min_ratio > target_max_min_color_ratio and wp.config.verbose:
+        if max_min_ratio > target_max_min_color_ratio and warp_verbose_enabled():
             warnings.warn(
                 f"Color balancing terminated early: max/min ratio {max_min_ratio:.3f} "
                 f"exceeds target {target_max_min_color_ratio:.3f}. "

--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -13,6 +13,8 @@ import warp.sparse as sp
 from warp.fem.linalg import array_axpy
 from warp.optim.linear import LinearOperator, cg, cr, gmres
 
+from newton._warp_config import warp_verbose_enabled
+
 from .contact_solver_kernels import (
     apply_nodal_impulse_warmstart,
     apply_subgrid_impulse,
@@ -1660,7 +1662,7 @@ def solve_rheology(
     jacobi_warmstart_smoother_iterations: int = 5,
     temporary_store: fem.TemporaryStore | None = None,
     use_graph: bool = True,
-    verbose: bool = wp.config.verbose,
+    verbose: bool = warp_verbose_enabled(),
 ):
     """Solve coupled plasticity and collider contact to compute grid velocities.
 

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -14,6 +14,7 @@ import warp.fem as fem
 import warp.sparse as wps
 
 import newton
+from newton._warp_config import warp_verbose_enabled
 
 from ...core.types import override
 from ..flags import SolverNotifyFlags
@@ -635,7 +636,7 @@ class SolverImplicitMPM(SolverBase):
         config: Solver configuration. See :class:`SolverImplicitMPM.Config`.
         temporary_store: Optional Warp FEM temporary store for reusing scratch
             allocations across steps.
-        verbose: Enable verbose solver output. Defaults to ``wp.config.verbose``.
+        verbose: Enable verbose solver output. Defaults to Warp debug logging.
         enable_timers: Enable per-section wall-clock timings.
     """
 
@@ -929,7 +930,7 @@ class SolverImplicitMPM(SolverBase):
         self.tolerance = float(config.tolerance)
 
         self.temporary_store = temporary_store
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else warp_verbose_enabled()
         self.enable_timers = enable_timers
 
         self.velocity_basis = "Q1"

--- a/newton/_src/solvers/kamino/tests/__init__.py
+++ b/newton/_src/solvers/kamino/tests/__init__.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import numpy as np
 import warp as wp
 
+from newton._warp_config import set_warp_config_value_compat
+
 ###
 # Module interface
 ###
@@ -53,7 +55,7 @@ def setup_tests(verbose: bool = False, device: wp.DeviceLike | str | None = None
     wp.init()
     wp.config.mode = "release"
     wp.config.enable_backward = False
-    wp.config.verbose = False
+    set_warp_config_value_compat("verbose", False)
     wp.config.verify_fp = False
     wp.config.verify_cuda = False
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ...core.types import MAXVAL, override, vec5, vec10
 from ...geometry import GeoType, Mesh, ShapeFlags
 from ...sim import (
@@ -2471,7 +2473,7 @@ class SolverMuJoCo(SolverBase):
                 joint_start = int(tendon_joint_adr[i])
                 joint_num = int(tendon_joint_num[i])
                 if joint_num <= 0:
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(f"Warning: Skipping tendon {i} during MuJoCo export because it has no joint wraps.")
                     continue
 
@@ -2513,7 +2515,7 @@ class SolverMuJoCo(SolverBase):
                     fixed_wraps.append((joint_name, coef))
 
                 if len(fixed_wraps) == 0:
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(
                             f"Warning: Skipping tendon {i} during MuJoCo export "
                             "because no valid joint wraps were resolved."
@@ -2838,12 +2840,12 @@ class SolverMuJoCo(SolverBase):
                 dof_idx = target_idx
                 dofs_per_world = len(dof_to_mjc_joint)
                 if dof_idx < 0 or dof_idx >= dofs_per_world:
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} has invalid DOF target {dof_idx}")
                     continue
                 mjc_joint_idx = dof_to_mjc_joint[dof_idx]
                 if mjc_joint_idx < 0 or mjc_joint_idx >= len(mjc_joint_names):
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} DOF {dof_idx} not mapped to MuJoCo joint")
                     continue
                 target_name = mjc_joint_names[mjc_joint_idx]
@@ -2852,17 +2854,17 @@ class SolverMuJoCo(SolverBase):
                     mjc_tendon_idx = selected_tendons.index(target_idx)
                     target_name = mjc_tendon_names[mjc_tendon_idx]
                 except (ValueError, IndexError):
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} references tendon {target_idx} not in MuJoCo")
                     continue
             elif trntype == int(SolverMuJoCo.TrnType.BODY):
                 if target_idx < 0 or target_idx >= len(model.body_label):
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} has invalid body target {target_idx}")
                     continue
                 target_name = body_name_mapping.get(target_idx)
                 if target_name is None:
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(
                             f"Warning: MuJoCo actuator {mujoco_act_idx} references body {target_idx} "
                             "not present in the MuJoCo export."
@@ -2878,7 +2880,7 @@ class SolverMuJoCo(SolverBase):
                 if site_name is None:
                     site_name = site_mapping.get(target_idx)
                 if site_name is None:
-                    if wp.config.verbose:
+                    if warp_verbose_enabled():
                         print(
                             f"Warning: MuJoCo actuator {mujoco_act_idx} site target "
                             f"'{target_label}' not found in site mapping"
@@ -2887,7 +2889,7 @@ class SolverMuJoCo(SolverBase):
                 target_name = site_name
             else:
                 # TODO: Support slidercrank and jointinparent transmission types
-                if wp.config.verbose:
+                if warp_verbose_enabled():
                     print(f"Warning: MuJoCo actuator {mujoco_act_idx} has unsupported trntype {trntype}")
                 continue
 
@@ -3297,7 +3299,7 @@ class SolverMuJoCo(SolverBase):
             return
         if any(getattr(state_out, field) is not None for field in rne_postconstraint_fields):
             # required for cfrc_ext, cfrc_int, cacc
-            if wp.config.verbose:
+            if warp_verbose_enabled():
                 print("Setting model.sensor_rne_postconstraint True")
             m.sensor_rne_postconstraint = True
 
@@ -4671,7 +4673,7 @@ class SolverMuJoCo(SolverBase):
                     # Retrieve heightfield source
                     hfield_src = model.shape_source[shape]
                     if hfield_src is None:
-                        if wp.config.verbose:
+                        if warp_verbose_enabled():
                             print(f"Warning: Heightfield shape {shape} has no source data, skipping")
                         continue
 
@@ -5217,7 +5219,7 @@ class SolverMuJoCo(SolverBase):
             target_name = body_name_mapping.get(body_idx)
             if target_name is None:
                 target_name = model.body_label[body_idx].replace("/", "_")
-                if wp.config.verbose:
+                if warp_verbose_enabled():
                     print(
                         f"Warning: MuJoCo equality constraint references body {body_idx} "
                         "not present in the MuJoCo export."

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -9,6 +9,8 @@ from typing import Any
 import numpy as np
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
+
 from ...core.types import override
 from ...sim import (
     Contacts,
@@ -477,7 +479,7 @@ class SolverVBD(SolverBase):
         self.particle_q_rest = model.particle_q
 
         # Tile solve settings
-        if model.device.is_cpu and particle_enable_tile_solve and wp.config.verbose:
+        if model.device.is_cpu and particle_enable_tile_solve and warp_verbose_enabled():
             print("Info: Tiled solve requires model.device='cuda'. Tiled solve is disabled.")
 
         self.use_particle_tile_solve = particle_enable_tile_solve and model.device.is_cuda

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 import warp as wp
 from warp.types import is_array
 
+from newton._warp_config import warp_verbose_enabled
+
 from ..sim import Control, JointType, Model, State, eval_fk, eval_jacobian, eval_mass_matrix
 
 if TYPE_CHECKING:
@@ -515,7 +517,7 @@ class ArticulationView:
         self.device = model.device
 
         if verbose is None:
-            verbose = wp.config.verbose
+            verbose = warp_verbose_enabled()
 
         # FIXME: avoid/reduce this readback?
         model_articulation_start = model.articulation_start.numpy()

--- a/newton/_warp_config.py
+++ b/newton/_warp_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility helpers for Warp logging configuration.
+
+Important:
+    Remove this forwarding layer once Newton requires ``warp-lang>=1.14.0``.
+"""
+
+from typing import Any
+
+import warp as wp
+
+_DEPRECATED_LOG_CONFIG_KEYS = {"quiet", "verbose"}
+
+
+def _has_log_level_api(warp_module: Any = wp) -> bool:
+    return (
+        hasattr(warp_module.config, "log_level")
+        and hasattr(warp_module, "LOG_DEBUG")
+        and hasattr(warp_module, "LOG_INFO")
+        and hasattr(warp_module, "LOG_WARNING")
+    )
+
+
+def warp_config_hasattr(name: str, warp_module: Any = wp) -> bool:
+    """Return whether ``warp.config`` supports *name* without touching deprecated log keys."""
+    if name in _DEPRECATED_LOG_CONFIG_KEYS and _has_log_level_api(warp_module):
+        return True
+    return hasattr(warp_module.config, name)
+
+
+def warp_verbose_enabled(warp_module: Any = wp) -> bool:
+    """Return whether Warp-style verbose/debug logging is enabled."""
+    legacy_verbose = bool(vars(warp_module.config).get("verbose", False))
+    if _has_log_level_api(warp_module):
+        return legacy_verbose or warp_module.config.log_level <= warp_module.LOG_DEBUG
+    return legacy_verbose
+
+
+def set_warp_quiet(enabled: bool = True, warp_module: Any = wp) -> None:
+    """Suppress Warp info-level output, preserving compatibility with older Warp versions."""
+    if _has_log_level_api(warp_module):
+        if enabled:
+            if warp_module.config.log_level < warp_module.LOG_WARNING:
+                warp_module.config.log_level = warp_module.LOG_WARNING
+        elif warp_module.config.log_level == warp_module.LOG_WARNING:
+            warp_module.config.log_level = warp_module.LOG_INFO
+        return
+
+    warp_module.config.quiet = enabled
+
+
+def set_warp_config_value_compat(name: str, value: Any, warp_module: Any = wp) -> None:
+    """Set a ``warp.config`` value, translating legacy ``verbose``/``quiet`` keys."""
+    if _has_log_level_api(warp_module):
+        if name == "verbose":
+            if value:
+                if warp_module.config.log_level > warp_module.LOG_DEBUG:
+                    warp_module.config.log_level = warp_module.LOG_DEBUG
+            elif warp_module.config.log_level == warp_module.LOG_DEBUG:
+                warp_module.config.log_level = warp_module.LOG_INFO
+            return
+
+        if name == "quiet":
+            set_warp_quiet(bool(value), warp_module=warp_module)
+            return
+
+    setattr(warp_module.config, name, value)

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -14,6 +14,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._warp_config import set_warp_config_value_compat, set_warp_quiet, warp_config_hasattr
 from newton.tests.unittest_utils import find_nan_members
 
 
@@ -631,7 +632,7 @@ def _apply_warp_config(parser, args):
 
         key, value_str = entry.split("=", 1)
 
-        if not hasattr(wp.config, key):
+        if not warp_config_hasattr(key):
             parser.error(f"invalid --warp-config key '{key}': not a recognized warp.config setting")
 
         try:
@@ -639,7 +640,7 @@ def _apply_warp_config(parser, args):
         except (ValueError, SyntaxError):
             value = value_str
 
-        setattr(wp.config, key, value)
+        set_warp_config_value_compat(key, value)
 
 
 def _raise_benchmark_priority(realtime=False):
@@ -716,7 +717,7 @@ def init(parser=None):
 
     # Suppress Warp compilation messages if requested
     if args.quiet:
-        wp.config.quiet = True
+        set_warp_quiet()
 
     # Set device if specified
     if args.device:

--- a/newton/tests/test_lazy_init.py
+++ b/newton/tests/test_lazy_init.py
@@ -3,6 +3,7 @@
 
 """Assert that ``import newton`` does not trigger ``wp.init()``."""
 
+import os
 import subprocess
 import sys
 import unittest
@@ -10,6 +11,9 @@ import unittest
 
 class TestLazyInit(unittest.TestCase):
     def test_import_newton_does_not_init_warp(self):
+        env = os.environ.copy()
+        env["PYTHONWARNINGS"] = "error::DeprecationWarning"
+
         result = subprocess.run(
             [
                 sys.executable,
@@ -17,6 +21,7 @@ class TestLazyInit(unittest.TestCase):
                 "import newton; import warp._src.context as wpc; import sys; sys.exit(0 if wpc.runtime is None else 1)",
             ],
             capture_output=True,
+            env=env,
             text=True,
             check=False,
         )

--- a/newton/tests/test_warp_config_cli.py
+++ b/newton/tests/test_warp_config_cli.py
@@ -6,9 +6,11 @@
 import contextlib
 import io
 import unittest
+import warnings
 
 import warp as wp
 
+from newton._warp_config import warp_verbose_enabled
 from newton.examples import _apply_warp_config, create_parser
 
 
@@ -16,7 +18,12 @@ class TestWarpConfigCLI(unittest.TestCase):
     """Tests for :func:`_apply_warp_config`."""
 
     def setUp(self):
-        self._saved_config = {attr: getattr(wp.config, attr) for attr in dir(wp.config) if not attr.startswith("__")}
+        deprecated_log_attrs = {"quiet", "verbose"} if hasattr(wp.config, "log_level") else set()
+        self._saved_config = {
+            attr: getattr(wp.config, attr)
+            for attr in dir(wp.config)
+            if not attr.startswith("__") and attr not in deprecated_log_attrs
+        }
 
     def tearDown(self):
         for attr, value in self._saved_config.items():
@@ -32,7 +39,10 @@ class TestWarpConfigCLI(unittest.TestCase):
         """No --warp-config flags should be a no-op."""
         parser, args = self._parse()
         _apply_warp_config(parser, args)
-        self.assertEqual(wp.config.verbose, self._saved_config["verbose"])
+        if hasattr(wp.config, "log_level"):
+            self.assertEqual(wp.config.log_level, self._saved_config["log_level"])
+        else:
+            self.assertEqual(warp_verbose_enabled(), self._saved_config["verbose"])
 
     def test_int_override(self):
         """Integer values should be parsed via literal_eval."""
@@ -49,8 +59,26 @@ class TestWarpConfigCLI(unittest.TestCase):
     def test_bool_override(self):
         """Boolean values should be parsed correctly."""
         parser, args = self._parse("--warp-config", "verbose=True")
-        _apply_warp_config(parser, args)
-        self.assertIs(wp.config.verbose, True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            _apply_warp_config(parser, args)
+        self.assertIs(warp_verbose_enabled(), True)
+
+    def test_legacy_verbose_flag_is_honored(self):
+        """A legacy verbose flag set outside Newton should still enable verbose behavior."""
+        if not hasattr(wp.config, "log_level"):
+            self.skipTest("log_level compatibility only applies to newer Warp versions")
+
+        config_dict = vars(wp.config)
+        old_verbose = config_dict.get("verbose", False)
+        old_log_level = wp.config.log_level
+        try:
+            config_dict["verbose"] = True
+            wp.config.log_level = wp.LOG_INFO
+            self.assertIs(warp_verbose_enabled(), True)
+        finally:
+            config_dict["verbose"] = old_verbose
+            wp.config.log_level = old_log_level
 
     def test_none_override(self):
         """None values should be accepted."""

--- a/uv.lock
+++ b/uv.lock
@@ -6785,17 +6785,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.14.0.dev20260511"
+version = "1.14.0.dev20260514"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3cbb102762dd5dd04566fdf20273cbd199f3bc924bea9a184e546ca07a7ef0b2" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ea4716c41ec21ac4e53d05bd963c3eeec10a52b5a202c732ca20ae1479423b0b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e656b608ec0bd0fd70716740dc2da54e94d278ba945571b4a224a554a17aec81" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-win_amd64.whl", hash = "sha256:79b94796dad92ecaa21b82a785167310236fff07dad89092e9017ff4fa5274fd" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260514-py3-none-macosx_11_0_arm64.whl", hash = "sha256:092a362fd717961c6cbdc8b3f48e5b847631fa09d6a5b7796af0f844d36c3cc0" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260514-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:db0ea6e939497562a093637be3cfa83a6b9005e7915f67ca4bf04a1ae3d42f68" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260514-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:bb35b04146dcfe75d3256b72356dc37daa8fc08e726365b978417ab21e58b4a2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260514-py3-none-win_amd64.whl", hash = "sha256:befc0c4fe4f31a16da5c96281476b5423555054df2c0ee8f4e574980a89f970a" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Migrate Newton's Warp logging configuration use away from deprecated `wp.config.verbose` and `wp.config.quiet` access while preserving compatibility with `warp-lang>=1.13.0`.

This adds a private compatibility layer for Warp logging settings, updates Newton runtime/config call sites to use it, and keeps `wp.config.verbose_warnings` untouched since Warp still supports it. The lock file and ASV config now point at `warp-lang==1.14.0.dev20260514`, which includes the logging deprecations used to verify the migration.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
PYTHONWARNINGS=error::DeprecationWarning uv run --extra dev -m newton.tests -k test_warp_config_cli
uv run --extra dev -m newton.tests -k test_lazy_init
uvx pre-commit run -a
```

Also verified that `asv/benchmarks/**` is unchanged relative to the parent commit, so benchmark source hashes are not invalidated by this compatibility work:

```bash
git diff --exit-code HEAD^ -- asv/benchmarks
```

## Bug fix

**Steps to reproduce:**

1. Install a Warp build with the `wp.config.verbose` / `wp.config.quiet` deprecations, such as `warp-lang==1.14.0.dev20260514`.
2. Treat deprecations as errors:
   ```bash
   PYTHONWARNINGS=error::DeprecationWarning uv run --extra dev -m newton.tests -k test_warp_config_cli
   ```
3. Run Newton code paths that read or write the deprecated Warp logging config values.

**Minimal reproduction:**

```python
import warp as wp

wp.config.quiet = True
```

## Discussion

The forwarding shims in `newton._warp_config` are only present so Newton can support both `warp-lang==1.13.0` and Warp versions with the new `wp.config.log_level` API.

If Newton 1.3 is expected to raise its minimum Warp floor to `warp-lang>=1.14.0`, then this pull request should be simplified: set the minimum version to 1.14.0 and drop the touched lines that only exist to support both Warp logging APIs. That would minimize the migration to direct `wp.config.log_level` use and avoid carrying a temporary compatibility layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Warp dependency to a newer pre-release version.
  * Improved compatibility layer for Warp logging configuration across different Warp versions.
  * Standardized verbosity configuration throughout the library for consistent behavior.

* **Tests**
  * Enhanced test robustness for Warp configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2888)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->