### PR TITLE
Fix #2492: MJCF body euler convention + <compiler> include-merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
 - Fix MJCF `euler` producing wrong orientations for multi-component angles (used extrinsic instead of intrinsic rotation).
 - Fix MJCF reading only the first `<compiler>` element; attributes are now merged across all elements in document order including `<include>`-expanded children.
+- Fix MJCF worldbody static geoms bypassing the visual/collider class filter, so `parse_visuals=False` now drops visual-class geoms attached directly to `<worldbody>` too (previously only filtered geoms inside `<body>` elements).
 - Fix `ViewerFile` playback dropping namespaced custom attributes (e.g. `model.mujoco.geom_solimp`) when restoring into a fresh `Model`.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 - Fix `eval_fk()` overwriting VBD-simulated `JointType.CABLE` body poses.
 - Fix `SolverXPBD` `body_parent_f` reporting to include `Control.joint_f` contributions and accumulate multiple inbound joint contributions, matching the `SolverMuJoCo` and `SolverFeatherstone` convention.
 - Fix MJCF `xyaxes` parsing to treat the second vector as Y and derive Z from X cross Y.
+- Fix MJCF `euler` producing wrong orientations for multi-component angles (used extrinsic instead of intrinsic rotation).
+- Fix MJCF reading only the first `<compiler>` element; attributes are now merged across all elements in document order including `<include>`-expanded children.
 - Fix `ViewerFile` playback dropping namespaced custom attributes (e.g. `model.mujoco.geom_solimp`) when restoring into a fresh `Model`.
 - Fix mesh-convex and heightfield-convex contacts missing when shapes are separated by margin but still within the contact envelope.
 - Fix `brick_stacking` example contact gaps to avoid oversized contact envelopes around the robot, table, and ground.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2353,14 +2353,15 @@ def parse_mjcf(
             )
 
         # -----------------
-        # add static geoms
+        # add static geoms — partition by class so `parse_visuals=False` /
+        # `parse_visuals_as_colliders=True` apply uniformly to worldbody
+        # geoms too (not just geoms inside bodies).
 
