### PR TITLE
Rename SensorContact sensing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Normalize negative scale components to `abs()` in `ModelBuilder.add_shape*` for symmetric primitives (sphere, box, capsule, cylinder, ellipsoid, plane, gaussian); these shapes are point-symmetric so sign flips produce identical geometry. If you relied on a negative scale to flip such a shape, apply the mirror through the shape's transform (`xform`) instead.
 - Reject negative scale components on `ModelBuilder.add_shape_cone()` and heightfield shapes (previously silently accepted, produced invalid geometry). To mirror a cone, apply the flip through the shape's `xform`; to mirror a heightfield, pre-mirror the source height data and pass a positive scale.
 - Change `SolverKamino.reset()` signature from `reset(state_out, ...)` to `reset(state, ...)` to match `SolverBase.reset()` and reset in place on `state`; remove beta `state_out=` and legacy positional reset-target compatibility, migrate `state_out=` calls to `state=`, and pass reset targets by keyword, such as `base_q=...`
+- Rename `SensorContact` sensing-object API names: `sensing_obj_idx` to `sensing_indices`, `sensing_obj_type` to `sensing_type`, `sensing_obj_transforms` to `sensing_transforms`, `sensing_obj_bodies` to `sensing_bodies`, and `sensing_obj_shapes` to `sensing_shapes`; the old names remain deprecated aliases for compatibility.
 - Change `SensorTiledCamera` default packed `color` and `albedo` outputs to sRGB-encoded bytes so authored display colors render at the expected display brightness; pass `RenderConfig(output_color_space=ColorSpace.LINEAR)` to preserve the previous linear-byte behavior.
 - Accept plain `int` flag bitmasks in solver reset and model-change notification APIs so users can define extension bits beyond `StateFlags` and `ModelFlags`.
 - Bump `newton-usd-schemas` to `>=0.3.1`
@@ -84,10 +85,10 @@
 
 - Remove `SensorContact.net_force` (deprecated in 1.1.0); use `SensorContact.total_force` and `SensorContact.force_matrix` instead
 - Remove `include_total` parameter from `SensorContact` (deprecated in 1.1.0); use `measure_total` instead
-- Remove `SensorContact.sensing_objs` (deprecated in 1.1.0); use `SensorContact.sensing_obj_idx` and `SensorContact.sensing_obj_type` instead
+- Remove `SensorContact.sensing_objs` (deprecated in 1.1.0); use `SensorContact.sensing_indices` and `SensorContact.sensing_type` instead
 - Remove `SensorContact.counterparts` and `SensorContact.reading_indices` (deprecated in 1.1.0); use `SensorContact.counterpart_indices` and `SensorContact.counterpart_type` instead
 - Remove `SensorContact.shape` (deprecated in 1.1.0); use `total_force.shape` / `force_matrix.shape` instead
-- Remove `SensorContact.ObjectType` enum (deprecated in 1.1.0); use the `sensing_obj_type` and `counterpart_type` attributes instead
+- Remove `SensorContact.ObjectType` enum (deprecated in 1.1.0); use the `sensing_type` and `counterpart_type` attributes instead
 - Remove `raycast_kernel_no_hfield`; use `raycast_kernel` instead
 - Remove the deprecated `newton.examples.compute_world_offsets` helper; use `ModelBuilder.replicate()` instead
 

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -26,15 +26,15 @@ from newton.utils import EventTracer
 _NEW_LAYOUT_AVAILABLE = hasattr(newton, "use_coord_layout_targets")
 
 
-def _target_q(obj):
+def _target_q(owner):
     """Resolve the joint-position-target array across pre/post #2556 layouts.
 
     On pre-PR Newton (no ``joint_target_q``) falls back to ``joint_target_pos``.
     Used by the benchmark harness so ``asv compare`` works against both refs.
     """
-    target = getattr(obj, "joint_target_q", None)
+    target = getattr(owner, "joint_target_q", None)
     if target is None:
-        target = getattr(obj, "joint_target_pos", None)
+        target = getattr(owner, "joint_target_pos", None)
     return target
 
 
@@ -366,7 +366,7 @@ class Example:
         self.sensor_contact = None
         sensing_bodies = ROBOT_CONFIGS.get(robot, {}).get("sensing_bodies", None)
         if sensing_bodies is not None:
