### PR TITLE
USD: support GeomSubset visual materials + demote orphan-primvar warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,7 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
-- Fix USD visual mesh imports to preserve face-material `GeomSubset` colors and textures by splitting material subsets into separate render meshes
+- Fix USD visual mesh imports to preserve face-material `UsdGeom.Subset` colors and textures by splitting material subsets into separate render meshes; collision/physics import behavior is unchanged
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
+- Fix USD visual mesh imports to preserve face-material `GeomSubset` colors and textures by splitting material subsets into separate render meshes
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 import warnings
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -148,41 +147,6 @@ def has_applied_api_schema(prim: Usd.Prim, schema_name: str) -> bool:
         True if the schema is applied to the prim, False otherwise.
     """
     return prim.HasAPI(schema_name) or schema_name in _get_raw_api_schemas(prim)
-
-
-_ST_SUBSET_PRIMVAR_RE = re.compile(r"^st(?:_\d+)?$")
-
-
-def has_orphan_subset_primvars(prim: Usd.Prim) -> bool:
-    """Detect the malformed "GeomSubsets stripped but per-subset primvars retained" pattern.
-
-    Some USD assets (e.g. Isaac Sim's Boston Dynamics Spot lower-leg meshes) carry sibling
-    ``st_N`` primvars (``st``, ``st_1``, ``st_2``, ...) that were originally each bound to a
-    separate face-based ``UsdGeom.Subset``, but the subsets were later removed in authoring while
-    the primvars were left in place. Without subsets there is no way to map the primvars back to
-    faces, so the importer cannot recover UVs even though the data is present.
-
-    Args:
-        prim: The USD prim to inspect for the orphan-primvar pattern.
-
-    Returns:
-        True when the prim has no face-based ``UsdGeom.Subset`` children but does carry more
-        than one UV-shaped primvar (``st`` plus at least one ``st_N`` sibling).
-    """
-    if not prim or not prim.IsValid():
-        return False
-    for child in prim.GetChildren():
-        try:
-            if not child.IsA(UsdGeom.Subset):
-                continue
-            element_type = UsdGeom.Subset(child).GetElementTypeAttr().Get()
-        except Exception:
-            continue
-        if element_type == UsdGeom.Tokens.face:
-            return False
-    primvars_api = UsdGeom.PrimvarsAPI(prim)
-    st_count = sum(1 for pv in primvars_api.GetPrimvars() if _ST_SUBSET_PRIMVAR_RE.match(pv.GetPrimvarName()))
-    return st_count > 1
 
 
 @overload
@@ -1186,24 +1150,15 @@ def get_mesh(
         # were converted to per-vertex. Avoid a second split here.
         if uvs_interpolation == UsdGeom.Tokens.faceVarying and not did_split_vertices:
             if len(uvs) != len(indices):
-                # Some USD assets carry per-GeomSubset UV primvars (`st`, `st_1`, ...) but no GeomSubsets to
-                # bind them to faces (likely an authoring tool removed subsets but left the primvars). Without
-                # subset bindings the primvar-to-face mapping is unrecoverable; demote to info-level since
-                # there is nothing the caller can do about it and the noisier warning misleads users.
-                if has_orphan_subset_primvars(prim):
-                    logger.info(
-                        "Mesh %s: UV primvar 'st' length %d does not match indices length %d and no "
-                        "GeomSubsets are authored to bind the sibling `st_N` primvars; dropping UVs.",
-                        prim.GetPath(),
-                        len(uvs),
-                        len(indices),
-                    )
-                else:
-                    warnings.warn(
-                        f"UV primvar length ({len(uvs)}) does not match indices length ({len(indices)}) for mesh {prim.GetPath()}; "
-                        "dropping UVs.",
-                        stacklevel=2,
-                    )
+                # A dropped UV is a render-only concern (it never affects simulation), so route the
+                # diagnostic through `logger.info` instead of `warnings.warn`. Consumers can raise the
+                # `newton` logger to INFO to surface these notices when investigating an asset.
+                logger.info(
+                    "Mesh %s: UV primvar length (%d) does not match indices length (%d); dropping UVs.",
+                    prim.GetPath(),
+                    len(uvs),
+                    len(indices),
+                )
                 uvs = None
             else:
                 corner_flat = _triangulate_face_varying_indices(counts, flip_winding)

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import warnings
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -149,29 +150,38 @@ def has_applied_api_schema(prim: Usd.Prim, schema_name: str) -> bool:
     return prim.HasAPI(schema_name) or schema_name in _get_raw_api_schemas(prim)
 
 
+_ST_SUBSET_PRIMVAR_RE = re.compile(r"^st(?:_\d+)?$")
+
+
 def has_orphan_subset_primvars(prim: Usd.Prim) -> bool:
     """Detect the malformed "GeomSubsets stripped but per-subset primvars retained" pattern.
 
     Some USD assets (e.g. Isaac Sim's Boston Dynamics Spot lower-leg meshes) carry sibling
     ``st_N`` primvars (``st``, ``st_1``, ``st_2``, ...) that were originally each bound to a
-    separate ``UsdGeom.Subset``, but the subsets were later removed in authoring while the
-    primvars were left in place. Without subsets there is no way to map the primvars back to
+    separate face-based ``UsdGeom.Subset``, but the subsets were later removed in authoring while
+    the primvars were left in place. Without subsets there is no way to map the primvars back to
     faces, so the importer cannot recover UVs even though the data is present.
+
+    Args:
+        prim: The USD prim to inspect for the orphan-primvar pattern.
 
     Returns:
         True when the prim has no face-based ``UsdGeom.Subset`` children but does carry more
-        than one ``st``-prefixed primvar (i.e. ``st`` plus at least one ``st_N`` sibling).
+        than one UV-shaped primvar (``st`` plus at least one ``st_N`` sibling).
     """
     if not prim or not prim.IsValid():
         return False
     for child in prim.GetChildren():
         try:
-            if child.IsA(UsdGeom.Subset):
-                return False
+            if not child.IsA(UsdGeom.Subset):
+                continue
+            element_type = UsdGeom.Subset(child).GetElementTypeAttr().Get()
         except Exception:
             continue
+        if element_type == UsdGeom.Tokens.face:
+            return False
     primvars_api = UsdGeom.PrimvarsAPI(prim)
-    st_count = sum(1 for pv in primvars_api.GetPrimvars() if pv.GetPrimvarName().startswith("st"))
+    st_count = sum(1 for pv in primvars_api.GetPrimvars() if _ST_SUBSET_PRIMVAR_RE.match(pv.GetPrimvarName()))
     return st_count > 1
 
 

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -19,7 +19,7 @@ from ..sim.model import Model
 from ..utils.color import color_linear_to_srgb
 from ..utils.texture import linear_texture_to_srgb, load_texture
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("newton")
 
 AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import warnings
 from collections.abc import Iterable, Sequence
@@ -16,6 +17,8 @@ from ..geometry import Gaussian, Mesh
 from ..sim.model import Model
 from ..utils.color import color_linear_to_srgb
 from ..utils.texture import linear_texture_to_srgb, load_texture
+
+logger = logging.getLogger(__name__)
 
 AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
@@ -144,6 +147,32 @@ def has_applied_api_schema(prim: Usd.Prim, schema_name: str) -> bool:
         True if the schema is applied to the prim, False otherwise.
     """
     return prim.HasAPI(schema_name) or schema_name in _get_raw_api_schemas(prim)
+
+
+def has_orphan_subset_primvars(prim: Usd.Prim) -> bool:
+    """Detect the malformed "GeomSubsets stripped but per-subset primvars retained" pattern.
+
+    Some USD assets (e.g. Isaac Sim's Boston Dynamics Spot lower-leg meshes) carry sibling
+    ``st_N`` primvars (``st``, ``st_1``, ``st_2``, ...) that were originally each bound to a
+    separate ``UsdGeom.Subset``, but the subsets were later removed in authoring while the
+    primvars were left in place. Without subsets there is no way to map the primvars back to
+    faces, so the importer cannot recover UVs even though the data is present.
+
+    Returns:
+        True when the prim has no face-based ``UsdGeom.Subset`` children but does carry more
+        than one ``st``-prefixed primvar (i.e. ``st`` plus at least one ``st_N`` sibling).
+    """
+    if not prim or not prim.IsValid():
+        return False
+    for child in prim.GetChildren():
+        try:
+            if child.IsA(UsdGeom.Subset):
+                return False
+        except Exception:
+            continue
+    primvars_api = UsdGeom.PrimvarsAPI(prim)
+    st_count = sum(1 for pv in primvars_api.GetPrimvars() if pv.GetPrimvarName().startswith("st"))
+    return st_count > 1
 
 
 @overload
@@ -1147,11 +1176,24 @@ def get_mesh(
         # were converted to per-vertex. Avoid a second split here.
         if uvs_interpolation == UsdGeom.Tokens.faceVarying and not did_split_vertices:
             if len(uvs) != len(indices):
-                warnings.warn(
-                    f"UV primvar length ({len(uvs)}) does not match indices length ({len(indices)}) for mesh {prim.GetPath()}; "
-                    "dropping UVs.",
-                    stacklevel=2,
-                )
+                # Some USD assets carry per-GeomSubset UV primvars (`st`, `st_1`, ...) but no GeomSubsets to
+                # bind them to faces (likely an authoring tool removed subsets but left the primvars). Without
+                # subset bindings the primvar-to-face mapping is unrecoverable; demote to info-level since
+                # there is nothing the caller can do about it and the noisier warning misleads users.
+                if has_orphan_subset_primvars(prim):
+                    logger.info(
+                        "Mesh %s: UV primvar 'st' length %d does not match indices length %d and no "
+                        "GeomSubsets are authored to bind the sibling `st_N` primvars; dropping UVs.",
+                        prim.GetPath(),
+                        len(uvs),
+                        len(indices),
+                    )
+                else:
+                    warnings.warn(
+                        f"UV primvar length ({len(uvs)}) does not match indices length ({len(indices)}) for mesh {prim.GetPath()}; "
+                        "dropping UVs.",
+                        stacklevel=2,
+                    )
                 uvs = None
             else:
                 corner_flat = _triangulate_face_varying_indices(counts, flip_winding)

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -1150,9 +1150,6 @@ def get_mesh(
         # were converted to per-vertex. Avoid a second split here.
         if uvs_interpolation == UsdGeom.Tokens.faceVarying and not did_split_vertices:
             if len(uvs) != len(indices):
-                # A dropped UV is a render-only concern (it never affects simulation), so route the
-                # diagnostic through `logger.info` instead of `warnings.warn`. Consumers can raise the
-                # `newton` logger to INFO to surface these notices when investigating an asset.
                 logger.info(
                     "Mesh %s: UV primvar length (%d) does not match indices length (%d); dropping UVs.",
                     prim.GetPath(),

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -534,16 +534,10 @@ def parse_usd(
         if texture is not None:
             mesh.texture = texture
         if mesh.texture is not None and mesh.uvs is None:
-            # See usd.utils.has_orphan_subset_primvars: when the asset was authored with per-subset
-            # UV primvars but had its GeomSubsets stripped, UVs are unrecoverable and the matching
-            # length-mismatch notice was already logged. Avoid emitting a second, redundant warning.
-            if usd.has_orphan_subset_primvars(prim):
-                logger.info("Mesh %s: dropping texture because UVs could not be recovered.", path_name)
-            else:
-                warnings.warn(
-                    f"Warning: mesh {path_name} has a texture but no UVs; texture will be ignored.",
-                    stacklevel=2,
-                )
+            # A dropped texture is a render-only concern (it never affects simulation), so route the
+            # diagnostic through `logger.info` instead of `warnings.warn`. See the matching length-mismatch
+            # site in `newton._src.usd.utils.get_mesh` for the reasoning.
+            logger.info("Mesh %s: dropping texture because UVs could not be recovered.", path_name)
             mesh.texture = None
         if material_props.get("color") is not None and mesh.texture is None:
             mesh.color = material_props["color"]

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -544,6 +544,183 @@ def parse_usd(
             mesh.metallic = material_props["metallic"]
         return mesh
 
+    def _get_face_material_subsets(prim: Usd.Prim) -> list[Usd.Prim]:
+        """Return face-based material subsets authored directly under a mesh prim."""
+        subsets = []
+        for child in prim.GetChildren():
+            try:
+                is_subset = child.IsA(UsdGeom.Subset)
+            except Exception:
+                is_subset = False
+            if not is_subset:
+                continue
+
+            subset = UsdGeom.Subset(child)
+            element_type = subset.GetElementTypeAttr().Get()
+            if element_type != UsdGeom.Tokens.face:
+                continue
+            family_name = subset.GetFamilyNameAttr().Get()
+            if family_name and family_name != "materialBind":
+                continue
+            indices = subset.GetIndicesAttr().Get()
+            if not indices:
+                continue
+            subsets.append(child)
+        return subsets
+
+    def _get_subset_uvs(prim: Usd.Prim, used_vertices: np.ndarray, expected_count: int) -> np.ndarray | None:
+        """Return UVs for a material subset when a matching primvar is authored."""
+        max_used_vertex = int(np.max(used_vertices, initial=-1))
+        full_mesh_uvs = None
+        for primvar in UsdGeom.PrimvarsAPI(prim).GetPrimvars():
+            name = primvar.GetBaseName()
+            if not name.startswith("st"):
+                continue
+            values = primvar.Get()
+            if values is None:
+                continue
+            uvs = np.asarray(values, dtype=np.float32)
+            if primvar.IsIndexed():
+                indices = primvar.GetIndices()
+                if indices is None:
+                    continue
+                indices = np.asarray(indices, dtype=np.int32)
+                if len(indices) == expected_count:
+                    uvs = uvs[indices]
+                    if len(uvs) == expected_count:
+                        return uvs
+                    continue
+                if len(indices) > max_used_vertex:
+                    uvs = uvs[indices]
+                else:
+                    continue
+            if len(uvs) == expected_count:
+                return uvs
+            if full_mesh_uvs is None and len(uvs) > max_used_vertex:
+                full_mesh_uvs = uvs[used_vertices]
+        return full_mesh_uvs
+
+    def _make_visual_submesh(
+        mesh: Mesh,
+        triangle_indices: np.ndarray,
+        material_props: dict[str, Any],
+        *,
+        prim: Usd.Prim,
+        path_name: str,
+    ) -> Mesh | None:
+        """Create a render-only mesh slice for the selected triangle rows."""
+        if len(triangle_indices) == 0:
+            return None
+
+        triangles = mesh.indices.reshape(-1, 3)[triangle_indices]
+        used_vertices = np.unique(triangles)
+        vertex_remap = np.full(len(mesh.vertices), -1, dtype=np.int32)
+        vertex_remap[used_vertices] = np.arange(len(used_vertices), dtype=np.int32)
+
+        normals = None
+        if mesh.normals is not None and len(mesh.normals) == len(mesh.vertices):
+            normals = mesh.normals[used_vertices]
+
+        uvs = None
+        if mesh.uvs is not None and len(mesh.uvs) == len(mesh.vertices):
+            uvs = mesh.uvs[used_vertices]
+        elif material_props.get("texture") is not None:
+            uvs = _get_subset_uvs(prim, used_vertices, len(used_vertices))
+
+        submesh = Mesh(
+            mesh.vertices[used_vertices],
+            vertex_remap[triangles].reshape(-1),
+            normals=normals,
+            uvs=uvs,
+            compute_inertia=False,
+            is_solid=mesh.is_solid,
+            maxhullvert=mesh.maxhullvert,
+        )
+
+        texture = material_props.get("texture")
+        if texture:
+            submesh.texture = texture
+        if submesh.texture is not None and submesh.uvs is None:
+            warnings.warn(
+                f"Warning: mesh material subset {path_name} has a texture but no UVs; texture will be ignored.",
+                stacklevel=2,
+            )
+            submesh.texture = None
+
+        color = material_props.get("color")
+        if color is not None:
+            submesh.color = color
+        elif submesh.texture is not None:
+            submesh.color = (1.0, 1.0, 1.0)
+        if material_props.get("roughness") is not None:
+            submesh.roughness = material_props["roughness"]
+        if material_props.get("metallic") is not None:
+            submesh.metallic = material_props["metallic"]
+        return submesh
+
+    def _get_visual_material_subset_meshes(prim: Usd.Prim) -> list[tuple[str, Mesh]]:
+        """Load one render mesh per USD material subset when subsets are authored."""
+        subsets = _get_face_material_subsets(prim)
+        if not subsets:
+            return []
+
+        mesh_schema = UsdGeom.Mesh(prim)
+        face_counts = mesh_schema.GetFaceVertexCountsAttr().Get()
+        if face_counts is None:
+            return []
+        face_counts = np.asarray(face_counts, dtype=np.int32)
+        if len(face_counts) == 0 or np.any(face_counts < 3):
+            return []
+
+        subset_props = [(str(subset.GetPath()), usd.resolve_material_properties_for_prim(subset)) for subset in subsets]
+        mesh = _get_mesh_cached(prim)
+        triangle_face_indices = np.repeat(np.arange(len(face_counts), dtype=np.int32), face_counts - 2)
+        covered_faces = np.zeros(len(face_counts), dtype=bool)
+
+        submeshes = []
+        for subset_path, material_props in subset_props:
+            subset = UsdGeom.Subset(stage.GetPrimAtPath(subset_path))
+            subset_indices = np.asarray(subset.GetIndicesAttr().Get(), dtype=np.int32)
+            valid = (subset_indices >= 0) & (subset_indices < len(face_counts))
+            if not np.all(valid):
+                warnings.warn(
+                    f"Warning: mesh material subset {subset_path} has face indices outside the mesh face range; "
+                    "out-of-range indices will be ignored.",
+                    stacklevel=2,
+                )
+                subset_indices = subset_indices[valid]
+            if len(subset_indices) == 0:
+                continue
+
+            face_mask = np.zeros(len(face_counts), dtype=bool)
+            face_mask[subset_indices] = True
+            triangle_indices = np.nonzero(face_mask[triangle_face_indices])[0]
+            submesh = _make_visual_submesh(mesh, triangle_indices, material_props, prim=prim, path_name=subset_path)
+            if submesh is None:
+                continue
+            covered_faces[subset_indices] = True
+            submeshes.append((subset_path, submesh))
+
+        if not submeshes:
+            return []
+
+        uncovered_faces = np.nonzero(~covered_faces)[0]
+        if len(uncovered_faces) > 0:
+            face_mask = np.zeros(len(face_counts), dtype=bool)
+            face_mask[uncovered_faces] = True
+            triangle_indices = np.nonzero(face_mask[triangle_face_indices])[0]
+            fallback_mesh = _make_visual_submesh(
+                mesh,
+                triangle_indices,
+                _get_material_props_cached(prim),
+                prim=prim,
+                path_name=str(prim.GetPath()),
+            )
+            if fallback_mesh is not None:
+                submeshes.insert(0, (str(prim.GetPath()), fallback_mesh))
+
+        return submeshes
+
     def _get_tetmesh_cached(prim: Usd.Prim) -> TetMesh:
         """Load and cache TetMesh data to avoid repeated USD extraction."""
         prim_path = str(prim.GetPath())
@@ -746,16 +923,38 @@ def parse_usd(
                     label=path_name,
                 )
             elif type_name == "mesh":
-                mesh = _get_mesh_with_visual_material(prim, path_name=path_name)
-                shape_id = builder.add_shape_mesh(
-                    parent_body_id,
-                    xform,
-                    scale=scale,
-                    mesh=mesh,
-                    cfg=visual_shape_cfg_for_prim,
-                    color=shape_color,
-                    label=path_name,
-                )
+                subset_meshes = _get_visual_material_subset_meshes(prim)
+                if subset_meshes:
+                    for subset_path, subset_mesh in subset_meshes:
+                        subset_shape_id = builder.add_shape_mesh(
+                            parent_body_id,
+                            xform,
+                            scale=scale,
+                            mesh=subset_mesh,
+                            cfg=visual_shape_cfg_for_prim,
+                            color=None,
+                            label=subset_path,
+                        )
+                        path_shape_map[subset_path] = subset_shape_id
+                        path_shape_scale[subset_path] = scale
+                        if shape_id < 0:
+                            shape_id = subset_shape_id
+                        if verbose:
+                            print(
+                                f"Added visual shape {subset_path} ({type_name} material subset) "
+                                f"with id {subset_shape_id}."
+                            )
+                else:
+                    mesh = _get_mesh_with_visual_material(prim, path_name=path_name)
+                    shape_id = builder.add_shape_mesh(
+                        parent_body_id,
+                        xform,
+                        scale=scale,
+                        mesh=mesh,
+                        cfg=visual_shape_cfg_for_prim,
+                        color=shape_color,
+                        label=path_name,
+                    )
             elif type_name == "particlefield3dgaussiansplat":
                 gaussian = usd.get_gaussian(prim)
                 shape_id = builder.add_shape_gaussian(
@@ -767,7 +966,11 @@ def parse_usd(
                     color=shape_color,
                     label=path_name,
                 )
-            elif len(type_name) > 0 and type_name not in {"xform", "tetmesh"} and verbose:
+            elif (
+                len(type_name) > 0
+                and type_name not in {"geomsubset", "material", "scope", "shader", "xform", "tetmesh"}
+                and verbose
+            ):
                 print(f"Warning: Unsupported geometry type {type_name} at {path_name} while loading visual shapes.")
 
             if shape_id >= 0:

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -688,6 +688,12 @@ def parse_usd(
 
         submeshes = []
         for subset_path, material_props in subset_props:
+            # `resolve_material_properties_for_prim` does not fall back from a subset to its parent mesh
+            # (see `newton/_src/usd/utils.py` resolve_material_properties_for_prim). If a subset binds no
+            # visible material, let the uncovered-faces fallback below apply the parent mesh material
+            # instead of producing a materialless submesh and hiding the parent material on those faces.
+            if not any(value is not None for value in material_props.values()):
+                continue
             subset = UsdGeom.Subset(stage.GetPrimAtPath(subset_path))
             subset_indices = np.asarray(subset.GetIndicesAttr().Get(), dtype=np.int32)
             valid = (subset_indices >= 0) & (subset_indices < len(face_counts))

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -8,6 +8,7 @@ import copy
 import datetime
 import inspect
 import itertools
+import logging
 import math
 import os
 import posixpath
@@ -44,6 +45,8 @@ from ..usd import utils as usd
 from ..usd.schema_resolver import PrimType, SchemaResolver, SchemaResolverManager
 from ..usd.schemas import SchemaResolverNewton
 from .import_utils import should_show_collider
+
+logger = logging.getLogger(__name__)
 
 AttributeFrequency = Model.AttributeFrequency
 
@@ -531,10 +534,16 @@ def parse_usd(
         if texture is not None:
             mesh.texture = texture
         if mesh.texture is not None and mesh.uvs is None:
-            warnings.warn(
-                f"Warning: mesh {path_name} has a texture but no UVs; texture will be ignored.",
-                stacklevel=2,
-            )
+            # See usd.utils.has_orphan_subset_primvars: when the asset was authored with per-subset
+            # UV primvars but had its GeomSubsets stripped, UVs are unrecoverable and the matching
+            # length-mismatch notice was already logged. Avoid emitting a second, redundant warning.
+            if usd.has_orphan_subset_primvars(prim):
+                logger.info("Mesh %s: dropping texture because UVs could not be recovered.", path_name)
+            else:
+                warnings.warn(
+                    f"Warning: mesh {path_name} has a texture but no UVs; texture will be ignored.",
+                    stacklevel=2,
+                )
             mesh.texture = None
         if material_props.get("color") is not None and mesh.texture is None:
             mesh.color = material_props["color"]

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -46,7 +46,7 @@ from ..usd.schema_resolver import PrimType, SchemaResolver, SchemaResolverManage
 from ..usd.schemas import SchemaResolverNewton
 from .import_utils import should_show_collider
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("newton")
 
 AttributeFrequency = Model.AttributeFrequency
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -534,9 +534,6 @@ def parse_usd(
         if texture is not None:
             mesh.texture = texture
         if mesh.texture is not None and mesh.uvs is None:
-            # A dropped texture is a render-only concern (it never affects simulation), so route the
-            # diagnostic through `logger.info` instead of `warnings.warn`. See the matching length-mismatch
-            # site in `newton._src.usd.utils.get_mesh` for the reasoning.
             logger.info("Mesh %s: dropping texture because UVs could not be recovered.", path_name)
             mesh.texture = None
         if material_props.get("color") is not None and mesh.texture is None:
@@ -644,10 +641,7 @@ def parse_usd(
         if texture:
             submesh.texture = texture
         if submesh.texture is not None and submesh.uvs is None:
-            warnings.warn(
-                f"Warning: mesh material subset {path_name} has a texture but no UVs; texture will be ignored.",
-                stacklevel=2,
-            )
+            logger.info("Mesh material subset %s: dropping texture because UVs could not be recovered.", path_name)
             submesh.texture = None
 
         color = material_props.get("color")
@@ -692,10 +686,10 @@ def parse_usd(
             subset_indices = np.asarray(subset.GetIndicesAttr().Get(), dtype=np.int32)
             valid = (subset_indices >= 0) & (subset_indices < len(face_counts))
             if not np.all(valid):
-                warnings.warn(
-                    f"Warning: mesh material subset {subset_path} has face indices outside the mesh face range; "
+                logger.info(
+                    "Mesh material subset %s: face indices outside the mesh face range; "
                     "out-of-range indices will be ignored.",
-                    stacklevel=2,
+                    subset_path,
                 )
                 subset_indices = subset_indices[valid]
             if len(subset_indices) == 0:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5250,6 +5250,98 @@ def Xform "Articulation" (
         np.testing.assert_allclose(np.array(blue_mesh.color), np.array([1.0, 1.0, 1.0]), atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_has_orphan_subset_primvars_detects_pattern(self):
+        from pxr import Sdf, Usd, UsdGeom
+
+        from newton._src.usd.utils import has_orphan_subset_primvars  # noqa: PLC0415
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+
+        def _make_mesh(path: str) -> UsdGeom.Mesh:
+            mesh = UsdGeom.Mesh.Define(stage, path)
+            mesh.CreatePointsAttr().Set([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)])
+            mesh.CreateFaceVertexCountsAttr().Set([3])
+            mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2])
+            return mesh
+
+        single_st = _make_mesh("/SingleSt")
+        UsdGeom.PrimvarsAPI(single_st).CreatePrimvar(
+            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+        ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+        self.assertFalse(has_orphan_subset_primvars(single_st.GetPrim()))
+
+        with_subset = _make_mesh("/WithSubset")
+        for name in ("st", "st_1"):
+            UsdGeom.PrimvarsAPI(with_subset).CreatePrimvar(
+                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+            ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+        subset = UsdGeom.Subset.Define(stage, "/WithSubset/face0")
+        subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+        subset.CreateIndicesAttr().Set([0])
+        self.assertFalse(has_orphan_subset_primvars(with_subset.GetPrim()))
+
+        orphan = _make_mesh("/Orphan")
+        for name in ("st", "st_1", "st_2"):
+            UsdGeom.PrimvarsAPI(orphan).CreatePrimvar(
+                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+            ).Set([(0.0, 0.0)])
+        self.assertTrue(has_orphan_subset_primvars(orphan.GetPrim()))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_orphan_subset_primvars_demotes_uv_warnings(self):
+        """When a mesh has orphan `st_N` primvars without subsets, importer should not warn."""
+        import warnings as _warnings  # noqa: PLC0415
+
+        from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        mesh = UsdGeom.Mesh.Define(stage, "/Body/VisualMesh")
+        mesh.CreatePointsAttr().Set(
+            [
+                (-0.5, -0.5, 0.0),
+                (0.5, -0.5, 0.0),
+                (0.5, 0.5, 0.0),
+                (-0.5, 0.5, 0.0),
+            ]
+        )
+        mesh.CreateFaceVertexCountsAttr().Set([3, 3])
+        mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 0, 2, 3])
+        # Author multiple `st_N` primvars with the wrong length and no GeomSubsets to bind them.
+        # This mimics the malformed authoring pattern observed on Isaac Sim's Spot lower-leg meshes.
+        for name in ("st", "st_1", "st_2"):
+            UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+            ).Set([(0.0, 0.0)])
+
+        material = UsdShade.Material.Define(stage, "/Materials/Tex")
+        shader = UsdShade.Shader.Define(stage, "/Materials/Tex/PreviewSurface")
+        shader.CreateIdAttr("UsdPreviewSurface")
+        tex = UsdShade.Shader.Define(stage, "/Materials/Tex/DiffuseTexture")
+        tex.CreateIdAttr("UsdUVTexture")
+        tex.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("ignored.png"))
+        tex.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(tex.ConnectableAPI(), "rgb")
+        material.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+        UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
+
+        builder = newton.ModelBuilder()
+        with _warnings.catch_warnings(record=True) as caught:
+            _warnings.simplefilter("always")
+            builder.add_usd(stage)
+        uv_warnings = [
+            w for w in caught if "UV primvar length" in str(w.message) or "has a texture but no UVs" in str(w.message)
+        ]
+        self.assertEqual(uv_warnings, [], f"unexpected UV warnings: {[str(w.message) for w in uv_warnings]}")
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_material_density_used_by_mass_properties(self):
         """Test that physics material density contributes to imported body mass/inertia."""
         from pxr import Usd, UsdGeom, UsdPhysics, UsdShade

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5288,6 +5288,29 @@ def Xform "Articulation" (
             ).Set([(0.0, 0.0)])
         self.assertTrue(has_orphan_subset_primvars(orphan.GetPrim()))
 
+        # A non-face subset (e.g. point/edge) should not disqualify the orphan pattern, since
+        # only face subsets bind per-subset UV primvars.
+        with_point_subset = _make_mesh("/WithPointSubset")
+        for name in ("st", "st_1"):
+            UsdGeom.PrimvarsAPI(with_point_subset).CreatePrimvar(
+                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+            ).Set([(0.0, 0.0)])
+        point_subset = UsdGeom.Subset.Define(stage, "/WithPointSubset/points")
+        point_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.point)
+        point_subset.CreateIndicesAttr().Set([0])
+        self.assertTrue(has_orphan_subset_primvars(with_point_subset.GetPrim()))
+
+        # Primvar names that merely start with "st" (e.g. "stiffness") must not be counted as
+        # UV subset primvars.
+        st_prefixed = _make_mesh("/StPrefixed")
+        UsdGeom.PrimvarsAPI(st_prefixed).CreatePrimvar(
+            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+        ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+        UsdGeom.PrimvarsAPI(st_prefixed).CreatePrimvar(
+            "stiffness", Sdf.ValueTypeNames.FloatArray, UsdGeom.Tokens.constant
+        ).Set([1.0])
+        self.assertFalse(has_orphan_subset_primvars(st_prefixed.GetPrim()))
+
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_orphan_subset_primvars_demotes_uv_warnings(self):
         """When a mesh has orphan `st_N` primvars without subsets, importer should not warn."""

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5164,6 +5164,92 @@ def Xform "Articulation" (
         self.assertAlmostEqual(rolling, 0.08, places=4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_visual_mesh_material_subsets_create_separate_visual_shapes(self):
+        """Test that visual mesh material subsets import as separate colored shapes."""
+        from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, Vt
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        mesh = UsdGeom.Mesh.Define(stage, "/Body/VisualMesh")
+        mesh.CreatePointsAttr().Set(
+            [
+                (-0.5, -0.5, 0.0),
+                (0.5, -0.5, 0.0),
+                (0.5, 0.5, 0.0),
+                (-0.5, 0.5, 0.0),
+            ]
+        )
+        mesh.CreateFaceVertexCountsAttr().Set([3, 3])
+        mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 0, 2, 3])
+        st = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar("st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
+        st.Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
+
+        grey_material = UsdShade.Material.Define(stage, "/Materials/Grey")
+        grey_shader = UsdShade.Shader.Define(stage, "/Materials/Grey/PreviewSurface")
+        grey_shader.CreateIdAttr("UsdPreviewSurface")
+        grey_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).Set((0.5, 0.5, 0.5))
+        grey_material.CreateSurfaceOutput().ConnectToSource(grey_shader.ConnectableAPI(), "surface")
+        UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(grey_material)
+
+        red_material = UsdShade.Material.Define(stage, "/Materials/Red")
+        red_shader = UsdShade.Shader.Define(stage, "/Materials/Red/PreviewSurface")
+        red_shader.CreateIdAttr("UsdPreviewSurface")
+        red_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).Set((1.0, 0.0, 0.0))
+        red_material.CreateSurfaceOutput().ConnectToSource(red_shader.ConnectableAPI(), "surface")
+
+        blue_material = UsdShade.Material.Define(stage, "/Materials/Blue")
+        blue_shader = UsdShade.Shader.Define(stage, "/Materials/Blue/PreviewSurface")
+        blue_shader.CreateIdAttr("UsdPreviewSurface")
+        blue_texture = UsdShade.Shader.Define(stage, "/Materials/Blue/DiffuseTexture")
+        blue_texture.CreateIdAttr("UsdUVTexture")
+        blue_texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("blue.png"))
+        blue_texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        blue_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(
+            blue_texture.ConnectableAPI(), "rgb"
+        )
+        blue_material.CreateSurfaceOutput().ConnectToSource(blue_shader.ConnectableAPI(), "surface")
+
+        red_subset = UsdGeom.Subset.Define(stage, "/Body/VisualMesh/red")
+        red_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+        red_subset.CreateFamilyNameAttr().Set("materialBind")
+        red_subset.CreateIndicesAttr().Set(Vt.IntArray([0]))
+        UsdShade.MaterialBindingAPI.Apply(red_subset.GetPrim()).Bind(red_material)
+
+        blue_subset = UsdGeom.Subset.Define(stage, "/Body/VisualMesh/blue")
+        blue_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+        blue_subset.CreateFamilyNameAttr().Set("materialBind")
+        blue_subset.CreateIndicesAttr().Set(Vt.IntArray([1]))
+        UsdShade.MaterialBindingAPI.Apply(blue_subset.GetPrim()).Bind(blue_material)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+
+        self.assertIn("/Body/VisualMesh/red", result["path_shape_map"])
+        self.assertIn("/Body/VisualMesh/blue", result["path_shape_map"])
+
+        red_shape = result["path_shape_map"]["/Body/VisualMesh/red"]
+        blue_shape = result["path_shape_map"]["/Body/VisualMesh/blue"]
+
+        self.assertEqual(builder.shape_count, 2)
+        self.assertEqual(builder.shape_label[red_shape], "/Body/VisualMesh/red")
+        self.assertEqual(builder.shape_label[blue_shape], "/Body/VisualMesh/blue")
+
+        red_mesh = builder.shape_source[red_shape]
+        blue_mesh = builder.shape_source[blue_shape]
+        self.assertEqual(len(red_mesh.indices), 3)
+        self.assertEqual(len(blue_mesh.indices), 3)
+        np.testing.assert_allclose(np.array(red_mesh.color), np.array([1.0, 0.0, 0.0]), atol=1e-6, rtol=1e-6)
+        self.assertIsNotNone(blue_mesh.uvs)
+        self.assertEqual(blue_mesh.texture, "blue.png")
+        np.testing.assert_allclose(np.array(blue_mesh.color), np.array([1.0, 1.0, 1.0]), atol=1e-6, rtol=1e-6)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_material_density_used_by_mass_properties(self):
         """Test that physics material density contributes to imported body mass/inertia."""
         from pxr import Usd, UsdGeom, UsdPhysics, UsdShade

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5250,70 +5250,9 @@ def Xform "Articulation" (
         np.testing.assert_allclose(np.array(blue_mesh.color), np.array([1.0, 1.0, 1.0]), atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
-    def test_has_orphan_subset_primvars_detects_pattern(self):
-        from pxr import Sdf, Usd, UsdGeom
-
-        from newton._src.usd.utils import has_orphan_subset_primvars  # noqa: PLC0415
-
-        stage = Usd.Stage.CreateInMemory()
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-
-        def _make_mesh(path: str) -> UsdGeom.Mesh:
-            mesh = UsdGeom.Mesh.Define(stage, path)
-            mesh.CreatePointsAttr().Set([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)])
-            mesh.CreateFaceVertexCountsAttr().Set([3])
-            mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2])
-            return mesh
-
-        single_st = _make_mesh("/SingleSt")
-        UsdGeom.PrimvarsAPI(single_st).CreatePrimvar(
-            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-        ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
-        self.assertFalse(has_orphan_subset_primvars(single_st.GetPrim()))
-
-        with_subset = _make_mesh("/WithSubset")
-        for name in ("st", "st_1"):
-            UsdGeom.PrimvarsAPI(with_subset).CreatePrimvar(
-                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-            ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
-        subset = UsdGeom.Subset.Define(stage, "/WithSubset/face0")
-        subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
-        subset.CreateIndicesAttr().Set([0])
-        self.assertFalse(has_orphan_subset_primvars(with_subset.GetPrim()))
-
-        orphan = _make_mesh("/Orphan")
-        for name in ("st", "st_1", "st_2"):
-            UsdGeom.PrimvarsAPI(orphan).CreatePrimvar(
-                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-            ).Set([(0.0, 0.0)])
-        self.assertTrue(has_orphan_subset_primvars(orphan.GetPrim()))
-
-        # A non-face subset (e.g. point/edge) should not disqualify the orphan pattern, since
-        # only face subsets bind per-subset UV primvars.
-        with_point_subset = _make_mesh("/WithPointSubset")
-        for name in ("st", "st_1"):
-            UsdGeom.PrimvarsAPI(with_point_subset).CreatePrimvar(
-                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-            ).Set([(0.0, 0.0)])
-        point_subset = UsdGeom.Subset.Define(stage, "/WithPointSubset/points")
-        point_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.point)
-        point_subset.CreateIndicesAttr().Set([0])
-        self.assertTrue(has_orphan_subset_primvars(with_point_subset.GetPrim()))
-
-        # Primvar names that merely start with "st" (e.g. "stiffness") must not be counted as
-        # UV subset primvars.
-        st_prefixed = _make_mesh("/StPrefixed")
-        UsdGeom.PrimvarsAPI(st_prefixed).CreatePrimvar(
-            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-        ).Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
-        UsdGeom.PrimvarsAPI(st_prefixed).CreatePrimvar(
-            "stiffness", Sdf.ValueTypeNames.FloatArray, UsdGeom.Tokens.constant
-        ).Set([1.0])
-        self.assertFalse(has_orphan_subset_primvars(st_prefixed.GetPrim()))
-
-    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
-    def test_orphan_subset_primvars_demotes_uv_warnings(self):
-        """When a mesh has orphan `st_N` primvars without subsets, importer should not warn."""
+    def test_uv_length_mismatch_uses_info_logging(self):
+        """Dropped-UV/texture diagnostics are render-only and surface via `logger.info`, not `warnings.warn`."""
+        import logging as _logging  # noqa: PLC0415
         import warnings as _warnings  # noqa: PLC0415
 
         from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
@@ -5337,12 +5276,11 @@ def Xform "Articulation" (
         )
         mesh.CreateFaceVertexCountsAttr().Set([3, 3])
         mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 0, 2, 3])
-        # Author multiple `st_N` primvars with the wrong length and no GeomSubsets to bind them.
-        # This mimics the malformed authoring pattern observed on Isaac Sim's Spot lower-leg meshes.
-        for name in ("st", "st_1", "st_2"):
-            UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
-                name, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
-            ).Set([(0.0, 0.0)])
+        # Author a single face-varying `st` primvar whose length does not match the mesh's
+        # face-corner count, so the importer must drop UVs and (downstream) the bound texture.
+        UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+        ).Set([(0.0, 0.0)])
 
         material = UsdShade.Material.Define(stage, "/Materials/Tex")
         shader = UsdShade.Shader.Define(stage, "/Materials/Tex/PreviewSurface")
@@ -5356,13 +5294,17 @@ def Xform "Articulation" (
         UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
 
         builder = newton.ModelBuilder()
-        with _warnings.catch_warnings(record=True) as caught:
+        with _warnings.catch_warnings(record=True) as caught, self.assertLogs("newton", level=_logging.INFO) as log_ctx:
             _warnings.simplefilter("always")
             builder.add_usd(stage)
         uv_warnings = [
             w for w in caught if "UV primvar length" in str(w.message) or "has a texture but no UVs" in str(w.message)
         ]
         self.assertEqual(uv_warnings, [], f"unexpected UV warnings: {[str(w.message) for w in uv_warnings]}")
+
+        joined = "\n".join(log_ctx.output)
+        self.assertIn("UV primvar length", joined)
+        self.assertIn("dropping texture because UVs could not be recovered", joined)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_material_density_used_by_mass_properties(self):


### PR DESCRIPTION
## Summary

Builds on @eric-heiden's prototype for #2806. Two commits:

1. `Fix USD GeomSubset visual materials` (author: @eric-heiden) — rebased cleanly from `eric-heiden:horde/usd-geomsubset-materials` onto current `main` with zero conflicts. Splits visual meshes by `UsdGeom.Subset` so each subset's material/UVs reach ViewerGL. Collision mesh import is unchanged.
2. `Demote orphan-subset UV warnings to info-level` (author: @vreutskyy) — adds `usd.utils.has_orphan_subset_primvars()` and routes the `UV primvar length…` and `texture but no UVs` notices through `logging.info` instead of `warnings.warn` when a mesh has per-subset UV primvars but no GeomSubsets to bind them. There is nothing the caller can do in that case and the noise gets blanket-tagged as `[Error]` by Isaac Sim's omni.kit logger.

Fixes #2806. Also reduces the NVBugs #6216854 warning spam on the Isaac Sim Spot asset (verified locally — see commit message and the follow-up comment on #2806).

## Test plan

- [x] `uv run -m newton.tests -k test_visual_mesh_material_subsets_create_separate_visual_shapes` — Eric's existing regression test passes.
- [x] `uv run -m newton.tests -k test_has_orphan_subset_primvars_detects_pattern` — new unit test for the helper.
- [x] `uv run -m newton.tests -k test_orphan_subset_primvars_demotes_uv_warnings` — new integration test asserting no `UserWarning` for the orphan pattern.
- [x] Both new tests verified to **fail** against commit 1 alone (regression-failing test discipline).
- [x] `uvx pre-commit run --files <touched>` clean.
- [x] Manual: import `Assets/Isaac/6.0/Isaac/Robots/BostonDynamics/spot/spot.usd` via `ModelBuilder.add_usd` — loads with `bodies=17, shapes=41, joints=17` and clean stderr (only Pixar's `{1.0, 1.0, 1.0}` inertia-floor notices remain, unrelated to this PR).

Happy to fold this into your own PR if you'd prefer, @eric-heiden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Visual mesh imports now preserve per-material colors and textures by creating separate render meshes for material subsets; collision/physics import unchanged.
  * UV-related logging is suppressed or demoted when meshes exhibit orphaned subset primvars; unsupported-geometry warnings refined.

* **Tests**
  * Added regression tests for material-subset visual imports and orphan subset primvar handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->