### PR TITLE
Require Warp 1.14 logging API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Remove the `cbor2` `<6` dependency ceiling after updating recorder deserialization to accept mapping-like decoded containers
+- Require Warp 1.14 and configure Warp logging through `warp.config.log_level`; use Newton's `--quiet` flag or `--warp-config log_level=...` instead of legacy `verbose` or `quiet` config keys
 
 ### Fixed
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.14.0.dev20260511 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U --pre warp-lang==1.14.0.dev20260518 --index-url=https://pypi.nvidia.com/",
     "python -m pip install -U mujoco==3.8.1",
     "python -m pip install -U mujoco-warp==3.8.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/asv/benchmarks/compilation/bench_example_load.py
+++ b/asv/benchmarks/compilation/bench_example_load.py
@@ -7,7 +7,7 @@ import sys
 import warp as wp
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 

--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -11,7 +11,7 @@ os.environ["PYGLET_HEADLESS"] = "1"
 import warp as wp
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 

--- a/asv/benchmarks/setup/bench_sdf.py
+++ b/asv/benchmarks/setup/bench_sdf.py
@@ -5,7 +5,7 @@ import numpy as np
 import warp as wp
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import newton
 import newton.examples

--- a/asv/benchmarks/simulation/bench_cable.py
+++ b/asv/benchmarks/simulation/bench_cable.py
@@ -7,7 +7,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import newton.examples
 from newton.examples.cable.example_cable_pile import Example as ExampleCablePile

--- a/asv/benchmarks/simulation/bench_cloth.py
+++ b/asv/benchmarks/simulation/bench_cloth.py
@@ -4,7 +4,7 @@
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import newton.examples
 from newton.examples.cloth.example_cloth_franka import Example as ExampleClothManipulation

--- a/asv/benchmarks/simulation/bench_contacts.py
+++ b/asv/benchmarks/simulation/bench_contacts.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import importlib
 

--- a/asv/benchmarks/simulation/bench_heightfield.py
+++ b/asv/benchmarks/simulation/bench_heightfield.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import numpy as np
 

--- a/asv/benchmarks/simulation/bench_ik.py
+++ b/asv/benchmarks/simulation/bench_ik.py
@@ -10,7 +10,7 @@ import numpy as np
 import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 wp.config.enable_backward = False
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -7,7 +7,7 @@ import sys
 import warp as wp
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import newton
 import newton.examples

--- a/asv/benchmarks/simulation/bench_selection.py
+++ b/asv/benchmarks/simulation/bench_selection.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import newton
 import newton.examples

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -5,7 +5,7 @@ import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 import math
 

--- a/asv/benchmarks/simulation/bench_viewer.py
+++ b/asv/benchmarks/simulation/bench_viewer.py
@@ -10,7 +10,7 @@ os.environ["PYGLET_HEADLESS"] = "1"
 import warp as wp
 
 wp.config.enable_backward = False
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 
 from asv_runner.benchmarks.mark import skip_benchmark_if
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -205,7 +205,7 @@ import newton
 
 warnings.filterwarnings("ignore")
 
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 wp.init()
 """
 

--- a/docs/tutorials/01_robotics.ipynb
+++ b/docs/tutorials/01_robotics.ipynb
@@ -63,7 +63,7 @@
     "import newton.ik as ik\n",
     "import newton.utils\n",
     "\n",
-    "wp.config.quiet = True"
+    "wp.config.log_level = wp.LOG_WARNING"
    ]
   },
   {

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -359,7 +359,8 @@ class SensorContact:
                 against shape labels, or list of patterns where any one matches.
             measure_total: If True (default), :attr:`total_force` and :attr:`total_force_friction` are allocated.
                 If False, both are None.
-            verbose: If True, print details. If None, uses Warp debug logging.
+            verbose: If True, print details. If False, suppress details. If None, print details when
+                ``wp.config.log_level`` is configured for debug logging.
             request_contact_attributes: If True (default), transparently request the extended contact attribute
                 ``force`` from the model.
             include_total: Deprecated. Use ``measure_total`` instead.

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -359,7 +359,7 @@ class SensorContact:
                 against shape labels, or list of patterns where any one matches.
             measure_total: If True (default), :attr:`total_force` and :attr:`total_force_friction` are allocated.
                 If False, both are None.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
             request_contact_attributes: If True (default), transparently request the extended contact attribute
                 ``force`` from the model.
             include_total: Deprecated. Use ``measure_total`` instead.
@@ -379,7 +379,7 @@ class SensorContact:
             raise ValueError("At most one of `counterpart_bodies` and `counterpart_shapes` may be specified.")
 
         self.device = model.device
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
 
         # request contact force attribute
         if request_contact_attributes:

--- a/newton/_src/sensors/sensor_frame_transform.py
+++ b/newton/_src/sensors/sensor_frame_transform.py
@@ -134,13 +134,13 @@ class SensorFrameTransform:
             reference_sites: List of site indices, single pattern to match against
                 site labels, or list of patterns where any one matches. Must expand
                 to one site or the same number as ``shapes``.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
 
         Raises:
             ValueError: If arguments are invalid or no labels match.
         """
         self.model = model
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
 
         # Resolve label patterns to indices
         original_shapes = shapes

