### PR TITLE
Add examples guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ If you installed from source with uv, substitute `uv run` for `python` in the co
         <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_anymal_c_walk.jpg" alt="Anymal C Walk">
       </a>
     </td>
-    <td></td>
+    <td align="center" width="33%">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_policy.py">
+        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_policy.jpg" alt="Policy">
+      </a>
+    </td>
   </tr>
   <tr>
     <td align="center" width="33%">
@@ -196,13 +200,11 @@ If you installed from source with uv, substitute `uv run` for `python` in the co
     <td align="center" width="33%">
       <code>python -m newton.examples robot_anymal_c_walk</code>
     </td>
+    <td align="center" width="33%">
+      <code>python -m newton.examples robot_policy</code>
+    </td>
   </tr>
   <tr>
-    <td align="center" width="33%">
-      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_policy.py">
-        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_policy.jpg" alt="Policy">
-      </a>
-    </td>
     <td align="center" width="33%">
       <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_ur10.py">
         <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_ur10.jpg" alt="UR10">
@@ -213,36 +215,21 @@ If you installed from source with uv, substitute `uv run` for `python` in the co
         <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_panda_hydro.jpg" alt="Panda Hydro">
       </a>
     </td>
+    <td align="center" width="33%">
+      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_allegro_hand.py">
+        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_allegro_hand.jpg" alt="Allegro Hand">
+      </a>
+    </td>
   </tr>
   <tr>
-    <td align="center" width="33%">
-      <code>python -m newton.examples robot_policy</code>
-    </td>
     <td align="center" width="33%">
       <code>python -m newton.examples robot_ur10</code>
     </td>
     <td align="center" width="33%">
       <code>python -m newton.examples robot_panda_hydro</code>
     </td>
-  </tr>
-  <tr>
-    <td align="center" width="33%">
-      <a href="https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_allegro_hand.py">
-        <img width="320" src="https://raw.githubusercontent.com/newton-physics/newton/main/docs/images/examples/example_robot_allegro_hand.jpg" alt="Allegro Hand">
-      </a>
-    </td>
-    <td align="center" width="33%">
-    </td>
-    <td align="center" width="33%">
-    </td>
-  </tr>
-  <tr>
     <td align="center" width="33%">
       <code>python -m newton.examples robot_allegro_hand</code>
-    </td>
-    <td align="center" width="33%">
-    </td>
-    <td align="center" width="33%">
     </td>
   </tr>
   <tr>

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -875,6 +875,40 @@ Commit hashes can be used instead of relative references:
 
             asv run --launch-method spawn abc1234..def5678
 
+Benchmarking runnable examples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a quick timing check on a runnable example, use ``--benchmark`` with a
+fixed ``--num-frames`` value:
+
+.. tab-set::
+    :sync-group: env
+
+    .. tab-item:: uv
+        :sync: uv
+
+        .. code-block:: console
+
+            uv run -m newton.examples robot_cartpole --benchmark --num-frames 1000
+
+    .. tab-item:: venv
+        :sync: venv
+
+        .. code-block:: console
+
+            python -m newton.examples robot_cartpole --benchmark --num-frames 1000
+
+``--benchmark`` uses the null viewer internally and prints FPS after a short
+warmup. When comparing code changes, prefer keeping ``--num-frames`` fixed so
+each run completes the same simulation workload.
+
+Passing a value to ``--benchmark``, such as ``--benchmark 10``, sets a duration
+limit in seconds. The run stops when either the duration or ``--num-frames`` is
+reached. This can be useful for quick smoke checks, but fixed-frame runs are
+usually easier to compare across code changes. ``--viewer null`` runs without
+rendering but does not print benchmark results, and ``--headless`` is not
+equivalent because it still uses a rendering viewer path.
+
 Running benchmarks standalone
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -189,30 +189,24 @@ Robotics
      - .. image:: ../images/examples/example_robot_anymal_c_walk.jpg
           :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_anymal_c_walk.py
           :alt: robot_anymal_c_walk
