### PR TITLE
Add opt-in leaf-or-label matching for ArticulationView and sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `ArticulationView.joint_labels`, `link_labels` (aliased as `body_labels`), and `shape_labels` exposing the full template-articulation labels alongside the existing leaf-only `*_names`, so callers can disambiguate selected entries whose leaf names collide.
 - Add `newton.actuators.SchemaNames` exposing the canonical USD schema token constants used by `parse_actuator_prim` for actuator USD parsing
 - Parse URDF `<material>` colors (inline `<color rgba>` and named material references) during import and apply them to `ModelBuilder.shape_color` for all shape types
+- Add `match_full_labels` to `ArticulationView` and the `SensorContact`, `SensorIMU`, and `SensorFrameTransform` sensors, enabling label patterns to match leaf (final `/`-delimited) names in addition to full labels (so a path pattern like `"*/left/fingertip"` can target one of several entries sharing a leaf). Matching is unchanged by default; a `DeprecationWarning` is emitted when a pattern would match differently under the upcoming default (`match_full_labels=True`), which will become the default in a future release.
 - Add robotics tutorial notebook covering ModelBuilder, solvers, CUDA graphs, IK, and pick-and-place
 - Add opt-in `collapse_massless_fixed_root` to URDF and MJCF importers to collapse massless fixed-root chains for maximal-coordinate solvers while preserving topology by default
 - Add USD parsing for `NewtonSiteAPI` to mark shapes as sites.

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -9,7 +9,7 @@ import numpy as np
 import warp as wp
 
 from ..sim import Contacts, Model, State
-from ..utils.selection import match_labels
+from ..utils.selection import match_labels_with_transition, warn_label_match_transition
 
 # Object type constants used in the sensing-object transform kernel.
 _OBJ_TYPE_SHAPE = 1
@@ -323,6 +323,7 @@ class SensorContact:
         measure_total: bool = True,
         verbose: bool | None = None,
         request_contact_attributes: bool = True,
+        match_full_labels: bool = False,
     ):
         """Initialize the SensorContact.
 
@@ -346,6 +347,10 @@ class SensorContact:
                 ``wp.config.log_level`` is configured for debug logging.
             request_contact_attributes: If True (default), transparently request the extended contact attribute
                 ``force`` from the model.
+            match_full_labels: If ``True``, body/shape patterns match leaf names as well as
+                full labels; ``False`` (default) matches full labels only and warns when the
+                upcoming default of ``True`` would match differently. The default will become
+                ``True`` in a future release.
         """
         if (sensing_obj_bodies is None) == (sensing_obj_shapes is None):
             raise ValueError("Exactly one of `sensing_obj_bodies` and `sensing_obj_shapes` must be specified")
@@ -360,28 +365,38 @@ class SensorContact:
         if request_contact_attributes:
             model.request_contact_attributes("force")
 
+        match_would_change = False
+
+        def _resolve(labels, pattern):
+            nonlocal match_would_change
+            indices, differs = match_labels_with_transition(labels, pattern, match_full_labels)
+            match_would_change = match_would_change or differs
+            return indices
+
         if sensing_obj_bodies is not None:
-            s_bodies = match_labels(model.body_label, sensing_obj_bodies)
+            s_bodies = _resolve(model.body_label, sensing_obj_bodies)
             _check_index_bounds(s_bodies, len(model.body_label), "sensing_obj_bodies", "bodies")
             s_shapes = []
         else:
             s_bodies = []
-            s_shapes = match_labels(model.shape_label, sensing_obj_shapes)
+            s_shapes = _resolve(model.shape_label, sensing_obj_shapes)
             _check_index_bounds(s_shapes, len(model.shape_label), "sensing_obj_shapes", "shapes")
 
         using_counterparts = True
         if counterpart_bodies is not None:
-            c_bodies = match_labels(model.body_label, counterpart_bodies)
+            c_bodies = _resolve(model.body_label, counterpart_bodies)
             _check_index_bounds(c_bodies, len(model.body_label), "counterpart_bodies", "bodies")
             c_shapes = []
         elif counterpart_shapes is not None:
             c_bodies = []
