### PR TITLE
Cherry-picks for 1.2.1 patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Add opt-in `validate_mesh` parameter to `ModelBuilder.add_cloth_mesh()`, `ModelBuilder.add_soft_mesh()`, and `style3d.add_cloth_mesh()` that warns on degenerate geometry; add public `newton.utils.validate_triangle_mesh()` and `newton.utils.validate_tet_mesh()` utilities
+- Add `ViewerGL.show_loading_splash()` / `ViewerGL.hide_loading_splash()` displaying a stylized Newton's-cradle overlay while the GL viewer waits on Warp kernel compilation; raised automatically by `newton.examples.init()` for visible GL viewers
+- Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
+- Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
+- Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
+- Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
+
+### Changed
+
+- Remove the `cbor2` `<6` dependency ceiling after updating recorder deserialization to accept mapping-like decoded containers
+- Require Warp 1.14 and configure Warp logging through `warp.config.log_level`; use Newton's `--quiet` flag or `--warp-config log_level=...` instead of legacy `verbose` or `quiet` config keys
+- Auto-scale `ViewerGL` contact arrows, joint axes, and COM markers by `Viewer.scene_scale`; to approximate the previous fixed sizes after `set_model()`, set `viewer.renderer.arrow_length_scale = 0.1 / viewer.scene_scale`, `viewer.renderer.joint_scale = 0.1 / viewer.scene_scale`, and `viewer.renderer.com_scale = 0.1 / viewer.scene_scale`.
+
+### Deprecated
+
+- Deprecate loading `.pt` / `.pth` (TorchScript) checkpoints via `ControllerNeuralMLP`; the legacy TorchScript / dict-checkpoint path still works (with a `DeprecationWarning`) when PyTorch is installed but will be removed in a future release. `ControllerNeuralLSTM` requires re-exporting to ONNX with the metadata properties documented in its class docstring; pointing it at a `.pt` checkpoint now raises `NotImplementedError` with migration guidance. Convert the MLP checkpoint to ONNX once with `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` and load the resulting `.onnx` file.
+
+### Fixed
+
+- Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
+- Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
+- Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
+- Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
+- Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
+- Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
+- Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
+- Fix USD import of revolute and D6-angular joint `limit_ke` / `limit_kd` from `mjc:solreflimit` being over-scaled by ~57x
+
 ## [1.2.0] - 2026-05-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,14 @@
 # Changelog
 
-## [Unreleased]
+## [1.2.1] - 2026-05-26
 
 ### Added
 
-- Add opt-in `validate_mesh` parameter to `ModelBuilder.add_cloth_mesh()`, `ModelBuilder.add_soft_mesh()`, and `style3d.add_cloth_mesh()` that warns on degenerate geometry; add public `newton.utils.validate_triangle_mesh()` and `newton.utils.validate_tet_mesh()` utilities
-- Add `ViewerGL.show_loading_splash()` / `ViewerGL.hide_loading_splash()` displaying a stylized Newton's-cradle overlay while the GL viewer waits on Warp kernel compilation; raised automatically by `newton.examples.init()` for visible GL viewers
-- Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
-- Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
-- Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
-- Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
-
-### Changed
-
-- Remove the `cbor2` `<6` dependency ceiling after updating recorder deserialization to accept mapping-like decoded containers
-- Require Warp 1.14 and configure Warp logging through `warp.config.log_level`; use Newton's `--quiet` flag or `--warp-config log_level=...` instead of legacy `verbose` or `quiet` config keys
-- Auto-scale `ViewerGL` contact arrows, joint axes, and COM markers by `Viewer.scene_scale`; to approximate the previous fixed sizes after `set_model()`, set `viewer.renderer.arrow_length_scale = 0.1 / viewer.scene_scale`, `viewer.renderer.joint_scale = 0.1 / viewer.scene_scale`, and `viewer.renderer.com_scale = 0.1 / viewer.scene_scale`.
-
-### Deprecated
-
-- Deprecate loading `.pt` / `.pth` (TorchScript) checkpoints via `ControllerNeuralMLP`; the legacy TorchScript / dict-checkpoint path still works (with a `DeprecationWarning`) when PyTorch is installed but will be removed in a future release. `ControllerNeuralLSTM` requires re-exporting to ONNX with the metadata properties documented in its class docstring; pointing it at a `.pt` checkpoint now raises `NotImplementedError` with migration guidance. Convert the MLP checkpoint to ONNX once with `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` and load the resulting `.onnx` file.
+- Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 
 ### Fixed
 
-- Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
-- Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
-- Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
-- Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
-- Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
-- Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
-- Fix USD import of revolute and D6-angular joint `limit_ke` / `limit_kd` from `mjc:solreflimit` being over-scaled by ~57x
 
 ## [1.2.0] - 2026-05-12
 

--- a/newton/_src/geometry/collision_core.py
+++ b/newton/_src/geometry/collision_core.py
@@ -932,7 +932,7 @@ def mesh_vs_convex_midphase(
     shape_type: wp.array[int],
     shape_data: wp.array[wp.vec4],
     shape_source_ptr: wp.array[wp.uint64],
-    rigid_gap: float,
+    contact_threshold: float,
     triangle_pairs: wp.array[wp.vec3i],
     triangle_pairs_count: wp.array[int],
 ):
@@ -952,7 +952,7 @@ def mesh_vs_convex_midphase(
         shape_type: Array of shape types
         shape_data: Array of shape data (vec4: scale.xyz, margin.w)
         shape_source_ptr: Array of mesh/SDF source pointers
-        rigid_gap: Contact gap for rigid bodies
+        contact_threshold: Contact candidate distance [m], including margin and gap
         triangle_pairs: Output array for triangle pairs (mesh_shape, non_mesh_shape, tri_index)
         triangle_pairs_count: Counter for triangle pairs
     """
@@ -990,20 +990,21 @@ def mesh_vs_convex_midphase(
 
     # The mesh's own BVH was built over the *unscaled* ``mesh.points``: the world
     # position of vertex v is ``X_mesh_ws * (mesh_scale ⊙ v)``. Therefore we must
-    # convert both the AABB and the contact gap from scaled mesh-local space to
-    # unscaled (BVH) space before querying. With non-uniform scale this is a
-    # per-axis division; the gap, isotropic in world space, becomes anisotropic.
+    # convert both the AABB and the contact threshold from scaled mesh-local
+    # space to unscaled (BVH) space before querying. With non-uniform scale
+    # this is a per-axis division; the threshold, isotropic in world space,
+    # becomes anisotropic.
     mesh_scale_vec4 = shape_data[mesh_shape]
     mesh_scale = wp.vec3(mesh_scale_vec4[0], mesh_scale_vec4[1], mesh_scale_vec4[2])
     aabb_lower_bvh, aabb_upper_bvh = aabb_to_unscaled(aabb_lower, aabb_upper, mesh_scale)
 
-    # Per-axis margin in BVH (unscaled) units. ``rigid_gap`` is a world-space
-    # distance; in unscaled mesh-local space that is ``rigid_gap / |mesh_scale_i|``
+    # Per-axis margin in BVH (unscaled) units. ``contact_threshold`` is a world-space
+    # distance; in unscaled mesh-local space that is ``contact_threshold / |mesh_scale_i|``
     # along each axis.
     margin_vec = wp.vec3(
-        rigid_gap / wp.max(wp.abs(mesh_scale[0]), 1.0e-12),
-        rigid_gap / wp.max(wp.abs(mesh_scale[1]), 1.0e-12),
-        rigid_gap / wp.max(wp.abs(mesh_scale[2]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[0]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[1]), 1.0e-12),
+        contact_threshold / wp.max(wp.abs(mesh_scale[2]), 1.0e-12),
     )
     aabb_lower = aabb_lower_bvh - margin_vec
     aabb_upper = aabb_upper_bvh + margin_vec

--- a/newton/_src/geometry/narrow_phase.py
+++ b/newton/_src/geometry/narrow_phase.py
@@ -834,6 +834,7 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
                 shape_transform,
                 shape_collision_aabb_lower,
                 shape_collision_aabb_upper,
+                shape_data,
                 shape_gap,
                 triangle_pairs,
                 triangle_pairs_count,
@@ -867,12 +868,16 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
         # Get non-mesh shape world transform
         X_ws = shape_transform[non_mesh_shape]
 
-        # Use per-shape contact gaps for consistent pairwise thresholding.
+        # Use the same margin+gap shell for triangle candidates that the
+        # narrow phase uses when accepting contacts.
         gap_non_mesh = shape_gap[non_mesh_shape]
         gap_mesh = shape_gap[mesh_shape]
         gap_sum = gap_non_mesh + gap_mesh
+        margin_non_mesh = shape_data[non_mesh_shape][3]
+        margin_mesh = shape_data[mesh_shape][3]
+        contact_threshold = gap_sum + margin_non_mesh + margin_mesh
 
-        # Call mesh_vs_convex_midphase with the shape_data and pair gap sum.
+        # Call mesh_vs_convex_midphase with the shape_data and pair contact threshold.
         mesh_vs_convex_midphase(
             j,
             mesh_shape,
@@ -883,7 +888,7 @@ def narrow_phase_find_mesh_triangle_overlaps_kernel(
             shape_types,
             shape_data,
             shape_source,
-            gap_sum,
+            contact_threshold,
             triangle_pairs,
             triangle_pairs_count,
         )

--- a/newton/_src/utils/heightfield.py
+++ b/newton/_src/utils/heightfield.py
@@ -293,6 +293,7 @@ def heightfield_vs_convex_midphase(
     shape_transform: wp.array[wp.transform],
     shape_collision_aabb_lower: wp.array[wp.vec3],
     shape_collision_aabb_upper: wp.array[wp.vec3],
+    shape_data: wp.array[wp.vec4],
     shape_gap: wp.array[float],
     triangle_pairs: wp.array[wp.vec3i],
     triangle_pairs_count: wp.array[int],
@@ -320,6 +321,7 @@ def heightfield_vs_convex_midphase(
             shape (scale already baked in).
         shape_collision_aabb_upper: Local-space AABB upper bounds for each
             shape (scale already baked in).
+        shape_data: Shape data array containing per-shape margins.
         shape_gap: Per-shape contact gaps.
         triangle_pairs: Output buffer for ``(hfield_shape, other_shape, tri_idx)`` triples.
         triangle_pairs_count: Atomic counter for emitted triangle pairs.
@@ -351,10 +353,12 @@ def heightfield_vs_convex_midphase(
     )
 
     gap_sum = shape_gap[hfield_shape] + shape_gap[other_shape]
-    gap_vec = wp.vec3(gap_sum, gap_sum, gap_sum)
+    margin_sum = shape_data[hfield_shape][3] + shape_data[other_shape][3]
+    contact_threshold = gap_sum + margin_sum
+    threshold_vec = wp.vec3(contact_threshold, contact_threshold, contact_threshold)
 
-    aabb_lower = center_in_hfield - half_in_hfield - gap_vec
-    aabb_upper = center_in_hfield + half_in_hfield + gap_vec
+    aabb_lower = center_in_hfield - half_in_hfield - threshold_vec
+    aabb_upper = center_in_hfield + half_in_hfield + threshold_vec
 
     # Map AABB to grid cell indices
     dx = 2.0 * hfd.hx / wp.float32(hfd.ncol - 1)

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -568,8 +568,11 @@ class ArticulationView:
         arti_joint_types = []
         arti_link_ids = []
         arti_link_names = []
+        arti_link_template_labels = []
+        arti_joint_template_labels = []
         arti_shape_ids = []
         arti_shape_names = []
+        arti_shape_template_labels = []
 
         # gather joint info
         arti_joint_begin = int(model_articulation_start[arti_0])
@@ -584,6 +587,7 @@ class ArticulationView:
         for joint_id in range(arti_joint_begin, arti_joint_end):
             # joint_id = arti_joint_begin + idx
             arti_joint_ids.append(joint_id)
+            arti_joint_template_labels.append(model.joint_label[joint_id])
             arti_joint_names.append(get_name_from_label(model.joint_label[joint_id]))
             arti_joint_types.append(model_joint_type[joint_id])
             link_id = int(model_joint_child[joint_id])
@@ -593,6 +597,7 @@ class ArticulationView:
         arti_link_ids = sorted(arti_link_ids)
         arti_link_count = len(arti_link_ids)
         for link_id in arti_link_ids:
+            arti_link_template_labels.append(model.body_label[link_id])
             arti_link_names.append(get_name_from_label(model.body_label[link_id]))
             arti_shape_ids.extend(model.body_shapes[link_id])
 
@@ -600,6 +605,7 @@ class ArticulationView:
         arti_shape_ids = sorted(arti_shape_ids)
         arti_shape_count = len(arti_shape_ids)
         for shape_id in arti_shape_ids:
+            arti_shape_template_labels.append(model.shape_label[shape_id])
             arti_shape_names.append(get_name_from_label(model.shape_label[shape_id]))
 
         # compute counts and offsets of joints, links, etc.
@@ -797,13 +803,16 @@ class ArticulationView:
         selected_link_indices = sorted(link_include_indices - link_exclude_indices)
 
         self.joint_names = []
+        self.joint_template_labels = []
         self.joint_dof_names = []
         self.joint_dof_counts = []
         self.joint_coord_names = []
         self.joint_coord_counts = []
         self.link_names = []
+        self.link_template_labels = []
         self.link_shapes = []
         self.shape_names = []
+        self.shape_template_labels = []
 
         # populate info for selected joints and dofs
         selected_joint_dof_indices = []
@@ -812,6 +821,7 @@ class ArticulationView:
             joint_id = arti_joint_ids[joint_idx]
             joint_name = arti_joint_names[joint_idx]
             self.joint_names.append(joint_name)
+            self.joint_template_labels.append(arti_joint_template_labels[joint_idx])
             # joint dofs
             dof_begin = int(model_joint_qd_start[joint_id])
             dof_end = int(model_joint_qd_start[joint_id + 1])
@@ -843,6 +853,7 @@ class ArticulationView:
         for link_idx, arti_link_idx in enumerate(selected_link_indices):
             body_id = arti_link_ids[arti_link_idx]
             self.link_names.append(arti_link_names[arti_link_idx])
+            self.link_template_labels.append(arti_link_template_labels[arti_link_idx])
             shape_ids = model.body_shapes[body_id]
             for shape_id in shape_ids:
                 arti_shape_idx = arti_shape_ids.index(shape_id)
@@ -853,6 +864,7 @@ class ArticulationView:
         selected_shape_indices = sorted(selected_shape_indices)
         for shape_idx, arti_shape_idx in enumerate(selected_shape_indices):
             self.shape_names.append(arti_shape_names[arti_shape_idx])
+            self.shape_template_labels.append(arti_shape_template_labels[arti_shape_idx])
             link_idx = shape_link_idx[arti_shape_idx]
             self.link_shapes[link_idx].append(shape_idx)
 
@@ -1111,6 +1123,11 @@ class ArticulationView:
     def body_shapes(self):
         """Alias for `link_shapes`."""
         return self.link_shapes
+
+    @property
+    def body_template_labels(self):
+        """Alias for `link_template_labels`."""
+        return self.link_template_labels
 
     # ========================================================================================
     # Generic attribute API

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -10,6 +10,8 @@ import warp.examples
 
 import newton
 from newton import GeoType
+from newton._src.geometry import create_mesh_terrain
+from newton._src.geometry.flags import ShapeFlags
 from newton._src.sim.collide import _compute_per_world_shape_pairs_max, _estimate_rigid_contact_max
 from newton.examples import test_body_state
 from newton.tests.unittest_utils import add_function_test, get_cuda_test_devices
@@ -870,8 +872,6 @@ class TestShapePairsMaxScaling(unittest.TestCase):
     @staticmethod
     def _make_model(num_worlds, shapes_per_world, num_global=0, shape_flags_value=None):
         """Build a minimal Model with the given world/shape layout."""
-        from newton._src.geometry.flags import ShapeFlags  # noqa: PLC0415
-
         total = num_worlds * shapes_per_world + num_global
         world_ids = np.repeat(np.arange(num_worlds, dtype=np.int32), shapes_per_world)
         if num_global > 0:
@@ -1107,10 +1107,95 @@ class TestDeterministicPipeline(unittest.TestCase):
     pass
 
 
+class TestMeshConvexMidphase(unittest.TestCase):
+    """Test mesh-vs-convex triangle candidate generation."""
+
+    pass
+
+
+class TestHeightfieldConvexMidphase(unittest.TestCase):
+    """Test heightfield-vs-convex triangle candidate generation."""
+
+    pass
+
+
+def test_mesh_convex_midphase_queries_margin_shell(test, device):
+    margin = 0.02
+    gap = 0.005
+    radius = 0.1
+    surface_separation = 0.03
+
+    cfg = newton.ModelBuilder.ShapeConfig(margin=margin, gap=gap)
+    builder = newton.ModelBuilder()
+
+    vertices = np.array(
+        [
+            [-1.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [-1.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    indices = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    builder.add_shape_mesh(body=-1, mesh=newton.Mesh(vertices, indices), cfg=cfg)
+
+    body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, radius + surface_separation), wp.quat_identity()))
+    builder.add_joint_free(child=body)
+    builder.add_shape_sphere(body=body, radius=radius, cfg=cfg)
+
+    model = builder.finalize(device=device)
+    state = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+    pipeline = newton.CollisionPipeline(model, broad_phase="nxn")
+    contacts = pipeline.contacts()
+    pipeline.collide(state, contacts)
+
+    contact_count = int(contacts.rigid_contact_count.numpy()[0])
+    test.assertGreater(contact_count, 0)
+
+
+def test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge(test, device):
+    margin = 0.02
+    gap = 0.005
+    radius = 0.1
+    surface_separation = 0.03
+
+    cfg = newton.ModelBuilder.ShapeConfig(margin=margin, gap=gap)
+    builder = newton.ModelBuilder()
+
+    heightfield = newton.Heightfield(
+        data=np.zeros((3, 3), dtype=np.float32),
+        nrow=3,
+        ncol=3,
+        hx=1.0,
+        hy=1.0,
+        min_z=0.0,
+        max_z=0.0,
+    )
+    builder.add_shape_heightfield(heightfield=heightfield, cfg=cfg)
+
+    body = builder.add_body(
+        xform=wp.transform(wp.vec3(1.0 + radius + surface_separation, 0.0, 0.0), wp.quat_identity())
+    )
+    builder.add_joint_free(child=body)
+    builder.add_shape_sphere(body=body, radius=radius, cfg=cfg)
+
+    model = builder.finalize(device=device)
+    state = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+
+    pipeline = newton.CollisionPipeline(model, broad_phase="nxn")
+    contacts = pipeline.contacts()
+    pipeline.collide(state, contacts)
+
+    contact_count = int(contacts.rigid_contact_count.numpy()[0])
+    test.assertGreater(contact_count, 0)
+
+
 def _build_deterministic_scene(device):
     """Build the mixed-shape scene from example_basic_shapes6_determinism."""
-    from newton._src.geometry import create_mesh_terrain  # noqa: PLC0415
-
     builder = newton.ModelBuilder()
 
     # Procedural mesh terrain ground
@@ -1503,6 +1588,22 @@ add_function_test(
     TestDeterministicPipeline,
     "test_deterministic_pipeline_sticky_500_steps",
     test_deterministic_pipeline_sticky_500_steps,
+    devices=get_cuda_test_devices(),
+    check_output=False,
+)
+
+add_function_test(
+    TestMeshConvexMidphase,
+    "test_mesh_convex_midphase_queries_margin_shell",
+    test_mesh_convex_midphase_queries_margin_shell,
+    devices=get_cuda_test_devices(),
+    check_output=False,
+)
+
+add_function_test(
+    TestHeightfieldConvexMidphase,
+    "test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge",
+    test_heightfield_convex_midphase_queries_margin_shell_at_lateral_edge,
     devices=get_cuda_test_devices(),
     check_output=False,
 )

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -69,6 +69,50 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.get_dof_velocities(state).shape, (1, 1, 0))
         self.assertEqual(view.get_dof_forces(control).shape, (1, 1, 0))
 
+    def test_template_labels_preserve_full_paths(self):
+        """Two-finger gripper whose distal bodies, finger joints, and tip
+        shapes each share a colliding leaf name. ``*_names`` attributes
+        collapse to the leaf; ``*_template_labels`` attributes expose the
+        full slash-delimited labels from the template articulation so
+        callers can still distinguish entries and recover selection order.
+        """
+        builder = newton.ModelBuilder()
+        palm = builder.add_link(label="palm")
+        left = builder.add_link(label="palm/left/fingertip")
+        right = builder.add_link(label="palm/right/fingertip")
+        builder.add_shape_box(body=left, hx=0.01, hy=0.01, hz=0.02, label="palm/left/tip_collision")
+        builder.add_shape_box(body=right, hx=0.01, hy=0.01, hz=0.02, label="palm/right/tip_collision")
+        j_root = builder.add_joint_free(parent=-1, child=palm, label="root")
+        j_left = builder.add_joint_revolute(
+            parent=palm, child=left, axis=(0.0, 0.0, 1.0), label="palm/left/fingertip_joint"
+        )
+        j_right = builder.add_joint_revolute(
+            parent=palm, child=right, axis=(0.0, 0.0, 1.0), label="palm/right/fingertip_joint"
+        )
+        builder.add_articulation([j_root, j_left, j_right], label="gripper")
+        model = builder.finalize()
+
+        view = ArticulationView(model, "gripper", include_links="fingertip")
+
+        # Leaf collisions are visible on the *_names attributes...
+        self.assertEqual(view.link_count, 2)
+        self.assertEqual(view.link_names, ["fingertip", "fingertip"])
+        self.assertEqual(view.shape_names, ["tip_collision", "tip_collision"])
+
+        # ...and disambiguated on the *_template_labels attributes.
+        self.assertEqual(
+            view.link_template_labels,
+            ["palm/left/fingertip", "palm/right/fingertip"],
+        )
+        self.assertEqual(
+            view.shape_template_labels,
+            ["palm/left/tip_collision", "palm/right/tip_collision"],
+        )
+        self.assertIn("palm/left/fingertip_joint", view.joint_template_labels)
+        self.assertIn("palm/right/fingertip_joint", view.joint_template_labels)
+        self.assertEqual(len(view.joint_template_labels), view.joint_count)
+        self.assertEqual(view.body_template_labels, view.link_template_labels)
+
     def _test_selection_shapes(self, floating: bool):
         # load articulation
         ant = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Prepare 1.2.1 release by cherry-picking from main:

  - Backport bf9a8f1 / #2916: Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin
  but still within the contact envelope.
  - Backport a5f95f9 / #2935: Add `ArticulationView.joint_template_labels`, `link_template_labels`, and
  `shape_template_labels` for disambiguating selected entries with colliding leaf names.
  - Add `1.2.1` changelog section with only these two backported release notes.