-            self.sensor_contact = SensorContact(self.model, sensing_obj_bodies=sensing_bodies, counterpart_bodies="*")
+            self.sensor_contact = SensorContact(self.model, sensing_bodies=sensing_bodies, counterpart_bodies="*")
             self.contacts = newton.Contacts(
                 self.solver.get_max_contact_count(),
                 0,

--- a/docs/concepts/extended_attributes.rst
+++ b/docs/concepts/extended_attributes.rst
@@ -54,7 +54,7 @@ creating the sensor before allocating contacts is sufficient:
    builder.add_shape_sphere(body, radius=0.1, label="ball")
    model = builder.finalize()
 
-   sensor = SensorContact(model, sensing_obj_shapes="ball")
+   sensor = SensorContact(model, sensing_shapes="ball")
    contacts = model.contacts()
    print(contacts.force is not None)
 

--- a/docs/concepts/sensors.rst
+++ b/docs/concepts/sensors.rst
@@ -87,7 +87,7 @@ Examples::
    SensorIMU(model, sites="foot_*")
 
    # list of patterns: union of two groups
-   SensorContact(model, sensing_obj_shapes=["*Plate*", "*Flap*"])
+   SensorContact(model, sensing_shapes=["*Plate*", "*Flap*"])
 
    # list of indices: explicit selection
    SensorFrameTransform(model, shapes=[0, 3, 7], reference_sites=[1])

--- a/newton/_src/sensors/sensor_contact.py
+++ b/newton/_src/sensors/sensor_contact.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Literal
+import warnings
+from typing import Any, Literal
 
 import numpy as np
 import warp as wp
@@ -11,15 +12,37 @@ import warp as wp
 from ..sim import Contacts, Model, State
 from ..utils.selection import match_labels
 
-# Object type constants used in the sensing-object transform kernel.
-_OBJ_TYPE_SHAPE = 1
-_OBJ_TYPE_BODY = 2
+_UNSET = object()
+
+_SENSING_KIND_SHAPE = 1
+_SENSING_KIND_BODY = 2
+
+_SENSING_OBJ_IDX_DEPRECATION_MSG = (
+    "SensorContact.sensing_obj_idx is deprecated; use SensorContact.sensing_indices. "
+    "The alias will be removed in a future release."
+)
+_SENSING_OBJ_TYPE_DEPRECATION_MSG = (
+    "SensorContact.sensing_obj_type is deprecated; use SensorContact.sensing_type. "
+    "The alias will be removed in a future release."
+)
+_SENSING_OBJ_TRANSFORMS_DEPRECATION_MSG = (
+    "SensorContact.sensing_obj_transforms is deprecated; use SensorContact.sensing_transforms. "
+    "The alias will be removed in a future release."
+)
+_SENSING_OBJ_BODIES_DEPRECATION_MSG = (
+    "SensorContact(..., sensing_obj_bodies=...) is deprecated; use sensing_bodies=... instead. "
+    "The alias will be removed in a future release."
+)
+_SENSING_OBJ_SHAPES_DEPRECATION_MSG = (
+    "SensorContact(..., sensing_obj_shapes=...) is deprecated; use sensing_shapes=... instead. "
+    "The alias will be removed in a future release."
+)
 
 
 @wp.kernel(enable_backward=False)
-def compute_sensing_obj_transforms_kernel(
+def compute_sensing_transforms_kernel(
     indices: wp.array[wp.int32],
-    obj_types: wp.array[wp.int32],
+    sensing_kinds: wp.array[wp.int32],
     shape_body: wp.array[wp.int32],
     shape_transform: wp.array[wp.transform],
     body_q: wp.array[wp.transform],
@@ -27,16 +50,16 @@ def compute_sensing_obj_transforms_kernel(
     transforms: wp.array[wp.transform],
 ):
     tid = wp.tid()
-    idx = indices[tid]
-    obj_type = obj_types[tid]
-    if obj_type == wp.static(_OBJ_TYPE_BODY):
-        transforms[tid] = body_q[idx]
-    elif obj_type == wp.static(_OBJ_TYPE_SHAPE):
-        body_idx = shape_body[idx]
-        if body_idx >= 0:
-            transforms[tid] = wp.transform_multiply(body_q[body_idx], shape_transform[idx])
+    index = indices[tid]
+    sensing_kind = sensing_kinds[tid]
+    if sensing_kind == wp.static(_SENSING_KIND_BODY):
+        transforms[tid] = body_q[index]
+    elif sensing_kind == wp.static(_SENSING_KIND_SHAPE):
+        body_index = shape_body[index]
+        if body_index >= 0:
+            transforms[tid] = wp.transform_multiply(body_q[body_index], shape_transform[index])
         else:
-            transforms[tid] = shape_transform[idx]
+            transforms[tid] = shape_transform[index]
 
 
 @wp.kernel(enable_backward=False)
@@ -55,17 +78,17 @@ def accumulate_contact_forces_kernel(
     total_force_friction: wp.array[wp.vec3],
 ):
     """Accumulate per-contact forces and friction into total and/or per-counterpart arrays. Parallelizes over contacts."""
-    con_idx = wp.tid()
-    if con_idx >= num_contacts[0]:
+    contact_index = wp.tid()
+    if contact_index >= num_contacts[0]:
         return
 
-    shape0 = contact_shape0[con_idx]
-    shape1 = contact_shape1[con_idx]
+    shape0 = contact_shape0[contact_index]
+    shape1 = contact_shape1[contact_index]
     assert shape0 >= 0 and shape1 >= 0
-    force = wp.spatial_top(contact_force[con_idx])
+    force = wp.spatial_top(contact_force[contact_index])
 
     # Decompose into normal and friction (tangential) components
-    n = contact_normal[con_idx]
+    n = contact_normal[contact_index]
     len_sq = wp.dot(n, n)
     if wp.abs(len_sq - 1.0) > 1.0e-4:
         n = wp.normalize(n)
@@ -125,9 +148,9 @@ def expand_body_to_shape_kernel(
 
 def _check_index_bounds(indices: list[int], count: int, param_name: str, entity_name: str) -> None:
     """Raise IndexError if any index is out of range [0, count)."""
-    for idx in indices:
-        if idx < 0 or idx >= count:
-            raise IndexError(f"{param_name} contains index {idx}, but model only has {count} {entity_name}")
+    for index in indices:
+        if index < 0 or index >= count:
+            raise IndexError(f"{param_name} contains index {index}, but model only has {count} {entity_name}")
 
 
 def _split_globals(indices: list[int], local_start: int, tail_global_start: int):
@@ -183,8 +206,8 @@ def _assign_counterpart_columns(
     """
     col_map = np.full(n_entities, -1, dtype=np.int32)
 
-    for col, idx in enumerate(c_globals):
-        col_map[idx] = col
+    for col, index in enumerate(c_globals):
+        col_map[index] = col
     n_global_cols = len(c_globals)
 
     counterparts_by_world: list[list[int]] = []
@@ -226,9 +249,9 @@ class SensorContact:
 
     When counterparts are specified, the force matrix has shape ``(sum_of_sensors_across_worlds, max_counterparts)``
     where ``max_counterparts`` is the maximum counterpart count of any single world. Row order matches
-    :attr:`sensing_obj_idx`. Columns beyond a world's own counterpart count are zero-padded.
+    :attr:`sensing_indices`. Columns beyond a world's own counterpart count are zero-padded.
 
-    :attr:`sensing_obj_idx` and :attr:`counterpart_indices` are flat lists that describe the structure of the output
+    :attr:`sensing_indices` and :attr:`counterpart_indices` are flat lists that describe the structure of the output
     arrays.
 
     .. rubric:: Terms
@@ -262,7 +285,7 @@ class SensorContact:
             builder.add_shape_sphere(body, radius=0.1, label="ball")
             model = builder.finalize()
 
-            sensor = SensorContact(model, sensing_obj_shapes="ball")
+            sensor = SensorContact(model, sensing_shapes="ball")
             solver = newton.solvers.SolverMuJoCo(model)
             state = model.state()
             contacts = model.contacts()
@@ -270,72 +293,119 @@ class SensorContact:
             solver.step(state, state, None, None, dt=1.0 / 60.0)
             solver.update_contacts(contacts)
             sensor.update(state, contacts)
-            force = sensor.total_force.numpy()  # (n_sensing_objs, 3)
+            force = sensor.total_force.numpy()  # (n_sensing, 3)
 
     Raises:
         ValueError: If the configuration of sensing/counterpart objects is invalid.
     """
 
-    sensing_obj_type: Literal["body", "shape"]
-    """Whether :attr:`sensing_obj_idx` contains body indices (``"body"``) or shape indices (``"shape"``)."""
-
-    sensing_obj_idx: list[int]
+    sensing_indices: list[int]
     """Body or shape index per sensing object, matching the row of output arrays. For ``list[int]`` inputs the caller's
     order is preserved; for string patterns the order follows ascending body/shape index."""
+
+    sensing_type: Literal["body", "shape"]
+    """Whether :attr:`sensing_indices` contains body indices (``"body"``) or shape indices (``"shape"``)."""
+
+    counterpart_indices: list[list[int]]
+    """Counterpart body or shape indices per sensing object. ``counterpart_indices[i]`` lists the counterparts for row
+    ``i``. Global counterparts appear first, followed by per-world locals in ascending index order."""
 
     counterpart_type: Literal["body", "shape"] | None
     """Whether :attr:`counterpart_indices` contains body indices (``"body"``) or shape indices (``"shape"``).
     ``None`` when no counterparts are specified."""
 
-    counterpart_indices: list[list[int]]
-    """Counterpart body or shape indices per sensing object. ``counterpart_indices[i]`` lists the counterparts for row ``i``. Global counterparts appear first, followed by per-world locals in ascending index order."""
-
     total_force: wp.array[wp.vec3] | None
-    """Total contact force [N] per sensing object, shape ``(n_sensing_objs,)``, dtype :class:`vec3`.
+    """Total contact force [N] per sensing object, shape ``(n_sensing,)``, dtype :class:`vec3`.
     ``None`` when ``measure_total=False``."""
 
     force_matrix: wp.array2d[wp.vec3] | None
-    """Per-counterpart contact forces [N], shape ``(n_sensing_objs, max_counterparts)``, dtype :class:`vec3`.
+    """Per-counterpart contact forces [N], shape ``(n_sensing, max_counterparts)``, dtype :class:`vec3`.
     Entry ``[i, j]`` is the force on sensing object ``i`` from counterpart ``counterpart_indices[i][j]``, in world
     frame. ``None`` when no counterparts are specified."""
 
     total_force_friction: wp.array[wp.vec3] | None
-    """Total friction (tangential) contact force [N] per sensing object, shape ``(n_sensing_objs,)``,
+    """Total friction (tangential) contact force [N] per sensing object, shape ``(n_sensing,)``,
     dtype :class:`vec3`. ``None`` when ``measure_total=False``."""
 
     force_matrix_friction: wp.array2d[wp.vec3] | None
-    """Per-counterpart friction (tangential) contact forces [N], shape ``(n_sensing_objs, max_counterparts)``,
+    """Per-counterpart friction (tangential) contact forces [N], shape ``(n_sensing, max_counterparts)``,
     dtype :class:`vec3`. Entry ``[i, j]`` is the friction force on sensing object ``i`` from counterpart
     ``counterpart_indices[i][j]``, in world frame. ``None`` when no counterparts are specified."""
 
-    sensing_obj_transforms: wp.array[wp.transform]
+    sensing_transforms: wp.array[wp.transform]
     """World-frame transforms of sensing objects [m, unitless quaternion],
-    shape ``(n_sensing_objs,)``, dtype :class:`transform`."""
+    shape ``(n_sensing,)``, dtype :class:`transform`."""
+
+    @property
+    def sensing_obj_idx(self) -> list[int]:
+        """Deprecated alias for :attr:`sensing_indices`.
+
+        .. deprecated:: 1.4
+            Use :attr:`sensing_indices` instead.
+        """
+        warnings.warn(_SENSING_OBJ_IDX_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        return self.sensing_indices
+
+    @sensing_obj_idx.setter
+    def sensing_obj_idx(self, value: list[int]) -> None:
+        warnings.warn(_SENSING_OBJ_IDX_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        self.sensing_indices = value
+
+    @property
+    def sensing_obj_type(self) -> Literal["body", "shape"]:
+        """Deprecated alias for :attr:`sensing_type`.
+
+        .. deprecated:: 1.4
+            Use :attr:`sensing_type` instead.
+        """
+        warnings.warn(_SENSING_OBJ_TYPE_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        return self.sensing_type
+
+    @sensing_obj_type.setter
+    def sensing_obj_type(self, value: Literal["body", "shape"]) -> None:
+        warnings.warn(_SENSING_OBJ_TYPE_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        self.sensing_type = value
+
+    @property
+    def sensing_obj_transforms(self) -> wp.array[wp.transform]:
+        """Deprecated alias for :attr:`sensing_transforms`.
+
+        .. deprecated:: 1.4
+            Use :attr:`sensing_transforms` instead.
+        """
+        warnings.warn(_SENSING_OBJ_TRANSFORMS_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        return self.sensing_transforms
+
+    @sensing_obj_transforms.setter
+    def sensing_obj_transforms(self, value: wp.array[wp.transform]) -> None:
+        warnings.warn(_SENSING_OBJ_TRANSFORMS_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+        self.sensing_transforms = value
 
     def __init__(
         self,
         model: Model,
         *,
-        sensing_obj_bodies: str | list[str] | list[int] | None = None,
-        sensing_obj_shapes: str | list[str] | list[int] | None = None,
+        sensing_bodies: str | list[str] | list[int] | None = None,
+        sensing_shapes: str | list[str] | list[int] | None = None,
         counterpart_bodies: str | list[str] | list[int] | None = None,
         counterpart_shapes: str | list[str] | list[int] | None = None,
         measure_total: bool = True,
         verbose: bool | None = None,
         request_contact_attributes: bool = True,
+        **kwargs: Any,
     ):
         """Initialize the SensorContact.
 
-        Exactly one of ``sensing_obj_bodies`` or ``sensing_obj_shapes`` must be specified to define the sensing
-        objects. At most one of ``counterpart_bodies`` or ``counterpart_shapes`` may be specified. If neither is
-        specified, only :attr:`total_force` and :attr:`total_force_friction` are available (no per-counterpart breakdown).
+        Exactly one of ``sensing_bodies`` or ``sensing_shapes`` must be specified to define the sensing objects. At most
+        one of ``counterpart_bodies`` or ``counterpart_shapes`` may be specified. If neither is specified, only
+        :attr:`total_force` and :attr:`total_force_friction` are available (no per-counterpart breakdown).
 
         Args:
             model: The simulation model providing shape/body definitions and world layout.
-            sensing_obj_bodies: List of body indices, single pattern to match
-                against body labels, or list of patterns where any one matches.
-            sensing_obj_shapes: List of shape indices, single pattern to match
-                against shape labels, or list of patterns where any one matches.
+            sensing_bodies: List of body indices, single pattern to match against body labels, or list of patterns where
+                any one matches.
+            sensing_shapes: List of shape indices, single pattern to match against shape labels, or list of patterns
+                where any one matches.
             counterpart_bodies: List of body indices, single pattern to match
                 against body labels, or list of patterns where any one matches.
             counterpart_shapes: List of shape indices, single pattern to match
@@ -347,8 +417,28 @@ class SensorContact:
             request_contact_attributes: If True (default), transparently request the extended contact attribute
                 ``force`` from the model.
         """
-        if (sensing_obj_bodies is None) == (sensing_obj_shapes is None):
-            raise ValueError("Exactly one of `sensing_obj_bodies` and `sensing_obj_shapes` must be specified")
+        deprecated_sensing_bodies = kwargs.pop("sensing_obj_bodies", _UNSET)
+        if deprecated_sensing_bodies is not _UNSET:
+            warnings.warn(_SENSING_OBJ_BODIES_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if sensing_bodies is not None and deprecated_sensing_bodies is not None:
+                raise TypeError("Specify only one of `sensing_bodies` and deprecated `sensing_obj_bodies`.")
+            if deprecated_sensing_bodies is not None:
+                sensing_bodies = deprecated_sensing_bodies
+
+        deprecated_sensing_shapes = kwargs.pop("sensing_obj_shapes", _UNSET)
+        if deprecated_sensing_shapes is not _UNSET:
+            warnings.warn(_SENSING_OBJ_SHAPES_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if sensing_shapes is not None and deprecated_sensing_shapes is not None:
+                raise TypeError("Specify only one of `sensing_shapes` and deprecated `sensing_obj_shapes`.")
+            if deprecated_sensing_shapes is not None:
+                sensing_shapes = deprecated_sensing_shapes
+
+        if kwargs:
+            unexpected = next(iter(kwargs))
+            raise TypeError(f"SensorContact.__init__() got an unexpected keyword argument '{unexpected}'")
+
+        if (sensing_bodies is None) == (sensing_shapes is None):
+            raise ValueError("Exactly one of `sensing_bodies` and `sensing_shapes` must be specified")
 
         if (counterpart_bodies is not None) and (counterpart_shapes is not None):
             raise ValueError("At most one of `counterpart_bodies` and `counterpart_shapes` may be specified.")
@@ -360,14 +450,14 @@ class SensorContact:
         if request_contact_attributes:
             model.request_contact_attributes("force")
 
-        if sensing_obj_bodies is not None:
-            s_bodies = match_labels(model.body_label, sensing_obj_bodies)
-            _check_index_bounds(s_bodies, len(model.body_label), "sensing_obj_bodies", "bodies")
+        if sensing_bodies is not None:
+            s_bodies = match_labels(model.body_label, sensing_bodies)
+            _check_index_bounds(s_bodies, len(model.body_label), "sensing_bodies", "bodies")
             s_shapes = []
         else:
             s_bodies = []
-            s_shapes = match_labels(model.shape_label, sensing_obj_shapes)
-            _check_index_bounds(s_shapes, len(model.shape_label), "sensing_obj_shapes", "shapes")
+            s_shapes = match_labels(model.shape_label, sensing_shapes)
+            _check_index_bounds(s_shapes, len(model.shape_label), "sensing_shapes", "shapes")
 
         using_counterparts = True
         if counterpart_bodies is not None:
@@ -385,8 +475,8 @@ class SensorContact:
 
         world_count = model.world_count
 
-        # Determine whether sensing objects and counterparts are body-level or shape-level.
-        sensing_is_body = sensing_obj_bodies is not None
+        # Determine whether sensing and counterparts are body-level or shape-level.
+        sensing_is_body = sensing_bodies is not None
         counterpart_is_body = counterpart_bodies is not None
         sensing_indices = s_bodies if sensing_is_body else s_shapes
         counterpart_indices = c_bodies if counterpart_is_body else c_shapes
@@ -400,7 +490,7 @@ class SensorContact:
 
         sensing_indices_ordered = list(sensing_indices)  # preserve user's original order
         sensing_indices = _ensure_sorted_unique(
-            sensing_indices, "sensing_obj_bodies" if sensing_is_body else "sensing_obj_shapes"
+            sensing_indices, "sensing_bodies" if sensing_is_body else "sensing_shapes"
         )
         counterpart_indices = _ensure_sorted_unique(
             counterpart_indices, "counterpart_bodies" if counterpart_is_body else "counterpart_shapes"
@@ -491,9 +581,9 @@ class SensorContact:
             self.force_matrix = None
             self.force_matrix_friction = None
 
-        self.sensing_obj_type = "body" if sensing_is_body else "shape"
+        self.sensing_type = "body" if sensing_is_body else "shape"
         self.counterpart_type = "body" if counterpart_is_body else ("shape" if counterpart_indices else None)
-        self.sensing_obj_idx = sensing_indices_ordered
+        self.sensing_indices = sensing_indices_ordered
 
         # Map each sensing object to its world's counterpart list.
         world_starts = np.array(sensing_world_start[:world_count])
@@ -502,7 +592,7 @@ class SensorContact:
 
         if self.verbose:
             print("SensorContact initialized:")
-            print(f"  Sensing objects: {n_rows} ({self.sensing_obj_type}s)")
+            print(f"  Sensing objects: {n_rows} ({self.sensing_type}s)")
             print(
                 f"  Counterpart columns: {max_readings}"
                 + (f" ({self.counterpart_type}s)" if self.counterpart_type else "")
@@ -513,10 +603,10 @@ class SensorContact:
             )
 
         self._model = model
-        self._sensing_obj_indices = wp.array(sensing_indices_ordered, dtype=wp.int32, device=self.device)
-        obj_type = _OBJ_TYPE_BODY if sensing_is_body else _OBJ_TYPE_SHAPE
-        self._sensing_obj_types = wp.full(n_rows, obj_type, dtype=wp.int32, device=self.device)
-        self.sensing_obj_transforms = wp.zeros(n_rows, dtype=wp.transform, device=self.device)
+        self._sensing_indices = wp.array(sensing_indices_ordered, dtype=wp.int32, device=self.device)
+        sensing_kind = _SENSING_KIND_BODY if sensing_is_body else _SENSING_KIND_SHAPE
+        self._sensing_kinds = wp.full(n_rows, sensing_kind, dtype=wp.int32, device=self.device)
+        self.sensing_transforms = wp.zeros(n_rows, dtype=wp.transform, device=self.device)
 
     def update(self, state: State | None, contacts: Contacts):
         """Update the contact sensor readings based on the provided state and contacts.
@@ -533,20 +623,20 @@ class SensorContact:
             ValueError: If ``contacts.force`` is None.
             ValueError: If ``contacts.device`` does not match the sensor's device.
         """
-        # update sensing object transforms
-        n = len(self._sensing_obj_indices)
+        # update sensing transforms
+        n = len(self._sensing_indices)
         if n > 0 and state is not None and state.body_q is not None:
             wp.launch(
-                compute_sensing_obj_transforms_kernel,
+                compute_sensing_transforms_kernel,
                 dim=n,
                 inputs=[
-                    self._sensing_obj_indices,
-                    self._sensing_obj_types,
+                    self._sensing_indices,
+                    self._sensing_kinds,
                     self._model.shape_body,
                     self._model.shape_transform,
                     state.body_q,
                 ],
-                outputs=[self.sensing_obj_transforms],
+                outputs=[self.sensing_transforms],
                 device=self.device,
             )
 

--- a/newton/examples/sensors/example_sensor_contact.py
+++ b/newton/examples/sensors/example_sensor_contact.py
@@ -47,7 +47,7 @@ class Example:
         # finalize model
         self.model = builder.finalize()
 
-        self.flap_contact_sensor = SensorContact(self.model, sensing_obj_shapes="*Flap", verbose=True)
+        self.flap_contact_sensor = SensorContact(self.model, sensing_shapes="*Flap", verbose=True)
 
         # String patterns return matches in ascending shape index order.
         # Plate1 has a lower index than Plate2 (added first), so row 0 → Plate1, row 1 → Plate2.
@@ -55,7 +55,7 @@ class Example:
         counterpart_labels = ["*Cube*", "*Sphere*"]
         self.plate_contact_sensor = SensorContact(
             self.model,
-            sensing_obj_shapes=plate_labels,
+            sensing_shapes=plate_labels,
             counterpart_shapes=counterpart_labels,
             measure_total=False,
             verbose=True,
@@ -150,7 +150,7 @@ class Example:
                 continue
             if np.abs(net_force[i, self.counterpart_col[i]]).max() == 0:
                 continue
-            plate_shape = self.plate_contact_sensor.sensing_obj_idx[i]
+            plate_shape = self.plate_contact_sensor.sensing_indices[i]
             counterpart_shape = self.plate_contact_sensor.counterpart_indices[i][self.counterpart_col[i]]
             self.plates_touched[i] = True
             plate_label = self.model.shape_label[plate_shape]
@@ -207,9 +207,9 @@ class Example:
         )
         assert len(find_nonfinite_members(self.flap_contact_sensor)) == 0
         assert len(find_nonfinite_members(self.plate_contact_sensor)) == 0
-        # sensing_obj_idx preserves the input order given to the sensor.
-        assert self.model.shape_label[self.plate_contact_sensor.sensing_obj_idx[0]] == "/env/Plate1"
-        assert self.model.shape_label[self.plate_contact_sensor.sensing_obj_idx[1]] == "/env/Plate2"
+        # sensing_indices preserves the input order given to the sensor.
+        assert self.model.shape_label[self.plate_contact_sensor.sensing_indices[0]] == "/env/Plate1"
+        assert self.model.shape_label[self.plate_contact_sensor.sensing_indices[1]] == "/env/Plate2"
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -82,7 +82,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body=-1, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        contact_sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="*")
+        contact_sensor = SensorContact(model, sensing_bodies="*", counterpart_bodies="*")
 
         test_contacts = [
             {"pair": (0, 2), "normal": [0.0, 0.0, -1.0], "force": 1.0},
@@ -171,7 +171,7 @@ class TestSensorContact(unittest.TestCase):
                 assert_np_equal(total_forces[0], scenario["force_on_A_from_all"])
                 assert_np_equal(total_forces[1], scenario["force_on_B_from_all"])
 
-    def test_sensing_obj_transforms(self):
+    def test_sensing_transforms(self):
         """Test that sensing object transforms are computed correctly."""
         device = wp.get_device()
 
@@ -182,7 +182,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(1, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         body_pos_a = wp.vec3(1.0, 2.0, 3.0)
         body_pos_b = wp.vec3(4.0, 5.0, 6.0)
@@ -197,11 +197,11 @@ class TestSensorContact(unittest.TestCase):
         contacts = create_contacts(device, [], naconmax=1)
         sensor.update(state, contacts)
 
-        transforms = sensor.sensing_obj_transforms.numpy()
+        transforms = sensor.sensing_transforms.numpy()
         assert_np_equal(transforms[0][:3], [1.0, 2.0, 3.0])
         assert_np_equal(transforms[1][:3], [4.0, 5.0, 6.0])
 
-    def test_sensing_obj_transforms_shapes(self):
+    def test_sensing_transforms_shapes(self):
         """Test transforms for shape-type sensing objects, including ground shapes."""
         device = wp.get_device()
 
@@ -213,7 +213,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body=-1, xform=shape1_xform, hx=0.1, hy=0.1, hz=0.1, label="ground")
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_shapes="*")
+        sensor = SensorContact(model, sensing_shapes="*")
 
         body_pos = wp.vec3(1.0, 2.0, 3.0)
         body_q = wp.array(
@@ -226,19 +226,19 @@ class TestSensorContact(unittest.TestCase):
         contacts = create_contacts(device, [], naconmax=1)
         sensor.update(state, contacts)
 
-        transforms = sensor.sensing_obj_transforms.numpy()
+        transforms = sensor.sensing_transforms.numpy()
         # shape on a body: body_q * shape_transform -> (1+0.5, 2+0.25, 3+0.125)
         assert_np_equal(transforms[0][:3], [1.5, 2.25, 3.125])
-        # ground shape (body_idx == -1): shape_transform only -> (10, 20, 30)
+        # ground shape (body index == -1): shape_transform only -> (10, 20, 30)
         assert_np_equal(transforms[1][:3], [10.0, 20.0, 30.0])
 
     def test_per_world_attributes(self):
-        """sensing_obj_idx and counterpart_indices are flat lists."""
+        """sensing_indices and counterpart_indices are flat lists."""
         model = _make_two_world_model()
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
-        self.assertEqual(sensor.sensing_obj_idx, [0, 1])
+        self.assertEqual(sensor.sensing_indices, [0, 1])
         self.assertEqual(len(sensor.counterpart_indices), 2)
         # No explicit counterparts — each row has an empty counterpart list
         self.assertEqual(sensor.counterpart_indices[0], [])
@@ -248,7 +248,7 @@ class TestSensorContact(unittest.TestCase):
         """Per-world construction produces no cross-world counterpart columns."""
         model = _make_two_world_model(include_ground=True)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="*")
+        sensor = SensorContact(model, sensing_bodies="*", counterpart_shapes="*")
 
         counterpart_col = sensor._counterpart_shape_to_col.numpy()
         # Ground (shape 2, global) should have a counterpart column
@@ -268,7 +268,7 @@ class TestSensorContact(unittest.TestCase):
         device = wp.get_device()
         model = _make_two_world_model(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[3.0])
         sensor.update(None, contacts)
@@ -291,14 +291,14 @@ class TestSensorContact(unittest.TestCase):
         model = builder.finalize()
 
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_shapes="*")  # "*" matches ground too
+            SensorContact(model, sensing_shapes="*")  # "*" matches ground too
 
     def test_order_preservation(self):
         """Sensing objects preserve caller's order for list[int] inputs."""
         model = _make_two_world_model()
         # Pass indices in reverse order: [1, 0]
-        sensor = SensorContact(model, sensing_obj_bodies=[1, 0])
-        self.assertEqual(sensor.sensing_obj_idx, [1, 0])
+        sensor = SensorContact(model, sensing_bodies=[1, 0])
+        self.assertEqual(sensor.sensing_indices, [1, 0])
 
         contacts = create_contacts(model.device, [(0, 1)], naconmax=4, forces=[3.0])
         sensor.update(None, contacts)
@@ -307,10 +307,39 @@ class TestSensorContact(unittest.TestCase):
         np.testing.assert_allclose(total[0], [0, 0, -3.0], atol=1e-5)
         np.testing.assert_allclose(total[1], [0, 0, 3.0], atol=1e-5)
 
+    def test_deprecated_sensing_object_aliases(self):
+        """Deprecated sensing object aliases warn and return the new attributes."""
+        model = _make_two_world_model()
+        sensor = SensorContact(model, sensing_bodies=[1, 0])
+
+        with self.assertWarnsRegex(DeprecationWarning, "sensing_indices"):
+            legacy_indices = sensor.sensing_obj_idx
+        self.assertIs(legacy_indices, sensor.sensing_indices)
+
+        with self.assertWarnsRegex(DeprecationWarning, "sensing_type"):
+            legacy_type = sensor.sensing_obj_type
+        self.assertEqual(legacy_type, sensor.sensing_type)
+
+        with self.assertWarnsRegex(DeprecationWarning, "sensing_transforms"):
+            legacy_transforms = sensor.sensing_obj_transforms
+        self.assertIs(legacy_transforms, sensor.sensing_transforms)
+
+    def test_deprecated_sensing_constructor_aliases(self):
+        """Deprecated sensing constructor keywords warn and map to the new keywords."""
+        model = _make_two_world_model()
+
+        with self.assertWarnsRegex(DeprecationWarning, "sensing_bodies"):
+            body_sensor = SensorContact(model, sensing_obj_bodies=[1, 0])
+        self.assertEqual(body_sensor.sensing_indices, [1, 0])
+
+        with self.assertWarnsRegex(DeprecationWarning, "sensing_shapes"):
+            shape_sensor = SensorContact(model, sensing_obj_shapes=["s0"])
+        self.assertEqual(shape_sensor.sensing_indices, [0])
+
     def test_measure_total_false(self):
         """measure_total=False produces total_force=None and populates force_matrix."""
         model = _make_two_world_model(include_ground=True)
-        sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="*", measure_total=False)
+        sensor = SensorContact(model, sensing_bodies="*", counterpart_shapes="*", measure_total=False)
         self.assertIsNone(sensor.total_force)
 
         contacts = create_contacts(model.device, [(0, 2)], naconmax=4, forces=[5.0])
@@ -324,19 +353,19 @@ class TestSensorContact(unittest.TestCase):
         """Duplicate sensing object indices raise ValueError."""
         model = _make_two_world_model()
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_bodies=[0, 0])
+            SensorContact(model, sensing_bodies=[0, 0])
 
     def test_unmatched_pattern_raises(self):
         """Sensing or counterpart patterns that match nothing raise ValueError."""
         model = _make_two_world_model()
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_bodies="nonexistent")
+            SensorContact(model, sensing_bodies="nonexistent")
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_shapes="nonexistent")
+            SensorContact(model, sensing_shapes="nonexistent")
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="nonexistent")
+            SensorContact(model, sensing_bodies="*", counterpart_bodies="nonexistent")
         with self.assertRaises(ValueError):
