### PR TITLE
Migrate tests off deprecated joint-target and collider aliases

### DIFF
--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -1816,9 +1816,9 @@ def _cable_revolute_drive_tracks_target_impl(test: unittest.TestCase, device):
     contacts = model.contacts()
 
     # Set drive target position.
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[dof_idx] = target_angle
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 
@@ -1943,9 +1943,9 @@ def _cable_revolute_drive_limit_impl(test: unittest.TestCase, device):
     control = model.control()
     contacts = model.contacts()
 
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[dof_idx] = target_angle
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 
@@ -2216,9 +2216,9 @@ def _cable_prismatic_drive_tracks_target_impl(test: unittest.TestCase, device):
     contacts = model.contacts()
 
     # Set drive target position.
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[dof_idx] = target_displacement
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 
@@ -2343,9 +2343,9 @@ def _cable_prismatic_drive_limit_impl(test: unittest.TestCase, device):
     control = model.control()
     contacts = model.contacts()
 
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[dof_idx] = target_displacement
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 
@@ -2929,10 +2929,10 @@ def _cable_d6_drive_tracks_target_impl(test: unittest.TestCase, device):
     contacts = model.contacts()
 
     # Set drive target positions.
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[lin_dof_idx] = target_displacement
     tp[ang_dof_idx] = target_angle
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 
@@ -3084,10 +3084,10 @@ def _cable_d6_drive_limit_impl(test: unittest.TestCase, device):
     control = model.control()
     contacts = model.contacts()
 
-    tp = control.joint_target_pos.numpy()
+    tp = control.joint_target_q.numpy()
     tp[qd_s] = target_displacement
     tp[qd_s + 1] = target_angle
-    control.joint_target_pos = wp.array(tp, dtype=float, device=device)
+    control.joint_target_q = wp.array(tp, dtype=float, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=10)
 

--- a/newton/tests/test_implicit_mpm.py
+++ b/newton/tests/test_implicit_mpm.py
@@ -179,9 +179,10 @@ def test_finite_difference_collider_velocity(test, device):
         end_mean_x = np.mean(state_0.particle_q.numpy()[:, 0])
         return end_mean_x - init_mean_x
 
-    # Run with both modes
-    displacement_instantaneous = run_simulation("instantaneous")
-    displacement_finite_diff = run_simulation("finite_difference")
+    # Run with both modes ('instantaneous'/'finite_difference' are deprecated
+    # aliases for 'forward'/'backward').
+    displacement_instantaneous = run_simulation("forward")
+    displacement_finite_diff = run_simulation("backward")
 
     # With instantaneous mode and body_qd=0, particles should barely move
     # (they see zero collider velocity, so no friction drag)

