### PR TITLE
Renamed SensorTiledCameraBenchmark to FastSensorTiledCamera so it gets picked up by CI ASV runs

### DIFF
--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -10,6 +10,7 @@ wp.config.log_level = wp.LOG_WARNING
 import math
 
 import newton
+from newton import ShapeFlags
 from newton.sensors import SensorTiledCamera
 
 NICE_NAMES = {}
@@ -46,6 +47,9 @@ class FastSensorTiledCamera:
             newton.utils.download_asset("franka_emika_panda") / "urdf/fr3_franka_hand.urdf",
             floating=False,
         )
+        COLLIDE = int(ShapeFlags.COLLIDE_SHAPES) | int(ShapeFlags.COLLIDE_PARTICLES)
+        franka.shape_flags = [int(f) & ~COLLIDE for f in franka.shape_flags]
+        franka.shape_collision_filter_pairs = []
 
         scene = newton.ModelBuilder()
         scene.replicate(franka, world_count)

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -8,12 +8,23 @@ wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
 import math
+import os
 
 import newton
 from newton import ShapeFlags
 from newton.sensors import SensorTiledCamera
 
 NICE_NAMES = {}
+ASV_RUN_TILED_CAMERA_BENCHMARKS_ENV_VAR = "NEWTON_RUN_TILED_CAMERA_BENCHMARKS"
+TILED_BENCHMARK_METHODS = {
+    "time_rendering_tiled_color_depth",
+    "time_rendering_tiled_color_only",
+    "time_rendering_tiled_depth_only",
+}
+
+
+def run_tiled_camera_benchmarks():
+    return os.environ.get(ASV_RUN_TILED_CAMERA_BENCHMARKS_ENV_VAR, "").lower() in {"1", "true", "yes", "on"}
 
 
 def nice_name(value):
@@ -38,6 +49,12 @@ def nice_name_collector():
 class FastSensorTiledCamera:
     param_names = ["resolution", "world_count", "iterations"]
     params = ([64], [4096], [50])
+
+    def __dir__(self):
+        names = super().__dir__()
+        if run_tiled_camera_benchmarks():
+            return names
+        return [name for name in names if name not in TILED_BENCHMARK_METHODS]
 
     def setup(self, resolution: int, world_count: int, iterations: int):
         self.device = wp.get_preferred_device()
@@ -87,18 +104,19 @@ class FastSensorTiledCamera:
         self.tiled_camera_sensor.sync_transforms(self.state)
 
         # Warmup Kernels
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
-        self.tiled_camera_sensor.render_config.tile_width = 8
-        self.tiled_camera_sensor.render_config.tile_height = 8
-        for out_color, out_depth in [(True, True), (True, False), (False, True)]:
-            for _ in range(iterations):
-                self.tiled_camera_sensor.update(
-                    self.state,
-                    self.camera_transforms,
-                    self.camera_rays,
-                    color_image=self.color_image if out_color else None,
-                    depth_image=self.depth_image if out_depth else None,
-                )
+        if run_tiled_camera_benchmarks():
+            self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
+            self.tiled_camera_sensor.render_config.tile_width = 8
+            self.tiled_camera_sensor.render_config.tile_height = 8
+            for out_color, out_depth in [(True, True), (True, False), (False, True)]:
+                for _ in range(iterations):
+                    self.tiled_camera_sensor.update(
+                        self.state,
+                        self.camera_transforms,
+                        self.camera_rays,
+                        color_image=self.color_image if out_color else None,
+                        depth_image=self.depth_image if out_depth else None,
+                    )
 
         self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         for out_color, out_depth in [(True, True), (True, False), (False, True)]:
@@ -152,7 +170,7 @@ class FastSensorTiledCamera:
         wp.synchronize()
 
     @nice_name("Rendering (Tiled)")
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_color_depth(self, resolution: int, world_count: int, iterations: int):
         self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
         self.tiled_camera_sensor.render_config.tile_width = 8
@@ -168,7 +186,7 @@ class FastSensorTiledCamera:
         wp.synchronize()
 
     @nice_name("Rendering (Tiled) (Color Only)")
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_color_only(self, resolution: int, world_count: int, iterations: int):
         self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
         self.tiled_camera_sensor.render_config.tile_width = 8
@@ -183,7 +201,7 @@ class FastSensorTiledCamera:
         wp.synchronize()
 
     @nice_name("Rendering (Tiled) (Depth Only)")
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_depth_only(self, resolution: int, world_count: int, iterations: int):
         self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
         self.tiled_camera_sensor.render_config.tile_width = 8
@@ -237,7 +255,15 @@ if __name__ == "__main__":
         choices=benchmark_list.keys(),
         help="Run a specific benchmark; may be repeated to run multiple (e.g., --bench A --bench B).",
     )
+    parser.add_argument(
+        "--include-tiled",
+        action="store_true",
+        help=f"Run the tiled render-order benchmarks. For ASV, set {ASV_RUN_TILED_CAMERA_BENCHMARKS_ENV_VAR}=1.",
+    )
     args = parser.parse_known_args()[0]
+
+    if args.include_tiled:
+        os.environ[ASV_RUN_TILED_CAMERA_BENCHMARKS_ENV_VAR] = "1"
 
     if args.bench is None:
         benchmarks = benchmark_list.keys()

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -34,7 +34,7 @@ def nice_name_collector():
 
 
 @nice_name_collector()
-class SensorTiledCameraBenchmark:
+class FastSensorTiledCamera:
     param_names = ["resolution", "world_count", "iterations"]
     params = ([64], [4096], [50])
 
@@ -221,7 +221,7 @@ if __name__ == "__main__":
     from newton.utils import run_benchmark
 
     benchmark_list = {
-        "SensorTiledCameraBenchmark": SensorTiledCameraBenchmark,
+        "FastSensorTiledCamera": FastSensorTiledCamera,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -78,8 +78,8 @@ class FastSensorTiledCamera:
         self.color_image = self.tiled_camera_sensor.utils.create_color_image_output(resolution, resolution)
         self.depth_image = self.tiled_camera_sensor.utils.create_depth_image_output(resolution, resolution)
 
-        self.model.bvh_refit_shapes(self.state)
-        self.model.bvh_refit_particles(self.state)
+        self.model.bvh_build_shapes(self.state)
+        self.model.bvh_build_particles(self.state)
         self.tiled_camera_sensor.sync_transforms(self.state)
 
         # Warmup Kernels


### PR DESCRIPTION
## Summary

Rename `SensorTiledCameraBenchmark` to `FastSensorTiledCamera` in `asv/benchmarks/simulation/bench_sensor_tiled_camera.py` so the benchmark is picked up by CI ASV runs.

## Background

ASV discovers benchmark classes by scanning for names that match a specific pattern. The previous name `SensorTiledCameraBenchmark` did not match the expected naming convention, causing the tiled
camera benchmark to be silently skipped during CI runs. Renaming to `FastSensorTiledCamera` ensures it is included.

## Changes

- Renamed class `SensorTiledCameraBenchmark` → `FastSensorTiledCamera`
- Updated the `__main__` benchmark registry to reference the new class name

## Testing

Benchmark can be run locally with:
```bash
uvx --with virtualenv asv run --launch-method spawn main^!
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to enable additional tiled render-order benchmarks so they are discoverable and runnable.

* **Chores**
  * Renamed an internal benchmark for clearer identification in listings.
  * Benchmark setup now rebuilds scene acceleration data and clears model collision settings for more consistent, reliable results.
* **Behavior**
  * Tiled-render benchmark methods are hidden by default and only exposed when the tiled benchmark option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->