-            c_shapes = match_labels(model.shape_label, counterpart_shapes)
+            c_shapes = _resolve(model.shape_label, counterpart_shapes)
             _check_index_bounds(c_shapes, len(model.shape_label), "counterpart_shapes", "shapes")
         else:
             c_shapes = []
             c_bodies = []
             using_counterparts = False
+
+        warn_label_match_transition("SensorContact", match_full_labels, match_would_change)
 
         world_count = model.world_count
 

--- a/newton/_src/sensors/sensor_frame_transform.py
+++ b/newton/_src/sensors/sensor_frame_transform.py
@@ -8,7 +8,7 @@ import warp as wp
 from ..geometry import ShapeFlags
 from ..sim.model import Model
 from ..sim.state import State
-from ..utils.selection import match_labels
+from ..utils.selection import match_labels_with_transition, warn_label_match_transition
 
 
 @wp.kernel
@@ -124,6 +124,7 @@ class SensorFrameTransform:
         reference_sites: str | list[str] | list[int],
         *,
         verbose: bool | None = None,
+        match_full_labels: bool = False,
     ):
         """Initialize the SensorFrameTransform.
 
@@ -136,6 +137,10 @@ class SensorFrameTransform:
                 to one site or the same number as ``shapes``.
             verbose: If True, print details. If False, suppress details. If None, print details when
                 ``wp.config.log_level`` is configured for debug logging.
+            match_full_labels: If ``True``, ``shapes``/``reference_sites`` patterns match leaf
+                names as well as full labels; ``False`` (default) matches full labels only and
+                warns when the upcoming default of ``True`` would match differently. The default
+                will become ``True`` in a future release.
 
         Raises:
             ValueError: If arguments are invalid or no labels match.
@@ -145,9 +150,12 @@ class SensorFrameTransform:
 
         # Resolve label patterns to indices
         original_shapes = shapes
-        shapes = match_labels(model.shape_label, shapes)
+        shapes, _shapes_differ = match_labels_with_transition(model.shape_label, shapes, match_full_labels)
         original_reference_sites = reference_sites
-        reference_sites = match_labels(model.shape_label, reference_sites)
+        reference_sites, _refs_differ = match_labels_with_transition(
+            model.shape_label, reference_sites, match_full_labels
+        )
+        warn_label_match_transition("SensorFrameTransform", match_full_labels, _shapes_differ or _refs_differ)
 
         # Validate shape indices
         if not shapes:

--- a/newton/_src/sensors/sensor_imu.py
+++ b/newton/_src/sensors/sensor_imu.py
@@ -8,7 +8,7 @@ import warp as wp
 from ..geometry.flags import ShapeFlags
 from ..sim.model import Model
 from ..sim.state import State
-from ..utils.selection import match_labels
+from ..utils.selection import match_labels_with_transition, warn_label_match_transition
 
 
 @wp.kernel
@@ -118,6 +118,7 @@ class SensorIMU:
         *,
         verbose: bool | None = None,
         request_state_attributes: bool = True,
+        match_full_labels: bool = False,
     ):
         """Initialize SensorIMU.
 
@@ -132,6 +133,10 @@ class SensorIMU:
                 ``wp.config.log_level`` is configured for debug logging.
             request_state_attributes: If True (default), transparently request the extended state attribute ``body_qdd`` from the model.
                 If False, ``model`` is not modified and the attribute must be requested elsewhere before calling ``model.state()``.
