### PR TITLE
Add AWS runner region fallback

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -10,12 +10,14 @@ name: GPU Unit Tests on AWS EC2 (Reusable)
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
+  # Prefer the validated US capacity order before Asia-Pacific fallback.
+  AWS_REGION_CANDIDATES: ${{ inputs.region-candidates || 'us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2' }}
   AWS_INSTANCE_TYPE: ${{ inputs.instance-type || 'g7e.2xlarge' }}
   AWS_VOLUME_SIZE: ${{ inputs.volume-size || '92' }}
   AWS_VOLUME_TYPE: gp3
-  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
+  AWS_RUNNER_RESOURCE_TAG: newton-github-runner
   HOME: /actions-runner
 
 on:
@@ -36,6 +38,11 @@ on:
         required: false
         type: string
         default: '92'
+      region-candidates:
+        description: 'Space-separated AWS regions to try'
+        required: false
+        type: string
+        default: ''
     secrets:
       GH_PERSONAL_ACCESS_TOKEN:
         required: true
@@ -48,6 +55,11 @@ on:
         required: false
         type: string
         default: 'g7e.2xlarge'
+      region-candidates:
+        description: 'Space-separated AWS regions to try'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   start-runner:
@@ -60,11 +72,17 @@ jobs:
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-ec2-runner.outputs.region }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -72,20 +90,11 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
-      - name: Get the latest AWS Deep Learning Base GPU AMI
-        run: |
-          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
-          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
-            --owners amazon \
-            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
-            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
-            --output text)
-          if [[ -z "$LATEST_AMI_ID" ]]; then
-            echo "❌ No AMI ID found. Exiting."
-            exit 1
-          fi
-          echo "Latest AMI ID found: $LATEST_AMI_ID"
-          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+
+      - name: Discover AWS runner networking
+        id: discover-runner-config
+        run: python scripts/ci/discover_aws_runner_config.py
+
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
@@ -95,11 +104,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          availability-zones-config: >
-            [
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
-            ]
+          availability-zones-config: ${{ steps.discover-runner-config.outputs.availability-zones-config }}
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
@@ -129,6 +134,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
@@ -230,14 +236,22 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate launch region
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' && needs.start-runner.outputs.region == '' }}
+        run: |
+          echo "::error::EC2 instance ID exists but the launch region output is empty."
+          exit 1
+
       - name: Configure AWS credentials
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
       - name: Stop EC2 runner
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop

