### PR TITLE
Cap newton-actuators to <0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ sim = [
     # MuJoCo simulation
     "mujoco-warp>=3.8.0.3,~=3.8.0",  # MuJoCo, warp-accelerated (3.8.0 was broken)
     "mujoco~=3.8.0",        # MuJoCo physics engine
-    "newton-actuators>=0.1.0",  # deprecated — kept for backward compat, will be removed
+    "newton-actuators>=0.1.0,<0.1.1",  # deprecated — kept for backward compat, will be removed; <0.1.1 avoids 0.1.1's import-time DeprecationWarning
 ]
 
 # Optional: ONNX policy inference (used by ControllerNeuralMLP / ControllerNeuralLSTM

--- a/uv.lock
+++ b/uv.lock
@@ -3703,7 +3703,7 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'rtx'" },
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
-    { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0" },
+    { name = "newton-actuators", marker = "extra == 'sim'", specifier = ">=0.1.0,<0.1.1" },
     { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.3.1" },
     { name = "onnx", marker = "extra == 'onnx'", specifier = ">=1.16.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },


### PR DESCRIPTION
`newton-actuators` 0.1.1 emits a `DeprecationWarning` at import time. The example test suite runs example subprocesses with `PYTHONWARNINGS=error::DeprecationWarning`, so that warning becomes a fatal import error and every non-opted-out example test fails on a fresh install.

CI doesn't catch this because it resolves from the lockfile, which pins 0.1.0; only fresh resolutions pick up 0.1.1. This caps the dependency (deprecated, kept only for backward compatibility) below 0.1.1 so fresh installs match the already-locked behavior — the lock already resolves to 0.1.0, so this only tightens the published constraint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version constraint to ensure improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->