### PR TITLE
Cherry-pick 1.2.1 PRs onto release-1.2

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Test Summary
         if: ${{ !cancelled() }}
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           PYTHONFAULTHANDLER: "1"
         run: uv run --extra dev -m newton.tests --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Test Summary
         if: ${{ !cancelled() }}
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Test Summary
         if: ${{ !cancelled() }}
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Test Summary
         if: ${{ !cancelled() }}
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
+- Fix USD visual mesh imports to preserve face-material `UsdGeom.Subset` colors and textures by splitting material subsets into separate render meshes; collision/physics import behavior is unchanged
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,8 @@
 ### Fixed
 
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
-- Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.
-- Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.
-- Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
-- Fix `SolverVBD` custom attribute setup so `vbd:joint_is_hard` can be authored without implicitly enabling Dahl cable friction by calling `SolverVBD.register_custom_attributes(..., dahl_defaults_enabled=False)`.
-- Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
-- Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
-- Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
-- Fix USD import of revolute and D6-angular joint `limit_ke` / `limit_kd` from `mjc:solreflimit` being over-scaled by ~57x
 - Fix `ArticulationView` link selections for closed-loop joints so BODY-frequency accessors expose each physical body once.
-- Fix USD import losing authored negative scales on shape and parent xforms, so mirrored primitives and meshes are now imported with the correct signed scale
+- Fix USD visual mesh imports to preserve face-material `UsdGeom.Subset` colors and textures by splitting material subsets into separate render meshes; collision/physics import behavior is unchanged
 
 ## [1.2.0] - 2026-05-12
 
@@ -108,7 +100,6 @@
 
 - Fix `remesh_convex_hull` raising `QhullError` on degenerate (coincident, collinear, or coplanar) point clouds; it now returns a zero-volume fallback mesh with a `UserWarning`, raises `ValueError` on empty input, and retries Qhull with `QJ` joggle as a last resort on the 3D path
 - Fix narrow-phase CPU launches using GPU-sized block dimensions with kernels that observe `wp.block_dim() == 1`, avoiding out-of-bounds tile and strided-loop indexing until Warp GH-1413 is fixed
-- Fix USD visual mesh imports to preserve face-material `UsdGeom.Subset` colors and textures by splitting material subsets into separate render meshes; collision/physics import behavior is unchanged
 - Fix `ViewerGL` Step button remaining clickable while the simulation is running; the button is now greyed out when not paused
 - Fix `ViewerGL` `Plots` window opening on top of the `Performance Stats` overlay by anchoring its default position to the bottom-right corner; user-dragged positions persisted in `imgui.ini` are unaffected
 - Fix the example viewer's Reset button discarding user-provided CLI options (e.g. `--world-count`) and rebuilding the example with parser defaults instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 ### Fixed
 
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
+- Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.
+- Fix `ModelBuilder.collapse_fixed_joints()` producing a NaN center of mass when collapsing joints between zero-mass bodies.
+- Fix `SolverMuJoCo` returning `State.joint_qd` in world frame for root `FREE` joints with non-identity `parent_xform`, violating the documented parent-frame contract and corrupting derived `body_qd`.
+- Fix `SolverVBD` custom attribute setup so `vbd:joint_is_hard` can be authored without implicitly enabling Dahl cable friction by calling `SolverVBD.register_custom_attributes(..., dahl_defaults_enabled=False)`.
+- Fix `example_softbody_gift` emitting spurious non-manifold edge warnings caused by mismatched 5-tet diagonals across adjacent cubes in the soft body mesh.
+- Fix `basic_conveyor` example emitting a spurious inertia validation warning at finalize.
+- Fix `SolverMuJoCo` generated MuJoCo joint names for multi-axis D6 joints to avoid duplicate names
+- Fix USD import of revolute and D6-angular joint `limit_ke` / `limit_kd` from `mjc:solreflimit` being over-scaled by ~57x
+- Fix `ArticulationView` link selections for closed-loop joints so BODY-frequency accessors expose each physical body once.
+- Fix USD import losing authored negative scales on shape and parent xforms, so mirrored primitives and meshes are now imported with the correct signed scale
 
 ## [1.2.0] - 2026-05-12
 

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import warnings
 from collections.abc import Iterable, Sequence
