### PR TITLE
Add template joint, link, and shape labels to `ArticulationView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `ViewerGL.show_loading_splash()` / `ViewerGL.hide_loading_splash()` displaying a stylized Newton's-cradle overlay while the GL viewer waits on Warp kernel compilation; raised automatically by `newton.examples.init()` for visible GL viewers
 - Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
 - Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
+- Add `ArticulationView.joint_template_labels`, `link_template_labels`, and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add `ViewerGL.show_loading_splash()` / `ViewerGL.hide_loading_splash()` displaying a stylized Newton's-cradle overlay while the GL viewer waits on Warp kernel compilation; raised automatically by `newton.examples.init()` for visible GL viewers
 - Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
 - Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
-- Add `ArticulationView.joint_template_labels`, `link_template_labels`, and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
+- Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
 

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -1124,6 +1124,11 @@ class ArticulationView:
         """Alias for `link_shapes`."""
         return self.link_shapes
 
+    @property
+    def body_template_labels(self):
+        """Alias for `link_template_labels`."""
+        return self.link_template_labels
+
     # ========================================================================================
     # Generic attribute API
 

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -568,8 +568,11 @@ class ArticulationView:
         arti_joint_types = []
         arti_link_ids = []
         arti_link_names = []
+        arti_link_template_labels = []
+        arti_joint_template_labels = []
         arti_shape_ids = []
         arti_shape_names = []
+        arti_shape_template_labels = []
 
         # gather joint info
         arti_joint_begin = int(model_articulation_start[arti_0])
@@ -584,6 +587,7 @@ class ArticulationView:
         for joint_id in range(arti_joint_begin, arti_joint_end):
             # joint_id = arti_joint_begin + idx
             arti_joint_ids.append(joint_id)
+            arti_joint_template_labels.append(model.joint_label[joint_id])
             arti_joint_names.append(get_name_from_label(model.joint_label[joint_id]))
             arti_joint_types.append(model_joint_type[joint_id])
             link_id = int(model_joint_child[joint_id])
@@ -593,6 +597,7 @@ class ArticulationView:
         arti_link_ids = sorted(arti_link_ids)
         arti_link_count = len(arti_link_ids)
         for link_id in arti_link_ids:
+            arti_link_template_labels.append(model.body_label[link_id])
             arti_link_names.append(get_name_from_label(model.body_label[link_id]))
             arti_shape_ids.extend(model.body_shapes[link_id])
 
@@ -600,6 +605,7 @@ class ArticulationView:
         arti_shape_ids = sorted(arti_shape_ids)
         arti_shape_count = len(arti_shape_ids)
         for shape_id in arti_shape_ids:
+            arti_shape_template_labels.append(model.shape_label[shape_id])
             arti_shape_names.append(get_name_from_label(model.shape_label[shape_id]))
 
         # compute counts and offsets of joints, links, etc.
@@ -797,13 +803,16 @@ class ArticulationView:
         selected_link_indices = sorted(link_include_indices - link_exclude_indices)
 
         self.joint_names = []
+        self.joint_template_labels = []
         self.joint_dof_names = []
         self.joint_dof_counts = []
         self.joint_coord_names = []
         self.joint_coord_counts = []
         self.link_names = []
+        self.link_template_labels = []
         self.link_shapes = []
         self.shape_names = []
+        self.shape_template_labels = []
 
         # populate info for selected joints and dofs
         selected_joint_dof_indices = []
@@ -812,6 +821,7 @@ class ArticulationView:
             joint_id = arti_joint_ids[joint_idx]
             joint_name = arti_joint_names[joint_idx]
             self.joint_names.append(joint_name)
+            self.joint_template_labels.append(arti_joint_template_labels[joint_idx])
             # joint dofs
             dof_begin = int(model_joint_qd_start[joint_id])
             dof_end = int(model_joint_qd_start[joint_id + 1])
@@ -843,6 +853,7 @@ class ArticulationView:
         for link_idx, arti_link_idx in enumerate(selected_link_indices):
             body_id = arti_link_ids[arti_link_idx]
             self.link_names.append(arti_link_names[arti_link_idx])
+            self.link_template_labels.append(arti_link_template_labels[arti_link_idx])
             shape_ids = model.body_shapes[body_id]
             for shape_id in shape_ids:
                 arti_shape_idx = arti_shape_ids.index(shape_id)
@@ -853,6 +864,7 @@ class ArticulationView:
         selected_shape_indices = sorted(selected_shape_indices)
         for shape_idx, arti_shape_idx in enumerate(selected_shape_indices):
             self.shape_names.append(arti_shape_names[arti_shape_idx])
+            self.shape_template_labels.append(arti_shape_template_labels[arti_shape_idx])
             link_idx = shape_link_idx[arti_shape_idx]
             self.link_shapes[link_idx].append(shape_idx)
 

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -69,6 +69,49 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.get_dof_velocities(state).shape, (1, 1, 0))
         self.assertEqual(view.get_dof_forces(control).shape, (1, 1, 0))
 
+    def test_template_labels_preserve_full_paths(self):
+        """Two-finger gripper whose distal bodies, finger joints, and tip
+        shapes each share a colliding leaf name. ``*_names`` attributes
+        collapse to the leaf; ``*_template_labels`` attributes expose the
+        full slash-delimited labels from the template articulation so
+        callers can still distinguish entries and recover selection order.
+        """
+        builder = newton.ModelBuilder()
+        palm = builder.add_link(label="palm")
+        left = builder.add_link(label="palm/left/fingertip")
+        right = builder.add_link(label="palm/right/fingertip")
+        builder.add_shape_box(body=left, hx=0.01, hy=0.01, hz=0.02, label="palm/left/tip_collision")
+        builder.add_shape_box(body=right, hx=0.01, hy=0.01, hz=0.02, label="palm/right/tip_collision")
+        j_root = builder.add_joint_free(parent=-1, child=palm, label="root")
+        j_left = builder.add_joint_revolute(
+            parent=palm, child=left, axis=(0.0, 0.0, 1.0), label="palm/left/fingertip_joint"
+        )
+        j_right = builder.add_joint_revolute(
+            parent=palm, child=right, axis=(0.0, 0.0, 1.0), label="palm/right/fingertip_joint"
+        )
+        builder.add_articulation([j_root, j_left, j_right], label="gripper")
+        model = builder.finalize()
+
+        view = ArticulationView(model, "gripper", include_links="fingertip")
+
+        # Leaf collisions are visible on the *_names attributes...
+        self.assertEqual(view.link_count, 2)
+        self.assertEqual(view.link_names, ["fingertip", "fingertip"])
+        self.assertEqual(view.shape_names, ["tip_collision", "tip_collision"])
+
+        # ...and disambiguated on the *_template_labels attributes.
+        self.assertEqual(
+            view.link_template_labels,
+            ["palm/left/fingertip", "palm/right/fingertip"],
+        )
+        self.assertEqual(
+            view.shape_template_labels,
+            ["palm/left/tip_collision", "palm/right/tip_collision"],
+        )
+        self.assertIn("palm/left/fingertip_joint", view.joint_template_labels)
+        self.assertIn("palm/right/fingertip_joint", view.joint_template_labels)
+        self.assertEqual(len(view.joint_template_labels), view.joint_count)
+
     def _test_selection_shapes(self, floating: bool):
         # load articulation
         ant = newton.ModelBuilder()

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -111,6 +111,7 @@ class TestSelection(unittest.TestCase):
         self.assertIn("palm/left/fingertip_joint", view.joint_template_labels)
         self.assertIn("palm/right/fingertip_joint", view.joint_template_labels)
         self.assertEqual(len(view.joint_template_labels), view.joint_count)
+        self.assertEqual(view.body_template_labels, view.link_template_labels)
 
     def _test_selection_shapes(self, floating: bool):
         # load articulation


### PR DESCRIPTION
## Description

Resolves #2914 

This PR adds three new attributes to `ArticulationView`:

- `body_template_labels`
- `joint_template_labels`
- `link_template_labels`

They augment the existing `body_names`, `joint_names`, and `link_names` attributes and are useful for disambiguating between objects that share the final part of their slash-separated names. The new attributes contain the full labels of the joints, links and bodies matched for the template articulation.

The `template_` infix flags that these attributes are sourced from the first articulation only, which typically includes a world-specific prefix when applied to replicated worlds.

The existing `*_names` attributes are unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes (no docstrings on the existing `*_names` attributes to parallel, and no entries in `docs/`)
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m unittest newton.tests.test_selection -v
```