+            match_full_labels: If ``True``, ``sites`` patterns match leaf names as well as
+                full labels; ``False`` (default) matches full labels only and warns when the
+                upcoming default of ``True`` would match differently. The default will become
+                ``True`` in a future release.
         Raises:
             ValueError: If no labels match or invalid sites are passed.
         """
@@ -140,7 +145,8 @@ class SensorIMU:
         self.verbose = verbose if verbose is not None else wp.config.log_level <= wp.LOG_DEBUG
 
         original_sites = sites
-        sites = match_labels(model.shape_label, sites)
+        sites, _match_differs = match_labels_with_transition(model.shape_label, sites, match_full_labels)
+        warn_label_match_transition("SensorIMU", match_full_labels, _match_differs)
         if not sites:
             if isinstance(original_sites, list) and len(original_sites) == 0:
                 raise ValueError("'sites' must not be empty")

--- a/newton/_src/utils/selection.py
+++ b/newton/_src/utils/selection.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import warnings
 from fnmatch import fnmatch
 from types import NoneType
 from typing import TYPE_CHECKING, Any
@@ -394,7 +395,7 @@ def find_matching_ids(pattern: str, labels: list[str], world_ids, world_count: i
     return grouped_ids, global_ids
 
 
-def match_labels(labels: list[str], pattern: str | list[str] | list[int]) -> list[int]:
+def match_labels(labels: list[str], pattern: str | list[str] | list[int], match_leaf: bool = False) -> list[int]:
     """Find indices of elements in ``labels`` that match ``pattern``.
 
     See :ref:`label-matching` for the pattern syntax accepted across Newton APIs.
@@ -405,6 +406,8 @@ def match_labels(labels: list[str], pattern: str | list[str] | list[int]) -> lis
             A ``list[str]`` matches any pattern.
             A ``list[int]`` is returned as-is (indices used directly).
             Mixing ``str`` and ``int`` in the same list is not allowed.
+        match_leaf: If ``True``, also match a pattern against each label's leaf
+            (final ``/``-delimited component). Slash-bearing patterns stay precise.
 
     Returns:
         Unique list of matching indices, or ``pattern`` itself for ``list[int]``.
@@ -412,8 +415,12 @@ def match_labels(labels: list[str], pattern: str | list[str] | list[int]) -> lis
     Raises:
         TypeError: If list elements are not all ``str`` or all ``int``.
     """
+
+    def matches(label: str, pat: str) -> bool:
+        return fnmatch(label, pat) or (match_leaf and fnmatch(get_name_from_label(label), pat))
+
     if isinstance(pattern, str):
-        return [idx for idx, label in enumerate(labels) if fnmatch(label, pattern)]
+        return [idx for idx, label in enumerate(labels) if matches(label, pattern)]
 
     if not isinstance(pattern, list):
         raise TypeError(f"Expected a list of str patterns or a list of int indices, got: {type(pattern)}")
@@ -432,10 +439,60 @@ def match_labels(labels: list[str], pattern: str | list[str] | list[int]) -> lis
         if not validation_failure:
             return pattern
     elif all(isinstance(item, str) for item in pattern):
-        return [idx for idx, label in enumerate(labels) if any(fnmatch(label, p) for p in pattern)]
+        return [idx for idx, label in enumerate(labels) if any(matches(label, p) for p in pattern)]
 
     types = {type(item).__name__ for item in pattern}
     raise TypeError(f"Expected a list of str patterns or a list of int indices, got: {', '.join(sorted(types))}")
+
+
+# Hint appended to the DeprecationWarning emitted while leaf-or-label matching is opt-in.
+_MATCH_FULL_LABELS_HINT = (
+    "Pass match_full_labels=True to adopt the new default now, or match_full_labels=False to keep the current behavior."
+)
+
+
+def match_labels_with_transition(
+    labels: list[str], pattern: str | list[str] | list[int], match_full_labels: bool
+) -> tuple[list[int], bool]:
+    """Resolve ``pattern`` for callers that currently match full labels only.
+
+    Returns ``(indices, differs)``; ``differs`` is ``True`` only when ``match_full_labels``
+    is False and enabling leaf matching would change the result.
+    """
+    if match_full_labels:
+        return match_labels(labels, pattern, match_leaf=True), False
+    legacy = match_labels(labels, pattern)
+    new = match_labels(labels, pattern, match_leaf=True)
+    return legacy, set(legacy) != set(new)
+
+
+def warn_label_match_transition(context: str, match_full_labels: bool, differs: bool) -> None:
+    """Warn about the pending leaf-or-label default change, only when ``match_full_labels``
+    is False and enabling it would change the result."""
+    if not match_full_labels and differs:
+        warnings.warn(
+            f"{context} label matching will change in a future Newton release: the match_full_labels "
+            f"default will become True, so patterns will match leaf names in addition to full labels, "
+            f"changing the matched entities. " + _MATCH_FULL_LABELS_HINT,
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
+def _match_view_indices(
+    full_labels: list[str],
+    leaf_labels: list[str],
+    pattern: str | list[str] | list[int],
+    count: int,
+    match_full_labels: bool,
+) -> tuple[list[int], bool]:
+    """Resolve an ``ArticulationView`` include/exclude pattern to in-range indices,
+    returning ``(indices, differs)`` for the leaf-or-label transition."""
+    if match_full_labels:
+        return [i for i in match_labels(full_labels, pattern, match_leaf=True) if 0 <= i < count], False
+    legacy = [i for i in match_labels(leaf_labels, pattern) if 0 <= i < count]
+    new = [i for i in match_labels(full_labels, pattern, match_leaf=True) if 0 <= i < count]
+    return legacy, set(legacy) != set(new)
 
 
 def all_equal(values):
@@ -498,6 +555,11 @@ class ArticulationView:
         exclude_joint_types (list[int] | None): List of joint types to exclude.
         include_loop_closing_joints (bool): If True, include converted loop-closing joints.
         verbose (bool | None): If True, prints selection summary.
+        match_full_labels (bool): If ``True``, ``include_*``/``exclude_*`` patterns match full
+            labels as well as leaf names (so ``"*/left/fingertip"`` can target one of several
+            entries sharing a leaf); ``False`` (default) matches leaf names only and warns when
+            the upcoming default of ``True`` would select differently. The default will become
+            ``True`` in a future release.
     """
 
     def __init__(
@@ -512,6 +574,7 @@ class ArticulationView:
         exclude_joint_types: list[int] | None = None,
         include_loop_closing_joints: bool = False,
         verbose: bool | None = None,
+        match_full_labels: bool = False,
     ):
         self.model = model
         self.device = model.device
