### PR TITLE
Parse contact response attributes from NewtonMaterialAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add `newton.utils.OnnxRuntime`, a graph-capturable ONNX inference engine backed solely by Warp kernels (no `onnxruntime` or `torch` runtime dependency); used by `ControllerNeuralMLP` and `ControllerNeuralLSTM` to load `.onnx` policies. To migrate a TorchScript policy, run `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` once and point the controllers at the resulting `.onnx` file. The `onnx` package is now an optional extra (`pip install newton[onnx]`); install it explicitly to use the ONNX runtime.
 - Add USD parsing for `NewtonSiteAPI` to mark shapes as sites.
+- Parse contact response attributes (`ke`, `kd`, `kf`, `ka`) from `NewtonMaterialAPI` on bound materials during USD import
 
 ### Changed
 
@@ -21,6 +22,7 @@
 
 ### Deprecated
 
+- Deprecate `newton:contact_ke`/`kd`/`kf`/`ka` custom attributes on shape prims; author contact response attributes on the bound `NewtonMaterialAPI` material instead
 - Deprecate loading `.pt` / `.pth` (TorchScript) checkpoints via `ControllerNeuralMLP`; the legacy TorchScript / dict-checkpoint path still works (with a `DeprecationWarning`) when PyTorch is installed but will be removed in a future release. `ControllerNeuralLSTM` requires re-exporting to ONNX with the metadata properties documented in its class docstring; pointing it at a `.pt` checkpoint now raises `NotImplementedError` with migration guidance. Convert the MLP checkpoint to ONNX once with `torch.onnx.export(model, dummy_input, "policy.onnx", opset_version=17)` and load the resulting `.onnx` file.
 
 ### Removed

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1654,20 +1654,103 @@ Example:
 USD Integration
 ---------------
 
-Custom collision properties can be authored in USD:
+Newton provides several USD schema APIs for authoring collision and contact
+properties directly in ``.usda`` files.
+
+**NewtonCollisionAPI** — per-shape collision tuning (margin, gap):
 
 .. code-block:: usda
 
-    def Xform "Box" (
-        prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
+    def Cube "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI", "NewtonCollisionAPI"]
+    ) {
+        float newton:contactMargin = 0.001
+        float newton:contactGap = 0.02
+    }
+
+.. list-table:: NewtonCollisionAPI Attributes
+   :header-rows: 1
+   :widths: 25 50 15 10
+
+   * - Attribute
+     - Description
+     - Default
+     - Unit
+   * - ``newton:contactMargin``
+     - Distance at which contact detection activates
+     - 0.0
+     - m
+   * - ``newton:contactGap``
+     - Additional separation maintained between shapes
+     - ``-inf`` (builder default)
+     - m
+
+**NewtonMaterialAPI** — contact response (ke/kd/kf/ka) authored on materials:
+
+.. code-block:: usda
+
+    def Material "RubberMaterial" (
+        prepend apiSchemas = ["PhysicsMaterialAPI", "NewtonMaterialAPI"]
+    ) {
+        float physics:staticFriction = 1.0
+        float physics:dynamicFriction = 0.8
+        float newton:torsionalFriction = 0.1
+        float newton:rollingFriction = 0.01
+        float newton:contactStiffness = 5000.0
+        float newton:contactDamping = 200.0
+        float newton:contactFrictionStiffness = 800.0
+        float newton:contactAdhesion = 0.0
+    }
+
+    def Cube "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    ) {
+        rel material:binding:physics = </RubberMaterial>
+    }
+
+.. list-table:: NewtonMaterialAPI Contact Response Attributes
+   :header-rows: 1
+   :widths: 25 50 15 10
+
+   * - Attribute
+     - Description
+     - Default
+     - Unit
+   * - ``newton:contactStiffness``
+     - Normal stiffness of the contact response
+     - ``-inf`` (builder default)
+     - N/m
+   * - ``newton:contactDamping``
+     - Normal damping of the contact response
+     - ``-inf`` (builder default)
+     - N·s/m
+   * - ``newton:contactFrictionStiffness``
+     - Stiffness of the tangential friction response
+     - ``-inf`` (builder default)
+     - N/m
+   * - ``newton:contactAdhesion``
+     - Adhesion distance; a value of 0 or less disables adhesion
+     - ``-inf`` (builder default)
+     - m
+
+A value of ``-inf`` means "use the builder default." See the `Contact Materials`_
+table above for the mapping between these USD attributes and the
+:class:`~ModelBuilder.ShapeConfig` / :class:`~Model` arrays.
+
+**NewtonMeshCollisionAPI** — mesh-specific collision settings:
+
+Applied on top of ``PhysicsMeshCollisionAPI`` to control mesh approximation.
+Currently exposes ``newton:maxHullVertices`` for convex hull generation.
+
+**Custom Properties** — additional per-shape attributes that Newton reads:
+
+.. code-block:: usda
+
+    def Cube "Collider" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
     ) {
         custom int newton:collision_group = 1
-        custom int newton:world = 0
-        custom float newton:contact_ke = 100000.0
-        custom float newton:contact_kd = 1000.0
-        custom float newton:contact_kf = 1000.0
-        custom float newton:contact_ka = 0.0
-        custom float newton:margin = 0.00001
+        custom bool newton:is_sensor = false
     }
 
 See :doc:`custom_attributes` and :doc:`usd_parsing` for details.

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -84,9 +84,6 @@ class SchemaResolverNewton(SchemaResolver):
             # Collisions: newton margin == newton:contactMargin, newton gap == newton:contactGap
             "margin": SchemaAttribute("newton:contactMargin", 0.0),
             "gap": SchemaAttribute("newton:contactGap", float("-inf")),