-     -
-   * - ``python -m newton.examples robot_anymal_d``
-     - ``python -m newton.examples robot_anymal_c_walk``
-     -
-   * - .. image:: ../images/examples/example_robot_policy.jpg
+     - .. image:: ../images/examples/example_robot_policy.jpg
           :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_policy.py
           :alt: robot_policy
-     - .. image:: ../images/examples/example_robot_ur10.jpg
+   * - ``python -m newton.examples robot_anymal_d``
+     - ``python -m newton.examples robot_anymal_c_walk``
+     - ``python -m newton.examples robot_policy``
+   * - .. image:: ../images/examples/example_robot_ur10.jpg
           :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_ur10.py
           :alt: robot_ur10
      - .. image:: ../images/examples/example_robot_panda_hydro.jpg
           :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_panda_hydro.py
           :alt: robot_panda_hydro
-   * - ``python -m newton.examples robot_policy``
-     - ``python -m newton.examples robot_ur10``
-     - ``python -m newton.examples robot_panda_hydro``
-   * - .. image:: ../images/examples/example_robot_allegro_hand.jpg
+     - .. image:: ../images/examples/example_robot_allegro_hand.jpg
           :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_allegro_hand.py
           :alt: robot_allegro_hand
-     -
-     -
-   * - ``python -m newton.examples robot_allegro_hand``
-     -
-     -
+   * - ``python -m newton.examples robot_ur10``
+     - ``python -m newton.examples robot_panda_hydro``
+     - ``python -m newton.examples robot_allegro_hand``
 
 Cables
 ^^^^^^

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -109,8 +109,8 @@ For example:
 Example Gallery
 ---------------
 
