### PR TITLE
docs: fix solver API support matrix and examples

### DIFF
--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -104,7 +104,7 @@ Supported Features
      - 🟨 :ref:`limited joint support <Joint feature support>`
      - ✅
      - ✅
-     - ❌
+     - ✅
      - ❌
    * - :class:`~newton.solvers.SolverXPBD`
      - Implicit
@@ -372,8 +372,8 @@ control, or model arrays. In practice, this starts by calling
     model = builder.finalize(requires_grad=True)
     solver = newton.solvers.SolverSemiImplicit(model)
 
-    state_in = model.state()
-    state_out = model.state()
+    state_in = model.state(requires_grad=True)
+    state_out = model.state(requires_grad=True)
     control = model.control()
     loss = wp.zeros(1, dtype=float, requires_grad=True)
     target = wp.vec3(0.25, 0.0, 0.0)

--- a/docs/api/newton_solvers_style3d.rst
+++ b/docs/api/newton_solvers_style3d.rst
@@ -7,11 +7,15 @@ newton.solvers.style3d
 Style3D solver module.
 
 This module provides helper functions for setting up Style3D cloth assets.
-Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver
-import path.
+Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver class.
 
-.. py:module:: newton.solvers.style3d
-.. currentmodule:: newton.solvers.style3d
+.. note::
+
+   This page documents helper functions exposed through the ``newton.solvers.style3d`` attribute.
+   Because ``newton.solvers`` is a module rather than a package, use
+   ``from newton.solvers import style3d`` instead of ``import newton.solvers.style3d``.
+
+.. currentmodule:: newton._src.solvers.style3d
 
 .. rubric:: Functions
 

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -178,7 +178,21 @@ def write_module_page(mod_name: str) -> None:
     if doc:
         lines.extend([doc, ""])
 
-    lines.extend([f".. py:module:: {mod_name}", f".. currentmodule:: {mod_name}", ""])
+    if is_solver_submodule:
+        lines.extend(
+            [
+                ".. note::",
+                "",
+                f"   This page documents helper functions exposed through the ``{mod_name}`` attribute.",
+                "   Because ``newton.solvers`` is a module rather than a package, use",
+                f"   ``from newton.solvers import {sub_name}`` instead of ``import {mod_name}``.",
+                "",
+                f".. currentmodule:: newton._src.solvers.{sub_name}",
+                "",
+            ]
+        )
+    else:
+        lines.extend([f".. py:module:: {mod_name}", f".. currentmodule:: {mod_name}", ""])
 
     # Render a simple bullet list of submodules (no autosummary/toctree) to
     # avoid generating stub pages that can cause duplicate descriptions.

--- a/newton/_src/solvers/style3d/__init__.py
+++ b/newton/_src/solvers/style3d/__init__.py
@@ -5,8 +5,7 @@
 Style3D solver module.
 
 This module provides helper functions for setting up Style3D cloth assets.
-Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver
-import path.
+Use :class:`~newton.solvers.SolverStyle3D` as the canonical public solver class.
 """
 
 from .cloth import (

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -102,7 +102,7 @@ Supported Features
      - 🟨 :ref:`limited joint support <Joint feature support>`
      - ✅
      - ✅
-     - ❌
+     - ✅
      - ❌
    * - :class:`~newton.solvers.SolverXPBD`
      - Implicit
@@ -370,8 +370,8 @@ control, or model arrays. In practice, this starts by calling
     model = builder.finalize(requires_grad=True)
     solver = newton.solvers.SolverSemiImplicit(model)
 
-    state_in = model.state()
-    state_out = model.state()
+    state_in = model.state(requires_grad=True)
+    state_out = model.state(requires_grad=True)
     control = model.control()
     loss = wp.zeros(1, dtype=float, requires_grad=True)
     target = wp.vec3(0.25, 0.0, 0.0)


### PR DESCRIPTION
## Summary
- Mark SolverVBD soft-body support as supported in the solver feature matrix
- Use differentiable states in the solver differentiability snippet
- Clarify the public import pattern for Style3D helper functions

## Test Plan
- `uv run python docs/generate_api.py`
- `uv run python -m sphinx -b doctest -E -D nbsphinx_execute=never . /tmp/newton-docs-doctest api/newton_solvers.rst api/newton_solvers_style3d.rst` from `docs/`
- `uv run python /tmp/newton_diffsim_snippet_check.py`
- `uv run --with ruff ruff check docs/generate_api.py newton/solvers.py newton/_src/solvers/style3d/__init__.py`
- `uv run --with ruff ruff format --check docs/generate_api.py newton/solvers.py newton/_src/solvers/style3d/__init__.py`
- `uvx pre-commit run --files docs/api/newton_solvers.rst docs/api/newton_solvers_style3d.rst docs/generate_api.py newton/_src/solvers/style3d/__init__.py newton/solvers.py`

Note: a full docs build was not used as the final verification because local notebook execution hit an unrelated MuJoCo dependency mismatch in `tutorials/01_robotics.ipynb`. The targeted solver doctest passed with notebook execution disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated solver feature support matrix to reflect newly available capability
  * Clarified import paths and guidance for accessing solver helper functions
  * Improved code examples to properly demonstrate gradient computation in differentiable operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->