### PR TITLE
Fix mesh contact signs with parity queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.
 - Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.
+- Fix mesh and convex-mesh contact sign classification for watertight meshes with nearby opposing surfaces or inconsistent triangle winding.
 - Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
 - Fix `SolverVBD` custom attribute setup so `vbd:joint_is_hard` can be authored without implicitly enabling Dahl cable friction by calling `SolverVBD.register_custom_attributes(..., dahl_defaults_enabled=False)`.
 - Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.

--- a/newton/_src/geometry/kernels.py
+++ b/newton/_src/geometry/kernels.py
@@ -867,15 +867,11 @@ def closest_edge_coordinate_cylinder(
 
 @wp.func
 def mesh_sdf(mesh: wp.uint64, point: wp.vec3, max_dist: float):
-    face_index = int(0)
-    face_u = float(0.0)
-    face_v = float(0.0)
-    sign = float(0.0)
-    res = wp.mesh_query_point_sign_normal(mesh, point, max_dist, sign, face_index, face_u, face_v)
+    res = wp.mesh_query_point_sign_parity(mesh, point, max_dist)
 
-    if res:
-        closest = wp.mesh_eval_position(mesh, face_index, face_u, face_v)
-        return wp.length(point - closest) * sign
+    if res.result:
+        closest = wp.mesh_eval_position(mesh, res.face, res.u, res.v)
+        return wp.length(point - closest) * res.sign
     return max_dist
 
 
@@ -896,14 +892,10 @@ def sdf_mesh(mesh: wp.uint64, point: wp.vec3, max_dist: float):
 
 @wp.func
 def closest_point_mesh(mesh: wp.uint64, point: wp.vec3, max_dist: float):
-    face_index = int(0)
-    face_u = float(0.0)
-    face_v = float(0.0)
-    sign = float(0.0)
-    res = wp.mesh_query_point_sign_normal(mesh, point, max_dist, sign, face_index, face_u, face_v)
+    res = wp.mesh_query_point_sign_parity(mesh, point, max_dist)
 
-    if res:
-        return wp.mesh_eval_position(mesh, face_index, face_u, face_v)
+    if res.result:
+        return wp.mesh_eval_position(mesh, res.face, res.u, res.v)
     # return arbitrary point from mesh
     return wp.mesh_eval_position(mesh, 0, 0.0, 0.0)
 
@@ -1102,9 +1094,13 @@ def create_soft_contacts(
         # Use magnitude of components: the search radius must always be positive
         # regardless of mirror parity.
         min_scale = wp.min(wp.min(wp.abs(geo_scale[0]), wp.abs(geo_scale[1])), wp.abs(geo_scale[2]))
-        if wp.mesh_query_point_sign_normal(
-            mesh, wp.cw_div(x_local, geo_scale), margin + radius / min_scale, sign, face_index, face_u, face_v
-        ):
+        query = wp.mesh_query_point_sign_parity(mesh, wp.cw_div(x_local, geo_scale), margin + radius / min_scale)
+        if query.result:
+            sign = query.sign
+            face_index = query.face
+            face_u = query.u
+            face_v = query.v
+
             shape_p = wp.mesh_eval_position(mesh, face_index, face_u, face_v)
             shape_v = wp.mesh_eval_velocity(mesh, face_index, face_u, face_v)
 

--- a/newton/_src/geometry/sdf_contact.py
+++ b/newton/_src/geometry/sdf_contact.py
@@ -116,7 +116,7 @@ def sample_sdf_using_mesh(
     """
     Sample signed distance to mesh surface using mesh query.
 
-    Uses wp.mesh_query_point_sign_normal to find the closest point on the mesh
+    Uses wp.mesh_query_point_sign_parity to find the closest point on the mesh
     and compute the signed distance. This is compatible with the return type of
     sample_sdf_extrapolated.
 
@@ -128,16 +128,11 @@ def sample_sdf_using_mesh(
     Returns:
         The signed distance value (negative inside, positive outside)
     """
-    face_index = int(0)
-    face_u = float(0.0)
-    face_v = float(0.0)
-    sign = float(0.0)
+    res = wp.mesh_query_point_sign_parity(mesh_id, world_pos, max_dist)
 
-    res = wp.mesh_query_point_sign_normal(mesh_id, world_pos, max_dist, sign, face_index, face_u, face_v)
-
-    if res:
-        closest = wp.mesh_eval_position(mesh_id, face_index, face_u, face_v)
-        return wp.length(world_pos - closest) * sign
+    if res.result:
+        closest = wp.mesh_eval_position(mesh_id, res.face, res.u, res.v)
+        return wp.length(world_pos - closest) * res.sign
 
     return max_dist
 
@@ -151,7 +146,7 @@ def sample_sdf_grad_using_mesh(
     """
     Sample signed distance and gradient to mesh surface using mesh query.
 
-    Uses wp.mesh_query_point_sign_normal to find the closest point on the mesh
+    Uses wp.mesh_query_point_sign_parity to find the closest point on the mesh
     and compute both the signed distance and the gradient direction. This is
     compatible with the return type of sample_sdf_grad_extrapolated.
 
@@ -168,16 +163,12 @@ def sample_sdf_grad_using_mesh(
         - distance: Signed distance value (negative inside, positive outside)
         - gradient: Normalized direction of increasing distance
     """
-    face_index = int(0)
-    face_u = float(0.0)
-    face_v = float(0.0)
-    sign = float(0.0)
     gradient = wp.vec3(0.0, 0.0, 0.0)
 
-    res = wp.mesh_query_point_sign_normal(mesh_id, world_pos, max_dist, sign, face_index, face_u, face_v)
+    res = wp.mesh_query_point_sign_parity(mesh_id, world_pos, max_dist)
 
-    if res:
-        closest = wp.mesh_eval_position(mesh_id, face_index, face_u, face_v)
+    if res.result:
+        closest = wp.mesh_eval_position(mesh_id, res.face, res.u, res.v)
         diff = world_pos - closest
         dist = wp.length(diff)
 
@@ -185,21 +176,21 @@ def sample_sdf_grad_using_mesh(
             # Gradient points from surface toward query point, scaled by sign
             # When outside (sign > 0): gradient points away from surface (correct for SDF)
             # When inside (sign < 0): gradient points toward surface (correct for SDF)
-            gradient = (diff / dist) * sign
+            gradient = (diff / dist) * res.sign
         else:
             # Point is exactly on surface - use face normal
             # Get the face normal from the mesh
             mesh = wp.mesh_get(mesh_id)
-            i0 = mesh.indices[face_index * 3 + 0]
-            i1 = mesh.indices[face_index * 3 + 1]
-            i2 = mesh.indices[face_index * 3 + 2]
+            i0 = mesh.indices[res.face * 3 + 0]
+            i1 = mesh.indices[res.face * 3 + 1]
+            i2 = mesh.indices[res.face * 3 + 2]
             v0 = mesh.points[i0]
             v1 = mesh.points[i1]
             v2 = mesh.points[i2]
             face_normal = wp.normalize(wp.cross(v1 - v0, v2 - v0))
-            gradient = face_normal * sign
+            gradient = face_normal * res.sign
 
-        return dist * sign, gradient
+        return dist * res.sign, gradient
 
     # No hit found - return max distance with arbitrary gradient
     return max_dist, wp.vec3(0.0, 0.0, 1.0)

--- a/newton/tests/test_collision_pipeline.py
+++ b/newton/tests/test_collision_pipeline.py
@@ -11,8 +11,10 @@ import warp.examples
 import newton
 from newton import GeoType
 from newton._src.geometry import create_mesh_terrain
-from newton._src.geometry.flags import ShapeFlags
+from newton._src.geometry.flags import ParticleFlags, ShapeFlags
+from newton._src.geometry.kernels import create_soft_contacts, mesh_sdf
 from newton._src.sim.collide import _compute_per_world_shape_pairs_max, _estimate_rigid_contact_max
+from newton._src.utils.heightfield import HeightfieldData
 from newton.examples import test_body_state
 from newton.tests.unittest_utils import add_function_test, get_cuda_test_devices
 
@@ -450,6 +452,334 @@ for mode_name, test_func in mesh_mesh_sdf_tests:
             broad_phase=broad_phase,
             check_output=False,  # Disable output checking due to Warp module loading messages
         )
+
+
+# ============================================================================
+# Mesh sign query regressions
+# ============================================================================
+
+
+class TestMeshSignQueries(unittest.TestCase):
+    pass
+
+
+@wp.kernel
+def _query_mesh_signs(
+    mesh: wp.uint64,
+    points: wp.array[wp.vec3],
+    max_dist: float,
+    parity_sign: wp.array[float],
+    normal_sign: wp.array[float],
+):
+    i = wp.tid()
+    p = points[i]
+
+    parity = wp.mesh_query_point_sign_parity(mesh, p, max_dist)
+    parity_sign[i] = parity.sign if parity.result else 0.0
+
+    sign = float(0.0)
+    face = int(0)
+    u = float(0.0)
+    v = float(0.0)
+    normal_hit = wp.mesh_query_point_sign_normal(mesh, p, max_dist, sign, face, u, v)
+    normal_sign[i] = sign if normal_hit else 0.0
+
+
+@wp.kernel
+def _query_mesh_sdf(
+    mesh: wp.uint64,
+    points: wp.array[wp.vec3],
+    max_dist: float,
+    distances: wp.array[float],
+):
+    i = wp.tid()
+    distances[i] = mesh_sdf(mesh, points[i], max_dist)
+
+
+@wp.func
+def _solid_angle(point: wp.vec3, a: wp.vec3, b: wp.vec3, c: wp.vec3) -> float:
+    pa = a - point
+    pb = b - point
+    pc = c - point
+    la = wp.length(pa)
+    lb = wp.length(pb)
+    lc = wp.length(pc)
+    numerator = wp.dot(pa, wp.cross(pb, pc))
+    denominator = la * lb * lc + wp.dot(pa, pb) * lc + wp.dot(pb, pc) * la + wp.dot(pc, pa) * lb
+    return 2.0 * wp.atan2(numerator, denominator)
+
+
+@wp.kernel
+def _query_brute_force_winding_signs(
+    vertices: wp.array[wp.vec3],
+    indices: wp.array[int],
+    face_count: int,
+    points: wp.array[wp.vec3],
+    signs: wp.array[float],
+):
+    i = wp.tid()
+    point = points[i]
+    angle_sum = float(0.0)
+
+    for face_index in range(face_count):
+        offset = face_index * 3
+        a = vertices[indices[offset + 0]]
+        b = vertices[indices[offset + 1]]
+        c = vertices[indices[offset + 2]]
+        angle_sum += _solid_angle(point, a, b, c)
+
+    winding_number = angle_sum / 12.566370614359172
+    if wp.abs(winding_number) > 0.5:
+        signs[i] = -1.0
+    else:
+        signs[i] = 1.0
+
+
+def _make_warp_mesh(vertices: np.ndarray, faces: np.ndarray, device) -> wp.Mesh:
+    return wp.Mesh(
+        points=wp.array(vertices.astype(np.float32), dtype=wp.vec3, device=device),
+        indices=wp.array(faces.astype(np.int32).reshape(-1), dtype=wp.int32, device=device),
+    )
+
+
+def _make_mixed_winding_convex_pile_proxy() -> tuple[np.ndarray, np.ndarray]:
+    hx, hy, hz = 0.12, 0.07, 0.05
+    vertices = np.array(
+        [
+            [-hx, -hy, -hz],
+            [hx, -hy, -hz],
+            [hx, hy, -hz],
+            [-hx, hy, -hz],
+            [-hx, -hy, hz],
+            [hx, -hy, hz],
+            [hx, hy, hz],
+            [-hx, hy, hz],
+        ],
+        dtype=np.float32,
+    )
+
+    faces = np.array(
+        [
+            [0, 2, 1],
+            [0, 3, 2],
+            [4, 5, 6],
+            [4, 6, 7],
+            [0, 1, 5],
+            [0, 5, 4],
+            [3, 7, 6],
+            [3, 6, 2],
+            [0, 4, 7],
+            [0, 7, 3],
+            # Intentionally mixed winding on the +X face. This reproduces the
+            # failure mode from compacted convex hulls whose triangle winding
+            # is not consistently outward.
+            [1, 6, 2],
+            [1, 5, 6],
+        ],
+        dtype=np.int32,
+    )
+    return vertices, faces
+
+
+def _make_watertight_box(
+    center: tuple[float, float, float],
+    half_extents: tuple[float, float, float],
+) -> tuple[np.ndarray, np.ndarray]:
+    cx, cy, cz = center
+    hx, hy, hz = half_extents
+    vertices = np.array(
+        [
+            [cx - hx, cy - hy, cz - hz],
+            [cx + hx, cy - hy, cz - hz],
+            [cx + hx, cy + hy, cz - hz],
+            [cx - hx, cy + hy, cz - hz],
+            [cx - hx, cy - hy, cz + hz],
+            [cx + hx, cy - hy, cz + hz],
+            [cx + hx, cy + hy, cz + hz],
+            [cx - hx, cy + hy, cz + hz],
+        ],
+        dtype=np.float32,
+    )
+    faces = np.array(
+        [
+            [0, 2, 1],
+            [0, 3, 2],
+            [4, 5, 6],
+            [4, 6, 7],
+            [0, 1, 5],
+            [0, 5, 4],
+            [3, 7, 6],
+            [3, 6, 2],
+            [0, 4, 7],
+            [0, 7, 3],
+            [1, 2, 6],
+            [1, 6, 5],
+        ],
+        dtype=np.int32,
+    )
+    return vertices, faces
+
+
+def _make_thin_gap_box_pair() -> tuple[np.ndarray, np.ndarray]:
+    gap = 2.0e-4
+    hx, hy, hz = 0.75, 0.55, 0.45
+    left_vertices, left_faces = _make_watertight_box((-hx - 0.5 * gap, 0.0, 0.0), (hx, hy, hz))
+    right_vertices, right_faces = _make_watertight_box((hx + 0.5 * gap, 0.0, 0.0), (hx, hy, hz))
+    vertices = np.vstack([left_vertices, right_vertices]).astype(np.float32)
+    faces = np.vstack([left_faces, right_faces + left_vertices.shape[0]]).astype(np.int32)
+    return vertices, faces
+
+
+def _sample_thin_gap_points(sample_count: int = 8192) -> np.ndarray:
+    rng = np.random.default_rng(23)
+    gap = 2.0e-4
+    hy, hz = 0.55, 0.45
+    points = np.empty((sample_count, 3), dtype=np.float32)
+    points[:, 0] = rng.uniform(-0.45 * gap, 0.45 * gap, sample_count)
+    points[:, 1] = rng.uniform(-0.8 * hy, 0.8 * hy, sample_count)
+    points[:, 2] = rng.uniform(-0.8 * hz, 0.8 * hz, sample_count)
+    return points
+
+
+def test_mixed_winding_convex_pile_contact_normal(test, device):
+    vertices, faces = _make_mixed_winding_convex_pile_proxy()
+    mesh = _make_warp_mesh(vertices, faces, device)
+
+    query_point = np.array([[0.13, 0.018, 0.012]], dtype=np.float32)
+    points = wp.array(query_point, dtype=wp.vec3, device=device)
+    parity_sign = wp.zeros(1, dtype=wp.float32, device=device)
+    normal_sign = wp.zeros(1, dtype=wp.float32, device=device)
+
+    wp.launch(_query_mesh_signs, dim=1, inputs=[mesh.id, points, 0.1, parity_sign, normal_sign], device=device)
+
+    test.assertGreater(float(parity_sign.numpy()[0]), 0.0)
+    test.assertLess(float(normal_sign.numpy()[0]), 0.0)
+
+    soft_contact_count = wp.zeros(1, dtype=wp.int32, device=device)
+    soft_contact_particle = wp.empty(1, dtype=wp.int32, device=device)
+    soft_contact_shape = wp.empty(1, dtype=wp.int32, device=device)
+    soft_contact_body_pos = wp.empty(1, dtype=wp.vec3, device=device)
+    soft_contact_body_vel = wp.empty(1, dtype=wp.vec3, device=device)
+    soft_contact_normal = wp.empty(1, dtype=wp.vec3, device=device)
+    soft_contact_tids = wp.empty(1, dtype=wp.int32, device=device)
+
+    wp.launch(
+        create_soft_contacts,
+        dim=1,
+        inputs=[
+            points,
+            wp.array([0.05], dtype=wp.float32, device=device),
+            wp.array([int(ParticleFlags.ACTIVE)], dtype=wp.int32, device=device),
+            wp.array([-1], dtype=wp.int32, device=device),
+            wp.empty(0, dtype=wp.transform, device=device),
+            wp.array([wp.transform()], dtype=wp.transform, device=device),
+            wp.array([-1], dtype=wp.int32, device=device),
+            wp.array([int(GeoType.CONVEX_MESH)], dtype=wp.int32, device=device),
+            wp.array([wp.vec3(1.0, 1.0, 1.0)], dtype=wp.vec3, device=device),
+            wp.array([mesh.id], dtype=wp.uint64, device=device),
+            wp.array([-1], dtype=wp.int32, device=device),
+            0.0,
+            1,
+            1,
+            wp.array([int(ShapeFlags.COLLIDE_PARTICLES)], dtype=wp.int32, device=device),
+            wp.array([0], dtype=wp.int32, device=device),
+            wp.empty(0, dtype=HeightfieldData, device=device),
+            wp.empty(0, dtype=wp.float32, device=device),
+        ],
+        outputs=[
+            soft_contact_count,
+            soft_contact_particle,
+            soft_contact_shape,
+            soft_contact_body_pos,
+            soft_contact_body_vel,
+            soft_contact_normal,
+            soft_contact_tids,
+        ],
+        device=device,
+    )
+
+    test.assertEqual(int(soft_contact_count.numpy()[0]), 1)
+    normal = np.asarray(soft_contact_normal.numpy()[0], dtype=np.float32)
+    test.assertGreater(float(np.dot(normal, np.array([1.0, 0.0, 0.0], dtype=np.float32))), 0.99)
+
+
+def test_parity_sign_accuracy_exceeds_normal_query(test, device):
+    vertices, faces = _make_thin_gap_box_pair()
+    points_np = _sample_thin_gap_points()
+    vertices_wp = wp.array(vertices, dtype=wp.vec3, device=device)
+    indices_wp = wp.array(faces.reshape(-1), dtype=wp.int32, device=device)
+    points_wp = wp.array(points_np, dtype=wp.vec3, device=device)
+    mesh = wp.Mesh(points=vertices_wp, indices=indices_wp)
+
+    expected_signs_wp = wp.zeros(points_np.shape[0], dtype=wp.float32, device=device)
+    wp.launch(
+        _query_brute_force_winding_signs,
+        dim=points_np.shape[0],
+        inputs=[vertices_wp, indices_wp, faces.shape[0], points_wp, expected_signs_wp],
+        device=device,
+    )
+
+    parity_signs = wp.zeros(points_np.shape[0], dtype=wp.float32, device=device)
+    normal_signs = wp.zeros(points_np.shape[0], dtype=wp.float32, device=device)
+    wp.launch(
+        _query_mesh_signs,
+        dim=points_np.shape[0],
+        inputs=[mesh.id, points_wp, 10.0, parity_signs, normal_signs],
+        device=device,
+    )
+
+    distances = wp.zeros(points_np.shape[0], dtype=wp.float32, device=device)
+    wp.launch(
+        _query_mesh_sdf,
+        dim=points_np.shape[0],
+        inputs=[mesh.id, points_wp, 10.0, distances],
+        device=device,
+    )
+
+    expected_signs = expected_signs_wp.numpy()
+    production_signs = np.where(distances.numpy() < 0.0, -1.0, 1.0).astype(np.float32)
+    parity_accuracy = float(np.mean(parity_signs.numpy() == expected_signs))
+    production_accuracy = float(np.mean(production_signs == expected_signs))
+    normal_accuracy = float(np.mean(normal_signs.numpy() == expected_signs))
+
+    test.assertTrue(np.all(expected_signs > 0.0))
+    test.assertGreaterEqual(
+        parity_accuracy,
+        0.99,
+        f"Parity query accuracy was {parity_accuracy:.3f} against brute-force winding",
+    )
+    test.assertGreaterEqual(
+        production_accuracy,
+        0.99,
+        f"mesh_sdf accuracy was {production_accuracy:.3f} against brute-force winding",
+    )
+    test.assertLessEqual(
+        normal_accuracy,
+        0.05,
+        f"Expected the old normal query to fail in the thin gap, got accuracy {normal_accuracy:.3f}",
+    )
+    test.assertGreater(
+        production_accuracy,
+        normal_accuracy + 0.9,
+        f"Expected parity-backed mesh_sdf accuracy ({production_accuracy:.3f}) to exceed "
+        f"normal-query accuracy ({normal_accuracy:.3f})",
+    )
+
+
+add_function_test(
+    TestMeshSignQueries,
+    "test_mixed_winding_convex_pile_contact_normal",
+    test_mixed_winding_convex_pile_contact_normal,
+    devices=devices,
+    check_output=False,
+)
+add_function_test(
+    TestMeshSignQueries,
+    "test_parity_sign_accuracy_exceeds_normal_query",
+    test_parity_sign_accuracy_exceeds_normal_query,
+    devices=devices,
+    check_output=False,
+)
 
 
 # ============================================================================


### PR DESCRIPTION
## Description

Fix mesh contact sign classification by switching mesh SDF/contact sign queries from the closest-normal sign heuristic to Warp's parity sign query. The normal-sign heuristic can misclassify points near inconsistent triangle winding and near separate, opposing watertight surfaces; parity evaluates the closed-volume sign directly.

This PR also adds focused regressions for both cases:

- Mixed-winding convex pile proxy: reproduces the rigid pile winding issue and verifies the contact normal is generated on the expected side.
- Proper thin-gap geometry: two consistently outward-wound, watertight boxes separated by a `2e-4 m` gap, with random points sampled in the outside gap and checked against a GPU brute-force winding-number oracle.
<img width="2040" height="850" alt="image" src="https://github.com/user-attachments/assets/e3ad28de-1203-443c-813f-1874b995a737" />

Accuracy data from the thin-gap test, 8,192 random samples in the outside gap:

| Device | Winding oracle outside | Old normal query | Direct parity query | Production `mesh_sdf` |
| --- | ---: | ---: | ---: | ---: |
| CPU | 8192/8192 | 0/8192 = 0% | 8192/8192 = 100% | 8192/8192 = 100% |
| CUDA | 8192/8192 | 0/8192 = 0% | 8192/8192 = 100% | 8192/8192 = 100% |

Red check: restoring the old implementation makes `test_parity_sign_accuracy_exceeds_normal_query_cuda_0` fail with `mesh_sdf accuracy was 0.000 against brute-force winding`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_mesh_sign_query
uvx pre-commit run -a
```

Both commands pass locally on CPU and CUDA.

## Bug fix

**Steps to reproduce:**

1. Build a watertight mesh setup with either inconsistent triangle winding in a local proxy, or two separate watertight surfaces with opposing normals very close to each other.
2. Query mesh SDF/contact signs with the old closest-normal sign query.
3. Observe outside points classified as inside, leading to incorrect contact behavior.

**Minimal reproduction:**

```python
uv run --extra dev -m newton.tests -k test_mesh_sign_query
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed mesh and convex-mesh contact sign classification for watertight meshes with nearby opposing surfaces or inconsistent triangle winding.

* **Tests**
  * Added regression tests validating mesh contact accuracy and correct normal orientation in edge-case configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/3004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->