@@ -771,6 +834,17 @@ class ArticulationView:
             inner_link_stride = arti_link_count
             inner_shape_stride = arti_shape_count
 
+        # Resolve include/exclude patterns. Matching currently uses leaf names; the
+        # upcoming default also matches full labels. Track whether enabling that would
+        # change the selection so we can warn while the new behavior is opt-in.
+        match_would_change = False
+
+        def resolve(full_labels, leaf_labels, pattern, count):
+            nonlocal match_would_change
+            indices, differs = _match_view_indices(full_labels, leaf_labels, pattern, count, match_full_labels)
+            match_would_change = match_would_change or differs
+            return indices
+
         # create joint inclusion set
         if include_joints is None and include_joint_types is None:
             joint_include_indices = set(range(arti_joint_count))
@@ -778,7 +852,7 @@ class ArticulationView:
             joint_include_indices = set()
             if include_joints is not None:
                 joint_include_indices.update(
-                    idx for idx in match_labels(arti_joint_names, include_joints) if 0 <= idx < arti_joint_count
+                    resolve(arti_joint_labels, arti_joint_names, include_joints, arti_joint_count)
                 )
             if include_joint_types is not None:
                 for idx in range(arti_joint_count):
@@ -788,9 +862,7 @@ class ArticulationView:
         # create joint exclusion set
         joint_exclude_indices = set()
         if exclude_joints is not None:
-            joint_exclude_indices.update(
-                idx for idx in match_labels(arti_joint_names, exclude_joints) if 0 <= idx < arti_joint_count
-            )
+            joint_exclude_indices.update(resolve(arti_joint_labels, arti_joint_names, exclude_joints, arti_joint_count))
         if exclude_joint_types is not None:
             for idx in range(arti_joint_count):
                 if arti_joint_types[idx] in exclude_joint_types:
@@ -800,15 +872,21 @@ class ArticulationView:
         if include_links is None:
             link_include_indices = set(range(arti_link_count))
         else:
-            link_include_indices = {
-                idx for idx in match_labels(arti_link_names, include_links) if 0 <= idx < arti_link_count
-            }
+            link_include_indices = set(resolve(arti_link_labels, arti_link_names, include_links, arti_link_count))
 
         # create link exclusion set
         link_exclude_indices = set()
         if exclude_links is not None:
