### PR TITLE
Add USD parsing for NewtonMassAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 - Normalize negative scale components to `abs()` in `ModelBuilder.add_shape*` for symmetric primitives (sphere, box, capsule, cylinder, ellipsoid, plane, gaussian); these shapes are point-symmetric so sign flips produce identical geometry. If you relied on a negative scale to flip such a shape, apply the mirror through the shape's transform (`xform`) instead.
 - Reject negative scale components on `ModelBuilder.add_shape_cone()` and heightfield shapes (previously silently accepted, produced invalid geometry). To mirror a cone, apply the flip through the shape's `xform`; to mirror a heightfield, pre-mirror the source height data and pass a positive scale.
 - Change `SensorTiledCamera` default packed `color` and `albedo` outputs to sRGB-encoded bytes so authored display colors render at the expected display brightness; pass `RenderConfig(output_color_space=ColorSpace.LINEAR)` to preserve the previous linear-byte behavior.
-- Bump `newton-usd-schemas` to `>=0.3.0b1` for the final `NewtonMassAPI` schema
 - Bump `newton-usd-schemas` to `>=0.3.0b1`
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0
-- Bump `newton-usd-schemas` to `>=0.2.0` introducing new experimental actuator schemas & re-aligning friction defaults
+- Bump `newton-usd-schemas` to `>=0.3.0b1` introducing `NewtonMassAPI` schema and new experimental actuator schemas
 - Restrict `usd-core` to `<26.5` to avoid deprecation warnings introduced in 26.5
 - Require explicit `SensorTiledCamera` BVH lifecycle management instead of implicit camera maintenance: call `newton.geometry.build_bvh_shape()` / `build_bvh_particle()` once after setup, then `refit_bvh_shape()` / `refit_bvh_particle()` before rendering frames that change geometry
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Normalize negative scale components to `abs()` in `ModelBuilder.add_shape*` for symmetric primitives (sphere, box, capsule, cylinder, ellipsoid, plane, gaussian); these shapes are point-symmetric so sign flips produce identical geometry. If you relied on a negative scale to flip such a shape, apply the mirror through the shape's transform (`xform`) instead.
 - Reject negative scale components on `ModelBuilder.add_shape_cone()` and heightfield shapes (previously silently accepted, produced invalid geometry). To mirror a cone, apply the flip through the shape's `xform`; to mirror a heightfield, pre-mirror the source height data and pass a positive scale.
 - Change `SensorTiledCamera` default packed `color` and `albedo` outputs to sRGB-encoded bytes so authored display colors render at the expected display brightness; pass `RenderConfig(output_color_space=ColorSpace.LINEAR)` to preserve the previous linear-byte behavior.
+- Bump `newton-usd-schemas` to `>=0.3.0b1` for the final `NewtonMassAPI` schema
 
 ### Deprecated
 
@@ -134,7 +135,7 @@
 - Bump `GitPython` lower bound to `>=3.1.47` to pick up the fix for GHSA-x2qx-6953-8485 (`multi_options` argument injection in `Repo.clone_from`)
 - Bump `open3d` floor to `>=0.19.0`
 - Bump `meshio` floor to `>=5.3.5`; `5.3.0` calls `np.string_` which was removed in NumPy 2.0
-- Bump `newton-usd-schemas` to `>=0.3.0b1` introducing `NewtonMassAPI` schema and new experimental actuator schemas
+- Bump `newton-usd-schemas` to `>=0.2.0` introducing new experimental actuator schemas & re-aligning friction defaults
 - Restrict `usd-core` to `<26.5` to avoid deprecation warnings introduced in 26.5
 - Require explicit `SensorTiledCamera` BVH lifecycle management instead of implicit camera maintenance: call `newton.geometry.build_bvh_shape()` / `build_bvh_particle()` once after setup, then `refit_bvh_shape()` / `refit_bvh_particle()` before rendering frames that change geometry
 - Increase conveyor rail roughness in `example_basic_conveyor` to reduce mirror-like reflections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Normalize negative scale components to `abs()` in `ModelBuilder.add_shape*` for symmetric primitives (sphere, box, capsule, cylinder, ellipsoid, plane, gaussian); these shapes are point-symmetric so sign flips produce identical geometry. If you relied on a negative scale to flip such a shape, apply the mirror through the shape's transform (`xform`) instead.
 - Reject negative scale components on `ModelBuilder.add_shape_cone()` and heightfield shapes (previously silently accepted, produced invalid geometry). To mirror a cone, apply the flip through the shape's `xform`; to mirror a heightfield, pre-mirror the source height data and pass a positive scale.
 - Change `SensorTiledCamera` default packed `color` and `albedo` outputs to sRGB-encoded bytes so authored display colors render at the expected display brightness; pass `RenderConfig(output_color_space=ColorSpace.LINEAR)` to preserve the previous linear-byte behavior.
-- Bump `newton-usd-schemas` to `>=0.3.0b1`
+- Bump `newton-usd-schemas` to `>=0.3.0`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Reject negative scale components on `ModelBuilder.add_shape_cone()` and heightfield shapes (previously silently accepted, produced invalid geometry). To mirror a cone, apply the flip through the shape's `xform`; to mirror a heightfield, pre-mirror the source height data and pass a positive scale.
 - Change `SensorTiledCamera` default packed `color` and `albedo` outputs to sRGB-encoded bytes so authored display colors render at the expected display brightness; pass `RenderConfig(output_color_space=ColorSpace.LINEAR)` to preserve the previous linear-byte behavior.
 - Bump `newton-usd-schemas` to `>=0.3.0b1` for the final `NewtonMassAPI` schema
+- Bump `newton-usd-schemas` to `>=0.3.0b1`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `ViewerRTX`, a real-time ray-traced viewer powered by NVIDIA OVRTX.
 - Support negative (mirrored) scale on mesh, convex hull, and SDF shapes, so a single `Mesh` instance can be shared across shapes with different signed scales without re-baking
 - Add `newton.utils.ColorSpace`, `color_srgb_to_linear()`, `color_linear_to_srgb()`, and `SensorTiledCamera.RenderConfig.output_color_space` for color-space boundaries
+- Add USD parsing for `NewtonMassAPI`: shell mass model (`newton:massModel`), shell thickness (`newton:shellThickness`), and compact inertia tensor (`newton:inertia`)
 
 ### Changed
 

--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -78,6 +78,8 @@ For rigid bodies with ``UsdPhysics.MassAPI`` applied, Newton resolves each inert
    is used.
 3. When ``physics:mass`` is authored but inertia is not, the inertia
    accumulated from collision shapes is scaled by ``authored_mass / accumulated_mass``.
+   Shell colliders (``newton:massModel = "shell"``) contribute shell-derived inertia to the
+   accumulation before this scaling is applied.
 4. For any remaining unresolved properties, Newton falls back to
    ``UsdPhysics.RigidBodyAPI.ComputeMassProperties(...)``.
    In this fallback path, collider contributions use a two-level precedence:

