### PR TITLE
Preserve API SPDX years

### DIFF
--- a/docs/api/_toctree.rst
+++ b/docs/api/_toctree.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+.. SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 .. SPDX-License-Identifier: CC-BY-4.0
 
 .. toctree::

--- a/docs/api/newton_actuators.rst
+++ b/docs/api/newton_actuators.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+.. SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 .. SPDX-License-Identifier: CC-BY-4.0
 
 newton.actuators

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -27,8 +27,10 @@ from __future__ import annotations
 import importlib
 import inspect
 import pkgutil
+import re
 import shutil
 import sys
+from datetime import datetime
 from pathlib import Path
 from types import ModuleType
 
@@ -53,6 +55,9 @@ TOCTREE_RST = OUTPUT_DIR / "_toctree.rst"
 # file).  Keeping them alongside the .rst files avoids clutter elsewhere.
 TOCTREE_DIR = "_generated"  # sub-folder inside OUTPUT_DIR
 
+COPYRIGHT_RE = re.compile(r"^\.\. SPDX-FileCopyrightText: Copyright \(c\) \d{4} The Newton Developers$")
+_COPYRIGHT_LINES: dict[Path, str] = {}
+
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
@@ -70,6 +75,42 @@ def public_symbols(mod: ModuleType) -> list[str]:
         return not inspect.ismodule(getattr(mod, name))
 
     return sorted(filter(is_public, dir(mod)))
+
+
+def _read_copyright_line(path: Path) -> str | None:
+    try:
+        first_line = path.read_text(encoding="utf-8").splitlines()[0]
+    except (IndexError, OSError):
+        return None
+
+    if COPYRIGHT_RE.fullmatch(first_line):
+        return first_line
+    return None
+
+
+def _snapshot_copyright_lines() -> None:
+    """Remember generated files' original copyright lines before regeneration."""
+    _COPYRIGHT_LINES.clear()
+    if not OUTPUT_DIR.exists():
+        return
+
+    for path in OUTPUT_DIR.glob("*.rst"):
+        existing_line = _read_copyright_line(path)
+        if existing_line:
+            _COPYRIGHT_LINES[path.resolve()] = existing_line
+
+
+def copyright_line(path: Path) -> str:
+    """Return the SPDX copyright line for a generated file."""
+    existing_line = _COPYRIGHT_LINES.get(path.resolve())
+    if existing_line:
+        return existing_line
+
+    existing_line = _read_copyright_line(path)
+    if existing_line:
+        return existing_line
+
+    return f".. SPDX-FileCopyrightText: Copyright (c) {datetime.now().year} The Newton Developers"
 
 
 def api_modules() -> list[str]:
@@ -173,9 +214,10 @@ def write_module_page(mod_name: str) -> None:
 
     title = mod_name
     underline = "=" * len(title)
+    outfile = OUTPUT_DIR / f"{mod_name.replace('.', '_')}.rst"
 
     lines: list[str] = [
-        ".. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers",
+        copyright_line(outfile),
         ".. SPDX-License-Identifier: CC-BY-4.0",
         "",
         title,
@@ -296,7 +338,6 @@ def write_module_page(mod_name: str) -> None:
 
         lines.append("")
 
-    outfile = OUTPUT_DIR / f"{mod_name.replace('.', '_')}.rst"
     outfile.parent.mkdir(parents=True, exist_ok=True)
     outfile.write_text("\n".join(lines), encoding="utf-8")
     print(f"Wrote {outfile.relative_to(REPO_ROOT)} ({len(symbols)} symbols)")
@@ -316,7 +357,7 @@ def write_api_toctree(modules: list[str]) -> None:
     top-level toctree entries.
     """
     lines = [
-        ".. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers",
+        copyright_line(TOCTREE_RST),
         ".. SPDX-License-Identifier: CC-BY-4.0",
         "",
         ".. toctree::",
@@ -334,6 +375,7 @@ def write_api_toctree(modules: list[str]) -> None:
 
 def generate_all() -> None:
     """Regenerate all API ``.rst`` files under :data:`OUTPUT_DIR`."""
+    _snapshot_copyright_lines()
 
     # delete previously generated files
     shutil.rmtree(OUTPUT_DIR, ignore_errors=True)

--- a/newton/tests/test_generate_api.py
+++ b/newton/tests/test_generate_api.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from docs import generate_api
+
+
+class TestGenerateApiCopyright(unittest.TestCase):
+    def tearDown(self):
+        generate_api._COPYRIGHT_LINES.clear()
+
+    def test_copyright_line_preserves_existing_generated_year(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            api_page = output_dir / "newton_existing.rst"
+            existing_line = ".. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers"
+            api_page.write_text(
+                "\n".join(
+                    [
+                        existing_line,
+                        ".. SPDX-License-Identifier: CC-BY-4.0",
+                        "",
+                        "newton.existing",
+                        "===============",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(generate_api, "OUTPUT_DIR", output_dir):
+                generate_api._snapshot_copyright_lines()
+            api_page.unlink()
+
+            self.assertEqual(generate_api.copyright_line(api_page), existing_line)
+
+    def test_copyright_line_uses_current_year_for_new_generated_file(self):
+        class FakeDateTime:
+            @classmethod
+            def now(cls):
+                return SimpleNamespace(year=2042)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            api_page = Path(tmp) / "newton_new.rst"
+
+            with mock.patch.object(generate_api, "datetime", FakeDateTime):
+                self.assertEqual(
+                    generate_api.copyright_line(api_page),
+                    ".. SPDX-FileCopyrightText: Copyright (c) 2042 The Newton Developers",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Preserve correct SPDX copyright years when regenerating API docs.

`docs/generate_api.py` previously hard-coded `2025` into every generated
`docs/api/*.rst` file. That is wrong for newly generated API pages created in
later years, and it can also overwrite the original creation year for existing
generated files.

This change snapshots existing generated API page SPDX lines before deleting
`docs/api/`, reuses those lines for regenerated files, and uses the current year
only for genuinely new generated pages.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change; not applicable)

## Test plan

```bash
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_generate_api
uv run python docs/generate_api.py
```

Verified that rerunning `docs/generate_api.py` does not produce unrelated
`docs/api` diffs.

## Bug fix

**Steps to reproduce:**

1. Add a new public API module or symbol that causes `docs/generate_api.py` to
   create a new `docs/api/*.rst` file in 2026 or later.
2. Run:

   ```bash
   uv run python docs/generate_api.py
   ```

3. Observe that the new generated page receives a hard-coded 2025 SPDX year
   instead of the file creation year.

**Minimal reproduction:**

```python
from pathlib import Path

source = Path("docs/generate_api.py").read_text(encoding="utf-8")
assert '".. SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers"' in source
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * API documentation generation now preserves existing SPDX copyright lines when regenerating files and falls back to the current year for newly generated pages.

* **Documentation**
  * API docs headers updated to reflect the current copyright year.

* **Tests**
  * Added tests covering copyright preservation and year-fallback behavior during API documentation generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->