### PR TITLE
Bump warp-lang to 1.14.0

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -16,7 +16,7 @@
   "build_command": ["python -m build --wheel -o {build_cache_dir} {build_dir}"],
   "install_command": [
     "python -m pip install -U numpy",
-    "python -m pip install -U --pre warp-lang==1.14.0rc2 --index-url=https://pypi.nvidia.com/",
+    "python -m pip install -U warp-lang==1.14.0",
     "python -m pip install -U mujoco==3.8.1",
     "python -m pip install -U mujoco-warp==3.8.1",
     "python -m pip install -U torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ description = "A GPU-accelerated physics engine for robotics simulation"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "warp-lang>=1.14.0rc2",
+    "warp-lang>=1.14.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3734,7 +3734,7 @@ requires-dist = [
     { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'importers'", specifier = ">=2.2.0" },
     { name = "viser", marker = "extra == 'docs'", specifier = "==1.0.26" },
     { name = "viser", marker = "extra == 'notebook'", specifier = "==1.0.26" },
-    { name = "warp-lang", specifier = ">=1.14.0rc2", index = "https://pypi.nvidia.com/" },
+    { name = "warp-lang", specifier = ">=1.14.0", index = "https://pypi.nvidia.com/" },
 ]
 provides-extras = ["sim", "onnx", "importers", "remesh", "examples", "rtx", "torch-cu12", "torch-cu13", "dev", "docs", "notebook"]
 
@@ -6812,17 +6812,17 @@ wheels = [
 
 [[package]]
 name = "warp-lang"
-version = "1.14.0rc2"
+version = "1.14.0"
 source = { registry = "https://pypi.nvidia.com/" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-6-newton-torch-cu12' and extra == 'extra-6-newton-torch-cu13')" },
 ]
 wheels = [
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0rc2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6bca65a5d5713e01394378a78ba9e06b0e844ab993e6c5de26b894114bee447" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0rc2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ec84beb7fdd73429b5ddfc6d584579ecd8bc302cc0b53e2a78562aee88a4659a" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0rc2-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:006898be1ea18eb4fa5a9faa306e811baa71dad57d2abe41d3c61bb3475cca01" },
-    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0rc2-py3-none-win_amd64.whl", hash = "sha256:8a6f9e4501e1133c34b7acd80eb51446a3112173a49c5e8a51b96a2c218c92cb" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:12656050545cc77bf9b9b155399496c1a6279b5b6c59e407507d6858a2beb4a2" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:70cd127d0e9109417099649fedf9d00f39f1307ccb7a6e9fb87661337868d7de" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:f482787e8da9c9ef045601fde99095e16d604fbcc3cbb4a1e0cef0769388b316" },
+    { url = "https://pypi.nvidia.com/warp-lang/warp_lang-1.14.0-py3-none-win_amd64.whl", hash = "sha256:936b49ec78237f9760e58cbe9c46ee6f4244aefbd62071c4fa9fd3b313dfa878" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Move the `warp-lang` dependency from the `1.14.0rc2` release candidate to the stable `1.14.0` release. This updates `pyproject.toml`, the asv benchmark install command in `asv.conf.json`, and the resolved version in `uv.lock`.

The `[tool.uv.sources]` nvidia package index entry for `warp-lang` is intentionally kept, since it will be needed again for upcoming dev nightly bumps.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

The `CHANGELOG.md` already records "Require Warp 1.14" from a prior PR; moving from the release candidate to the stable build adds no new user-facing behavior.

## Test plan

```
uvx pre-commit run -a
uv lock
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated warp-lang dependency from pre-release to stable version in package configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/newton-physics/newton/pull/3046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->