-The command-line list is the canonical catalog. The galleries below show the
-examples that have preview images in the docs.
+The command-line list shows all available examples. The galleries below show
+the examples that have preview images in the docs.
 
 Basic and Visualization
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -1,0 +1,535 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+.. SPDX-License-Identifier: CC-BY-4.0
+
+Examples
+========
+
+Newton ships runnable examples that demonstrate focused simulation workflows
+across rigid bodies, robotics, cloth, cables, MPM, sensors, differentiable
+simulation, and other areas. Use the examples to browse concrete scenes,
+compare solver configurations, or start from a working script.
+
+Install the examples extra before running the packaged examples:
+
+.. code-block:: console
+
+    pip install "newton[examples]"
+
+When working from a source checkout, use ``uv run`` from the repository root:
+
+.. code-block:: console
+
+    uv run -m newton.examples --list
+
+Network and Asset Downloads
+---------------------------
+
+Some examples download external assets the first time they run. Newton pins
+these asset repositories to known revisions and caches downloads locally, so
+later runs can reuse the cached files. Many of these assets come from the
+`newton-assets <https://github.com/newton-physics/newton-assets>`__ repository.
+Some examples use other pinned external asset repositories for robot models,
+meshes, or policies.
+
+Examples that need external assets require network access the first time they
+run. After the assets are cached, later runs can reuse them offline.
+
+Browse Examples
+---------------
+
+List the available examples from the command line:
+
+.. code-block:: console
+
+    python -m newton.examples --list
+
+Launch the default example browser:
+
+.. code-block:: console
+
+    python -m newton.examples
+
+The GL viewer includes an examples side panel for browsing examples by
+category. Selecting an entry switches to that example, and the viewer can reset
+the current example while preserving the relevant command-line options.
+
+Run an Example
+--------------
+
+Run any listed short name with ``python -m newton.examples <name>``. For
+example:
+
+.. code-block:: console
+
+    python -m newton.examples basic_pendulum
+    python -m newton.examples basic_shapes
+    python -m newton.examples robot_cartpole
+
+Use ``--help`` after a short name to show the options for that example,
+including common options and any example-specific flags:
+
+.. code-block:: console
+
+    python -m newton.examples robot_cartpole --help
+
+The examples share common command-line options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 54 22
+
+   * - Option
+     - Description
+     - Example
+   * - ``--viewer``
+     - Select the viewer: ``gl``, ``usd``, ``rtx``, ``rerun``, ``viser``, or
+       ``null``.
+     - ``--viewer usd``
+   * - ``--device``
+     - Select the Warp device.
+     - ``--device cuda:0``
+   * - ``--num-frames``
+     - Set the number of frames for finite runs and file output.
+     - ``--num-frames 500``
+   * - ``--output-path``
+     - Set the output path for file-based viewers.
+     - ``--output-path output.usd``
+   * - ``--test``
+     - Run example validation checks when available.
+     - ``--viewer null --test``
+
+For example:
+
+.. code-block:: console
+
+    python -m newton.examples basic_viewer --viewer usd --output-path my_output.usd
+    python -m newton.examples basic_urdf --device cuda:0
+    python -m newton.examples basic_viewer --viewer gl --num-frames 500 --device cpu
+
+Example Gallery
+---------------
+
+The command-line list is the canonical catalog. The galleries below show the
+examples that have preview images in the docs.
+
+Basic and Visualization
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_basic_pendulum.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_pendulum.py
+          :alt: basic_pendulum
+     - .. image:: ../images/examples/example_basic_urdf.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_urdf.py
+          :alt: basic_urdf
+     - .. image:: ../images/examples/example_basic_viewer.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_viewer.py
+          :alt: basic_viewer
+   * - ``python -m newton.examples basic_pendulum``
+     - ``python -m newton.examples basic_urdf``
+     - ``python -m newton.examples basic_viewer``
+   * - .. image:: ../images/examples/example_basic_shapes.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_shapes.py
+          :alt: basic_shapes
+     - .. image:: ../images/examples/example_basic_joints.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_joints.py
+          :alt: basic_joints
+     - .. image:: ../images/examples/example_basic_conveyor.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_conveyor.py
+          :alt: basic_conveyor
+   * - ``python -m newton.examples basic_shapes``
+     - ``python -m newton.examples basic_joints``
+     - ``python -m newton.examples basic_conveyor``
+   * - .. image:: ../images/examples/example_basic_heightfield.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_heightfield.py
+          :alt: basic_heightfield
+     - .. image:: ../images/examples/example_recording.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_recording.py
+          :alt: recording
+     - .. image:: ../images/examples/example_replay_viewer.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_replay_viewer.py
+          :alt: replay_viewer
+   * - ``python -m newton.examples basic_heightfield``
+     - ``python -m newton.examples recording``
+     - ``python -m newton.examples replay_viewer``
+   * - .. image:: ../images/examples/example_basic_plotting.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/basic/example_basic_plotting.py
+          :alt: basic_plotting
+     -
+     -
+   * - ``python -m newton.examples basic_plotting``
+     -
+     -
+
+Robotics
+^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_robot_cartpole.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_cartpole.py
+          :alt: robot_cartpole
+     - .. image:: ../images/examples/example_robot_g1.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_g1.py
+          :alt: robot_g1
+     - .. image:: ../images/examples/example_robot_h1.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_h1.py
+          :alt: robot_h1
+   * - ``python -m newton.examples robot_cartpole``
+     - ``python -m newton.examples robot_g1``
+     - ``python -m newton.examples robot_h1``
+   * - .. image:: ../images/examples/example_robot_anymal_d.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_anymal_d.py
+          :alt: robot_anymal_d
+     - .. image:: ../images/examples/example_robot_anymal_c_walk.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_anymal_c_walk.py
+          :alt: robot_anymal_c_walk
+     -
+   * - ``python -m newton.examples robot_anymal_d``
+     - ``python -m newton.examples robot_anymal_c_walk``
+     -
+   * - .. image:: ../images/examples/example_robot_policy.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_policy.py
+          :alt: robot_policy
+     - .. image:: ../images/examples/example_robot_ur10.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_ur10.py
+          :alt: robot_ur10
+     - .. image:: ../images/examples/example_robot_panda_hydro.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_panda_hydro.py
+          :alt: robot_panda_hydro
+   * - ``python -m newton.examples robot_policy``
+     - ``python -m newton.examples robot_ur10``
+     - ``python -m newton.examples robot_panda_hydro``
+   * - .. image:: ../images/examples/example_robot_allegro_hand.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/robot/example_robot_allegro_hand.py
+          :alt: robot_allegro_hand
+     -
+     -
+   * - ``python -m newton.examples robot_allegro_hand``
+     -
+     -
+
+Cables
+^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_cable_twist.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cable/example_cable_twist.py
+          :alt: cable_twist
+     - .. image:: ../images/examples/example_cable_y_junction.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cable/example_cable_y_junction.py
+          :alt: cable_y_junction
+     - .. image:: ../images/examples/example_cable_bundle_hysteresis.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cable/example_cable_bundle_hysteresis.py
+          :alt: cable_bundle_hysteresis
+   * - ``python -m newton.examples cable_twist``
+     - ``python -m newton.examples cable_y_junction``
+     - ``python -m newton.examples cable_bundle_hysteresis``
+   * - .. image:: ../images/examples/example_cable_pile.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cable/example_cable_pile.py
+          :alt: cable_pile
+     - .. image:: ../images/examples/example_cable_cross_slide_table.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cable/example_cable_cross_slide_table.py
+          :alt: cable_cross_slide_table
+     -
+   * - ``python -m newton.examples cable_pile``
+     - ``python -m newton.examples cable_cross_slide_table``
+     -
+
+Cloth
+^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_cloth_bending.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_bending.py
+          :alt: cloth_bending
+     - .. image:: ../images/examples/example_cloth_hanging.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_hanging.py
+          :alt: cloth_hanging
+     - .. image:: ../images/examples/example_cloth_style3d.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_style3d.py
+          :alt: cloth_style3d
+   * - ``python -m newton.examples cloth_bending``
+     - ``python -m newton.examples cloth_hanging``
+     - ``python -m newton.examples cloth_style3d``
+   * - .. image:: ../images/examples/example_cloth_h1.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_h1.py
+          :alt: cloth_h1
+     - .. image:: ../images/examples/example_cloth_twist.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_twist.py
+          :alt: cloth_twist
+     - .. image:: ../images/examples/example_cloth_franka.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_franka.py
+          :alt: cloth_franka
+   * - ``python -m newton.examples cloth_h1``
+     - ``python -m newton.examples cloth_twist``
+     - ``python -m newton.examples cloth_franka``
+   * - .. image:: ../images/examples/example_cloth_rollers.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_rollers.py
+          :alt: cloth_rollers
+     - .. image:: ../images/examples/example_cloth_poker_cards.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/cloth/example_cloth_poker_cards.py
+          :alt: cloth_poker_cards
+     -
+   * - ``python -m newton.examples cloth_rollers``
+     - ``python -m newton.examples cloth_poker_cards``
+     -
+
+Inverse Kinematics
+^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_ik_franka.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_franka.py
+          :alt: ik_franka
+     - .. image:: ../images/examples/example_ik_h1.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_h1.py
+          :alt: ik_h1
+     - .. image:: ../images/examples/example_ik_custom.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_custom.py
+          :alt: ik_custom
+   * - ``python -m newton.examples ik_franka``
+     - ``python -m newton.examples ik_h1``
+     - ``python -m newton.examples ik_custom``
+   * - .. image:: ../images/examples/example_ik_cube_stacking.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/ik/example_ik_cube_stacking.py
+          :alt: ik_cube_stacking
+     -
+     -
+   * - ``python -m newton.examples ik_cube_stacking``
+     -
+     -
+
+Material Point Method
+^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_mpm_granular.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_granular.py
+          :alt: mpm_granular
+     - .. image:: ../images/examples/example_mpm_anymal.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_anymal.py
+          :alt: mpm_anymal
+     - .. image:: ../images/examples/example_mpm_twoway_coupling.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_twoway_coupling.py
+          :alt: mpm_twoway_coupling
+   * - ``python -m newton.examples mpm_granular``
+     - ``python -m newton.examples mpm_anymal``
+     - ``python -m newton.examples mpm_twoway_coupling``
+   * - .. image:: ../images/examples/example_mpm_grain_rendering.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_grain_rendering.py
+          :alt: mpm_grain_rendering
+     - .. image:: ../images/examples/example_mpm_multi_material.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_multi_material.py
+          :alt: mpm_multi_material
+     - .. image:: ../images/examples/example_mpm_viscous.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_viscous.py
+          :alt: mpm_viscous
+   * - ``python -m newton.examples mpm_grain_rendering``
+     - ``python -m newton.examples mpm_multi_material``
+     - ``python -m newton.examples mpm_viscous``
+   * - .. image:: ../images/examples/example_mpm_beam_twist.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_beam_twist.py
+          :alt: mpm_beam_twist
+     - .. image:: ../images/examples/example_mpm_snow_ball.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/mpm/example_mpm_snow_ball.py
+          :alt: mpm_snow_ball
+     -
+   * - ``python -m newton.examples mpm_beam_twist``
+     - ``python -m newton.examples mpm_snow_ball``
+     -
+
+Sensors
+^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_sensor_contact.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/sensors/example_sensor_contact.py
+          :alt: sensor_contact
+     - .. image:: ../images/examples/example_sensor_tiled_camera.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/sensors/example_sensor_tiled_camera.py
+          :alt: sensor_tiled_camera
+     - .. image:: ../images/examples/example_sensor_imu.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/sensors/example_sensor_imu.py
+          :alt: sensor_imu
+   * - ``python -m newton.examples sensor_contact``
+     - ``python -m newton.examples sensor_tiled_camera``
+     - ``python -m newton.examples sensor_imu``
+
+Selection
+^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_selection_cartpole.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/selection/example_selection_cartpole.py
+          :alt: selection_cartpole
+     - .. image:: ../images/examples/example_selection_materials.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/selection/example_selection_materials.py
+          :alt: selection_materials
+     - .. image:: ../images/examples/example_selection_articulations.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/selection/example_selection_articulations.py
+          :alt: selection_articulations
+   * - ``python -m newton.examples selection_cartpole``
+     - ``python -m newton.examples selection_materials``
+     - ``python -m newton.examples selection_articulations``
+   * - .. image:: ../images/examples/example_selection_multiple.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/selection/example_selection_multiple.py
+          :alt: selection_multiple
+     -
+     -
+   * - ``python -m newton.examples selection_multiple``
+     -
+     -
+
+Differentiable Simulation
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_diffsim_ball.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_ball.py
+          :alt: diffsim_ball
+     - .. image:: ../images/examples/example_diffsim_cloth.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_cloth.py
+          :alt: diffsim_cloth
+     - .. image:: ../images/examples/example_diffsim_drone.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_drone.py
+          :alt: diffsim_drone
+   * - ``python -m newton.examples diffsim_ball``
+     - ``python -m newton.examples diffsim_cloth``
+     - ``python -m newton.examples diffsim_drone``
+   * - .. image:: ../images/examples/example_diffsim_spring_cage.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_spring_cage.py
+          :alt: diffsim_spring_cage
+     - .. image:: ../images/examples/example_diffsim_soft_body.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_soft_body.py
+          :alt: diffsim_soft_body
+     - .. image:: ../images/examples/example_diffsim_bear.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/diffsim/example_diffsim_bear.py
+          :alt: diffsim_bear
+   * - ``python -m newton.examples diffsim_spring_cage``
+     - ``python -m newton.examples diffsim_soft_body``
+     - ``python -m newton.examples diffsim_bear``
+
+Multiphysics
+^^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_softbody_gift.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_softbody_gift.py
+          :alt: softbody_gift
+     - .. image:: ../images/examples/example_softbody_dropping_to_cloth.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_softbody_dropping_to_cloth.py
+          :alt: softbody_dropping_to_cloth
+     - .. image:: ../images/examples/example_rigid_soft_contact.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/multiphysics/example_rigid_soft_contact.py
+          :alt: rigid_soft_contact
+   * - ``python -m newton.examples softbody_gift``
+     - ``python -m newton.examples softbody_dropping_to_cloth``
+     - ``python -m newton.examples rigid_soft_contact``
+
+Contacts
+^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_nut_bolt_hydro.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/contacts/example_nut_bolt_hydro.py
+          :alt: nut_bolt_hydro
+     - .. image:: ../images/examples/example_nut_bolt_sdf.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/contacts/example_nut_bolt_sdf.py
+          :alt: nut_bolt_sdf
+     - .. image:: ../images/examples/example_brick_stacking.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/contacts/example_brick_stacking.py
+          :alt: brick_stacking
+   * - ``python -m newton.examples nut_bolt_hydro``
+     - ``python -m newton.examples nut_bolt_sdf``
+     - ``python -m newton.examples brick_stacking``
+   * - .. image:: ../images/examples/example_pyramid.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/contacts/example_pyramid.py
+          :alt: pyramid
+     - .. image:: ../images/examples/example_contacts_rj45_plug.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/contacts/example_contacts_rj45_plug.py
+          :alt: contacts_rj45_plug
+     -
+   * - ``python -m newton.examples pyramid``
+     - ``python -m newton.examples contacts_rj45_plug``
+     -
+
+Soft Bodies
+^^^^^^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_softbody_hanging.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/softbody/example_softbody_hanging.py
+          :alt: softbody_hanging
+     - .. image:: ../images/examples/example_softbody_franka.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/softbody/example_softbody_franka.py
+          :alt: softbody_franka
+     -
+   * - ``python -m newton.examples softbody_hanging``
+     - ``python -m newton.examples softbody_franka``
+     -
+
+Kamino
+^^^^^^
+
+.. list-table::
+   :widths: 33 33 33
+   :class: gallery
+
+   * - .. image:: ../images/examples/example_kamino_basic_dr_testmech.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/kamino/example_kamino_basic_dr_testmech.py
+          :alt: kamino_basic_dr_testmech
+     - .. image:: ../images/examples/example_kamino_basic_fourbar.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/kamino/example_kamino_basic_fourbar.py
+          :alt: kamino_basic_fourbar
+     - .. image:: ../images/examples/example_kamino_basic_heterogeneous.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/kamino/example_kamino_basic_heterogeneous.py
+          :alt: kamino_basic_heterogeneous
+   * - ``python -m newton.examples kamino_basic_dr_testmech``
+     - ``python -m newton.examples kamino_basic_fourbar``
+     - ``python -m newton.examples kamino_basic_heterogeneous``
+   * - .. image:: ../images/examples/example_kamino_robot_anymal_d.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/kamino/example_kamino_robot_anymal_d.py
+          :alt: kamino_robot_anymal_d
+     - .. image:: ../images/examples/example_kamino_robot_dr_legs.jpg
+          :target: https://github.com/newton-physics/newton/blob/main/newton/examples/kamino/example_kamino_robot_dr_legs.py
+          :alt: kamino_robot_dr_legs
+     -
+   * - ``python -m newton.examples kamino_robot_anymal_d``
+     - ``python -m newton.examples kamino_robot_dr_legs``
+     -

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -238,6 +238,8 @@ install the most specific set for your use case.
 Next Steps
 ----------
 
