### PR TITLE
Add deprecation directives to warned-only API symbols

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2153,6 +2153,9 @@ class ModelBuilder:
         slot is dropped; other joints copy verbatim. Mutations do not
         propagate back. Raises :class:`AttributeError` under
         :data:`newton.use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_q` instead.
         """
         import newton  # noqa: PLC0415
 
@@ -2176,6 +2179,9 @@ class ModelBuilder:
         fresh copy — mutations do not propagate back. Raises
         :class:`AttributeError` under
         :data:`newton.use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_qd` instead.
         """
         import newton  # noqa: PLC0415
 
@@ -6090,6 +6096,10 @@ class ModelBuilder:
         The ellipsoid is centered at its local origin as defined by `xform`, with semi-axes
         `rx`, `ry`, `rz` along the local X, Y, Z axes respectively.
 
+        .. deprecated:: 1.1
+            The ``a``, ``b``, ``c`` parameter names are deprecated; use
+            ``rx``, ``ry``, ``rz`` instead.
+
         Note:
             Ellipsoid collision is handled by the GJK/MPR collision pipeline,
             which provides accurate collision detection for all convex shape pairs.
@@ -6520,6 +6530,10 @@ class ModelBuilder:
 
         The Gaussian is attached as a ``GeoType.GAUSSIAN`` shape for rendering.
         Collision is handled separately via *collision_proxy*.
+
+        .. deprecated:: 1.1
+            Passing ``gaussian`` as the second positional argument is
+            deprecated; pass it via the ``gaussian=`` keyword instead.
 
         Args:
             body: The index of the parent body this shape belongs to.

--- a/newton/_src/sim/control.py
+++ b/newton/_src/sim/control.py
@@ -96,6 +96,9 @@ class Control:
         """Deprecated alias for :attr:`joint_target_q` (DOF-shape only).
         Raises :class:`AttributeError` under
         :data:`newton.use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_q` instead.
         """
         if self._use_coord_layout_targets:
             raise AttributeError(_JOINT_TARGET_POS_UNAVAILABLE_MSG)
@@ -114,6 +117,9 @@ class Control:
         """Deprecated alias for :attr:`joint_target_qd`. Raises
         :class:`AttributeError` under
         :data:`newton.use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_qd` instead.
         """
         if self._use_coord_layout_targets:
             raise AttributeError(_JOINT_TARGET_VEL_UNAVAILABLE_MSG)

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -1143,6 +1143,9 @@ class Model:
         """Deprecated alias for :attr:`joint_target_q` (DOF-shape only).
         Raises :class:`AttributeError` when this Model was built under
         :attr:`use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_q` instead.
         """
         import warnings  # noqa: PLC0415
 
@@ -1177,6 +1180,9 @@ class Model:
         """Deprecated alias for :attr:`joint_target_qd`. Raises
         :class:`AttributeError` when this Model was built under
         :attr:`use_coord_layout_targets` ``True``.
+
+        .. deprecated:: 1.3
+            Use :attr:`joint_target_qd` instead.
         """
         import warnings  # noqa: PLC0415
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -1896,6 +1896,10 @@ class ViewerBase(ABC):
     def update_shape_colors(self, shape_colors: dict[int, wp.vec3 | tuple[float, float, float]]):
         """
         Set colors for a set of shapes at runtime.
+
+        .. deprecated:: 1.1
+            Write to :attr:`Model.shape_color` instead.
+
         Args:
             shape_colors: mapping from shape index -> color
         """


### PR DESCRIPTION
## Description

Documentation-only change: add `.. deprecated:: X.Y` directives to deprecated public API symbols that warn at runtime and are already listed in `CHANGELOG.md`, but whose docstrings carried no directive — so they did not appear in the rendered API deprecation index. The directives are annotated with the release in which each symbol was deprecated:

- `Control` / `Model` / `ModelBuilder` `joint_target_pos` / `joint_target_vel` → `1.3`
- `ViewerBase.update_shape_colors()` → `1.1`
- `add_shape_ellipsoid()` `a` / `b` / `c` parameter names → `1.1`
- `add_shape_gaussian()` positional `gaussian` argument → `1.1`

The last two follow the existing precedent of the `armature`-parameter deprecation on `add_link()` / `add_body()` (method-level directive whose text scopes it to the parameter).

**Intentionally left untouched** (no clean directive home, or the owning method is still supported and already annotated in its `Args:`): the USD-data names (`newton:contact_*`, `mjc:solref`, `newton:armature`), `Model.mujoco.dof_passive_damping`, and the `SolverVBD` parameter-level deprecations (`rigid_enable_dahl_friction`, `register_custom_attributes(dahl_defaults_enabled=...)`).

No behavior change; the deprecation warnings and changelog entries are unchanged.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Docstring-only change. Verified `py_compile` and the `ruff`, `ruff format`, typos, and warp-array-syntax pre-commit hooks pass on the four edited files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced deprecation notices across the simulation builder and control modules with explicit version numbers and migration paths to recommended alternatives.
  * Improved guidance for geometric shape creation methods, clarifying parameter naming conventions.
  * Updated shape color management deprecation documentation with clear migration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->