### PR TITLE
Fix #2491: pin FR3v2 dynamics test integrator to Euler

### DIFF
--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1961,22 +1961,26 @@ class TestMenagerie_FrankaFr3V2(TestMenagerieMJCF):
     """Franka FR3 v2 arm."""
 
     robot_folder = "franka_fr3_v2"
-    # FR3v2's MJCF doesn't author <option integrator=...>, so native picks
-    # MuJoCo's default (Euler / integrator=0). Newton's SolverMuJoCo auto-
-    # selects IMPLICITFAST (integrator=3) for this model. Without pinning,
-    # the dynamics comparison steps the two sides with different integrators
-    # — identical forces produce ~5x different qvel updates at step 0 (#2491).
-    solver_integrator = "euler"
     num_steps = 20
     fk_enabled = True
     fk_tolerance = 5e-6  # float32 precision (max diff ~1.2e-6)
     backfill_model = True
-    # Float32 + GPU atomic-reduction non-determinism in mjwarp, amplified by
-    # FR3v2's position actuators (kp=4500). Measured via 15-trial native-vs-
-    # native comparison: qvel diff ranges 1.2e-5 to 1.9e-3, mean 7.9e-4.
-    # Newton-vs-native tracks the same range (max 2.0e-3). Tolerance set
-    # ~2.5x above the measured worst.
-    dynamics_tolerance = 5e-3
+    # FR3v2's MJCF doesn't author <option integrator=...>, so native picks
+    # MuJoCo's default (Euler / integrator=0) while Newton's SolverMuJoCo
+    # auto-selects IMPLICITFAST (integrator=3). Without alignment, the two
+    # sides step with different integrators and identical forces produce
+    # ~5x different qvel updates at step 0 (#2491). Pin native to Newton's
+    # choice in _align_models so we test Newton's actual default behavior.
+    # Float32 + GPU atomic-reduction non-determinism floor under IMPLICITFAST,
+    # measured via 15-trial native-vs-native: qvel diff peaks at 1.98e-4
+    # (mean 1.25e-4). Newton-vs-native max 1.98e-4. Tolerance ~2.5x above.
+    dynamics_tolerance = 5e-4
+
+    def _align_models(self, newton_solver, native_mjw_model, mj_model):
+        # Sync native's integrator to whichever one Newton's SolverMuJoCo
+        # picked (so the dynamics comparison runs both engines on the
+        # integrator Newton would use in production).
+        native_mjw_model.opt.integrator = newton_solver.mjw_model.opt.integrator
 
 
 class TestMenagerie_KinovaGen3(TestMenagerieMJCF):
@@ -2368,9 +2372,6 @@ class TestMenagerie_AgilityCassie(TestMenagerieMJCF):
     # the observed native-vs-native variance with safety margin.
     dynamics_tolerance = 1e-4
     backfill_model = True
-    # Cassie's MJCF doesn't specify <option integrator=...>, so native uses
-    # MuJoCo's default (Euler). Pin Newton's integrator to match.
-    solver_integrator = "euler"
     # eq_data: compilation-dependent for CONNECT constraints; body2 anchor is
     # derived from body_quat, which differs due to inertia re-diagonalization.
     # jnt_actfrclimited: Newton unconditionally sets True with effort_limit=1e6,
@@ -2382,6 +2383,13 @@ class TestMenagerie_AgilityCassie(TestMenagerieMJCF):
         "jnt_actfrclimited",
     ]
     model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"eq_data"}
+
+    def _align_models(self, newton_solver, native_mjw_model, mj_model):
+        # Cassie's MJCF doesn't specify <option integrator=...>, so native picks
+        # MuJoCo's default (Euler) while Newton's SolverMuJoCo auto-selects
+        # IMPLICITFAST. Sync native to Newton's choice so we test Newton's
+        # actual default behavior (rather than forcing both to Euler).
+        native_mjw_model.opt.integrator = newton_solver.mjw_model.opt.integrator
 
 
 # -----------------------------------------------------------------------------

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -1961,11 +1961,22 @@ class TestMenagerie_FrankaFr3V2(TestMenagerieMJCF):
     """Franka FR3 v2 arm."""
 
     robot_folder = "franka_fr3_v2"