--- a/newton/_src/sensors/sensor_frame_transform.py
+++ b/newton/_src/sensors/sensor_frame_transform.py
@@ -134,7 +134,8 @@ class SensorFrameTransform:
             reference_sites: List of site indices, single pattern to match against
                 site labels, or list of patterns where any one matches. Must expand
                 to one site or the same number as ``shapes``.
-            verbose: If True, print details. If None, uses Warp debug logging.
+            verbose: If True, print details. If False, suppress details. If None, print details when
+                ``wp.config.log_level`` is configured for debug logging.
 
         Raises:
             ValueError: If arguments are invalid or no labels match.

--- a/newton/_src/sensors/sensor_imu.py
+++ b/newton/_src/sensors/sensor_imu.py
@@ -128,7 +128,8 @@ class SensorIMU:
             model: The model to use.
             sites: List of site indices, single pattern to match against site
                 labels, or list of patterns where any one matches.
-            verbose: If True, print details. If None, uses Warp debug logging.
+            verbose: If True, print details. If False, suppress details. If None, print details when
+                ``wp.config.log_level`` is configured for debug logging.
             request_state_attributes: If True (default), transparently request the extended state attribute ``body_qdd`` from the model.
                 If False, ``model`` is not modified and the attribute must be requested elsewhere before calling ``model.state()``.
         Raises:

--- a/newton/_src/sensors/sensor_imu.py
+++ b/newton/_src/sensors/sensor_imu.py
@@ -128,7 +128,7 @@ class SensorIMU:
             model: The model to use.
             sites: List of site indices, single pattern to match against site
                 labels, or list of patterns where any one matches.
-            verbose: If True, print details. If None, uses ``wp.config.verbose``.
+            verbose: If True, print details. If None, uses Warp debug logging.
             request_state_attributes: If True (default), transparently request the extended state attribute ``body_qdd`` from the model.
                 If False, ``model`` is not modified and the attribute must be requested elsewhere before calling ``model.state()``.
         Raises:
@@ -136,7 +136,7 @@ class SensorIMU:
         """
 
         self.model = model
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
 
         original_sites = sites
         sites = match_labels(model.shape_label, sites)

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4828,13 +4828,11 @@ class ModelBuilder:
             plt.legend(loc="upper left", fontsize=6)
         plt.show()
 
-    def collapse_fixed_joints(
-        self, verbose: bool = wp.config.verbose, joints_to_keep: list[str] | None = None
-    ) -> dict[str, Any]:
+    def collapse_fixed_joints(self, verbose: bool = False, joints_to_keep: list[str] | None = None) -> dict[str, Any]:
         """Removes fixed joints from the model and merges the bodies they connect. This is useful for simplifying the model for faster and more stable simulation.
 
         Args:
-            verbose: If True, print additional information about the collapsed joints. Defaults to the value of `wp.config.verbose`.
+            verbose: If True, print additional information about the collapsed joints.
             joints_to_keep: An optional list of joint labels to be excluded from the collapse process.
         """
 

--- a/newton/_src/sim/graph_coloring.py
+++ b/newton/_src/sim/graph_coloring.py
@@ -344,7 +344,7 @@ def color_graph(
             particle_colors.__ctype__(),
         )
 
-        if max_min_ratio > target_max_min_color_ratio and wp.config.verbose:
+        if max_min_ratio > target_max_min_color_ratio and wp.config.log_level <= wp.LOG_DEBUG:
             warnings.warn(
                 f"Color balancing terminated early: max/min ratio {max_min_ratio:.3f} "
                 f"exceeds target {target_max_min_color_ratio:.3f}. "

--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -1660,7 +1660,7 @@ def solve_rheology(
     jacobi_warmstart_smoother_iterations: int = 5,
     temporary_store: fem.TemporaryStore | None = None,
     use_graph: bool = True,
-    verbose: bool = wp.config.verbose,
+    verbose: bool = wp.config.log_level <= wp.LOG_DEBUG,
 ):
     """Solve coupled plasticity and collider contact to compute grid velocities.
 

--- a/newton/_src/solvers/implicit_mpm/solve_rheology.py
+++ b/newton/_src/solvers/implicit_mpm/solve_rheology.py
@@ -1660,7 +1660,7 @@ def solve_rheology(
     jacobi_warmstart_smoother_iterations: int = 5,
     temporary_store: fem.TemporaryStore | None = None,
     use_graph: bool = True,
-    verbose: bool = wp.config.log_level <= wp.LOG_DEBUG,
+    verbose: bool | None = None,
 ):
     """Solve coupled plasticity and collider contact to compute grid velocities.
 
@@ -1710,12 +1710,15 @@ def solve_rheology(
             for Jacobi solver).
         temporary_store: Temporary storage arena for intermediate arrays.
         use_graph: If True, uses conditional CUDA graphs for the iteration loop.
-        verbose: If True, prints residuals/iteration counts.
+        verbose: If True, print residuals/iteration counts. If False, suppress details. If None, print details when
+            ``wp.config.log_level`` is configured for debug logging.
 
     Returns:
         A captured execution graph handle when ``use_graph`` is True and the
         device supports it; otherwise ``None``.
     """
+
+    verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
 
     subgrid_collisions = collision.collider_mat.nnz > 0
     if subgrid_collisions:

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -635,7 +635,8 @@ class SolverImplicitMPM(SolverBase):
         config: Solver configuration. See :class:`SolverImplicitMPM.Config`.
         temporary_store: Optional Warp FEM temporary store for reusing scratch
             allocations across steps.
-        verbose: Enable verbose solver output. Defaults to Warp debug logging.
+        verbose: If True, enable verbose solver output. If False, suppress details. If None, enable verbose output when
+            ``wp.config.log_level`` is configured for debug logging.
         enable_timers: Enable per-section wall-clock timings.
     """
 

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -635,7 +635,7 @@ class SolverImplicitMPM(SolverBase):
         config: Solver configuration. See :class:`SolverImplicitMPM.Config`.
         temporary_store: Optional Warp FEM temporary store for reusing scratch
             allocations across steps.
-        verbose: Enable verbose solver output. Defaults to ``wp.config.verbose``.
+        verbose: Enable verbose solver output. Defaults to Warp debug logging.
         enable_timers: Enable per-section wall-clock timings.
     """
 
@@ -929,7 +929,7 @@ class SolverImplicitMPM(SolverBase):
         self.tolerance = float(config.tolerance)
 
         self.temporary_store = temporary_store
-        self.verbose = verbose if verbose is not None else wp.config.verbose
+        self.verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
         self.enable_timers = enable_timers
 
         self.velocity_basis = "Q1"