--- a/scripts/ci/discover_aws_runner_config.py
+++ b/scripts/ci/discover_aws_runner_config.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discover AWS EC2 runner networking for GitHub Actions.
+
+The script is designed to run inside ``aws_gpu_tests.yml`` after AWS
+credentials are configured. It writes one GitHub Actions step output:
+
+``availability-zones-config``
+    JSON array passed to ``machulav/ec2-github-runner``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+AwsCall = Callable[..., Any]
+Warn = Callable[[str], None]
+AWS_CLI_TIMEOUT_SECONDS = 120
+
+
+def warning(message: str) -> None:
+    """Emit a GitHub Actions warning annotation."""
+    print(f"::warning::{message}", flush=True)
+
+
+def error(message: str) -> None:
+    """Emit a GitHub Actions error annotation."""
+    print(f"::error::{message}", flush=True)
+
+
+def print_aws_cli_output(label: str, output: str | bytes | None) -> None:
+    """Print captured AWS CLI output to stderr when available."""
+    if not output:
+        return
+    if isinstance(output, bytes):
+        output = output.decode(errors="replace")
+    print(f"AWS CLI {label}:", file=sys.stderr)
+    print(output, file=sys.stderr)
+
+
+def aws(region: str, *args: str) -> Any | None:
+    """Run an AWS EC2 CLI command and parse the JSON response.
+
+    Args:
+        region: AWS region name.
+        args: Arguments placed after ``aws ec2``.
+
+    Returns:
+        Parsed JSON output, or ``None`` when the command fails or returns no
+        output.
+    """
+    cmd = ["aws", "ec2", *args, "--region", region, "--output", "json"]
+    command_label = f"aws ec2 {args[0]}" if args else "aws ec2"
+    try:
+        completed = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=AWS_CLI_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        warning(f"{region}: AWS CLI command timed out after {AWS_CLI_TIMEOUT_SECONDS}s: {command_label}")
+        print_aws_cli_output("stdout before timeout", exc.stdout)
+        print_aws_cli_output("stderr before timeout", exc.stderr)
+        return None
+    except subprocess.CalledProcessError as exc:
+        warning(f"{region}: AWS CLI command failed: {command_label}")
+        print_aws_cli_output("stdout", exc.stdout)
+        print_aws_cli_output("stderr", exc.stderr)
+        return None
+
+    output = completed.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except ValueError as exc:
+        warning(f"{region}: AWS CLI command returned invalid JSON: {command_label}")
+        print(f"Invalid JSON output from AWS CLI: {exc}", file=sys.stderr)
+        print(f"Output prefix: {output[:1000]!r}", file=sys.stderr)
+        return None
+
+
+def allows_outbound_internet(security_group: Mapping[str, Any]) -> bool:
+    """Return whether a security group has IPv4 internet egress."""
+    for permission in security_group.get("IpPermissionsEgress", []):
+        for ip_range in permission.get("IpRanges", []):
+            if ip_range.get("CidrIp") == "0.0.0.0/0":
+                return True
+    return False
+
+
+def discover_candidates(
+    regions: Sequence[str],
+    instance_type: str,
+    tag_key: str,
+    aws_call: AwsCall = aws,
+    warn: Warn = warning,
+) -> list[dict[str, str]]:
+    """Discover eligible EC2 runner candidates.
+
+    Args:
+        regions: Ordered AWS regions to inspect.
+        instance_type: EC2 instance type requested by the workflow.
+        tag_key: Tag key used to find eligible subnets and security groups.
+        aws_call: AWS EC2 call helper.
+        warn: Warning callback.
+
+    Returns:
+        Candidate objects accepted by ``machulav/ec2-github-runner``.
+    """
+    candidates: list[dict[str, str]] = []
+
+    for region in regions:
+        print(f"Checking {region} for {instance_type}", flush=True)
+
+        offered_zone_ids = aws_call(
+            region,
+            "describe-instance-type-offerings",
+            "--location-type",
+            "availability-zone-id",
+            "--filters",
+            f"Name=instance-type,Values={instance_type}",
+            "--query",
+            "InstanceTypeOfferings[].Location",
+        )
+        if not offered_zone_ids:
+            warn(f"{region}: {instance_type} is not offered in any availability zone; skipping region")
+            continue
+        offered_zone_ids = set(offered_zone_ids)
+        print(f"{region}: {instance_type} offered AZ IDs: {', '.join(sorted(offered_zone_ids))}", flush=True)
+
+        images = aws_call(
+            region,
+            "describe-images",
+            "--owners",
+            "amazon",
+            "--filters",
+            "Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????",
+            "Name=state,Values=available",
+            "--query",
+            "reverse(sort_by(Images, &CreationDate))[:1].ImageId",
+        )
+        if not images:
+            warn(f"{region}: no Deep Learning Base GPU AMI found; skipping region")
+            continue
+        image_id = images[0]
+
+        subnets = aws_call(
+            region,
+            "describe-subnets",
+            "--filters",
+            f"Name=tag:{tag_key},Values=true",
+            "--query",
+            "Subnets[]",
+        )
+        if not subnets:
+            warn(f"{region}: no tagged subnets found; skipping region")
+            continue
+
+        security_groups = aws_call(
+            region,
+            "describe-security-groups",
+            "--filters",
+            f"Name=tag:{tag_key},Values=true",
+            "--query",
+            "SecurityGroups[]",
+        )
+        groups_by_vpc: dict[str, list[Mapping[str, Any]]] = {}
+        for security_group in security_groups or []:
+            if not allows_outbound_internet(security_group):
+                warn(
+                    f"{region}: security group {security_group['GroupId']} "
+                    "does not allow outbound traffic to 0.0.0.0/0; skipping security group"
+                )
+                continue
+            groups_by_vpc.setdefault(security_group["VpcId"], []).append(security_group)
+        for vpc_groups in groups_by_vpc.values():
+            vpc_groups.sort(key=lambda security_group: security_group["GroupId"])
+
+        seen_zone_ids = set()
+        eligible_count = 0
+        subnets.sort(key=lambda subnet: (subnet.get("AvailabilityZoneId", ""), subnet["SubnetId"]))
+
+        for subnet in subnets:
+            subnet_id = subnet["SubnetId"]
+            vpc_id = subnet["VpcId"]
+            zone_name = subnet.get("AvailabilityZone", "")
+            zone_id = subnet.get("AvailabilityZoneId", "")
+
+            if not zone_id:
+                warn(f"{region}: subnet {subnet_id} has no AvailabilityZoneId; skipping subnet")
+                continue
+
+            if zone_id not in offered_zone_ids:
+                warn(
+                    f"{region}: {instance_type} is not offered in {zone_name} ({zone_id}); skipping subnet {subnet_id}"
+                )
+                continue
+
+            if zone_id in seen_zone_ids:
+                warn(f"{region}: skipping duplicate subnet {subnet_id} for availability zone ID {zone_id}")
+                continue
+
+            vpc_groups = groups_by_vpc.get(vpc_id, [])
+            if not vpc_groups:
+                warn(f"{region}: subnet {subnet_id} in VPC {vpc_id} has no tagged security group; skipping subnet")
+                continue
+
+            security_group_id = vpc_groups[0]["GroupId"]
+            seen_zone_ids.add(zone_id)
+            eligible_count += 1
+            candidates.append(
+                {
+                    "imageId": image_id,
+                    "subnetId": subnet_id,
+                    "securityGroupId": security_group_id,
+                    "region": region,
+                }
+            )
+            print(
+                "Candidate: "
+                f"region={region} az={zone_name} az_id={zone_id} "
+                f"vpc={vpc_id} subnet={subnet_id} security_group={security_group_id}",
+                flush=True,
+            )
+
+        if eligible_count == 0:
+            warn(f"{region}: no eligible subnet/security-group pairs found")
+
+    return candidates
+
+
+def set_output(name: str, value: str) -> None:
+    """Write a key-value pair to the GitHub Actions step-output file."""
+    path = os.environ.get("GITHUB_OUTPUT", "")
+    if path:
+        with open(path, "a", encoding="utf-8") as output_file:
+            output_file.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    """Entry point for the workflow step."""
+    regions = os.environ["AWS_REGION_CANDIDATES"].split()
+    instance_type = os.environ["AWS_INSTANCE_TYPE"]
+    tag_key = os.environ["AWS_RUNNER_RESOURCE_TAG"]
+
+    candidates = discover_candidates(regions, instance_type, tag_key)
+    if not candidates:
+        error("No eligible EC2 runner candidates were discovered.")
+        return 1
+
+    config = json.dumps(candidates, separators=(",", ":"))
+    json.loads(config)
+
+    print("Generated availability-zones-config:", flush=True)
+    print(json.dumps(candidates, indent=2), flush=True)
+
+    set_output("availability-zones-config", config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Adds region fallback to the reusable AWS GPU EC2 runner workflow. The workflow
no longer relies on two hard-coded `us-east-2` subnet candidates; it discovers
eligible runner networking from tagged AWS resources and passes the selected
launch region through to teardown.

The default region order is:

```text
us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2
```

That order is based on fork validation: the US regions all started
`g7e.12xlarge` runners successfully, `ap-northeast-1` also worked, and
`ap-northeast-2` had current `g7e.12xlarge` capacity failures in both supported
AZs. Trying the validated US regions first should reduce aborted launch
attempts before finding a runner.

The discovery script:

- queries each candidate region for AZ-ID-level instance type offerings
- logs offered AZ IDs permanently for setup/debug visibility
- discovers tagged `newton-github-runner=true` subnets and security groups
- keeps one subnet per supported AZ ID
- skips unsupported or duplicate tagged subnets with warnings
- requires a same-VPC tagged security group with outbound IPv4 internet egress
- soft-fails per region on AWS CLI failures, timeouts, empty output, and
  malformed JSON so later regions can still be tried

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change; not user-facing)

