### PR TITLE
Allow specifying recording ID for ViewerRerun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `ViewerGL.show_loading_splash()` / `ViewerGL.hide_loading_splash()` displaying a stylized Newton's-cradle overlay while the GL viewer waits on Warp kernel compilation; raised automatically by `newton.examples.init()` for visible GL viewers
 - Add `cable_cross_slide_table` example demonstrating a cable-driven XY table
 - Add an optional `kernel_block_dim` argument to `SensorTiledCamera.update()` for tuning the Warp ray-tracer's `render_megakernel` launch shape.
+- Add `rec_id` parameter to `ViewerRerun` for specifying the recording ID, enabling multiple processes to share a single Rerun recording
 - Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -132,7 +132,7 @@ class ViewerRerun(ViewerBase):
         Args:
             app_id: Application ID for rerun (defaults to 'newton-viewer').
                                  Use different IDs to differentiate between parallel viewer instances.
-            rec_id (str | None): Recording ID for rerun. If provided, multiple processes using the
+            rec_id: Recording ID for rerun. If provided, multiple processes using the
                                  same recording ID will share a single recording, allowing their data
                                  to be visualized together. If None, a random ID is generated.
             address: Optional server address to connect to a remote rerun server via gRPC.

--- a/newton/_src/viewer/viewer_rerun.py
+++ b/newton/_src/viewer/viewer_rerun.py
@@ -113,6 +113,7 @@ class ViewerRerun(ViewerBase):
         self,
         *,
         app_id: str | None = None,
+        rec_id: str | None = None,
         address: str | None = None,
         serve_web_viewer: bool = True,
         web_port: int = 9090,
@@ -131,6 +132,9 @@ class ViewerRerun(ViewerBase):
         Args:
             app_id: Application ID for rerun (defaults to 'newton-viewer').
                                  Use different IDs to differentiate between parallel viewer instances.
+            rec_id (str | None): Recording ID for rerun. If provided, multiple processes using the
+                                 same recording ID will share a single recording, allowing their data
+                                 to be visualized together. If None, a random ID is generated.
             address: Optional server address to connect to a remote rerun server via gRPC.
                                   You will need to start a stand-alone rerun server first, e.g. by typing ``rerun`` in your terminal.
                                   See rerun.io documentation for supported address formats.
@@ -153,6 +157,7 @@ class ViewerRerun(ViewerBase):
         super().__init__()
 
         self.app_id = app_id or "newton-viewer"
+        self.rec_id = rec_id
         self._running = True
         self._viewer_process = None
         self.keep_historical_data = keep_historical_data
@@ -167,7 +172,7 @@ class ViewerRerun(ViewerBase):
 
         # Initialize rerun using a blueprint that only shows the 3D view and a collapsed time panel
         blueprint = self._get_blueprint()
-        rr.init(self.app_id, default_blueprint=blueprint)
+        rr.init(self.app_id, recording_id=self.rec_id, default_blueprint=blueprint)
 
         if record_to_rrd is not None:
             rr.save(record_to_rrd, default_blueprint=blueprint)

--- a/newton/tests/test_viewer_rerun_init_args.py
+++ b/newton/tests/test_viewer_rerun_init_args.py
@@ -44,7 +44,7 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     # Verify rr.init was called with app_id as positional arg and blueprint
                     from unittest.mock import ANY
 
-                    self.mock_rr.init.assert_called_once_with("newton-viewer", default_blueprint=ANY)
+                    self.mock_rr.init.assert_called_once_with("newton-viewer", recording_id=None, default_blueprint=ANY)
 
                     # Verify rr.serve_grpc() was called
                     self.mock_rr.serve_grpc.assert_called_once()
@@ -71,7 +71,7 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     # Verify rr.init was called with app_id as positional arg and blueprint
                     from unittest.mock import ANY
 
