### PR TITLE
List all solvers in overview

### DIFF
--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -20,7 +20,8 @@ Key Features
 ------------
 
 * **GPU-accelerated**: Leverages NVIDIA Warp for fast, scalable simulation.
-* **Multiple solver implementations**: XPBD, VBD, MuJoCo, Featherstone, SemiImplicit.
+* **Multiple solver implementations**: XPBD, VBD, MuJoCo, Featherstone,
+  SemiImplicit, Kamino, ImplicitMPM, and Style3D.
 * **Modular design**: Easily extendable with new solvers and components.
 * **Differentiable**: Supports differentiable simulation for machine learning and optimization.
 * **Rich Import/Export**: Load models from URDF, MJCF, USD, and more.
@@ -102,7 +103,7 @@ Core Concepts
 - :doc:`Solver <../api/newton_solvers>`: Advances the simulation by
   integrating physics, handling contacts, and enforcing constraints.
   Newton provides multiple solver backends, including XPBD, VBD,
-  MuJoCo, Featherstone, and SemiImplicit.
+  MuJoCo, Featherstone, SemiImplicit, Kamino, ImplicitMPM, and Style3D.
 - :doc:`Sensors <../concepts/sensors>`: Compute observations from
   :class:`~newton.State`, :class:`~newton.Contacts`, sites, and shapes.
   Many sensors rely on optional :doc:`extended attributes


### PR DESCRIPTION
## Description

Updates the Overview guide so its solver lists match the public solver
matrix. The page previously named XPBD, VBD, MuJoCo, Featherstone, and
SemiImplicit, but omitted Kamino, ImplicitMPM, and Style3D.

This addresses NEW-2 from #2183 without changing runtime behavior.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not needed: docs-only copy fix)

## Test plan

```bash
uvx pre-commit run -a
WARP_CACHE_PATH=/tmp/newton-warp-cache-newton-root \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-newton-root \
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

## Bug fix

**Steps to reproduce:**

1. Open `docs/guide/overview.rst`.
2. Read the Key Features solver list and the Core Concepts solver summary.
3. Compare those lists with `docs/api/newton_solvers.rst`.
4. Observe that the overview omits Kamino, ImplicitMPM, and Style3D.

**Minimal reproduction:**

```python
# Documentation-only issue; no runtime reproduction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the overview guide with a more comprehensive list of supported Newton solver backends in the Key Features and Core Concepts sections, including additional solver implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->