-            link_exclude_indices.update(
-                idx for idx in match_labels(arti_link_names, exclude_links) if 0 <= idx < arti_link_count
+            link_exclude_indices.update(resolve(arti_link_labels, arti_link_names, exclude_links, arti_link_count))
+
+        if not match_full_labels and match_would_change:
+            warnings.warn(
+                "ArticulationView label matching will change in a future Newton release: the "
+                "match_full_labels default will become True, so include_*/exclude_* patterns will "
+                "match full template-articulation labels in addition to leaf names, changing this "
+                "selection. " + _MATCH_FULL_LABELS_HINT,
+                DeprecationWarning,
+                stacklevel=2,
             )
 
         # compute selected indices

--- a/newton/tests/test_selection.py
+++ b/newton/tests/test_selection.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+import warnings
 
 import numpy as np
 import warp as wp
 
 import newton
 import newton.examples
+from newton._src.utils.selection import match_labels, match_labels_with_transition, warn_label_match_transition
 from newton.selection import ArticulationView
 from newton.tests.unittest_utils import assert_np_equal
 
@@ -26,6 +28,79 @@ def origin_velocity_from_body_qd(model, body_q, body_qd, body_idx):
         dtype=np.float32,
     )
     return body_qd[body_idx, :3] - np.cross(body_qd[body_idx, 3:6], com_world)
+
+
+_MATCH_LABELS = ["palm", "palm/left/fingertip", "palm/right/fingertip"]
+_TRANSITION_LABELS = ["foot", "robot/foot", "robot/hand"]
+
+
+def _build_gripper_model():
+    """Two-finger gripper whose distal bodies, finger joints, and tip shapes
+    each share a colliding leaf name (``fingertip`` / ``tip_collision``)."""
+    builder = newton.ModelBuilder()
+    palm = builder.add_link(label="palm")
+    left = builder.add_link(label="palm/left/fingertip")
+    right = builder.add_link(label="palm/right/fingertip")
+    builder.add_shape_box(body=left, hx=0.01, hy=0.01, hz=0.02, label="palm/left/tip_collision")
+    builder.add_shape_box(body=right, hx=0.01, hy=0.01, hz=0.02, label="palm/right/tip_collision")
+    j_root = builder.add_joint_free(parent=-1, child=palm, label="root")
+    j_left = builder.add_joint_revolute(
+        parent=palm, child=left, axis=(0.0, 0.0, 1.0), label="palm/left/fingertip_joint"
+    )
+    j_right = builder.add_joint_revolute(
+        parent=palm, child=right, axis=(0.0, 0.0, 1.0), label="palm/right/fingertip_joint"
+    )
+    builder.add_articulation([j_root, j_left, j_right], label="gripper")
+    return builder.finalize()
+
+
+class TestMatchLabels(unittest.TestCase):
+    def test_full_label_only_by_default(self):
+        # Default matches the full label only: a bare leaf does not match a
+        # hierarchical label, a path pattern does.
+        self.assertEqual(match_labels(_MATCH_LABELS, "fingertip"), [])
+        self.assertEqual(match_labels(_MATCH_LABELS, "*/left/fingertip"), [1])
+
+    def test_match_leaf_adds_basename_matches(self):
+        self.assertEqual(match_labels(_MATCH_LABELS, "fingertip", match_leaf=True), [1, 2])
+        # Path patterns are unaffected (still precise).
+        self.assertEqual(match_labels(_MATCH_LABELS, "*/left/fingertip", match_leaf=True), [1])
+
+    def test_slash_pattern_never_matches_leaf(self):
+        self.assertEqual(match_labels(_MATCH_LABELS, "palm/right/fingertip", match_leaf=True), [2])
+
+    def test_integer_indices_pass_through(self):
+        self.assertEqual(match_labels(_MATCH_LABELS, [0, 2], match_leaf=True), [0, 2])
+
+
+class TestMatchLabelsTransition(unittest.TestCase):
+    def test_true_matches_leaf_no_drift(self):
+        idx, differs = match_labels_with_transition(_TRANSITION_LABELS, "foot", True)
+        self.assertEqual(idx, [0, 1])
+        self.assertFalse(differs)
+
+    def test_false_keeps_full_label_reports_drift(self):
+        idx, differs = match_labels_with_transition(_TRANSITION_LABELS, "foot", False)
+        self.assertEqual(idx, [0])
+        self.assertTrue(differs)
+
+    def test_false_no_drift_for_flat_labels(self):
+        idx, differs = match_labels_with_transition(["a", "b"], "a", False)
+        self.assertEqual(idx, [0])
+        self.assertFalse(differs)
+
+
+class TestWarnLabelMatchTransition(unittest.TestCase):
+    def test_warns_when_false_and_differs(self):
+        with self.assertWarns(DeprecationWarning):
+            warn_label_match_transition("X", False, True)
+
+    def test_silent_otherwise(self):
+        # Adopting (True) is silent; so is the default (False) when nothing would change.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            warn_label_match_transition("X", True, True)
+            warn_label_match_transition("X", False, False)
 
 
 class TestSelection(unittest.TestCase):
