### PR TITLE
Add repository guard pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,20 @@ ci:
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-case-conflict
+      - id: check-illegal-windows-names
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.15.9


### PR DESCRIPTION
## Description

Add focused built-in pre-commit-hooks checks for repository hygiene and common mistakes. The main guard is `check-added-large-files` with an explicit 500 KB limit so accidental large assets are blocked before they enter the repo, which matters because Newton does not use Git LFS.

This also adds low-noise checks for case/path portability, JSON/TOML/YAML syntax, merge conflict markers, broken symlinks, Python debugger statements, and accidentally committed private keys.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

Notes:

- Test coverage is via pre-commit validation and targeted hook probes; this is a config-only change.
- No documentation update is needed because the existing development docs already direct contributors to run pre-commit.
- No changelog entry is needed because this is contributor tooling, not user-facing behavior.

## Test plan

```bash
uvx pre-commit install
uvx pre-commit run check-added-large-files --files precommit-large-file-probe.jpg
uvx pre-commit run check-illegal-windows-names --files CON
uvx pre-commit run -a
uvx pre-commit validate-config
git diff --check
```

The large-file probe confirmed that a staged 513 KB file is rejected by the 500 KB limit. The Windows-name probe confirmed that a reserved `CON` filename is rejected. The full pre-commit suite passed without requiring any Newton source, docs, or asset cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to include additional pre-commit checks for code quality and security (file size validation, naming conventions, secret detection, and merge conflict prevention).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->