### PR TITLE
Fix recorder dropping AttributeNamespace contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fix `eval_fk()` overwriting VBD-simulated `JointType.CABLE` body poses.
 - Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
+- Fix `ViewerFile` playback dropping namespaced custom attributes (e.g. `model.mujoco.geom_solimp`) when restoring into a fresh `Model`.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.
 - Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -602,78 +602,79 @@ def pointer_as_key(obj, format_type: str = "json", cache: ArrayCache | None = No
     return serialize(obj, callback, format_type=format_type, cache=cache)
 
 
+_MISSING = object()
+
+
 def transfer_to_model(source_dict: Mapping[str, Any], target_obj, post_load_init_callback=None, _path=""):
     """
-    Recursively transfer values from source_dict to target_obj, respecting the tree structure.
-    Only transfers values where both source and target have matching attributes.
+    Recursively transfer values from ``source_dict`` into ``target_obj``.
+
+    The walk is source-driven: each non-private key in ``source_dict`` is matched against
+    the corresponding slot on ``target_obj``. Source keys not declared on ``target_obj``
+    are dropped, with one exception — ``Model.AttributeNamespace`` targets hold arbitrary
+    user-defined keys, and ``Model.AttributeNamespace`` values in the source are created
+    on the target if missing (so namespaces like ``model.mujoco`` roundtrip).
 
     Args:
         source_dict: Mapping-like decoded values to transfer from deserialization.
         target_obj: Target object to receive the values.
-        post_load_init_callback: Optional function taking (target_obj, path) called after all children are processed.
+        post_load_init_callback: Optional function taking (target_obj, path) called after
+            all children are processed.
         _path: Internal parameter tracking the current path.
     """
     if not hasattr(target_obj, "__dict__"):
         return
-
-    # Handle case where source_dict is not mapping-like (primitive value)
     if not isinstance(source_dict, Mapping):
         return
 
-    # Iterate through all attributes of the target object
-    for attr_name in dir(target_obj):
-        # Skip private/magic methods and properties
+    target_is_namespace = isinstance(target_obj, Model.AttributeNamespace)
+
+    for attr_name, source_value in source_dict.items():
         if attr_name.startswith("_"):
             continue
+        target_value = getattr(target_obj, attr_name, _MISSING)
 
-        # Skip if attribute doesn't exist in target or is not settable
-        try:
-            target_value = getattr(target_obj, attr_name)
-        except (AttributeError, TypeError, RuntimeError):
-            # Skip attributes that can't be accessed (including CUDA stream on CPU devices)
-            continue
+        # Source carries a serialized AttributeNamespace (e.g. ``model.mujoco``) that the
+        # target does not have yet. ``Model.AttributeNamespace`` serializes as a generic
+        # dict with a ``_name`` marker from ``self._name = name`` in ``__init__``.
+        if (
+            isinstance(source_value, Mapping)
+            and "_name" in source_value
+            and not isinstance(target_value, Model.AttributeNamespace)
+        ):
+            ns = Model.AttributeNamespace(source_value["_name"])
+            try:
+                setattr(target_obj, attr_name, ns)
+            except (AttributeError, TypeError):
+                continue
+            target_value = ns
 
-        # Skip methods and non-data attributes
-        if callable(target_value):
-            continue
-
-        # Check if source_dict has this attribute (optimization: single dict lookup)
-        source_value = source_dict.get(attr_name, _MISSING := object())
-        if source_value is _MISSING:
-            continue
-
-        # Handle different types of values
-        if hasattr(target_value, "__dict__") and isinstance(source_value, Mapping):
-            # Recursively transfer for custom objects
-            # Build path only when needed (optimization: lazy string formatting)
+        # Recurse into sub-objects (namespaces and other custom objects with a __dict__).
+        if isinstance(source_value, Mapping) and target_value is not _MISSING and hasattr(target_value, "__dict__"):
             current_path = f"{_path}.{attr_name}" if _path else attr_name
             transfer_to_model(source_value, target_value, post_load_init_callback, current_path)
-        elif isinstance(source_value, list | tuple) and hasattr(target_value, "__len__"):
-            # Handle sequences - try to transfer if lengths match or target is empty
-            try:
-                # Optimization: cache len() call to avoid redundant computation
-                target_len = len(target_value)
-                if target_len == 0 or target_len == len(source_value):
-                    # For now, just assign the value directly
-                    # In a more sophisticated implementation, you might want to handle
-                    # element-wise transfer for lists of objects
-                    setattr(target_obj, attr_name, source_value)
-            except (TypeError, AttributeError):
-                # If we can't handle the sequence, try direct assignment
-                try:
-                    setattr(target_obj, attr_name, source_value)
-                except (AttributeError, TypeError):
-                    # Skip if we can't set the attribute
-                    pass
-        else:
-            # Direct assignment for primitive types and other values
-            try:
-                setattr(target_obj, attr_name, source_value)
-            except (AttributeError, TypeError):
-                # Skip if we can't set the attribute (e.g., read-only property)
-                pass
+            continue
 
-    # Call post_load_init_callback after all children have been processed
+        # Drop source keys not declared on the target. AttributeNamespace targets hold
+        # arbitrary user-defined keys by design, so they bypass this guard.
+        if target_value is _MISSING and not target_is_namespace:
+            continue
+
+        # Length-match guard for Python sequences: refuse to overwrite a populated target
+        # list/array with a mismatched-length source list.
+        if isinstance(source_value, list | tuple) and target_value is not _MISSING and hasattr(target_value, "__len__"):
+            try:
+                target_len = len(target_value)
+            except TypeError:
+                target_len = None
+            if target_len is not None and target_len != 0 and target_len != len(source_value):
+                continue
+
+        try:
+            setattr(target_obj, attr_name, source_value)
+        except (AttributeError, TypeError):
+            pass
+
     if post_load_init_callback is not None:
         post_load_init_callback(target_obj, _path)
 

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -612,8 +612,9 @@ def transfer_to_model(source_dict: Mapping[str, Any], target_obj, post_load_init
     The walk is source-driven: each non-private key in ``source_dict`` is matched against
     the corresponding slot on ``target_obj``. Source keys not declared on ``target_obj``
     are dropped, with one exception — ``Model.AttributeNamespace`` targets hold arbitrary
-    user-defined keys, and ``Model.AttributeNamespace`` values in the source are created
-    on the target if missing (so namespaces like ``model.mujoco`` roundtrip).
+    user-defined keys, so a namespace target accepts every source key. When the source
+    carries a ``Model.AttributeNamespace`` (reconstructed by :func:`deserialize`) that the
+    target lacks, it is installed wholesale so namespaces like ``model.mujoco`` roundtrip.
 
     Args:
         source_dict: Mapping-like decoded values to transfer from deserialization.
@@ -634,22 +635,24 @@ def transfer_to_model(source_dict: Mapping[str, Any], target_obj, post_load_init
             continue
         target_value = getattr(target_obj, attr_name, _MISSING)
 
-        # Source carries a serialized AttributeNamespace (e.g. ``model.mujoco``) that the
-        # target does not have yet. ``Model.AttributeNamespace`` serializes as a generic
-        # dict with a ``_name`` marker from ``self._name = name`` in ``__init__``.
-        if (
-            isinstance(source_value, Mapping)
-            and "_name" in source_value
-            and not isinstance(target_value, Model.AttributeNamespace)
-        ):
-            ns = Model.AttributeNamespace(source_value["_name"])
-            try:
-                setattr(target_obj, attr_name, ns)
-            except (AttributeError, TypeError):
-                continue
-            target_value = ns
+        # Source carries a reconstructed AttributeNamespace (e.g. ``model.mujoco``).
+        # Install it on the target only when the slot is empty; if the target already has
+        # a namespace there, merge attrs into it; otherwise skip rather than overwrite a
+        # non-namespace target.
+        if isinstance(source_value, Model.AttributeNamespace):
+            if target_value is _MISSING:
+                try:
+                    setattr(target_obj, attr_name, source_value)
+                except (AttributeError, TypeError):
+                    pass
+            elif isinstance(target_value, Model.AttributeNamespace):
+                for ns_attr, ns_value in vars(source_value).items():
+                    if ns_attr.startswith("_"):
+                        continue
+                    setattr(target_value, ns_attr, ns_value)
+            continue
 
-        # Recurse into sub-objects (namespaces and other custom objects with a __dict__).
+        # Recurse into sub-objects (custom objects with a __dict__) when source is a dict.
         if isinstance(source_value, Mapping) and target_value is not _MISSING and hasattr(target_value, "__dict__"):
             current_path = f"{_path}.{attr_name}" if _path else attr_name
             transfer_to_model(source_value, target_value, post_load_init_callback, current_path)
@@ -738,8 +741,28 @@ def deserialize(data, callback, _path="", format_type="json", cache: ArrayCache 
 
     # Custom objects
     if "attributes" in data:
-        # For now, return a simple dict representation
-        # In a full implementation, you might want to reconstruct the actual class
+        # Reconstruct AttributeNamespace as a real instance so downstream consumers
+        # (notably ``transfer_to_model``) can identify it without resorting to a
+        # heuristic on serialized field names.
+        if type_name == "AttributeNamespace":
+            attrs_data = data["attributes"]
+            name_data = attrs_data.get("_name")
+            ns_name = (
+                deserialize(name_data, callback, f"{_path}._name" if _path else "_name", format_type, cache)
+                if name_data is not None
+                else ""
+            )
+            ns = Model.AttributeNamespace(ns_name)
+            for attr, value in attrs_data.items():
+                if attr == "_name":
+                    continue
+                setattr(
+                    ns,
+                    attr,
+                    deserialize(value, callback, f"{_path}.{attr}" if _path else attr, format_type, cache),
+                )
+            return ns
+        # Fallback: return a flat dict of decoded attributes for other custom classes.
         return {
             attr: deserialize(value, callback, f"{_path}.{attr}" if _path else attr, format_type, cache)
             for attr, value in data["attributes"].items()

--- a/newton/tests/test_recorder.py
+++ b/newton/tests/test_recorder.py
@@ -704,22 +704,26 @@ def test_real_model_recording_roundtrip(test: TestRecorder, device):
                 test.assertEqual(restored_model.joint_count, model.joint_count)
                 test.assertEqual(restored_model.shape_count, model.shape_count)
 
-                # Verify MuJoCo attributes loaded (these use dynamic vec5 types)
-                if hasattr(model, "mujoco") and hasattr(restored_model, "mujoco"):
-                    for attr_name in ["geom_solimp", "solimplimit", "solimpfriction"]:
-                        if hasattr(model.mujoco, attr_name):
-                            original = getattr(model.mujoco, attr_name)
-                            restored = getattr(restored_model.mujoco, attr_name, None)
-                            test.assertIsNotNone(
-                                restored, f"MuJoCo attribute {attr_name} not restored in {format_name}"
-                            )
-                            if original is not None and restored is not None:
-                                np.testing.assert_allclose(
-                                    restored.numpy(),
-                                    original.numpy(),
-                                    atol=1e-6,
-                                    err_msg=f"MuJoCo {attr_name} data mismatch in {format_name}",
-                                )
+                # Verify MuJoCo attributes loaded (these use dynamic vec5 types).
+                # SolverMuJoCo.register_custom_attributes guarantees ``model.mujoco`` and
+                # the three attributes below exist after finalize; restored_model.mujoco
+                # must be created during playback.
+                test.assertTrue(
+                    hasattr(restored_model, "mujoco"),
+                    f"mujoco namespace not restored in {format_name}",
+                )
+                for attr_name in ["geom_solimp", "solimplimit", "solimpfriction"]:
+                    original = getattr(model.mujoco, attr_name)
+                    restored = getattr(restored_model.mujoco, attr_name, None)
+                    test.assertIsNotNone(
+                        restored, f"MuJoCo attribute {attr_name} not restored in {format_name}"
+                    )
+                    np.testing.assert_allclose(
+                        restored.numpy(),
+                        original.numpy(),
+                        atol=1e-6,
+                        err_msg=f"MuJoCo {attr_name} data mismatch in {format_name}",
+                    )
 
             finally:
                 if os.path.exists(file_path):

--- a/newton/tests/test_recorder.py
+++ b/newton/tests/test_recorder.py
@@ -715,9 +715,7 @@ def test_real_model_recording_roundtrip(test: TestRecorder, device):
                 for attr_name in ["geom_solimp", "solimplimit", "solimpfriction"]:
                     original = getattr(model.mujoco, attr_name)
                     restored = getattr(restored_model.mujoco, attr_name, None)
-                    test.assertIsNotNone(
-                        restored, f"MuJoCo attribute {attr_name} not restored in {format_name}"
-                    )
+                    test.assertIsNotNone(restored, f"MuJoCo attribute {attr_name} not restored in {format_name}")
                     np.testing.assert_allclose(
                         restored.numpy(),
                         original.numpy(),


### PR DESCRIPTION
## Description

`transfer_to_model` walked `dir(target_obj)` and copied matching source
keys into the target. A fresh `newton.Model()` does not declare
namespace attributes like `mujoco` — those are created at finalize time
via `add_attribute`. As a result, the namespace key in the serialized
model was silently dropped on every recorder roundtrip.

Switch `transfer_to_model` to a source-driven walk: iterate source keys,
create `Model.AttributeNamespace` targets on demand when the source
carries one (detected by the `_name` marker emitted from
`self._name = name`), and recurse. Non-namespace targets keep the
"drop unknown source keys" guarantee; populated sequences keep the
length-match guard.

The existing `test_real_model_recording_roundtrip` assertion was masked
by a defensive `hasattr(restored_model, "mujoco")` guard wrapping the
namespace check — the guard was always False because the namespace
never made it through transfer, so the inner `assertIsNotNone` never
ran. With the fix, the namespace now roundtrips and the guard becomes
truthy, so the assertion actually executes.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_recorder
uv run --extra dev -m newton.tests -k test_viewer
```

## Bug fix

**Steps to reproduce:**

1. Build a model with a custom-attribute namespace (e.g. by calling
   `SolverMuJoCo.register_custom_attributes(builder)`).
2. Record the model with `ViewerFile`, save, then load.
3. Play the recording back into a fresh `newton.Model()`.
4. Observe that `restored_model.mujoco` is missing — every namespaced
   custom attribute (e.g. `geom_solimp`) is silently lost.

**Minimal reproduction:**

```python
import tempfile
import newton
from newton._src.utils.import_mjcf import parse_mjcf
from newton._src.viewer.viewer_file import ViewerFile

builder = newton.ModelBuilder()
newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
parse_mjcf(builder, newton.examples.get_asset("nv_humanoid.xml"), up_axis="Z")
model = builder.finalize(device="cpu")

recorder = ViewerFile("rec.json", auto_save=False)
recorder.record_model(model)
with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
    path = tmp.name
recorder.save_recording(path)

loader = ViewerFile(path, auto_save=False)
loader.load_recording()
restored = newton.Model(device="cpu")
loader.playback_model(restored)

assert hasattr(restored, "mujoco")          # fails without this PR
assert restored.mujoco.geom_solimp is not None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved model data-transfer/loading to be more robust and consistent when restoring state.

* **Bug Fixes**
  * Preserve and restore namespaced custom attributes (e.g., model namespaces) so restored models match originals more faithfully.

* **Tests**
  * Strengthened round‑trip tests to assert recreation of namespaces and exact restoration of custom attribute arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->