@@ -70,28 +145,10 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.get_dof_forces(control).shape, (1, 1, 0))
 
     def test_labels_preserve_full_paths(self):
-        """Two-finger gripper whose distal bodies, finger joints, and tip
-        shapes each share a colliding leaf name. ``*_names`` attributes
-        collapse to the leaf; ``*_labels`` attributes expose the
-        full slash-delimited labels from the template articulation so
-        callers can still distinguish entries and recover selection order.
-        """
-        builder = newton.ModelBuilder()
-        palm = builder.add_link(label="palm")
-        left = builder.add_link(label="palm/left/fingertip")
-        right = builder.add_link(label="palm/right/fingertip")
-        builder.add_shape_box(body=left, hx=0.01, hy=0.01, hz=0.02, label="palm/left/tip_collision")
-        builder.add_shape_box(body=right, hx=0.01, hy=0.01, hz=0.02, label="palm/right/tip_collision")
-        j_root = builder.add_joint_free(parent=-1, child=palm, label="root")
-        j_left = builder.add_joint_revolute(
-            parent=palm, child=left, axis=(0.0, 0.0, 1.0), label="palm/left/fingertip_joint"
-        )
-        j_right = builder.add_joint_revolute(
-            parent=palm, child=right, axis=(0.0, 0.0, 1.0), label="palm/right/fingertip_joint"
-        )
-        builder.add_articulation([j_root, j_left, j_right], label="gripper")
-        model = builder.finalize()
-
+        """``*_names`` collapse colliding entries to their leaf; ``*_labels``
+        expose the full slash-delimited labels from the template articulation
+        so callers can distinguish them and recover selection order."""
+        model = _build_gripper_model()
         view = ArticulationView(model, "gripper", include_links="fingertip")
 
         # Leaf collisions are visible on the *_names attributes...
@@ -100,14 +157,8 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(view.shape_names, ["tip_collision", "tip_collision"])
 
         # ...and disambiguated on the *_labels attributes.
-        self.assertEqual(
-            view.link_labels,
-            ["palm/left/fingertip", "palm/right/fingertip"],
-        )
-        self.assertEqual(
-            view.shape_labels,
-            ["palm/left/tip_collision", "palm/right/tip_collision"],
-        )
+        self.assertEqual(view.link_labels, ["palm/left/fingertip", "palm/right/fingertip"])
+        self.assertEqual(view.shape_labels, ["palm/left/tip_collision", "palm/right/tip_collision"])
         self.assertIn("palm/left/fingertip_joint", view.joint_labels)
         self.assertIn("palm/right/fingertip_joint", view.joint_labels)
         self.assertEqual(len(view.joint_labels), view.joint_count)
@@ -139,6 +190,45 @@ class TestSelection(unittest.TestCase):
         self.assertEqual(body_layout.value_count, len(model.body_label))
         self.assertEqual(view.get_link_transforms(model).shape, (1, 1, 2))
         self.assertEqual(view.get_link_velocities(model).shape, (1, 1, 2))
