### PR TITLE
Fix mesh-convex margin candidate query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
+- Fix mesh-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Fixed
 
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
-- Fix mesh-convex contacts missing when shapes are separated by margin but still within the contact envelope.
+- Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 

--- a/newton/_src/geometry/collision_core.py
+++ b/newton/_src/geometry/collision_core.py
@@ -932,7 +932,7 @@ def mesh_vs_convex_midphase(
     shape_type: wp.array[int],
     shape_data: wp.array[wp.vec4],
     shape_source_ptr: wp.array[wp.uint64],
-    rigid_gap: float,
+    contact_threshold: float,
     triangle_pairs: wp.array[wp.vec3i],
     triangle_pairs_count: wp.array[int],
 ):
@@ -952,7 +952,7 @@ def mesh_vs_convex_midphase(
         shape_type: Array of shape types
         shape_data: Array of shape data (vec4: scale.xyz, margin.w)
         shape_source_ptr: Array of mesh/SDF source pointers
-        rigid_gap: Contact gap for rigid bodies
+        contact_threshold: Contact candidate distance [m], including margin and gap
         triangle_pairs: Output array for triangle pairs (mesh_shape, non_mesh_shape, tri_index)
         triangle_pairs_count: Counter for triangle pairs
     """
@@ -990,20 +990,21 @@ def mesh_vs_convex_midphase(
 
     # The mesh's own BVH was built over the *unscaled* ``mesh.points``: the world
     # position of vertex v is ``X_mesh_ws * (mesh_scale ⊙ v)``. Therefore we must
-    # convert both the AABB and the contact gap from scaled mesh-local space to
-    # unscaled (BVH) space before querying. With non-uniform scale this is a
-    # per-axis division; the gap, isotropic in world space, becomes anisotropic.
+    # convert both the AABB and the contact threshold from scaled mesh-local
+    # space to unscaled (BVH) space before querying. With non-uniform scale
+    # this is a per-axis division; the threshold, isotropic in world space,
+    # becomes anisotropic.
     mesh_scale_vec4 = shape_data[mesh_shape]
     mesh_scale = wp.vec3(mesh_scale_vec4[0], mesh_scale_vec4[1], mesh_scale_vec4[2])
     aabb_lower_bvh, aabb_upper_bvh = aabb_to_unscaled(aabb_lower, aabb_upper, mesh_scale)
 
-    # Per-axis margin in BVH (unscaled) units. ``rigid_gap`` is a world-space
-    # distance; in unscaled mesh-local space that is ``rigid_gap / |mesh_scale_i|``
+    # Per-axis margin in BVH (unscaled) units. ``contact_threshold`` is a world-space
+    # distance; in unscaled mesh-local space that is ``contact_threshold / |mesh_scale_i|``
     # along each axis.
     margin_vec = wp.vec3(
-        rigid_gap / wp.max(wp.abs(mesh_scale[0]), 1.0e-12),
-        rigid_gap / wp.max(wp.abs(mesh_scale[1]), 1.0e-12),
-        rigid_gap / wp.max(wp.abs(mesh_scale[2]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[0]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[1]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[2]), 1.0e-12),
     )
     aabb_lower = aabb_lower_bvh - margin_vec
     aabb_upper = aabb_upper_bvh + margin_vec

--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -867,12 +867,16 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
         # Get non-mesh shape world transform
         X_ws = shape_transform[non_mesh_shape]
 
-        # Use per-shape contact gaps for consistent pairwise thresholding.
+        # Use the same margin+gap shell for triangle candidates that the
+        # narrow phase uses when accepting contacts.
         gap_non_mesh = shape_gap[non_mesh_shape]
         gap_mesh = shape_gap[mesh_shape]
         gap_sum = gap_non_mesh + gap_mesh
+        margin_non_mesh = shape_data[non_mesh_shape][3]
+        margin_mesh = shape_data[mesh_shape][3]
+        contact_threshold = gap_sum + margin_non_mesh + margin_mesh
 
-        # Call mesh_vs_convex_midphase with the shape_data and pair gap sum.
+        # Call mesh_vs_convex_midphase with the shape_data and pair contact threshold.
         mesh_vs_convex_midphase(
             j,
             mesh_shape,
@@ -883,7 +887,7 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
             shape_types,
             shape_data,
             shape_source,
-            gap_sum,
+            contact_threshold,
             triangle_pairs,
             triangle_pairs_count,
         )

--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -834,6 +834,7 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
                 shape_transform,
                 shape_collision_aabb_lower,
                 shape_collision_aabb_upper,
+                shape_data,
                 shape_gap,
                 triangle_pairs,
                 triangle_pairs_count,

--- a/newton/_src/utils/heightfield.py
+++ b/newton/_src/utils/heightfield.py
@@ -293,6 +293,7 @@ def heightfield_vs_convex_midphase(
     shape_transform: wp.array[wp.transform],
     shape_collision_aabb_lower: wp.array[wp.vec3],
     shape_collision_aabb_upper: wp.array[wp.vec3],
+    shape_data: wp.array[wp.vec4],
     shape_gap: wp.array[float],
     triangle_pairs: wp.array[wp.vec3i],
     triangle_pairs_count: wp.array[int],
@@ -320,6 +321,7 @@ def heightfield_vs_convex_midphase(
             shape (scale already baked in).
         shape_collision_aabb_upper: Local-space AABB upper bounds for each
             shape (scale already baked in).
+        shape_data: Shape data array containing per-shape margins.
         shape_gap: Per-shape contact gaps.
         triangle_pairs: Output buffer for ``(hfield_shape, other_shape, tri_idx)`` triples.
         triangle_pairs_count: Atomic counter for emitted triangle pairs.
@@ -351,10 +353,12 @@ def heightfield_vs_convex_midphase(
     )
 
     gap_sum = shape_gap[hfield_shape] + shape_gap[other_shape]
-    gap_vec = wp.vec3(gap_sum, gap_sum, gap_sum)
+    margin_sum = shape_data[hfield_shape][3] + shape_data[other_shape][3]
+    contact_threshold = gap_sum + margin_sum
+    threshold_vec = wp.vec3(contact_threshold, contact_threshold, contact_threshold)
 
-    aabb_lower = center_in_hfield - half_in_hfield - gap_vec
-    aabb_upper = center_in_hfield + half_in_hfield + gap_vec
+    aabb_lower = center_in_hfield - half_in_hfield - threshold_vec
+    aabb_upper = center_in_hfield + half_in_hfield + threshold_vec
 
     # Map AABB to grid cell indices
     dx = 2.0 * hfd.hx / wp.float32(hfd.ncol - 1)

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -1113,6 +1113,12 @@ class TestMeshConvexMidphase(unittest.TestCase):
     pass
 
 
+class TestHeightfieldConvexMidphase(unittest.TestCase):
+    """Test heightfield-vs-convex triangle candidate generation."""
+
+    pass
+
+
 def test_mesh_convex_midphase_queries_margin_shell(test, device):
     margin = 0.02
     gap = 0.005
@@ -1135,6 +1141,44 @@ def test_mesh_convex_midphase_queries_margin_shell(test, device):
     builder.add_shape_mesh(body=-1, mesh=newton.Mesh(vertices, indices), cfg=cfg)
 
     body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius + surface_separation), wp.quat_identity()))
+    builder.add_joint_free(child=body)
+    builder.add_shape_sphere(body=body, radius=radius, cfg=cfg)
+
+    model = builder.finalize(device=device)
+    state = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+    pipeline = newton.CollisionPipeline(model, broad_phase="nxn")
+    contacts = pipeline.contacts()
+    pipeline.collide(state, contacts)
+
+    contact_count = int(contacts.rigid_contact_count.numpy()[0])
+    test.assertGreater(contact_count, 0)
+
+
+def test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge(test, device):
+    margin = 0.02
+    gap = 0.005
+    radius = 0.1
+    surface_separation = 0.03
+
+    cfg = newton.ModelBuilder.ShapeConfig(margin=margin, gap=gap)
+    builder = newton.ModelBuilder()
+
+    heightfield = newton.Heightfield(
+        data=np.zeros((3, 3), dtype=np.float32),
+        nrow=3,
+        ncol=3,
+        hx=1.0,
+        hy=1.0,
+        min_z=0.0,
+        max_z=0.0,
+    )
+    builder.add_shape_heightfield(heightfield=heightfield, cfg=cfg)
+
+    body = builder.add_body(
+        xform=wp.transform(wp.vec3(1.0 + radius + surface_separation, 0.0, 0.0), wp.quat_identity())
+    )
     builder.add_joint_free(child=body)
     builder.add_shape_sphere(body=body, radius=radius, cfg=cfg)
 
@@ -1552,6 +1596,14 @@ add_function_test(
     TestMeshConvexMidphase,
     "test_mesh_convex_midphase_queries_margin_shell",
     test_mesh_convex_midphase_queries_margin_shell,
+    devices=get_cuda_test_devices(),
+    check_output=False,
+)
+
+add_function_test(
+    TestHeightfieldConvexMidphase,
+    "test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge",
+    test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge,
     devices=get_cuda_test_devices(),
     check_output=False,
 )

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -10,6 +10,8 @@ import warp.examples
 
 import newton
 from newton import GeoType
+from newton._src.geometry import create_mesh_terrain
+from newton._src.geometry.flags import ShapeFlags
 from newton._src.sim.collide import _compute_per_world_shape_pairs_max, _estimate_rigid_contact_max
 from newton.examples import test_body_state
 from newton.tests.unittest_utils import add_function_test, get_cuda_test_devices
@@ -870,8 +872,6 @@ class TestShapePairsMaxScaling(unittest.TestCase):
     @staticmethod
     def _make_model(num_worlds, shapes_per_world, num_global=0, shape_flags_value=None):
         """Build a minimal Model with the given world/shape layout."""
-        from newton._src.geometry.flags import ShapeFlags  # noqa: PLC0415
-
         total = num_worlds * shapes_per_world + num_global
         world_ids = np.repeat(np.arange(num_worlds, dtype=np.int32), shapes_per_world)
         if num_global > 0:
@@ -1107,10 +1107,51 @@ class TestDeterministicPipeline(unittest.TestCase):
     pass
 
 
+class TestMeshConvexMidphase(unittest.TestCase):
+    """Test mesh-vs-convex triangle candidate generation."""
+
+    pass
+
+
+def test_mesh_convex_midphase_queries_margin_shell(test, device):
+    margin = 0.02
+    gap = 0.005
+    radius = 0.1
+    surface_separation = 0.03
+
+    cfg = newton.ModelBuilder.ShapeConfig(margin=margin, gap=gap)
+    builder = newton.ModelBuilder()
+
+    vertices = np.array(
+        [
+            [-1.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    indices = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    builder.add_shape_mesh(body=-1, mesh=newton.Mesh(vertices, indices), cfg=cfg)
+
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius + surface_separation), wp.quat_identity()))
+    builder.add_joint_free(child=body)
+    builder.add_shape_sphere(body=body, radius=radius, cfg=cfg)
+
+    model = builder.finalize(device=device)
+    state = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+    pipeline = newton.CollisionPipeline(model, broad_phase="nxn")
+    contacts = pipeline.contacts()
+    pipeline.collide(state, contacts)
+
+    contact_count = int(contacts.rigid_contact_count.numpy()[0])
+    test.assertGreater(contact_count, 0)
+
+
 def _build_deterministic_scene(device):
     """Build the mixed-shape scene from example_basic_shapes6_determinism."""
-    from newton._src.geometry import create_mesh_terrain  # noqa: PLC0415
-
     builder = newton.ModelBuilder()
 
     # Procedural mesh terrain ground
@@ -1503,6 +1544,14 @@ add_function_test(
     TestDeterministicPipeline,
     "test_deterministic_pipeline_sticky_500_steps",
     test_deterministic_pipeline_sticky_500_steps,
+    devices=get_cuda_test_devices(),
+    check_output=False,
+)
+
+add_function_test(
+    TestMeshConvexMidphase,
+    "test_mesh_convex_midphase_queries_margin_shell",
+    test_mesh_convex_midphase_queries_margin_shell,
     devices=get_cuda_test_devices(),
     check_output=False,
 )


### PR DESCRIPTION
## Description

Fix mesh-vs-convex and heightfield-vs-convex midphase candidate generation to query candidates using the full `margin + gap` contact envelope, not just `gap`.

This keeps the mesh BVH query and heightfield grid-cell lookup consistent with broad-phase AABB expansion and final contact acceptance. Without this, valid margin-shell contacts can be culled before narrow phase processing.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k Midphase
uv run --extra dev ruff check newton/_src/geometry/collision_core.py newton/_src/geometry/narrow_phase.py newton/_src/utils/heightfield.py newton/tests/test_collision_pipeline.py
git diff --check
```

## Bug fix

**Steps to reproduce:**

1. Create a mesh-vs-sphere or heightfield-vs-sphere scene with per-shape `margin=0.02`, `gap=0.005`.
2. Place the sphere with true surface separation `0.03`.
3. Run the Newton collision pipeline.
4. Without this PR, no contact is generated even though `0.03 <= margin_a + margin_b + gap_a + gap_b`.

The heightfield regression covers the lateral edge case where grid-cell candidate lookup can cull the contact before narrow phase. Vertical margin-shell contacts above the heightfield already reached narrow phase because the grid lookup is driven by XY cell overlap.

**Minimal reproduction:**

```python
# Covered by:
# uv run --extra dev -m newton.tests -k Midphase
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing mesh–convex and heightfield–convex contacts when shapes are separated by margin but still lie within the contact envelope; contact thresholds now include per-shape margin.
* **Tests**
  * Added midphase tests verifying contacts are produced for mesh/heightfield vs convex cases when margins/gaps match.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->