### PR TITLE
Optimize runtime of Kamino unit tests

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -525,7 +525,7 @@ def mul_mask_float(mask: wp.int32, value: wp.float32) -> wp.float32:
 
 @cache
 def create_eval_min_num_iterations_kernel(TILE_SIZE: int):
-    @wp.kernel
+    @wp.kernel(module="unique", enable_backward=False)
     def _eval_min_num_iterations(
         # Inputs
         world_actuated_coord_offsets: wp.array[wp.int32],
@@ -1271,6 +1271,10 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
     (returned in this order)
     """
 
+    # Create separate warp module for compiling kernels in this factory
+    module = wp.get_module(__name__ + "_tile_2d")
+    module.options.update({"enable_backward": False})
+
     @wp.func
     def clip_to_one(x: wp.float32):
         """
@@ -1278,7 +1282,7 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
         """
         return wp.min(x, 1.0)
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_pattern_T_pattern(
         # Inputs
         sparsity_pattern: wp.array3d[wp.float32],
@@ -1329,7 +1333,7 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
             tile_out_3d_clipped = wp.tile_map(clip_to_one, tile_out_3d)
             wp.tile_store(pattern_T_pattern, tile_out_3d_clipped, offset=(wd_id, i * TILE_SIZE_VRS, j * TILE_SIZE_VRS))
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_jacobian_T_jacobian(
         # Inputs
         constraints_jacobian: wp.array3d[wp.float32],
@@ -1382,7 +1386,7 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
             tile_out_3d = wp.tile_reshape(tile_out, (1, TILE_SIZE_VRS, TILE_SIZE_VRS))
             wp.tile_store(jacobian_T_jacobian, tile_out_3d, offset=(wd_id, i * TILE_SIZE_VRS, j * TILE_SIZE_VRS))
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_jacobian_T_constraints(
         # Inputs
         constraints_jacobian: wp.array3d[wp.float32],
@@ -1458,6 +1462,10 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
     (returned in this order)
     """
 
+    # Create separate warp module for compiling kernels in this factory
+    module = wp.get_module(__name__ + "_tile_1d")
+    module.options.update({"enable_backward": False})
+
     @wp.func
     def _isnan(x: wp.float32) -> wp.int32:
         """Calls wp.isnan and converts the result to int32"""
@@ -1465,7 +1473,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
 
     TILE_SIZE = TILE_SIZE_VRS if use_regularization else TILE_SIZE_CTS
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_max_residual(
         # Inputs
         residual: wp.array2d[wp.float32],
@@ -1503,7 +1511,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
                         if check_val == curr_val:
                             break
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_merit_function(
         # Inputs
         constraints: wp.array2d[wp.float32],
@@ -1528,7 +1536,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
             if tid == 0:
                 wp.atomic_add(merit_function_val, wd_id, segment_error)
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_regularizer(
         # Inputs
         first_body_id: wp.array[wp.int32],
@@ -1570,7 +1578,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
         if tid == 0:
             wp.atomic_add(merit_function_val, wd_id, 0.5 * reg_weight * reg)
 
-    @wp.kernel
+    @wp.kernel(module=module)
     def _eval_merit_function_gradient(
         # Inputs
         step: wp.array2d[wp.float32],

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -642,7 +642,7 @@ def make_desaxce_correction_and_velocity_bias_kernel(has_contacts: bool, collect
         collect_info: Whether to persist the De Saxce correction to solver_s.
     """
 
-    @wp.kernel
+    @wp.kernel(module="unique", enable_backward=False)
     def _compute_desaxce_correction_and_velocity_bias(
         # Inputs:
         problem_dim: wp.array[int32],
@@ -1181,7 +1181,7 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
     num_tiles_cts = (n_cts_max + tile_size - 1) // tile_size
     num_tiles_u = (n_u_max + tile_size - 1) // tile_size
 
-    @wp.kernel
+    @wp.kernel(module="unique", enable_backward=False)
     def _compute_infnorm_residuals(
         # Inputs:
         problem_nl: wp.array[int32],
@@ -1325,7 +1325,7 @@ def _make_compute_infnorm_residuals_accel_kernel(tile_size: int, n_cts_max: int,
     num_tiles_cts = (n_cts_max + tile_size - 1) // tile_size
     num_tiles_u = (n_u_max + tile_size - 1) // tile_size
 
-    @wp.kernel
+    @wp.kernel(module="unique", enable_backward=False)
     def _compute_infnorm_residuals_accel(
         # Inputs:
         problem_nl: wp.array[int32],

--- a/newton/_src/solvers/kamino/tests/test_geometry_aggregation.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_aggregation.py
@@ -24,8 +24,7 @@ class TestContactAggregation(unittest.TestCase):
         if not test_context.setup_done:
             setup_tests(clear_cache=False)
         self.default_device = wp.get_device(test_context.device)
-        # self.verbose = test_context.verbose  # Set to True for detailed output
-        self.verbose = True  # Set to True for detailed output
+        self.verbose = test_context.verbose  # Set to True for detailed output
 
         # Set debug-level logging to print verbose test output to console
         if self.verbose:

--- a/newton/_src/solvers/kamino/tests/test_geometry_unified.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_unified.py
@@ -112,7 +112,7 @@ def test_unified_pipeline(
     model: ModelKamino = builder.finalize(device)
     data: DataKamino = model.data()
     state: StateKamino = model.state()
-    contacts = ContactsKamino(model=model, device=device)
+    contacts = ContactsKamino(capacity=[400 for i in range(builder.num_worlds)], device=device)
 
     # Run the narrow-phase test over each broad-phase backend
     if broadphase_modes is None:

--- a/newton/_src/solvers/kamino/tests/test_geometry_unified.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_unified.py
@@ -107,16 +107,18 @@ def test_unified_pipeline(
     Runs the unified collision detection pipeline using all broad-phase backends
     on a system specified via a ModelBuilderKamino and checks the results.
     """
+
+    # Create a test model and data
+    model: ModelKamino = builder.finalize(device)
+    data: DataKamino = model.data()
+    state: StateKamino = model.state()
+    contacts = ContactsKamino(model=model, device=device)
+
     # Run the narrow-phase test over each broad-phase backend
     if broadphase_modes is None:
         broadphase_modes = ["nxn", "sap", "explicit"]
     for bp_mode in broadphase_modes:
         msg.info("Testing unified CD on '%s' using '%s'", case, bp_mode)
-
-        # Create a test model and data
-        model: ModelKamino = builder.finalize(device)
-        data: DataKamino = model.data()
-        state: StateKamino = model.state()
 
         # Create a pipeline
         pipeline = CollisionPipelineUnifiedKamino(
@@ -124,12 +126,6 @@ def test_unified_pipeline(
             broadphase=bp_mode,
             default_gap=margin,
         )
-
-        # Create a contacts container using the worst-case capacity of NxN over model-wise geom pairs
-        # NOTE: This is required by the unified pipeline when using SAP and NXN broad-phases
-        capacity = 2 * max_contacts_per_pair * ((builder.num_geoms * (builder.num_geoms - 1)) // 2)
-        contacts = ContactsKamino(capacity=capacity, device=device)
-        contacts.clear()
 
         # Execute the unified collision detection pipeline
         pipeline.collide(data, state, contacts)
@@ -262,7 +258,15 @@ class TestCollisionPipelineUnified(unittest.TestCase):
         shape pair when placed exactly at their contact boundaries.
         """
         msg.info("Testing unified pipeline tests with exact boundaries")
-        # Each shape pair in its own world with
+
+        # Global builder and expected contacts dictionary
+        builder = ModelBuilderKamino()
+        expected_contacts = {
+            "model_active_contacts": 0,
+            "world_active_contacts": [],
+        }
+
+        # Fill builder and expected contacts with one world per shape pair
         for shape_pair in self.supported_shape_pairs:
             # Define any special kwargs for specific shape pairs
             kwargs = {}
@@ -272,18 +276,27 @@ class TestCollisionPipelineUnified(unittest.TestCase):
                 # the bottom box to avoid contacts on edges
                 kwargs["bottom_dims"] = (2.0, 2.0, 1.0)
 
-            # Retrieve the nominal expected contacts for the shape pair
-            expected_contacts = nominal_expected_contacts_per_shape_pair.get(shape_pair, 0)
-
-            # Run the narrow-phase test on the shape pair
-            test_unified_pipeline_on_shape_pair(
-                self,
-                shape_pair=shape_pair,
-                expected_contacts=expected_contacts,
-                margin=1.0e-5,  # Default contact margin
+            # Create a builder for the specified shape pair
+            builder_shape = testing.make_single_shape_pair_builder(
+                shapes=shape_pair,
                 distance=0.0,  # Exactly touching
-                builder_kwargs=kwargs,
+                **kwargs,
             )
+            builder.add_builder(builder_shape)
+
+            # Retrieve the nominal expected contacts for the shape pair
+            expected_contacts_shape = nominal_expected_contacts_per_shape_pair.get(shape_pair, 0)
+            expected_contacts["model_active_contacts"] += expected_contacts_shape
+            expected_contacts["world_active_contacts"].append(expected_contacts_shape)
+
+        # Run the narrow-phase test
+        test_unified_pipeline(
+            builder=builder,
+            expected=expected_contacts,
+            margin=1.0e-5,  # Default contact margin
+            case="all_primitive_shape_pairs_touching",
+            device=self.default_device,
+        )
 
     def test_02_on_each_primitive_shape_pair_apart(self):
         """
@@ -291,15 +304,31 @@ class TestCollisionPipelineUnified(unittest.TestCase):
         supported primitive shape pair when placed apart.
         """
         msg.info("Testing unified pipeline tests with shapes apart")
-        # Each shape pair in its own world with
+
+        # Global builder and expected contacts dictionary
+        builder = ModelBuilderKamino()
+        expected_contacts = {
+            "model_active_contacts": 0,
+            "world_active_contacts": [0 for _ in range(len(self.supported_shape_pairs))],
+        }
+
+        # Fill builder with one world per shape pair
         for shape_pair in self.supported_shape_pairs:
-            test_unified_pipeline_on_shape_pair(
-                self,
-                shape_pair=shape_pair,
-                expected_contacts=0,
-                margin=0.0,  # No contact margin
+            # Create a builder for the specified shape pair
+            builder_shape = testing.make_single_shape_pair_builder(
+                shapes=shape_pair,
                 distance=1e-6,  # Shapes apart with epsilon distance
             )
+            builder.add_builder(builder_shape)
+
+        # Run the narrow-phase test
+        test_unified_pipeline(
+            builder=builder,
+            expected=expected_contacts,
+            margin=0.0,  # No contact margin
+            case="all_primitive_shape_pairs_apart",
+            device=self.default_device,
+        )
 
     def test_03_on_each_primitive_shape_pair_apart_with_margin(self):
         """
@@ -307,9 +336,15 @@ class TestCollisionPipelineUnified(unittest.TestCase):
         primitive shape pair when placed apart but with contact margin.
         """
         msg.info("Testing unified pipeline tests with shapes apart")
-        # Each shape pair in its own world with
-        # - zero distance: (i.e., exactly touching)
-        # - zero margin: no preemption of collisions
+
+        # Global builder and expected contacts dictionary
+        builder = ModelBuilderKamino()
+        expected_contacts = {
+            "model_active_contacts": 0,
+            "world_active_contacts": [],
+        }
+
+        # Fill builder and expected contacts with one world per shape pair
         for shape_pair in self.supported_shape_pairs:
             # Define any special kwargs for specific shape pairs
             kwargs = {}
@@ -319,18 +354,27 @@ class TestCollisionPipelineUnified(unittest.TestCase):
                 # the bottom box to avoid contacts on edges
                 kwargs["bottom_dims"] = (2.0, 2.0, 1.0)
 
-            # Retrieve the nominal expected contacts for the shape pair
-            expected_contacts = nominal_expected_contacts_per_shape_pair.get(shape_pair, 0)
-
-            # Run the narrow-phase test on the shape pair
-            test_unified_pipeline_on_shape_pair(
-                self,
-                shape_pair=shape_pair,
-                expected_contacts=expected_contacts,
-                margin=1e-5,  # Contact margin
-                distance=1e-6,  # Shapes apart
-                builder_kwargs=kwargs,
+            # Create a builder for the specified shape pair
+            builder_shape = testing.make_single_shape_pair_builder(
+                shapes=shape_pair,
+                distance=0.0,  # Shapes apart
+                **kwargs,
             )
+            builder.add_builder(builder_shape)
+
+            # Retrieve the nominal expected contacts for the shape pair
+            expected_contacts_shape = nominal_expected_contacts_per_shape_pair.get(shape_pair, 0)
+            expected_contacts["model_active_contacts"] += expected_contacts_shape
+            expected_contacts["world_active_contacts"].append(expected_contacts_shape)
+
+        # Run the narrow-phase test
+        test_unified_pipeline(
+            builder=builder,
+            expected=expected_contacts,
+            margin=1.0e-5,  # Contact margin
+            case="all_primitive_shape_pairs_apart_with_margin",
+            device=self.default_device,
+        )
 
     ###
     # Tests for special cases of shape combinations/configurations

--- a/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_sequential.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_sequential.py
@@ -52,8 +52,8 @@ class TestLinAlgLLTSequential(unittest.TestCase):
         Test the sequential LLT solver on a single small problem.
         """
         # Constants
-        # N = 12  # Use this for visual debugging with small matrices
-        N = 2000  # Use this for performance testing with large matrices
+        N = 12  # Use this for unit testing with small matrices
+        # N = 2000  # Use this for performance testing with large matrices
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -202,10 +202,10 @@ class TestLinAlgLLTSequential(unittest.TestCase):
         Test the sequential LLT solver on a single small problem.
         """
         # Constants
-        # N_max = 16  # Use this for visual debugging with small matrices
-        # N_act = 11
-        N_max = 2000  # Use this for performance testing with large matrices
-        N_act = 1537
+        N_max = 16  # Use this for unit testing with small matrices
+        N_act = 11
+        # N_max = 2000  # Use this for performance testing with large matrices
+        # N_act = 1537
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -356,8 +356,8 @@ class TestLinAlgLLTSequential(unittest.TestCase):
         Test the sequential LLT solver on multiple small problems.
         """
         # Constants
-        N = [7, 8, 9, 10, 11]
-        # N = [16, 64, 128, 512, 1024]
+        N = [7, 8, 9, 10, 11]  # Use this for unit testing with small matrices
+        # N = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -518,10 +518,10 @@ class TestLinAlgLLTSequential(unittest.TestCase):
         Test the sequential LLT solver on multiple small problems.
         """
         # Constants
-        # N_max = [7, 8, 9, 14, 21]  # Use this for visual debugging with small matrices
-        # N_act = [5, 6, 4, 11, 17]
-        N_max = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
-        N_act = [11, 51, 101, 376, 999]
+        N_max = [7, 8, 9, 14, 21]  # Use this for unit testing with small matrices
+        N_act = [5, 6, 4, 11, 17]
+        # N_max = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
+        # N_act = [11, 51, 101, 376, 999]
 
         # Create a single-instance problem
         problem = RandomProblemLLT(

--- a/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_sequential.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_sequential.py
@@ -57,8 +57,8 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
         Test the sequential LLT solver on a single small problem.
         """
         # Constants
-        # N = 12  # Use this for visual debugging with small matrices
-        N = 2000  # Use this for performance testing with large matrices
+        N = 12  # Use this for unit testing with small matrices
+        # N = 2000  # Use this for performance testing with large matrices
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -192,10 +192,10 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
         Test the sequential LLT solver on a single small problem.
         """
         # Constants
-        # N_max = 16  # Use this for visual debugging with small matrices
-        # N_act = 11
-        N_max = 2000  # Use this for performance testing with large matrices
-        N_act = 1537
+        N_max = 16  # Use this for unit testing with small matrices
+        N_act = 11
+        # N_max = 2000  # Use this for performance testing with large matrices
+        # N_act = 1537
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -331,8 +331,8 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
         Test the sequential LLT solver on multiple small problems.
         """
         # Constants
-        N = [7, 8, 9, 10, 11]
-        # N = [16, 64, 128, 512, 1024]
+        N = [7, 8, 9, 10, 11]  # Use this for unit testing with small matrices
+        # N = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
 
         # Create a single-instance problem
         problem = RandomProblemLLT(
@@ -477,10 +477,10 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
         Test the sequential LLT solver on multiple small problems.
         """
         # Constants
-        # N_max = [7, 8, 9, 14, 21]  # Use this for visual debugging with small matrices
-        # N_act = [5, 6, 4, 11, 17]
-        N_max = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
-        N_act = [11, 51, 101, 376, 999]
+        N_max = [7, 8, 9, 14, 21]  # Use this for unit testing with small matrices
+        N_act = [5, 6, 4, 11, 17]
+        # N_max = [16, 64, 128, 512, 1024]  # Use this for performance testing with large matrices
+        # N_act = [11, 51, 101, 376, 999]
 
         # Create a single-instance problem
         problem = RandomProblemLLT(


### PR DESCRIPTION
## Description

This optimizes the runtime of Kamino internal unit tests and compilation, focusing on the main offenders (more in-depth optimizations following the same principles are very likely possible)

- Sequential LLT unit tests were switched to use smaller matrix sizes (was already in the code, just changed the commented version). Performance testing on larger matrices is still possible manually by chancing what is commented out (but as this solver is not used anywhere and not expected to perform well, the small sizes should be sufficient for unit testing)
- Kernel factories in PADMM and FK were moved to separate warp modules (while staying in the same Python file), so that changes to the factory parameters do not trigger recompilation of all other kernels in the same file.
- The 3 unified collision pipeline unit tests looping through all pairs of shapes were rearranged so that they use a single model with multiple worlds, rather than re-creating a new model and pipeline each time. The test time for this module goes from close to 2 minutes to 7 seconds.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

After the changes, running all unit tests takes now 80s on my machine (without re-compilations).
Clearing the cache + running the unit tests takes 349s.
I didn't write down the time from before the changes, but it was around 5 minutes without re-compilations, and a lot more with re-compilations (some of the multiple recompilations of PADMM kernels were taking about 2 minutes each).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated collision-pipeline tests to build/run combined cases, simplified contact setup, and removed redundant per-case allocations.
  * Reduced linear-algebra test problem sizes to unit-test scales.
  * Made test verbosity configurable.

* **Refactor**
  * Scoped kernel compilation into dedicated modules and disabled backward compilation for internal compute kernels to streamline build/runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->