+
+    def test_bare_leaf_matches_all_colliding_without_warning(self):
+        # A slash-free pattern matches by leaf under all modes; the upcoming
+        # default does not change it, so no DeprecationWarning is emitted.
+        model = _build_gripper_model()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            view = ArticulationView(model, "gripper", include_links="fingertip")
+        self.assertEqual(view.link_count, 2)
+
+    def test_path_pattern_warns_and_keeps_legacy_under_default(self):
+        # Under the opt-in default, a path pattern matches nothing (legacy
+        # leaf-only) and warns that the upcoming default would select it.
+        model = _build_gripper_model()
+        with self.assertWarns(DeprecationWarning):
+            view = ArticulationView(model, "gripper", include_links="*/left/fingertip")
+        self.assertEqual(view.link_count, 0)
+
+    def test_path_pattern_selects_one_when_opted_in(self):
+        model = _build_gripper_model()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            view = ArticulationView(model, "gripper", include_links="*/left/fingertip", match_full_labels=True)
+        self.assertEqual(view.link_labels, ["palm/left/fingertip"])
+
+    def test_path_pattern_matches_nothing_when_opted_out(self):
+        # Explicit match_full_labels=False keeps legacy matching but still warns about
+        # the pending default change (the opt-out does not silence the warning).
+        model = _build_gripper_model()
+        with self.assertWarns(DeprecationWarning):
+            view = ArticulationView(model, "gripper", include_links="*/left/fingertip", match_full_labels=False)
+        self.assertEqual(view.link_count, 0)
+
+    def test_full_label_exclude_carves_one_when_opted_in(self):
+        model = _build_gripper_model()
+        view = ArticulationView(
+            model, "gripper", include_links="fingertip", exclude_links="*/left/fingertip", match_full_labels=True
+        )
+        self.assertEqual(view.link_labels, ["palm/right/fingertip"])
 
     def _test_selection_shapes(self, floating: bool):
         # load articulation

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -3,6 +3,7 @@
 
 import types
 import unittest
+import warnings
 
 import numpy as np
 import warp as wp
@@ -760,6 +761,28 @@ class TestSensorContactMuJoCo(unittest.TestCase):
 
         total_weight = (mass_a + mass_b + mass_c) * g
         self.assertAlmostEqual(base_force[0, 2], -total_weight, delta=total_weight * 0.01)
+
+
+class TestSensorContactLabelMatching(unittest.TestCase):
+    @staticmethod
+    def _model():
+        builder = newton.ModelBuilder()
+        a = builder.add_body(label="robot")  # flat label
+        builder.add_shape_box(a, hx=0.1, hy=0.1, hz=0.1)
+        b = builder.add_body(label="arm/robot")  # hierarchical, same leaf
+        builder.add_shape_box(b, hx=0.1, hy=0.1, hz=0.1)
+        return builder.finalize()
+
+    def test_match_full_labels_true_matches_leaf(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sensor = SensorContact(self._model(), sensing_obj_bodies="robot", match_full_labels=True)
+        self.assertEqual(sensor.sensing_obj_idx, [0, 1])
+
+    def test_default_warns_and_keeps_full_label_only(self):
+        with self.assertWarns(DeprecationWarning):
+            sensor = SensorContact(self._model(), sensing_obj_bodies="robot")
+        self.assertEqual(sensor.sensing_obj_idx, [0])
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_sensor_frame_transform.py
+++ b/newton/tests/test_sensor_frame_transform.py
@@ -4,6 +4,7 @@
 """Tests for SensorFrameTransform."""
 
 import unittest
+import warnings
 
 import numpy as np
 import warp as wp
@@ -628,6 +629,28 @@ class TestSensorFrameTransform(unittest.TestCase):
             sensor_int.transforms.numpy(),
             sensor_str.transforms.numpy(),
         )