--- a/newton/_src/solvers/kamino/tests/__init__.py
+++ b/newton/_src/solvers/kamino/tests/__init__.py
@@ -53,7 +53,7 @@ def setup_tests(verbose: bool = False, device: wp.DeviceLike | str | None = None
     wp.init()
     wp.config.mode = "release"
     wp.config.enable_backward = False
-    wp.config.verbose = False
+    wp.config.log_level = wp.LOG_INFO
     wp.config.verify_fp = False
     wp.config.verify_cuda = False
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -2471,7 +2471,7 @@ class SolverMuJoCo(SolverBase):
                 joint_start = int(tendon_joint_adr[i])
                 joint_num = int(tendon_joint_num[i])
                 if joint_num <= 0:
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(f"Warning: Skipping tendon {i} during MuJoCo export because it has no joint wraps.")
                     continue
 
@@ -2513,7 +2513,7 @@ class SolverMuJoCo(SolverBase):
                     fixed_wraps.append((joint_name, coef))
 
                 if len(fixed_wraps) == 0:
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(
                             f"Warning: Skipping tendon {i} during MuJoCo export "
                             "because no valid joint wraps were resolved."
@@ -2838,12 +2838,12 @@ class SolverMuJoCo(SolverBase):
                 dof_idx = target_idx
                 dofs_per_world = len(dof_to_mjc_joint)
                 if dof_idx < 0 or dof_idx >= dofs_per_world:
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} has invalid DOF target {dof_idx}")
                     continue
                 mjc_joint_idx = dof_to_mjc_joint[dof_idx]
                 if mjc_joint_idx < 0 or mjc_joint_idx >= len(mjc_joint_names):
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} DOF {dof_idx} not mapped to MuJoCo joint")
                     continue
                 target_name = mjc_joint_names[mjc_joint_idx]
