### PR TITLE
refactor: use public Warp graph coloring APIs

### DIFF
--- a/newton/_src/sim/graph_coloring.py
+++ b/newton/_src/sim/graph_coloring.py
@@ -14,6 +14,14 @@ class ColoringAlgorithm(Enum):
     GREEDY = 1
 
 
+def _to_warp_coloring_algorithm(algorithm: ColoringAlgorithm | wp.utils.GraphColoringAlgorithm):
+    if isinstance(algorithm, wp.utils.GraphColoringAlgorithm):
+        return algorithm
+    if isinstance(algorithm, ColoringAlgorithm):
+        return wp.utils.GraphColoringAlgorithm[algorithm.name]
+    return wp.utils.GraphColoringAlgorithm(algorithm)
+
+
 @wp.kernel
 def validate_graph_coloring(edge_indices: wp.array2d[int], colors: wp.array[int]):
     edge_idx = wp.tid()
@@ -23,67 +31,15 @@ def validate_graph_coloring(edge_indices: wp.array2d[int], colors: wp.array[int]
     wp.expect_neq(colors[e_v_1], colors[e_v_2])
 
 
-@wp.kernel
-def count_color_group_size(
-    colors: wp.array[int],
-    group_sizes: wp.array[int],
-):
-    for particle_idx in range(colors.shape[0]):
-        particle_color = colors[particle_idx]
-        group_sizes[particle_color] = group_sizes[particle_color] + 1
-
-
-@wp.kernel
-def fill_color_groups(
-    colors: wp.array[int],
-    group_fill_count: wp.array[int],
-    group_offsets: wp.array[int],
-    # flattened color groups
-    color_groups_flatten: wp.array[int],
-):
-    for particle_idx in range(colors.shape[0]):
-        particle_color = colors[particle_idx]
-        group_offset = group_offsets[particle_color]
-        group_idx = group_fill_count[particle_color]
-        color_groups_flatten[group_idx + group_offset] = wp.int32(particle_idx)
-
-        group_fill_count[particle_color] = group_idx + 1
-
-
-def convert_to_color_groups(num_colors, particle_colors, return_wp_array=False, device="cpu") -> list[int]:
-    group_sizes = wp.zeros(shape=(num_colors,), dtype=int, device="cpu")
-    wp.launch(kernel=count_color_group_size, inputs=[particle_colors, group_sizes], device="cpu", dim=1)
-
-    group_sizes_np = group_sizes.numpy()
-    group_offsets_np = np.concatenate([np.array([0]), np.cumsum(group_sizes_np)])
-    group_offsets = wp.array(group_offsets_np, dtype=int, device="cpu")
-
-    group_fill_count = wp.zeros(shape=(num_colors,), dtype=int, device="cpu")
-    color_groups_flatten = wp.empty(shape=(group_sizes_np.sum(),), dtype=int, device="cpu")
-    wp.launch(
-        kernel=fill_color_groups,
-        inputs=[particle_colors, group_fill_count, group_offsets, color_groups_flatten],
-        device="cpu",
-        dim=1,
+def convert_to_color_groups(num_colors, particle_colors, return_wp_array=False, device="cpu"):
+    return list(
+        wp.utils.graph_coloring_get_groups(
+            particle_colors,
+            num_colors,
+            return_wp_array,
+            device,
+        )
     )
-
-    color_groups_flatten_np = color_groups_flatten.numpy()
-
-    color_groups = []
-    if return_wp_array:
-        for color_idx in range(num_colors):
-            color_groups.append(
-                wp.array(
-                    color_groups_flatten_np[group_offsets_np[color_idx] : group_offsets_np[color_idx + 1]],
-                    dtype=int,
-                    device=device,
-                )
-            )
-    else:
-        for color_idx in range(num_colors):
-            color_groups.append(color_groups_flatten_np[group_offsets_np[color_idx] : group_offsets_np[color_idx + 1]])
-
-    return color_groups
 
 
 def _canonicalize_edges_np(edges_np: np.ndarray) -> np.ndarray:
@@ -328,20 +284,18 @@ def color_graph(
     else:
         indices = wp.clone(graph_edge_indices, device="cpu")
 
-    num_colors = wp._src.context.runtime.core.wp_graph_coloring(
-        num_nodes,
-        indices.__ctype__(),
-        algorithm.value,
-        particle_colors.__ctype__(),
+    num_colors = wp.utils.graph_coloring_assign(
+        indices,
+        particle_colors,
+        _to_warp_coloring_algorithm(algorithm),
     )
 
     if balance_colors:
-        max_min_ratio = wp._src.context.runtime.core.wp_balance_coloring(
-            num_nodes,
-            indices.__ctype__(),
+        max_min_ratio = wp.utils.graph_coloring_balance(
+            indices,
+            particle_colors,
             num_colors,
             target_max_min_color_ratio,
-            particle_colors.__ctype__(),
         )
 
         if max_min_ratio > target_max_min_color_ratio and wp.config.verbose:

--- a/newton/tests/test_coloring.py
+++ b/newton/tests/test_coloring.py
@@ -12,6 +12,7 @@ import warp.examples
 from newton import ModelBuilder
 from newton._src.sim.graph_coloring import (
     ColoringAlgorithm,
+    color_graph,
     construct_trimesh_graph_edges,
     convert_to_color_groups,
     validate_graph_coloring,
@@ -97,6 +98,26 @@ def color_lattice_grid(num_x, num_y):
     return color_groups
 
 
+def test_color_graph_returns_valid_color_groups(test, device):
+    """Newton graph coloring should return valid color groups for a simple graph."""
+    with wp.ScopedDevice(device):
+        graph_edges = wp.array([[0, 1], [1, 2], [2, 3]], dtype=wp.int32, device="cpu")
+
+        color_groups = color_graph(4, graph_edges, balance_colors=True, algorithm=ColoringAlgorithm.MCS)
+
+        test.assertIsInstance(color_groups, list)
+        test.assertGreater(len(color_groups), 0)
+
+        node_colors = np.full(4, -1, dtype=np.int32)
+        for color, group in enumerate(color_groups):
+            group_np = group.numpy() if isinstance(group, wp.array) else group
+            node_colors[group_np] = color
+
+        test.assertTrue(np.all(node_colors >= 0))
+        for edge in graph_edges.numpy():
+            test.assertNotEqual(node_colors[edge[0]], node_colors[edge[1]])
+
+
 @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
 def test_coloring_trimesh(test, device):
     from pxr import Usd, UsdGeom
@@ -122,16 +143,15 @@ def test_coloring_trimesh(test, device):
 
         model = builder.finalize()
 
-        particle_colors = wp.empty(shape=(model.particle_count), dtype=int, device="cpu")
+        particle_colors = wp.empty(shape=(model.particle_count), dtype=wp.int32, device="cpu")
 
-        edge_indices_cpu = wp.array(model.edge_indices.numpy()[:, 2:], dtype=int, device="cpu")
+        edge_indices_cpu = wp.array(model.edge_indices.numpy()[:, 2:], dtype=wp.int32, device="cpu")
 
         # coloring without bending
-        num_colors_greedy = wp._src.context.runtime.core.wp_graph_coloring(
-            model.particle_count,
-            edge_indices_cpu.__ctype__(),
-            ColoringAlgorithm.GREEDY.value,
-            particle_colors.__ctype__(),
+        num_colors_greedy = wp.utils.graph_coloring_assign(
+            edge_indices_cpu,
+            particle_colors,
+            wp.utils.GraphColoringAlgorithm.GREEDY,
         )
         wp.launch(
             kernel=validate_graph_coloring,
@@ -140,11 +160,10 @@ def test_coloring_trimesh(test, device):
             device="cpu",
         )
 
-        num_colors_mcs = wp._src.context.runtime.core.wp_graph_coloring(
-            model.particle_count,
-            edge_indices_cpu.__ctype__(),
-            ColoringAlgorithm.MCS.value,
-            particle_colors.__ctype__(),
+        num_colors_mcs = wp.utils.graph_coloring_assign(
+            edge_indices_cpu,
+            particle_colors,
+            wp.utils.GraphColoringAlgorithm.MCS,
         )
         wp.launch(
             kernel=validate_graph_coloring,
@@ -155,18 +174,16 @@ def test_coloring_trimesh(test, device):
 
         # coloring with bending
         edge_indices_cpu_with_bending = construct_trimesh_graph_edges(model.edge_indices, True)
-        num_colors_greedy = wp._src.context.runtime.core.wp_graph_coloring(
-            model.particle_count,
-            edge_indices_cpu_with_bending.__ctype__(),
-            ColoringAlgorithm.GREEDY.value,
-            particle_colors.__ctype__(),
+        num_colors_greedy = wp.utils.graph_coloring_assign(
+            edge_indices_cpu_with_bending,
+            particle_colors,
+            wp.utils.GraphColoringAlgorithm.GREEDY,
         )
-        wp._src.context.runtime.core.wp_balance_coloring(
-            model.particle_count,
-            edge_indices_cpu_with_bending.__ctype__(),
+        wp.utils.graph_coloring_balance(
+            edge_indices_cpu_with_bending,
+            particle_colors,
             num_colors_greedy,
             1.1,
-            particle_colors.__ctype__(),
         )
         wp.launch(
             kernel=validate_graph_coloring,
@@ -175,18 +192,16 @@ def test_coloring_trimesh(test, device):
             device="cpu",
         )
 
-        num_colors_mcs = wp._src.context.runtime.core.wp_graph_coloring(
-            model.particle_count,
-            edge_indices_cpu_with_bending.__ctype__(),
-            ColoringAlgorithm.MCS.value,
-            particle_colors.__ctype__(),
+        num_colors_mcs = wp.utils.graph_coloring_assign(
+            edge_indices_cpu_with_bending,
+            particle_colors,
+            wp.utils.GraphColoringAlgorithm.MCS,
         )
-        max_min_ratio = wp._src.context.runtime.core.wp_balance_coloring(
-            model.particle_count,
-            edge_indices_cpu_with_bending.__ctype__(),
+        max_min_ratio = wp.utils.graph_coloring_balance(
+            edge_indices_cpu_with_bending,
+            particle_colors,
             num_colors_mcs,
             1.1,
-            particle_colors.__ctype__(),
         )
         wp.launch(
             kernel=validate_graph_coloring,
@@ -299,7 +314,7 @@ def test_combine_coloring(test, device):
         # all particles has been colored exactly once
         assert_np_equal(particle_number_colored, 0)
 
-        edge_indices_cpu = wp.array(model.edge_indices.numpy()[:, 2:], dtype=int, device="cpu")
+        edge_indices_cpu = wp.array(model.edge_indices.numpy()[:, 2:], dtype=wp.int32, device="cpu")
         wp.launch(
             kernel=validate_graph_coloring,
             inputs=[edge_indices_cpu, wp.array(particle_colors, dtype=int, device="cpu")],
@@ -474,6 +489,12 @@ class TestColoring(unittest.TestCase):
 
 add_function_test(TestColoring, "test_coloring_trimesh", test_coloring_trimesh, devices=devices, check_output=False)
 add_function_test(TestColoring, "test_combine_coloring", test_combine_coloring, devices=devices)
+add_function_test(
+    TestColoring,
+    "test_color_graph_returns_valid_color_groups",
+    test_color_graph_returns_valid_color_groups,
+    devices=devices,
+)
 
 # Rigid body coloring tests
 add_function_test(


### PR DESCRIPTION
## Summary
- Replace private Warp core graph coloring calls with public `wp.utils` graph coloring helpers
- Delegate color group packing to Warp's public graph coloring API while preserving Newton's list return shape
- Update coloring tests to cover the migrated graph coloring behavior

## Test Plan
- [x] `uv run python -m unittest newton.tests.test_coloring.TestColoring -v`
- [x] `uv run python -m unittest newton.tests.test_softbody -v`
- [x] `uv run python -m newton.examples softbody_hanging --viewer null --num-frames 1 --device cpu`
- [x] `uv run python -m newton.examples cloth_hanging --viewer null --num-frames 1 --device cpu`
- [x] `uv run --with ruff ruff check newton/_src/sim/graph_coloring.py newton/tests/test_coloring.py`
- [x] `uv run --with ruff ruff format --check newton/_src/sim/graph_coloring.py newton/tests/test_coloring.py`
- [x] `uvx pre-commit run --files newton/_src/sim/graph_coloring.py newton/tests/test_coloring.py`

Closes #87


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test to validate graph coloring output correctness
  * Updated existing coloring tests for improved validation coverage

* **Refactor**
  * Optimized graph coloring implementation for improved maintainability and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->