### PR TITLE
Handle jointless-articulation warnings in USD tests

### DIFF
--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 import math
 import os
 import tempfile
@@ -23,6 +24,46 @@ from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import USD_AVAILABLE, assert_np_equal, get_test_devices
 
 devices = get_test_devices()
+
+
+_INVALID_ARTICULATION_DESC = "Warning: Invalid ArticulationDesc descriptor"
+
+
+def _expect_jointless_articulation_warning(test):
+    """Require the benign jointless-articulation warning on OpenUSD < 26.0.
+
+    ``UsdPhysics.LoadUsdPhysicsFromRange`` in OpenUSD < 26.0 (e.g. the
+    ``usd-exchange`` build resolved on ``aarch64``) reports an articulation root
+    that has no joints as an invalid ``ArticulationDesc``, which
+    :func:`~newton.utils.parse_usd` surfaces as a ``UserWarning``; usd-core
+    >= 26.0 treats it as valid. The fixtures wrapped here intentionally import
+    single-body (jointless) articulations -- a shape Newton parses identically
+    either way. On the USD versions that emit it, assert exactly that warning
+    while leaving every other warning subject to the ambient policy, so an
+    unexpected ``newton.*`` warning here still fails under ``--strict-warnings``.
+    """
+
+    @functools.wraps(test)
+    def wrapper(self, *args, **kwargs):
+        from pxr import Usd
+
+        if Usd.GetVersion() >= (0, 26, 0):
+            return test(self, *args, **kwargs)
+        with warnings.catch_warnings(record=True) as caught:
+            # Record (do not escalate) only the expected warning; the inherited
+            # "error" filter still applies to everything else under strict mode.
+            warnings.filterwarnings("always", message=_INVALID_ARTICULATION_DESC, category=UserWarning)
+            result = test(self, *args, **kwargs)
+        self.assertTrue(
+            any(
+                issubclass(w.category, UserWarning) and str(w.message).startswith(_INVALID_ARTICULATION_DESC)
+                for w in caught
+            ),
+            f"expected a {_INVALID_ARTICULATION_DESC!r} warning on OpenUSD < 26.0",
+        )
+        return result
+
+    return wrapper
 
 
 class TestImportUsdArticulation(unittest.TestCase):
@@ -456,6 +497,7 @@ def Xform "Root" (
         self.assertIn("/World/RevJoint2", builder.joint_label)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_import_articulation_parent_offset(self):
         from pxr import Usd
 
@@ -4914,9 +4956,7 @@ def Xform "World"
         float mjc:option:impratio = 99.0
     }
 
