### PR TITLE
Warm model-init benchmark caches before timing

### DIFF
--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -34,7 +34,12 @@ class KpiInitializeModel:
     timeout = 3600
 
     def setup(self, robot, world_count):
-        wp.init()
+        # Finalize a small model first so the asset download and one-time kernel
+        # compilation stay out of the timed build. Use the default (benchmark)
+        # device so the kernels warmed here are the ones the timed call reuses.
+        builder = Example.create_model_builder(robot, 1, randomize=False, seed=123)
+        _model = builder.finalize()
+        wp.synchronize_device()
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_initialize_model(self, robot, world_count):
@@ -56,7 +61,6 @@ class KpiInitializeSolver:
     timeout = 3600
 
     def setup(self, robot, world_count):
-        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -82,7 +86,6 @@ class KpiInitializeViewerGL:
     min_run_count = 1
 
     def setup(self, robot, world_count):
-        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -111,12 +114,17 @@ class FastInitializeModel:
     min_run_count = 1
 
     def setup_cache(self):
-        # Load a small model to cache the kernels
+        # Finalize small models first so the asset download and one-time kernel
+        # compilation stay out of the timed builds. Warp compiles per device
+        # target, so warm both the default device (for time_initialize_model)
+        # and CPU (for peakmem_initialize_model_cpu). Fresh builder per
+        # finalize: finalize() mutates builder state in place.
         for robot in self.params[0]:
-            builder = Example.create_model_builder(robot, 1, randomize=False, seed=123)
-            model = builder.finalize(device="cpu")
-            del model
-            del builder
+            for device in (None, "cpu"):
+                builder = Example.create_model_builder(robot, 1, randomize=False, seed=123)
+                model = builder.finalize(device=device)
+                del model
+                del builder
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_initialize_model(self, robot, world_count):
@@ -148,7 +156,6 @@ class FastInitializeSolver:
     min_run_count = 1
 
     def setup(self, robot, world_count):
-        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -174,7 +181,6 @@ class FastInitializeViewerGL:
     min_run_count = 1
 
     def setup(self, robot, world_count):
-        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model

--- a/asv/benchmarks/setup/bench_model.py
+++ b/asv/benchmarks/setup/bench_model.py
@@ -61,6 +61,7 @@ class KpiInitializeSolver:
     timeout = 3600
 
     def setup(self, robot, world_count):
+        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -86,6 +87,7 @@ class KpiInitializeViewerGL:
     min_run_count = 1
 
     def setup(self, robot, world_count):
+        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -156,6 +158,7 @@ class FastInitializeSolver:
     min_run_count = 1
 
     def setup(self, robot, world_count):
+        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model
@@ -181,6 +184,7 @@ class FastInitializeViewerGL:
     min_run_count = 1
 
     def setup(self, robot, world_count):
+        wp.init()
         builder = Example.create_model_builder(robot, world_count, randomize=True, seed=123)
 
         # finalize model


### PR DESCRIPTION
## Description

The `setup/bench_model` initialization benchmarks were timing costs that the measured region should not include. `KpiInitializeModel.setup` only called `wp.init()`, so its timed `time_initialize_model` paid for the g1 asset download (a `git` fetch via `download_asset`) and first-time Warp kernel compilation. Both are one-time, cached on disk, and owned by the toolchain rather than the model-building code the benchmark intends to track, so they add noise and can mask real regressions in the build path. This warms them in `setup` by finalizing a small `world_count=1` model on the default benchmark device before the timed build runs; the timed region still builds and finalizes at the full `world_count`, so it measures the model-building work that scales with model size.

`FastInitializeModel.setup_cache` already warmed caches, but only finalized on CPU, which left CUDA kernel compilation inside its CUDA `time_initialize_model`. Warp compiles kernels separately per device target, so this finalizes on both the default device (for `time_initialize_model`) and CPU (for `peakmem_initialize_model_cpu`).

The now-redundant `wp.init()` calls are dropped from the remaining setups: building a model already initializes Warp, and `FastInitializeModel` never called it.

Compile cost stays tracked deliberately in the `compilation/` group (`bench_example_load.py`), which clears the kernel cache and times a cold load, so excluding it here does not lose that signal.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

This touches only asv benchmark setup; `newton` runtime behavior is unchanged, so there is no user-facing change (no `CHANGELOG` entry) and no docs to update. The edited `setup`/`setup_cache` paths were exercised on CPU to confirm they run. The benchmarks can be run on a CUDA machine with:

```
uv run python asv/benchmarks/setup/bench_model.py --bench KpiInitializeModel --bench FastInitializeModel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved benchmark setup to pre-warm small models so timed initializations reuse already-prepared kernels.
  * Expanded warm-up to finalize models on both the default device and CPU (per robot), improving device synchronization and cache pre-compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->