### PR TITLE
Address URDF performance regression introduced by #1579

### DIFF
--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -321,9 +321,9 @@ def parse_urdf(
         if color_el is not None:
             rgba = color_el.get("rgba")
             if rgba:
-                values = np.fromstring(rgba, sep=" ", dtype=np.float32)
-                if len(values) >= 3:
-                    color = (float(values[0]), float(values[1]), float(values[2]))
+                parts = rgba.split()
+                if len(parts) >= 3:
+                    color = (float(parts[0]), float(parts[1]), float(parts[2]))
 
         texture_el = material_element.find("texture")
         if texture_el is not None:
@@ -359,6 +359,14 @@ def parse_urdf(
         if material_element is None:
             return {"color": None, "texture": None}
         mat_name = material_element.get("name")
+
+        # Fast path: pure name reference to an already-parsed material. URDFs
+        # typically define materials once at the top level and then reference
+        # them by name on individual geoms (`<material name="foo"/>` with no
+        # children). Skip the XML re-parse in that common case.
+        if mat_name and mat_name in materials and len(material_element) == 0:
+            return dict(materials[mat_name])
+
         color, texture = _parse_material_properties(material_element)
 
         if mat_name and mat_name in materials:


### PR DESCRIPTION
## Summary

Two small, behavior-preserving optimizations to the URDF material resolution path in `newton/_src/utils/import_urdf.py` that address a performance regression introduced by #1579:

- **Cache-first fast path in `resolve_material()`.** URDFs typically define materials once at the top level and then reference them by name on individual geoms (`<material name="foo"/>` with no inline child elements). When the referenced name is already in the top-level `materials` cache, return a copy of the cached entry directly instead of re-walking the XML element via `_parse_material_properties()`. Robots that reuse a small set of material names across many shapes benefit most.
- **Replace `np.fromstring` with `str.split` + `float()`.** The `np.fromstring(rgba, sep=" ", dtype=np.float32)` form used to parse RGBA values has been deprecated since NumPy 1.14; every call passes through the `DeprecationWarning` machinery. For three or four floats, the pure-Python parse is faster regardless.

## Why

Newton's asv dashboard showed an example-load slowdown across several URDF-loading examples (BasicUrdf, ClothFranka, RobotAnymal, ClothTwist, ...) starting at #1579. Profiling pointed to redundant re-parsing of materials whose name was already resolved by the top-level pass, plus the deprecation overhead of `np.fromstring`.

## Behavior

No semantic change. The `test_import_urdf.*` tests that cover named and inline material colors (added in #1579) all pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URDF material color parsing to correctly extract RGB color values.
  * Enhanced material resolution with caching to improve performance when importing URDF files with repeated material references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->