### PR TITLE
Fix ArticulationView axis for loop links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
 - Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
 - Fix USD import of revolute and D6-angular joint `limit_ke` / `limit_kd` from `mjc:solreflimit` being over-scaled by ~57x
+- Fix `ArticulationView` link selections for closed-loop joints so BODY-frequency accessors expose each physical body once.
 - Fix USD import losing authored negative scales on shape and parent xforms, so mirrored primitives and meshes are now imported with the correct signed scale
 
 ## [1.2.0] - 2026-05-12

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -594,7 +594,7 @@ class ArticulationView:
             arti_link_ids.append(link_id)
 
         # use link order as they appear in the model
-        arti_link_ids = sorted(arti_link_ids)
+        arti_link_ids = sorted(set(arti_link_ids))
         arti_link_count = len(arti_link_ids)
         for link_id in arti_link_ids:
             arti_link_template_labels.append(model.body_label[link_id])
@@ -617,6 +617,7 @@ class ArticulationView:
         joint_coord_counts = list_of_lists(world_count)
         root_joint_types = list_of_lists(world_count)
         link_starts = list_of_lists(world_count)
+        link_counts = list_of_lists(world_count)
         shape_starts = list_of_lists(world_count)
         shape_counts = list_of_lists(world_count)
         for world_id in range(world_count):
@@ -644,9 +645,12 @@ class ArticulationView:
                 for j in range(joint_start, joint_end):
                     link_id = int(model_joint_child[j])
                     link_ids.append(link_id)
+                link_ids = sorted(set(link_ids))
+                for link_id in link_ids:
                     link_shapes = model.body_shapes.get(link_id, [])
                     shape_ids.extend(link_shapes)
                 link_starts[world_id].append(min(link_ids))
+                link_counts[world_id].append(len(link_ids))
                 num_shapes = len(shape_ids)
                 if num_shapes > 0:
                     shape_starts[world_id].append(min(shape_ids))
@@ -655,12 +659,12 @@ class ArticulationView:
                 shape_counts[world_id].append(num_shapes)
 
         # make sure counts are the same for all articulations
-        # NOTE: we currently assume that link count is the same as joint count
         if not (
             all_equal(joint_counts)
             and all_equal(joint_dof_counts)
             and all_equal(joint_coord_counts)
             and all_equal(root_joint_types)
+            and all_equal(link_counts)
             and all_equal(shape_counts)
         ):
             raise ValueError("Articulations are not identical")

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -113,6 +113,33 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(len(view.joint_template_labels), view.joint_count)
         self.assertEqual(view.body_template_labels, view.link_template_labels)
 
+    def test_duplicate_joint_child_is_one_link(self):
+        """BODY-frequency link axis uses unique physical bodies, not joint slots."""
+        builder = newton.ModelBuilder()
+        root = builder.add_link(label="root")
+        tip = builder.add_link(label="tip")
+        builder.add_shape_box(body=tip, hx=0.01, hy=0.01, hz=0.01, label="tip_shape")
+
+        j_root = builder.add_joint_free(parent=-1, child=root, label="root_joint")
+        j_tip = builder.add_joint_revolute(parent=root, child=tip, axis=wp.vec3(0.0, 0.0, 1.0), label="tip_joint")
+        j_tip_duplicate = builder.add_joint_fixed(parent=root, child=tip, label="tip_duplicate_joint")
+        builder.add_articulation([j_root, j_tip, j_tip_duplicate], label="robot")
+        model = builder.finalize()
+
+        view = ArticulationView(model, "robot")
+
+        self.assertEqual(list(model.body_label), ["root", "tip"])
+        self.assertEqual(view.link_count, 2)
+        self.assertEqual(view.link_names, ["root", "tip"])
+        self.assertEqual(view.link_template_labels, ["root", "tip"])
+        self.assertEqual(view.shape_count, 1)
+        self.assertEqual(view.shape_template_labels, ["tip_shape"])
+
+        body_layout = view.frequency_layouts[newton.Model.AttributeFrequency.BODY]
+        self.assertEqual(body_layout.value_count, len(model.body_label))
+        self.assertEqual(view.get_link_transforms(model).shape, (1, 1, 2))
+        self.assertEqual(view.get_link_velocities(model).shape, (1, 1, 2))
+
     def _test_selection_shapes(self, floating: bool):
         # load articulation
         ant = newton.ModelBuilder()


### PR DESCRIPTION
## Description

`ArticulationView` was building its BODY/link axis by collecting one `model.joint_child[joint_id]` entry for every joint in the selected articulation. Closed-loop joints can legitimately point additional joints at an already-existing physical body, so the view ended up exposing duplicate link slots for the same body.

This PR deduplicates those link IDs while preserving the existing body-id/model ordering. It also applies the same unique-body accounting when validating per-articulation link and shape layout counts, so BODY-frequency accessors (`body_q`, `body_qd`, body attributes, link transforms/velocities) stay aligned with physical body arrays.

Changes:

- Deduplicate `ArticulationView` link IDs with `sorted(set(...))`, preserving the current body-id ordering policy.
- Track unique link counts when checking that matched articulations have identical layout.
- Add a regression test for duplicate `joint_child` entries mapping to one BODY-frequency link.
- Add a `CHANGELOG.md` entry under `Fixed`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_duplicate_joint_child_is_one_link
uv run --extra dev -m newton.tests -k test_selection
uvx pre-commit run -a
```

I also validated against the local Digit repro script. The repro script itself is intentionally not included in this PR; it was only used to demonstrate the bug and verify the fix.

```bash
uv run --extra importers python repro/loop_closure_link_axis/repro.py
```

Before this fix, the repro reported:

```text
len(model.body_label) = 43
len(model.joint_child) = 49
view.link_count = 49
BODY frequency layout value_count=49
```

After this fix, the same repro reports:

```text
view.link_count = 43
len(view.link_template_labels) = 43
len(set(view.link_template_labels)) = 43
0 link_template_labels appear at multiple per-link slots
```

## Bug fix

**Steps to reproduce:**

1. Load a closed-loop articulation where multiple joints have the same child body. The Digit repro script used here loads `digit_v4.usd`, builds an `ArticulationView`, and compares the view link axis against `model.body_label` / `model.body_q`.
2. Observe that `model.body_label` contains 43 physical bodies while `model.joint_child` contains 49 joint-child entries.
3. Without this PR, `ArticulationView` exposes 49 link slots and duplicate full-path `link_template_labels` such as `/Digit/left_leg_tarsus` and `/Digit/right_leg_toe_roll`.
4. BODY-frequency accessors then use a 49-wide layout against physical-body arrays such as `model.body_q`, which are only 43-wide.

**Minimal reproduction:**

```python
import newton
from newton.selection import ArticulationView

builder = newton.ModelBuilder()
root = builder.add_link(label="root")
tip = builder.add_link(label="tip")

j_root = builder.add_joint_free(parent=-1, child=root, label="root_joint")
j_tip = builder.add_joint_revolute(parent=root, child=tip, axis=(0.0, 0.0, 1.0), label="tip_joint")
j_tip_duplicate = builder.add_joint_fixed(parent=root, child=tip, label="tip_duplicate_joint")
builder.add_articulation([j_root, j_tip, j_tip_duplicate], label="robot")

model = builder.finalize()
view = ArticulationView(model, "robot")

assert len(model.body_label) == 2
assert view.link_count == 2
assert view.link_template_labels == ["root", "tip"]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed link selection in articulation views for closed-loop joint configurations to ensure BODY-frequency accessors correctly expose each physical body exactly once.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->