-- Run ``python -m newton.examples --list`` to see all available examples and check out the :doc:`visualization` guide to learn how to interact with the example simulations.
+- Run ``python -m newton.examples --list`` to see all available examples,
+  browse the :doc:`examples` guide, and check out the :doc:`visualization`
+  guide to learn how to interact with the example simulations.
 - See the :doc:`compatibility` guide for Newton's supported platforms, versioning scheme, and deprecation policy.
 - Check out the :doc:`development` guide to learn how to contribute to Newton, or how to use alternative installation methods.

--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -134,6 +134,7 @@ Quick Links
 
 - :doc:`installation` — Setup Newton and run a first example in a couple of minutes
 - :doc:`tutorials` — Browse the guide's tutorial landing page
+- :doc:`examples` — Browse runnable simulation examples by workflow
 - :doc:`Introduction tutorial </tutorials/00_introduction>` — Walk through a first hands-on tutorial
 - :doc:`../faq` — Frequently asked questions
 - :doc:`development` — For developers and code contributors

--- a/docs/guide/tutorials.rst
+++ b/docs/guide/tutorials.rst
@@ -14,7 +14,7 @@ Open the notebooks directly in Colab:
 - :doc:`Introduction </tutorials/00_introduction>` |intro-colab|
 - :doc:`Robotics </tutorials/01_robotics>` |robotics-colab|
 