-    def Xform "Articulation" (
-        prepend apiSchemas = ["PhysicsArticulationRootAPI"]
-    )
+    def Xform "Articulation"
     {
         def Xform "Body1" (
             prepend apiSchemas = ["PhysicsRigidBodyAPI"]
@@ -5123,9 +5163,8 @@ def Xform "Articulation" (
         material_prim.GetAttribute("newton:torsionalFriction").Set(0.15)
         material_prim.GetAttribute("newton:rollingFriction").Set(0.08)
 
-        # Create an articulation with a body and collider
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        # Create a free-floating body with a collider (no joints, so no articulation)
+        UsdGeom.Xform.Define(stage, "/Articulation")
 
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         body_prim = body.GetPrim()
@@ -5787,8 +5826,7 @@ def Xform "Articulation" (
         UsdGeom.SetStageMetersPerUnit(stage, 1.0)
         UsdPhysics.Scene.Define(stage, "/physicsScene")
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -5824,8 +5862,7 @@ def Xform "Articulation" (
         UsdGeom.SetStageMetersPerUnit(stage, 1.0)
         UsdPhysics.Scene.Define(stage, "/physicsScene")
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -5879,8 +5916,7 @@ def Xform "Articulation" (
         mat_partial_prim.GetAttribute("newton:contactStiffness").Set(3000.0)
         mat_partial_prim.GetAttribute("newton:contactDamping").Set(150.0)
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -5946,8 +5982,7 @@ def Xform "Articulation" (
         mat_prim.GetAttribute("newton:contactFrictionGain").Set(float("-inf"))
         mat_prim.GetAttribute("newton:contactAdhesion").Set(float("-inf"))
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -5992,8 +6027,7 @@ def Xform "Articulation" (
         mat_authored_prim.GetAttribute("newton:contactFrictionGain").Set(600.0)
         mat_authored_prim.GetAttribute("newton:contactAdhesion").Set(0.02)
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -6019,7 +6053,10 @@ def Xform "Articulation" (
 
         builder = newton.ModelBuilder()
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            # Record only the deprecation warnings this test asserts on; leave every
+            # other warning subject to the ambient policy so --strict-warnings still
+            # fails on an unexpected newton.* warning here.
+            warnings.filterwarnings("always", category=DeprecationWarning)
             result = builder.add_usd(stage)
             dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
             dep_msgs = [str(x.message) for x in dep_warnings]
@@ -6041,15 +6078,22 @@ def Xform "Articulation" (
         self.assertAlmostEqual(model.shape_material_kf.numpy()[idx_both], 600.0, places=1)
         self.assertAlmostEqual(model.shape_material_ka.numpy()[idx_both], 0.02, places=4)
 
-        # Deprecation warnings from both shapes (legacy attrs always emit migration signal)
-        ke_warnings = [m for m in dep_msgs if "newton:contact_ke" in m]
-        kd_warnings = [m for m in dep_msgs if "newton:contact_kd" in m]
-        kf_warnings = [m for m in dep_msgs if "newton:contact_kf" in m]
-        ka_warnings = [m for m in dep_msgs if "newton:contact_ka" in m]
-        self.assertEqual(len(ke_warnings), 2)
-        self.assertEqual(len(kd_warnings), 2)
-        self.assertEqual(len(kf_warnings), 2)
-        self.assertEqual(len(ka_warnings), 2)
+        # Each legacy attr emits an exact migration message naming its replacement;
+        # both shapes author all four, so each message must appear exactly twice.
+        legacy_to_material = {
+            "newton:contact_ke": "newton:contactStiffness",
+            "newton:contact_kd": "newton:contactDamping",
+            "newton:contact_kf": "newton:contactFrictionGain",
+            "newton:contact_ka": "newton:contactAdhesion",
+        }
+        for legacy_attr, material_attr in legacy_to_material.items():
+            expected_msg = (
+                f"'{legacy_attr}' on shape prim is deprecated; "
+                f"author '{material_attr}' on the bound NewtonMaterialAPI material instead."
+            )
+            self.assertEqual(
+                dep_msgs.count(expected_msg), 2, f"expected exactly two {legacy_attr!r} deprecation warnings"
+            )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_contact_response_solref_over_material(self):
@@ -6070,8 +6114,7 @@ def Xform "Articulation" (
         mat_prim.GetAttribute("newton:contactStiffness").Set(4000.0)
         mat_prim.GetAttribute("newton:contactDamping").Set(100.0)
 
-        articulation = UsdGeom.Xform.Define(stage, "/Articulation")
-        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+        UsdGeom.Xform.Define(stage, "/Articulation")
         body = UsdGeom.Xform.Define(stage, "/Articulation/Body")
         UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
 
@@ -7365,6 +7408,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertTrue(quat_match, f"Body orientation should include import xform. Got {actual_quat}")
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_parent_body_attaches_to_existing_body(self):
         """Test that parent_body attaches the USD root to an existing body."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7442,6 +7486,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertEqual(robot_articulation, gripper_articulation)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_parent_body_with_base_joint_creates_d6(self):
         """Test that parent_body with base_joint creates a D6 joint to parent."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7494,6 +7539,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertEqual(model.joint_parent.numpy()[1], robot_body_idx)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_parent_body_creates_joint_to_parent(self):
         """Test that parent_body creates a joint connecting to the parent body."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7540,6 +7586,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertEqual(joint_articulation[0], joint_articulation[initial_joint_count])
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_floating_true_with_parent_body_raises_error(self):
         """Test that floating=True with parent_body raises an error."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7580,6 +7627,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertIn("parent_body", str(cm.exception))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_floating_false_with_parent_body_succeeds(self):
         """Test that floating=False with parent_body is explicitly allowed."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7622,6 +7670,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertEqual(len(model.articulation_start.numpy()) - 1, 1)  # Single articulation
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_non_sequential_articulation_attachment(self):
         """Test that attaching to a non-sequential articulation raises an error."""
         from pxr import Usd, UsdGeom, UsdPhysics
@@ -7684,6 +7733,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertIn("not part of any articulation", str(cm.exception))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    @_expect_jointless_articulation_warning
     def test_three_level_hierarchical_composition(self):
         """Test attaching multiple levels: arm → gripper → sensor."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics


### PR DESCRIPTION
## Description

`test_import_usd` has several fixtures that intentionally import single-body (jointless) articulations. OpenUSD < 26.0 — the `usd-exchange` build resolved on `aarch64` — reports an articulation root with no joints as an invalid `ArticulationDesc`, so `parse_usd` emits a `UserWarning`; usd-core >= 26.0 (every other platform) treats it as valid. Newton imports the body identically either way, so these tests pass today, but they fail on `aarch64` only once the suite escalates `newton.*` warnings to errors (the upcoming `--strict-warnings` mode in #3044).

Changes:

- Drop the unnecessary `ArticulationRootAPI` from the parsing fixtures that only used it as scaffolding around a single body (material / contact response / gap / margin / solref / mujoco-options). They do not test articulations.
- For the composition and parent-offset fixtures, where the articulation is the behavior under test, assert exactly the expected warning on OpenUSD < 26.0 (scoped by `Usd.GetVersion()`), while leaving every other warning subject to the ambient policy so an unexpected `newton.*` warning still fails under strict mode.
- Tighten `test_contact_response_legacy_shape_fallback`: replace the blanket `simplefilter("always")`, which masked every warning, with a `DeprecationWarning`-scoped filter, and exact-match the per-attribute migration messages instead of substring-matching.

This is preparatory cleanup with no behavior change on `main` (the warning is non-fatal without `--strict-warnings`), so #3044 can go green on `aarch64`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — not applicable, test-only

## Test plan

Verified on both USD builds by simulating #3044's strict filters (`filterwarnings("error", category=DeprecationWarning)` and `filterwarnings("error", module=r"newton(\.|$)")`): on usd-core 26.0+ the affected tests pass and the `_expect_*` decorator is a no-op; on the usd-exchange (OpenUSD 25.5) build the parsing fixtures emit no warning, the decorated fixtures record and assert exactly the expected warning, and an unrelated warning still escalates.

```
uv run --extra dev -m newton.tests -k SampleAssets
uv run --extra dev -m newton.tests -k test_import_articulation_parent_offset
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to handle OpenUSD version compatibility warnings (versions older than 26.0).
  * Refactored physics articulation tests to properly manage deprecation warnings with stricter validation.
  * Added helper mechanisms for version-specific warning handling in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->