### PR TITLE
Quote torch extra in install docs

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -129,7 +129,7 @@ to check the supported CUDA version (shown in the top-right corner of the output
 
 .. code-block:: console
 
-    pip install newton[torch-cu12] --extra-index-url https://download.pytorch.org/whl/cu128
+    pip install "newton[torch-cu12]" --extra-index-url https://download.pytorch.org/whl/cu128
     python -m newton.examples robot_anymal_c_walk
 
 .. note::


### PR DESCRIPTION
## Description

Quotes the `newton[torch-cu12]` requirement in the installation guide's
PyTorch example. The surrounding extras examples are already quoted, but this
one command was fragile in shells such as zsh where square brackets can be
interpreted as glob syntax before pip runs.

This addresses the 2026-05-31-A docs audit finding from #2183.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not needed: docs-only copy fix)

## Test plan

```bash
uvx pre-commit run -a
rg -n 'pip install newton\[' docs README.md .github -g '!docs/_build/**' -S || true
WARP_CACHE_PATH=/tmp/newton-warp-cache-newton-root \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-newton-root \
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

## Bug fix

**Steps to reproduce:**

1. Open `docs/guide/installation.rst`.
2. Copy the `pip install newton[torch-cu12] ...` command from the PyTorch
   example.
3. Run it in a shell that treats unquoted square brackets as glob syntax, such
   as zsh.
4. Observe that the shell can fail before invoking pip.

**Minimal reproduction:**

```python
# Documentation-only issue; no runtime reproduction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated PyTorch CUDA 12.x installation instructions with corrected command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->