-You can also explore the examples in the ``newton/examples/`` directory for more use cases.
+For more runnable scenarios, browse the :doc:`examples` guide.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Newton Physics
    guide/compatibility
    guide/visualization
    guide/tutorials
+   guide/examples
    Development <guide/development>
 
 .. toctree::


### PR DESCRIPTION
## Description

Refs #2183.

Add a User Guide page for Newton's runnable examples so the docs advertise the
examples workflow in the same spirit as the README. The new page covers:

- installing and listing examples with `python -m newton.examples --list`
- launching examples and common viewer/device options
- first-run network access for examples that download assets
- an embedded screenshot gallery linked to the corresponding example sources

The page is linked from the User Guide navigation, Tutorials, Overview, and
Installation pages.

Follow-up commits also document per-example `--help`, compact the Robot
examples gallery layout in both `README.md` and the guide page, and add
developer-facing guidance for benchmarking runnable examples in
`docs/guide/development.rst`.

## Screenshot

<img width="720" height="1302" alt="newton-examples-basic-gallery-clean" src="https://github.com/user-attachments/assets/5918281e-d758-4b65-81b8-9656de94d2cb" />

## Checklist

- [x] New or existing tests cover these changes (docs-only change; verified with docs build)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable; docs-only change)

## Test plan

