### PR TITLE
Migrate tests off deprecated ellipsoid/SDF aliases

### DIFF
--- a/newton/tests/test_mesh_backface.py
+++ b/newton/tests/test_mesh_backface.py
@@ -108,7 +108,7 @@ def _build_collision_only(mesh, shape_type, shape_pos, shape_scale=None, shape_r
         builder.add_shape_capsule(body, radius=radius, half_height=half_height)
     elif shape_type == GeoType.ELLIPSOID:
         sx, sy, sz = shape_scale if shape_scale else (0.1, 0.15, 0.08)
-        builder.add_shape_ellipsoid(body, a=sx, b=sy, c=sz)
+        builder.add_shape_ellipsoid(body, rx=sx, ry=sy, rz=sz)
     elif shape_type == GeoType.CONVEX_MESH:
         convex = newton.Mesh.create_box(0.1, 0.1, 0.1, compute_inertia=False)
         builder.add_shape_convex_hull(body, mesh=convex)

--- a/newton/tests/test_sdf_usd.py
+++ b/newton/tests/test_sdf_usd.py
@@ -133,7 +133,7 @@ class TestSDFUSDParsing(unittest.TestCase):
             # shared Mesh — finalize() must not mutate user-owned geometry).
             model = builder.finalize(device=device)
             self.assertGreaterEqual(
-                int(model.shape_sdf_index.numpy()[s1]),
+                int(model._shape_sdf_index.numpy()[s1]),
                 0,
                 "Expected an SDF entry for shape s1 in the finalized model.",
             )
@@ -193,7 +193,7 @@ class TestSDFUSDParsing(unittest.TestCase):
 
             model = builder.finalize(device=device)
             self.assertGreaterEqual(
-                int(model.shape_sdf_index.numpy()[s1]),
+                int(model._shape_sdf_index.numpy()[s1]),
                 0,
                 "Expected SDF built from default_shape_cfg during finalize.",
             )
@@ -267,7 +267,7 @@ class TestSDFUSDParsing(unittest.TestCase):
             # shared Mesh.
             model = builder.finalize(device=device)
             self.assertGreaterEqual(
-                int(model.shape_sdf_index.numpy()[s1]),
+                int(model._shape_sdf_index.numpy()[s1]),
                 0,
                 "Expected SDF built with sdfPadding during finalize.",
             )
@@ -396,7 +396,7 @@ class TestSDFUSDParsing(unittest.TestCase):
 
             model = builder.finalize(device=device)
             self.assertGreaterEqual(
-                int(model.shape_sdf_index.numpy()[s1]),
+                int(model._shape_sdf_index.numpy()[s1]),
                 0,
                 "Applied SDF API should land an SDF entry on the finalized model.",
             )
@@ -493,8 +493,8 @@ class TestSDFUSDParsing(unittest.TestCase):
         builder.shape_sdf_max_resolution[s1] = 32
 
         model = builder.finalize(device=device)
-        idx0 = int(model.shape_sdf_index.numpy()[s0])
-        idx1 = int(model.shape_sdf_index.numpy()[s1])
+        idx0 = int(model._shape_sdf_index.numpy()[s0])
+        idx1 = int(model._shape_sdf_index.numpy()[s1])
 
         self.assertGreaterEqual(idx0, 0)
         self.assertGreaterEqual(idx1, 0)


### PR DESCRIPTION
## Description

`test_mesh_backface` and `test_sdf_usd` still call deprecated APIs:

- `add_shape_ellipsoid(a=, b=, c=)` — deprecated in favor of `rx=, ry=, rz=`
- `Model.shape_sdf_index` — deprecated public alias of `Model._shape_sdf_index` (slated for removal in Newton 1.5)

Both emit `DeprecationWarning`, so these tests error under any warnings-as-errors policy. This migrates the call sites to the current spellings — `rx/ry/rz` for the ellipsoid semi-axes (mapping `a→rx, b→ry, c→rz`), and `Model._shape_sdf_index`, which the other SDF tests (`test_sdf_compute`, `test_sdf_texture`) already use. Test-only change; no production code touched.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not a user-facing change)

## Test plan

```
uv run --extra dev python -W error::DeprecationWarning -m unittest newton.tests.test_mesh_backface newton.tests.test_sdf_usd
uv run --extra dev -m newton.tests -k test_sdf_usd
```

## Bug fix

**Steps to reproduce (without this PR, on `main`):**

```
uv run --extra dev python -W error::DeprecationWarning -m unittest newton.tests.test_mesh_backface newton.tests.test_sdf_usd
```

Observe `FAILED (errors=10)`: 5 from `add_shape_ellipsoid`'s deprecated `a/b/c` parameters and 5 from `Model.shape_sdf_index`. With this PR the same command reports `OK`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for ellipsoid shape construction parameter validation.
  * Updated test assertions for SDF shape index tracking and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->