### PR TITLE
Cherry-pick ArticulationView label rename (#3057) onto release-1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `ArticulationView.joint_template_labels`, `link_template_labels` (aliased as `body_template_labels`), and `shape_template_labels` exposing the raw template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
+- Add `ArticulationView.joint_labels`, `link_labels` (aliased as `body_labels`), and `shape_labels` exposing the full template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 
 ### Fixed
 

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -568,11 +568,11 @@ class ArticulationView:
         arti_joint_types = []
         arti_link_ids = []
         arti_link_names = []
-        arti_link_template_labels = []
-        arti_joint_template_labels = []
+        arti_link_labels = []
+        arti_joint_labels = []
         arti_shape_ids = []
         arti_shape_names = []
-        arti_shape_template_labels = []
+        arti_shape_labels = []
 
         # gather joint info
         arti_joint_begin = int(model_articulation_start[arti_0])
@@ -587,7 +587,7 @@ class ArticulationView:
         for joint_id in range(arti_joint_begin, arti_joint_end):
             # joint_id = arti_joint_begin + idx
             arti_joint_ids.append(joint_id)
-            arti_joint_template_labels.append(model.joint_label[joint_id])
+            arti_joint_labels.append(model.joint_label[joint_id])
             arti_joint_names.append(get_name_from_label(model.joint_label[joint_id]))
             arti_joint_types.append(model_joint_type[joint_id])
             link_id = int(model_joint_child[joint_id])
@@ -597,7 +597,7 @@ class ArticulationView:
         arti_link_ids = sorted(set(arti_link_ids))
         arti_link_count = len(arti_link_ids)
         for link_id in arti_link_ids:
-            arti_link_template_labels.append(model.body_label[link_id])
+            arti_link_labels.append(model.body_label[link_id])
             arti_link_names.append(get_name_from_label(model.body_label[link_id]))
             arti_shape_ids.extend(model.body_shapes[link_id])
 
@@ -605,7 +605,7 @@ class ArticulationView:
         arti_shape_ids = sorted(arti_shape_ids)
         arti_shape_count = len(arti_shape_ids)
         for shape_id in arti_shape_ids:
-            arti_shape_template_labels.append(model.shape_label[shape_id])
+            arti_shape_labels.append(model.shape_label[shape_id])
             arti_shape_names.append(get_name_from_label(model.shape_label[shape_id]))
 
         # compute counts and offsets of joints, links, etc.
@@ -807,16 +807,16 @@ class ArticulationView:
         selected_link_indices = sorted(link_include_indices - link_exclude_indices)
 
         self.joint_names = []
-        self.joint_template_labels = []
+        self.joint_labels = []
         self.joint_dof_names = []
         self.joint_dof_counts = []
         self.joint_coord_names = []
         self.joint_coord_counts = []
         self.link_names = []
-        self.link_template_labels = []
+        self.link_labels = []
         self.link_shapes = []
         self.shape_names = []
-        self.shape_template_labels = []
+        self.shape_labels = []
 
         # populate info for selected joints and dofs
         selected_joint_dof_indices = []
@@ -825,7 +825,7 @@ class ArticulationView:
             joint_id = arti_joint_ids[joint_idx]
             joint_name = arti_joint_names[joint_idx]
             self.joint_names.append(joint_name)
-            self.joint_template_labels.append(arti_joint_template_labels[joint_idx])
+            self.joint_labels.append(arti_joint_labels[joint_idx])
             # joint dofs
             dof_begin = int(model_joint_qd_start[joint_id])
             dof_end = int(model_joint_qd_start[joint_id + 1])
@@ -857,7 +857,7 @@ class ArticulationView:
         for link_idx, arti_link_idx in enumerate(selected_link_indices):
             body_id = arti_link_ids[arti_link_idx]
             self.link_names.append(arti_link_names[arti_link_idx])
-            self.link_template_labels.append(arti_link_template_labels[arti_link_idx])
+            self.link_labels.append(arti_link_labels[arti_link_idx])
             shape_ids = model.body_shapes[body_id]
             for shape_id in shape_ids:
                 arti_shape_idx = arti_shape_ids.index(shape_id)
@@ -868,7 +868,7 @@ class ArticulationView:
         selected_shape_indices = sorted(selected_shape_indices)
         for shape_idx, arti_shape_idx in enumerate(selected_shape_indices):
             self.shape_names.append(arti_shape_names[arti_shape_idx])
-            self.shape_template_labels.append(arti_shape_template_labels[arti_shape_idx])
+            self.shape_labels.append(arti_shape_labels[arti_shape_idx])
             link_idx = shape_link_idx[arti_shape_idx]
             self.link_shapes[link_idx].append(shape_idx)
 
@@ -1129,9 +1129,9 @@ class ArticulationView:
         return self.link_shapes
 
     @property
-    def body_template_labels(self):
-        """Alias for `link_template_labels`."""
-        return self.link_template_labels
+    def body_labels(self):
+        """Alias for `link_labels`."""
+        return self.link_labels
 
     # ========================================================================================
     # Generic attribute API

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -69,10 +69,10 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.get_dof_velocities(state).shape, (1, 1, 0))
         self.assertEqual(view.get_dof_forces(control).shape, (1, 1, 0))
 
