### PR TITLE
fix usd import of an orphaned fixed joint to world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Fix USD import losing authored negative scales on shape and parent xforms, so mirrored primitives and meshes are now imported with the correct signed scale
 - Fix rigid-rigid friction in `SolverVBD` for contacts with nonzero `rigid_contact_offset0/rigid_contact_offset1`.
 - Respect USD color-space metadata for scalar material colors and convert linear-authored USD color textures to display space when loading them
+- Fix USD import of orphaned body-to-world fixed joints not accounting for ancestor xform offsets, so pinned bodies now FK to the correct world pose (env origin + spawn xform)
 
 ## [1.2.0] - 2026-05-12
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2356,34 +2356,32 @@ def parse_usd(
         free_joints_auto_inserted = not (no_articulations and has_joints)
         if is_body_to_world and free_joints_auto_inserted and not is_fixed_joint:
             continue
-        # For body-to-world joints, `body0` is empty so there is no world-side
-        # prim to inherit a frame from. Authoring tools commonly write
-        # `localPose0` relative to the joint prim's USD ancestor Xform rather
-        # than in world coords, leaving the joint anchor offset by that
-        # ancestor's world transform. Recover the missing world-side frame
-        # from the child body's world pose and the joint's local poses so the
-        # joint chain FK reproduces the imported child world pose:
-        #   joint chain: child_world = orphan_incoming_xform * parent_tf * inv(child_tf)
-        #   ⇒ orphan_incoming_xform = child_world * child_tf * inv(parent_tf)
-        # Algebraically degenerates to identity when `localPose0` is already in
-        # world coords (then child_world * child_tf == parent_tf).
-        orphan_incoming_xform = incoming_world_xform
-        if is_body_to_world:
-            _, _, parent_tf_o, child_tf_o = resolve_joint_parent_child(  # pyright: ignore[reportAssignmentType]
-                joint_desc, path_body_map, get_transforms=True
-            )
-            child_path_o = body1_path if body0_path in ("", "/") else body0_path
-            child_prim_o = stage.GetPrimAtPath(child_path_o) if child_path_o else None
-            if (
-                parent_tf_o is not None
-                and child_tf_o is not None
-                and child_prim_o is not None
-                and child_prim_o.IsValid()
-            ):
-                child_world_xform_o = usd.get_transform(child_prim_o, local=False, xform_cache=xform_cache)
-                world_body_xform_o = child_world_xform_o * child_tf_o * wp.transform_inverse(parent_tf_o)
-                orphan_incoming_xform = incoming_world_xform * world_body_xform_o
         try:
+            # Body-to-world joints (the world side may be body0 or body1) have no
+            # world-side prim to inherit a frame from, and authoring tools often
+            # write the world-side localPose relative to a USD ancestor Xform
+            # instead of in world coords. Recover the missing world-side frame from
+            # the child body's world pose and the joint local poses so the joint
+            # chain FK reproduces the imported child world pose:
+            #   world_body = child_world * child_tf * inv(parent_tf)
+            # The world-side localPose cancels, so the joint anchors at the
+            # USD-authored child body pose however that pose was authored.
+            orphan_incoming_xform = incoming_world_xform
+            if is_body_to_world:
+                _, _, parent_tf_o, child_tf_o = resolve_joint_parent_child(  # pyright: ignore[reportAssignmentType]
+                    joint_desc, path_body_map, get_transforms=True
+                )
+                child_path_o = body1_path if body0_path in ("", "/") else body0_path
+                child_prim_o = stage.GetPrimAtPath(child_path_o) if child_path_o else None
+                if (
+                    parent_tf_o is not None
+                    and child_tf_o is not None
+                    and child_prim_o is not None
+                    and child_prim_o.IsValid()
+                ):
+                    child_world_xform_o = usd.get_transform(child_prim_o, local=False, xform_cache=xform_cache)
+                    world_body_xform_o = child_world_xform_o * child_tf_o * wp.transform_inverse(parent_tf_o)
+                    orphan_incoming_xform = incoming_world_xform * world_body_xform_o
             joint_index = parse_joint(joint_desc, incoming_xform=orphan_incoming_xform)
             # Handle body-to-world FIXED joints separately to ensure proper welding.
             # Creates an articulation for the body-to-world FIXED joint (consistent with MuJoCo approach)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -2356,8 +2356,35 @@ def parse_usd(
         free_joints_auto_inserted = not (no_articulations and has_joints)
         if is_body_to_world and free_joints_auto_inserted and not is_fixed_joint:
             continue
+        # For body-to-world joints, `body0` is empty so there is no world-side
+        # prim to inherit a frame from. Authoring tools commonly write
+        # `localPose0` relative to the joint prim's USD ancestor Xform rather
+        # than in world coords, leaving the joint anchor offset by that
+        # ancestor's world transform. Recover the missing world-side frame
+        # from the child body's world pose and the joint's local poses so the
+        # joint chain FK reproduces the imported child world pose:
+        #   joint chain: child_world = orphan_incoming_xform * parent_tf * inv(child_tf)
+        #   ⇒ orphan_incoming_xform = child_world * child_tf * inv(parent_tf)
+        # Algebraically degenerates to identity when `localPose0` is already in
+        # world coords (then child_world * child_tf == parent_tf).
+        orphan_incoming_xform = incoming_world_xform
+        if is_body_to_world:
+            _, _, parent_tf_o, child_tf_o = resolve_joint_parent_child(  # pyright: ignore[reportAssignmentType]
+                joint_desc, path_body_map, get_transforms=True
+            )
+            child_path_o = body1_path if body0_path in ("", "/") else body0_path
+            child_prim_o = stage.GetPrimAtPath(child_path_o) if child_path_o else None
+            if (
+                parent_tf_o is not None
+                and child_tf_o is not None
+                and child_prim_o is not None
+                and child_prim_o.IsValid()
+            ):
+                child_world_xform_o = usd.get_transform(child_prim_o, local=False, xform_cache=xform_cache)
+                world_body_xform_o = child_world_xform_o * child_tf_o * wp.transform_inverse(parent_tf_o)
+                orphan_incoming_xform = incoming_world_xform * world_body_xform_o
         try:
-            joint_index = parse_joint(joint_desc, incoming_xform=incoming_world_xform)
+            joint_index = parse_joint(joint_desc, incoming_xform=orphan_incoming_xform)
             # Handle body-to-world FIXED joints separately to ensure proper welding.
             # Creates an articulation for the body-to-world FIXED joint (consistent with MuJoCo approach)
             if joint_index is not None and is_body_to_world and is_fixed_joint:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -338,6 +338,44 @@ def Xform "Root" (
         self.assertEqual(model.body_count, 3)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_orphan_world_fixed_joint_respects_env_offset_and_xform(self):
+        """Orphan body-to-world fixed joints must FK to env-origin + spawn xform."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        env = UsdGeom.Xform.Define(stage, "/World/env")
+        env.AddTranslateOp().Set(Gf.Vec3d(100.0, 200.0, 0.0))
+
+        link = UsdGeom.Xform.Define(stage, "/World/env/PinnedLink")
+        UsdPhysics.RigidBodyAPI.Apply(link.GetPrim())
+
+        fixed = UsdPhysics.FixedJoint.Define(stage, "/World/env/PinnedLink/FixedJoint")
+        fixed.CreateBody1Rel().SetTargets([link.GetPath()])
+        fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage, xform=wp.transform((5.0, 0.0, 0.0), wp.quat_identity()))
+
+        link_idx = builder.body_label.index("/World/env/PinnedLink")
+        joint_idx = builder.joint_label.index("/World/env/PinnedLink/FixedJoint")
+        self.assertEqual(builder.joint_type[joint_idx], newton.JointType.FIXED)
+        self.assertEqual(builder.joint_parent[joint_idx], -1)
+
+        expected_pos = np.array([105.0, 200.0, 0.0])
+        assert_np_equal(np.array(builder.joint_X_p[joint_idx].p), expected_pos, tol=1e-4)
+
+        model = builder.finalize()
+        state = model.state()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+        np.testing.assert_allclose(state.body_q.numpy()[link_idx, :3], expected_pos, atol=1e-4)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_collapse_fixed_joints_preserves_orphan_joints(self):
         """collapse_fixed_joints must not drop orphan joints or their bodies."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -342,38 +342,59 @@ def Xform "Root" (
         """Orphan body-to-world fixed joints must FK to env-origin + spawn xform."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
-        stage = Usd.Stage.CreateInMemory()
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-        UsdPhysics.Scene.Define(stage, "/physicsScene")
+        local_pose0 = wp.transform(wp.vec3(0.1, 0.2, 0.3), wp.quat(0.0, 0.0, 0.7071068, 0.7071068))  # 90deg about z
+        local_pose1 = wp.transform(wp.vec3(-0.2, 0.05, 0.4), wp.quat(0.7071068, 0.0, 0.0, 0.7071068))  # 90deg about x
 
-        env = UsdGeom.Xform.Define(stage, "/World/env")
-        env.AddTranslateOp().Set(Gf.Vec3d(100.0, 200.0, 0.0))
+        for side in ["body0", "body1"]:  # Test the world being on either body0 or body1
+            with self.subTest(side=side):
+                stage = Usd.Stage.CreateInMemory()
+                UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+                UsdPhysics.Scene.Define(stage, "/physicsScene")
 
-        link = UsdGeom.Xform.Define(stage, "/World/env/PinnedLink")
-        UsdPhysics.RigidBodyAPI.Apply(link.GetPrim())
+                env = UsdGeom.Xform.Define(stage, "/World/env")
+                env.AddTranslateOp().Set(Gf.Vec3d(100.0, 200.0, 0.0))
 
-        fixed = UsdPhysics.FixedJoint.Define(stage, "/World/env/PinnedLink/FixedJoint")
-        fixed.CreateBody1Rel().SetTargets([link.GetPath()])
-        fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
-        fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
-        fixed.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
-        fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+                link = UsdGeom.Xform.Define(stage, "/World/env/PinnedLink")
+                UsdPhysics.RigidBodyAPI.Apply(link.GetPrim())
 
-        builder = newton.ModelBuilder()
-        builder.add_usd(stage, xform=wp.transform((5.0, 0.0, 0.0), wp.quat_identity()))
+                fixed = UsdPhysics.FixedJoint.Define(stage, "/World/env/PinnedLink/FixedJoint")
+                if side == "body0":
+                    fixed.CreateBody0Rel().SetTargets([link.GetPath()])
+                else:
+                    fixed.CreateBody1Rel().SetTargets([link.GetPath()])
+                p0, q0 = local_pose0.p, local_pose0.q
+                p1, q1 = local_pose1.p, local_pose1.q
+                fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(float(p0[0]), float(p0[1]), float(p0[2])))
+                fixed.CreateLocalRot0Attr().Set(Gf.Quatf(float(q0[3]), float(q0[0]), float(q0[1]), float(q0[2])))
+                fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(float(p1[0]), float(p1[1]), float(p1[2])))
+                fixed.CreateLocalRot1Attr().Set(Gf.Quatf(float(q1[3]), float(q1[0]), float(q1[1]), float(q1[2])))
 
-        link_idx = builder.body_label.index("/World/env/PinnedLink")
-        joint_idx = builder.joint_label.index("/World/env/PinnedLink/FixedJoint")
-        self.assertEqual(builder.joint_type[joint_idx], newton.JointType.FIXED)
-        self.assertEqual(builder.joint_parent[joint_idx], -1)
+                builder = newton.ModelBuilder()
+                builder.add_usd(stage, xform=wp.transform(wp.vec3(5.0, 0.0, 0.0), wp.quat_identity()))
 
-        expected_pos = np.array([105.0, 200.0, 0.0])
-        assert_np_equal(np.array(builder.joint_X_p[joint_idx].p), expected_pos, tol=1e-4)
+                link_idx = builder.body_label.index("/World/env/PinnedLink")
+                joint_idx = builder.joint_label.index("/World/env/PinnedLink/FixedJoint")
+                self.assertEqual(builder.joint_type[joint_idx], newton.JointType.FIXED)
+                self.assertEqual(builder.joint_parent[joint_idx], -1)
 
-        model = builder.finalize()
-        state = model.state()
-        newton.eval_fk(model, model.joint_q, model.joint_qd, state)
-        np.testing.assert_allclose(state.body_q.numpy()[link_idx, :3], expected_pos, atol=1e-4)
+                # Check the fixed joint frame by validating the joint_X_c.
+                # Checking joint_X_p is left to the FK check below, which implicitly validates it.
+                expected_X_c = local_pose0 if side == "body0" else local_pose1
+                joint_X_c = builder.joint_X_c[joint_idx]
+                assert_np_equal(np.array(joint_X_c.p), np.array(expected_X_c.p), tol=1e-4)
+                # Compare rotations by the angle between them (q and -q are equal).
+                q_err = joint_X_c.q * wp.quat_inverse(expected_X_c.q)
+                self.assertLessEqual(2.0 * math.acos(min(1.0, abs(q_err[3]))), 1e-4)
+
+                model = builder.finalize()
+                state = model.state()
+                newton.eval_fk(model, model.joint_q, model.joint_qd, state)
+                # Check that the body is in the right pose: FK reproduces spawn * USD child world pose
+                # (env origin + spawn translation, identity rotation).
+                body_q = state.body_q.numpy()[link_idx]
+                assert_np_equal(body_q[:3], np.array([105.0, 200.0, 0.0]), tol=1e-4)
+                q_err = wp.quat(*body_q[3:7]) * wp.quat_inverse(wp.quat_identity())
+                self.assertLessEqual(2.0 * math.acos(min(1.0, abs(q_err[3]))), 1e-4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_collapse_fixed_joints_preserves_orphan_joints(self):


### PR DESCRIPTION
## Description

This PR fixes the transform of orphaned fixed joints when importing a model with an environment offset. This shows up when using Kamino USD models with fixed joints (but without ArticulationRootAPI) in IsaacLab, with Isaaclab giving them an environment offset. 

The new unit test illustrates well what went wrong: The importer was ignoring the environment offset when determining the world location of the fixed joint. The changed importer will derive the fixed joint location from the child transform instead.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

A minimal unit test was added
 ```
 uv run --extra dev -m newton.tests -k test_orphan_world_fixed_joint_respects_env_offset_and_xform
 ``` 

## Bug fix

**Steps to reproduce:**

The new unit tests fails with the old code. I will have a `joint_X_p = (5.0, 0.0, 0.0)`, which excludes the environment offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * USD import now correctly resolves forward kinematics for orphaned body-to-world fixed joints by accounting for ancestor transform and spawn offsets, ensuring pinned bodies reach the intended world pose.
* **Tests**
  * Added a test verifying orphaned world-fixed joints respect environment offsets and spawn transforms.
* **Documentation**
  * Changelog updated to document the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->