### PR TITLE
Remove newton actuators dependency and clean up add_actuator()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Remove `include_total` parameter from `SensorContact` (deprecated in 1.1.0); use `measure_total` instead
 - Remove `SensorContact.sensing_objs` (deprecated in 1.1.0); use `SensorContact.sensing_obj_idx` and `SensorContact.sensing_obj_type` instead
 - Remove `SensorContact.counterparts` and `SensorContact.reading_indices` (deprecated in 1.1.0); use `SensorContact.counterpart_indices` and `SensorContact.counterpart_type` instead
+- Remove `newton-actuators` package dependency and the legacy `ModelBuilder.add_actuator(actuator_class, input_indices=..., output_indices=..., **kwargs)` calling convention (deprecated in 1.2.0); use `newton.actuators` controller classes (e.g. `ControllerPD`, `ControllerPID`) with the per-DOF signature `ModelBuilder.add_actuator(controller_class, index=..., clamping=[...], delay_steps=..., **ctrl_kwargs)` instead
 - Remove `SensorContact.shape` (deprecated in 1.1.0); use `total_force.shape` / `force_matrix.shape` instead
 - Remove `SensorContact.ObjectType` enum (deprecated in 1.1.0); use the `sensing_obj_type` and `counterpart_type` attributes instead
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -13,14 +13,11 @@ import warnings
 from collections import Counter, deque
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import warp as wp
 
-from ..actuators.clamping.clamping_max_effort import ClampingMaxEffort
-from ..actuators.controllers.controller_pd import ControllerPD
-from ..actuators.controllers.controller_pid import ControllerPID
 from ..core.types import (
     MAXVAL,
     Axis,
@@ -67,11 +64,6 @@ from .graph_coloring import (
     construct_particle_graph,
 )
 from .model import Model
-
-try:
-    from newton_actuators import Actuator as _LegacyActuator
-except ImportError:
-    _LegacyActuator = None
 
 if TYPE_CHECKING:
     from pxr import Usd
@@ -1707,86 +1699,10 @@ class ModelBuilder:
                     f"Custom attribute '{attr_key}' has unsupported frequency {custom_attr.frequency} for joints"
                 )
 
