### PR TITLE
Clarify uv example extra usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Before running the examples below, install Newton with the examples extra:
 pip install "newton[examples]"
 ```
 
-If you installed from source with uv, substitute `uv run` for `python` in the commands below.
+If you run the examples from a source checkout with uv, use
+`uv run --extra examples -m newton.examples <example_name>` instead of the
+`python -m newton.examples <example_name>` commands below.
 
 <table>
   <tr>


### PR DESCRIPTION
## Description

Clarify the README instructions for running examples from a source checkout with uv. The updated wording shows the inline `uv run --extra examples -m newton.examples <example_name>` form so optional example/viewer dependencies such as `pyglet` are available.

## Checklist

- [x] New or existing tests cover these changes (N/A: README wording only)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (N/A: no behavior change)

## Test plan

Not run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new instructions for running examples when installing from source with `uv`. Users will now find the explicit command `uv run --extra examples -m newton.examples <example_name>` along with clarified guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->