### PR TITLE
Fix brick stacking contact gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
+- Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.
 - Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.

--- a/newton/examples/contacts/example_brick_stacking.py
+++ b/newton/examples/contacts/example_brick_stacking.py
@@ -438,7 +438,7 @@ class Example:
         scene = newton.ModelBuilder()
         scene.add_builder(franka_builder)
         self.add_bricks(scene)
-        scene.add_ground_plane(cfg=newton.ModelBuilder.ShapeConfig(mu=0.75))
+        scene.add_ground_plane(cfg=newton.ModelBuilder.ShapeConfig(mu=0.75, gap=0.01))
 
         self.model = scene.finalize()
 
@@ -492,6 +492,7 @@ class Example:
 
     def build_franka_with_table(self):
         builder = newton.ModelBuilder()
+        builder.rigid_gap = 0.005
         newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
 
         builder.add_urdf(


### PR DESCRIPTION
## Description

Fixes newton-physics/newton#2878.

This PR reduces oversized contact envelopes in the `brick_stacking` example:

- Sets a smaller default rigid contact gap for the Franka/table builder.
- Gives the ground plane an explicit contact gap instead of inheriting the global `ModelBuilder.rigid_gap` default.
- Keeps the existing brick stacking behavior while reducing visually floating contacts around the robot, table, and ground.

### Updated Contact Behavior

Before this change, non-brick scene geometry could inherit a much larger contact gap than the scale of the bricks, producing contact arrows far away from the visible surfaces.

- Brick stacking contacts after smaller contact gaps:
<img width="1908" height="1099" alt="brick_contacts" src="https://github.com/user-attachments/assets/7939b1a7-2a46-4790-a5fb-0e6323d7ac7f" />

- The `Margin + Gap` collision visualization now shows a much tighter envelope around the robot/table scene geometry:
<img width="1908" height="1099" alt="brick_envelope" src="https://github.com/user-attachments/assets/4eac0f5a-021c-4a1e-8bf9-310b2a383bc9" />


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev --extra examples -m newton.tests -k brick_stacking
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the `brick_stacking` example.
2. Enable contact visualization, or enable the `Margin + Gap` collision visualization in the viewer.
3. Observe oversized contact envelopes/contact arrows around the robot, table, and ground compared with the visible geometry scale.

**Minimal reproduction:**

```bash
uv run --extra examples -m newton.examples brick_stacking
```