-        parse_shapes(
+        _process_body_geoms(
+            geoms=world.findall("geom"),
             defaults=world_defaults,
             body_name="world",
             link=-1,
-            geoms=world.findall("geom"),
-            density=default_shape_density,
             incoming_xform=xform,
             label_prefix=root_label_path,
         )

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -327,7 +327,7 @@ def parse_mjcf(
     mjcf_dirname = base_dir or "."  # Backward compatible fallback for mesh paths
 
     use_degrees = True  # angles are in degrees by default
-    euler_seq = [0, 1, 2]  # XYZ by default
+    eulerseq = "xyz"  # default sequence (lowercase = body-frame axes per MuJoCo's actual behavior)
 
     # load joint defaults
     default_joint_limit_lower = builder.default_joint_cfg.limit_lower
@@ -374,11 +374,14 @@ def parse_mjcf(
         compiler_attribs.update(c.attrib)
     if compiler_attribs:
         use_degrees = compiler_attribs.get("angle", "degree").lower() == "degree"
-        euler_seq = ["xyz".index(c) for c in compiler_attribs.get("eulerseq", "xyz").lower()]
+        # Per-character case carries the intrinsic/extrinsic axis convention
+        # (lowercase = body-frame axis, uppercase = world-frame axis); keep it.
+        eulerseq = compiler_attribs.get("eulerseq", "xyz")
         mesh_dir = compiler_attribs.get("meshdir", ".")
         texture_dir = compiler_attribs.get("texturedir", mesh_dir)
         fitaabb = compiler_attribs.get("fitaabb", "false").lower() == "true"
     else:
+        eulerseq = "xyz"
         mesh_dir = "."
         texture_dir = "."
         fitaabb = False
@@ -578,20 +581,17 @@ def parse_mjcf(
 
         return wp.types.vector(length, wp.float32)(out)
 
-    def quat_from_euler_mjcf(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
-        """Convert MJCF euler to intrinsic-rotation quaternion (matches MuJoCo).
+    def quat_from_euler_mjcf(e: wp.vec3, seq: str) -> wp.quat:
+        """Convert MJCF euler to quaternion respecting per-character ``eulerseq`` case.
 
-        Composes ``q_axis[i](e[0]) * q_axis[j](e[1]) * q_axis[k](e[2])``.
+        For each character, lowercase composes around the body-frame axis
+        (right-multiply) and uppercase composes around the world-frame axis
+        (left-multiply). The default ``"xyz"`` yields ``qx*qy*qz``; ``"XYZ"``
+        yields ``qz*qy*qx``; mixed cases yield the corresponding hybrid.
         """
         half = np.asarray([float(e[0]), float(e[1]), float(e[2])]) * 0.5
         c = np.cos(half)
         s = np.sin(half)
-
-        def axis_quat(axis_idx: int, idx: int) -> np.ndarray:
-            q = np.zeros(4)
-            q[0] = c[idx]
-            q[1 + axis_idx] = s[idx]
-            return q
 
         def qmul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
             aw, ax, ay, az = a
@@ -605,7 +605,14 @@ def parse_mjcf(
                 ]
             )
 
-        result = qmul(qmul(axis_quat(i, 0), axis_quat(j, 1)), axis_quat(k, 2))
+        result = np.array([1.0, 0.0, 0.0, 0.0])  # identity (w, x, y, z)
+        for n, ch in enumerate(seq):
+            axis_idx = "xyz".index(ch.lower())
+            q = np.zeros(4)
+            q[0] = c[n]
+            q[1 + axis_idx] = s[n]
+            result = qmul(result, q) if ch.islower() else qmul(q, result)
+
         return wp.quat(float(result[1]), float(result[2]), float(result[3]), float(result[0]))
 
     def parse_orientation(attrib) -> wp.quat:
@@ -617,7 +624,7 @@ def parse_mjcf(
             if use_degrees:
                 euler *= np.pi / 180
             # Keep MuJoCo-compatible semantics for non-XYZ sequences.
-            return quat_from_euler_mjcf(wp.vec3(euler), *euler_seq)
+            return quat_from_euler_mjcf(wp.vec3(euler), eulerseq)
         if "axisangle" in attrib:
             axisangle = np.array(attrib["axisangle"].split(), dtype=float)
             angle = axisangle[3]

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -368,13 +368,16 @@ def parse_mjcf(
         attr for attr in builder.custom_attributes.values() if attr.frequency == "mujoco:actuator"
     ]
 
-    compiler = root.find("compiler")
-    if compiler is not None:
-        use_degrees = compiler.attrib.get("angle", "degree").lower() == "degree"
-        euler_seq = ["xyz".index(c) for c in compiler.attrib.get("eulerseq", "xyz").lower()]
-        mesh_dir = compiler.attrib.get("meshdir", ".")
-        texture_dir = compiler.attrib.get("texturedir", mesh_dir)
-        fitaabb = compiler.attrib.get("fitaabb", "false").lower() == "true"
+    # Merge all <compiler> elements (document order, later wins) — matches MuJoCo.
+    compiler_attribs: dict[str, str] = {}
+    for c in root.iter("compiler"):
+        compiler_attribs.update(c.attrib)
+    if compiler_attribs:
+        use_degrees = compiler_attribs.get("angle", "degree").lower() == "degree"
+        euler_seq = ["xyz".index(c) for c in compiler_attribs.get("eulerseq", "xyz").lower()]
+        mesh_dir = compiler_attribs.get("meshdir", ".")
+        texture_dir = compiler_attribs.get("texturedir", mesh_dir)
+        fitaabb = compiler_attribs.get("fitaabb", "false").lower() == "true"
     else:
         mesh_dir = "."
         texture_dir = "."
@@ -389,7 +392,7 @@ def parse_mjcf(
             [AttributeFrequency.ONCE, AttributeFrequency.WORLD]
         )
         if builder_custom_attr_option:
-            option_elems = [compiler, *root.findall("option")]
+            option_elems = [*root.findall("compiler"), *root.findall("option")]
             for elem in option_elems:
                 if elem is not None:
                     parsed = parse_custom_attributes(elem.attrib, builder_custom_attr_option, "mjcf")
@@ -576,22 +579,34 @@ def parse_mjcf(
         return wp.types.vector(length, wp.float32)(out)
 
     def quat_from_euler_mjcf(e: wp.vec3, i: int, j: int, k: int) -> wp.quat:
-        """Convert Euler angles using MuJoCo's axis-sequence convention."""
-        half_e = e * 0.5
+        """Convert MJCF euler to intrinsic-rotation quaternion (matches MuJoCo).
 
-        cr = wp.cos(half_e[i])
-        sr = wp.sin(half_e[i])
-        cp = wp.cos(half_e[j])
-        sp = wp.sin(half_e[j])
-        cy = wp.cos(half_e[k])
-        sy = wp.sin(half_e[k])
+        Composes ``q_axis[i](e[0]) * q_axis[j](e[1]) * q_axis[k](e[2])``.
+        """
+        half = np.asarray([float(e[0]), float(e[1]), float(e[2])]) * 0.5
+        c = np.cos(half)
+        s = np.sin(half)
 
-        return wp.quat(
-            (cy * sr * cp - sy * cr * sp),
-            (cy * cr * sp + sy * sr * cp),
-            (sy * cr * cp - cy * sr * sp),
-            (cy * cr * cp + sy * sr * sp),
-        )
+        def axis_quat(axis_idx: int, idx: int) -> np.ndarray:
+            q = np.zeros(4)
+            q[0] = c[idx]
+            q[1 + axis_idx] = s[idx]
+            return q
+
+        def qmul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+            aw, ax, ay, az = a
+            bw, bx, by, bz = b
+            return np.array(
+                [
+                    aw * bw - ax * bx - ay * by - az * bz,
+                    aw * bx + ax * bw + ay * bz - az * by,
+                    aw * by - ax * bz + ay * bw + az * bx,
+                    aw * bz + ax * by - ay * bx + az * bw,
+                ]
+            )
+
+        result = qmul(qmul(axis_quat(i, 0), axis_quat(j, 1)), axis_quat(k, 2))
+        return wp.quat(float(result[1]), float(result[2]), float(result[3]), float(result[0]))
 
     def parse_orientation(attrib) -> wp.quat:
         if "quat" in attrib:

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -327,7 +327,7 @@ def parse_mjcf(
     mjcf_dirname = base_dir or "."  # Backward compatible fallback for mesh paths
 
     use_degrees = True  # angles are in degrees by default
-    eulerseq = "xyz"  # default sequence (lowercase = body-frame axes per MuJoCo's actual behavior)
+    eulerseq = "xyz"  # default sequence (lowercase = intrinsic axes, per MuJoCo)
 
     # load joint defaults
     default_joint_limit_lower = builder.default_joint_cfg.limit_lower
@@ -375,7 +375,8 @@ def parse_mjcf(
     if compiler_attribs:
         use_degrees = compiler_attribs.get("angle", "degree").lower() == "degree"
         # Per-character case carries the intrinsic/extrinsic axis convention
-        # (lowercase = body-frame axis, uppercase = world-frame axis); keep it.
+        # (lowercase = intrinsic / rotates with the frame, uppercase =
+        # extrinsic / fixed in the parent frame); keep it.
         eulerseq = compiler_attribs.get("eulerseq", "xyz")
         mesh_dir = compiler_attribs.get("meshdir", ".")
         texture_dir = compiler_attribs.get("texturedir", mesh_dir)
@@ -584,10 +585,11 @@ def parse_mjcf(
     def quat_from_euler_mjcf(e: wp.vec3, seq: str) -> wp.quat:
         """Convert MJCF euler to quaternion respecting per-character ``eulerseq`` case.
 
-        For each character, lowercase composes around the body-frame axis
-        (right-multiply) and uppercase composes around the world-frame axis
-        (left-multiply). The default ``"xyz"`` yields ``qx*qy*qz``; ``"XYZ"``
-        yields ``qz*qy*qx``; mixed cases yield the corresponding hybrid.
+        For each character, lowercase is intrinsic (the axis rotates with the
+        frame; right-multiply) and uppercase is extrinsic (the axis stays fixed
+        in the parent frame; left-multiply). The default ``"xyz"`` yields
+        ``qx*qy*qz``; ``"XYZ"`` yields ``qz*qy*qx``; mixed cases yield the
+        corresponding hybrid.
         """
         half = np.asarray([float(e[0]), float(e[1]), float(e[2])]) * 0.5
         c = np.cos(half)

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -312,38 +312,52 @@ class TestImportMjcfBasic(unittest.TestCase):
         self.assertTrue(same or negated, "Site quaternion mismatch (accounting for q/-q equivalence)")
 
     def test_body_euler_matches_mujoco(self):
-        """Body ``euler`` quaternion must match MuJoCo at default ``eulerseq=xyz``.
-
-        Uses three non-zero components so the intrinsic-vs-extrinsic
-        difference shows up above float32 noise.
+        """Sweep every 3-character ``eulerseq`` from ``{x,y,z,X,Y,Z}`` (216
+        combinations, including Tait-Bryan, proper-Euler, and degenerate
+        repeated-axis sequences) and assert Newton's body quaternion matches
+        MuJoCo's for a fixed non-trivial ``euler``. Skips sequences MuJoCo
+        itself rejects; flags any sequence Newton accepts that MuJoCo doesn't.
         """
-        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+        from itertools import product  # noqa: PLC0415
+
+        mujoco = SolverMuJoCo.import_mujoco()[0]
+        euler = "0.3 1.2 -0.7"
+        chars = "xyzXYZ"
+        compared = 0
+        for triple in product(chars, repeat=3):
+            seq = "".join(triple)
+            mjcf = f"""<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="test">
-    <compiler angle="radian"/>
+    <compiler angle="radian" eulerseq="{seq}"/>
     <worldbody>
-        <body name="test_body" euler="0.3 1.2 -0.7">
+        <body name="test_body" euler="{euler}">
             <geom type="box" size="0.1 0.1 0.1"/>
         </body>
     </worldbody>
 </mujoco>"""
+            try:
+                native_m = mujoco.MjModel.from_xml_string(mjcf)
+            except Exception:
+                # MuJoCo rejected this eulerseq; Newton must too.
+                with self.assertRaises(Exception, msg=f"Newton accepts eulerseq={seq!r} that MuJoCo rejects"):
+                    newton.ModelBuilder().add_mjcf(mjcf)
+                continue
 
-        builder = newton.ModelBuilder()
-        builder.add_mjcf(mjcf_content)
-        model = builder.finalize()
-        body_idx = model.body_label.index("test/worldbody/test_body")
-        newton_xyzw = np.array(model.body_q.numpy()[body_idx, 3:], dtype=np.float64)
+            builder = newton.ModelBuilder()
+            builder.add_mjcf(mjcf)
+            model = builder.finalize()
+            body_idx = model.body_label.index("test/worldbody/test_body")
+            newton_xyzw = np.array(model.body_q.numpy()[body_idx, 3:], dtype=np.float64)
 
-        native_wxyz = np.array(
-            SolverMuJoCo.import_mujoco()[0].MjModel.from_xml_string(mjcf_content).body_quat[1], dtype=np.float64
-        )
-        native_xyzw = np.array([native_wxyz[1], native_wxyz[2], native_wxyz[3], native_wxyz[0]], dtype=np.float64)
+            native_wxyz = np.array(native_m.body_quat[1], dtype=np.float64)
+            native_xyzw = np.array([native_wxyz[1], native_wxyz[2], native_wxyz[3], native_wxyz[0]], dtype=np.float64)
+            same = np.allclose(newton_xyzw, native_xyzw, rtol=1e-6, atol=1e-6)
+            negated = np.allclose(newton_xyzw, -native_xyzw, rtol=1e-6, atol=1e-6)
+            self.assertTrue(same or negated, f"eulerseq={seq!r}: newton={newton_xyzw} native={native_xyzw}")
+            compared += 1
 
-        same = np.allclose(newton_xyzw, native_xyzw, rtol=1e-6, atol=1e-6)
-        negated = np.allclose(newton_xyzw, -native_xyzw, rtol=1e-6, atol=1e-6)
-        self.assertTrue(
-            same or negated,
-            f"Body quaternion mismatch (accounting for q/-q equivalence): newton={newton_xyzw} native={native_xyzw}",
-        )
+        # Sanity: at least the default-style sequences must have run.
+        self.assertGreater(compared, 0, "no eulerseq combinations actually compared")
 
     def test_compiler_merge_across_includes(self):
         """``<compiler>`` attributes merge globally across ``<include>``-expanded

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -338,8 +338,10 @@ class TestImportMjcfBasic(unittest.TestCase):
             try:
                 native_m = mujoco.MjModel.from_xml_string(mjcf)
             except Exception:
-                # MuJoCo rejected this eulerseq; Newton must too.
-                with self.assertRaises(Exception, msg=f"Newton accepts eulerseq={seq!r} that MuJoCo rejects"):
+                # MuJoCo rejected this eulerseq; Newton must too. Either side
+                # may raise an MJCF-parsing-specific exception type we don't
+                # want to enumerate, so the assertion is intentionally broad.
+                with self.assertRaises(Exception, msg=f"Newton accepts eulerseq={seq!r} that MuJoCo rejects"):  # noqa: B017
                     newton.ModelBuilder().add_mjcf(mjcf)
                 continue
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -311,6 +311,122 @@ class TestImportMjcfBasic(unittest.TestCase):
         negated = np.allclose(newton_xyzw, -native_xyzw, rtol=1e-6, atol=1e-6)
         self.assertTrue(same or negated, "Site quaternion mismatch (accounting for q/-q equivalence)")
 
+    def test_body_euler_matches_mujoco(self):
+        """Body ``euler`` quaternion must match MuJoCo at default ``eulerseq=xyz``.
+
+        Uses three non-zero components so the intrinsic-vs-extrinsic
+        difference shows up above float32 noise.
+        """
+        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="test">
+    <compiler angle="radian"/>
+    <worldbody>
+        <body name="test_body" euler="0.3 1.2 -0.7">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>"""
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content)
+        model = builder.finalize()
+        body_idx = model.body_label.index("test/worldbody/test_body")
+        newton_xyzw = np.array(model.body_q.numpy()[body_idx, 3:], dtype=np.float64)
+
+        native_wxyz = np.array(
+            SolverMuJoCo.import_mujoco()[0].MjModel.from_xml_string(mjcf_content).body_quat[1], dtype=np.float64
+        )
+        native_xyzw = np.array([native_wxyz[1], native_wxyz[2], native_wxyz[3], native_wxyz[0]], dtype=np.float64)
+
+        same = np.allclose(newton_xyzw, native_xyzw, rtol=1e-6, atol=1e-6)
+        negated = np.allclose(newton_xyzw, -native_xyzw, rtol=1e-6, atol=1e-6)
+        self.assertTrue(
+            same or negated,
+            f"Body quaternion mismatch (accounting for q/-q equivalence): newton={newton_xyzw} native={native_xyzw}",
+        )
+
+    def test_compiler_merge_across_includes(self):
+        """``<compiler>`` attributes merge globally across ``<include>``-expanded
+        files (document order, later wins, scope is not file-local).
+
+        Both layouts (inner-compiler-after-outer and outer-compiler-after-inner)
+        check that the latest compiler wins for ALL bodies regardless of which
+        file authored them.
+        """
+        import os  # noqa: PLC0415
+        import tempfile  # noqa: PLC0415
+
+        mujoco = SolverMuJoCo.import_mujoco()[0]
+
+        inner_xml = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="inner">
+    <compiler angle="radian"/>
+    <worldbody>
+        <body name="inner_body" euler="0 1.57 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+        layouts = {
+            "inner_compiler_wins": """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="outer">
+    <compiler angle="degree"/>
+    <worldbody>
+        <body name="outer_body" euler="0 1.57 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+    <include file="inner.xml"/>
+</mujoco>
+""",
+            "outer_compiler_wins": """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="outer">
+    <include file="inner.xml"/>
+    <worldbody>
+        <body name="outer_body" euler="0 1.57 0">
+            <geom type="box" size="0.1 0.1 0.1"/>
+        </body>
+    </worldbody>
+    <compiler angle="degree"/>
+</mujoco>
+""",
+        }
+
+        for layout_name, outer_xml in layouts.items():
+            with tempfile.TemporaryDirectory() as d:
+                with open(os.path.join(d, "outer.xml"), "w") as f:
+                    f.write(outer_xml)
+                with open(os.path.join(d, "inner.xml"), "w") as f:
+                    f.write(inner_xml)
+
+                # MuJoCo (the ground truth) — loads and merges across includes
+                native = mujoco.MjModel.from_xml_path(os.path.join(d, "outer.xml"))
+
+                # Newton — must produce the same body quats
+                builder = newton.ModelBuilder()
+                builder.add_mjcf(os.path.join(d, "outer.xml"))
+                model = builder.finalize()
+
+            for native_idx in range(1, native.nbody):  # skip worldbody
+                name = native.body(native_idx).name
+                native_wxyz = np.array(native.body_quat[native_idx], dtype=np.float64)
+                native_xyzw = np.array(
+                    [native_wxyz[1], native_wxyz[2], native_wxyz[3], native_wxyz[0]], dtype=np.float64
+                )
+                # Find the body in Newton's label-path scheme (`outer/worldbody/<name>`)
+                matches = [j for j in range(model.body_count) if model.body_label[j].endswith(name)]
+                self.assertEqual(len(matches), 1, f"Body {name!r} not uniquely found in Newton model")
+                newton_xyzw = np.array(model.body_q.numpy()[matches[0], 3:], dtype=np.float64)
+
+                same = np.allclose(newton_xyzw, native_xyzw, rtol=1e-6, atol=1e-6)
+                negated = np.allclose(newton_xyzw, -native_xyzw, rtol=1e-6, atol=1e-6)
+                self.assertTrue(
+                    same or negated,
+                    f"Compiler-merge layout={layout_name!r} body={name!r}: newton={newton_xyzw} native={native_xyzw}",
+                )
+
     def test_root_body_with_custom_xform(self):
         """Test 1: Root body with custom xform parameter (with rotation) → verify transform is properly applied."""
         # Add a 45-degree rotation around Z to the body

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -367,9 +367,6 @@ class TestImportMjcfBasic(unittest.TestCase):
         check that the latest compiler wins for ALL bodies regardless of which
         file authored them.
         """
-        import os  # noqa: PLC0415
-        import tempfile  # noqa: PLC0415
-
         mujoco = SolverMuJoCo.import_mujoco()[0]
 
         inner_xml = """<?xml version="1.0" encoding="utf-8"?>

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2178,12 +2178,17 @@ class TestMenagerie_Aloha(TestMenagerieMJCF):
     """ALOHA bimanual system."""
 
     robot_folder = "aloha"
-    # Dynamics and FK disabled: multiple MJCF import issues (#2492)
-    num_steps = 0
-    fk_enabled = False  # FK fails (xpos diff 0.14) due to import bugs (#2492)
-    # TODO(#2492): dof_damping, jnt_range, eq_, ngeom differ
-    # jnt_ is broad but needed: compare_jnt_range runs outside model_skip_fields
-    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"dof_damping", "eq_", "neq", "ngeom", "jnt_"}
+    num_steps = 20
+    fk_enabled = True
+    # Aloha's MJCF doesn't author `<option integrator=...>`, so sync native
+    # to Newton's auto-selected IMPLICITFAST (same pattern as FR3v2/Cassie).
+    # 15-trial native-vs-native qvel diff is bit-exact (0); newton-vs-native
+    # max 1.43e-6 (float32 noise). Tolerance set ~7x for headroom.
+    dynamics_tolerance = 1e-5
+    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"ngeom"}
+
+    def _align_models(self, newton_solver, native_mjw_model, mj_model):
+        native_mjw_model.opt.integrator = newton_solver.mjw_model.opt.integrator
 
 
 class TestMenagerie_GoogleRobot(TestMenagerieMJCF):

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -2185,7 +2185,6 @@ class TestMenagerie_Aloha(TestMenagerieMJCF):
     # 15-trial native-vs-native qvel diff is bit-exact (0); newton-vs-native
     # max 1.43e-6 (float32 noise). Tolerance set ~7x for headroom.
     dynamics_tolerance = 1e-5
-    model_skip_fields = DEFAULT_MODEL_SKIP_FIELDS | {"ngeom"}
 
     def _align_models(self, newton_solver, native_mjw_model, mj_model):
         native_mjw_model.opt.integrator = newton_solver.mjw_model.opt.integrator


### PR DESCRIPTION
## Description

Closes most of #2492.

Two interacting MJCF import bugs prevented Aloha (and any model that chains `<include>`s past a `<compiler>` element) from importing correctly:

1. **`quat_from_euler_mjcf` used extrinsic rotation** where MuJoCo's default `eulerseq=xyz` is intrinsic. The two agreed when at most one input angle was non-zero, so the bug stayed invisible until a body like Aloha's `gripper_base` used `euler="0 1.57 -1.57"`.
2. **`parse_mjcf` only read the first `<compiler>` element** via `root.find("compiler")`. After `<include>` expansion the root has one compiler per source file; MuJoCo merges them globally with later overriding earlier. Aloha loads via `scene.xml` (`<compiler/>`, defaults `angle="degree"`) and includes `aloha.xml` (`<compiler angle="radian"/>`). Newton's first-only read treated aloha's radian-authored eulers as degrees, dwarfing the convention bug.

Both fixes verified empirically against MuJoCo (regression tests included). The two layouts — inner-compiler-after-outer and outer-compiler-after-inner — are both checked: in each case, the latest-in-document-order compiler wins for ALL bodies, regardless of which file authored them. Newton now matches.

Also enables `TestMenagerie_Aloha` FK and dynamics: same `_align_models` integrator-pin pattern as FR3v2/Cassie (#2970); tolerance backed by a 15-trial native-vs-native characterization (0 variance under IMPLICITFAST, newton-vs-native max 1.43e-6).

The remaining `geom_group` flattening (Newton imports 2 extra type-7 geoms vs native and collapses all to `group=0`) is a separate concern left in #2492 as the only follow-up.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated

## Test plan

```
uv run --extra dev -m newton.tests -k test_import_mjcf
uv run --extra dev -m newton.tests -k TestMenagerie_Aloha
```

All `test_import_mjcf` cases pass (213 incl. 2 new regression tests for body `euler` and compiler-merge across includes). `TestMenagerie_Aloha` runs FK and dynamics under the integrator pin.

## Bug fix

**Steps to reproduce (without this PR):**

1. Temporarily flip `num_steps = 0 → 20` and `fk_enabled = False → True` on `TestMenagerie_Aloha`.
2. Run `uv run --extra dev -m newton.tests -k TestMenagerie_Aloha`.
3. Observe: FK fails on the four finger bodies (xpos diff ~5e-2 m). Their parent `gripper_base` body has `euler="0 1.57 -1.57"` in MJCF; Newton imports as near-identity quaternion because the included `<compiler angle="radian"/>` is lost and the eulers are then treated as degrees.

**Fix:** `quat_from_euler_mjcf` rewritten to compose intrinsic rotations; `parse_mjcf` merges all `<compiler>` elements (later overrides earlier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MJCF Euler-angle conversion to match MuJoCo intrinsic rotation semantics.
  * Fixed merging of MJCF compiler attributes across included files (document-order, later wins).
  * Ensured static worldbody geoms honor visual/collider filtering so visuals can be dropped as configured.

* **Tests**
  * Added regression tests validating Euler conversion and compiler-merge behavior against MuJoCo.
  * Enabled dynamics/forward-kinematics in compatibility tests and tightened comparison tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->