### PR TITLE
Cap warp-lang to <1.14 on release-1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.13.0",
+    "warp-lang>=1.13.0,<1.14",  # <1.14 stays on the 1.13 logging API; 1.14 deprecates warp.config.verbose, which this release still reads
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3542,7 +3542,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.13.0" },
+    { name = "warp-lang", specifier = ">=1.13.0,<1.14" },
 ]
 provides-extras = ["sim", "importers", "remesh", "examples", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 


### PR DESCRIPTION
This release reads `warp.config.verbose` (e.g. as a default argument in `ModelBuilder.collapse_fixed_joints`), which warp 1.14 deprecates and turns into an import-time `DeprecationWarning`. The example test suite runs example subprocesses with `PYTHONWARNINGS=error::DeprecationWarning`, so on a fresh install that resolves `warp-lang>=1.13.0` up to 1.14 the warning becomes a fatal import error and the example tests fail.

The `release-1.2` code targets the warp 1.13 logging API. The migration to `warp.config.log_level` (#2900) only exists on `main` and isn't appropriate to backport onto a stable release. Capping below 1.14 keeps this release on the warp line it was written for. The lockfile already resolves to 1.13.0, so this only tightens the published constraint.