-            SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="nonexistent")
+            SensorContact(model, sensing_bodies="*", counterpart_shapes="nonexistent")
 
     def test_global_counterpart_in_all_worlds(self):
         """Global counterparts (e.g., ground) appear in every sensing object's counterpart list."""
@@ -344,14 +373,14 @@ class TestSensorContact(unittest.TestCase):
 
         sensor = SensorContact(
             model,
-            sensing_obj_bodies="*",
+            sensing_bodies="*",
             counterpart_shapes=["ground"],
             measure_total=False,
         )
 
         # Both sensing objects should have the ground as a counterpart
         for i in range(2):
-            self.assertIn(2, sensor.counterpart_indices[i], f"Sensing obj {i} missing ground counterpart")
+            self.assertIn(2, sensor.counterpart_indices[i], f"Sensing row {i} missing ground counterpart")
 
     def test_friction_force_orthogonal_to_normal(self):
         """Friction force is orthogonal to the contact normal."""
@@ -364,7 +393,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body_b, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         # Force has normal component (z) and tangential component (x)
         # Normal is [0,0,1], force spatial vector is (3, 0, 5, 0, 0, 0)
@@ -405,7 +434,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body=-1, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         # Contact 0: shape0=0(A), shape1=1(B), normal=[0,0,1], force=(1,2,3)
         #   normal_comp = dot((1,2,3),(0,0,1))*(0,0,1) = (0,0,3)