-                    self.mock_rr.init.assert_called_once_with("newton-viewer", default_blueprint=ANY)
+                    self.mock_rr.init.assert_called_once_with("newton-viewer", recording_id=None, default_blueprint=ANY)
 
                     # Verify rr.spawn() was called
                     self.mock_rr.spawn.assert_called_once()
@@ -94,7 +94,7 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     # Verify rr.init was called with app_id as positional arg and blueprint
                     from unittest.mock import ANY
 
-                    self.mock_rr.init.assert_called_once_with("newton-viewer", default_blueprint=ANY)
+                    self.mock_rr.init.assert_called_once_with("newton-viewer", recording_id=None, default_blueprint=ANY)
 
                     # Verify rr.connect_grpc() was called with the address
                     self.mock_rr.connect_grpc.assert_called_once_with(test_address)
@@ -138,7 +138,7 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     # Verify rr.init was called with custom app_id as positional arg and blueprint
                     from unittest.mock import ANY
 
-                    self.mock_rr.init.assert_called_once_with(custom_app_id, default_blueprint=ANY)
+                    self.mock_rr.init.assert_called_once_with(custom_app_id, recording_id=None, default_blueprint=ANY)
 
                     # Verify the viewer stored the app_id correctly
                     self.assertEqual(viewer.app_id, custom_app_id)
@@ -253,6 +253,39 @@ class TestViewerRerunInitArgs(unittest.TestCase):
                     # Verify parameters were stored correctly
                     self.assertTrue(viewer_true.keep_scalar_history)
                     self.assertFalse(viewer_false.keep_scalar_history)
+
+    def test_custom_rec_id_used(self):
+        """Test that custom rec_id is stored and passed to rr.init."""
+        with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
+            with patch("newton._src.viewer.viewer_rerun.rrb", self.mock_rrb):
+                with patch("newton._src.viewer.viewer_rerun.is_jupyter_notebook", return_value=False):
+                    from newton._src.viewer.viewer_rerun import ViewerRerun
+
+                    custom_rec_id = "shared-recording-42"
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        viewer = ViewerRerun(rec_id=custom_rec_id)
+
+                    from unittest.mock import ANY
+
+                    self.mock_rr.init.assert_called_once_with(
+                        "newton-viewer", recording_id=custom_rec_id, default_blueprint=ANY
+                    )
+
+                    self.assertEqual(viewer.rec_id, custom_rec_id)
+
+    def test_default_rec_id_is_none(self):
+        """Test that rec_id defaults to None when not provided."""
+        with patch("newton._src.viewer.viewer_rerun.rr", self.mock_rr):
+            with patch("newton._src.viewer.viewer_rerun.rrb", self.mock_rrb):
+                with patch("newton._src.viewer.viewer_rerun.is_jupyter_notebook", return_value=False):
+                    from newton._src.viewer.viewer_rerun import ViewerRerun
+
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        viewer = ViewerRerun()
+
+                    self.assertIsNone(viewer.rec_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Allows specifying the recording ID for the Rerun Viewer. This is needed for when a different process is also logging to Rerun and you want data from both to appear in the same recording, ie be on one timeline.

Example application: I'm using Newton as a simulator with the PX4 Autopilot. I have a PX4 module that uses Rerun to log  data (eg state estimate). If I can specify the same application ID (already possible) AND recording ID (this PR), then the Rerun viewer shows data from both sources, allowing for a great debug/visualization experience.

I think this is a feature that is valuable for all devs that run other software that uses Rerun for logging alongside Newton.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

2 new tests that are run as part of `uv run --extra dev -m newton.tests -k test_viewer_rerun_init_args`:

- `test_custom_rec_id_used` — verifies a custom rec_id is stored on the viewer and forwarded to rr.init as recording_id
- `test_default_rec_id_is_none` — verifies rec_id defaults to None when not provided

## New feature / API change

```python
from newton.viewer import ViewerRerun

viewer = ViewerRerun(app_id="my-app", rec_id="shared-recording")
```