New test: `newton.tests.test_selection.TestSelection.test_template_labels_preserve_full_paths` builds a two-finger parallel gripper whose distal bodies, finger joints, and tip shapes each share a colliding leaf name.

## New feature / API change

```python
import newton
from newton.selection import ArticulationView

builder = newton.ModelBuilder()
palm = builder.add_link(label="palm")
left = builder.add_link(label="palm/left/fingertip")
right = builder.add_link(label="palm/right/fingertip")
j_root = builder.add_joint_free(parent=-1, child=palm)
j_left = builder.add_joint_revolute(parent=palm, child=left, axis=(0.0, 0.0, 1.0))
j_right = builder.add_joint_revolute(parent=palm, child=right, axis=(0.0, 0.0, 1.0))
builder.add_articulation([j_root, j_left, j_right], label="gripper")
model = builder.finalize()

view = ArticulationView(model, "gripper", include_links="fingertip")

view.link_names            # ['fingertip', 'fingertip']                        ← leaf collision (unchanged)
view.link_template_labels  # ['palm/left/fingertip', 'palm/right/fingertip']   ← disambiguated
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selection now preserves full template paths for articulation components alongside their displayed identifiers, enabling unambiguous identification when multiple components share the same leaf name.

* **Tests**
  * Added a unit test confirming that displayed names collapse to leaf identifiers while the preserved full template paths retain complete, ordered path information for disambiguation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->