### PR TITLE
Fix basic_conveyor inertia validation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
+- Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 
 ## [1.2.0] - 2026-05-12
 

--- a/newton/examples/basic/example_basic_conveyor.py
+++ b/newton/examples/basic/example_basic_conveyor.py
@@ -182,6 +182,7 @@ class Example:
         )
 
         belt_cfg = newton.ModelBuilder.ShapeConfig(
+            density=0.0,  # mass and inertia are authored explicitly on the belt body below
             mu=1.2,
             ke=1.0e5,  # vbd only
             kd=0.0,  # vbd only
@@ -234,8 +235,24 @@ class Example:
             metallic=0.9,
         )
 
+        # Annular-ring inertia about the belt's COM (ring axis along Z).
+        belt_mass = 15.0
+        belt_radii_sum_sq = belt_inner_radius**2 + belt_outer_radius**2
+        belt_i_transverse = belt_mass / 12.0 * (3.0 * belt_radii_sum_sq + (2.0 * BELT_HALF_THICKNESS) ** 2)
+        belt_i_axial = 0.5 * belt_mass * belt_radii_sum_sq
         self.belt_body = builder.add_link(
-            mass=15.0,
+            mass=belt_mass,
+            inertia=wp.mat33(
+                belt_i_transverse,
+                0.0,
+                0.0,
+                0.0,
+                belt_i_transverse,
+                0.0,
+                0.0,
+                0.0,
+                belt_i_axial,
+            ),
             is_kinematic=True,
             label="conveyor_belt",
         )

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -251,6 +251,14 @@ add_example_test(
     test_options={"num-frames": 150},
 )
 
+add_example_test(
+    TestBasicExamples,
+    name="basic.example_basic_conveyor",
+    devices=test_devices,
+    use_viewer=True,
+    test_options={"num-frames": 100},
+)
+
 
 class TestCableExamples(unittest.TestCase):
     pass


### PR DESCRIPTION
## Description

The `basic_conveyor` example emits a spurious warning at `builder.finalize()`:

```
UserWarning: Inertia validation corrected 1 bodies. Set validate_inertia_detailed=True for detailed per-body warnings.
```

With detailed validation enabled, the warning resolves to:

```
UserWarning: Inertia matrix for body 'conveyor_belt' is not symmetric, making it symmetric
```

The kinematic conveyor belt was created with `mass=15.0` and no authored inertia; the mesh-shape integrator then accumulated a tensor with sub-tolerance asymmetry onto the body, which the validator caught at finalize.

Fix: author an analytical annular-ring inertia tensor on `add_link()` (about the belt's COM, ring axis along Z) and set `density=0.0` on `belt_cfg` so the mesh shape no longer accumulates mass/inertia. The body now carries a clean, symmetric inertia, and the authored mass is exactly 15 kg instead of `15 + mesh_volume * density`.

Closes #2635 (sub-task of epic #2362).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv run --extra examples -m newton.examples basic_conveyor --viewer null --num-frames 5 --test` — exits 0, no `Inertia validation` warning. Re-run with `builder.validate_inertia_detailed = True` patched in locally — also silent (no per-body warning).
- GPU smoke test: `uv run --extra examples -m newton.examples basic_conveyor` on RTX 3080 — belt spins, bags rest on it, no warnings.
- `uvx pre-commit run --files newton/examples/basic/example_basic_conveyor.py CHANGELOG.md` — passes.

## Bug fix

**Steps to reproduce (without this PR):**

1. `uv run --extra examples -m newton.examples basic_conveyor`
2. Observe `UserWarning: Inertia validation corrected 1 bodies.` in stderr at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spurious inertia validation warning emitted during finalization of the basic conveyor example.

* **Tests**
  * Added an example test that runs the conveyor demo with the viewer for extended frames to ensure it remains warning-free.

* **Documentation**
  * Updated changelog with an entry noting the fix for the basic conveyor example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->