### PR TITLE
Exclude Superpowers docs from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ rspec.xml
 .claude/settings.local.json
 .claude/worktrees/
 .mcp.json
+/docs/superpowers/
 
 # Claude Code sandbox artifacts (empty placeholder files created in repo root)
 .bash_profile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ exclude_patterns = [
     "_build",
     "Thumbs.db",
     ".DS_Store",
+    "superpowers",
     "sphinx-env/**",
     "sphinx-env",
     "**/site-packages/**",


### PR DESCRIPTION
## Description

Ignore the generated `docs/superpowers/` tree and exclude it from Sphinx source discovery. These are transient planning artifacts, so they should not appear in Git status or docs builds.

This mirrors Warp's setup and keeps local Superpowers planning output outside project documentation.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change; not user-facing)

## Test plan

```bash
git check-ignore -v docs/superpowers/plans/2026-06-01-aws-runner-region-fallbacks.md
git diff --check -- .gitignore docs/conf.py
uvx pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git and documentation build configurations to exclude a directory from tracking and documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->