### PR TITLE
Bump main version to 1.4.0.dev0

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -71,6 +71,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.3.0.dev0``
+     - ``1.4.0.dev0``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.3.0.dev0"
+version = "1.4.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3403,7 +3403,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.3.0.dev0"
+version = "1.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Advance the development version on `main` from `1.3.0.dev0` to `1.4.0.dev0`, per the code-freeze step of the release process guide (`docs/guide/release.rst`): when the `release-X.Y` branch is cut, `main` moves to `X.(Y+1).0.dev0`.

Also regenerates `docs/api` for the updated `__version__` constant and syncs `uv.lock` to the new package version.

## Checklist

- [ ] New or existing tests cover these changes — N/A, version metadata only
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A, not a user-facing change

## Test plan

`uv run docs/generate_api.py` and `uvx pre-commit run` pass; no functional change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped from 1.3.0.dev0 to 1.4.0.dev0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->