@@ -14,6 +15,8 @@ import warp as wp
 from ..core.types import Axis, AxisType
 from ..geometry import Gaussian, Mesh
 from ..sim.model import Model
+
+logger = logging.getLogger("newton")
 
 AttributeAssignment = Model.AttributeAssignment
 AttributeFrequency = Model.AttributeFrequency
@@ -1098,10 +1101,11 @@ def get_mesh(
         # were converted to per-vertex. Avoid a second split here.
         if uvs_interpolation == UsdGeom.Tokens.faceVarying and not did_split_vertices:
             if len(uvs) != len(indices):
-                warnings.warn(
-                    f"UV primvar length ({len(uvs)}) does not match indices length ({len(indices)}) for mesh {prim.GetPath()}; "
-                    "dropping UVs.",
-                    stacklevel=2,
+                logger.info(
+                    "Mesh %s: UV primvar length (%d) does not match indices length (%d); dropping UVs.",
+                    prim.GetPath(),
+                    len(uvs),
+                    len(indices),
                 )
                 uvs = None
             else:

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -8,6 +8,7 @@ import copy
 import datetime
 import inspect
 import itertools
+import logging
 import os
 import posixpath
 import re
@@ -38,6 +39,8 @@ from ..usd import utils as usd
 from ..usd.schema_resolver import PrimType, SchemaResolver, SchemaResolverManager
 from ..usd.schemas import SchemaResolverNewton
 from .import_utils import should_show_collider
+
+logger = logging.getLogger("newton")
 
 AttributeFrequency = Model.AttributeFrequency
 
@@ -520,10 +523,7 @@ def parse_usd(
         if texture:
             mesh.texture = texture
         if mesh.texture is not None and mesh.uvs is None:
-            warnings.warn(
-                f"Warning: mesh {path_name} has a texture but no UVs; texture will be ignored.",
-                stacklevel=2,
-            )
+            logger.info("Mesh %s: dropping texture because UVs could not be recovered.", path_name)
             mesh.texture = None
         if material_props.get("color") is not None and mesh.texture is None:
             mesh.color = material_props["color"]
@@ -532,6 +532,186 @@ def parse_usd(
         if material_props.get("metallic") is not None:
             mesh.metallic = material_props["metallic"]
         return mesh
+
+    def _get_face_material_subsets(prim: Usd.Prim) -> list[Usd.Prim]:
+        """Return face-based material subsets authored directly under a mesh prim."""
+        subsets = []
+        for child in prim.GetChildren():
+            try:
+                is_subset = child.IsA(UsdGeom.Subset)
+            except Exception:
+                is_subset = False
+            if not is_subset:
+                continue
+
+            subset = UsdGeom.Subset(child)
+            element_type = subset.GetElementTypeAttr().Get()
+            if element_type != UsdGeom.Tokens.face:
+                continue
+            family_name = subset.GetFamilyNameAttr().Get()
+            if family_name and family_name != "materialBind":
+                continue
+            indices = subset.GetIndicesAttr().Get()
+            if not indices:
+                continue
+            subsets.append(child)
+        return subsets
+
+    def _get_subset_uvs(prim: Usd.Prim, used_vertices: np.ndarray, expected_count: int) -> np.ndarray | None:
+        """Return UVs for a material subset when a matching primvar is authored."""
+        max_used_vertex = int(np.max(used_vertices, initial=-1))
+        full_mesh_uvs = None
+        for primvar in UsdGeom.PrimvarsAPI(prim).GetPrimvars():
+            name = primvar.GetBaseName()
+            if not name.startswith("st"):
+                continue
+            values = primvar.Get()
+            if values is None:
+                continue
+            uvs = np.asarray(values, dtype=np.float32)
+            if primvar.IsIndexed():
+                indices = primvar.GetIndices()
+                if indices is None:
+                    continue
+                indices = np.asarray(indices, dtype=np.int32)
+                if len(indices) == expected_count:
+                    uvs = uvs[indices]
+                    if len(uvs) == expected_count:
+                        return uvs
+                    continue
+                if len(indices) > max_used_vertex:
+                    uvs = uvs[indices]
+                else:
+                    continue
+            if len(uvs) == expected_count:
+                return uvs
+            if full_mesh_uvs is None and len(uvs) > max_used_vertex:
+                full_mesh_uvs = uvs[used_vertices]
+        return full_mesh_uvs
+
+    def _make_visual_submesh(
+        mesh: Mesh,
+        triangle_indices: np.ndarray,
+        material_props: dict[str, Any],
+        *,
+        prim: Usd.Prim,
+        path_name: str,
+    ) -> Mesh | None:
+        """Create a render-only mesh slice for the selected triangle rows."""
+        if len(triangle_indices) == 0:
+            return None
+
+        triangles = mesh.indices.reshape(-1, 3)[triangle_indices]
+        used_vertices = np.unique(triangles)
+        vertex_remap = np.full(len(mesh.vertices), -1, dtype=np.int32)
+        vertex_remap[used_vertices] = np.arange(len(used_vertices), dtype=np.int32)
+
+        normals = None
+        if mesh.normals is not None and len(mesh.normals) == len(mesh.vertices):
+            normals = mesh.normals[used_vertices]
+
+        uvs = None
+        if mesh.uvs is not None and len(mesh.uvs) == len(mesh.vertices):
+            uvs = mesh.uvs[used_vertices]
+        elif material_props.get("texture") is not None:
+            uvs = _get_subset_uvs(prim, used_vertices, len(used_vertices))
+
+        submesh = Mesh(
+            mesh.vertices[used_vertices],
+            vertex_remap[triangles].reshape(-1),
+            normals=normals,
+            uvs=uvs,
+            compute_inertia=False,
+            is_solid=mesh.is_solid,
+            maxhullvert=mesh.maxhullvert,
+        )
+
+        texture = material_props.get("texture")
+        if texture:
+            submesh.texture = texture
+        if submesh.texture is not None and submesh.uvs is None:
+            logger.info("Mesh material subset %s: dropping texture because UVs could not be recovered.", path_name)
+            submesh.texture = None
+
+        color = material_props.get("color")
+        if color is not None:
+            submesh.color = color
+        elif submesh.texture is not None:
+            submesh.color = (1.0, 1.0, 1.0)
+        if material_props.get("roughness") is not None:
+            submesh.roughness = material_props["roughness"]
+        if material_props.get("metallic") is not None:
+            submesh.metallic = material_props["metallic"]
+        return submesh
+
+    def _get_visual_material_subset_meshes(prim: Usd.Prim) -> list[tuple[str, Mesh]]:
+        """Load one render mesh per USD material subset when subsets are authored."""
+        subsets = _get_face_material_subsets(prim)
+        if not subsets:
+            return []
+
+        mesh_schema = UsdGeom.Mesh(prim)
+        face_counts = mesh_schema.GetFaceVertexCountsAttr().Get()
+        if face_counts is None:
+            return []
+        face_counts = np.asarray(face_counts, dtype=np.int32)
+        if len(face_counts) == 0 or np.any(face_counts < 3):
+            return []
+
+        subset_props = [(str(subset.GetPath()), usd.resolve_material_properties_for_prim(subset)) for subset in subsets]
+        mesh = _get_mesh_cached(prim)
+        triangle_face_indices = np.repeat(np.arange(len(face_counts), dtype=np.int32), face_counts - 2)
+        covered_faces = np.zeros(len(face_counts), dtype=bool)
+
+        submeshes = []
+        for subset_path, material_props in subset_props:
+            # `resolve_material_properties_for_prim` does not fall back from a subset to its parent mesh
+            # (see `newton/_src/usd/utils.py` resolve_material_properties_for_prim). If a subset binds no
+            # visible material, let the uncovered-faces fallback below apply the parent mesh material
+            # instead of producing a materialless submesh and hiding the parent material on those faces.
+            if not any(value is not None for value in material_props.values()):
+                continue
+            subset = UsdGeom.Subset(stage.GetPrimAtPath(subset_path))
+            subset_indices = np.asarray(subset.GetIndicesAttr().Get(), dtype=np.int32)
+            valid = (subset_indices >= 0) & (subset_indices < len(face_counts))
+            if not np.all(valid):
+                logger.info(
+                    "Mesh material subset %s: face indices outside the mesh face range; "
+                    "out-of-range indices will be ignored.",
+                    subset_path,
+                )
+                subset_indices = subset_indices[valid]
+            if len(subset_indices) == 0:
+                continue
+
+            face_mask = np.zeros(len(face_counts), dtype=bool)
+            face_mask[subset_indices] = True
+            triangle_indices = np.nonzero(face_mask[triangle_face_indices])[0]
+            submesh = _make_visual_submesh(mesh, triangle_indices, material_props, prim=prim, path_name=subset_path)
+            if submesh is None:
+                continue
+            covered_faces[subset_indices] = True
+            submeshes.append((subset_path, submesh))
+
+        if not submeshes:
+            return []
+
+        uncovered_faces = np.nonzero(~covered_faces)[0]
+        if len(uncovered_faces) > 0:
+            face_mask = np.zeros(len(face_counts), dtype=bool)
+            face_mask[uncovered_faces] = True
+            triangle_indices = np.nonzero(face_mask[triangle_face_indices])[0]
+            fallback_mesh = _make_visual_submesh(
+                mesh,
+                triangle_indices,
+                _get_material_props_cached(prim),
+                prim=prim,
+                path_name=str(prim.GetPath()),
+            )
+            if fallback_mesh is not None:
+                submeshes.insert(0, (str(prim.GetPath()), fallback_mesh))
+
+        return submeshes
 
     def _get_tetmesh_cached(prim: Usd.Prim) -> TetMesh:
         """Load and cache TetMesh data to avoid repeated USD extraction."""
@@ -735,16 +915,38 @@ def parse_usd(
                     label=path_name,
                 )
             elif type_name == "mesh":
-                mesh = _get_mesh_with_visual_material(prim, path_name=path_name)
-                shape_id = builder.add_shape_mesh(
-                    parent_body_id,
-                    xform,
-                    scale=scale,
-                    mesh=mesh,
-                    cfg=visual_shape_cfg_for_prim,
-                    color=shape_color,
-                    label=path_name,
-                )
+                subset_meshes = _get_visual_material_subset_meshes(prim)
+                if subset_meshes:
+                    for subset_path, subset_mesh in subset_meshes:
+                        subset_shape_id = builder.add_shape_mesh(
+                            parent_body_id,
+                            xform,
+                            scale=scale,
+                            mesh=subset_mesh,
+                            cfg=visual_shape_cfg_for_prim,
+                            color=None,
+                            label=subset_path,
+                        )
+                        path_shape_map[subset_path] = subset_shape_id
+                        path_shape_scale[subset_path] = scale
+                        if shape_id < 0:
+                            shape_id = subset_shape_id
+                        if verbose:
+                            print(
+                                f"Added visual shape {subset_path} ({type_name} material subset) "
+                                f"with id {subset_shape_id}."
+                            )
+                else:
+                    mesh = _get_mesh_with_visual_material(prim, path_name=path_name)
+                    shape_id = builder.add_shape_mesh(
+                        parent_body_id,
+                        xform,
+                        scale=scale,
+                        mesh=mesh,
+                        cfg=visual_shape_cfg_for_prim,
+                        color=shape_color,
+                        label=path_name,
+                    )
             elif type_name == "particlefield3dgaussiansplat":
                 gaussian = usd.get_gaussian(prim)
                 shape_id = builder.add_shape_gaussian(
@@ -756,7 +958,11 @@ def parse_usd(
                     color=shape_color,
                     label=path_name,
                 )
-            elif len(type_name) > 0 and type_name not in {"xform", "tetmesh"} and verbose:
+            elif (
+                len(type_name) > 0
+                and type_name not in {"geomsubset", "material", "scope", "shader", "xform", "tetmesh"}
+                and verbose
+            ):
                 print(f"Warning: Unsupported geometry type {type_name} at {path_name} while loading visual shapes.")
 
             if shape_id >= 0:

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -594,7 +594,7 @@ class ArticulationView:
             arti_link_ids.append(link_id)
 
         # use link order as they appear in the model
-        arti_link_ids = sorted(arti_link_ids)
+        arti_link_ids = sorted(set(arti_link_ids))
         arti_link_count = len(arti_link_ids)
         for link_id in arti_link_ids:
             arti_link_template_labels.append(model.body_label[link_id])
@@ -617,6 +617,7 @@ class ArticulationView:
         joint_coord_counts = list_of_lists(world_count)
         root_joint_types = list_of_lists(world_count)
         link_starts = list_of_lists(world_count)
+        link_counts = list_of_lists(world_count)
         shape_starts = list_of_lists(world_count)
         shape_counts = list_of_lists(world_count)
         for world_id in range(world_count):
@@ -644,9 +645,12 @@ class ArticulationView:
                 for j in range(joint_start, joint_end):
                     link_id = int(model_joint_child[j])
                     link_ids.append(link_id)
+                link_ids = sorted(set(link_ids))
+                for link_id in link_ids:
                     link_shapes = model.body_shapes.get(link_id, [])
                     shape_ids.extend(link_shapes)
                 link_starts[world_id].append(min(link_ids))
+                link_counts[world_id].append(len(link_ids))
                 num_shapes = len(shape_ids)
                 if num_shapes > 0:
                     shape_starts[world_id].append(min(shape_ids))
@@ -655,12 +659,12 @@ class ArticulationView:
                 shape_counts[world_id].append(num_shapes)
 
         # make sure counts are the same for all articulations
-        # NOTE: we currently assume that link count is the same as joint count
         if not (
             all_equal(joint_counts)
             and all_equal(joint_dof_counts)
             and all_equal(joint_coord_counts)
             and all_equal(root_joint_types)
+            and all_equal(link_counts)
             and all_equal(shape_counts)
         ):
             raise ValueError("Articulations are not identical")

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4486,6 +4486,149 @@ def Xform "Articulation" (
         self.assertAlmostEqual(rolling, 0.08, places=4)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_visual_mesh_material_subsets_create_separate_visual_shapes(self):
+        """Test that visual mesh material subsets import as separate colored shapes."""
+        from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade, Vt
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        mesh = UsdGeom.Mesh.Define(stage, "/Body/VisualMesh")
+        mesh.CreatePointsAttr().Set(
+            [
+                (-0.5, -0.5, 0.0),
+                (0.5, -0.5, 0.0),
+                (0.5, 0.5, 0.0),
+                (-0.5, 0.5, 0.0),
+            ]
+        )
+        mesh.CreateFaceVertexCountsAttr().Set([3, 3])
+        mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 0, 2, 3])
+        st = UsdGeom.PrimvarsAPI(mesh).CreatePrimvar("st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
+        st.Set([(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)])
+
+        grey_material = UsdShade.Material.Define(stage, "/Materials/Grey")
+        grey_shader = UsdShade.Shader.Define(stage, "/Materials/Grey/PreviewSurface")
+        grey_shader.CreateIdAttr("UsdPreviewSurface")
+        grey_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).Set((0.5, 0.5, 0.5))
+        grey_material.CreateSurfaceOutput().ConnectToSource(grey_shader.ConnectableAPI(), "surface")
+        UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(grey_material)
+
+        red_material = UsdShade.Material.Define(stage, "/Materials/Red")
+        red_shader = UsdShade.Shader.Define(stage, "/Materials/Red/PreviewSurface")
+        red_shader.CreateIdAttr("UsdPreviewSurface")
+        red_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).Set((1.0, 0.0, 0.0))
+        red_material.CreateSurfaceOutput().ConnectToSource(red_shader.ConnectableAPI(), "surface")
+
+        blue_material = UsdShade.Material.Define(stage, "/Materials/Blue")
+        blue_shader = UsdShade.Shader.Define(stage, "/Materials/Blue/PreviewSurface")
+        blue_shader.CreateIdAttr("UsdPreviewSurface")
+        blue_texture = UsdShade.Shader.Define(stage, "/Materials/Blue/DiffuseTexture")
+        blue_texture.CreateIdAttr("UsdUVTexture")
+        blue_texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("blue.png"))
+        blue_texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        blue_shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(
+            blue_texture.ConnectableAPI(), "rgb"
+        )
+        blue_material.CreateSurfaceOutput().ConnectToSource(blue_shader.ConnectableAPI(), "surface")
+
+        red_subset = UsdGeom.Subset.Define(stage, "/Body/VisualMesh/red")
+        red_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+        red_subset.CreateFamilyNameAttr().Set("materialBind")
+        red_subset.CreateIndicesAttr().Set(Vt.IntArray([0]))
+        UsdShade.MaterialBindingAPI.Apply(red_subset.GetPrim()).Bind(red_material)
+
+        blue_subset = UsdGeom.Subset.Define(stage, "/Body/VisualMesh/blue")
+        blue_subset.CreateElementTypeAttr().Set(UsdGeom.Tokens.face)
+        blue_subset.CreateFamilyNameAttr().Set("materialBind")
+        blue_subset.CreateIndicesAttr().Set(Vt.IntArray([1]))
+        UsdShade.MaterialBindingAPI.Apply(blue_subset.GetPrim()).Bind(blue_material)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+
+        self.assertIn("/Body/VisualMesh/red", result["path_shape_map"])
+        self.assertIn("/Body/VisualMesh/blue", result["path_shape_map"])
+
+        red_shape = result["path_shape_map"]["/Body/VisualMesh/red"]
+        blue_shape = result["path_shape_map"]["/Body/VisualMesh/blue"]
+
+        self.assertEqual(builder.shape_count, 2)
+        self.assertEqual(builder.shape_label[red_shape], "/Body/VisualMesh/red")
+        self.assertEqual(builder.shape_label[blue_shape], "/Body/VisualMesh/blue")
+
+        red_mesh = builder.shape_source[red_shape]
+        blue_mesh = builder.shape_source[blue_shape]
+        self.assertEqual(len(red_mesh.indices), 3)
+        self.assertEqual(len(blue_mesh.indices), 3)
+        np.testing.assert_allclose(np.array(red_mesh.color), np.array([1.0, 0.0, 0.0]), atol=1e-6, rtol=1e-6)
+        self.assertIsNotNone(blue_mesh.uvs)
+        self.assertEqual(blue_mesh.texture, "blue.png")
+        np.testing.assert_allclose(np.array(blue_mesh.color), np.array([1.0, 1.0, 1.0]), atol=1e-6, rtol=1e-6)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_uv_length_mismatch_uses_info_logging(self):
+        """Dropped-UV/texture diagnostics are render-only and surface via `logger.info`, not `warnings.warn`."""
+        import logging as _logging  # noqa: PLC0415
+        import warnings as _warnings  # noqa: PLC0415
+
+        from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        mesh = UsdGeom.Mesh.Define(stage, "/Body/VisualMesh")
+        mesh.CreatePointsAttr().Set(
+            [
+                (-0.5, -0.5, 0.0),
+                (0.5, -0.5, 0.0),
+                (0.5, 0.5, 0.0),
+                (-0.5, 0.5, 0.0),
+            ]
+        )
+        mesh.CreateFaceVertexCountsAttr().Set([3, 3])
+        mesh.CreateFaceVertexIndicesAttr().Set([0, 1, 2, 0, 2, 3])
+        # Author a single face-varying `st` primvar whose length does not match the mesh's
+        # face-corner count, so the importer must drop UVs and (downstream) the bound texture.
+        UsdGeom.PrimvarsAPI(mesh).CreatePrimvar(
+            "st", Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying
+        ).Set([(0.0, 0.0)])
+
+        material = UsdShade.Material.Define(stage, "/Materials/Tex")
+        shader = UsdShade.Shader.Define(stage, "/Materials/Tex/PreviewSurface")
+        shader.CreateIdAttr("UsdPreviewSurface")
+        tex = UsdShade.Shader.Define(stage, "/Materials/Tex/DiffuseTexture")
+        tex.CreateIdAttr("UsdUVTexture")
+        tex.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("ignored.png"))
+        tex.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+        shader.CreateInput("baseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(tex.ConnectableAPI(), "rgb")
+        material.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+        UsdShade.MaterialBindingAPI.Apply(mesh.GetPrim()).Bind(material)
+
+        builder = newton.ModelBuilder()
+        with _warnings.catch_warnings(record=True) as caught, self.assertLogs("newton", level=_logging.INFO) as log_ctx:
+            _warnings.simplefilter("always")
+            builder.add_usd(stage)
+        uv_warnings = [
+            w for w in caught if "UV primvar length" in str(w.message) or "has a texture but no UVs" in str(w.message)
+        ]
+        self.assertEqual(uv_warnings, [], f"unexpected UV warnings: {[str(w.message) for w in uv_warnings]}")
+
+        joined = "\n".join(log_ctx.output)
+        self.assertIn("UV primvar length", joined)
+        self.assertIn("dropping texture because UVs could not be recovered", joined)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_material_density_used_by_mass_properties(self):
         """Test that physics material density contributes to imported body mass/inertia."""
         from pxr import Usd, UsdGeom, UsdPhysics, UsdShade

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -113,6 +113,33 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(len(view.joint_template_labels), view.joint_count)
         self.assertEqual(view.body_template_labels, view.link_template_labels)
 
+    def test_duplicate_joint_child_is_one_link(self):
+        """BODY-frequency link axis uses unique physical bodies, not joint slots."""
+        builder = newton.ModelBuilder()
+        root = builder.add_link(label="root")
+        tip = builder.add_link(label="tip")
+        builder.add_shape_box(body=tip, hx=0.01, hy=0.01, hz=0.01, label="tip_shape")
+
+        j_root = builder.add_joint_free(parent=-1, child=root, label="root_joint")
+        j_tip = builder.add_joint_revolute(parent=root, child=tip, axis=wp.vec3(0.0, 0.0, 1.0), label="tip_joint")
+        j_tip_duplicate = builder.add_joint_fixed(parent=root, child=tip, label="tip_duplicate_joint")
+        builder.add_articulation([j_root, j_tip, j_tip_duplicate], label="robot")
+        model = builder.finalize()
+
+        view = ArticulationView(model, "robot")
+
+        self.assertEqual(list(model.body_label), ["root", "tip"])
+        self.assertEqual(view.link_count, 2)
+        self.assertEqual(view.link_names, ["root", "tip"])
+        self.assertEqual(view.link_template_labels, ["root", "tip"])
+        self.assertEqual(view.shape_count, 1)
+        self.assertEqual(view.shape_template_labels, ["tip_shape"])
+
+        body_layout = view.frequency_layouts[newton.Model.AttributeFrequency.BODY]
+        self.assertEqual(body_layout.value_count, len(model.body_label))
+        self.assertEqual(view.get_link_transforms(model).shape, (1, 1, 2))
+        self.assertEqual(view.get_link_velocities(model).shape, (1, 1, 2))
+
     def _test_selection_shapes(self, floating: bool):
         # load articulation
         ant = newton.ModelBuilder()


### PR DESCRIPTION
Cherry-picks two merged PRs from the 1.2.1 milestone onto `release-1.2`.

## Cherry-picked

- #2972 — Fix `ArticulationView` axis for loop links
- #2985 — USD: support GeomSubset visual materials + demote orphan-primvar warnings

Both applied with only trivial conflicts (an import-ordering conflict in `import_usd.py`; an unused `import math` left over from main-only code was dropped). USD import tests (201) and selection tests (36) pass on the branch.

## Not included

#2926 (Make ViewerGL GUI DPI-aware and movable) is also on the 1.2.1 milestone but cannot be cleanly cherry-picked: it was written after the OVRTX viewer refactor (#1861) introduced `viewer_gui.py`, where most of the fix lives, and that module does not exist on `release-1.2`. It will be backported separately against the older inline `viewer_gl.py` structure.

The remaining milestone items (#2916, #2935, #2958, plus issues #2674, #2806, #2914) are already on `release-1.2`.
