### PR TITLE
Don't warn on the (0, 0) solref-limit sentinel

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7277,11 +7277,14 @@ class SolverMuJoCo(SolverBase):
         # Validate authored RAW ``mujoco.solreflimit`` values once per notify.
         # MuJoCo's solref domain is ``(timeconst > 0, dampratio > 0)`` for the
         # standard interpretation or ``(< 0, < 0)`` for the direct
-        # stiffness/damping mode; mixed signs or zero components silently
-        # disable the limit or trigger divide-by-zero in MuJoCo's
+        # stiffness/damping mode; mixed signs or a single zero component
+        # silently disable the limit or trigger divide-by-zero in MuJoCo's
         # ``k_eff = 1/(τ²·ζ²)``. Surface the misconfiguration once via a
         # warning so users can correct the authored value; the kernel cannot
-        # warn from inside Warp.
+        # warn from inside Warp. The all-zero ``(0, 0)`` solref is the
+        # documented MuJoCo "inherit the model default" sentinel and is
+        # forwarded verbatim, so it is intentionally excluded here -- matching
+        # the MJCF importer, which preserves it without warning.
         if (
             joint_limit_solref_mode is not None
             and joint_limit_solref is not None
@@ -7293,7 +7296,10 @@ class SolverMuJoCo(SolverBase):
             if np.any(raw_mask):
                 tc = raw_np[raw_mask, 0]
                 dr = raw_np[raw_mask, 1]
-                invalid = (tc == 0.0) | (dr == 0.0) | (np.sign(tc) != np.sign(dr))
+                # ``(0, 0)`` is the MuJoCo inherit-default sentinel, not a
+                # misconfiguration; flag only a single zero or mixed signs.
+                both_zero = (tc == 0.0) & (dr == 0.0)
+                invalid = ((tc == 0.0) | (dr == 0.0) | (np.sign(tc) != np.sign(dr))) & ~both_zero
                 if np.any(invalid):
                     bad = np.flatnonzero(raw_mask)[invalid]
                     warnings.warn(


### PR DESCRIPTION
## Description

`SolverMuJoCo` validated authored RAW `mujoco.solreflimit` and warned on any zero component. But `(0, 0)` is the documented MuJoCo "inherit the model default" sentinel: the MJCF importer (`import_mjcf.py`) already preserves it verbatim and explicitly excludes it from its own equivalent warning, and the solver forwards it unchanged. Warning on it is a false positive that fires on legitimate input.

This excludes the all-zero sentinel from the validity check, keeping the warning for genuinely misconfigured values (a single zero component, or mixed signs). The existing `*_zero_solreflimit_is_preserved_*` tests already assert the value is preserved; they now also pass under a warnings-as-errors policy without changes.

No `CHANGELOG` entry: the warning was introduced after the last release, so there is no released behavior to note.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (warning is unreleased)

## Test plan

```
uv run --extra dev -m newton.tests -k test_mujoco_solver.TestMuJoCoSolverInvweightScaledSolref
```

## Bug fix

**Steps to reproduce (without this PR):**

Author a joint with `mujoco.solreflimit = (0, 0)` (the MuJoCo "use default" sentinel, e.g. `solreflimit="0 0"` in MJCF) and construct a `SolverMuJoCo`. A spurious `UserWarning` is emitted ("Authored mujoco.solreflimit has invalid components ... expected two same-sign non-zero values"), even though the importer and solver intentionally preserve `(0, 0)` verbatim. With this PR the warning no longer fires for the all-zero sentinel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Refined validation logic for MuJoCo solver parameters to correctly identify and handle default values, reducing false-positive warning messages during configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->