## Test plan

Local/static validation on the final squashed branch:

```bash
uv run --no-project python -m py_compile scripts/ci/discover_aws_runner_config.py
npx --yes github-actionlint .github/workflows/aws_gpu_tests.yml
uvx --from zizmor zizmor .github/workflows/aws_gpu_tests.yml
git diff --check upstream/main...HEAD
uvx pre-commit run -a
```

Workflow invariant check:

```text
US-first default: True
generic region-candidates override kept: True
fork-only validation guards removed: True
fork-only probe input/job/script removed: True
start/stop guards are upstream-only for newton-physics/newton: True
```

AWS setup findings used for validation:

```text
us-east-1:      use1-az2, use1-az6
us-east-2:      use2-az1, use2-az2
us-west-2:      usw2-az1, usw2-az2, usw2-az3, usw2-az4
ap-northeast-1: apne1-az1, apne1-az4
ap-northeast-2: apne2-az1, apne2-az2
```

Read-only subnet probe:

- https://github.com/shi-eric/newton/actions/runs/26012890988
- verified one tagged public runner subnet per supported AZ ID
- verified public IPv4 auto-assign and internet-gateway route coverage
- verified no tagged unsupported runner subnets remained
- verified same-VPC tagged security groups

Live one-region runner spawn validation:

