### PR TITLE
Change installation guide "Quick Start" to avoid using optional dependencies

### DIFF
--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -152,9 +152,9 @@ See a list of all available examples (also browsable from the viewer's side pane
 Quick Start
 ^^^^^^^^^^^
 
-After installing Newton, you can build
-models, create solvers, and run simulations directly from Python. A typical
-workflow looks like this:
+After installing Newton with the base package, you can build models, create
+solvers, and run simulations directly from Python. This example uses only the
+required dependencies installed by ``pip install newton``:
 
 .. code-block:: python
 
@@ -163,12 +163,16 @@ workflow looks like this:
 
     # Build a model
     builder = newton.ModelBuilder()
-    builder.add_mjcf("robot.xml")        # or add_urdf() / add_usd()
+    body = builder.add_body(
+        xform=wp.transform((0.0, 1.0, 0.0), wp.quat_identity()),
+        mass=1.0,
+    )
+    builder.add_shape_sphere(body, radius=0.25)
     builder.add_ground_plane()
     model = builder.finalize()
 
     # Create a solver and allocate state
-    solver = newton.solvers.SolverMuJoCo(model)
+    solver = newton.solvers.SolverXPBD(model)
     state_0 = model.state()
     state_1 = model.state()
     control = model.control()
@@ -177,15 +181,21 @@ workflow looks like this:
     newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
 
     # Step the simulation
-    for step in range(1000):
+    for step in range(120):
         state_0.clear_forces()
         model.collide(state_0, contacts)
-        solver.step(state_0, state_1, control, contacts, 1.0 / 60.0 / 4.0)
+        solver.step(state_0, state_1, control, contacts, 1.0 / 60.0)
         state_0, state_1 = state_1, state_0
 
-For robot-learning workflows with parallel environments (as used by
-`Isaac Lab <https://isaac-sim.github.io/IsaacLab/>`_), you can replicate a
-robot template across many worlds and step them all simultaneously on the GPU:
+The following workflow uses :class:`~newton.solvers.SolverMuJoCo`, so install
+the optional simulation dependencies first:
+
+.. code-block:: console
+
+    pip install "newton[sim]"
+
+Then build a robot template, replicate it across many worlds, and step them all
+simultaneously on the GPU:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Description

Fix the installation guide Quick Start so the first copy-paste snippet matches the base `pip install newton` dependency set. The previous snippet used a placeholder `robot.xml` asset and `SolverMuJoCo`. That made the first Python example depend on a local file and on optional MuJoCo simulation packages for the solver.

The Quick Start now builds a primitive sphere model and steps it with `SolverXPBD`, which only depends on the base Newton install. A separate `SolverMuJoCo` workflow remains documented below it with an explicit `pip install "newton[sim]"` prerequisite.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

Docs-only change; no changelog entry was added.

## Test plan

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
uv run python <updated Quick Start snippet>

WARP_CACHE_PATH=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html

WARP_CACHE_PATH=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
WARP_CACHE_ROOT=/tmp/newton-warp-cache-shi-eric-fix-installation-quickstart \
uvx pre-commit run -a

git diff --check
```

## Bug fix

**Steps to reproduce:**

1. Install Newton with the base package: `pip install newton`.
2. Copy the Quick Start snippet from the installation guide before this PR.
3. Run the snippet.
4. Observe that it references a placeholder `robot.xml` asset and uses `SolverMuJoCo`, which requires optional MuJoCo packages.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
builder.add_mjcf("robot.xml")
model = builder.finalize()
solver = newton.solvers.SolverMuJoCo(model)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start to show a base XPBD solver workflow with a simple scene build, short simulation loop, and state updates.
  * Added a separate MuJoCo-oriented workflow and instructions for installing optional simulation extras.
  * Clarified differences between the base package and optional simulation features to help users choose the right setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

