### PR TITLE
Fix and clean up sensor contact scene asset

### DIFF
--- a/newton/examples/assets/sensor_contact_scene.usda
+++ b/newton/examples/assets/sensor_contact_scene.usda
@@ -19,9 +19,8 @@ def DistantLight "DistantLight" (
     color3f inputs:shaping:focusTint
     asset inputs:shaping:ies:file
     double3 xformOp:rotateXYZ = (45, 0, 90)
-    double3 xformOp:scale = (1, 1, 1)
     double3 xformOp:translate = (0, 0, 0)
-    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ"]
 }
 
 def Xform "env" (
@@ -29,13 +28,11 @@ def Xform "env" (
 {
     def Xform "Anchor"
     (
-        prepend apiSchemas = ["PhysicsArticulationRootAPI", "PhysicsRigidBodyAPI", "PhysicsMassAPI"]
+        prepend apiSchemas = ["PhysicsArticulationRootAPI", "PhysicsRigidBodyAPI"]
     )
     {
-        double3 xformOp:rotateXYZ = (0, 0, 0)
-        double3 xformOp:scale = (1, 1, 1)
         double3 xformOp:translate = (0, 0, 0.01)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+        uniform token[] xformOpOrder = ["xformOp:translate"]
 
     }
 
@@ -43,10 +40,11 @@ def Xform "env" (
         prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
     )
     {
-        double3 xformOp:rotateXYZ = (0, 0, 0)
-        double3 xformOp:scale = (0.4, 0.4, 0.04)
+        double size = 0.8
+        float3[] extent = [(-0.4, -0.4, -0.4), (0.4, 0.4, 0.4)]
+        double3 xformOp:scale = (1, 1, 0.1)
         double3 xformOp:translate = (0, 0, 1.96)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:scale"]
     }
 
     def PhysicsRevoluteJoint "Hinge" (
@@ -61,8 +59,8 @@ def Xform "env" (
         uniform token physics:axis = "X"
         rel physics:body0 = </env/Anchor>
         rel physics:body1 = </env/Flap>
-        point3f physics:localPos0 = (0, 0.4, 2)
-        point3f physics:localPos1 = (0, 1.0, 1)
+        point3f physics:localPos0 = (0, 0.4, 1.99)
+        point3f physics:localPos1 = (0, 0.4, 0.4)
     }
 
     def PhysicsFixedJoint "AnchorJoint" {
@@ -75,13 +73,12 @@ def Xform "env" (
         prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsCollisionAPI"]
     )
     {
-        double3 xformOp:rotateXYZ = (0, 0, 0)
-        double3 xformOp:scale = (0.1, 0.1, 0.1)
-        #double3 xformOp:scale = (0.1, 0.1, 0.1)
+        double size = 0.2
+        float3[] extent = [(-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)]
         double3 xformOp:translate = (-0.15, 0, 2.1)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+        uniform token[] xformOpOrder = ["xformOp:translate"]
 
-        float physics:density = 1
+        float physics:density = 1000
 
     }
 
@@ -89,21 +86,22 @@ def Xform "env" (
         prepend apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsMassAPI", "PhysicsCollisionAPI"]
     )
     {
-        #double radius = 0.1
-        double3 xformOp:rotateXYZ = (0, 0, 0)
-        double3 xformOp:scale = (0.1, 0.1, 0.1)
+        double radius = 0.1
+        float3[] extent = [(-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)]
         double3 xformOp:translate = (0.15, 0, 2.1)
-        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+        uniform token[] xformOpOrder = ["xformOp:translate"]
 
-        float physics:density = 1
+        float physics:density = 1000
     }
 
     def Cube "Plate1" (
         prepend apiSchemas = ["PhysicsCollisionAPI"]
     )
     {
+        double size = 0.8
+        float3[] extent = [(-0.4, -0.4, -0.4), (0.4, 0.4, 0.4)]
         double3 xformOp:rotateXYZ = (-35, 0, 0)
-        double3 xformOp:scale = (0.4, 0.6, 0.02)
+        double3 xformOp:scale = (1, 1.5, 0.05)
         double3 xformOp:translate = (0, -0.6, 1.2)
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
     }
@@ -112,12 +110,13 @@ def Xform "env" (
         prepend apiSchemas = ["PhysicsCollisionAPI"]
     )
     {
+        double size = 0.8
+        float3[] extent = [(-0.4, -0.4, -0.4), (0.4, 0.4, 0.4)]
         double3 xformOp:rotateXYZ = (35, 0, 0)
-        double3 xformOp:scale = (0.4, 0.6, 0.02)
+        double3 xformOp:scale = (1, 1.5, 0.05)
         double3 xformOp:translate = (0, 0.6, 0.5)
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
     }
 
 
 }
-


### PR DESCRIPTION

## Description

Fixes and cleans up sensor contact scene asset:
- removes MassAPI on static body to avoid warning for invalid mass (#2641)
- increases density on shapes to 1000 kg/m^3 for better stability
- removes unneeded scale and rotation xforms
- fixes hinge transform that was inconsistent with fk

Resolves #2641

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**
```bash
uv run --extra examples -m newton.examples sensor_contact
```
```
Warning: The rigid body at /env/Anchor has a possibly invalid inertia tensor of {1.0, 1.0, 1.0} and a negative mass.
Either specify correct values in the mass properties, or add collider(s) to any shape(s) that you wish to
automatically compute mass properties for. If you do not want the objects to collide, add colliders regardless then
disable the 'enable collision' property. [python3.12]
```

