### PR TITLE
Add contact force handling in Kamino to Newton conversion

### DIFF
--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -897,6 +897,9 @@ def _convert_contacts_kamino_to_newton(
     kamino_position_A: wp.array[vec3f],
     kamino_position_B: wp.array[vec3f],
     kamino_gapfunc: wp.array[vec4f],
+    kamino_frame: wp.array[quatf],
+    kamino_reaction: wp.array[vec3f],
+    kamino_mode: wp.array[int32],
     shape_body: wp.array[int32],
     body_q: wp.array[wp.transformf],
     # outputs
@@ -906,6 +909,7 @@ def _convert_contacts_kamino_to_newton(
     rigid_contact_point0: wp.array[vec3f],
     rigid_contact_point1: wp.array[vec3f],
     rigid_contact_normal: wp.array[vec3f],
+    rigid_contact_force: wp.array[wp.spatial_vector],
 ):
     """Converts Kamino's internal contact representation to Newton's Contacts format."""
     # Retrieve the contact index for this thread
@@ -952,6 +956,13 @@ def _convert_contacts_kamino_to_newton(
     rigid_contact_normal[cid] = vec3f(gapfunc[0], gapfunc[1], gapfunc[2])
     rigid_contact_point0[cid] = wp.transform_point(X_inv_a, position_A)
     rigid_contact_point1[cid] = wp.transform_point(X_inv_b, position_B)
+
+    # Force on shape0 (world frame); zero for inactive contacts.
+    if rigid_contact_force:
+        force_world = vec3f(0.0, 0.0, 0.0)
+        if kamino_mode[cid] != ContactMode.INACTIVE:
+            force_world = wp.quat_rotate(kamino_frame[cid], kamino_reaction[cid])
+        rigid_contact_force[cid] = wp.spatial_vector(-force_world, vec3f(0.0, 0.0, 0.0))
 
 
 ###
@@ -1083,6 +1094,9 @@ def convert_contacts_kamino_to_newton(
             contacts_in.data.position_A,
             contacts_in.data.position_B,
             contacts_in.data.gapfunc,
+            contacts_in.data.frame,
+            contacts_in.data.reaction,
+            contacts_in.data.mode,
             model.shape_body,
             state.body_q,
         ],
@@ -1093,6 +1107,7 @@ def convert_contacts_kamino_to_newton(
             contacts_out.rigid_contact_point0,
             contacts_out.rigid_contact_point1,
             contacts_out.rigid_contact_normal,
+            contacts_out.force,
         ],
         device=model.device,
     )

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -8,9 +8,11 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.solvers.kamino._src.geometry import ContactAggregation
 from newton.sensors import SensorContact
-from newton.solvers import SolverMuJoCo
+from newton.solvers import SolverKamino, SolverMuJoCo
 from newton.tests.unittest_utils import assert_np_equal
+from newton.tests.utils import basics
 
 
 def _make_two_world_model(device=None, include_ground=False):
@@ -760,6 +762,73 @@ class TestSensorContactMuJoCo(unittest.TestCase):
 
         total_weight = (mass_a + mass_b + mass_c) * g
         self.assertAlmostEqual(base_force[0, 2], -total_weight, delta=total_weight * 0.01)
+
+
+class TestSensorContactKamino(unittest.TestCase):
+    """End-to-end contact-sensor tests using the Kamino solver.
+
+    Regression coverage that the Kamino->Newton conversion populates ``Contacts.force`` so
+    ``SensorContact.total_force`` matches ``ContactAggregation``.
+    """
+
+    def test_box_on_plane_total_force_matches_aggregation(self):
+        # Build a single box resting on a static ground plane.
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        SolverKamino.register_custom_attributes(builder)
+        builder.default_shape_cfg.margin = 0.0
+        builder.default_shape_cfg.gap = 0.0
+        basics.build_box_on_plane(builder=builder)
+        model = builder.finalize(skip_validation_joints=True)
+
+        # Use Kamino's internal collision detector (steps run with ``contacts=None``).
+        config = SolverKamino.Config.from_model(model)
+        config.use_collision_detector = True
+        config.use_fk_solver = False
+        solver = SolverKamino(model=model, config=config)
+
+        # SensorContact requests the ``force`` contact attribute, so allocate the
+        # output ``Contacts`` buffer afterwards to pick it up.
+        sensor = SensorContact(model, sensing_obj_bodies=["box"])
+        contacts = newton.Contacts(
+            rigid_contact_max=200,
+            soft_contact_max=0,
+            device=model.device,
+            requested_attributes=model.get_requested_contact_attributes(),
+        )
+        self.assertIsNotNone(contacts.force, "force attribute must be allocated for the sensor path")
+
+        # Kamino's per-body aggregation reads the same internal contacts the conversion does.
+        aggregation = ContactAggregation(solver._model_kamino, solver._contacts_kamino)
+
+        state_in, state_out, control = model.state(), model.state(), model.control()
+        sim_dt = 1.0 / 240.0
+
+        # Settle the box on the plane.
+        for _ in range(120):
+            solver.step(state_in, state_out, control, None, sim_dt)
+            state_in, state_out = state_out, state_in
+
+        # Average over a few steps for stability.
+        avg_steps = 10
+        sensor_acc = np.zeros((1, 3))
+        agg_acc = np.zeros((1, 3))
+        for _ in range(avg_steps):
+            solver.step(state_in, state_out, control, None, sim_dt)
+            state_in, state_out = state_out, state_in
+            solver.update_contacts(contacts, state_in)
+            sensor.update(state_in, contacts)
+            aggregation.compute(skip_if_no_contacts=False)
+            sensor_acc += sensor.total_force.numpy()
+            # The box is body 0 of world 0.
+            agg_acc += aggregation.body_net_force.numpy()[0, 0]
+        sensor_force = sensor_acc[0] / avg_steps
+        agg_force = agg_acc[0] / avg_steps
+
+        # Regression: the stock sensor must now report a non-zero, upward contact force.
+        self.assertGreater(np.linalg.norm(sensor_force), 1e-6, "SensorContact reported zero force under Kamino")
+        self.assertGreater(sensor_force[2], 0.0, "Normal contact force on the box should be upward")
+        # Equivalence: it must match Kamino's per-body aggregation.
+        np.testing.assert_allclose(sensor_force, agg_force, atol=1e-5, rtol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`SolverKamino.update_contacts()` converted Kamino's internal contacts to a `newton.Contacts` object but dropped the per-contact forces, so `newton.sensors.SensorContact` reported zero `total_force` under `SolverKamino` (it only worked for MuJoCo). This fills in the forces so the contact sensor works identically across backends.

### Changes
- Populate `Contacts.force` in `convert_contacts_kamino_to_newton`: each contact reaction (local frame) is rotated to world frame and written as the force on `shape0`, matching `SensorContact`'s sign convention.
- Inactive contacts contribute zero; the write is guarded so it's a no-op when `Contacts.force` isn't allocated.
- The reaction is the PADMM impulse and is forwarded verbatim (no `1/dt` rescaling), so values match the existing per-body contact aggregation.
- Add `TestSensorContactKamino` (box-on-plane) asserting `total_force` is non-zero and equals `ContactAggregation.body_net_force` under `SolverKamino`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact-force output is now available for Kamino solver contacts, with automatic world-frame transformation based on contact geometry.

* **Tests**
  * Added regression test to verify contact forces are correctly converted and numerically match solver aggregation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->