### PR TITLE
Fix MJCF xyaxes parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -559,7 +559,8 @@ def parse_mjcf(
         if "xyaxes" in attrib:
             xyaxes = np.fromstring(attrib["xyaxes"], sep=" ")
             xaxis = wp.normalize(wp.vec3(*xyaxes[:3]))
-            zaxis = wp.normalize(wp.vec3(*xyaxes[3:]))
+            yaxis = wp.vec3(*xyaxes[3:])
+            zaxis = wp.normalize(wp.cross(xaxis, yaxis))
             yaxis = wp.normalize(wp.cross(zaxis, xaxis))
             rot_matrix = np.array([xaxis, yaxis, zaxis]).T
             return wp.quat_from_matrix(wp.mat33(rot_matrix))

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -247,6 +247,31 @@ class TestImportMjcfBasic(unittest.TestCase):
         # So [0.7071068, 0, 0, 0.7071068] becomes [0, 0, 0.7071068, 0.7071068]
         np.testing.assert_allclose(body_quat, [0, 0, 0.7071068, 0.7071068], atol=1e-6)
 
+    def test_xyaxes_uses_x_and_y_axes(self):
+        """MJCF xyaxes specifies X then Y, not X then Z."""
+        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test">
+    <worldbody>
+        <body name="test_body" xyaxes="1 0 0 0 0 1">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>"""
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content)
+        model = builder.finalize()
+
+        body_idx = model.body_label.index("test/worldbody/test_body")
+        body_quat = model.body_q.numpy()[body_idx, 3:]
+        quat = wp.quat(*body_quat)
+
+        actual_y = np.array(wp.quat_rotate(quat, wp.vec3(0.0, 1.0, 0.0)), dtype=np.float64)
+        actual_z = np.array(wp.quat_rotate(quat, wp.vec3(0.0, 0.0, 1.0)), dtype=np.float64)
+
+        np.testing.assert_allclose(actual_y, [0.0, 0.0, 1.0], atol=1e-6)
+        np.testing.assert_allclose(actual_z, [0.0, -1.0, 0.0], atol=1e-6)
+
     def test_site_euler_sequence_matches_mujoco(self):
         """Non-default compiler eulerseq should match MuJoCo site orientation."""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Description

Fix MJCF `xyaxes` parsing to match MuJoCo semantics. The importer previously treated the second triplet as the frame Z axis, but MuJoCo defines `xyaxes` as X followed by Y, with Z derived from X cross Y.

This changes Newton to:
- normalize the authored X axis
- read the second vector as Y
- derive Z from `cross(X, Y)`
- re-orthogonalize Y from `cross(Z, X)`

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_xyaxes_uses_x_and_y_axes
uv run --extra dev -m newton.tests -k test_import_mjcf
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Import an MJCF body with `xyaxes="1 0 0 0 0 1"`.
2. Inspect the imported body frame.
3. Without this PR, Newton treats the second triplet as Z, so local Z maps to world +Z instead of local Y mapping to world +Z.

**Minimal reproduction:**

```python
import newton

mjcf = """
<mujoco model="test">
  <worldbody>
    <body name="test_body" xyaxes="1 0 0 0 0 1">
      <geom type="box" size="0.1 0.1 0.1"/>
    </body>
  </worldbody>
</mujoco>
"""

builder = newton.ModelBuilder()
builder.add_mjcf(mjcf)
model = builder.finalize()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MuJoCo model import handling of the `xyaxes` attribute to correctly interpret axis orientation for imported models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->