--- a/newton/tests/test_joint_controllers.py
+++ b/newton/tests/test_joint_controllers.py
@@ -62,8 +62,8 @@ def test_revolute_controller(
     newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
 
     control = model.control()
-    control.joint_target_pos = wp.array([pos_target_val], dtype=wp.float32, device=device)
-    control.joint_target_vel = wp.array([vel_target_val], dtype=wp.float32, device=device)
+    control.joint_target_q = wp.array([pos_target_val], dtype=wp.float32, device=device)
+    control.joint_target_qd = wp.array([vel_target_val], dtype=wp.float32, device=device)
 
     sim_dt = 1.0 / 60.0
     sim_time = 0.0
@@ -373,8 +373,8 @@ def test_effort_limit_clamping(
     state_0.joint_qd.assign([initial_qd])
 
     control = model.control()
-    control.joint_target_pos = wp.array([0.0], dtype=wp.float32, device=device)
-    control.joint_target_vel = wp.array([0.0], dtype=wp.float32, device=device)
+    control.joint_target_q = wp.array([0.0], dtype=wp.float32, device=device)
+    control.joint_target_qd = wp.array([0.0], dtype=wp.float32, device=device)
 
     dt = 0.01
 
@@ -466,8 +466,8 @@ def test_qfrc_actuator(
     state_0.joint_qd.assign([initial_qd])
 
     control = model.control()
-    control.joint_target_pos = wp.array([0.0], dtype=wp.float32, device=device)
-    control.joint_target_vel = wp.array([0.0], dtype=wp.float32, device=device)
+    control.joint_target_q = wp.array([0.0], dtype=wp.float32, device=device)
+    control.joint_target_qd = wp.array([0.0], dtype=wp.float32, device=device)
 
     dt = 0.01
 

--- a/newton/tests/test_joint_drive.py
+++ b/newton/tests/test_joint_drive.py
@@ -186,8 +186,8 @@ class TestJointDrive(unittest.TestCase):
         model.joint_target_kd.assign(joint_drive_dampings)
         state_in.joint_q.assign(joint_start_positions)
         state_in.joint_qd.assign(joint_start_velocities)
-        control.joint_target_pos.assign(joint_pos_targets)
-        control.joint_target_vel.assign(joint_vel_targets)
+        control.joint_target_q.assign(joint_pos_targets)
+        control.joint_target_qd.assign(joint_vel_targets)
         newton.eval_fk(model, state_in.joint_q, state_in.joint_qd, state_in)
 
         # Recompute the expected velocity outcomes
@@ -225,7 +225,7 @@ class TestJointDrive(unittest.TestCase):
 
         model.joint_target_ke.assign(joint_drive_stiffnesses)
         model.joint_target_kd.assign(joint_drive_dampings)
-        control.joint_target_vel.assign(joint_vel_targets)
+        control.joint_target_qd.assign(joint_vel_targets)
         state_in.joint_q.assign(joint_start_positions)
         state_in.joint_qd.assign(joint_start_velocities)
         newton.eval_fk(model, state_in.joint_q, state_in.joint_qd, state_in)

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -289,8 +289,8 @@ class StepResponseControlStrategy(ControlStrategy):
             and getattr(newton_solver, "mjc_actuator_ctrl_source", None) is not None
             and getattr(newton_solver, "mjc_actuator_to_newton_idx", None) is not None
         ):
-            self._joint_target_pos = newton_control.joint_target_pos
-            self._joint_target_vel = newton_control.joint_target_vel
+            self._joint_target_pos = newton_control.joint_target_q
+            self._joint_target_vel = newton_control.joint_target_qd
             self._mjc_actuator_ctrl_source = newton_solver.mjc_actuator_ctrl_source
             self._mjc_actuator_to_newton_idx = newton_solver.mjc_actuator_to_newton_idx
             self._dofs_per_world = self._joint_target_pos.shape[0] // num_worlds

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1540,8 +1540,8 @@ class TestMenagerieUSD(TestMenagerieBase):
             # joint_target_pos (initial DOF targets from the USD posture) would apply
             # nonzero forces every world for actuators we didn't drive — surfaced on
             # WonikAllegro where tha0's initial target 0.8295 stayed in every world.
-            joint_target_pos = np.zeros_like(newton_control.joint_target_pos.numpy())
-            joint_target_vel = np.zeros_like(newton_control.joint_target_vel.numpy())
+            joint_target_pos = np.zeros_like(newton_control.joint_target_q.numpy())
+            joint_target_vel = np.zeros_like(newton_control.joint_target_qd.numpy())
             dofs_per_world = joint_target_pos.shape[0] // num_worlds
 
             native_ctrl_np = np.zeros((num_worlds, num_actuators), dtype=np.float32)
@@ -1566,8 +1566,8 @@ class TestMenagerieUSD(TestMenagerieBase):
                         joint_target_vel[w * dofs_per_world + (-(idx + 2))] = target
             native_mjw_data.ctrl.assign(native_ctrl_np)
             newton_control.mujoco.ctrl.assign(newton_ctrl_np)
-            newton_control.joint_target_pos.assign(joint_target_pos)
-            newton_control.joint_target_vel.assign(joint_target_vel)
+            newton_control.joint_target_q.assign(joint_target_pos)
+            newton_control.joint_target_qd.assign(joint_target_vel)
 
             # qpos / qvel permutation arrays (native_idx -> newton_idx).
             nq = int(native_mjw_data.qpos.shape[1])

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -9034,7 +9034,7 @@ class TestMuJoCoSolverDuplicateBodyNames(unittest.TestCase):
 
         # Set the drive targets.
         joint_target_pos = [0.2, 0.2, 0.2]
-        control.joint_target_pos.assign(joint_target_pos)
+        control.joint_target_q.assign(joint_target_pos)
         expected_joint_q = [0.2, 0.2, 0.2]
 
         # Run the sim and test the joint speed outcome against the expected outcome.

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -534,7 +534,7 @@ class TestSelection(unittest.TestCase):
         # Get the attributes associated with "joint3"
         joint_dof_positions = joint_view.get_dof_positions(model).numpy().copy()
         joint_limit_lower = joint_view.get_attribute("joint_limit_lower", model).numpy().copy()
-        joint_target_pos = joint_view.get_attribute("joint_target_pos", model).numpy().copy()
+        joint_target_pos = joint_view.get_attribute("joint_target_q", model).numpy().copy()
 
         # Modify the attributes associated with "joint3"
         val = 1.0
@@ -810,15 +810,15 @@ class TestSelection(unittest.TestCase):
         joint_view.set_dof_positions(state_0, wp_joint_dof_positions, mask)
         joint_view.set_dof_positions(model, wp_joint_dof_positions, mask)
         joint_view.set_attribute("joint_limit_lower", model, wp_joint_limit_lowers, mask)
-        joint_view.set_attribute("joint_target_pos", control, wp_joint_target_pos, mask)
-        joint_view.set_attribute("joint_target_pos", model, wp_joint_target_pos, mask)
+        joint_view.set_attribute("joint_target_q", control, wp_joint_target_pos, mask)
+        joint_view.set_attribute("joint_target_q", model, wp_joint_target_pos, mask)
 
         # Get the updated values from model, state, control.
         measured_state_joint_dof_positions = state_0.joint_q.numpy()
         measured_model_joint_dof_positions = model.joint_q.numpy()
         measured_model_joint_limit_lower = model.joint_limit_lower.numpy()
-        measured_control_joint_target_pos = control.joint_target_pos.numpy()
-        measured_model_joint_target_pos = model.joint_target_pos.numpy()
+        measured_control_joint_target_pos = control.joint_target_q.numpy()
+        measured_model_joint_target_pos = model.joint_target_q.numpy()
 
         # Test that the modified values were correctly set in model, state and control
         for i in range(0, num_joints):


### PR DESCRIPTION
## Description

Migrate in-process tests off deprecated joint-target and collider aliases to their current names:

- `Control`/`Model.joint_target_pos` → `joint_target_q`
- `Control`/`Model.joint_target_vel` → `joint_target_qd`
- `collider_velocity_mode` `'instantaneous'`/`'finite_difference'` → `'forward'`/`'backward'`

These are exact aliases under the default configuration, so the changes preserve behavior and only drop the `DeprecationWarning` each access currently emits. Tests that intentionally exercise the deprecated aliases (`test_model.py`) or already wrap the access in `catch_warnings` are left unchanged.

Split out of #3044 so it can merge first: that PR enables `--deprecations-as-errors` in CI, which turns these warnings into hard failures. Landing this migration on a clean `main` first lets the strict-CI flip go green.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_joint_drive -k test_joint_controllers -k test_selection
```

Test-only change; the renamed paths are exercised by the existing suites in the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated joint drive, controller, and selection tests to use revised target control field references across multiple test scenarios.
  * Modernized test infrastructure for joint velocity control, drive limits, and actuator routing implementations.
  * Ensured consistent test suite support for updated control field naming conventions in joint configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->