### PR TITLE
Fix Sphinx docs API toctree ownership

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -7,20 +7,6 @@ newton
 .. py:module:: newton
 .. currentmodule:: newton
 
-.. toctree::
-   :hidden:
-
-   newton_actuators
-   newton_geometry
-   newton_ik
-   newton_math
-   newton_selection
-   newton_sensors
-   newton_solvers
-   newton_usd
-   newton_utils
-   newton_viewer
-
 .. rubric:: Submodules
 
 - :doc:`newton.actuators <newton_actuators>`

--- a/docs/generate_api.py
+++ b/docs/generate_api.py
@@ -162,8 +162,11 @@ def solver_submodule_pages() -> list[str]:
     return modules
 
 
-def write_module_page(mod_name: str) -> None:
+def write_module_page(mod_name: str, api_toctree_modules: set[str] | None = None) -> None:
     """Create an .rst file for *mod_name* under *OUTPUT_DIR*."""
+
+    if api_toctree_modules is None:
+        api_toctree_modules = set(api_modules())
 
     is_solver_submodule = mod_name.startswith("newton.solvers.") and mod_name != "newton.solvers"
     if is_solver_submodule:
@@ -246,25 +249,24 @@ def write_module_page(mod_name: str) -> None:
     else:
         lines.extend([f".. py:module:: {mod_name}", f".. currentmodule:: {mod_name}", ""])
 
-    # Render a simple bullet list of submodules (no autosummary/toctree) to
-    # avoid generating stub pages that can cause duplicate descriptions.
     if modules and not is_solver_submodule:
         modules.sort()
-        lines.extend(
-            [
-                ".. toctree::",
-                "   :hidden:",
-                "",
-            ]
-        )
-        for sub in modules:
-            modname = f"{mod_name}.{sub}"
-            docname = modname.replace(".", "_")
-            lines.append(f"   {docname}")
-        lines.append("")
+        nested_modules = [sub for sub in modules if f"{mod_name}.{sub}" not in api_toctree_modules]
+        if nested_modules:
+            lines.extend(
+                [
+                    ".. toctree::",
+                    "   :hidden:",
+                    "",
+                ]
+            )
+            for sub in nested_modules:
+                modname = f"{mod_name}.{sub}"
+                docname = modname.replace(".", "_")
+                lines.append(f"   {docname}")
+            lines.append("")
 
         lines.extend([".. rubric:: Submodules", ""])
-        # Link to sibling generated module pages without creating autosummary stubs.
         for sub in modules:
             modname = f"{mod_name}.{sub}"
             docname = modname.replace(".", "_")
@@ -385,7 +387,7 @@ def generate_all() -> None:
     all_modules = modules + [mod for mod in extra_solver_modules if mod not in modules]
 
     for mod in all_modules:
-        write_module_page(mod)
+        write_module_page(mod, set(modules))
 
     write_api_toctree(modules)
 


### PR DESCRIPTION
## Description

Fix generated API toctree ownership so top-level API submodule pages are owned only by the API reference toctree included from `docs/index.rst`.

Previously, `docs/api/_toctree.rst` and the hidden submodule toctree in `docs/api/newton.rst` both referenced pages such as `api/newton_solvers`, so normal Sphinx builds printed repeated consistency messages about documents referenced in multiple toctrees. Sphinx was already selecting the `index` owner; this PR removes the duplicate `api/newton` ownership.

This does not remove rendered submodule links from the `newton` API page. The generated `newton` page keeps its visible `:doc:` bullet list for submodules, and this PR removes only the hidden toctree entries that made `api/newton` an additional structural parent. Nested API pages that are not top-level reference entries still keep their parent toctree relationship.

Addresses the 2026-05-31-D documentation audit finding in #2183.

## Checklist

- [x] Existing checks cover these changes - the Sphinx docs build exercises the toctree consistency check directly.
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change) - Not applicable; this only removes docs-build consistency noise.

## Test plan

Existing generator tests still pass:

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-fix-api-toctree-owners WARP_CACHE_ROOT=/tmp/newton-warp-cache-fix-api-toctree-owners uv run --extra dev -m newton.tests -k test_generate_api
```

The behavior regression is covered by the Sphinx build, which reached `checking consistency... done` without the repeated `document is referenced in multiple toctrees` messages:

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-fix-api-toctree-owners WARP_CACHE_ROOT=/tmp/newton-warp-cache-fix-api-toctree-owners uv run --extra docs --extra sim sphinx-build -j auto -W -D exclude_patterns=_build,Thumbs.db,.DS_Store,sphinx-env/**,sphinx-env,**/site-packages/**,**/lib/**,api/_toctree.rst,superpowers/** -b html docs docs/_build/html
```

Pre-commit also passes:

```bash
WARP_CACHE_PATH=/tmp/newton-warp-cache-fix-api-toctree-owners WARP_CACHE_ROOT=/tmp/newton-warp-cache-fix-api-toctree-owners uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run a normal HTML docs build on current `main`.
2. Observe repeated Sphinx consistency messages for `docs/api/newton_*.rst` pages being referenced by both `api/newton` and `index` toctrees.

**Minimal reproduction:**

```bash
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined API documentation structure to improve navigation: hidden automatic submodule navigation entries were removed or restricted so only relevant nested modules are included.
  * Maintained existing module/class/function listings; no public API or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
