### PR TITLE
Slim down example options table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,16 +817,20 @@ If you installed from source with uv, substitute `uv run` for `python` in the co
 
 ### Example Options
 
-The examples support the following command-line arguments:
+All examples share a common set of command-line options. The most commonly used ones are:
 
-| Argument        | Description                                                                                         | Default                      |
-| --------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `--viewer`      | Viewer type: `gl` (OpenGL window), `usd` (USD file output), `rerun` (ReRun), or `null` (no viewer). | `gl`                         |
-| `--device`      | Compute device to use, e.g., `cpu`, `cuda:0`, etc.                                                  | `None` (default Warp device) |
-| `--num-frames`  | Number of frames to simulate (for USD output).                                                      | `100`                        |
-| `--output-path` | Output path for USD files (required if `--viewer usd` is used).                                     | `None`                       |
+| Argument        | Description                                                              | Default                      |
+| --------------- | ------------------------------------------------------------------------ | ---------------------------- |
+| `--viewer`      | Viewer to use: `gl`, `usd`, `rerun`, `viser`, or `null`.                 | `gl`                         |
+| `--device`      | Compute device to use, e.g., `cpu`, `cuda:0`.                            | `None` (default Warp device) |
+| `--num-frames`  | Total number of frames to simulate.                                      | `100`                        |
+| `--output-path` | Path to the output USD file (used by the `usd` viewer).                  | `output.usd`                 |
 
-Some examples may add additional arguments (see their respective source files for details).
+For the complete, always-current list of options — plus any arguments a specific example adds — run:
+
+```bash
+python -m newton.examples <example_name> --help
+```
 
 ### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ All examples share a common set of command-line options. The most commonly used 
 
 | Argument        | Description                                                              | Default                      |
 | --------------- | ------------------------------------------------------------------------ | ---------------------------- |
-| `--viewer`      | Viewer to use: `gl`, `usd`, `rerun`, `viser`, or `null`.                 | `gl`                         |
+| `--viewer`      | Viewer to use: `gl`, `usd`, `rtx`, `rerun`, `viser`, or `null`.          | `gl`                         |
 | `--device`      | Compute device to use, e.g., `cpu`, `cuda:0`.                            | `None` (default Warp device) |
 | `--num-frames`  | Total number of frames to simulate.                                      | `100`                        |
 | `--output-path` | Path to the output USD file (used by the `usd` viewer).                  | `output.usd`                 |


### PR DESCRIPTION
## Description

The README duplicated the example CLI argument parser (`newton/examples/__init__.py:create_parser`) as a hand-maintained table, and it had drifted out of sync: it listed a stale `--output-path` default (`None` instead of `output.usd`), omitted the `viser` viewer choice, and was missing the other options that `create_parser` adds to every example.

Rather than re-sync an exhaustive table that will keep drifting, this trims the "Example Options" section to a short curated list of the options end-users reach for most (`--viewer`, `--device`, `--num-frames`, `--output-path`) and points readers to `python -m newton.examples <example_name> --help` for the complete, always-current list — including any example-specific arguments. The argparse parser stays the single source of truth.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Docs-only change. Verified the curated options and defaults against `create_parser` in `newton/examples/__init__.py`, and confirmed `python -m newton.examples <example_name> --help` renders the full option list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the example options into a unified, table-based presentation for clarity
  * Updated descriptions and default values for viewer, device, frame count and output path options
  * Added guidance to view full example-specific options using the examples' help command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->