### PR TITLE
Use region fallback in AWS workflows

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -7,12 +7,14 @@ name: GPU Benchmarks on AWS EC2 (Reusable)
 # Workflow configuration variables
 env:
   AWS_REGION: us-east-2
+  # Prefer the validated US capacity order before Asia-Pacific fallback.
+  AWS_REGION_CANDIDATES: ${{ inputs.region-candidates || 'us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2' }}
   AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
+  AWS_RUNNER_RESOURCE_TAG: newton-github-runner
   HOME: /actions-runner
 
 on:
@@ -26,6 +28,11 @@ on:
       base_ref:
         description: 'Base ref to compare against (for ASV)'
         required: true
+        type: string
+        default: ''
+      region-candidates:
+        description: 'Space-separated AWS regions to try'
+        required: false
         type: string
         default: ''
     secrets:
@@ -43,11 +50,17 @@ jobs:
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-ec2-runner.outputs.region }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -55,20 +68,11 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
-      - name: Get the latest AWS Deep Learning Base GPU AMI
-        run: |
-          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
-          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
-            --owners amazon \
-            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
-            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
-            --output text)
-          if [[ -z "$LATEST_AMI_ID" ]]; then
-            echo "❌ No AMI ID found. Exiting."
-            exit 1
-          fi
-          echo "Latest AMI ID found: $LATEST_AMI_ID"
-          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+
+      - name: Discover AWS runner networking
+        id: discover-runner-config
+        run: python scripts/ci/discover_aws_runner_config.py
+
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
@@ -78,11 +82,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          availability-zones-config: >
-            [
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
-            ]
+          availability-zones-config: ${{ steps.discover-runner-config.outputs.availability-zones-config }}
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
@@ -204,21 +204,29 @@ jobs:
     needs:
       - start-runner
       - gpu-benchmarks
-    if: always() && github.repository == 'newton-physics/newton'
+    if: always() && needs.start-runner.result != 'skipped' && github.repository == 'newton-physics/newton'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
 
+      - name: Validate launch region
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' && needs.start-runner.outputs.region == '' }}
+        run: |
+          echo "::error::EC2 instance ID exists but the launch region output is empty."
+          exit 1
+
       - name: Configure AWS credentials
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
       - name: Stop EC2 runner
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop

--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -221,7 +221,7 @@ jobs:
         if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -246,7 +246,7 @@ jobs:
         if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -184,7 +184,7 @@ jobs:
         if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -6,12 +6,14 @@ name: Minimum Dependency Version Tests on AWS EC2 (Reusable)
 
 env:
   AWS_REGION: us-east-2
+  # Prefer the validated US capacity order before Asia-Pacific fallback.
+  AWS_REGION_CANDIDATES: us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2
   AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
+  AWS_RUNNER_RESOURCE_TAG: newton-github-runner
   HOME: /actions-runner
 
 on:
@@ -34,11 +36,17 @@ jobs:
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-ec2-runner.outputs.region }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -47,20 +55,9 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
-      - name: Get the latest AWS Deep Learning Base GPU AMI
-        run: |
-          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
-          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
-            --owners amazon \
-            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
-            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
-            --output text)
-          if [[ -z "$LATEST_AMI_ID" ]]; then
-            echo "❌ No AMI ID found. Exiting."
-            exit 1
-          fi
-          echo "Latest AMI ID found: $LATEST_AMI_ID"
-          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+      - name: Discover AWS runner networking
+        id: discover-runner-config
+        run: python scripts/ci/discover_aws_runner_config.py
 
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -71,11 +68,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          availability-zones-config: >
-            [
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
-            ]
+          availability-zones-config: ${{ steps.discover-runner-config.outputs.availability-zones-config }}
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
@@ -181,14 +174,22 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate launch region
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' && needs.start-runner.outputs.region == '' }}
+        run: |
+          echo "::error::EC2 instance ID exists but the launch region output is empty."
+          exit 1
+
       - name: Configure AWS credentials
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
       - name: Stop EC2 runner
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -5,12 +5,14 @@ name: MuJoCo Warp Tests on AWS EC2 (Reusable)
 
 env:
   AWS_REGION: us-east-2
+  # Prefer the validated US capacity order before Asia-Pacific fallback.
+  AWS_REGION_CANDIDATES: us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2
   AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
+  AWS_RUNNER_RESOURCE_TAG: newton-github-runner
   HOME: /actions-runner
 
 on:
@@ -33,11 +35,17 @@ jobs:
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-ec2-runner.outputs.region }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -46,20 +54,9 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
-      - name: Get the latest AWS Deep Learning Base GPU AMI
-        run: |
-          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
-          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
-            --owners amazon \
-            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
-            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
-            --output text)
-          if [[ -z "$LATEST_AMI_ID" ]]; then
-            echo "❌ No AMI ID found. Exiting."
-            exit 1
-          fi
-          echo "Latest AMI ID found: $LATEST_AMI_ID"
-          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+      - name: Discover AWS runner networking
+        id: discover-runner-config
+        run: python scripts/ci/discover_aws_runner_config.py
 
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -70,11 +67,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          availability-zones-config: >
-            [
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
-            ]
+          availability-zones-config: ${{ steps.discover-runner-config.outputs.availability-zones-config }}
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
@@ -188,14 +181,22 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate launch region
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' && needs.start-runner.outputs.region == '' }}
+        run: |
+          echo "::error::EC2 instance ID exists but the launch region output is empty."
+          exit 1
+
       - name: Configure AWS credentials
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
       - name: Stop EC2 runner
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -186,7 +186,7 @@ jobs:
         if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -5,12 +5,14 @@ name: Warp Nightly Build Tests on AWS EC2 (Reusable)
 
 env:
   AWS_REGION: us-east-2
