### PR TITLE
Add Colab links for tutorial notebooks

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -56,3 +56,32 @@ dl.py.attribute {
 .admonition.experimental > .admonition-title {
     background-color: var(--pst-color-warning-bg);
 }
+
+.notebook-link-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.6rem;
+    align-items: center;
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+}
+
+.notebook-link-bar a {
+    border: 1px solid var(--pst-color-border);
+    border-radius: 0.25rem;
+    padding: 0.2rem 0.55rem;
+    color: var(--pst-color-link);
+    text-decoration: none;
+    background: var(--pst-color-background);
+}
+
+.notebook-link-bar a:hover {
+    border-color: var(--pst-color-link);
+    color: var(--pst-color-link-hover);
+    text-decoration: none;
+}
+
+.notebook-link-bar a:focus-visible {
+    outline: 2px solid var(--pst-color-accent);
+    outline-offset: 2px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,23 @@ nbsphinx_timeout = 600
 # Allow errors in notebook execution (useful for development)
 nbsphinx_allow_errors = False
 
+nbsphinx_prolog = r"""
+{% if env.docname.startswith("tutorials/") %}
+{% set notebook_name = env.docname.split("/")[-1] + ".ipynb" %}
+{% set notebook_path = "docs/" + env.docname + ".ipynb" %}
+{% set github_url = "https://github.com/newton-physics/newton/blob/" + env.config.github_version + "/" + notebook_path %}
+{% set colab_url = "https://colab.research.google.com/github/newton-physics/newton/blob/" + env.config.github_version + "/" + notebook_path %}
+
+.. raw:: html
+
+   <div class="notebook-link-bar">
+      <a href="{{ notebook_name }}">Download notebook</a>
+      <a href="{{ github_url }}">View on GitHub</a>
+      <a href="{{ colab_url }}">Open in Colab</a>
+   </div>
+{% endif %}
+"""
+
 
 templates_path = ["_templates"]
 exclude_patterns = [
@@ -198,6 +215,16 @@ source_suffix = {
 extlinks = {
     "github": (f"https://github.com/newton-physics/newton/blob/{github_version}/%s", "%s"),
 }
+
+rst_epilog = f"""
+.. |intro-colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/newton-physics/newton/blob/{github_version}/docs/tutorials/00_introduction.ipynb
+   :alt: Open in Colab
+
+.. |robotics-colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/newton-physics/newton/blob/{github_version}/docs/tutorials/01_robotics.ipynb
+   :alt: Open in Colab
+"""
 
 doctest_global_setup = """
 import warnings
@@ -454,6 +481,8 @@ def _on_builder_inited(_app: Any) -> None:
 
 
 def setup(app: Any) -> None:
+    app.add_config_value("github_version", github_version, "env")
+
     # Regenerate API .rst files so builds always reflect the current public API.
     from generate_api import generate_all  # noqa: PLC0415
 

--- a/docs/guide/tutorials.rst
+++ b/docs/guide/tutorials.rst
@@ -4,7 +4,16 @@
 Tutorials
 =========
 
-This section contains tutorials to help you get started with Newton.
+These tutorial notebooks help you get started with Newton. They can be
+opened in Colab, but runtime resources and GPU availability can vary. When a
+notebook detects that it is running in Colab, its first code cell installs the
+notebook dependencies from PyPI.
+
+Open the notebooks directly in Colab:
+
+- :doc:`Introduction </tutorials/00_introduction>` |intro-colab|
+- :doc:`Robotics </tutorials/01_robotics>` |robotics-colab|
+
 You can also explore the examples in the ``newton/examples/`` directory for more use cases.
 
 .. toctree::

--- a/docs/tutorials/00_introduction.ipynb
+++ b/docs/tutorials/00_introduction.ipynb
@@ -45,6 +45,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Colab setup: install Newton before importing it.\n",
+    "import importlib.util\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    IN_COLAB = importlib.util.find_spec(\"google.colab\") is not None\n",
+    "except ModuleNotFoundError:\n",
+    "    IN_COLAB = False\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"newton[notebook]\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from pathlib import Path\n",
     "\n",
     "import warp as wp\n",
@@ -441,6 +461,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/docs/tutorials/01_robotics.ipynb
+++ b/docs/tutorials/01_robotics.ipynb
@@ -55,6 +55,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Colab setup: install Newton before importing it.\n",
+    "import importlib.util\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "try:\n",
+    "    IN_COLAB = importlib.util.find_spec(\"google.colab\") is not None\n",
+    "except ModuleNotFoundError:\n",
+    "    IN_COLAB = False\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"newton[notebook]\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import warp as wp\n",
     "\n",
@@ -1928,6 +1948,12 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": [],
+   "toc_visible": true
+  },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",
    "language": "python",

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -9,6 +9,7 @@ import os
 import warnings
 from pathlib import Path
 from typing import Any, ClassVar
+from urllib.parse import urlparse
 
 import numpy as np
 import warp as wp
@@ -298,6 +299,86 @@ class ViewerViser(ViewerBase):
             return f"{jupyter_base_url}/proxy/{port}{normalized_path}{query}"
 
         return f"http://{local_host}:{port}{normalized_path}{query}"
+
+    @staticmethod
+    def _get_colab_output() -> Any | None:
+        """Return google.colab.output when Colab iframe display is available."""
+        try:
+            from google.colab import output  # noqa: PLC0415
+        except Exception:
+            return None
+
+        if not hasattr(output, "serve_kernel_port_as_iframe"):
+            return None
+
+        return output
+
+    @classmethod
+    def _display_colab_iframe(
+        cls,
+        port: int,
+        *,
+        path: str = "/",
+        query: str = "",
+        width: int | str = "100%",
+        height: int | str = 400,
+    ) -> bool:
+        """Display a local server port in Colab when the Colab helper is available."""
+        output = cls._get_colab_output()
+        if output is None:
+            return False
+
+        normalized_path = "/" if path in ("", "/") else "/" + path.lstrip("/")
+        normalized_query = ""
+        if query:
+            normalized_query = query if query.startswith("?") else "?" + query
+        iframe_path = f"{normalized_path}{normalized_query}"
+
+        try:
+            output.serve_kernel_port_as_iframe(port, path=iframe_path, width=width, height=height)
+        except TypeError:
+            output.serve_kernel_port_as_iframe(port, path=iframe_path, height=height)
+
+        return True
+
+    @classmethod
+    def _colab_iframe_target_from_url(cls, player_url: str) -> tuple[int, str, str] | None:
+        """Extract a Colab iframe target from an absolute or Jupyter proxy URL."""
+        parsed_url = urlparse(player_url)
+
+        proxy_target = None
+        path_segments = parsed_url.path.split("/")
+        for index, segment in enumerate(path_segments[:-1]):
+            if segment != "proxy":
+                continue
+
+            port_text = path_segments[index + 1]
+            if not port_text.isdecimal():
+                continue
+
+            proxy_port = int(port_text)
+            if proxy_port > 65535:
+                continue
+
+            downstream_segments = path_segments[index + 2 :]
+            if not downstream_segments or downstream_segments == [""]:
+                downstream_path = "/"
+            else:
+                downstream_path = "/" + "/".join(downstream_segments)
+            proxy_target = (proxy_port, downstream_path, parsed_url.query)
+
+        if proxy_target is not None:
+            return proxy_target
+
+        try:
+            parsed_port = parsed_url.port
+        except ValueError:
+            parsed_port = None
+
+        if parsed_port is not None:
+            return parsed_port, parsed_url.path or "/", parsed_url.query
+
+        return None
 
     @classmethod
     def get_viser_client_dir(cls) -> Path:
@@ -1313,6 +1394,9 @@ class ViewerViser(ViewerBase):
         from .viewer import is_sphinx_build  # noqa: PLC0415
 
         if self._record_to_viser is None:
+            if self._display_colab_iframe(self._port, width=width, height=height):
+                return None
+
             # No recording - display the live server via IFrame
             return display(IFrame(src=self.url, width=width, height=height))
 
@@ -1364,6 +1448,18 @@ class ViewerViser(ViewerBase):
                 self._record_to_viser,
                 camera_request=self._camera_request,
             )
+            colab_target = self._colab_iframe_target_from_url(player_url)
+            if colab_target is not None:
+                colab_port, colab_path, colab_query = colab_target
+                if self._display_colab_iframe(
+                    colab_port,
+                    path=colab_path,
+                    query=colab_query,
+                    width=width,
+                    height=height,
+                ):
+                    return None
+
             return display(IFrame(src=player_url, width=width, height=height))
 
     def _ipython_display_(self):


### PR DESCRIPTION
## Description

Add consistent tutorial notebook entry points for rendered Sphinx docs. Each
rendered tutorial notebook now gets a link bar with:

- Download notebook
- View on GitHub
- Open in Colab

The tutorial guide also exposes Colab badges while preserving the existing
visible tutorial notebook outline. The notebooks include Colab metadata that
requests a GPU/T4 runtime, and their setup cells install `newton[notebook]`
when they detect Colab.

`ViewerViser` now detects Colab and uses Colab's iframe port helper for notebook
viewer output. This source change is required for Viser blocks to show correctly
inside Colab. Until a Newton release containing this change is published to
PyPI, notebooks that install `newton[notebook]` from PyPI will still get the old
viewer behavior. Branch validation used a temporary git install of this branch;
released-docs behavior should work once the viewer change is included in the
published Newton package.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change) — N/A for this docs/notebook discoverability change

## Test plan

```bash
uvx pre-commit run -a
```

```bash
python3 -S - <<'PY'
import json
from pathlib import Path

for path in [Path('docs/tutorials/00_introduction.ipynb'), Path('docs/tutorials/01_robotics.ipynb')]:
    nb = json.loads(path.read_text())
    setup_cells = [
        cell for cell in nb['cells']
        if cell.get('cell_type') == 'code'
        and ''.join(cell.get('source', [])).startswith('# Colab setup')
    ]
    assert len(setup_cells) == 1
    namespace = {'__name__': '__main__'}
    exec(''.join(setup_cells[0]['source']), namespace)
    assert namespace['IN_COLAB'] is False
print('Colab setup cells handle missing google package')
PY
```

```bash
uv run python - <<'PY'
import json
from pathlib import Path

expected_colab = {'gpuType': 'T4', 'provenance': [], 'toc_visible': True}
for path in [Path('docs/tutorials/00_introduction.ipynb'), Path('docs/tutorials/01_robotics.ipynb')]:
    nb = json.loads(path.read_text())
    md = nb.get('metadata', {})
    assert md.get('accelerator') == 'GPU'
    assert md.get('colab') == expected_colab
print('notebook colab metadata OK')
PY
```

```bash
uv run python - <<'PY'
import nbformat

for path in ['docs/tutorials/00_introduction.ipynb', 'docs/tutorials/01_robotics.ipynb']:
    nb = nbformat.read(path, as_version=4)
    nbformat.validate(nb)
print('nbformat validation OK')
PY
```

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-colab-docs-fix \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-colab-docs-fix \
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs /tmp/newton-docs-colab-fix
```

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-colab-tutorials \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-colab-tutorials \
uv run --extra docs --extra sim sphinx-build -W -b html -D nbsphinx_execute=never docs /tmp/newton-docs-tutorials-visible
```

Verified the generated `guide/tutorials.html` contains the visible tutorial
outline and Colab badge content.

Manual Colab checks:

- Opened `00_introduction.ipynb` from the fork/branch in Colab with a temporary
  git install of this branch plus the NVIDIA package index for
  `warp-lang==1.14.0rc2`; the notebook ran and Viser opened inline.
- Opened `01_robotics.ipynb` from the fork/branch in Colab. The Franka mesh
  import path emitted noisy `trimesh` / SciPy fallback tracebacks in the Colab
  runtime, but execution continued and Viser opened inline.

## Bug fix

**Steps to reproduce:**

1. Open a Newton tutorial notebook in Colab from GitHub.
2. Run the notebook with the currently released PyPI Newton package.
3. Reach a Viser display cell.
4. The notebook may try to expose a `localhost:<port>` viewer directly instead
   of using Colab's iframe port bridge.

**Minimal reproduction:**

```python
from newton.viewer import ViewerViser

viewer = ViewerViser()
viewer.show_notebook()
```

## New feature / API change

```python
from newton.viewer import ViewerViser

viewer = ViewerViser()
viewer.show_notebook()  # Uses Colab's iframe helper when running inside Colab.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Colab integration to tutorial notebooks with automatic dependency installation when running in Colab environment.
  * Added "Download notebook" and "Open in Colab" links throughout tutorial documentation.
  * Configured tutorials with GPU acceleration settings for optimal Colab performance.
  * Enhanced viewer with Google Colab iframe playback capabilities for interactive visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->