### PR TITLE
Point install/actuator docs at ONNX, not torch

### DIFF
--- a/docs/concepts/actuators.rst
+++ b/docs/concepts/actuators.rst
@@ -170,11 +170,12 @@ state objects — simply omit them:
 Differentiability and Graph Capture
 -----------------------------------
 
-Whether an actuator supports differentiability and CUDA graph capture depends on
-its controller.  :class:`ControllerPD` and :class:`ControllerPID` are fully
-graphable.  Neural-network controllers (:class:`ControllerNeuralMLP`,
-:class:`ControllerNeuralLSTM`) require PyTorch and are not graphable due to
-framework interop overhead.
+All built-in controllers are graphable and differentiable, including the
+neural-network controllers (:class:`ControllerNeuralMLP`,
+:class:`ControllerNeuralLSTM`), which run their ONNX policies on Newton's
+Warp-backed runtime.  The one exception is the deprecated TorchScript checkpoint
+path, which requires PyTorch and is not graphable due to framework interop
+overhead.
 
 :meth:`Actuator.is_graphable` returns ``True`` when all components can be
 captured in a CUDA graph.
@@ -193,10 +194,10 @@ Controllers
 * :class:`ControllerPD` — proportional-derivative control law (stateless).
 * :class:`ControllerPID` — proportional-integral-derivative control law
   (stateful: integral accumulator with anti-windup clamp).
-* :class:`ControllerNeuralMLP` — MLP neural-network controller (requires
-  PyTorch, stateful: position/velocity history buffers).
-* :class:`ControllerNeuralLSTM` — LSTM neural-network controller (requires
-  PyTorch, stateful: hidden/cell state).
+* :class:`ControllerNeuralMLP` — MLP neural-network controller (ONNX policy,
+  stateful: position/velocity history buffers).
+* :class:`ControllerNeuralLSTM` — LSTM neural-network controller (ONNX policy,
+  stateful: hidden/cell state).
 
 See the API documentation for each controller's control-law equations.
 

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -174,10 +174,10 @@ Pass ``--help`` to either run method below to see all available flags.
             # run tests
             python -m newton.tests
             
-Most tests run when the ``dev`` extras are installed. The tests using PyTorch
-to run inference on an RL policy are skipped if the ``torch`` dependency is
-not installed. In order to run these tests, include the ``torch-cu12`` or
-``torch-cu13`` extras matching your NVIDIA driver's CUDA support:
+Most tests run with the ``dev`` extras installed. A few tests cover the
+deprecated TorchScript checkpoint path and are skipped without the ``torch``
+dependency; to run them, add the ``torch-cu12`` or ``torch-cu13`` extra matching
+your NVIDIA driver's CUDA support:
 
 .. tab-set::
     :sync-group: env

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -110,8 +110,6 @@ with other packages:
     ``examples`` extra). If you encounter installation errors, we recommend upgrading to a later
     Python version, or follow the :doc:`development` guide to install Newton using ``uv``.
 
-.. _running-examples:
-
 Running Examples
 ^^^^^^^^^^^^^^^^
 
@@ -122,26 +120,13 @@ After installing Newton with the ``examples`` extra, launch the default
 
     python -m newton.examples
 
-Run an example that runs RL policy inference. Choose the extra matching your
-NVIDIA driver's CUDA support (``torch-cu12`` for CUDA 12.x, ``torch-cu13`` for
-CUDA 13.x) and the corresponding pytorch wheel (e.g, ``128`` for CUDA 12.8); run ``nvidia-smi``
-to check the supported CUDA version (shown in the top-right corner of the output):
+Run an example that runs RL policy inference. RL policies ship as ONNX files and
+run on Newton's Warp-backed runtime, so the ``examples`` extra is all you need —
+no PyTorch installation is required:
 
 .. code-block:: console
 
-    pip install newton[torch-cu12] --extra-index-url https://download.pytorch.org/whl/cu128
     python -m newton.examples robot_anymal_c_walk
-
-.. note::
-
-    The ``torch-cu12`` extra installs PyTorch built against CUDA 12.8. If your
-    driver only supports CUDA 12.4 or 12.5 (check with ``nvidia-smi``), you
-    need to install PyTorch 2.6.0 manually instead:
-
-    .. code-block:: console
-
-        pip install "newton[examples]"
-        pip install torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
 
 See a list of all available examples (also browsable from the viewer's side panel):
 
@@ -228,9 +213,9 @@ Additional optional dependency sets are defined in ``pyproject.toml``:
    * - ``examples``
      - Dependencies for running examples, including visualization (includes ``sim`` + ``importers``)
    * - ``torch-cu12``
-     - PyTorch (CUDA 12.8+) for running RL policy examples (includes ``examples``); see :ref:`note above <running-examples>` for CUDA 12.4–12.5
+     - PyTorch (CUDA 12.8+) for Kamino RL training scripts (includes ``examples``)
    * - ``torch-cu13``
-     - PyTorch (CUDA 13) for running RL policy examples (includes ``examples``)
+     - PyTorch (CUDA 13) for Kamino RL training scripts (includes ``examples``)
    * - ``notebook``
      - Jupyter notebook support with Rerun visualization (includes ``examples``)
    * - ``dev``

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -120,9 +120,7 @@ After installing Newton with the ``examples`` extra, launch the default
 
     python -m newton.examples
 
-Run an example that runs RL policy inference. RL policies ship as ONNX files and
-run on Newton's Warp-backed runtime, so the ``examples`` extra is all you need —
-no PyTorch installation is required:
+Run an example with RL policy inference:
 
 .. code-block:: console
 


### PR DESCRIPTION
## Description

RL policy inference now runs on Newton's Warp-backed ONNX runtime, so the `torch` extras are no longer required to run the examples. This brings the docs in line with that change so PyTorch is mentioned only where it is still needed (Kamino RL training and the deprecated TorchScript checkpoint path):

- `docs/guide/installation.rst`: drop the `torch-cu12` install from the RL-inference quick start (the `examples` extra already pulls in ONNX support) and reframe the `torch-cu12`/`torch-cu13` extras-table rows as Kamino RL training scripts. Also removes a now-orphaned label.
- `docs/concepts/actuators.rst`: correct the claim that the neural-network controllers require PyTorch and are not graphable — the ONNX-backed controllers are graphable; only the deprecated TorchScript checkpoint path requires PyTorch.
- `docs/guide/development.rst`: reframe the torch-gated tests around the deprecated TorchScript checkpoint path rather than generic RL inference, and shorten the paragraph.

## Checklist

- [ ] New or existing tests cover these changes (N/A — docs only)
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not needed: docs-only copy fix)

## Test plan

```bash
uvx pre-commit run --files docs/guide/installation.rst docs/guide/development.rst docs/concepts/actuators.rst
# Confirm no remaining torch in the getting-started flow and no orphaned label refs:
grep -rn 'running-examples' docs --include='*.rst'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that built-in controllers are graphable and differentiable, with ONNX-based controllers supported (TorchScript deprecated path excluded)
  * Updated neural controller descriptions to reflect ONNX-based implementations and state/buffer behaviors
  * Specified PyTorch is only required for a deprecated checkpoint path and for training scripts/examples, not for ONNX inference
  * Simplified RL inference example and streamlined installation/testing guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->