+  # Prefer the validated US capacity order before Asia-Pacific fallback.
+  AWS_REGION_CANDIDATES: us-east-1 us-east-2 us-west-2 ap-northeast-1 ap-northeast-2
   AWS_INSTANCE_TYPE: g7e.2xlarge
   AWS_VOLUME_SIZE: 92
   AWS_VOLUME_TYPE: gp3
-  AWS_SECURITY_GROUP_IDS: sg-07807c44e7f2a368a
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
+  AWS_RUNNER_RESOURCE_TAG: newton-github-runner
   HOME: /actions-runner
 
 on:
@@ -33,11 +35,17 @@ jobs:
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+      region: ${{ steps.start-ec2-runner.outputs.region }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
           egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
@@ -46,20 +54,9 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
-      - name: Get the latest AWS Deep Learning Base GPU AMI
-        run: |
-          echo "Finding the latest AWS Deep Learning Base GPU AMI..."
-          LATEST_AMI_ID=$(aws ec2 describe-images --region ${{ env.AWS_REGION }} \
-            --owners amazon \
-            --filters 'Name=name,Values=Deep Learning Base AMI with Single CUDA (Ubuntu 22.04) ????????' 'Name=state,Values=available' \
-            --query 'reverse(sort_by(Images, &CreationDate))[:1].ImageId' \
-            --output text)
-          if [[ -z "$LATEST_AMI_ID" ]]; then
-            echo "❌ No AMI ID found. Exiting."
-            exit 1
-          fi
-          echo "Latest AMI ID found: $LATEST_AMI_ID"
-          echo "LATEST_AMI_ID=$LATEST_AMI_ID" >> "$GITHUB_ENV"
+      - name: Discover AWS runner networking
+        id: discover-runner-config
+        run: python scripts/ci/discover_aws_runner_config.py
 
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -70,11 +67,7 @@ jobs:
           ec2-instance-type: ${{ env.AWS_INSTANCE_TYPE }}
           ec2-volume-size: ${{ env.AWS_VOLUME_SIZE }}
           ec2-volume-type: ${{ env.AWS_VOLUME_TYPE }}
-          availability-zones-config: >
-            [
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-051b9d2e71acf8047", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"},
-              {"imageId": "${{ env.LATEST_AMI_ID }}", "subnetId": "subnet-0c98bd06abe8ee5eb", "securityGroupId": "${{ env.AWS_SECURITY_GROUP_IDS }}"}
-            ]
+          availability-zones-config: ${{ steps.discover-runner-config.outputs.availability-zones-config }}
           pre-runner-script: |
             if [ -d /opt/dlami/nvme ]; then
               mkdir -p /opt/dlami/nvme/actions-runner/_work
@@ -183,14 +176,22 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate launch region
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' && needs.start-runner.outputs.region == '' }}
+        run: |
+          echo "::error::EC2 instance ID exists but the launch region output is empty."
+          exit 1
+
       - name: Configure AWS credentials
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6.0.0
         with:
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ needs.start-runner.outputs.region || env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
 
       - name: Stop EC2 runner
+        if: ${{ needs.start-runner.outputs.ec2-instance-id != '' }}
         uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop

--- a/scripts/ci/discover_aws_runner_config.py
+++ b/scripts/ci/discover_aws_runner_config.py
@@ -3,8 +3,8 @@
 
 """Discover AWS EC2 runner networking for GitHub Actions.
 
-The script is designed to run inside ``aws_gpu_tests.yml`` after AWS
-credentials are configured. It writes one GitHub Actions step output:
+The script is designed to run inside EC2-backed GPU GitHub Actions workflows
+after AWS credentials are configured. It writes one GitHub Actions step output:
 
 ``availability-zones-config``
     JSON array passed to ``machulav/ec2-github-runner``.


### PR DESCRIPTION
## Description

Update the remaining EC2-backed GPU workflows to use the dynamic AWS runner discovery path already used by `aws_gpu_tests.yml`.

This removes fixed `us-east-2` AMI/subnet/security-group runner setup from:

- `.github/workflows/aws_gpu_benchmarks.yml`
- `.github/workflows/minimum_deps_tests.yml`
- `.github/workflows/warp_nightly_tests.yml`
- `.github/workflows/mujoco_warp_tests.yml`

The workflows now discover tagged runner networking across the shared ordered region list, pass the generated `availability-zones-config` to `machulav/ec2-github-runner`, and use the selected launch region during teardown. The discovery helper docstring now reflects that it is shared by EC2-backed GPU workflows.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run python -m py_compile scripts/ci/discover_aws_runner_config.py
uvx pre-commit run -a
```

Also ran a local workflow audit confirming the upgraded workflows no longer contain the fixed security group, hardcoded subnet IDs, or local Deep Learning AMI lookup, and that each workflow includes runner discovery, selected region output, launch-region validation, and selected-region teardown.

## Bug fix

**Steps to reproduce:**

1. Trigger one of the remaining EC2-backed GPU workflows when `us-east-2` lacks suitable GPU capacity.
2. Observe the workflow only has fixed `us-east-2` runner networking available.
3. The runner launch can fail even when another configured AWS region has capacity.

**Minimal reproduction:**

```python
# CI-only runner provisioning issue; no Python reproduction applies.
```

## New feature / API change

```python
# No public API change.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a prioritized region-candidates input and ordered region preference for selecting AWS regions.
  * Start job now advertises the discovered launch region; runner startup uses dynamic discovery of availability-zone and network configuration instead of hardcoded values.
  * Hardened teardown: skip stop when start was skipped, validate discovered region when an instance ID exists, configure credentials with the discovered region, and only stop when an instance exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->