### PR TITLE
Handle deprecation warnings in actuator and sensor tests

### DIFF
--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -671,7 +671,7 @@ class TestActuatorStep(unittest.TestCase):
         control = model.control()
         for step_i in range(5):
             tgt = target_schedule[step_i]
-            _write_dof_values(model, control.joint_target_pos, dofs, [tgt] * n)
+            _write_dof_values(model, control.joint_target_q, dofs, [tgt] * n)
             written_targets.append(tgt)
 
             control.joint_f.zero_()
@@ -1362,7 +1362,7 @@ class TestStateReset(unittest.TestCase):
 
         control = model.control()
         for _step in range(3):
-            _write_dof_values(model, control.joint_target_pos, dofs, [10.0] * n)
+            _write_dof_values(model, control.joint_target_q, dofs, [10.0] * n)
             control.joint_f.zero_()
             actuator.step(state, control, state_0, state_1, 0.01)
             state_0, state_1 = state_1, state_0
@@ -1458,17 +1458,17 @@ class TestDelayGraphCapture(unittest.TestCase):
 
         # --- Eager ---
         solver, s0, s1, ctrl, act, act_a, act_b = _setup()
-        wp.copy(ctrl.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
+        wp.copy(ctrl.joint_target_q, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
         s0, s1, act_a, act_b = _loop(solver, s0, s1, ctrl, act, act_a, act_b, max_delay)
         eager_results = []
         for tgt in cycle_targets:
-            wp.copy(ctrl.joint_target_pos, wp.full(ndof, tgt, dtype=wp.float32, device=device))
+            wp.copy(ctrl.joint_target_q, wp.full(ndof, tgt, dtype=wp.float32, device=device))
             s0, s1, act_a, act_b = _loop(solver, s0, s1, ctrl, act, act_a, act_b, N)
             eager_results.append(s0.joint_q.numpy().copy())
 
         # --- Graph ---
         solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g = _setup()
-        wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
+        wp.copy(ctrl_g.joint_target_q, wp.full(ndof, warmup_target, dtype=wp.float32, device=device))
         s0_g, s1_g, act_a_g, act_b_g = _loop(solver_g, s0_g, s1_g, ctrl_g, act_g, act_a_g, act_b_g, max_delay)
         sub_dt = dt / K
         with wp.ScopedCapture(device=device) as capture:
@@ -1484,7 +1484,7 @@ class TestDelayGraphCapture(unittest.TestCase):
 
         graph_results = []
         for tgt in cycle_targets:
-            wp.copy(ctrl_g.joint_target_pos, wp.full(ndof, tgt, dtype=wp.float32, device=device))
+            wp.copy(ctrl_g.joint_target_q, wp.full(ndof, tgt, dtype=wp.float32, device=device))
             wp.capture_launch(graph)
             graph_results.append(s0_g.joint_q.numpy().copy())
 
@@ -1662,12 +1662,15 @@ class TestTargetPosIndicesSeparation(unittest.TestCase):
         target_pos_indices = _a([1], dtype=wp.uint32)  # DOF index 1 (joint_target_pos layout)
 
         ctrl = ControllerPD(kp=_a([kp]), kd=_a([0.0]), const_effort=_a([0.0]))
-        actuator = Actuator(
-            indices=indices,
-            controller=ctrl,
-            pos_indices=pos_indices,
-            target_pos_indices=target_pos_indices,
-        )
+        # This test deliberately exercises the legacy DOF-shaped target layout via
+        # the default attr resolution, which is deprecated and warns.
+        with self.assertWarns(DeprecationWarning):
+            actuator = Actuator(
+                indices=indices,
+                controller=ctrl,
+                pos_indices=pos_indices,
+                target_pos_indices=target_pos_indices,
+            )
 
         # joint_q is coord-shaped; actual position at coord index 3
         joint_q = _a([0.0, 0.0, 0.0, actual_pos])

--- a/newton/tests/test_sensor_tiled_camera_heightfield.py
+++ b/newton/tests/test_sensor_tiled_camera_heightfield.py
@@ -37,8 +37,8 @@ class TestSensorTiledCameraHeightfield(unittest.TestCase):
         # so the terrain robustly fills the whole frame.
         rays = sensor.utils.compute_pinhole_camera_rays(res, res, math.radians(30.0))
         depth = sensor.utils.create_depth_image_output(res, res)
-        newton.geometry.build_bvh_shape(model, state)
-        newton.geometry.build_bvh_particle(model, state)
+        model.bvh_build_shapes(state)
+        model.bvh_build_particles(state)
         sensor.sync_transforms(state)
 
         # Camera 5m above origin, identity orientation => looks straight down (-z).


### PR DESCRIPTION
## Description

These tests trip deprecation warnings that the upcoming opt-in `--strict-warnings` runner flag (#3044) escalates to errors. They are pre-existing warning debt that accumulated in `main` after the earlier cleanup PRs (#3058–#3061), so this continues that work and should merge before #3044.

- **`test_actuators`** — three tests write controller targets through the deprecated `Control.joint_target_pos` alias incidentally; migrate them to the canonical `joint_target_q` (the affected models are revolute-only, so the DOF and coord layouts are identical).
- **`test_actuators`** — `test_target_pos_read_from_dof_index_not_coord_index` deliberately exercises the legacy DOF-index target layout via the default attribute resolution, which is deprecated and warns. Assert the expected `DeprecationWarning` instead of suppressing it.
- **`test_sensor_tiled_camera_heightfield`** — migrate off the deprecated `newton.geometry.build_bvh_shape`/`build_bvh_particle` helpers to `model.bvh_build_shapes`/`model.bvh_build_particles`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

Test-only change with no user-facing behavior change, so no `CHANGELOG.md` entry.

## Test plan

The flag does not exist on `main` yet, so strict mode's deprecation axis is reproduced directly by escalating `DeprecationWarning` at the interpreter level:

```
PYTHONWARNINGS=error::DeprecationWarning uv run --extra dev -m newton.tests -k test_actuators
PYTHONWARNINGS=error::DeprecationWarning uv run --extra dev -m newton.tests -k test_sensor_tiled_camera_heightfield
```

Both modules pass with these changes; without them the five tests error on the escalated `DeprecationWarning`s.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Updated actuator pipeline integration tests to verify joint target handling across different execution paths.
* Updated sensor camera heightfield test setup for BVH construction verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->