### PR TITLE
docs: list all solver backends in guide overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Remove the `cbor2` `<6` dependency ceiling after updating recorder deserialization to accept mapping-like decoded containers
 - Require Warp 1.14 and configure Warp logging through `warp.config.log_level`; use Newton's `--quiet` flag or `--warp-config log_level=...` instead of legacy `verbose` or `quiet` config keys
+- Update guide overview to list all solver backends and reference the solver feature matrix
 - Auto-scale `ViewerGL` contact arrows, joint axes, and COM markers by `Viewer.scene_scale`; to approximate the previous fixed sizes after `set_model()`, set `viewer.renderer.arrow_length_scale = 0.1 / viewer.scene_scale`, `viewer.renderer.joint_scale = 0.1 / viewer.scene_scale`, and `viewer.renderer.com_scale = 0.1 / viewer.scene_scale`.
 
 ### Deprecated

--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -20,7 +20,9 @@ Key Features
 ------------
 
 * **GPU-accelerated**: Leverages NVIDIA Warp for fast, scalable simulation.
-* **Multiple solver implementations**: XPBD, VBD, MuJoCo, Featherstone, SemiImplicit.
+* **Multiple solver implementations**: Featherstone, ImplicitMPM, Kamino, MuJoCo,
+  SemiImplicit, Style3D, VBD, XPBD (see the :doc:`solver feature matrix
+  <../api/newton_solvers>`).
 * **Modular design**: Easily extendable with new solvers and components.
 * **Differentiable**: Supports differentiable simulation for machine learning and optimization.
 * **Rich Import/Export**: Load models from URDF, MJCF, USD, and more.
@@ -101,8 +103,9 @@ Core Concepts
   and forces applied during the simulation loop.
 - :doc:`Solver <../api/newton_solvers>`: Advances the simulation by
   integrating physics, handling contacts, and enforcing constraints.
-  Newton provides multiple solver backends, including XPBD, VBD,
-  MuJoCo, Featherstone, and SemiImplicit.
+  Newton provides multiple solver backends — see the
+  :doc:`solver feature matrix <../api/newton_solvers>` for the full
+  list and a feature comparison.
 - :doc:`Sensors <../concepts/sensors>`: Compute observations from
   :class:`~newton.State`, :class:`~newton.Contacts`, sites, and shapes.
   Many sensors rely on optional :doc:`extended attributes


### PR DESCRIPTION
The guide overview listed only five of the eight public solver backends. Update the Key Features bullet to enumerate all eight in the same alphabetical order used by the solver API reference, and replace the partial enumeration in the Core Concepts Solver bullet with a link to the solver feature matrix so the list is maintained in one place.

Addresses #2183.

## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guide overview to comprehensively list all available solver backends (ImplicitMPM, Kamino, MuJoCo SemiImplicit, Style3D, VBD, XPBD) with references to the solver feature matrix for detailed feature comparison information to assist users in selecting appropriate solvers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->