### PR TITLE
Fix nans when fusing fixed joints between massless bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
+- Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5030,7 +5030,10 @@ class ModelBuilder:
                         m, inertia, incoming_xform.p, incoming_xform.q
                     )
                     body_data[last_dynamic_body]["mass"] += m
-                    body_data[last_dynamic_body]["com"] = (m * com + source_m * source_com) / (m + source_m)
+                    total_mass = m + source_m
+                    if total_mass > 0.0:
+                        body_data[last_dynamic_body]["com"] = (m * com + source_m * source_com) / total_mass
+                    # else: both bodies massless; keep parent COM (avoids 0/0).
                     # indicate to recompute inverse mass, inertia for this body
                     body_data[last_dynamic_body]["inv_mass"] = None
             else:

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -749,6 +749,29 @@ class TestModelJoints(unittest.TestCase):
         self.assertAlmostEqual(builder.body_mass[0], 3.0)
         self.assertTrue(builder.body_lock_inertia[0])
 
+    def test_collapse_fixed_joints_massless_chain(self):
+        """Collapsing a chain of massless bodies into a positive-mass body must yield a finite center of mass."""
+        for use_articulation in (True, False):
+            with self.subTest(use_articulation=use_articulation):
+                builder = ModelBuilder()
+                root = builder.add_link(mass=0.0, label="massless_root")
+                dummy = builder.add_link(mass=0.0, label="massless_dummy")
+                mass_body = builder.add_link(mass=2.0, com=wp.vec3(1.0, 0.0, 0.0), label="mass_body")
+
+                joints = [
+                    builder.add_joint_free(parent=-1, child=root, label="floating_base"),
+                    builder.add_joint_fixed(parent=root, child=dummy, label="root_to_dummy"),
+                    builder.add_joint_fixed(parent=dummy, child=mass_body, label="dummy_to_mass_body"),
+                ]
+
+                if use_articulation:
+                    builder.add_articulation(joints)
+                builder.collapse_fixed_joints()
+
+                self.assertEqual(builder.body_count, 1)
+                self.assertAlmostEqual(builder.body_mass[0], 2.0)
+                assert_np_equal(np.array(builder.body_com[0]), np.array([1.0, 0.0, 0.0]))
+
     def test_collapse_fixed_joints_with_groups(self):
         """Test that collapse_fixed_joints correctly preserves world groups."""
         # Optionally enable debug printing


### PR DESCRIPTION
## Description

Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when the dynamic body and the merged source body both have zero mass. The previous code computed `(m * com +
source_m * source_com) / (m + source_m)`, which evaluates to `0/0` for two massless bodies and then poisons subsequent merges into the same chain. Guard the division and retain the parent
COM in that case.

Closes #2829.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_collapse_fixed_joints_massless_chain
```

Verified that the new test fails on `main` (`body_com[0]` is `[nan, nan, nan]`) and passes with the fix applied. Both `use_articulation=True` and `use_articulation=False` subTests are
covered.

## Bug fix

**Steps to reproduce:**

1. Build a chain `massless_root --free--> (massless_root) --fixed--> massless_dummy --fixed--> mass_body`.
2. Call `builder.collapse_fixed_joints()`.
3. Observe `builder.body_com[0]` is `[nan, nan, nan]` instead of the surviving body's COM.

**Minimal reproduction:**

```python
import warp as wp
import newton

builder = newton.ModelBuilder()
root = builder.add_link(mass=0.0, label="massless_root")
dummy = builder.add_link(mass=0.0, label="massless_dummy")
mass_body = builder.add_link(mass=2.0, com=wp.vec3(1.0, 0.0, 0.0), label="mass_body")

builder.add_joint_free(parent=-1, child=root)
builder.add_joint_fixed(parent=root, child=dummy)
builder.add_joint_fixed(parent=dummy, child=mass_body)

builder.collapse_fixed_joints()
print(builder.body_com[0])  # -> [nan, nan, nan] without this fix
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where collapsing fixed joints between zero-mass bodies could produce NaN center of mass values.

* **Tests**
  * Added unit test for collapsing fixed-joint chains containing massless intermediate bodies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->