--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -70,18 +70,26 @@ For rigid bodies with ``UsdPhysics.MassAPI`` applied, Newton resolves each inert
 (mass, inertia, center of mass) independently.  Authored attributes take precedence;
 ``UsdPhysics.RigidBodyAPI.ComputeMassProperties(...)`` provides baseline values for the rest.
 
-1. Authored ``physics:mass``, ``physics:diagonalInertia``, and ``physics:centerOfMass`` are
+1. ``newton:inertia`` (from ``NewtonMassAPI``) is a compact 6-element symmetric tensor
+   ``[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`` already in the body frame.  When authored, it
+   overrides ``physics:diagonalInertia`` and ``physics:principalAxes``.
+2. Authored ``physics:mass``, ``physics:diagonalInertia``, and ``physics:centerOfMass`` are
    applied directly when present.  If ``physics:principalAxes`` is missing, identity rotation
    is used.
-2. When ``physics:mass`` is authored but ``physics:diagonalInertia`` is not, the inertia
+3. When ``physics:mass`` is authored but inertia is not, the inertia
    accumulated from collision shapes is scaled by ``authored_mass / accumulated_mass``.
-3. For any remaining unresolved properties, Newton falls back to
+4. For any remaining unresolved properties, Newton falls back to
    ``UsdPhysics.RigidBodyAPI.ComputeMassProperties(...)``.
    In this fallback path, collider contributions use a two-level precedence:
 
    a. If collider ``UsdPhysics.MassAPI`` has authored ``mass`` and ``diagonalInertia``, those
       authored values are converted to unit-density collider mass information.
-   b. Otherwise, Newton derives unit-density collider mass information from collider geometry.
+   b. Otherwise, Newton derives unit-density collider mass information from collider
+      geometry.  When ``NewtonMassAPI`` is applied to the collider, ``newton:massModel``
+      controls whether inertia is derived from the full volume (``"solid"``, default) or a
+      thin shell at the surface (``"shell"``).  For shell shapes,
+      ``newton:shellThickness`` sets the wall thickness [m] measured inward from the outer
+      surface; the sentinel ``-inf`` (default) falls back to ``newton:contactMargin``.
 
    A collider is skipped (with warning) only if neither path provides usable collider mass
    information.

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -87,6 +87,9 @@ class SchemaResolverNewton(SchemaResolver):
             # Contact stiffness/damping
             "ke": SchemaAttribute("newton:contact_ke", None),
             "kd": SchemaAttribute("newton:contact_kd", None),
+            # Mass model
+            "mass_model": SchemaAttribute("newton:massModel", "solid"),
+            "shell_thickness": SchemaAttribute("newton:shellThickness"),
         },
         PrimType.BODY: {},
         PrimType.ARTICULATION: {
@@ -346,6 +349,8 @@ class SchemaResolverMjc(SchemaResolver):
             # Contact stiffness/damping from per-geom solref
             "ke": SchemaAttribute("mjc:solref", [0.02, 1.0], solref_to_stiffness),
             "kd": SchemaAttribute("mjc:solref", [0.02, 1.0], solref_to_damping),
+            # Mass model: mjc:shellinertia (bool) → "shell" / "solid"
+            "mass_model": SchemaAttribute("mjc:shellinertia", False, lambda v: "shell" if v else "solid"),
         },
         PrimType.MATERIAL: {
             # Materials

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -89,7 +89,7 @@ class SchemaResolverNewton(SchemaResolver):
             "kd": SchemaAttribute("newton:contact_kd", None),
             # Mass model
             "mass_model": SchemaAttribute("newton:massModel", "solid"),
-            "shell_thickness": SchemaAttribute("newton:shellThickness"),
+            "shell_thickness": SchemaAttribute("newton:shellThickness", float("-inf")),
         },
         PrimType.BODY: {},
         PrimType.ARTICULATION: {

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -8,6 +8,7 @@ import copy
 import datetime
 import inspect
 import itertools
+import math
 import os
 import posixpath
 import re
@@ -2525,6 +2526,8 @@ def parse_usd(
         shape_scale: wp.vec3,
         shape_src: Mesh | None,
         shape_axis=None,
+        is_solid: bool = True,
+        thickness: float = 0.0,
     ):
         """Build unit-density collider mass information from geometric shape parameters.
 
@@ -2533,7 +2536,7 @@ def parse_usd(
         properties are not available.
         """
         shape_mass, shape_com, shape_inertia = compute_inertia_shape(
-            shape_geo_type, shape_scale, shape_src, density=1.0
+            shape_geo_type, shape_scale, shape_src, density=1.0, is_solid=is_solid, thickness=thickness
         )
         if shape_mass <= 0.0:
             warnings.warn(
@@ -2676,6 +2679,18 @@ def parse_usd(
                     shape_kd = builder.default_shape_cfg.kd
 
                 shape_color = material_props.get("color")
+
+                # NewtonMassAPI: mass model and shell thickness
+                has_newton_mass = usd.has_applied_api_schema(prim, "NewtonMassAPI")
+                mass_model = usd.get_attribute(prim, "newton:massModel", "solid") if has_newton_mass else "solid"
+                shape_is_solid = mass_model != "shell"
+                shell_thickness_val = usd.get_attribute(prim, "newton:shellThickness") if has_newton_mass else None
+                if shell_thickness_val is not None and shell_thickness_val == float("-inf"):
+                    shell_thickness_val = None
+                # When shell thickness is authored, pass it as margin so compute_inertia_shape
+                # uses the correct thickness. The real collision margin is restored after add_shape.
+                inertia_margin = float(shell_thickness_val) if shell_thickness_val is not None else margin_val
+
                 shape_params = {
                     "body": body_id,
                     "xform": shape_xform,
@@ -2688,7 +2703,7 @@ def parse_usd(
                         ka=usd.get_float_with_fallback(
                             prim_and_scene, "newton:contact_ka", builder.default_shape_cfg.ka
                         ),
-                        margin=margin_val,
+                        margin=inertia_margin,
                         gap=gap_val,
                         mu=material.dynamicFriction,
                         restitution=material.restitution,
@@ -2697,6 +2712,7 @@ def parse_usd(
                         density=shape_density,
                         collision_group=collision_group,
                         is_visible=collider_is_visible,
+                        is_solid=shape_is_solid,
                     ),
                     "label": path,
                     "custom_attributes": shape_custom_attrs,
@@ -2809,6 +2825,12 @@ def parse_usd(
                 path_shape_map[path] = shape_id
                 path_shape_scale[path] = scale
 
+                # Restore the real collision margin when shell thickness was substituted.
+                # TODO: Consider adding a dedicated shell_thickness field to ShapeConfig
+                # so inertia thickness and collision margin don't share the same slot.
+                if shell_thickness_val is not None and shape_id >= 0:
+                    builder.shape_margin[shape_id] = margin_val
+
                 if body_path in bodies_requiring_mass_properties_fallback:
                     # Prepare collider mass information for ComputeMassProperties fallback path.
                     # Prefer authored collider MassAPI mass+diagonalInertia; otherwise derive
@@ -2857,6 +2879,8 @@ def parse_usd(
                                 shape_scale,
                                 shape_src,
                                 shape_axis,
+                                is_solid=shape_is_solid,
+                                thickness=inertia_margin,
                             )
                         if mass_info is not None:
                             rigid_body_mass_info_map[path] = mass_info
@@ -3032,6 +3056,35 @@ def parse_usd(
             has_authored_inertia = mass_api.GetDiagonalInertiaAttr().HasAuthoredValue()
             has_authored_com = mass_api.GetCenterOfMassAttr().HasAuthoredValue()
 
+            # newton:inertia (compact 6-element tensor) overrides physics:diagonalInertia + physics:principalAxes.
+            inertia_tensor_val = (
+                usd.get_attribute(prim, "newton:inertia") if usd.has_applied_api_schema(prim, "NewtonMassAPI") else None
+            )
+            has_inertia_tensor = inertia_tensor_val is not None
+            if has_inertia_tensor:
+                if len(inertia_tensor_val) != 6:
+                    warnings.warn(
+                        f"Body {body_path}: newton:inertia has {len(inertia_tensor_val)} elements, expected 6. Ignoring.",
+                        stacklevel=2,
+                    )
+                    has_inertia_tensor = False
+                elif not all(math.isfinite(v) for v in inertia_tensor_val):
+                    warnings.warn(
+                        f"Body {body_path}: newton:inertia contains non-finite values. Ignoring.",
+                        stacklevel=2,
+                    )
+                    has_inertia_tensor = False
+                elif any(v < 0.0 for v in inertia_tensor_val[:3]):
+                    warnings.warn(
+                        f"Body {body_path}: newton:inertia has negative diagonal elements. Ignoring.",
+                        stacklevel=2,
+                    )
+                    has_inertia_tensor = False
+                else:
+                    has_authored_inertia = True
+                    ixx, iyy, izz, ixy, ixz, iyz = inertia_tensor_val
+                    inertia_tensor = wp.mat33(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)
+
             # Compute baseline mass properties via mass computer when at least one property needs resolving.
             if not (has_authored_mass and has_authored_inertia and has_authored_com):
                 rigid_body_api = UsdPhysics.RigidBodyAPI(prim)
@@ -3061,11 +3114,13 @@ def parse_usd(
                     cmp_i_diag = Gf.Vec3f(0.0, 0.0, 0.0)
                     cmp_principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
 
-            # Inertia: authored diagonal + principal axes take precedence over mass computer.
+            # Inertia: newton:inertia > physics:diagonalInertia + physics:principalAxes > mass computer.
             # When mass is authored but inertia is not, keep accumulated inertia
             # (scaled to match authored mass below) instead of using mass computer
             # inertia, which may already reflect the authored mass.
-            if has_authored_inertia:
+            if has_inertia_tensor:
+                i_diag_np = None  # skip diagonal path; full matrix set below
+            elif has_authored_inertia:
                 i_diag_np = np.array(mass_api.GetDiagonalInertiaAttr().Get(), dtype=np.float32)
                 if np.any(i_diag_np < 0.0):
                     warnings.warn(
@@ -3087,7 +3142,13 @@ def parse_usd(
                 # Mass authored, inertia not: keep accumulated inertia and scale
                 # to match authored mass in the mass block below.
                 i_diag_np = None
-            if i_diag_np is not None and np.linalg.norm(i_diag_np) > 0.0:
+            if has_inertia_tensor:
+                builder.body_inertia[body_id] = inertia_tensor
+                if inertia_tensor != wp.mat33(0.0):
+                    builder.body_inv_inertia[body_id] = wp.inverse(inertia_tensor)
+                else:
+                    builder.body_inv_inertia[body_id] = wp.mat33(0.0)
+            elif i_diag_np is not None and np.linalg.norm(i_diag_np) > 0.0:
                 i_rot = usd.value_to_warp(principal_axes)
                 rot = np.array(wp.quat_to_matrix(i_rot), dtype=np.float32).reshape(3, 3)
                 inertia = rot @ np.diag(i_diag_np) @ rot.T

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2835,7 +2835,7 @@ def parse_usd(
                 # Restore the real collision margin when shell thickness was substituted.
                 # TODO: Consider adding a dedicated shell_thickness field to ShapeConfig
                 # so inertia thickness and collision margin don't share the same slot.
-                if shell_thickness_val is not None and shape_id >= 0:
+                if shell_thickness_val is not None and math.isfinite(float(shell_thickness_val)) and shape_id >= 0:
                     builder.shape_margin[shape_id] = margin_val
 
                 if body_path in bodies_requiring_mass_properties_fallback:

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3089,8 +3089,13 @@ def parse_usd(
                     has_inertia_tensor = False
                 else:
                     ixx, iyy, izz, ixy, ixz, iyz = inertia_tensor_val
-                    inertia_np = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)
-                    if np.any(np.linalg.eigvalsh(inertia_np) < 0.0):
+                    # Principal minors check for positive semidefiniteness (no numpy needed).
+                    if (
+                        ixx * iyy - ixy * ixy < 0.0
+                        or ixx * izz - ixz * ixz < 0.0
+                        or iyy * izz - iyz * iyz < 0.0
+                        or wp.determinant(wp.mat33(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)) < 0.0
+                    ):
                         warnings.warn(
                             f"Body {body_path}: newton:inertia is not positive semidefinite. Ignoring.",
                             stacklevel=2,
@@ -3159,8 +3164,7 @@ def parse_usd(
                 i_diag_np = None
             if has_inertia_tensor:
                 builder.body_inertia[body_id] = inertia_tensor
-                det = np.linalg.det(np.array(inertia_tensor).reshape(3, 3))
-                if det > 0.0:
+                if wp.determinant(inertia_tensor) > 0.0:
                     builder.body_inv_inertia[body_id] = wp.inverse(inertia_tensor)
                 else:
                     builder.body_inv_inertia[body_id] = wp.mat33(0.0)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2686,7 +2686,14 @@ def parse_usd(
                 shell_thickness_val = R.get_value(prim, PrimType.SHAPE, "shell_thickness")
                 # When shell thickness is authored, pass it as margin so compute_inertia_shape
                 # uses the correct thickness. The real collision margin is restored after add_shape.
-                inertia_margin = float(shell_thickness_val) if shell_thickness_val is not None else margin_val
+                if (
+                    shell_thickness_val is not None
+                    and math.isfinite(float(shell_thickness_val))
+                    and float(shell_thickness_val) >= 0.0
+                ):
+                    inertia_margin = float(shell_thickness_val)
+                else:
+                    inertia_margin = margin_val
 
                 shape_params = {
                     "body": body_id,
@@ -3078,9 +3085,17 @@ def parse_usd(
                     )
                     has_inertia_tensor = False
                 else:
-                    has_authored_inertia = True
                     ixx, iyy, izz, ixy, ixz, iyz = inertia_tensor_val
-                    inertia_tensor = wp.mat33(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)
+                    inertia_np = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)
+                    if np.any(np.linalg.eigvalsh(inertia_np) < 0.0):
+                        warnings.warn(
+                            f"Body {body_path}: newton:inertia is not positive semidefinite. Ignoring.",
+                            stacklevel=2,
+                        )
+                        has_inertia_tensor = False
+                    else:
+                        has_authored_inertia = True
+                        inertia_tensor = wp.mat33(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)
 
             # Compute baseline mass properties via mass computer when at least one property needs resolving.
             if not (has_authored_mass and has_authored_inertia and has_authored_com):
@@ -3141,7 +3156,8 @@ def parse_usd(
                 i_diag_np = None
             if has_inertia_tensor:
                 builder.body_inertia[body_id] = inertia_tensor
-                if inertia_tensor != wp.mat33(0.0):
+                det = np.linalg.det(np.array(inertia_tensor).reshape(3, 3))
+                if det > 0.0:
                     builder.body_inv_inertia[body_id] = wp.inverse(inertia_tensor)
                 else:
                     builder.body_inv_inertia[body_id] = wp.mat33(0.0)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3089,13 +3089,8 @@ def parse_usd(
                     has_inertia_tensor = False
                 else:
                     ixx, iyy, izz, ixy, ixz, iyz = inertia_tensor_val
-                    # Principal minors check for positive semidefiniteness (no numpy needed).
-                    if (
-                        ixx * iyy - ixy * ixy < 0.0
-                        or ixx * izz - ixz * ixz < 0.0
-                        or iyy * izz - iyz * iyz < 0.0
-                        or wp.determinant(wp.mat33(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz)) < 0.0
-                    ):
+                    inertia_np = np.array([[ixx, ixy, ixz], [ixy, iyy, iyz], [ixz, iyz, izz]], dtype=np.float64)
+                    if np.any(np.linalg.eigvalsh(inertia_np) < 0.0):
                         warnings.warn(
                             f"Body {body_path}: newton:inertia is not positive semidefinite. Ignoring.",
                             stacklevel=2,
@@ -3164,7 +3159,8 @@ def parse_usd(
                 i_diag_np = None
             if has_inertia_tensor:
                 builder.body_inertia[body_id] = inertia_tensor
-                if wp.determinant(inertia_tensor) > 0.0:
+                det = np.linalg.det(np.array(inertia_tensor).reshape(3, 3))
+                if det > 0.0:
                     builder.body_inv_inertia[body_id] = wp.inverse(inertia_tensor)
                 else:
                     builder.body_inv_inertia[body_id] = wp.mat33(0.0)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2686,12 +2686,15 @@ def parse_usd(
                 shell_thickness_val = R.get_value(prim, PrimType.SHAPE, "shell_thickness")
                 # When shell thickness is authored, pass it as margin so compute_inertia_shape
                 # uses the correct thickness. The real collision margin is restored after add_shape.
-                if (
-                    shell_thickness_val is not None
-                    and math.isfinite(float(shell_thickness_val))
-                    and float(shell_thickness_val) >= 0.0
-                ):
-                    inertia_margin = float(shell_thickness_val)
+                if shell_thickness_val is not None and math.isfinite(float(shell_thickness_val)):
+                    if float(shell_thickness_val) >= 0.0:
+                        inertia_margin = float(shell_thickness_val)
+                    else:
+                        warnings.warn(
+                            f"Shape {path}: negative shell thickness {shell_thickness_val}; falling back to margin.",
+                            stacklevel=2,
+                        )
+                        inertia_margin = margin_val
                 else:
                     inertia_margin = margin_val
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2680,13 +2680,10 @@ def parse_usd(
 
                 shape_color = material_props.get("color")
 
-                # NewtonMassAPI: mass model and shell thickness
-                has_newton_mass = usd.has_applied_api_schema(prim, "NewtonMassAPI")
-                mass_model = usd.get_attribute(prim, "newton:massModel", "solid") if has_newton_mass else "solid"
+                # Mass model and shell thickness (resolved across Newton / MuJoCo schemas)
+                mass_model = R.get_value(prim, PrimType.SHAPE, "mass_model", default="solid")
                 shape_is_solid = mass_model != "shell"
-                shell_thickness_val = usd.get_attribute(prim, "newton:shellThickness") if has_newton_mass else None
-                if shell_thickness_val is not None and shell_thickness_val == float("-inf"):
-                    shell_thickness_val = None
+                shell_thickness_val = R.get_value(prim, PrimType.SHAPE, "shell_thickness")
                 # When shell thickness is authored, pass it as margin so compute_inertia_shape
                 # uses the correct thickness. The real collision margin is restored after add_shape.
                 inertia_margin = float(shell_thickness_val) if shell_thickness_val is not None else margin_val

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3771,6 +3771,343 @@ def Xform "TestBody" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_newton_mass_api_parsing(self):
+        """Exhaustive test of NewtonMassAPI mass/inertia combinations.
+
+        Axes tested:
+          Mass source:    explicit physics:mass  vs  density-derived
+          Inertia source: newton:inertia  vs  physics:diagonalInertia  vs  density-derived
+          Shape mode:     solid  vs  shell+thickness  vs  shell+margin-fallback
+        """
+        from pxr import Usd
+
+        R = 0.5
+        density = 1000.0
+        shell_t = 0.05
+        margin_t = 0.03
+        authored_mass = 10.0
+
+        solid_mass = 4.0 / 3.0 * np.pi * R**3 * density
+        solid_I = 2.0 / 5.0 * solid_mass * R**2
+
+        def _shell_mass(t):
+            return 4.0 / 3.0 * np.pi * (R**3 - (R - t) ** 3) * density
+
+        def _shell_I(t):
+            m_outer = solid_mass
+            m_inner = 4.0 / 3.0 * np.pi * (R - t) ** 3 * density
+            return 2.0 / 5.0 * m_outer * R**2 - 2.0 / 5.0 * m_inner * (R - t) ** 2
+
+        def _scaled_I(shape_I, shape_mass, target_mass):
+            return shape_I * target_mass / shape_mass
+
+        usd_content = """#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def PhysicsScene "physicsScene"
+{
+}
+
+# 1) Shell + thickness + authored mass, no inertia → shell-derived inertia scaled to mass
+def Xform "ShellThicknessMass" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (0, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 10.0
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+    )
+    {
+        double radius = 0.5
+        uniform token newton:massModel = "shell"
+        float newton:shellThickness = 0.05
+    }
+}
+
+# 2) Shell + margin fallback + authored mass, no inertia → margin used as thickness
+def Xform "ShellMarginMass" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (2, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 10.0
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+    )
+    {
+        double radius = 0.5
+        uniform token newton:massModel = "shell"
+        float newton:contactMargin = 0.03
+    }
+}
+
+# 3) Solid + authored mass, no inertia → solid inertia scaled to mass
+def Xform "SolidMass" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (4, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 10.0
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+
+# 4) Explicit mass + newton:inertia tensor + shell collider
+def Xform "ExplicitTensor" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (6, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 5.0
+    double[] newton:inertia = [1.0, 2.0, 3.0, 0.1, 0.2, 0.3]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+    )
+    {
+        double radius = 0.5
+        uniform token newton:massModel = "shell"
+        float newton:shellThickness = 0.01
+    }
+}
+
+# 5) Explicit mass + diagonalInertia (no newton:inertia)
+def Xform "ExplicitDiag" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (8, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 3.0
+    float3 physics:diagonalInertia = (0.5, 1.0, 1.5)
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+
+# 6) Solid, no authored mass or inertia (all density-derived via mass computer)
+def Xform "SolidDensity" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (10, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+
+# 7) Shell, no authored mass or inertia (all density-derived via mass computer)
+def Xform "ShellDensity" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (12, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+    )
+    {
+        double radius = 0.5
+        uniform token newton:massModel = "shell"
+        float newton:shellThickness = 0.05
+    }
+}
+"""
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(usd_content)
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        self.assertEqual(builder.body_count, 7)
+        self.assertEqual(builder.shape_count, 7)
+
+        # --- 1) Shell + thickness + authored mass: inertia from shell geometry, scaled ---
+        body_id = builder.body_label.index("/ShellThicknessMass")
+        shape_idx = builder.shape_label.index("/ShellThicknessMass/Collider")
+        self.assertFalse(builder.shape_is_solid[shape_idx])
+        self.assertAlmostEqual(builder.body_mass[body_id], authored_mass, places=5)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected_shell_I = _scaled_I(_shell_I(shell_t), _shell_mass(shell_t), authored_mass)
+        np.testing.assert_allclose(np.diag(inertia), [expected_shell_I] * 3, rtol=1e-4)
+
+        # --- 2) Shell + margin fallback: different thickness → different inertia ---
+        body_id = builder.body_label.index("/ShellMarginMass")
+        shape_idx = builder.shape_label.index("/ShellMarginMass/Collider")
+        self.assertFalse(builder.shape_is_solid[shape_idx])
+        self.assertAlmostEqual(builder.body_mass[body_id], authored_mass, places=5)
+        inertia2 = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected_margin_I = _scaled_I(_shell_I(margin_t), _shell_mass(margin_t), authored_mass)
+        np.testing.assert_allclose(np.diag(inertia2), [expected_margin_I] * 3, rtol=1e-4)
+        # Thinner shell → higher I/m ratio → different inertia than body 1
+        self.assertFalse(
+            np.allclose(np.diag(inertia), np.diag(inertia2), atol=1e-3),
+            "Shell thickness vs margin fallback should produce different inertia",
+        )
+
+        # --- 3) Solid + authored mass: solid inertia, scaled ---
+        body_id = builder.body_label.index("/SolidMass")
+        shape_idx = builder.shape_label.index("/SolidMass/Collider")
+        self.assertTrue(builder.shape_is_solid[shape_idx])
+        self.assertAlmostEqual(builder.body_mass[body_id], authored_mass, places=5)
+        inertia3 = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected_solid_I = _scaled_I(solid_I, solid_mass, authored_mass)
+        np.testing.assert_allclose(np.diag(inertia3), [expected_solid_I] * 3, rtol=1e-4)
+        # Shell inertia/mass ratio > solid inertia/mass ratio at same authored mass
+        self.assertGreater(np.diag(inertia)[0], np.diag(inertia3)[0])
+
+        # --- 4) Explicit mass + newton:inertia tensor + shell collider ---
+        body_id = builder.body_label.index("/ExplicitTensor")
+        shape_idx = builder.shape_label.index("/ExplicitTensor/Collider")
+        self.assertFalse(builder.shape_is_solid[shape_idx])
+        self.assertAlmostEqual(builder.body_mass[body_id], 5.0, places=5)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected = np.array([[1.0, 0.1, 0.2], [0.1, 2.0, 0.3], [0.2, 0.3, 3.0]])
+        np.testing.assert_allclose(inertia, expected, atol=1e-5)
+
+        # --- 5) Explicit mass + diagonalInertia ---
+        body_id = builder.body_label.index("/ExplicitDiag")
+        self.assertAlmostEqual(builder.body_mass[body_id], 3.0, places=5)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        np.testing.assert_allclose(np.diag(inertia), [0.5, 1.0, 1.5], atol=1e-5)
+        np.testing.assert_allclose(inertia - np.diag(np.diag(inertia)), np.zeros((3, 3)), atol=1e-7)
+
+        # --- 6) Solid, density-derived mass & inertia (no authored values) ---
+        body_id = builder.body_label.index("/SolidDensity")
+        shape_idx = builder.shape_label.index("/SolidDensity/Collider")
+        self.assertTrue(builder.shape_is_solid[shape_idx])
+        self.assertGreater(builder.body_mass[body_id], 0.0)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        self.assertGreater(np.trace(inertia), 0.0)
+
+        # --- 7) Shell, density-derived mass & inertia (no authored values) ---
+        body_id = builder.body_label.index("/ShellDensity")
+        shape_idx = builder.shape_label.index("/ShellDensity/Collider")
+        self.assertFalse(builder.shape_is_solid[shape_idx])
+        solid_density_id = builder.body_label.index("/SolidDensity")
+        self.assertLess(builder.body_mass[body_id], builder.body_mass[solid_density_id])
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        self.assertGreater(np.trace(inertia), 0.0)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_newton_inertia_tensor_validation(self):
+        """Malformed newton:inertia tensors emit warnings and fall back to shape-derived values."""
+        from pxr import Usd
+
+        usd_content = """#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def PhysicsScene "physicsScene"
+{
+}
+
+def Xform "NonFinite" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (0, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    double[] newton:inertia = [1.0, 2.0, inf, 0.0, 0.0, 0.0]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+
+def Xform "NegativeDiag" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (2, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    double[] newton:inertia = [-1.0, 2.0, 3.0, 0.0, 0.0, 0.0]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+
+def Xform "WrongLength" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (4, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    double[] newton:inertia = [1.0, 2.0, 3.0]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
+"""
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(usd_content)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            builder = newton.ModelBuilder()
+            builder.add_usd(stage)
+
+        self.assertEqual(builder.body_count, 3)
+
+        body_id = builder.body_label.index("/NonFinite")
+        self.assertGreater(builder.body_mass[body_id], 0.0)
+
+        body_id = builder.body_label.index("/NegativeDiag")
+        self.assertGreater(builder.body_mass[body_id], 0.0)
+
+        body_id = builder.body_label.index("/WrongLength")
+        self.assertGreater(builder.body_mass[body_id], 0.0)
+
+        warning_messages = [str(w.message) for w in caught]
+        self.assertTrue(any("non-finite" in m for m in warning_messages))
+        self.assertTrue(any("negative diagonal" in m for m in warning_messages))
+        self.assertTrue(any("expected 6" in m for m in warning_messages))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_import_usd_gravcomp(self):
         """Test parsing of gravcomp from USD"""
         from pxr import Sdf, Usd, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3878,6 +3878,7 @@ def Xform "ExplicitTensor" (
 
     float physics:mass = 5.0
     double[] newton:inertia = [1.0, 2.0, 3.0, 0.1, 0.2, 0.3]
+    float3 physics:diagonalInertia = (9.0, 9.0, 9.0)
 
     def Sphere "Collider" (
         prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
@@ -4082,6 +4083,23 @@ def Xform "WrongLength" (
         double radius = 0.5
     }
 }
+
+def Xform "NotPSD" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (6, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    double[] newton:inertia = [1.0, 1.0, 1.0, 5.0, 5.0, 5.0]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
 """
         stage = Usd.Stage.CreateInMemory()
         stage.GetRootLayer().ImportFromString(usd_content)
@@ -4091,7 +4109,7 @@ def Xform "WrongLength" (
             builder = newton.ModelBuilder()
             builder.add_usd(stage)
 
-        self.assertEqual(builder.body_count, 3)
+        self.assertEqual(builder.body_count, 4)
 
         body_id = builder.body_label.index("/NonFinite")
         self.assertGreater(builder.body_mass[body_id], 0.0)
@@ -4102,10 +4120,14 @@ def Xform "WrongLength" (
         body_id = builder.body_label.index("/WrongLength")
         self.assertGreater(builder.body_mass[body_id], 0.0)
 
+        body_id = builder.body_label.index("/NotPSD")
+        self.assertGreater(builder.body_mass[body_id], 0.0)
+
         warning_messages = [str(w.message) for w in caught]
-        self.assertTrue(any("non-finite" in m for m in warning_messages))
-        self.assertTrue(any("negative diagonal" in m for m in warning_messages))
-        self.assertTrue(any("expected 6" in m for m in warning_messages))
+        self.assertTrue(any("non-finite" in m and "NonFinite" in m for m in warning_messages))
+        self.assertTrue(any("negative diagonal" in m and "NegativeDiag" in m for m in warning_messages))
+        self.assertTrue(any("expected 6" in m and "WrongLength" in m for m in warning_messages))
+        self.assertTrue(any("not positive semidefinite" in m and "NotPSD" in m for m in warning_messages))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_import_usd_gravcomp(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3982,6 +3982,25 @@ def Xform "SingularTensor" (
         double radius = 0.5
     }
 }
+
+# 10) newton:inertia without physics:diagonalInertia
+def Xform "TensorOnly" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (18, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 4.0
+    double[] newton:inertia = [1.0, 2.0, 3.0, 0.1, 0.2, 0.3]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
 """
         stage = Usd.Stage.CreateInMemory()
         stage.GetRootLayer().ImportFromString(usd_content)
@@ -3991,8 +4010,8 @@ def Xform "SingularTensor" (
             builder = newton.ModelBuilder()
             builder.add_usd(stage)
 
-        self.assertEqual(builder.body_count, 9)
-        self.assertEqual(builder.shape_count, 9)
+        self.assertEqual(builder.body_count, 10)
+        self.assertEqual(builder.shape_count, 10)
 
         # --- 1) Shell + thickness + authored mass: inertia from shell geometry, scaled ---
         body_id = builder.body_label.index("/ShellThicknessMass")
@@ -4080,6 +4099,13 @@ def Xform "SingularTensor" (
         np.testing.assert_allclose(inertia, expected, atol=1e-5)
         inv_inertia = np.array(builder.body_inv_inertia[body_id]).reshape(3, 3)
         np.testing.assert_allclose(inv_inertia, np.zeros((3, 3)), atol=1e-7)
+
+        # --- 10) newton:inertia without physics:diagonalInertia ---
+        body_id = builder.body_label.index("/TensorOnly")
+        self.assertAlmostEqual(builder.body_mass[body_id], 4.0, places=5)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected = np.array([[1.0, 0.1, 0.2], [0.1, 2.0, 0.3], [0.2, 0.3, 3.0]])
+        np.testing.assert_allclose(inertia, expected, atol=1e-5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_newton_inertia_tensor_validation(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3963,6 +3963,25 @@ def Xform "NegativeThickness" (
         float newton:contactMargin = 0.03
     }
 }
+
+# 9) Singular PSD inertia tensor (valid but non-invertible)
+def Xform "SingularTensor" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+)
+{
+    double3 xformOp:translate = (16, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 2.0
+    double[] newton:inertia = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.5
+    }
+}
 """
         stage = Usd.Stage.CreateInMemory()
         stage.GetRootLayer().ImportFromString(usd_content)
@@ -3972,8 +3991,8 @@ def Xform "NegativeThickness" (
             builder = newton.ModelBuilder()
             builder.add_usd(stage)
 
-        self.assertEqual(builder.body_count, 8)
-        self.assertEqual(builder.shape_count, 8)
+        self.assertEqual(builder.body_count, 9)
+        self.assertEqual(builder.shape_count, 9)
 
         # --- 1) Shell + thickness + authored mass: inertia from shell geometry, scaled ---
         body_id = builder.body_label.index("/ShellThicknessMass")
@@ -4052,6 +4071,15 @@ def Xform "NegativeThickness" (
         np.testing.assert_allclose(np.diag(inertia_neg), [expected_neg_I] * 3, rtol=1e-4)
         warning_messages = [str(w.message) for w in caught]
         self.assertTrue(any("negative shell thickness" in m and "NegativeThickness" in m for m in warning_messages))
+
+        # --- 9) Singular PSD tensor: valid but non-invertible, inv_inertia set to zero ---
+        body_id = builder.body_label.index("/SingularTensor")
+        self.assertAlmostEqual(builder.body_mass[body_id], 2.0, places=5)
+        inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected = np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        np.testing.assert_allclose(inertia, expected, atol=1e-5)
+        inv_inertia = np.array(builder.body_inv_inertia[body_id]).reshape(3, 3)
+        np.testing.assert_allclose(inv_inertia, np.zeros((3, 3)), atol=1e-7)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_newton_inertia_tensor_validation(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3954,12 +3954,13 @@ def Xform "NegativeThickness" (
     float physics:mass = 10.0
 
     def Sphere "Collider" (
-        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI", "NewtonCollisionAPI"]
     )
     {
         double radius = 0.5
         uniform token newton:massModel = "shell"
         float newton:shellThickness = -0.5
+        float newton:contactMargin = 0.03
     }
 }
 """
@@ -4041,11 +4042,14 @@ def Xform "NegativeThickness" (
         inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
         self.assertGreater(np.trace(inertia), 0.0)
 
-        # --- 8) Negative shell thickness: warning emitted, falls back to margin ---
+        # --- 8) Negative shell thickness: warning, falls back to margin, inertia matches margin path ---
         body_id = builder.body_label.index("/NegativeThickness")
         shape_idx = builder.shape_label.index("/NegativeThickness/Collider")
         self.assertFalse(builder.shape_is_solid[shape_idx])
         self.assertAlmostEqual(builder.body_mass[body_id], 10.0, places=5)
+        inertia_neg = np.array(builder.body_inertia[body_id]).reshape(3, 3)
+        expected_neg_I = _scaled_I(_shell_I(margin_t), _shell_mass(margin_t), 10.0)
+        np.testing.assert_allclose(np.diag(inertia_neg), [expected_neg_I] * 3, rtol=1e-4)
         warning_messages = [str(w.message) for w in caught]
         self.assertTrue(any("negative shell thickness" in m and "NegativeThickness" in m for m in warning_messages))
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3841,7 +3841,7 @@ def Xform "ShellMarginMass" (
     float physics:mass = 10.0
 
     def Sphere "Collider" (
-        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonCollisionAPI", "NewtonMassAPI"]
     )
     {
         double radius = 0.5

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3942,15 +3942,37 @@ def Xform "ShellDensity" (
         float newton:shellThickness = 0.05
     }
 }
+
+# 8) Shell with negative thickness → warning, falls back to margin
+def Xform "NegativeThickness" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+)
+{
+    double3 xformOp:translate = (14, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    float physics:mass = 10.0
+
+    def Sphere "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonMassAPI"]
+    )
+    {
+        double radius = 0.5
+        uniform token newton:massModel = "shell"
+        float newton:shellThickness = -0.5
+    }
+}
 """
         stage = Usd.Stage.CreateInMemory()
         stage.GetRootLayer().ImportFromString(usd_content)
 
-        builder = newton.ModelBuilder()
-        builder.add_usd(stage)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            builder = newton.ModelBuilder()
+            builder.add_usd(stage)
 
-        self.assertEqual(builder.body_count, 7)
-        self.assertEqual(builder.shape_count, 7)
+        self.assertEqual(builder.body_count, 8)
+        self.assertEqual(builder.shape_count, 8)
 
         # --- 1) Shell + thickness + authored mass: inertia from shell geometry, scaled ---
         body_id = builder.body_label.index("/ShellThicknessMass")
@@ -4018,6 +4040,14 @@ def Xform "ShellDensity" (
         self.assertLess(builder.body_mass[body_id], builder.body_mass[solid_density_id])
         inertia = np.array(builder.body_inertia[body_id]).reshape(3, 3)
         self.assertGreater(np.trace(inertia), 0.0)
+
+        # --- 8) Negative shell thickness: warning emitted, falls back to margin ---
+        body_id = builder.body_label.index("/NegativeThickness")
+        shape_idx = builder.shape_label.index("/NegativeThickness/Collider")
+        self.assertFalse(builder.shape_is_solid[shape_idx])
+        self.assertAlmostEqual(builder.body_mass[body_id], 10.0, places=5)
+        warning_messages = [str(w.message) for w in caught]
+        self.assertTrue(any("negative shell thickness" in m and "NegativeThickness" in m for m in warning_messages))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_newton_inertia_tensor_validation(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -3870,7 +3870,7 @@ def Xform "SolidMass" (
 
 # 4) Explicit mass + newton:inertia tensor + shell collider
 def Xform "ExplicitTensor" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (6, 0, 1)
@@ -3966,7 +3966,7 @@ def Xform "NegativeThickness" (
 
 # 9) Singular PSD inertia tensor (valid but non-invertible)
 def Xform "SingularTensor" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (16, 0, 1)
@@ -4096,7 +4096,7 @@ def PhysicsScene "physicsScene"
 }
 
 def Xform "NonFinite" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (0, 0, 1)
@@ -4113,7 +4113,7 @@ def Xform "NonFinite" (
 }
 
 def Xform "NegativeDiag" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (2, 0, 1)
@@ -4130,7 +4130,7 @@ def Xform "NegativeDiag" (
 }
 
 def Xform "WrongLength" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (4, 0, 1)
@@ -4147,7 +4147,7 @@ def Xform "WrongLength" (
 }
 
 def Xform "NotPSD" (
-    prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "NewtonMassAPI"]
+    prepend apiSchemas = ["PhysicsRigidBodyAPI", "NewtonMassAPI"]
 )
 {
     double3 xformOp:translate = (6, 0, 1)

--- a/newton/tests/test_schema_resolver.py
+++ b/newton/tests/test_schema_resolver.py
@@ -1632,6 +1632,59 @@ class TestSchemaResolver(unittest.TestCase):
         self.assertAlmostEqual(rolling, 0.1)
         self.assertAlmostEqual(torsional, 0.2)
 
+    def test_mass_model(self):
+        """Test mass_model resolution: newton:massModel and mjc:shellinertia."""
+        stage = Usd.Stage.CreateInMemory()
+        xform = UsdGeom.Xform.Define(stage, "/xform").GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(xform)
+        collider = UsdGeom.Sphere.Define(stage, "/xform/collider").GetPrim()
+        UsdPhysics.CollisionAPI.Apply(collider)
+
+        # No authored value → default "solid"
+        resolver = SchemaResolverManager([SchemaResolverNewton()])
+        mass_model = resolver.get_value(collider, PrimType.SHAPE, "mass_model")
+        self.assertEqual(mass_model, "solid")
+
+        # newton:massModel authored
+        collider.CreateAttribute("newton:massModel", Sdf.ValueTypeNames.Token).Set("shell")
+        mass_model = resolver.get_value(collider, PrimType.SHAPE, "mass_model")
+        self.assertEqual(mass_model, "shell")
+
+        # mjc:shellinertia = True → "shell"
+        resolver = SchemaResolverManager([SchemaResolverMjc(), SchemaResolverNewton()])
+        collider2 = UsdGeom.Sphere.Define(stage, "/xform/collider2").GetPrim()
+        UsdPhysics.CollisionAPI.Apply(collider2)
+        collider2.CreateAttribute("mjc:shellinertia", Sdf.ValueTypeNames.Bool).Set(True)
+        mass_model = resolver.get_value(collider2, PrimType.SHAPE, "mass_model")
+        self.assertEqual(mass_model, "shell")
+
+        # mjc:shellinertia = False → "solid"
+        collider2.GetAttribute("mjc:shellinertia").Set(False)
+        mass_model = resolver.get_value(collider2, PrimType.SHAPE, "mass_model")
+        self.assertEqual(mass_model, "solid")
+
+        # Newton priority over MuJoCo: newton:massModel wins
+        resolver = SchemaResolverManager([SchemaResolverNewton(), SchemaResolverMjc()])
+        collider.GetAttribute("newton:massModel").Set("solid")
+        collider.CreateAttribute("mjc:shellinertia", Sdf.ValueTypeNames.Bool).Set(True)
+        mass_model = resolver.get_value(collider, PrimType.SHAPE, "mass_model")
+        self.assertEqual(mass_model, "solid")
+
+        # Full import: mjc:shellinertia produces correct is_solid on shape
+        UsdPhysics.MassAPI.Apply(xform).CreateMassAttr().Set(10.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+        collider.GetAttribute("mjc:shellinertia").Set(True)
+        collider.CreateAttribute("mjc:margin", Sdf.ValueTypeNames.Float).Set(0.05)
+        # Remove newton:massModel so MjcResolver takes effect
+        collider.GetAttribute("newton:massModel").Clear()
+
+        builder = ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(stage, schema_resolvers=[SchemaResolverMjc(), SchemaResolverNewton()])
+
+        shell_idx = builder.shape_label.index("/xform/collider")
+        self.assertFalse(builder.shape_is_solid[shell_idx])
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.2.0",
+    "newton-usd-schemas>=0.3.0b1",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.3.0b1",
+    "newton-usd-schemas>=0.3.0",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -3704,7 +3704,7 @@ requires-dist = [
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
     { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.2.0" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.3.0b1" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.16.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
@@ -3754,11 +3754,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.2.0"
+version = "0.3.0b1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/9c/5a40c3fd86975172e01d46872e3f0b2c08409e22bdcac9d75e1e814f2e71/newton_usd_schemas-0.2.0.tar.gz", hash = "sha256:b483a029e54f4a7b06d3156c47860e3e8b77e33e3ee4c4fd525c335d74f898a0", size = 69375, upload-time = "2026-05-07T17:53:51.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/df/3fb4d01a0fd0b3f9d66349cac306c95cad9ccba694d38a64d6cc27bfcba9/newton_usd_schemas-0.3.0b1.tar.gz", hash = "sha256:515555aadf34c6a06290d25a4a93bb7d387d435386377bbc2bfb35c598d38883", size = 66248, upload-time = "2026-05-27T16:37:43.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/7c/79ff957c828116966894268a749eccf455e4d11f08ef66ea681084c3faaa/newton_usd_schemas-0.2.0-py3-none-any.whl", hash = "sha256:b6402affb6cdc59b0a237994ee5196cc1b43f04f766e527b7e6ef061c0719acf", size = 15551, upload-time = "2026-05-07T17:53:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/ff2a608bc2ad6fa72e2e8e6d5bcaeb95d5dbc57a85140e142f4bb884a3c6/newton_usd_schemas-0.3.0b1-py3-none-any.whl", hash = "sha256:4a3f877649ac3065089a7de8297194fa3450b5b48aa572de0a81b5cf371fee8d", size = 17810, upload-time = "2026-05-27T16:37:41.724Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3704,7 +3704,7 @@ requires-dist = [
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
     { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.3.0b1" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.3.0" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.16.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
@@ -3754,11 +3754,11 @@ wheels = [
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.3.0b1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/df/3fb4d01a0fd0b3f9d66349cac306c95cad9ccba694d38a64d6cc27bfcba9/newton_usd_schemas-0.3.0b1.tar.gz", hash = "sha256:515555aadf34c6a06290d25a4a93bb7d387d435386377bbc2bfb35c598d38883", size = 66248, upload-time = "2026-05-27T16:37:43.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/f7/83dd4a746f4620e1086cb0a5111b29436a3c7a48e49643116431cf78b266/newton_usd_schemas-0.3.0.tar.gz", hash = "sha256:99e32ddc215d3c9c22bb0387d2d0b458cc48555405b44d7e29bf2d0435bd5fea", size = 66860, upload-time = "2026-05-29T20:55:24.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/40/ff2a608bc2ad6fa72e2e8e6d5bcaeb95d5dbc57a85140e142f4bb884a3c6/newton_usd_schemas-0.3.0b1-py3-none-any.whl", hash = "sha256:4a3f877649ac3065089a7de8297194fa3450b5b48aa572de0a81b5cf371fee8d", size = 17810, upload-time = "2026-05-27T16:37:41.724Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6e/d5f48e38fe88fd6a74bd54774a12474e45fb070e40ef8cd398319d970360/newton_usd_schemas-0.3.0-py3-none-any.whl", hash = "sha256:d5714d896a6831368d00dc05f55df078047421d77b187e04b9b4ebaf7c16f478", size = 18153, upload-time = "2026-05-29T20:55:22.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add USD import support for `NewtonMassAPI` attributes: shell mass model (`newton:massModel`), shell thickness (`newton:shellThickness`), and compact 6-element inertia tensor (`newton:inertia`).

Requires `newton-usd-schemas>=0.3.0b1` which ships the final `NewtonMassAPI` schema.

### Shell mass model

When `newton:massModel` is set to `"shell"`, the importer computes shell (hollow) inertia for collider shapes instead of solid inertia. Shell thickness is sourced from `newton:shellThickness` when authored, falling back to the collision margin. The `_build_mass_info_from_shape_geometry` helper is now shell-aware so the density-derived mass computer path also produces correct shell inertia.

### Compact inertia tensor

`newton:inertia` accepts a 6-element array `[Ixx, Iyy, Izz, Ixy, Ixz, Iyz]` and takes precedence over `physics:diagonalInertia` + `physics:principalAxes`. Validation rejects tensors with wrong length, non-finite values, or negative diagonal elements, emitting warnings.

### SchemaResolver integration

`mass_model` and `shell_thickness` are surfaced through the `SchemaResolver` system so that MuJoCo-exported USD files with `mjc:shellinertia` are automatically resolved to the shell mass model without requiring `NewtonMassAPI` to be authored.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_newton_mass_api_parsing
uv run --extra dev -m newton.tests -k test_newton_inertia_tensor_validation
uv run --extra dev -m newton.tests -k test_mass_model
```

- `test_newton_mass_api_parsing` — 7 bodies covering all combinations of mass source (authored / density-derived) x inertia source (explicit tensor / diagonal / accumulated) x mass model (solid / shell with thickness / shell with margin fallback)
- `test_newton_inertia_tensor_validation` — 3 bodies with malformed `newton:inertia` (wrong length, non-finite values, negative diagonal) verifying warnings are emitted and tensors are ignored
- `test_mass_model` — SchemaResolver unit tests for `newton:massModel` and `mjc:shellinertia` resolution, priority ordering, and full-import integration verifying `is_solid` on the resulting shape

## New feature / API change

```python
import newton

# Shell mass model via USD attribute
# On a collider prim: newton:massModel = "shell", newton:shellThickness = 0.01
# The importer will compute hollow-shell inertia instead of solid inertia.

# Compact inertia tensor via USD attribute
# On a body prim: newton:inertia = [Ixx, Iyy, Izz, Ixy, Ixz, Iyz]
# Takes precedence over physics:diagonalInertia + physics:principalAxes.

# MuJoCo interop: mjc:shellinertia = true on a geom prim is automatically
# resolved to shell mass model through the SchemaResolver system.
```