### PR TITLE
Lower box density in two sensor contact tests

### DIFF
--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -632,14 +632,14 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 1e4
         builder.default_shape_cfg.kd = 1000.0
-        builder.default_shape_cfg.density = 1000.0
+        builder.default_shape_cfg.density = 100.0
 
         builder.add_shape_box(body=-1, hx=1.0, hy=1.0, hz=0.25, label="base")
         body_a = builder.add_body(xform=wp.transform(wp.vec3(0, 0, 0.8), wp.quat_identity()), label="a")
         builder.add_shape_box(body_a, hx=0.15, hy=0.15, hz=0.25)
 
         model = builder.finalize()
-        mass_a = 45.0
+        mass_a = 4.5
 
         try:
             solver = SolverMuJoCo(model, njmax=200)
@@ -685,7 +685,7 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         builder = newton.ModelBuilder()
         builder.default_shape_cfg.ke = 1e4
         builder.default_shape_cfg.kd = 1000.0
-        builder.default_shape_cfg.density = 1000.0
+        builder.default_shape_cfg.density = 100.0
 
         builder.add_shape_box(body=-1, hx=2.0, hy=2.0, hz=0.25, label="base")
         body_a = builder.add_body(xform=wp.transform(wp.vec3(-0.5, 0, 0.8), wp.quat_identity()), label="a")
@@ -696,7 +696,7 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         builder.add_shape_box(body_c, hx=0.1, hy=0.1, hz=0.25)
 
         model = builder.finalize()
-        mass_a, mass_b, mass_c = 45.0, 4.0, 20.0  # kg
+        mass_a, mass_b, mass_c = 4.5, 0.4, 2.0  # kg
 
         try:
             solver = SolverMuJoCo(model, njmax=200)


### PR DESCRIPTION
## Description

\`TestSensorContactMuJoCo.test_stacking_friction\` and \`test_parallel_scenario\` use a 45 kg primary body, producing contact normal forces around 440 N. With those magnitudes the new MuJoCo 3.9 line-search reduction \`previous_cost - current_cost\` can round to zero in float32 on the Warp CPU backend, causing the solver to declare convergence one iteration early. The contact impulse then under-damps and the box oscillates instead of settling.

Reducing the density to 100 keeps the test intent (sensor reports correct contact force on a settled body) while keeping the forces small enough that the precision issue does not trigger. The third test in the same class, \`test_stacking_scenario\`, already passed under both backends and is left untouched.

The underlying line-search precision issue is being fixed upstream by mujoco_warp [PR #1374](https://github.com/google-deepmind/mujoco_warp/pull/1374); once that lands in a release and Newton picks it up, this change still applies fine and just keeps the tests less sensitive.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] \`CHANGELOG.md\` has been updated (if user-facing change)

## Test plan

\`\`\`
uv run --extra dev -m newton.tests -k "test_sensor_contact"               # 22 tests pass on GPU
CUDA_VISIBLE_DEVICES= uv run --extra dev -m newton.tests \\
    -k "test_sensor_contact.TestSensorContactMuJoCo"                      # 3 tests pass on Warp CPU
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated sensor contact test simulation parameters to use revised physical scaling values. Test assertions and expected values have been adjusted accordingly to reflect the new simulation parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/2999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->