-    # Maps legacy newton_actuators class names to (newton.actuators controller class name, has_delay).
-    _LEGACY_ACTUATOR_CLASS_MAP: ClassVar[dict[str, tuple[str, bool]]] = {
-        "ActuatorPD": ("ControllerPD", False),
-        "ActuatorPID": ("ControllerPID", False),
-        "ActuatorDelayedPD": ("ControllerPD", True),
-    }
-
-    def _add_actuator_legacy(
-        self,
-        actuator_class: type,
-        input_indices: list[int] | None,
-        output_indices: list[int] | None,
-        **kwargs: Any,
-    ) -> None:
-        """Translate a legacy ``newton_actuators``-style call to the new API.
-
-        Mirrors the old ``main``-branch signature::
-
-            add_actuator(actuator_class, input_indices, output_indices=None, **kwargs)
-
-        *input_indices* / *output_indices* may arrive either as explicit
-        arguments or inside *kwargs* (keyword style).  All old per-DOF
-        params (``kp``, ``kd``, ``delay``, ``max_effort``, ``gear``, …)
-        are expected in *kwargs*.
-        """
-        if input_indices is None:
-            raise TypeError("Legacy add_actuator() requires 'input_indices'")
-
-        # --- Map old class name → new controller class ---
-        class_name = actuator_class.__name__
-        mapping = self._LEGACY_ACTUATOR_CLASS_MAP.get(class_name)
-        if mapping is None:
-            raise TypeError(
-                f"Unknown legacy actuator class '{class_name}'. "
-                f"Supported: {', '.join(self._LEGACY_ACTUATOR_CLASS_MAP)}."
-            )
-
-        ctrl_name, class_has_delay = mapping
-        controller_class: type = {"ControllerPD": ControllerPD, "ControllerPID": ControllerPID}[ctrl_name]
-
-        delay_val: int | None = kwargs.pop("delay_steps", kwargs.pop("delay", None))
-        if class_has_delay and delay_val is None:
-            raise ValueError(f"{class_name} requires a 'delay_steps' argument")
-
-        max_effort_val = kwargs.pop("max_force", None)
-        gear_val = kwargs.pop("gear", None)
-
-        if gear_val is not None and gear_val != 1.0:
-            warnings.warn(
-                f"'gear={gear_val}' is not supported in the new actuator API and will be "
-                f"ignored. Fold the gear ratio into kp/kd/const_effort manually.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-
-        clamping: list[tuple[type, dict[str, Any]]] | None = None
-        if max_effort_val is not None and max_effort_val != math.inf:
-            clamping = [(ClampingMaxEffort, {"max_effort": max_effort_val})]
-
-        if output_indices is not None and output_indices != input_indices:
-            warnings.warn(
-                "'output_indices' is not supported in the new actuator API and will be "
-                "ignored. Forces are written to the same DOF index by default.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-
-        for dof_idx in input_indices:
-            self.add_actuator(
-                controller_class,
-                index=dof_idx,
-                clamping=clamping,
-                delay_steps=delay_val,
-                **kwargs,
-            )
-
     def add_actuator(
         self,
-        controller_class: type[Controller] | None = None,
-        index: int | None = None,
+        controller_class: type[Controller],
+        index: int,
         clamping: list[tuple[type[Clamping], dict[str, Any]]] | None = None,
         delay_steps: int | None = None,
         pos_index: int | None = None,
@@ -1802,19 +1718,8 @@ class ModelBuilder:
         values are supported within the same group; the buffer is
         sized to ``max(delay_step_values)``.
 
-        .. deprecated::
-            The legacy ``newton_actuators`` signature is still accepted::
-
-                add_actuator(ActuatorPD, input_indices=[dof], kp=50.0)
-                add_actuator(ActuatorPD, [dof], kp=50.0)
-                add_actuator(actuator_class=ActuatorPD, input_indices=[dof], kp=50.0)
-
-            It will be removed in a future release.  Use the new per-DOF
-            signature instead.
-
         Args:
             controller_class: Controller class (e.g. :class:`~newton.actuators.ControllerPD`).
-                The deprecated keyword ``actuator_class`` is also accepted.
             index: DOF index into ``joint_qd``-shaped arrays (velocities,
                 velocity targets, feedforward, forces).
             clamping: Optional list of ``(ClampingClass, kwargs)`` tuples applied
@@ -1826,36 +1731,6 @@ class ModelBuilder:
                 where ``joint_q`` and ``joint_qd`` have different layouts.
             **kwargs: Per-DOF controller parameters (e.g. ``kp``, ``kd``).
         """
-        legacy_cls = kwargs.pop("actuator_class", None)
-        if (
-            legacy_cls is None
-            and _LegacyActuator is not None
-            and isinstance(controller_class, type)
-            and issubclass(controller_class, _LegacyActuator)
-        ):
-            legacy_cls = controller_class
-
-        if legacy_cls is not None:
-            warnings.warn(
-                "add_actuator() with a newton_actuators class is deprecated. "
-                "Use newton.actuators controller classes instead "
-                "(e.g. ControllerPD, ControllerPID).",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            input_indices = kwargs.pop("input_indices", index)
-            output_indices = kwargs.pop("output_indices", clamping)
-            if delay_steps is not None:
-                kwargs["delay_steps"] = delay_steps
-            self._add_actuator_legacy(legacy_cls, input_indices, output_indices, **kwargs)
-            return
-
-        if controller_class is None:
-            raise TypeError("add_actuator() requires 'controller_class'")
-
-        if index is None:
-            raise TypeError("add_actuator() missing required argument: 'index'")
-
         clamping = clamping or []
 
         # --- Resolve controller kwargs and separate shared from per-DOF ---

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -41,13 +41,6 @@ try:
 except ImportError:
     HAS_USD = False
 
-try:
-    from newton_actuators import ActuatorDelayedPD, ActuatorPD, ActuatorPID
-
-    _HAS_LEGACY_ACTUATORS = True
-except ImportError:
-    _HAS_LEGACY_ACTUATORS = False
-
 _HAS_ONNX = importlib.util.find_spec("onnx") is not None
 _HAS_TORCH = importlib.util.find_spec("torch") is not None
 
@@ -1178,110 +1171,7 @@ class TestActuatorBuilder(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# 6. Legacy newton_actuators backward compatibility
-# ---------------------------------------------------------------------------
-
-
-@unittest.skipUnless(_HAS_LEGACY_ACTUATORS, "newton_actuators not installed")
-class TestLegacyActuatorCompat(unittest.TestCase):
-    """Deprecated ``newton_actuators`` calling conventions must still work."""
-
-    def _make_builder(self, n_joints=2):
-        builder = newton.ModelBuilder()
-        links = [builder.add_link() for _ in range(n_joints)]
-        joints = []
-        for i, link in enumerate(links):
-            parent = -1 if i == 0 else links[i - 1]
-            joints.append(builder.add_joint_revolute(parent=parent, child=link, axis=newton.Axis.Z))
-        builder.add_articulation(joints)
-        dofs = [builder.joint_qd_start[j] for j in joints]
-        return builder, dofs
-
-    def test_legacy_positional_list(self):
-        """add_actuator(ActuatorPD, [dof], kp=...) — old positional style."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPD, [dofs[0]], kp=50.0, kd=5.0)
-        model = builder.finalize()
-        self.assertEqual(len(model.actuators), 1)
-        self.assertIsInstance(model.actuators[0].controller, ControllerPD)
-        np.testing.assert_array_almost_equal(model.actuators[0].controller.kp.numpy(), [50.0])
-
-    def test_legacy_keyword_input_indices(self):
-        """add_actuator(ActuatorPD, input_indices=[dof], kp=...)."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPD, input_indices=[dofs[0]], kp=100.0)
-        model = builder.finalize()
-        self.assertEqual(len(model.actuators), 1)
-        np.testing.assert_array_almost_equal(model.actuators[0].controller.kp.numpy(), [100.0])
-
-    def test_legacy_keyword_actuator_class(self):
-        """add_actuator(actuator_class=ActuatorPD, input_indices=[dof], kp=...)."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(actuator_class=ActuatorPD, input_indices=[dofs[0]], kp=75.0)
-        model = builder.finalize()
-        self.assertEqual(len(model.actuators), 1)
-        np.testing.assert_array_almost_equal(model.actuators[0].controller.kp.numpy(), [75.0])
-
-    def test_legacy_delayed_pd(self):
-        """ActuatorDelayedPD maps to ControllerPD + delay."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorDelayedPD, input_indices=[dofs[0]], kp=200.0, delay=3)
-        model = builder.finalize()
-        act = model.actuators[0]
-        self.assertIsInstance(act.controller, ControllerPD)
-        self.assertIsNotNone(act.delay)
-        np.testing.assert_array_equal(act.delay.delay_steps.numpy(), [3])
-
-    def test_legacy_pid(self):
-        """ActuatorPID maps to ControllerPID."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPID, [dofs[0]], kp=100.0, ki=10.0, kd=20.0)
-        model = builder.finalize()
-        act = model.actuators[0]
-        self.assertIsInstance(act.controller, ControllerPID)
-        np.testing.assert_array_almost_equal(act.controller.ki.numpy(), [10.0])
-
-    def test_legacy_max_force_becomes_clamping(self):
-        """max_force kwarg creates a ClampingMaxEffort on the new actuator."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPD, input_indices=[dofs[0]], kp=150.0, max_force=50.0)
-        model = builder.finalize()
-        act = model.actuators[0]
-        self.assertEqual(len(act.clamping), 1)
-        self.assertIsInstance(act.clamping[0], ClampingMaxEffort)
-        np.testing.assert_array_almost_equal(act.clamping[0].max_effort.numpy(), [50.0])
-
-    def test_legacy_output_indices_warns(self):
-        """output_indices != input_indices emits extra deprecation warning."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPD, [dofs[0]], [dofs[1]], kp=50.0)
-
-    def test_legacy_gear_warns(self):
-        """Non-unity gear emits a deprecation warning."""
-        builder, dofs = self._make_builder()
-        with self.assertWarns(DeprecationWarning):
-            builder.add_actuator(ActuatorPD, input_indices=[dofs[0]], kp=50.0, gear=2.0)
-
-    def test_new_api_no_warning(self):
-        """New-style calls must not emit DeprecationWarning."""
-        builder, dofs = self._make_builder()
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            builder.add_actuator(ControllerPD, index=dofs[0], kp=50.0)
-        dep = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        self.assertEqual(len(dep), 0, f"Unexpected warnings: {[str(x.message) for x in dep]}")
-
-
-# ---------------------------------------------------------------------------
-# 7. Parameter access via ArticulationView
+# 6. Parameter access via ArticulationView
 # ---------------------------------------------------------------------------
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ sim = [
     # MuJoCo simulation
     "mujoco-warp>=3.8.0.3,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
     "mujoco~=3.8.0",        # MuJoCo physics engine
-    "newton-actuators>=0.1.0",  # deprecated — kept for backward compat, will be removed
 ]
 
 # Optional: ONNX policy inference (used by ControllerNeuralMLP / ControllerNeuralLSTM

--- a/uv.lock
+++ b/uv.lock
@@ -3467,7 +3467,6 @@ dev = [
     { name = "meshio" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
     { name = "newton-usd-schemas" },
     { name = "onnx" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux') or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
@@ -3524,7 +3523,6 @@ examples = [
     { name = "meshio" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
     { name = "newton-usd-schemas" },
     { name = "onnx" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux') or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
@@ -3568,7 +3566,6 @@ notebook = [
     { name = "meshio" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
     { name = "newton-usd-schemas" },
     { name = "onnx" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux') or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
@@ -3614,7 +3611,6 @@ rtx = [
 sim = [
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
 ]
 torch-cu12 = [
     { name = "alphashape" },
@@ -3626,7 +3622,6 @@ torch-cu12 = [
     { name = "meshio" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
     { name = "newton-usd-schemas" },
     { name = "onnx" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux')" },
@@ -3653,7 +3648,6 @@ torch-cu13 = [
     { name = "meshio" },
     { name = "mujoco" },
     { name = "mujoco-warp" },
-    { name = "newton-actuators" },
     { name = "newton-usd-schemas" },
     { name = "onnx" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64') or (python_full_version < '3.13' and sys_platform != 'linux')" },
@@ -3703,7 +3697,6 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'rtx'" },
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
-    { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0" },
     { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.2.0" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.16.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
@@ -3740,17 +3733,6 @@ provides-extras = ["sim", "onnx", "importers", "remesh", "examples", "rtx", "tor
 
 [package.metadata.requires-dev]
 dev = [{ name = "asv", specifier = ">=0.6.4" }]
-
-[[package]]
-name = "newton-actuators"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "warp-lang" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/ee/3119604cad4ca894fb80ef8ccd06b6bbd0b485b38ddc152ca753c67e0e76/newton_actuators-0.1.0-py3-none-any.whl", hash = "sha256:ba08923d12faaed6ef2b36d06948321425aee11d2f67c43cbd74d88a2649acce", size = 25990, upload-time = "2026-01-28T10:17:14.975Z" },
-]
 
 [[package]]
 name = "newton-usd-schemas"


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed legacy `newton-actuators` package dependency and deprecated actuator API.
  * Updated `add_actuator()` method to use new per-DOF controller classes. Callers must now use `ControllerPD`, `ControllerPID`, and other controller classes from `newton.actuators` with the new signature requiring `controller_class` and `index` parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->