### PR TITLE
Disable flaky SDF construction benchmark

### DIFF
--- a/asv/benchmarks/setup/bench_sdf.py
+++ b/asv/benchmarks/setup/bench_sdf.py
@@ -189,7 +189,8 @@ class FastBuildSdf:
         self._mesh.clear_sdf()
         wp.synchronize_device()
 
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    # Disabled, see #2534.
+    @skip_benchmark_if(True)
     def time_build_sdf(self, max_resolution):
         for _ in range(_BUILDS_PER_SAMPLE[max_resolution]):
             _build_sdf(self._mesh, max_resolution=max_resolution)


### PR DESCRIPTION
## Description

Re-applies the workaround from #2535: skip `FastBuildSdf.time_build_sdf` via `@skip_benchmark_if(True)`. The warmup+batching mitigation in #2577 stabilized the `(32)`, `(64)`, and `(128)` parameters, but `(256)` remains bimodal at ~328 ms vs ~415 ms across CI runs and is currently flagging spurious 1.27× regressions on unrelated PRs.

Two unrelated PRs on the same day both landed in the slower mode:

| Run | Branch | `(256)` base → head |
|---|---|---|
| [26568152465](https://github.com/newton-physics/newton/actions/runs/26568152465) | `adenzler/urdf-material-resolve-perf` (URDF parsing only) | 328 → 412 ms (1.26×) |
| [26573933607](https://github.com/newton-physics/newton/actions/runs/26573933607) | `gdaviet/coupled-solver-framework` | 327 → 415 ms (1.27×) |

See #2534 for the broader discussion and possible long-term fixes (lock GPU clocks on the runner, or drop the `(256)` parameter).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

No behavior change to product code. The asv benchmark is now skipped at runtime; this matches what was previously done in #2535.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled a performance benchmark test as part of test maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->