| Instance type | Result | Evidence |
| --- | --- | --- |
| `g7e.2xlarge` | 5/5 regions registered a self-hosted runner and tore down successfully | [us-east-1](https://github.com/shi-eric/newton/actions/runs/26013125410), [us-east-2](https://github.com/shi-eric/newton/actions/runs/26013204747), [us-west-2](https://github.com/shi-eric/newton/actions/runs/26013273019), [ap-northeast-1](https://github.com/shi-eric/newton/actions/runs/26013375094), [ap-northeast-2](https://github.com/shi-eric/newton/actions/runs/26013455236) |
| `g7e.12xlarge` | 4/5 regions registered a self-hosted runner and tore down successfully | [us-east-1](https://github.com/shi-eric/newton/actions/runs/26013566258), [us-east-2](https://github.com/shi-eric/newton/actions/runs/26013656927), [us-west-2](https://github.com/shi-eric/newton/actions/runs/26013735060), [ap-northeast-1](https://github.com/shi-eric/newton/actions/runs/26013844791) |
| `g7e.12xlarge` / `ap-northeast-2` | both supported AZ candidates were tried, but AWS reported current capacity failures before any instance launched | [ap-northeast-2 capacity run](https://github.com/shi-eric/newton/actions/runs/26013934956) |

Full-list validation:

- Normal order, `g7e.12xlarge`: https://github.com/shi-eric/newton/actions/runs/26015432257
  - region list: `us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2`
  - discovery built candidates in all five regions
  - selected `us-east-1a / use1-az2`, subnet `subnet-0245fd048b57eb5f4`
  - registered runner `ec2-xso5i`
  - canceled after the GPU job reached `in_progress`
  - terminated instance `i-08eaa09979fd7d75e`
- Reordered fallback, `g7e.12xlarge`: https://github.com/shi-eric/newton/actions/runs/26016060694
  - region list: `ap-northeast-2 us-east-1 us-east-2 us-west-2 ap-northeast-1`
  - tried `ap-northeast-2a / apne2-az1`, subnet `subnet-09944094c2023ea41`; AWS reported insufficient `g7e.12xlarge` capacity
  - tried `ap-northeast-2b / apne2-az2`, subnet `subnet-06db999ad39260338`; AWS reported insufficient `g7e.12xlarge` capacity
  - fell through to `us-east-1a / use1-az2`, subnet `subnet-0245fd048b57eb5f4`
  - registered runner `ec2-oohu7`
  - canceled after the GPU job reached `in_progress`
  - terminated instance `i-0a4b74bf3a36dea45` and removed runner `ec2-oohu7`

These fork validation workflows used temporary fork-only dispatch guards so we
could exercise the AWS role from `shi-eric/newton`. Those guards and the
read-only probe workflow were removed before the final squashed commit; the PR
diff now contains only the production workflow change and the discovery script.

## Bug fix

**Steps to reproduce:**

1. Run the AWS GPU workflow while `g7e` capacity is unavailable in the
   hard-coded `us-east-2` subnet candidates.
2. Observe runner startup fail without trying prepared capacity in other
   enabled regions.

**Minimal reproduction:**

Not applicable; this is GitHub Actions/AWS runner infrastructure behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## Infrastructure & Testing

* **Infrastructure Improvements**
  * Enhanced AWS GPU testing infrastructure with improved region selection and configuration discovery.
  * Added support for configurable AWS region candidates and automated EC2 runner configuration.
  * Strengthened security practices in CI/CD workflow with credential handling improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->