@@ -454,7 +483,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body_b, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*", counterpart_bodies="*")
 
         # Force with tangential component: normal=[0,0,1], force=(2, 3, 7, 0, 0, 0)
         contacts = newton.Contacts(4, 0, device=device, requested_attributes={"force"})
@@ -484,14 +513,14 @@ class TestSensorContact(unittest.TestCase):
     def test_friction_force_measure_total_false(self):
         """measure_total=False produces total_force_friction=None."""
         model = _make_two_world_model(include_ground=True)
-        sensor = SensorContact(model, sensing_obj_bodies="*", counterpart_shapes="*", measure_total=False)
+        sensor = SensorContact(model, sensing_bodies="*", counterpart_shapes="*", measure_total=False)
         self.assertIsNone(sensor.total_force_friction)
         self.assertIsNotNone(sensor.force_matrix_friction)
 
     def test_friction_force_no_counterparts(self):
         """No counterparts produces force_matrix_friction=None."""
         model = _make_two_world_model()
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
         self.assertIsNone(sensor.force_matrix_friction)
         self.assertIsNotNone(sensor.total_force_friction)
 
@@ -500,7 +529,7 @@ class TestSensorContact(unittest.TestCase):
         device = wp.get_device()
         model = _make_two_world_model(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         # create_contacts builds force = magnitude * normal, so purely normal
         contacts = create_contacts(device, [(0, 1)], naconmax=4, forces=[5.0])
@@ -521,7 +550,7 @@ class TestSensorContact(unittest.TestCase):
         builder.add_shape_box(body_b, hx=0.1, hy=0.1, hz=0.1)
         model = builder.finalize(device=device)
 
-        sensor = SensorContact(model, sensing_obj_bodies="*")
+        sensor = SensorContact(model, sensing_bodies="*")
 
         # 30-degree incline normal: n = (0, -sin(30), cos(30)) = (0, -0.5, sqrt(3)/2)
         s30 = 0.5
@@ -578,7 +607,7 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         except ImportError as e:
             self.skipTest(f"MuJoCo not available: {e}")
 
-        sensor = SensorContact(model, sensing_obj_bodies=["a", "b"])
+        sensor = SensorContact(model, sensing_bodies=["a", "b"])
         contacts = newton.Contacts(
             solver.get_max_contact_count(),
             0,
@@ -646,7 +675,7 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         except ImportError as e:
             self.skipTest(f"MuJoCo not available: {e}")
 
-        sensor = SensorContact(model, sensing_obj_bodies=["a"])
+        sensor = SensorContact(model, sensing_bodies=["a"])
         contacts = newton.Contacts(
             solver.get_max_contact_count(),
             0,
@@ -703,8 +732,8 @@ class TestSensorContactMuJoCo(unittest.TestCase):
         except ImportError as e:
             self.skipTest(f"MuJoCo not available: {e}")
 
-        sensor_abc = SensorContact(model, sensing_obj_bodies=["a", "b", "c"])
-        sensor_base = SensorContact(model, sensing_obj_shapes=["base"])
+        sensor_abc = SensorContact(model, sensing_bodies=["a", "b", "c"])
+        sensor_base = SensorContact(model, sensing_shapes=["base"])
         contacts = newton.Contacts(
             solver.get_max_contact_count(),
             0,


### PR DESCRIPTION
## Description

Rename the `SensorContact` sensing-object API to use shorter public names:

- `sensing_obj_bodies` -> `sensing_bodies`
- `sensing_obj_shapes` -> `sensing_shapes`
- `sensing_obj_idx` -> `sensing_indices`
- `sensing_obj_type` -> `sensing_type`
- `sensing_obj_transforms` -> `sensing_transforms`

The released `sensing_obj*` spellings remain as deprecated warning aliases for compatibility. Docs, examples, tests, and the ASV benchmark now use the new names.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run docs/generate_api.py
uv run --extra dev -m newton.tests -k test_sensor_contact
uvx pre-commit run -a
```

## New feature / API change

```python
from newton.sensors import SensorContact

sensor = SensorContact(model, sensing_shapes="ball")
print(sensor.sensing_indices)
print(sensor.sensing_type)
print(sensor.sensing_transforms)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Renamed `SensorContact` API fields for improved clarity: `sensing_obj_idx` → `sensing_indices`, `sensing_obj_type` → `sensing_type`, `sensing_obj_transforms` → `sensing_transforms`, `sensing_obj_bodies` → `sensing_bodies`, `sensing_obj_shapes` → `sensing_shapes`. Old names retained as deprecated aliases.

* **Removed**
  * Deprecated `SensorContact` fields: `sensing_objs`, `counterparts`, `shape`, and `ObjectType` enum. Migration guidance provided in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->