```bash
uvx pre-commit run -a
```

```bash
WARP_CACHE_PATH=/tmp/warp-cache-newton-docs-examples-guide \
WARP_CACHE_ROOT=/tmp/warp-cache-newton-docs-examples-guide \
uv run --extra docs sphinx-build -b html -j auto docs docs/_build/html \
  -D "exclude_patterns=_build,Thumbs.db,.DS_Store,sphinx-env/**,sphinx-env,**/site-packages/**,**/lib/**,api/_toctree.rst,superpowers/**"
```

The docs build succeeded. The only warnings observed were pre-existing
multiple-toctree notices for API pages, not warnings from `guide/examples`.

Generated HTML checks for `docs/_build/html/guide/examples.html`:

- 72 gallery `<img>` tags
- 72 copied `example_*.jpg` files in `docs/_build/html/_images`
- 72 GitHub source links to example `.py` files
- headless Chrome loaded all 72 gallery images with `failed_images=0`
- desktop rendered image widths were about 223 px; mobile viewports scaled them down

Recent follow-up changes were also checked with focused Sphinx builds for the
modified pages and `uvx pre-commit run -a`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive user guide for discovering, installing, and running runnable simulation examples (commands, per-example help, shared options, and notes on network/asset downloads and caching).
  * Added an example gallery with image previews linking to runnable examples.
  * Updated docs index, installation notes, tutorials, and README to reference and surface the new examples guide.
  * Added guidance for benchmarking runnable examples and related command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