-    # Dynamics disabled: qvel diverges ~5x at step 0 even with ctrl=0 (#2491)
-    num_steps = 0
+    # FR3v2's MJCF doesn't author <option integrator=...>, so native picks
+    # MuJoCo's default (Euler / integrator=0). Newton's SolverMuJoCo auto-
+    # selects IMPLICITFAST (integrator=3) for this model. Without pinning,
+    # the dynamics comparison steps the two sides with different integrators
+    # — identical forces produce ~5x different qvel updates at step 0 (#2491).
+    solver_integrator = "euler"
+    num_steps = 20
     fk_enabled = True
     fk_tolerance = 5e-6  # float32 precision (max diff ~1.2e-6)
     backfill_model = True
+    # Float32 + GPU atomic-reduction non-determinism in mjwarp, amplified by
+    # FR3v2's position actuators (kp=4500). Measured via 15-trial native-vs-
+    # native comparison: qvel diff ranges 1.2e-5 to 1.9e-3, mean 7.9e-4.
+    # Newton-vs-native tracks the same range (max 2.0e-3). Tolerance set
+    # ~2.5x above the measured worst.
+    dynamics_tolerance = 5e-3
 
 
 class TestMenagerie_KinovaGen3(TestMenagerieMJCF):


### PR DESCRIPTION
## Description

Closes #2491.

`TestMenagerie_FrankaFr3V2.test_dynamics` was disabled because qvel diverged ~5x at step 0 with `ctrl=0`. Investigation showed this was a **test-setup bug**, not a Newton solver bug:

- FR3v2's MJCF doesn't author `<option integrator=...>`, so native mjwarp uses MuJoCo's default Euler (`integrator=0`).
- Newton's `SolverMuJoCo` auto-selects IMPLICITFAST (`integrator=3`) for this model.
- The dynamics test compared Newton's IMPLICITFAST output against native's Euler output on identical forces — same `M_inv * qfrc` but different integration formulas → wildly different qvel.

The skip-list comment at `opt.integrator` (line 410) is misleading: "The solver forces the correct integrator at runtime regardless" is true for Newton's side, but the native side keeps the MJCF default. The two sides must be pinned to the same integrator for the comparison to be meaningful.

This is the same situation as **Cassie** at line 2360 ("Cassie's MJCF doesn't specify `<option integrator=...>`, so native uses MuJoCo's default (Euler). Pin Newton's integrator to match."). Applying the same fix here.

After pinning `solver_integrator = "euler"`:
- Step-1 qvel diff: **1.76 rad/s → 2.4e-7** (7 orders of magnitude smaller, float32 precision).
- Newton-vs-native qvel matches native-vs-native variance (~1.9e-3 worst across 15 trials).

The tolerance is backed by a 15-trial native-vs-native + Newton-vs-native variance characterization (same protocol used for the USD menagerie tolerances in #2886).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A, internal test

## Test plan

```
uv run --extra dev -m newton.tests -k TestMenagerie_FrankaFr3V2
```

All 3 tests pass (1 skipped is the with-collisions variant, gated by other knobs).

## Bug fix

**Steps to reproduce (without this PR):**

1. Temporarily flip `num_steps = 0` → `num_steps = 20` on `TestMenagerie_FrankaFr3V2`.
2. Run `uv run --extra dev -m newton.tests -k TestMenagerie_FrankaFr3V2`.
3. Observe: `test_dynamics` fails at step 1 with qvel diff ~1.76 rad/s (~5x of joint 5's native value).

**Root cause:** `Newton.opt.integrator=3 (IMPLICITFAST)` vs `native.opt.integrator=0 (EULER)` — the test framework skips this field in model comparison (intentional: `opt.integrator` is in the skip list at line 412), but never aligns the two sides before stepping.

**Fix:** Pin `solver_integrator = "euler"` on the test class so both Newton and native step with the same integrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled dynamics step-response testing for the Franka Fr3 V2 robot with a 20-step run and tightened dynamics tolerance to 5e-4.
  * Updated Agility Cassie and Franka tests to synchronize integrator settings between simulators to ensure consistent dynamics comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->