### PR TITLE
Capture expected warnings in inertia validation tests

### DIFF
--- a/newton/tests/test_inertia_validation.py
+++ b/newton/tests/test_inertia_validation.py
@@ -65,7 +65,7 @@ class TestInertiaValidation(unittest.TestCase):
         bound_inertia = 1.0
         inertia = wp.mat33([[0.1, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 0.5]])
 
-        with self.assertWarns(UserWarning):
+        with self.assertWarnsRegex(UserWarning, r"Minimum eigenvalue .* is below bound"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(
                 mass, inertia, bound_inertia=bound_inertia
             )

--- a/newton/tests/test_inertia_validation.py
+++ b/newton/tests/test_inertia_validation.py
@@ -21,15 +21,13 @@ class TestInertiaValidation(unittest.TestCase):
         mass = -10.0
         inertia = wp.mat33([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "Negative mass"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, 0.0)
-            # Zero mass should have zero inertia
-            self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
-            self.assertTrue(len(w) > 0)
-            self.assertIn("Negative mass", str(w[0].message))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, 0.0)
+        # Zero mass should have zero inertia
+        self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
 
     def test_mass_bound(self):
         """Test that mass below bound is clamped."""
@@ -37,33 +35,29 @@ class TestInertiaValidation(unittest.TestCase):
         bound_mass = 1.0
         inertia = wp.mat33([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "below bound"):
             corrected_mass, _corrected_inertia, was_corrected = verify_and_correct_inertia(
                 mass, inertia, bound_mass=bound_mass
             )
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, bound_mass)
-            self.assertTrue(len(w) > 0)
-            self.assertIn("below bound", str(w[0].message))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, bound_mass)
 
     def test_negative_inertia_diagonal(self):
         """Test that negative inertia diagonal elements are corrected."""
         mass = 1.0
         inertia = wp.mat33([[-1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, -3.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "Eigenvalues below threshold detected"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, mass)
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, mass)
 
-            inertia_array = np.array(corrected_inertia).reshape(3, 3)
-            self.assertTrue(inertia_array[0, 0] >= 0)
-            self.assertTrue(inertia_array[1, 1] >= 0)
-            self.assertTrue(inertia_array[2, 2] >= 0)
-            self.assertTrue(len(w) > 0)
-            self.assertIn("Eigenvalues below threshold detected", str(w[0].message))
+        inertia_array = np.array(corrected_inertia).reshape(3, 3)
+        self.assertTrue(inertia_array[0, 0] >= 0)
+        self.assertTrue(inertia_array[1, 1] >= 0)
+        self.assertTrue(inertia_array[2, 2] >= 0)
 
     def test_inertia_bound(self):
         """Test that inertia diagonal elements below bound are clamped."""
@@ -71,19 +65,18 @@ class TestInertiaValidation(unittest.TestCase):
         bound_inertia = 1.0
         inertia = wp.mat33([[0.1, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 0.5]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarns(UserWarning):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(
                 mass, inertia, bound_inertia=bound_inertia
             )
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, mass)
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, mass)
 
-            inertia_array = np.array(corrected_inertia).reshape(3, 3)
-            self.assertGreaterEqual(inertia_array[0, 0], bound_inertia)
-            self.assertGreaterEqual(inertia_array[1, 1], bound_inertia)
-            self.assertGreaterEqual(inertia_array[2, 2], bound_inertia)
-            self.assertTrue(len(w) > 0)
+        inertia_array = np.array(corrected_inertia).reshape(3, 3)
+        self.assertGreaterEqual(inertia_array[0, 0], bound_inertia)
+        self.assertGreaterEqual(inertia_array[1, 1], bound_inertia)
+        self.assertGreaterEqual(inertia_array[2, 2], bound_inertia)
 
     def test_triangle_inequality_violation(self):
         """Test correction of inertia that violates triangle inequality."""
@@ -91,24 +84,21 @@ class TestInertiaValidation(unittest.TestCase):
         # Violates Ixx + Iyy >= Izz (0.1 + 0.1 < 10.0)
         inertia = wp.mat33([[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 10.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "triangle inequality"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(
                 mass, inertia, balance_inertia=True
             )
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, mass)
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, mass)
 
-            # Check that triangle inequalities are satisfied
-            inertia_array = np.array(corrected_inertia).reshape(3, 3)
-            Ixx, Iyy, Izz = inertia_array[0, 0], inertia_array[1, 1], inertia_array[2, 2]
+        # Check that triangle inequalities are satisfied
+        inertia_array = np.array(corrected_inertia).reshape(3, 3)
+        Ixx, Iyy, Izz = inertia_array[0, 0], inertia_array[1, 1], inertia_array[2, 2]
 
-            self.assertGreaterEqual(Ixx + Iyy, Izz - 1e-10)
-            self.assertGreaterEqual(Iyy + Izz, Ixx - 1e-10)
-            self.assertGreaterEqual(Izz + Ixx, Iyy - 1e-10)
-
-            self.assertTrue(len(w) > 0)
-            self.assertIn("triangle inequality", str(w[0].message))
+        self.assertGreaterEqual(Ixx + Iyy, Izz - 1e-10)
+        self.assertGreaterEqual(Iyy + Izz, Ixx - 1e-10)
+        self.assertGreaterEqual(Izz + Ixx, Iyy - 1e-10)
 
     def test_no_balance_inertia(self):
         """Test that triangle inequality violation is reported but not corrected when balance_inertia=False."""
@@ -116,22 +106,19 @@ class TestInertiaValidation(unittest.TestCase):
         # Violates Ixx + Iyy >= Izz
         inertia = wp.mat33([[0.1, 0.0, 0.0], [0.0, 0.1, 0.0], [0.0, 0.0, 10.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "triangle inequality"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(
                 mass, inertia, balance_inertia=False
             )
 
-            self.assertFalse(was_corrected)  # No correction made when balance_inertia=False
-            self.assertEqual(corrected_mass, mass)
+        self.assertFalse(was_corrected)  # No correction made when balance_inertia=False
+        self.assertEqual(corrected_mass, mass)
 
-            # Inertia should not be balanced
-            inertia_array = np.array(corrected_inertia).reshape(3, 3)
-            self.assertAlmostEqual(inertia_array[0, 0], 0.1)
-            self.assertAlmostEqual(inertia_array[1, 1], 0.1)
-            self.assertAlmostEqual(inertia_array[2, 2], 10.0)
-
-            self.assertTrue(len(w) > 0)
-            self.assertIn("triangle inequality", str(w[0].message))
+        # Inertia should not be balanced
+        inertia_array = np.array(corrected_inertia).reshape(3, 3)
+        self.assertAlmostEqual(inertia_array[0, 0], 0.1)
+        self.assertAlmostEqual(inertia_array[1, 1], 0.1)
+        self.assertAlmostEqual(inertia_array[2, 2], 10.0)
 
     def test_valid_inertia_no_correction(self):
         """Test that valid inertia is not corrected."""
@@ -139,12 +126,13 @@ class TestInertiaValidation(unittest.TestCase):
         inertia = wp.mat33([[2.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 4.0]])
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertFalse(was_corrected)
-            self.assertEqual(corrected_mass, mass)
-            self.assertTrue(np.allclose(np.array(corrected_inertia).reshape(3, 3), np.array(inertia).reshape(3, 3)))
-            self.assertEqual(len(w), 0)
+        self.assertFalse(was_corrected)
+        self.assertEqual(corrected_mass, mass)
+        self.assertTrue(np.allclose(np.array(corrected_inertia).reshape(3, 3), np.array(inertia).reshape(3, 3)))
+        self.assertEqual(len(w), 0)
 
     def test_model_builder_integration_fast(self):
         """Test that fast inertia validation works in ModelBuilder.finalize()."""
@@ -163,23 +151,24 @@ class TestInertiaValidation(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             model = builder.finalize()
 
-            # Should get one summary warning
-            self.assertEqual(len(w), 1)
-            self.assertIn("Inertia validation corrected 1 bodies", str(w[0].message))
-            self.assertIn("validate_inertia_detailed=True", str(w[0].message))
+        # Should get one summary warning
+        self.assertEqual(len(w), 1)
+        self.assertIn("Inertia validation corrected 1 bodies", str(w[0].message))
+        self.assertIn("validate_inertia_detailed=True", str(w[0].message))
 
-            # Check that mass and inertia were corrected
-            body_mass = model.body_mass.numpy()[body_idx]
-            body_inertia = model.body_inertia.numpy()[body_idx]
+        # Check that mass and inertia were corrected
+        body_mass = model.body_mass.numpy()[body_idx]
+        body_inertia = model.body_inertia.numpy()[body_idx]
 
-            self.assertGreaterEqual(body_mass, builder.bound_mass)
+        self.assertGreaterEqual(body_mass, builder.bound_mass)
 
-            Ixx, Iyy, Izz = body_inertia[0, 0], body_inertia[1, 1], body_inertia[2, 2]
-            self.assertGreaterEqual(Ixx, builder.bound_inertia)
-            self.assertGreaterEqual(Iyy, builder.bound_inertia)
-            self.assertGreaterEqual(Izz, builder.bound_inertia)
+        Ixx, Iyy, Izz = body_inertia[0, 0], body_inertia[1, 1], body_inertia[2, 2]
+        self.assertGreaterEqual(Ixx, builder.bound_inertia)
+        self.assertGreaterEqual(Iyy, builder.bound_inertia)
+        self.assertGreaterEqual(Izz, builder.bound_inertia)
 
     def test_model_builder_integration_detailed(self):
         """Test that detailed inertia validation works in ModelBuilder.finalize()."""
@@ -198,30 +187,29 @@ class TestInertiaValidation(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             model = builder.finalize()
 
-            # Should get multiple detailed warnings
-            self.assertGreater(len(w), 1)
-            warning_messages = [str(warning.message) for warning in w]
-            self.assertTrue(any("Mass 0.05 is below bound" in msg for msg in warning_messages))
+        # Should get multiple detailed warnings
+        self.assertGreater(len(w), 1)
+        warning_messages = [str(warning.message) for warning in w]
+        self.assertTrue(any("Mass 0.05 is below bound" in msg for msg in warning_messages))
 
-            # Check that mass and inertia were corrected
-            body_mass = model.body_mass.numpy()[body_idx]
-            body_inertia = model.body_inertia.numpy()[body_idx]
+        # Check that mass and inertia were corrected
+        body_mass = model.body_mass.numpy()[body_idx]
+        body_inertia = model.body_inertia.numpy()[body_idx]
 
-            self.assertGreaterEqual(body_mass, builder.bound_mass)
+        self.assertGreaterEqual(body_mass, builder.bound_mass)
 
-            Ixx, Iyy, Izz = body_inertia[0, 0], body_inertia[1, 1], body_inertia[2, 2]
-            self.assertGreaterEqual(Ixx, builder.bound_inertia)
-            self.assertGreaterEqual(Iyy, builder.bound_inertia)
-            self.assertGreaterEqual(Izz, builder.bound_inertia)
+        Ixx, Iyy, Izz = body_inertia[0, 0], body_inertia[1, 1], body_inertia[2, 2]
+        self.assertGreaterEqual(Ixx, builder.bound_inertia)
+        self.assertGreaterEqual(Iyy, builder.bound_inertia)
+        self.assertGreaterEqual(Izz, builder.bound_inertia)
 
-            # Check triangle inequalities
-            self.assertGreaterEqual(Ixx + Iyy, Izz - 1e-10)
-            self.assertGreaterEqual(Iyy + Izz, Ixx - 1e-10)
-            self.assertGreaterEqual(Izz + Ixx, Iyy - 1e-10)
-
-            self.assertTrue(len(w) > 0)
+        # Check triangle inequalities
+        self.assertGreaterEqual(Ixx + Iyy, Izz - 1e-10)
+        self.assertGreaterEqual(Iyy + Izz, Ixx - 1e-10)
+        self.assertGreaterEqual(Izz + Ixx, Iyy - 1e-10)
 
     def test_default_validation_catches_negative_mass(self):
         """Test that validation runs by default and catches critical issues."""
@@ -235,57 +223,52 @@ class TestInertiaValidation(unittest.TestCase):
         )
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             model = builder.finalize()
 
-            # Should get warning about issues found
-            self.assertEqual(len(w), 1)
-            self.assertIn("Inertia validation corrected 1 bodies", str(w[0].message))
+        # Should get warning about issues found
+        self.assertEqual(len(w), 1)
+        self.assertIn("Inertia validation corrected 1 bodies", str(w[0].message))
 
-            # Mass should be corrected to 0
-            body_mass = model.body_mass.numpy()[body_idx]
-            self.assertEqual(body_mass, 0.0)
+        # Mass should be corrected to 0
+        body_mass = model.body_mass.numpy()[body_idx]
+        self.assertEqual(body_mass, 0.0)
 
     def test_nan_mass(self):
         """Test that NaN mass is handled without crashing."""
         mass = float("nan")
         inertia = wp.mat33([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "NaN/Inf"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, 0.0)
-            self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
-            self.assertTrue(len(w) > 0)
-            self.assertIn("NaN/Inf", str(w[0].message))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, 0.0)
+        self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
 
     def test_nan_inertia(self):
         """Test that NaN inertia is handled without crashing."""
         mass = 1.0
         inertia = wp.mat33([[float("nan"), 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "NaN/Inf"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, 0.0)
-            self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
-            self.assertTrue(len(w) > 0)
-            self.assertIn("NaN/Inf", str(w[0].message))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, 0.0)
+        self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
 
     def test_inf_inertia(self):
         """Test that Inf inertia is handled without crashing."""
         mass = 1.0
         inertia = wp.mat33([[float("inf"), 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(UserWarning, "NaN/Inf"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, 0.0)
-            self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
-            self.assertTrue(len(w) > 0)
-            self.assertIn("NaN/Inf", str(w[0].message))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, 0.0)
+        self.assertTrue(np.allclose(np.array(corrected_inertia), 0.0))
 
     def test_zero_mass_not_overridden_by_bound(self):
         """Test that zero mass is not overridden by bound_mass (zero = static body)."""
@@ -293,26 +276,26 @@ class TestInertiaValidation(unittest.TestCase):
         bound_mass = 1.0
         inertia = wp.mat33([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
-        with warnings.catch_warnings(record=True):
+        with self.assertWarnsRegex(UserWarning, "should have zero inertia"):
             corrected_mass, _corrected_inertia, _was_corrected = verify_and_correct_inertia(
                 mass, inertia, bound_mass=bound_mass
             )
 
-            self.assertEqual(corrected_mass, 0.0)
+        self.assertEqual(corrected_mass, 0.0)
 
     def test_singular_inertia_repaired(self):
         """Test that singular inertia for positive-mass body is made positive-definite."""
         mass = 1.0
         inertia = wp.mat33([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 
-        with warnings.catch_warnings(record=True):
+        with self.assertWarnsRegex(UserWarning, "Eigenvalues below threshold detected"):
             corrected_mass, corrected_inertia, was_corrected = verify_and_correct_inertia(mass, inertia)
 
-            self.assertTrue(was_corrected)
-            self.assertEqual(corrected_mass, mass)
-            inertia_array = np.array(corrected_inertia).reshape(3, 3)
-            eigenvalues = np.linalg.eigvals(inertia_array)
-            self.assertTrue(np.all(eigenvalues > 0))
+        self.assertTrue(was_corrected)
+        self.assertEqual(corrected_mass, mass)
+        inertia_array = np.array(corrected_inertia).reshape(3, 3)
+        eigenvalues = np.linalg.eigvals(inertia_array)
+        self.assertTrue(np.all(eigenvalues > 0))
 
 
 class TestInertiaValidationParity(unittest.TestCase):
@@ -334,7 +317,11 @@ class TestInertiaValidationParity(unittest.TestCase):
                 label="test_body",
             )
 
+            # Inertia-correction warnings are an expected side effect here and are
+            # asserted directly in TestInertiaValidation; this helper only checks
+            # numeric parity between the two paths, so record (don't raise) them.
             with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
                 model = builder.finalize()
 
             mode = "detailed" if detailed else "fast"
@@ -424,6 +411,7 @@ class TestInertiaValidationParity(unittest.TestCase):
             idx = builder.add_body(mass=1.0, inertia=wp.mat33(inertia), label="near_symmetric")
 
             with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 model = builder.finalize()
 
             self.assertEqual(len(w), 0, f"Unexpected warnings: {[str(x.message) for x in w]}")
@@ -493,6 +481,7 @@ class TestInertiaValidationParity(unittest.TestCase):
                 builder.validate_inertia_detailed = detailed
                 idx = builder.add_body(mass=0.015, inertia=small_inertia, label="finger")
                 with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always")
                     model = builder.finalize()
                 self.assertEqual(len(w), 0, f"Unexpected warnings: {[str(x.message) for x in w]}")
                 np.testing.assert_allclose(model.body_inertia.numpy()[idx].diagonal(), diag, atol=1e-10)
@@ -507,6 +496,7 @@ class TestInertiaValidationParity(unittest.TestCase):
             builder.validate_inertia_detailed = detailed
             idx = builder.add_body(mass=0.0035, inertia=wp.mat33(small_inertia.astype(np.float32)), label="pad")
             with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
                 model = builder.finalize()
             self.assertEqual(len(w), 0, f"Unexpected warnings: {[str(x.message) for x in w]}")
             mode = "detailed" if detailed else "fast"
@@ -534,7 +524,9 @@ class TestInertiaValidationParity(unittest.TestCase):
                     label="test_body",
                 )
 
-                with warnings.catch_warnings(record=True):
+                # Fast and detailed paths emit different messages (per-issue vs.
+                # a single summary), so just assert a warning fired.
+                with self.assertWarns(UserWarning):
                     model = builder.finalize()
 
                 # Builder retains original (uncorrected) values


### PR DESCRIPTION
## Description

The inertia-validation tests wrap warning-emitting calls in `warnings.catch_warnings(record=True)` without `warnings.simplefilter("always")`. `catch_warnings` copies the ambient filter list rather than resetting it, so these tests silently depend on the process-wide policy showing `UserWarning`s. Under any policy that escalates warnings to errors — e.g. `python -W error::UserWarning`, or a consumer running the suite strictly — the expected correction warning is raised instead of recorded, and the test errors before its assertions run.

This makes warning capture independent of the ambient filter:

- blocks that expect a specific warning now use the unittest-native `assertWarns` / `assertWarnsRegex` (which reset to `simplefilter("always")` internally);
- record-and-count blocks (`len(w) == N`, including the "no warnings" cases) keep `catch_warnings(record=True)` but add `simplefilter("always")`;
- three blocks that previously swallowed an expected warning now assert it instead;
- the shared parity helper, which exercises many inputs and only checks numeric parity between the two validation paths, records (does not raise) the warnings it deliberately doesn't assert on.

No production code changes; behavior of `verify_and_correct_inertia` and `ModelBuilder.finalize()` is unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not a user-facing change)

## Test plan

```
uv run --extra dev python -W error::UserWarning -m unittest newton.tests.test_inertia_validation
uv run --extra dev -m newton.tests -k test_inertia_validation
```

## Bug fix

**Steps to reproduce (without this PR, on `main`):**

Run the suite under a warnings-as-errors policy using a stock interpreter flag — no special test infrastructure required:

```
uv run --extra dev python -W error::UserWarning -m unittest newton.tests.test_inertia_validation
```

Observe `FAILED (errors=29)`: expected `UserWarning`s (e.g. "Negative mass … setting to 0", "Mass … is below bound") are raised inside `catch_warnings(record=True)` blocks that lack `simplefilter("always")`, so they propagate instead of being recorded. With this PR the same command reports `OK`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized warning assertions across inertia validation and integration tests for consistent capture and absence checks
  * Added explicit checks for corrected mass/inertia values (including NaN/Inf, zero-with-bound, and singular-inertia repair)
  * Strengthened integration tests to verify bounds and triangle-inequality after corrections
  * Ensured parity tests record warnings without affecting comparison and preserved builder state checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->