### PR TITLE
Skip generate_api test outside source checkouts

### DIFF
--- a/newton/tests/test_generate_api.py
+++ b/newton/tests/test_generate_api.py
@@ -7,9 +7,19 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from docs import generate_api
+try:
+    from docs import generate_api
+except ModuleNotFoundError as exc:
+    # The ``docs`` package lives at the repository root and is not included in
+    # installed/wheel builds, so these tests only run from a source checkout.
+    # Re-raise anything other than a missing top-level ``docs`` package so that
+    # genuine import failures (e.g. a broken ``generate_api``) are not masked.
+    if exc.name != "docs":
+        raise
+    generate_api = None
 
 
+@unittest.skipUnless(generate_api is not None, "requires the docs/ package (source checkout only)")
 class TestGenerateApiCopyright(unittest.TestCase):
     def tearDown(self):
         generate_api._COPYRIGHT_LINES.clear()


### PR DESCRIPTION
## What

`test_generate_api` imports `docs.generate_api`, but the `docs` package lives at the repository root and is not shipped in installed/wheel builds. Running the bundled test suite from an installed package (e.g. `python -m unittest` against an installed `newton`) fails at import time with `ModuleNotFoundError: No module named 'docs'`.

## Change

Guard the import and skip `TestGenerateApiCopyright` when the top-level `docs` package is unavailable, following the optional-import pattern already used in the test suite (e.g. `test_download_assets.py`). Import errors other than a missing `docs` package are re-raised, so a genuinely broken `generate_api` is still surfaced rather than silently skipped.

Verified that an installed/non-source run now reports these tests as skipped instead of erroring, while a source checkout continues to run and pass them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test resilience by implementing conditional import handling. Tests now gracefully skip when optional dependencies are unavailable, reducing failures in non-source installation contexts while still catching genuine import errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->