### PR TITLE
docs: clarify solver integration docs

### DIFF
--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -51,7 +51,7 @@ Supported Features
      - Soft bodies
      - Differentiable
    * - :class:`~newton.solvers.SolverFeatherstone`
-     - Explicit
+     - Semi-implicit
      - ✅
      - ✅ generalized coordinates
      - ✅
@@ -75,7 +75,7 @@ Supported Features
      - ❌
      - ❌
    * - :class:`~newton.solvers.SolverMuJoCo`
-     - Explicit, Semi-implicit, Implicit
+     - Explicit, Semi-implicit, Implicit-in-velocity
      - ✅ :sup:`1`
      - ✅ generalized coordinates
      - ❌

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3132,7 +3132,7 @@ class SolverMuJoCo(SolverBase):
             sdf_iterations: Maximum SDF iterations. If None, uses model custom attribute or MuJoCo's default (10).
             sdf_initpoints: Number of SDF initialization points. If None, uses model custom attribute or MuJoCo's default (40).
             solver: Solver type. Can be "cg" or "newton", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("newton").
-            integrator: Integrator type. Can be "euler", "rk4", or "implicitfast", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("implicitfast").
+            integrator: Integrator type. Can be "euler", "rk4", "implicit", or "implicitfast", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("implicitfast").
             cone: The type of contact friction cone. Can be "pyramidal", "elliptic", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("pyramidal").
             jacobian: Jacobian computation method. Can be "dense", "sparse", or "auto", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or MuJoCo's default ("auto").
             impratio: Frictional-to-normal constraint impedance ratio. If None, uses model custom attribute or MuJoCo's default (1.0).

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3132,7 +3132,7 @@ class SolverMuJoCo(SolverBase):
             sdf_iterations: Maximum SDF iterations. If None, uses model custom attribute or MuJoCo's default (10).
             sdf_initpoints: Number of SDF initialization points. If None, uses model custom attribute or MuJoCo's default (40).
             solver: Solver type. Can be "cg" or "newton", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("newton").
-            integrator: Integrator type. Can be "euler", "rk4", "implicit", or "implicitfast", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("implicitfast").
+            integrator: Integrator type. Can be "euler", "rk4", or "implicitfast", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("implicitfast").
             cone: The type of contact friction cone. Can be "pyramidal", "elliptic", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or Newton's default ("pyramidal").
             jacobian: Jacobian computation method. Can be "dense", "sparse", or "auto", or their corresponding MuJoCo integer constants. If None, uses model custom attribute or MuJoCo's default ("auto").
             impratio: Frictional-to-normal constraint impedance ratio. If None, uses model custom attribute or MuJoCo's default (1.0).

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -49,7 +49,7 @@ Supported Features
      - Soft bodies
      - Differentiable
    * - :class:`~newton.solvers.SolverFeatherstone`
-     - Explicit
+     - Semi-implicit
      - ✅
      - ✅ generalized coordinates
      - ✅
@@ -73,7 +73,7 @@ Supported Features
      - ❌
      - ❌
    * - :class:`~newton.solvers.SolverMuJoCo`
-     - Explicit, Semi-implicit, Implicit
+     - Explicit, Semi-implicit, Implicit-in-velocity
      - ✅ :sup:`1`
      - ✅ generalized coordinates
      - ❌


### PR DESCRIPTION
## Description

Close https://github.com/newton-physics/newton/issues/3015 without changing runtime behavior.

Fix two solver integration documentation inconsistencies.

- Update the solver overview table so `SolverFeatherstone` is documented as semi-implicit, matching its class docstring and symplectic-Euler integration kernel.
- Clarify the `SolverMuJoCo` overview entry as `Explicit, Semi-implicit, Implicit-in-velocity`, matching the MuJoCo integrator categories exposed by Newton.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- Manually compared the updated documentation against:
  - `newton/_src/solvers/featherstone/solver_featherstone.py`
  - `newton/_src/solvers/featherstone/kernels.py`
  - `newton/_src/solvers/mujoco/solver_mujoco.py`
- Verified that the diff is limited to the intended documentation updates.

## Bug fix

**Steps to reproduce:**

1. Open `docs/api/newton_solvers.rst`.
2. Compare the `SolverFeatherstone` integration label against the `SolverFeatherstone` class docstring and `integrate_generalized_joints` implementation.
**Minimal reproduction:**

```python
# Documentation-only issue; no runtime reproduction.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the supported integration methods for `SolverFeatherstone` and `SolverMuJoCo` in the solver documentation to accurately reflect their capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->