### PR TITLE
Exclude companion files from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,10 @@
 # Root-level policy, config, and docs
 /*                                       @newton-physics/maintainers
 
+# Common PR companion files do not require maintainer approval
+/CHANGELOG.md
+/README.md
+
 # Repo tooling and config
 /.github/                                @newton-physics/maintainers
 /scripts/                                @newton-physics/maintainers


### PR DESCRIPTION
## Description

Exclude `CHANGELOG.md` and `README.md` from maintainer CODEOWNER approval by
adding explicit no-owner overrides after the root-level maintainer rule. These
files are common companion updates and should not trigger maintainer review on
their own.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository policies for documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->