### PR TITLE
Rename test_physics_validation to test_physics_verification

### DIFF
--- a/newton/tests/test_physics_verification.py
+++ b/newton/tests/test_physics_verification.py
@@ -1,6 +1,30 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+"""Physics verification tests.
+
+In the simulation V&V (verification and validation) paradigm, this module
+holds *verification* tests only — checks that the equations of motion and
+constitutive laws are implemented correctly. Each test compares simulator
+output against a closed-form analytical solution, a known kinematic identity,
+or a conservation law (energy, linear/angular momentum). They are not a
+measure of physical plausibility, real-world fidelity, or agreement with
+another simulator; those belong in separate validation or cross-code suites.
+
+Tests added here should:
+
+- Compare against an analytical reference (free fall, pendulum period,
+  projectile parabola, Coulomb friction threshold, restitution, conical
+  pendulum orbit, ...) or assert a conservation law on a closed system.
+- State the reference equation in a comment so the expected value is
+  reproducible without re-running the simulator.
+- Avoid "looks reasonable" thresholds — pick tolerances tied to the
+  integrator order and step size.
+
+Tests that only check qualitative behaviour (no bouncing, no NaN, stays
+above ground, matches another simulator's output) belong elsewhere.
+"""
+
 import unittest
 
 import numpy as np
@@ -10,7 +34,7 @@ import newton
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 
-class TestPhysicsValidation(unittest.TestCase):
+class TestPhysicsVerification(unittest.TestCase):
     pass
 
 
@@ -1386,7 +1410,7 @@ for device in devices:
             continue
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_free_fall_{solver_name}",
             test_free_fall,
             devices=[device],
@@ -1394,7 +1418,7 @@ for device in devices:
         )
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_projectile_motion_{solver_name}",
             test_projectile_motion,
             devices=[device],
@@ -1403,7 +1427,7 @@ for device in devices:
         )
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_momentum_conservation_{solver_name}",
             test_momentum_conservation,
             devices=[device],
@@ -1443,7 +1467,7 @@ for device in devices:
             continue
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_pendulum_period_{solver_name}",
             test_pendulum_period,
             devices=[device],
@@ -1458,7 +1482,7 @@ for device in devices:
             continue
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_energy_conservation_{solver_name}",
             test_energy_conservation,
             devices=[device],
@@ -1472,7 +1496,7 @@ for device in devices:
             continue
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_joint_actuation_{solver_name}",
             test_joint_actuation,
             devices=[device],
@@ -1484,7 +1508,7 @@ for device in devices:
     # Restitution test
     if device.is_cuda:
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             "test_restitution_xpbd",
             test_restitution,
             devices=[device],
@@ -1495,7 +1519,7 @@ for device in devices:
 
     if not device.is_cuda:
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             "test_restitution_mujoco_cpu",
             test_restitution_mujoco,
             devices=[device],
@@ -1504,7 +1528,7 @@ for device in devices:
         )
     if device.is_cuda:
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             "test_restitution_mujoco_warp",
             test_restitution_mujoco,
             devices=[device],
@@ -1528,14 +1552,14 @@ for device in devices:
             continue
 
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_fourbar_linkage_{solver_name}",
             test_fourbar_linkage,
             devices=[device],
             solver_fn=solver_fn,
         )
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_fourbar_linkage_loop_joint_{solver_name}",
             test_fourbar_linkage,
             devices=[device],
@@ -1543,21 +1567,21 @@ for device in devices:
             use_loop_joint=True,
         )
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_revolute_loop_joint_{solver_name}",
             test_revolute_loop_joint,
             devices=[device],
             solver_fn=solver_fn,
         )
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_ball_loop_joint_{solver_name}",
             test_ball_loop_joint,
             devices=[device],
             solver_fn=solver_fn,
         )
         add_function_test(
-            TestPhysicsValidation,
+            TestPhysicsVerification,
             f"test_fixed_loop_joint_{solver_name}",
             test_fixed_loop_joint,
             devices=[device],


### PR DESCRIPTION
## Description

Rename `newton/tests/test_physics_validation.py` to `test_physics_verification.py` and rename the `TestPhysicsValidation` class to `TestPhysicsVerification` to match what the file actually contains, and add a module-level docstring stating what belongs there so the distinction is preserved going forward.

In the simulation V&V (verification and validation) paradigm:

- **Verification** = "are we solving the equations right?" — analytical solutions, conservation laws, kinematic identities.
- **Validation** = "are we solving the right equations?" — agreement with experiments or a trusted reference.

Every test in this module is the former: free fall against `y(t) = h₀ + ½gt²`, small-angle pendulum period `T = 2π√(L/g)`, projectile parabolas, energy/momentum conservation, Coulomb friction thresholds, restitution, four-bar linkage closure, conical pendulum orbit, fixed-loop rigid L-shape under gravity. None of them measure physical plausibility or compare against another simulator — those would be validation or cross-code verification and belong in separate suites (e.g. the `test_menagerie_*` files).

The new module docstring states the entry criteria for future tests:

- Compare against an analytical reference or assert a conservation law on a closed system.
- State the reference equation in a comment.
- Pick tolerances tied to integrator order and step size, not "looks reasonable" thresholds.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change) — N/A, internal test file rename, no public API affected

## Test plan

```
uv run --extra dev -m newton.tests -k test_physics_verification
```

Ran the full module on CPU after the rename — 23 tests, all pass:

```
Ran 23 tests in 71.597s

OK
```

`uvx pre-commit run --files newton/tests/test_physics_verification.py` also passes (ruff, ruff-format, typos, warp-array-syntax).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance for physics verification, outlining expected checks and assertion placement.
* **Tests**
  * Renamed the physics test suite from "Validation" to "Verification" and updated test registrations to align with the new name.

**Note:** These are internal testing and documentation updates; no user-facing behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/3000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->