@@ -2852,17 +2852,17 @@ class SolverMuJoCo(SolverBase):
                     mjc_tendon_idx = selected_tendons.index(target_idx)
                     target_name = mjc_tendon_names[mjc_tendon_idx]
                 except (ValueError, IndexError):
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} references tendon {target_idx} not in MuJoCo")
                     continue
             elif trntype == int(SolverMuJoCo.TrnType.BODY):
                 if target_idx < 0 or target_idx >= len(model.body_label):
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(f"Warning: MuJoCo actuator {mujoco_act_idx} has invalid body target {target_idx}")
                     continue
                 target_name = body_name_mapping.get(target_idx)
                 if target_name is None:
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(
                             f"Warning: MuJoCo actuator {mujoco_act_idx} references body {target_idx} "
                             "not present in the MuJoCo export."
@@ -2878,7 +2878,7 @@ class SolverMuJoCo(SolverBase):
                 if site_name is None:
                     site_name = site_mapping.get(target_idx)
                 if site_name is None:
-                    if wp.config.verbose:
+                    if wp.config.log_level <= wp.LOG_DEBUG:
                         print(
                             f"Warning: MuJoCo actuator {mujoco_act_idx} site target "
                             f"'{target_label}' not found in site mapping"
@@ -2887,7 +2887,7 @@ class SolverMuJoCo(SolverBase):
                 target_name = site_name
             else:
                 # TODO: Support slidercrank and jointinparent transmission types
-                if wp.config.verbose:
+                if wp.config.log_level <= wp.LOG_DEBUG:
                     print(f"Warning: MuJoCo actuator {mujoco_act_idx} has unsupported trntype {trntype}")
                 continue
 
@@ -3297,7 +3297,7 @@ class SolverMuJoCo(SolverBase):
             return
         if any(getattr(state_out, field) is not None for field in rne_postconstraint_fields):
             # required for cfrc_ext, cfrc_int, cacc
-            if wp.config.verbose:
+            if wp.config.log_level <= wp.LOG_DEBUG:
                 print("Setting model.sensor_rne_postconstraint True")
             m.sensor_rne_postconstraint = True
 
@@ -4671,7 +4671,7 @@ class SolverMuJoCo(SolverBase):
                     # Retrieve heightfield source
                     hfield_src = model.shape_source[shape]
                     if hfield_src is None:
-                        if wp.config.verbose:
+                        if wp.config.log_level <= wp.LOG_DEBUG:
                             print(f"Warning: Heightfield shape {shape} has no source data, skipping")
                         continue
 
@@ -5217,7 +5217,7 @@ class SolverMuJoCo(SolverBase):
             target_name = body_name_mapping.get(body_idx)
             if target_name is None:
                 target_name = model.body_label[body_idx].replace("/", "_")
-                if wp.config.verbose:
+                if wp.config.log_level <= wp.LOG_DEBUG:
                     print(
                         f"Warning: MuJoCo equality constraint references body {body_idx} "
                         "not present in the MuJoCo export."

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -477,7 +477,7 @@ class SolverVBD(SolverBase):
         self.particle_q_rest = model.particle_q
 
         # Tile solve settings
-        if model.device.is_cpu and particle_enable_tile_solve and wp.config.verbose:
+        if model.device.is_cpu and particle_enable_tile_solve and wp.config.log_level <= wp.LOG_DEBUG:
             print("Info: Tiled solve requires model.device='cuda'. Tiled solve is disabled.")
 
         self.use_particle_tile_solve = particle_enable_tile_solve and model.device.is_cuda

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -515,7 +515,7 @@ class ArticulationView:
         self.device = model.device
 
         if verbose is None:
-            verbose = wp.config.verbose
+            verbose = wp.config.log_level <= wp.LOG_DEBUG
 
         # FIXME: avoid/reduce this readback?
         model_articulation_start = model.articulation_start.numpy()

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -721,7 +721,7 @@ def init(parser=None):
 
     # Suppress Warp compilation messages if requested
     if args.quiet:
-        wp.config.log_level = wp.LOG_WARNING
+        wp.config.log_level = max(wp.config.log_level, wp.LOG_WARNING)
 
     # Set device if specified
     if args.device:

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -16,6 +16,8 @@ import warp as wp
 import newton
 from newton.tests.unittest_utils import find_nan_members
 
+_DEPRECATED_WARP_CONFIG_KEYS = {"quiet", "verbose"}
+
 
 def get_source_directory() -> str:
     return os.path.realpath(os.path.dirname(__file__))
@@ -631,6 +633,9 @@ def _apply_warp_config(parser, args):
 
         key, value_str = entry.split("=", 1)
 
+        if key in _DEPRECATED_WARP_CONFIG_KEYS:
+            parser.error(f"invalid --warp-config key '{key}': use 'log_level' instead")
+
         if not hasattr(wp.config, key):
             parser.error(f"invalid --warp-config key '{key}': not a recognized warp.config setting")
 
@@ -716,7 +721,7 @@ def init(parser=None):
 
     # Suppress Warp compilation messages if requested
     if args.quiet:
-        wp.config.quiet = True
+        wp.config.log_level = wp.LOG_WARNING
 
     # Set device if specified
     if args.device:

--- a/newton/tests/test_lazy_init.py
+++ b/newton/tests/test_lazy_init.py
@@ -3,6 +3,7 @@
 
 """Assert that ``import newton`` does not trigger ``wp.init()``."""
 
+import os
 import subprocess
 import sys
 import unittest
@@ -10,6 +11,9 @@ import unittest
 
 class TestLazyInit(unittest.TestCase):
     def test_import_newton_does_not_init_warp(self):
+        env = os.environ.copy()
+        env["PYTHONWARNINGS"] = "error::DeprecationWarning"
+
         result = subprocess.run(
             [
                 sys.executable,
@@ -17,6 +21,7 @@ class TestLazyInit(unittest.TestCase):
                 "import newton; import warp._src.context as wpc; import sys; sys.exit(0 if wpc.runtime is None else 1)",
             ],
             capture_output=True,
+            env=env,
             text=True,
             check=False,
         )

--- a/newton/tests/test_warp_config_cli.py
+++ b/newton/tests/test_warp_config_cli.py
@@ -16,7 +16,12 @@ class TestWarpConfigCLI(unittest.TestCase):
     """Tests for :func:`_apply_warp_config`."""
 
     def setUp(self):
-        self._saved_config = {attr: getattr(wp.config, attr) for attr in dir(wp.config) if not attr.startswith("__")}
+        deprecated_log_attrs = {"quiet", "verbose"}
+        self._saved_config = {
+            attr: getattr(wp.config, attr)
+            for attr in dir(wp.config)
+            if not attr.startswith("__") and attr not in deprecated_log_attrs
+        }
 
     def tearDown(self):
         for attr, value in self._saved_config.items():
@@ -32,7 +37,7 @@ class TestWarpConfigCLI(unittest.TestCase):
         """No --warp-config flags should be a no-op."""
         parser, args = self._parse()
         _apply_warp_config(parser, args)
-        self.assertEqual(wp.config.verbose, self._saved_config["verbose"])
+        self.assertEqual(wp.config.log_level, self._saved_config["log_level"])
 
     def test_int_override(self):
         """Integer values should be parsed via literal_eval."""
@@ -48,9 +53,19 @@ class TestWarpConfigCLI(unittest.TestCase):
 
     def test_bool_override(self):
         """Boolean values should be parsed correctly."""
-        parser, args = self._parse("--warp-config", "verbose=True")
+        parser, args = self._parse("--warp-config", "verify_fp=True")
         _apply_warp_config(parser, args)
-        self.assertIs(wp.config.verbose, True)
+        self.assertIs(wp.config.verify_fp, True)
+
+    def test_deprecated_log_config_keys_error(self):
+        """Deprecated log config keys should point users to log_level."""
+        for key in ("quiet", "verbose"):
+            with self.subTest(key=key):
+                parser, args = self._parse("--warp-config", f"{key}=True")
+                stderr = io.StringIO()
+                with self.assertRaises(SystemExit), contextlib.redirect_stderr(stderr):
+                    _apply_warp_config(parser, args)
+                self.assertIn(f"invalid --warp-config key '{key}': use 'log_level' instead", stderr.getvalue())
 
     def test_none_override(self):
         """None values should be accepted."""

--- a/newton/tests/test_warp_config_cli.py
+++ b/newton/tests/test_warp_config_cli.py
@@ -5,11 +5,13 @@
 
 import contextlib
 import io
+import sys
 import unittest
+from unittest import mock
 
 import warp as wp
 
-from newton.examples import _apply_warp_config, create_parser
+from newton.examples import _apply_warp_config, create_parser, init
 
 
 class TestWarpConfigCLI(unittest.TestCase):
@@ -119,6 +121,16 @@ class TestWarpConfigCLI(unittest.TestCase):
         parser = create_parser()
         args = parser.parse_known_args([])[0]
         self.assertEqual(args.warp_config, [])
+
+    def test_quiet_preserves_stricter_log_level(self):
+        """--quiet should not lower an explicit stricter log_level override."""
+        parser = create_parser()
+        argv = ["example", "--viewer", "null", "--warp-config", "log_level=40", "--quiet"]
+        with mock.patch.object(sys, "argv", argv):
+            viewer, _args = init(parser)
+
+        self.assertIsNotNone(viewer)
+        self.assertEqual(wp.config.log_level, wp.LOG_ERROR)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.13.0",
+    "warp-lang>=1.14.0.dev20260514",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3713,7 +3713,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.13.0", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.14.0.dev20260514", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["sim", "onnx", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -6785,17 +6785,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.14.0.dev20260511"
+version = "1.14.0.dev20260518"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3cbb102762dd5dd04566fdf20273cbd199f3bc924bea9a184e546ca07a7ef0b2" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ea4716c41ec21ac4e53d05bd963c3eeec10a52b5a202c732ca20ae1479423b0b" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:e656b608ec0bd0fd70716740dc2da54e94d278ba945571b4a224a554a17aec81" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260511-py3-none-win_amd64.whl", hash = "sha256:79b94796dad92ecaa21b82a785167310236fff07dad89092e9017ff4fa5274fd" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260518-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c792ecb2a960052c66d43a8d746d6b3642bccf259499a2ad75689e7928b71078" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260518-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b5329fabfe2542261e43c9f774d9cda88711fca0878bd67fcd8f3a4aa8efb386" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260518-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:f7b03ccdd431affc349a8d3df6984f7de473e5fd1c9fef4088c11fa4132e0e4b" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0.dev20260518-py3-none-win_amd64.whl", hash = "sha256:40ac744dd469941ce0e862a570a9cc6367e8b09bf00d457c677ac2663d92b377" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Require Warp 1.14 and update Newton's logging configuration to use `warp.config.log_level` directly. The legacy Warp `verbose` and `quiet` config keys are deprecated upstream, so this removes the branch-only forwarding layer and avoids supporting older Warp versions that no longer satisfy Newton's dependency floor.

This also updates docs, tutorials, benchmarks, and example CLI handling to use `log_level`. `--warp-config verbose=...` and `--warp-config quiet=...` now fail with migration guidance to use `log_level` instead.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_warp_config_cli
uv run --extra dev -m newton.tests -k test_lazy_init
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Warp logging now uses a single log_level setting for verbosity instead of deprecated quiet/verbose flags.
  * CLI deprecations: using legacy warp-config keys (quiet, verbose) now triggers an error directing you to log_level.
  * Recommended CLI workflow: use --quiet and/or --warp-config log_level=... to control output.
  * Minimum required Warp version updated to 1.14+.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->