### PR TITLE
Add comment style guidance to AGENTS.md

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -25,6 +25,13 @@ reviews:
         placement order. For Deprecated, Changed, and Removed entries, verify
         the entry includes migration guidance telling users what replaces the
         old behavior.
+    - path: "**/*.py"
+      instructions: |
+        Flag inline code comments (not docstrings) that are verbose or
+        redundant: comments that restate what the code already shows, repeat
+        the same point in multiple places, or narrate obvious steps. Comments
+        should be brief and reserved for non-obvious code, explaining why
+        rather than what.
 chat:
   auto_reply: true
 issue_enrichment:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - Follow Google-style docstrings. Types in annotations, not docstrings. `Args:` use `name: description`.
   - Sphinx cross-refs (`:class:`, `:meth:`) with shortest possible targets. Prefer public API paths; never use `newton._src`.
   - SI units for physical quantities in public API docstrings: `"""Particle positions [m], shape [particle_count, 3]."""`. Joint-dependent: `[m or rad]`. Spatial vectors: `[N, N·m]`. Compound arrays: per-component. Skip non-physical fields.
+- Code comments: brief, and only for non-obvious code. Explain *why* (intent, constraints, edge cases), not *what* the code already shows. Prefer a cross-reference (doc, `:class:`/`:meth:`) over re-explaining context.
 - Run `docs/generate_api.py` when adding public API symbols.
 - Avoid new required dependencies. Strongly prefer not adding optional ones — use Warp, NumPy, or stdlib.
 - Create a feature branch before committing — never commit directly to `main`. Use `<username>/feature-desc`.


### PR DESCRIPTION
## Description

Agent-generated contributions have been producing verbose inline comments that over-explain the obvious and restate the same point in several places. This adds guidance to keep comments brief and useful.

- **AGENTS.md**: adds a directive that code comments should be brief and reserved for non-obvious code, explain *why* rather than *what*, and prefer a cross-reference over re-explaining context.
- **.coderabbit.yml**: mirrors the rule so automated review flags verbose or redundant inline comments. Scoped to Python files and excludes docstrings, which already have their own Google-style requirements.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Documentation and review-config only; no code changes. `pre-commit` passes on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented enhanced code quality standards for Python files to ensure clearer and more maintainable codebase practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->