### PR TITLE
Fix non-manifold edges in softbody_gift tet mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
+- Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 
 ## [1.2.0] - 2026-05-12

--- a/newton/examples/multiphysics/example_softbody_gift.py
+++ b/newton/examples/multiphysics/example_softbody_gift.py
@@ -79,23 +79,30 @@ def cloth_loop_around_box(
     )
 
 
+# 2x2x1 grid of unit cubes, each split into 5 tets. Adjacent cubes use
+# mirrored decompositions (checkerboard) so shared-face diagonals match
+# and the surface mesh stays manifold.
 PYRAMID_TET_INDICES = np.array(
     [
+        # cube (0,0,0): variant A
         [0, 1, 3, 9],
         [1, 4, 3, 13],
         [1, 3, 9, 13],
         [3, 9, 13, 12],
         [1, 9, 10, 13],
-        [1, 2, 4, 10],
-        [2, 5, 4, 14],
-        [2, 4, 10, 14],
-        [4, 10, 14, 13],
-        [2, 10, 11, 14],
-        [3, 4, 6, 12],
-        [4, 7, 6, 16],
-        [4, 6, 12, 16],
-        [6, 12, 16, 15],
-        [4, 12, 13, 16],
+        # cube (1,0,0): variant B
+        [1, 11, 5, 13],
+        [2, 5, 1, 11],
+        [4, 1, 5, 13],
+        [10, 11, 1, 13],
+        [14, 5, 11, 13],
+        # cube (0,1,0): variant B
+        [3, 13, 7, 15],
+        [4, 7, 3, 13],
+        [6, 3, 7, 15],
+        [12, 13, 3, 15],
+        [16, 7, 13, 15],
+        # cube (1,1,0): variant A
         [4, 5, 7, 13],
         [5, 8, 7, 17],
         [5, 7, 13, 17],


### PR DESCRIPTION
## Description

The soft body in `example_softbody_gift` is a 2x2x1 grid of unit cubes,
each split into 5 tets — but every cube used the same variant of the
5-tet decomposition. The decomposition comes in two mirror-image forms,
and adjacent cubes need opposite forms so the diagonals chosen on their
shared interior faces match. With all four cubes using one variant,
internal faces were triangulated with mismatched diagonals, so
`TetMesh.compute_surface_triangles` emitted both halves of each shared
face as boundary triangles, producing non-manifold edges (3 warnings
per run from `MeshAdjacency`).

Alternate the 5-tet variant per cube in a checkerboard pattern. Same
18 vertices and 20 tets, all with positive volume; the extracted
surface drops from 48 → 32 triangles (matches Euler V−E+F=2) and no
non-manifold edge warnings remain.

Closes #2637

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run -m newton.examples softbody_gift   # no non-manifold edge warnings
uv run --extra dev -m newton.tests -k example_softbody_gift   # passes
```

## Bug fix

**Steps to reproduce:**

1. `uv run -m newton.examples softbody_gift`
2. Observe three `UserWarning: Detected non-manifold edge` lines from
   `newton/_src/utils/mesh.py` during model build.

**Minimal reproduction:**

```python
import warnings
from newton._src.utils.mesh import MeshAdjacency
from newton._src.geometry.types import TetMesh
from newton.examples.multiphysics.example_softbody_gift import PYRAMID_TET_INDICES

surface = TetMesh.compute_surface_triangles(PYRAMID_TET_INDICES.flatten()).reshape(-1, 3)
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    MeshAdjacency(surface.tolist())
print(len(w), "non-manifold edge warnings")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spurious non-manifold edge warnings appearing in the soft-body example. These false warnings were being incorrectly triggered by the mesh generation process when creating stacked geometry blocks. The underlying configuration has been corrected to eliminate these warnings.

* **Documentation**
  * Updated changelog to reflect and document this fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->