-            # Contact stiffness/damping
-            "ke": SchemaAttribute("newton:contact_ke", None),
-            "kd": SchemaAttribute("newton:contact_kd", None),
         },
         PrimType.BODY: {},
         PrimType.ARTICULATION: {
@@ -95,6 +92,10 @@ class SchemaResolverNewton(SchemaResolver):
         PrimType.MATERIAL: {
             "mu_torsional": SchemaAttribute("newton:torsionalFriction", 0.25),
             "mu_rolling": SchemaAttribute("newton:rollingFriction", 0.0005),
+            "ke": SchemaAttribute("newton:contactStiffness", float("-inf")),
+            "kd": SchemaAttribute("newton:contactDamping", float("-inf")),
+            "kf": SchemaAttribute("newton:contactFrictionStiffness", float("-inf")),
+            "ka": SchemaAttribute("newton:contactAdhesion", float("-inf")),
         },
         PrimType.ACTUATOR: {},
     }

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -280,6 +280,10 @@ def parse_usd(
         rollingFriction: float = builder.default_shape_cfg.mu_rolling
         restitution: float = builder.default_shape_cfg.restitution
         density: float = builder.default_shape_cfg.density
+        ke: float = builder.default_shape_cfg.ke
+        kd: float = builder.default_shape_cfg.kd
+        kf: float = builder.default_shape_cfg.kf
+        ka: float = builder.default_shape_cfg.ka
 
     # load joint defaults
     default_joint_friction = builder.default_joint_cfg.friction
@@ -1768,6 +1772,13 @@ def parse_usd(
         if warn_invalid_desc(sdf_path, desc):
             continue
         prim = stage.GetPrimAtPath(sdf_path)
+
+        def _resolve_contact_attr(key, default, _prim=prim):
+            val = R.get_value(_prim, prim_type=PrimType.MATERIAL, key=key, verbose=verbose)
+            if val is None or val == float("-inf"):
+                return default
+            return float(val)
+
         material_specs[str(sdf_path)] = PhysicsMaterial(
             staticFriction=desc.staticFriction,
             dynamicFriction=desc.dynamicFriction,
@@ -1789,6 +1800,10 @@ def parse_usd(
             # Treat non-positive/unauthored material density as "use importer default".
             # Authored collider/body MassAPI mass+inertia is handled later.
             density=desc.density if desc.density > 0.0 else default_shape_density,
+            ke=_resolve_contact_attr("ke", builder.default_shape_cfg.ke),
+            kd=_resolve_contact_attr("kd", builder.default_shape_cfg.kd),
+            kf=_resolve_contact_attr("kf", builder.default_shape_cfg.kf),
+            ka=_resolve_contact_attr("ka", builder.default_shape_cfg.ka),
         )
 
     if UsdPhysics.ObjectType.RigidBody in ret_dict:
@@ -2585,7 +2600,6 @@ def parse_usd(
                     shape_density = material.density
                 else:
                     shape_density = default_shape_density
-                prim_and_scene = (prim, physics_scene_prim)
                 local_xform = wp.transform(shape_spec.localPos, usd.value_to_warp(shape_spec.localRot))
                 if body_id == -1:
                     shape_xform = incoming_world_xform * local_xform
@@ -2632,22 +2646,43 @@ def parse_usd(
                 ) and not hide_collider_for_body
                 collider_is_visible = collider_is_visible and _is_effectively_visible(prim)
 
-                shape_ke = R.get_value(
-                    prim,
-                    prim_type=PrimType.SHAPE,
-                    key="ke",
-                    verbose=verbose,
-                )
-                if shape_ke is None:
-                    shape_ke = builder.default_shape_cfg.ke
-                shape_kd = R.get_value(
-                    prim,
-                    prim_type=PrimType.SHAPE,
-                    key="kd",
-                    verbose=verbose,
-                )
-                if shape_kd is None:
-                    shape_kd = builder.default_shape_cfg.kd
+                shape_ke = material.ke
+                shape_kd = material.kd
+                shape_kf = material.kf
+                shape_ka = material.ka
+
+                # Per-shape resolver override (e.g. MuJoCo mjc:solref per-geom)
+                for attr_key in ("ke", "kd"):
+                    per_shape_val = R.get_value(prim, prim_type=PrimType.SHAPE, key=attr_key, verbose=verbose)
+                    if per_shape_val is not None and per_shape_val != float("-inf"):
+                        if attr_key == "ke":
+                            shape_ke = per_shape_val
+                        else:
+                            shape_kd = per_shape_val
+
+                # Legacy per-shape custom attrs (deprecated, lowest priority)
+                _LEGACY_CONTACT_ATTRS = {
+                    "ke": "newton:contact_ke",
+                    "kd": "newton:contact_kd",
+                    "kf": "newton:contact_kf",
+                    "ka": "newton:contact_ka",
+                }
+                shape_contact = {"ke": shape_ke, "kd": shape_kd, "kf": shape_kf, "ka": shape_ka}
+                for attr_key, legacy_name in _LEGACY_CONTACT_ATTRS.items():
+                    if shape_contact[attr_key] == builder.default_shape_cfg.__dict__[attr_key]:
+                        legacy_val = usd.get_attribute(prim, legacy_name)
+                        if legacy_val is not None:
+                            warnings.warn(
+                                f"'{legacy_name}' on shape prim is deprecated; "
+                                f"author '{attr_key}' on the bound NewtonMaterialAPI material instead.",
+                                DeprecationWarning,
+                                stacklevel=2,
+                            )
+                            shape_contact[attr_key] = float(legacy_val)
+                shape_ke = shape_contact["ke"]
+                shape_kd = shape_contact["kd"]
+                shape_kf = shape_contact["kf"]
+                shape_ka = shape_contact["ka"]
 
                 shape_color = material_props.get("color")
                 shape_params = {
@@ -2656,12 +2691,8 @@ def parse_usd(
                     "cfg": ModelBuilder.ShapeConfig(
                         ke=shape_ke,
                         kd=shape_kd,
-                        kf=usd.get_float_with_fallback(
-                            prim_and_scene, "newton:contact_kf", builder.default_shape_cfg.kf
-                        ),
-                        ka=usd.get_float_with_fallback(
-                            prim_and_scene, "newton:contact_ka", builder.default_shape_cfg.ka
-                        ),
+                        kf=shape_kf,
+                        ka=shape_ka,
                         margin=margin_val,
                         gap=gap_val,
                         mu=material.dynamicFriction,

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5205,6 +5205,182 @@ def Xform "Articulation" (
         self.assertAlmostEqual(model.shape_gap.numpy()[shape2_idx], 0.01, places=4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_contact_response_parsing(self):
+        """Test ke/kd/kf/ka parsed from NewtonMaterialAPI on bound material."""
+        from pxr import Usd, UsdGeom, UsdPhysics, UsdShade
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        # Material with all contact response attrs authored
+        mat_all = UsdShade.Material.Define(stage, "/Materials/AllAuthored")
+        mat_all_prim = mat_all.GetPrim()
+        mat_all_prim.ApplyAPI("NewtonMaterialAPI")
+        UsdPhysics.MaterialAPI.Apply(mat_all_prim)
+        mat_all_prim.GetAttribute("newton:contactStiffness").Set(5000.0)
+        mat_all_prim.GetAttribute("newton:contactDamping").Set(200.0)
+        mat_all_prim.GetAttribute("newton:contactFrictionStiffness").Set(800.0)
+        mat_all_prim.GetAttribute("newton:contactAdhesion").Set(0.01)
+
+        # Material with only ke/kd authored (kf/ka use builder defaults)
+        mat_partial = UsdShade.Material.Define(stage, "/Materials/PartialAuthored")
+        mat_partial_prim = mat_partial.GetPrim()
+        mat_partial_prim.ApplyAPI("NewtonMaterialAPI")
+        UsdPhysics.MaterialAPI.Apply(mat_partial_prim)
+        mat_partial_prim.GetAttribute("newton:contactStiffness").Set(3000.0)
+        mat_partial_prim.GetAttribute("newton:contactDamping").Set(150.0)
+
+        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        # Shape bound to full material
+        col1 = UsdGeom.Cube.Define(stage, "/Articulation/Body/ColAll")
+        col1_prim = col1.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col1_prim)
+        UsdShade.MaterialBindingAPI.Apply(col1_prim).Bind(mat_all, "physics")
+
+        # Shape bound to partial material
+        col2 = UsdGeom.Cube.Define(stage, "/Articulation/Body/ColPartial")
+        col2_prim = col2.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col2_prim)
+        UsdShade.MaterialBindingAPI.Apply(col2_prim).Bind(mat_partial, "physics")
+
+        # Shape with no material binding
+        col3 = UsdGeom.Cube.Define(stage, "/Articulation/Body/ColNone")
+        col3_prim = col3.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col3_prim)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+        model = builder.finalize()
+
+        idx_all = result["path_shape_map"]["/Articulation/Body/ColAll"]
+        idx_partial = result["path_shape_map"]["/Articulation/Body/ColPartial"]
+        idx_none = result["path_shape_map"]["/Articulation/Body/ColNone"]
+
+        # Full material: all four attrs from material
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx_all], 5000.0, places=1)
+        self.assertAlmostEqual(model.shape_material_kd.numpy()[idx_all], 200.0, places=1)
+        self.assertAlmostEqual(model.shape_material_kf.numpy()[idx_all], 800.0, places=1)
+        self.assertAlmostEqual(model.shape_material_ka.numpy()[idx_all], 0.01, places=4)
+
+        # Partial material: ke/kd from material, kf/ka from builder defaults
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx_partial], 3000.0, places=1)
+        self.assertAlmostEqual(model.shape_material_kd.numpy()[idx_partial], 150.0, places=1)
+        self.assertAlmostEqual(model.shape_material_kf.numpy()[idx_partial], builder.default_shape_cfg.kf, places=1)
+        self.assertAlmostEqual(model.shape_material_ka.numpy()[idx_partial], builder.default_shape_cfg.ka, places=4)
+
+        # No material: all from builder defaults
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx_none], builder.default_shape_cfg.ke, places=1)
+        self.assertAlmostEqual(model.shape_material_kd.numpy()[idx_none], builder.default_shape_cfg.kd, places=1)
+        self.assertAlmostEqual(model.shape_material_kf.numpy()[idx_none], builder.default_shape_cfg.kf, places=1)
+        self.assertAlmostEqual(model.shape_material_ka.numpy()[idx_none], builder.default_shape_cfg.ka, places=4)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_contact_response_inf_sentinel(self):
+        """Test that -inf authored on material attrs yields builder defaults."""
+        from pxr import Usd, UsdGeom, UsdPhysics, UsdShade
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        mat = UsdShade.Material.Define(stage, "/Materials/InfMat")
+        mat_prim = mat.GetPrim()
+        mat_prim.ApplyAPI("NewtonMaterialAPI")
+        UsdPhysics.MaterialAPI.Apply(mat_prim)
+        mat_prim.GetAttribute("newton:contactStiffness").Set(float("-inf"))
+        mat_prim.GetAttribute("newton:contactDamping").Set(float("-inf"))
+        mat_prim.GetAttribute("newton:contactFrictionStiffness").Set(float("-inf"))
+        mat_prim.GetAttribute("newton:contactAdhesion").Set(float("-inf"))
+
+        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        col = UsdGeom.Cube.Define(stage, "/Articulation/Body/Col")
+        col_prim = col.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col_prim)
+        UsdShade.MaterialBindingAPI.Apply(col_prim).Bind(mat, "physics")
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+        model = builder.finalize()
+
+        idx = result["path_shape_map"]["/Articulation/Body/Col"]
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx], builder.default_shape_cfg.ke, places=1)
+        self.assertAlmostEqual(model.shape_material_kd.numpy()[idx], builder.default_shape_cfg.kd, places=1)
+        self.assertAlmostEqual(model.shape_material_kf.numpy()[idx], builder.default_shape_cfg.kf, places=1)
+        self.assertAlmostEqual(model.shape_material_ka.numpy()[idx], builder.default_shape_cfg.ka, places=4)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_contact_response_legacy_shape_fallback(self):
+        """Test deprecated newton:contact_* attrs on shape prim as lowest-priority fallback."""
+        from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        # Material with NO contact response attrs
+        mat = UsdShade.Material.Define(stage, "/Materials/PlainMat")
+        mat_prim = mat.GetPrim()
+        mat_prim.ApplyAPI("NewtonMaterialAPI")
+        UsdPhysics.MaterialAPI.Apply(mat_prim)
+
+        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        # Shape with legacy custom attrs and material binding
+        col_legacy = UsdGeom.Cube.Define(stage, "/Articulation/Body/ColLegacy")
+        col_legacy_prim = col_legacy.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col_legacy_prim)
+        UsdShade.MaterialBindingAPI.Apply(col_legacy_prim).Bind(mat, "physics")
+        col_legacy_prim.CreateAttribute("newton:contact_ke", Sdf.ValueTypeNames.Float).Set(9999.0)
+        col_legacy_prim.CreateAttribute("newton:contact_kd", Sdf.ValueTypeNames.Float).Set(777.0)
+
+        # Shape where material has ke authored AND legacy is also present — material wins
+        mat_authored = UsdShade.Material.Define(stage, "/Materials/AuthoredMat")
+        mat_authored_prim = mat_authored.GetPrim()
+        mat_authored_prim.ApplyAPI("NewtonMaterialAPI")
+        UsdPhysics.MaterialAPI.Apply(mat_authored_prim)
+        mat_authored_prim.GetAttribute("newton:contactStiffness").Set(4000.0)
+
+        col_both = UsdGeom.Cube.Define(stage, "/Articulation/Body/ColBoth")
+        col_both_prim = col_both.GetPrim()
+        UsdPhysics.CollisionAPI.Apply(col_both_prim)
+        UsdShade.MaterialBindingAPI.Apply(col_both_prim).Bind(mat_authored, "physics")
+        col_both_prim.CreateAttribute("newton:contact_ke", Sdf.ValueTypeNames.Float).Set(1111.0)
+
+        builder = newton.ModelBuilder()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = builder.add_usd(stage)
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertTrue(len(deprecation_warnings) > 0, "Expected DeprecationWarning for legacy attrs")
+
+        model = builder.finalize()
+
+        idx_legacy = result["path_shape_map"]["/Articulation/Body/ColLegacy"]
+        idx_both = result["path_shape_map"]["/Articulation/Body/ColBoth"]
+
+        # Legacy fallback used when material has no contact attrs
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx_legacy], 9999.0, places=1)
+        self.assertAlmostEqual(model.shape_material_kd.numpy()[idx_legacy], 777.0, places=1)
+
+        # Material value wins over legacy attr
+        self.assertAlmostEqual(model.shape_material_ke.numpy()[idx_both], 4000.0, places=1)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_mimic_constraint_parsing(self):
         """Test that NewtonMimicAPI on a joint is parsed into a mimic constraint."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_schema_resolver.py
+++ b/newton/tests/test_schema_resolver.py
@@ -1632,6 +1632,57 @@ class TestSchemaResolver(unittest.TestCase):
         self.assertAlmostEqual(rolling, 0.1)
         self.assertAlmostEqual(torsional, 0.2)
 
+    def test_contact_response_attrs(self):
+        """Test ke/kd/kf/ka resolution on materials via PrimType.MATERIAL."""
+
+        stage = Usd.Stage.CreateInMemory()
+        material = UsdShade.Material.Define(stage, "/material").GetPrim()
+        material.ApplyAPI("NewtonMaterialAPI")
+
+        resolver = SchemaResolverManager([SchemaResolverNewton()])
+
+        # Unset attrs return the -inf sentinel default
+        for key in ("ke", "kd", "kf", "ka"):
+            val = resolver.get_value(material, PrimType.MATERIAL, key)
+            self.assertEqual(val, float("-inf"))
+
+        # Author explicit values
+        material.GetAttribute("newton:contactStiffness").Set(5000.0)
+        material.GetAttribute("newton:contactDamping").Set(200.0)
+        material.GetAttribute("newton:contactFrictionStiffness").Set(800.0)
+        material.GetAttribute("newton:contactAdhesion").Set(0.01)
+
+        self.assertAlmostEqual(resolver.get_value(material, PrimType.MATERIAL, "ke"), 5000.0)
+        self.assertAlmostEqual(resolver.get_value(material, PrimType.MATERIAL, "kd"), 200.0)
+        self.assertAlmostEqual(resolver.get_value(material, PrimType.MATERIAL, "kf"), 800.0)
+        self.assertAlmostEqual(resolver.get_value(material, PrimType.MATERIAL, "ka"), 0.01)
+
+    def test_contact_response_cross_resolver(self):
+        """Test that MuJoCo per-geom solref resolves ke/kd at SHAPE level."""
+
+        stage = Usd.Stage.CreateInMemory()
+        collider = UsdGeom.Cube.Define(stage, "/collider").GetPrim()
+        collider.CreateAttribute("mjc:solref", Sdf.ValueTypeNames.Float2Array).Set([(0.01, 0.5)])
+
+        resolver = SchemaResolverManager([SchemaResolverMjc()])
+        ke = resolver.get_value(collider, PrimType.SHAPE, "ke")
+        kd = resolver.get_value(collider, PrimType.SHAPE, "kd")
+        self.assertIsNotNone(ke)
+        self.assertIsNotNone(kd)
+        self.assertGreater(ke, 0)
+        self.assertGreater(kd, 0)
+
+    def test_contact_response_newton_not_on_shape(self):
+        """Verify Newton resolver has no ke/kd/kf/ka at SHAPE level."""
+
+        stage = Usd.Stage.CreateInMemory()
+        collider = UsdGeom.Cube.Define(stage, "/collider").GetPrim()
+
+        resolver = SchemaResolverManager([SchemaResolverNewton()])
+        for key in ("ke", "kd", "kf", "ka"):
+            val = resolver.get_value(collider, PrimType.SHAPE, key)
+            self.assertIsNone(val)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.2.0",
+    "newton-usd-schemas>=0.3.0",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)


### PR DESCRIPTION
## Description

Read contact response attributes (`ke`, `kd`, `kf`, `ka`) from `NewtonMaterialAPI` on bound materials during USD import, replacing the previous per-shape custom attribute approach.

Precedence order: per-shape resolver (MuJoCo `mjc:solref`) > material > legacy `newton:contact_*` shape attrs (with `DeprecationWarning`) > builder default.

Depends on newton-physics/newton-usd-schemas#65 (`newton-usd-schemas >= 0.3.0`).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_contact_response
uv run --extra dev -m newton.tests -k test_material_parsing
uv run --extra dev -m newton.tests -k test_material_friction_attributes
```

## New feature / API change

Contact response attributes are now authored on materials instead of shapes:

```usda
def Material "RubberMaterial" (
    prepend apiSchemas = ["PhysicsMaterialAPI", "NewtonMaterialAPI"]
) {
    float newton:contactStiffness = 5000.0
    float newton:contactDamping = 200.0
    float newton:contactFrictionStiffness = 800.0
    float newton:contactAdhesion = 0.0
}

def Cube "Collider" (
    prepend apiSchemas = ["PhysicsCollisionAPI"]
) {
    rel material:binding:physics = </RubberMaterial>
}
```

Legacy `newton:contact_ke`/`kd`/`kf`/`ka` custom attributes on shape prims still work as a lowest-priority fallback with a `DeprecationWarning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact response properties (stiffness, damping, friction stiffness, and adhesion) can now be authored on materials and are parsed during USD import.

* **Deprecated**
  * Authoring contact response properties directly on collision shapes is deprecated; use materials instead.

* **Documentation**
  * Enhanced documentation for collision schema, covering material-based and shape-based collision authoring.

* **Chores**
  * Updated Newton USD schema dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/3001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->