-    def test_template_labels_preserve_full_paths(self):
+    def test_labels_preserve_full_paths(self):
         """Two-finger gripper whose distal bodies, finger joints, and tip
         shapes each share a colliding leaf name. ``*_names`` attributes
-        collapse to the leaf; ``*_template_labels`` attributes expose the
+        collapse to the leaf; ``*_labels`` attributes expose the
         full slash-delimited labels from the template articulation so
         callers can still distinguish entries and recover selection order.
         """
@@ -99,19 +99,19 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.link_names, ["fingertip", "fingertip"])
         self.assertEqual(view.shape_names, ["tip_collision", "tip_collision"])
 
-        # ...and disambiguated on the *_template_labels attributes.
+        # ...and disambiguated on the *_labels attributes.
         self.assertEqual(
-            view.link_template_labels,
+            view.link_labels,
             ["palm/left/fingertip", "palm/right/fingertip"],
         )
         self.assertEqual(
-            view.shape_template_labels,
+            view.shape_labels,
             ["palm/left/tip_collision", "palm/right/tip_collision"],
         )
-        self.assertIn("palm/left/fingertip_joint", view.joint_template_labels)
-        self.assertIn("palm/right/fingertip_joint", view.joint_template_labels)
-        self.assertEqual(len(view.joint_template_labels), view.joint_count)
-        self.assertEqual(view.body_template_labels, view.link_template_labels)
+        self.assertIn("palm/left/fingertip_joint", view.joint_labels)
+        self.assertIn("palm/right/fingertip_joint", view.joint_labels)
+        self.assertEqual(len(view.joint_labels), view.joint_count)
+        self.assertEqual(view.body_labels, view.link_labels)
 
     def test_duplicate_joint_child_is_one_link(self):
         """BODY-frequency link axis uses unique physical bodies, not joint slots."""
@@ -131,9 +131,9 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(list(model.body_label), ["root", "tip"])
         self.assertEqual(view.link_count, 2)
         self.assertEqual(view.link_names, ["root", "tip"])
-        self.assertEqual(view.link_template_labels, ["root", "tip"])
+        self.assertEqual(view.link_labels, ["root", "tip"])
         self.assertEqual(view.shape_count, 1)
-        self.assertEqual(view.shape_template_labels, ["tip_shape"])
+        self.assertEqual(view.shape_labels, ["tip_shape"])
 
         body_layout = view.frequency_layouts[newton.Model.AttributeFrequency.BODY]
         self.assertEqual(body_layout.value_count, len(model.body_label))


### PR DESCRIPTION
## Description

Cherry-picks #3057 ("Rename `ArticulationView` template labels to labels") from `main` onto `release-1.2`.

The `*_template_labels` attributes are only present in the 1.2.1 release candidates, so renaming them to `*_labels` before 1.2.1 ships avoids releasing the `template_labels` name and then having to deprecate it. This brings `release-1.2` in line with `main`.

The cherry-pick applied cleanly to the code; the `[1.2.1]` CHANGELOG entry was reconciled in place (renamed the existing `*_template_labels` line rather than adding a second entry).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_selection
```

## Cherry-picked PRs

- #3057 — Rename `ArticulationView` template labels to labels