+
+
+class TestSensorFrameTransformLabelMatching(unittest.TestCase):
+    @staticmethod
+    def _model():
+        builder = newton.ModelBuilder()
+        body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        builder.add_site(body, label="probe")  # flat label
+        builder.add_site(body, label="left/probe")  # hierarchical, same leaf
+        builder.add_site(body, label="ref")
+        return builder.finalize()
+
+    def test_match_full_labels_true_matches_leaf(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sensor = SensorFrameTransform(self._model(), shapes="probe", reference_sites="ref", match_full_labels=True)
+        self.assertEqual(sensor.transforms.shape[0], 2)
+
+    def test_default_warns_and_keeps_full_label_only(self):
+        with self.assertWarns(DeprecationWarning):
+            sensor = SensorFrameTransform(self._model(), shapes="probe", reference_sites="ref")
+        self.assertEqual(sensor.transforms.shape[0], 1)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_sensor_imu.py
+++ b/newton/tests/test_sensor_imu.py
@@ -4,6 +4,7 @@
 """Tests for SensorIMU."""
 
 import unittest
+import warnings
 
 import numpy as np
 import warp as wp
@@ -201,6 +202,34 @@ class TestSensorIMU(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             SensorIMU(model, sites="nonexistent_*")
+
+
+class TestSensorIMULabelMatching(unittest.TestCase):
+    @staticmethod
+    def _model():
+        builder = newton.ModelBuilder()
+        body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        builder.add_site(body, label="imu")  # flat label
+        builder.add_site(body, label="left/imu")  # hierarchical, same leaf
+        return builder.finalize()
+
+    def test_match_full_labels_true_matches_leaf(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sensor = SensorIMU(self._model(), sites="imu", match_full_labels=True)
+        self.assertEqual(sensor.n_sensors, 2)
+
+    def test_default_warns_and_keeps_full_label_only(self):
+        with self.assertWarns(DeprecationWarning):
+            sensor = SensorIMU(self._model(), sites="imu")
+        self.assertEqual(sensor.n_sensors, 1)
+
+    def test_opt_out_keeps_full_label_only_but_still_warns(self):
+        # Explicit match_full_labels=False keeps full-label-only matching but does not
+        # silence the pending-default-change warning.
+        with self.assertWarns(DeprecationWarning):
+            sensor = SensorIMU(self._model(), sites="imu", match_full_labels=False)
+        self.assertEqual(sensor.n_sensors, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Lets `ArticulationView` and the contact/IMU/frame-transform sensors match label patterns against a label's **leaf** (final `/`-delimited component) in addition to the full label. This makes the `*_labels` attributes (renamed in #3057) usable as selection keys: a path pattern like `"*/left/fingertip"` can target one of several entries that share a leaf, and a slash-bearing `exclude_*` pattern can carve a single colliding entry out of a broad leaf-based include. A pattern containing `/` can never match a slash-free leaf, so such patterns stay precise.

This is **opt-in** to avoid changing behavior. `match_labels()` gains an internal `match_leaf` flag (default `False`), and `ArticulationView`, `SensorContact`, `SensorIMU`, and `SensorFrameTransform` gain a `match_full_labels: bool | None = None` parameter:

- `None` (default) keeps the current matching and emits a `DeprecationWarning` **only** when enabling leaf matching would change the result, so unaffected callers (flat labels, exact patterns, integer indices) are never warned.
- `True` adopts leaf-or-label matching now.
- `False` pins the current behavior.

The default will become `True` in a future release. This mirrors the `newton.use_coord_layout_targets` transition pattern (opt-in flag + `DeprecationWarning`, default flips later).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_selection
uv run --extra dev -m newton.tests -k test_sensor_contact
uv run --extra dev -m newton.tests -k test_sensor_imu
uv run --extra dev -m newton.tests -k test_sensor_frame_transform
```

## New feature / API change

```python
import newton

# Gripper with two fingertips sharing the leaf name "fingertip":
#   palm/left/fingertip, palm/right/fingertip
view = newton.selection.ArticulationView(
    model, "gripper", include_links="*/left/fingertip", match_full_labels=True
)
view.link_labels  # ['palm/left/fingertip'] — one of the colliding pair, targeted by path

# Without match_full_labels, today's behavior (leaf-only) is unchanged; a
# DeprecationWarning is emitted only if the upcoming default would select differently.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in match_full_labels option for articulation views and sensors so patterns can match full labels or leaf names; current behavior preserved by default.
* **Bug Fixes / Behavior**
  * Emits a deprecation warning when selections would change under the upcoming default.
* **Documentation**
  * Updated changelog and constructor docs to describe the new option and warning.
* **Tests**
  * Added tests covering matching modes and deprecation-warning cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->