### PR TITLE
Render ground planes as Viser grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fix `SolverMuJoCo` CPU backend dynamics for asymmetric MJCF `diaginertia` models whose principal moments are reordered during Newton/MJWarp synchronization
 - Fix `SolverMuJoCo` honoring force-space `shape_material_ke` / `shape_material_kd` for contacts (`use_mujoco_contacts=False`); authored `mjc:solref` is preserved via new `mujoco.solref` / `mujoco.solref_mode` per-shape custom attributes. Force-space scaling is unsupported on `use_mujoco_contacts=True` and the MuJoCo CPU backend.
 - Fix MJCF importer rejecting MuJoCo's one-value `solreflimit`/`solref` shorthand emitted by `mujoco.MjSpec.to_xml()` for default-valued joints, which broke `SolverMuJoCo(save_to_mjcf=...)` round-trips
+- Fix ground grid clipping in the Viser renderer
 
 ## [1.2.1] - 2026-06-04
 

--- a/newton/_src/viewer/viewer_viser.py
+++ b/newton/_src/viewer/viewer_viser.py
@@ -706,42 +706,10 @@ class ViewerViser(ViewerBase):
                 pass
 
     @staticmethod
-    def _build_plane_grid_points(width: float, length: float) -> np.ndarray:
-        """Create a finite grid of line segments in the local XY plane."""
-        width = max(float(width), 0.1)
-        length = max(float(length), 0.1)
-
-        spacing = max(min(width, length) / 10.0, 0.25)
-        spacing = min(spacing, 2.0)
-
-        nx = max(int(np.ceil(width / spacing)), 1)
-        ny = max(int(np.ceil(length / spacing)), 1)
-
-        xs = np.linspace(-width * 0.5, width * 0.5, nx + 1, dtype=np.float32)
-        ys = np.linspace(-length * 0.5, length * 0.5, ny + 1, dtype=np.float32)
-
-        segments = []
-        for x in xs:
-            segments.append([[x, -length * 0.5, 0.0], [x, length * 0.5, 0.0]])
-        for y in ys:
-            segments.append([[-width * 0.5, y, 0.0], [width * 0.5, y, 0.0]])
-
-        return np.asarray(segments, dtype=np.float32)
-
-    @staticmethod
-    def _rotate_points_wxyz(points: np.ndarray, quat_wxyz: np.ndarray) -> np.ndarray:
-        """Rotate points by a unit quaternion stored in WXYZ order."""
-        quat_wxyz = np.asarray(quat_wxyz, dtype=np.float32)
-        norm = np.linalg.norm(quat_wxyz)
-        if norm > 0.0:
-            quat_wxyz = quat_wxyz / norm
-
-        qvec = quat_wxyz[1:4]
-        flat_points = points.reshape(-1, 3)
-        uv = np.cross(qvec, flat_points)
-        uuv = np.cross(qvec, uv)
-        rotated = flat_points + 2.0 * (quat_wxyz[0] * uv + uuv)
-        return rotated.reshape(points.shape).astype(np.float32, copy=False)
+    def _plane_cell_size(width: float, length: float) -> float:
+        """Pick a grid cell size for a plane of the given extents."""
+        spacing = max(min(float(width), float(length)) / 10.0, 0.25)
+        return min(spacing, 2.0)
 
     def _log_plane_instances(
         self,
@@ -751,7 +719,7 @@ class ViewerViser(ViewerBase):
         scales: wp.array[wp.vec3] | None,
         hidden: bool = False,
     ):
-        """Render plane instances as finite line grids instead of opaque meshes."""
+        """Render plane instances as viser grids."""
         self._remove_plane_handles(name)
 
         if hidden or xforms is None:
@@ -768,30 +736,42 @@ class ViewerViser(ViewerBase):
         if scales_np is not None:
             scales_np = np.asarray(scales_np, dtype=np.float32)
 
-        width = float(plane_info["width"])
-        length = float(plane_info["length"])
-        grid_points = self._build_plane_grid_points(width, length)
+        base_width = float(plane_info["width"])
+        base_length = float(plane_info["length"])
 
-        all_points = []
+        handles = []
         for idx, (position, quat_wxyz) in enumerate(zip(positions, quats_wxyz, strict=False)):
-            instance_points = grid_points
+            width = base_width
+            length = base_length
+
+            # TODO: Compute cell size for the scaled width/length directly
+            cell_size = self._plane_cell_size(width, length)
+
             if scales_np is not None:
-                plane_scale = np.array([scales_np[idx][0], scales_np[idx][1], 1.0], dtype=np.float32)
-                instance_points = grid_points * plane_scale
-            instance_points = self._rotate_points_wxyz(instance_points, quat_wxyz) + position
-            all_points.append(instance_points)
+                sx = float(scales_np[idx][0])
+                sy = float(scales_np[idx][1])
+                width *= sx
+                length *= sy
+                cell_size *= max(sx, sy)
 
-        if not all_points:
-            return
+            # The plane's local frame has its normal along +Z, so the grid lies in the local XY plane.
+            handle = self._call_scene_method(
+                self._server.scene.add_grid,
+                name=f"{name}/grid_{idx}",
+                width=width,
+                height=length,
+                plane="xy",
+                cell_color=(150, 150, 150),
+                section_color=(110, 110, 110),
+                cell_size=cell_size,
+                section_size=cell_size,
+                position=tuple(float(v) for v in position),
+                wxyz=tuple(float(v) for v in quat_wxyz),
+            )
+            handles.append(handle)
 
-        handle = self._server.scene.add_line_segments(
-            name=f"{name}/grid",
-            points=np.concatenate(all_points, axis=0),
-            colors=(150, 150, 150),
-            line_width=1.5,
-        )
-
-        self._plane_handles[name] = handle
+        if handles:
+            self._plane_handles[name] = handles
 
     @override
     def log_instances(


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

After this PR, the ground grid is rendered as a Viser grid instead of Viser lines.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

Viewer output tested manually on examples `cloth_franka`, `robot_g1` and `ik_franka`. Local tests `uv run --extra dev -m newton.tests` outputs `OK (skipped=147)`.

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

The floor grid shows rendering artifacts from certain viewing angles in Viser.

Example:

```
uv run -m newton.examples cloth_franka --viewer viser
```

<img width="2730" height="1551" alt="Screenshot from 2026-06-04 17-15-00" src="https://github.com/user-attachments/assets/b749601d-549f-4ab9-a16f-46e5b466850b" />

An investigation with Claude leads to [these](https://github.com/pmndrs/three-stdlib/blob/main/src/lines/LineMaterial.js#L161-L162) lines in Three.js, which seems plausible. If the grid line starts or ends behind the camera then the sign is flipped.

Viser has a special primitive for grids which does not have the clipping problem. After this PR:

 
<img width="2730" height="1551" alt="Screenshot from 2026-06-04 17-15-35" src="https://github.com/user-attachments/assets/aff3ee7a-2ce0-4539-a43b-c00bbe9d6b94" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ground grid clipping issue in the Viser renderer.

* **Improvements**
  * Plane/grid visuals render more accurately and stably, preserving per-instance scaling so grids display correctly at different sizes, positions, and orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->