### PR TITLE
Fix missing int32 -> bool conversions in masks

### DIFF
--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -643,7 +643,7 @@ def _scale_row_vector_kernel(
     x: wp.array[Any],
     beta: Any,
     # Mask:
-    matrix_mask: wp.array[int32],
+    matrix_mask: wp.array[bool],
 ):
     """
     Computes a vector scaling for all active entries: y = beta * y
@@ -680,7 +680,7 @@ def _make_block_sparse_gemv_regularization_kernel(alpha: float32):
         y: wp.array[float32],
         z: wp.array[float32],
         # Mask:
-        matrix_mask: wp.array[int32],
+        matrix_mask: wp.array[bool],
     ):
         """
         Computes a generalized matrix-vector product with an added diagonal regularization component:

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -1475,7 +1475,7 @@ class SolutionMetrics:
             problem.delassus.matvec(
                 x=lambdas,
                 y=self._buffer_v,
-                world_mask=wp.ones((problem.data.num_worlds,), dtype=wp.int32, device=self.device),
+                world_mask=wp.ones((problem.data.num_worlds,), dtype=wp.bool, device=self.device),
             )
             problem.delassus.set_regularization(delassus_reg_prev)
             problem.delassus.set_preconditioner(delassus_pre_prev)

--- a/newton/_src/solvers/kamino/tests/test_dynamics_delassus.py
+++ b/newton/_src/solvers/kamino/tests/test_dynamics_delassus.py
@@ -965,7 +965,7 @@ class TestDelassusOperatorSparse(unittest.TestCase):
             mask_np = np.ones((model.size.num_worlds,), dtype=np.int32)
             if mask_worlds:
                 mask_np[::2] = 0
-            world_mask = wp.from_numpy(mask_np, dtype=wp.int32, device=self.default_device)
+            world_mask = wp.from_numpy(mask_np, dtype=wp.bool, device=self.default_device)
 
             # Compute different products (simple matvec, gemv, and gemv with beta = 0.0)
             delassus.matvec(input_vec, output_vec_matmul, world_mask)

--- a/newton/_src/solvers/kamino/tests/utils/extract.py
+++ b/newton/_src/solvers/kamino/tests/utils/extract.py
@@ -238,7 +238,7 @@ def extract_delassus_sparse(
 
     entry_start_np = delassus.bsm.row_start.numpy()
 
-    world_mask = wp.ones((num_worlds,), dtype=wp.int32, device=delassus._device)
+    world_mask = wp.ones((num_worlds,), dtype=wp.bool, device=delassus._device)
 
     for dim in range(max_dim):
         # Query the operator by computing the product with a vector where only entry `dim` is set to 1.


### PR DESCRIPTION
## Description

This fixes a few forgotten int32 -> bool conversions in mask arrays (cf #2934), that were breaking Kamino-internal unit tests. This went unnoticed as these are not yet part of the CI.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Kamino-internal unit tests now pass (in particular, test_dynamics_delassus.py, test_geometry_contacts.py and test_solver_metrics.py were broken).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal solver components to use consistent mask parameter types across computational kernels and utility functions for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->