### PR TITLE
Use positive MuJoCo solref for joint limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@
 - Fix USD import of orphaned body-to-world fixed joints not accounting for ancestor xform offsets, so pinned bodies now FK to the correct world pose (env origin + spawn xform)
 - Fix `SolverXPBD` tetrahedral constraints reading static model activations instead of runtime control activations
 - Fix `SolverXPBD` tetrahedral constraints ignoring FEM material stiffness and damping
-- Fix `SolverMuJoCo` joint-limit `jnt_solref` so the effective stiffness/damping at a joint limit matches the user-configured force-space `joint_limit_ke`/`joint_limit_kd` (`N·m/rad`, `N·m·s/rad`) instead of MuJoCo's acceleration-space default
+- Fix `SolverMuJoCo` joint-limit `jnt_solref` so the effective stiffness/damping at a joint limit matches the user-configured force-space `joint_limit_ke`/`joint_limit_kd` (`N·m/rad`, `N·m·s/rad`) while using MuJoCo's positive solref convention so timestep safety clamping remains active, instead of MuJoCo's acceleration-space default
 - Fix `SolverMuJoCo` to preserve authored zero-valued USD `mjc:solreflimit` values as raw MuJoCo data and avoid writing limit `solref` values to unlimited joints in saved MJCF
 - Honor authored `mujoco.solreflimit_mode` even when a non-zero `mujoco.solreflimit` is also present, so the explicit mode (force-space or raw) is authoritative
 - Fix `SolverMuJoCo` CPU backend overwriting `mj_model.body_iquat` with Newton's eigendecomposition result on every `BODY_INERTIAL_PROPERTIES` notify; the compiled principal-axes basis is now preserved, fixing single-contact box equilibrium (incorrect normal force) and stiff WELD-loop instabilities (`Nan, Inf or huge value in QACC`) caused by basis ambiguity on repeated eigenvalues

--- a/docs/integrations/mujoco.rst
+++ b/docs/integrations/mujoco.rst
@@ -142,10 +142,9 @@ Joint-limit stiffness and damping
 
 :attr:`~newton.Model.joint_limit_ke` and
 :attr:`~newton.Model.joint_limit_kd` are force-space gains (for example,
-``N·m/rad`` and ``N·m·s/rad`` for revolute joints). MuJoCo's negative
-``solreflimit`` convention stores stiffness and damping values, but the
-limit solver then converts them to an effective response using the owning
-DOF's ``dof_invweight0`` and the limit impedance parameter
+``N·m/rad`` and ``N·m·s/rad`` for revolute joints). MuJoCo converts
+``solreflimit`` to an effective limit response using the owning DOF's
+``dof_invweight0`` and the limit impedance parameter
 ``dmax = solimplimit[1]``:
 
 .. math::
@@ -154,12 +153,26 @@ DOF's ``dof_invweight0`` and the limit impedance parameter
    (\mathrm{dof\_invweight0} \cdot (1 - dmax))
 
 To keep Newton's force-space meaning,
-:class:`~newton.solvers.SolverMuJoCo` writes
-``solreflimit = (-ke * factor, -kd * factor)`` with
-``factor = dof_invweight0 * (1 - dmax)``. This update runs after MuJoCo has
-compiled or refreshed ``dof_invweight0``. If ``joint_limit_ke <= 0`` or
-``joint_limit_kd <= 0``, the solver restores MuJoCo's default
-``solreflimit`` value ``(0.02, 1.0)``.
+:class:`~newton.solvers.SolverMuJoCo` first scales the direct
+stiffness/damping pair by ``factor = dof_invweight0 * (1 - dmax)`` and then
+converts that pair to MuJoCo's positive ``(timeconst, dampratio)`` convention:
+
+.. math::
+
+   \begin{aligned}
+   k_\mathrm{stored} &= ke \cdot factor \\
+   b_\mathrm{stored} &= kd \cdot factor \\
+   \mathrm{timeconst} &= 2 / b_\mathrm{stored} \\
+   \mathrm{dampratio} &= b_\mathrm{stored} /
+      (2 \sqrt{k_\mathrm{stored}})
+   \end{aligned}
+
+The positive convention preserves the same unclamped force-space response as
+the equivalent direct stiffness/damping pair while allowing MuJoCo's
+``refsafe`` timestep clamp to soften limits that are too stiff for the step
+size. This update runs after MuJoCo has compiled or refreshed
+``dof_invweight0``. If ``joint_limit_ke <= 0`` or ``joint_limit_kd <= 0``, the
+solver restores MuJoCo's default ``solreflimit`` value ``(0.02, 1.0)``.
 
 MJCF- or USD-authored ``solreflimit`` values are already native MuJoCo
 parameters, so they are preserved verbatim through the
@@ -183,11 +196,10 @@ authored native value such as ``solreflimit="0 0"`` or USD
    ``solreflimit``; it has no field for "use Newton force-space
    scaling with these gains". The exporter therefore only writes
    ``solreflimit`` for ``SOLREF_MODE_RAW`` joints (where the authored
-   value carries the full intent). Re-importing the saved file
-   recovers the same MuJoCo dynamics, but ``joint_limit_ke`` /
+   value carries the full intent). ``joint_limit_ke`` /
    ``joint_limit_kd`` from the original ``SOLREF_MODE_FORCE_SPACE`` /
-   ``SOLREF_MODE_MJCF_DEFAULT`` joints will not be preserved — reapply
-   them on the rebuilt model if you need them.
+   ``SOLREF_MODE_MJCF_DEFAULT`` joints will not be preserved; reapply
+   them on the rebuilt model if you need those force-space gains.
 
 
 .. _shape-material-contact-stiffness-and-damping:

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2544,13 +2544,15 @@ def update_jnt_solref_from_invweight0_kernel(
     simulated restoring torque matches the user-specified ``limit_ke`` /
     ``limit_kd``.
 
-    The limit uses the negative (stiffness, damping) convention so the result is
-    ``solref = (-ke * factor, -kd * factor)``. When ``ke <= 0`` or ``kd <= 0``,
-    Newton restores MuJoCo's default ``(0.02, 1.0)`` pair so runtime disablement
-    matches a fresh model compiled without ``solreflimit``. MJCF-imported raw
-    ``solreflimit`` values are forwarded unchanged when present; MJCF joints
-    that rely on the implicit default keep MuJoCo's native ``(0.02, 1.0)`` until
-    ``joint_limit_ke``/``joint_limit_kd`` are changed by the user.
+    The force-space path converts the scaled direct stiffness/damping pair to
+    MuJoCo's positive ``(timeconst, dampratio)`` convention. This lets MuJoCo's
+    ``refsafe`` clamp soften constraints that are too stiff for the timestep.
+    When ``ke <= 0`` or ``kd <= 0``, Newton restores MuJoCo's default
+    ``(0.02, 1.0)`` pair so runtime disablement matches a fresh model compiled
+    without ``solreflimit``. MJCF-imported raw ``solreflimit`` values are
+    forwarded unchanged when present; MJCF joints that rely on the implicit
+    default keep MuJoCo's native ``(0.02, 1.0)`` until ``joint_limit_ke`` /
+    ``joint_limit_kd`` are changed by the user.
     ``dof_invweight0`` is only valid after MuJoCo's ``set_const_0`` /
     ``mj_setConst`` has run, so this kernel must be launched from
     :meth:`SolverMuJoCo.notify_model_changed` after those calls (and once at
@@ -2577,8 +2579,7 @@ def update_jnt_solref_from_invweight0_kernel(
         jnt_solimp: MuJoCo limit ``solimp`` per joint, shape ``[world, mjc_jnt]``
             with component ``[..., 1]`` carrying ``dmax``.
         jnt_solref: Output ``solref`` per joint, shape ``[world, mjc_jnt]``,
-            written in MuJoCo's negative-direct-mode convention
-            ``(-ke·factor, -kd·factor)``.
+            written in MuJoCo's positive ``(timeconst, dampratio)`` convention.
     """
     world, mjc_jnt = wp.tid()
     newton_dof = mjc_jnt_to_newton_dof[world, mjc_jnt]
@@ -2625,9 +2626,7 @@ def update_jnt_solref_from_invweight0_kernel(
         # Restore MuJoCo's compiled default so runtime ``ke -> 0`` or ``kd -> 0``
         # updates behave the same as a fresh model built without a custom limit
         # solref. Without the ``kd <= 0`` guard, a ``(ke>0, kd=0)`` pair would
-        # write ``solref = (-ke·factor, 0)``, which MuJoCo's negative-direct-mode
-        # convention treats as ``dampratio = 0`` and triggers a divide-by-zero
-        # in ``k_eff = 1/(τ²·ζ²)``.
+        # produce an infinite time constant in the positive solref conversion.
         jnt_solref[world, mjc_jnt] = wp.vec2(DEFAULT_LIMIT_SOLREF_TIMECONST, DEFAULT_LIMIT_SOLREF_DAMPRATIO)
         return
 
@@ -2639,7 +2638,12 @@ def update_jnt_solref_from_invweight0_kernel(
     if invw > 0.0 and dmax < 1.0:
         factor = invw * (1.0 - dmax)
 
-    jnt_solref[world, mjc_jnt] = wp.vec2(-ke * factor, -kd * factor)
+    direct_stiffness = wp.max(ke * factor, MJ_MINVAL)
+    direct_damping = wp.max(kd * factor, MJ_MINVAL)
+    timeconst = 2.0 / direct_damping
+    dampratio = direct_damping / (2.0 * wp.sqrt(direct_stiffness))
+
+    jnt_solref[world, mjc_jnt] = wp.vec2(timeconst, dampratio)
 
 
 @wp.kernel(enable_backward=False)

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -43,6 +43,7 @@ from .constants import (
     DEFAULT_LIMIT_SOLREF,
     HINGE_CONNECT_AXIS_OFFSET,
     KINEMATIC_ARMATURE,
+    MJ_MINVAL,
     SOLREF_MODE_FORCE_SPACE,
     SOLREF_MODE_MJCF_DEFAULT,
     SOLREF_MODE_RAW,
@@ -5520,7 +5521,7 @@ class SolverMuJoCo(SolverBase):
                         # item I6); skipping the seed also keeps ``save_to_mjcf``
                         # idempotent — re-imported FORCE_SPACE joints recover
                         # the same MJCF_DEFAULT state instead of being frozen
-                        # into RAW by a scaled solreflimit serialisation.
+                        # into RAW by a derived solreflimit serialisation.
                         joint_params["solref_limit"] = joint_solref_limit[ai]
                     if joint_solimp_limit is not None:
                         joint_params["solimp_limit"] = joint_solimp_limit[ai]
@@ -7469,8 +7470,8 @@ class SolverMuJoCo(SolverBase):
                     # Restore MuJoCo's compiled default so a zero-gain
                     # configuration matches a fresh model with no authored
                     # ``solreflimit``. A ``(ke>0, kd=0)`` pair would otherwise
-                    # write ``(-ke·factor, 0)`` and trigger MuJoCo's
-                    # divide-by-zero in ``k_eff = 1/(τ²·ζ²)``.
+                    # produce an infinite time constant in the positive
+                    # solref conversion.
                     jnt_solref[mjc_jnt] = DEFAULT_LIMIT_SOLREF
                     continue
 
@@ -7478,7 +7479,11 @@ class SolverMuJoCo(SolverBase):
                 invw = float(self.mj_model.dof_invweight0[dof_idx])
                 dmax = float(self.mj_model.jnt_solimp[mjc_jnt][1])
                 factor = invw * (1.0 - dmax) if invw > 0.0 and dmax < 1.0 else 1.0
-                jnt_solref[mjc_jnt] = (-ke * factor, -kd * factor)
+                direct_stiffness = max(ke * factor, MJ_MINVAL)
+                direct_damping = max(kd * factor, MJ_MINVAL)
+                timeconst = 2.0 / direct_damping
+                dampratio = direct_damping / (2.0 * math.sqrt(direct_stiffness))
+                jnt_solref[mjc_jnt] = (timeconst, dampratio)
 
             self.mj_model.jnt_solref[:] = jnt_solref
             self.mjw_model.jnt_solref.assign(jnt_solref.reshape(1, njnt, 2))

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -19,6 +19,7 @@ from newton._src.solvers.mujoco.constants import (
     DEFAULT_LIMIT_KD,
     DEFAULT_LIMIT_KE,
     KINEMATIC_ARMATURE,
+    MJ_MINVAL,
     SOLREF_MODE_FORCE_SPACE,
     SOLREF_MODE_MJCF_DEFAULT,
     SOLREF_MODE_RAW,
@@ -27,6 +28,15 @@ from newton._src.solvers.mujoco.equality import _add_equality_constraint
 from newton._src.solvers.mujoco.utils import MJC_OBJ_BODY, MJC_OBJ_JOINT, MjcEqualityTargetKind
 from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import USD_AVAILABLE, assert_np_equal
+
+
+def _expected_positive_limit_solref(ke: float, kd: float, factor: float) -> np.ndarray:
+    direct_stiffness = max(float(ke) * float(factor), MJ_MINVAL)
+    direct_damping = max(float(kd) * float(factor), MJ_MINVAL)
+    return np.array(
+        [2.0 / direct_damping, direct_damping / (2.0 * math.sqrt(direct_stiffness))],
+        dtype=np.float64,
+    )
 
 
 class TestMuJoCoSolver(unittest.TestCase):
@@ -1489,10 +1499,8 @@ class TestMuJoCoSolverJointProperties(TestMuJoCoSolverPropertiesBase):
 
     def test_joint_limit_solref_conversion(self):
         """
-        Verify that joint_limit_ke and joint_limit_kd are properly converted to MuJoCo's solref_limit
-        using the negative convention ``solref_limit = (-ke * factor, -kd * factor)`` where
-        ``factor = dof_invweight0 * (1 - dmax)`` makes MuJoCo's effective stiffness match the
-        force-space values users configure.
+        Verify that joint_limit_ke and joint_limit_kd are converted to MuJoCo's positive
+        ``solref_limit`` convention after scaling by ``dof_invweight0 * (1 - dmax)``.
         """
         # Skip if no joints
         if self.model.joint_dof_count == 0:
@@ -1535,14 +1543,14 @@ class TestMuJoCoSolverJointProperties(TestMuJoCoSolverPropertiesBase):
             invw = float(solver.mjw_model.dof_invweight0.numpy()[world_idx, dof_adr])
             dmax = float(solver.mjw_model.jnt_solimp.numpy()[world_idx, mjc_idx][1])
             factor = invw * (1.0 - dmax) if invw > 0.0 and dmax < 1.0 else 1.0
-            return -ke * factor, -kd * factor
+            return _expected_positive_limit_solref(ke, kd, factor)
 
         for world_idx in range(self.model.world_count):
             for _i, (mjc_idx, newton_dof_idx) in enumerate(
                 zip(mjc_revolute_indices, newton_revolute_dof_indices, strict=False)
             ):
                 global_dof_idx = world_idx * dofs_per_world + newton_dof_idx
-                expected_ke, expected_kd = expected_scaled_solref(
+                expected_solref = expected_scaled_solref(
                     world_idx, mjc_idx, initial_limit_ke[global_dof_idx], initial_limit_kd[global_dof_idx]
                 )
 
@@ -1553,15 +1561,15 @@ class TestMuJoCoSolverJointProperties(TestMuJoCoSolverPropertiesBase):
                 actual_solref = solver.mjw_model.jnt_solref.numpy()[world_idx, mjc_idx]
                 self.assertAlmostEqual(
                     float(actual_solref[0]),
-                    expected_ke,
-                    delta=abs(expected_ke) * rel_tol,
-                    msg=f"Initial solref stiffness for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
+                    expected_solref[0],
+                    delta=abs(expected_solref[0]) * rel_tol,
+                    msg=f"Initial solref time constant for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
                 )
                 self.assertAlmostEqual(
                     float(actual_solref[1]),
-                    expected_kd,
-                    delta=abs(expected_kd) * rel_tol,
-                    msg=f"Initial solref damping for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
+                    expected_solref[1],
+                    delta=abs(expected_solref[1]) * rel_tol,
+                    msg=f"Initial solref damping ratio for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
                 )
 
         # Test runtime update capability - update joint limit ke/kd values
@@ -1580,7 +1588,7 @@ class TestMuJoCoSolverJointProperties(TestMuJoCoSolverPropertiesBase):
                 zip(mjc_revolute_indices, newton_revolute_dof_indices, strict=False)
             ):
                 global_dof_idx = world_idx * dofs_per_world + newton_dof_idx
-                expected_ke, expected_kd = expected_scaled_solref(
+                expected_solref = expected_scaled_solref(
                     world_idx, mjc_idx, updated_limit_ke[global_dof_idx], updated_limit_kd[global_dof_idx]
                 )
 
@@ -1589,15 +1597,15 @@ class TestMuJoCoSolverJointProperties(TestMuJoCoSolverPropertiesBase):
                 actual_solref = solver.mjw_model.jnt_solref.numpy()[world_idx, mjc_idx]
                 self.assertAlmostEqual(
                     float(actual_solref[0]),
-                    expected_ke,
-                    delta=abs(expected_ke) * rel_tol,
-                    msg=f"Updated solref stiffness for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
+                    expected_solref[0],
+                    delta=abs(expected_solref[0]) * rel_tol,
+                    msg=f"Updated solref time constant for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
                 )
                 self.assertAlmostEqual(
                     float(actual_solref[1]),
-                    expected_kd,
-                    delta=abs(expected_kd) * rel_tol,
-                    msg=f"Updated solref damping for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
+                    expected_solref[1],
+                    delta=abs(expected_solref[1]) * rel_tol,
+                    msg=f"Updated solref damping ratio for MuJoCo joint {mjc_idx} (Newton DOF {newton_dof_idx}) in world {world_idx}",
                 )
 
     def test_joint_limit_range_conversion(self):
@@ -10133,9 +10141,10 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
     ``limit_kd`` as *force-space* stiffness/damping (N·m/rad). MuJoCo's
     limit-constraint solver, however, applies effective stiffness
     ``k_eff = k / (invweight * (1 - dmax))``. Unless the Newton→MuJoCo
-    ``jnt_solref`` conversion pre-multiplies by
-    ``dof_invweight0 * (1 - dmax)`` the simulated stiffness ends up
-    scaled by the DOF inertia instead of matching the configured
+    ``jnt_solref`` conversion pre-multiplies the direct stiffness/damping
+    pair by ``dof_invweight0 * (1 - dmax)`` before converting to MuJoCo's
+    positive ``(timeconst, dampratio)`` convention, the simulated stiffness
+    ends up scaled by the DOF inertia instead of matching the configured
     force-space limit response.
 
     The analogous scaling for ``shape_material_ke``/``kd`` on
@@ -10212,13 +10221,13 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
     ):
         if solref is not None:
             return np.array(solref, dtype=np.float64)
-        if ke <= 0.0:
+        if ke <= 0.0 or kd <= 0.0:
             return np.array([0.02, 1.0], dtype=np.float64)
 
         dof_invweight0 = float(solver.mj_model.dof_invweight0[0])
         dmax = float(solver.mj_model.jnt_solimp[0, 1])
         factor = dof_invweight0 * (1.0 - dmax) if dof_invweight0 > 0.0 and dmax < 1.0 else 1.0
-        return np.array([-ke * factor, -kd * factor], dtype=np.float64)
+        return _expected_positive_limit_solref(ke, kd, factor)
 
     def test_cpu_and_warp_joint_limit_solref_cases_match(self):
         """CPU and Warp backends must agree for each joint-limit ``solref`` branch."""
@@ -10300,7 +10309,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
                     np.testing.assert_allclose(mjw_solref, expected, rtol=1e-5, atol=1e-6)
 
     def test_joint_limit_solref_uses_dof_invweight0(self):
-        """``jnt_solref`` for joint limits must be scaled by ``dof_invweight0 * (1 - dmax)``."""
+        """``jnt_solref`` must use gains scaled by ``dof_invweight0 * (1 - dmax)``."""
         ke = 10000.0
         kd = 100.0
         # Use inertia = 0.5 so ``dof_invweight0 = 1/0.5 = 2`` and factor = 2 * 0.05 = 0.1,
@@ -10315,9 +10324,10 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
         factor = dof_invweight0 * (1.0 - dmax)
 
         actual_solref = solver.mjw_model.jnt_solref.numpy()[0, 0]
+        expected_solref = _expected_positive_limit_solref(ke, kd, factor)
         rel_tol = 1e-4
-        self.assertAlmostEqual(float(actual_solref[0]), -ke * factor, delta=abs(ke * factor) * rel_tol)
-        self.assertAlmostEqual(float(actual_solref[1]), -kd * factor, delta=abs(kd * factor) * rel_tol)
+        self.assertAlmostEqual(float(actual_solref[0]), expected_solref[0], delta=abs(expected_solref[0]) * rel_tol)
+        self.assertAlmostEqual(float(actual_solref[1]), expected_solref[1], delta=abs(expected_solref[1]) * rel_tol)
 
     def test_joint_limit_solref_updates_after_mass_change(self):
         """Changing inertia and notifying the solver must recompute the ``invweight0`` factor."""
@@ -10345,11 +10355,10 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
         # is computed in float64 on the host. Use a relative tolerance so the
         # assertion passes for float32 round-off on multi-thousand-scale values
         # while still rejecting the buggy 10x-too-stiff solref.
-        expected_ke = -ke * factor
-        expected_kd = -kd * factor
+        expected_solref = _expected_positive_limit_solref(ke, kd, factor)
         rel_tol = 1e-4
-        self.assertAlmostEqual(float(actual_solref[0]), expected_ke, delta=abs(expected_ke) * rel_tol)
-        self.assertAlmostEqual(float(actual_solref[1]), expected_kd, delta=abs(expected_kd) * rel_tol)
+        self.assertAlmostEqual(float(actual_solref[0]), expected_solref[0], delta=abs(expected_solref[0]) * rel_tol)
+        self.assertAlmostEqual(float(actual_solref[1]), expected_solref[1], delta=abs(expected_solref[1]) * rel_tol)
 
     def test_mjcf_unauthored_solreflimit_ke_updates_are_not_shadowed(self):
         """MJCF joints without ``solreflimit`` must keep the sentinel so ``limit_ke`` updates apply."""
@@ -10387,7 +10396,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
         dof_invweight0 = float(solver.mjw_model.dof_invweight0.numpy()[0, 0])
         dmax = float(solver.mjw_model.jnt_solimp.numpy()[0, 0][1])
         factor = dof_invweight0 * (1.0 - dmax) if dof_invweight0 > 0.0 and dmax < 1.0 else 1.0
-        expected_solref = np.array([-ke[0] * factor, -kd[0] * factor], dtype=np.float64)
+        expected_solref = _expected_positive_limit_solref(ke[0], kd[0], factor)
         actual_solref = np.array(solver.mjw_model.jnt_solref.numpy()[0, 0], dtype=np.float64)
 
         self.assertFalse(np.allclose(actual_solref, initial_solref))
@@ -10427,7 +10436,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
         dof_invweight0 = float(solver.mjw_model.dof_invweight0.numpy()[0, 0])
         dmax = float(solver.mjw_model.jnt_solimp.numpy()[0, 0][1])
         factor = dof_invweight0 * (1.0 - dmax) if dof_invweight0 > 0.0 and dmax < 1.0 else 1.0
-        expected_solref = np.array([-DEFAULT_LIMIT_KE * factor, -DEFAULT_LIMIT_KD * factor], dtype=np.float64)
+        expected_solref = _expected_positive_limit_solref(DEFAULT_LIMIT_KE, DEFAULT_LIMIT_KD, factor)
         actual_solref = np.array(solver.mjw_model.jnt_solref.numpy()[0, 0], dtype=np.float64)
 
         np.testing.assert_allclose(actual_solref, expected_solref, rtol=1e-5, atol=1e-6)
@@ -10540,10 +10549,10 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
             dof_invweight0 = float(solver.mj_model.dof_invweight0[0])
             dmax = float(solver.mj_model.jnt_solimp[0, 1])
             factor = dof_invweight0 * (1.0 - dmax)
-            expected_solref = np.array([-ke * factor, -kd * factor], dtype=np.float64)
+            expected_solref = _expected_positive_limit_solref(ke, kd, factor)
 
-            # Runtime ``MjModel`` still carries the scaled solref so MuJoCo
-            # produces the right force at this instant.
+            # Runtime ``MjModel`` still carries the derived solref so MuJoCo
+            # produces the right force at this instant while retaining refsafety.
             np.testing.assert_allclose(solver.mj_model.jnt_solref[0], expected_solref, rtol=1e-6, atol=1e-6)
 
             # Exported MJCF must NOT author ``solreflimit`` for this
@@ -10552,7 +10561,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
             joint = next(tree.iter("joint"))
             self.assertIsNone(
                 joint.get("solreflimit"),
-                "FORCE_SPACE joints must not persist a scaled solreflimit into the saved MJCF",
+                "FORCE_SPACE joints must not persist a derived solreflimit into the saved MJCF",
             )
         finally:
             os.unlink(xml_path)
@@ -10643,7 +10652,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
         dof_invweight0 = float(solver.mj_model.dof_invweight0[0])
         dmax = float(solimp[0, 1])
         factor = dof_invweight0 * (1.0 - dmax)
-        expected_solref = np.array([-ke * factor, -kd * factor], dtype=np.float64)
+        expected_solref = _expected_positive_limit_solref(ke, kd, factor)
         np.testing.assert_allclose(solver.mj_model.jnt_solref[0], expected_solref, rtol=1e-6, atol=1e-6)
 
     def test_joint_limit_solref_resets_to_default_when_limit_ke_is_disabled(self):
@@ -10679,7 +10688,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
             self.assertAlmostEqual(dof_invweight0, expected_invweight0, delta=1e-4)
             dmax = float(solver.mj_model.jnt_solimp[0, 1])
             factor = dof_invweight0 * (1.0 - dmax)
-            expected_solref = np.array([-ke * factor, -kd * factor], dtype=np.float64)
+            expected_solref = _expected_positive_limit_solref(ke, kd, factor)
             actual_solref = np.array(solver.mj_model.jnt_solref[0], dtype=np.float64)
             np.testing.assert_allclose(actual_solref, expected_solref, rtol=1e-6, atol=1e-6)
 
@@ -10814,7 +10823,7 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
                     dmax = float(solver.mjw_model.jnt_solimp.numpy()[0, 0][1])
                     actual_solref = np.array(solver.mjw_model.jnt_solref.numpy()[0, 0], dtype=np.float64)
                 factor = dof_invweight0 * (1.0 - dmax) if dof_invweight0 > 0.0 and dmax < 1.0 else 1.0
-                expected_solref = np.array([-ke * factor, -kd * factor], dtype=np.float64)
+                expected_solref = _expected_positive_limit_solref(ke, kd, factor)
 
                 self.assertFalse(np.allclose(actual_solref, [0.03, 0.7]))
                 np.testing.assert_allclose(actual_solref, expected_solref, rtol=1e-5, atol=1e-6)
@@ -10885,13 +10894,13 @@ class TestMuJoCoSolverInvweightScaledSolref(unittest.TestCase):
             invw = float(dof_invweight0[dof_idx])
             dmax = float(jnt_solimp[mjc_jnt][1])
             factor = invw * (1.0 - dmax) if invw > 0.0 and dmax < 1.0 else 1.0
-            expected = np.array([-ke * factor, -kd * factor], dtype=np.float64)
+            expected = _expected_positive_limit_solref(ke, kd, factor)
             np.testing.assert_allclose(
                 jnt_solref[mjc_jnt],
                 expected,
                 rtol=1e-5,
                 atol=1e-6,
-                err_msg=f"D6 DOF {mjc_jnt}: expected scaled solref {expected.tolist()}, "
+                err_msg=f"D6 DOF {mjc_jnt}: expected positive solref {expected.tolist()}, "
                 f"got {jnt_solref[mjc_jnt].tolist()}",
             )
 
@@ -11044,10 +11053,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
 
     Tests use ``use_mujoco_contacts=False`` explicitly so the
     Newton-contacts kernel (where the override lives) runs. They read
-    ``mjw_data.contact.solref`` back directly and compare to
-    ``(-ke·factor, -kd·factor)`` — mirroring the joint-limit suite
-    pattern (:meth:`TestMuJoCoSolverInvweightScaledSolref
-    .test_joint_limit_solref_uses_dof_invweight0`). ``use_mujoco_contacts
+    ``mjw_data.contact.solref`` back directly and compare to the contact
+    direct-mode pair ``(-ke·factor, -kd·factor)``. ``use_mujoco_contacts
     =True`` and the MuJoCo CPU backend remain unsupported for
     ``FORCE_SPACE``: MuJoCo's internal ``contact_params`` operates on
     per-geom ``solref`` and cannot reproduce the two-body invweight sum.


### PR DESCRIPTION
## Description

Closes #3109.

`SolverMuJoCo` now keeps the existing Newton force-space joint-limit scaling by `dof_invweight0 * (1 - dmax)`, but converts the scaled direct stiffness/damping pair to MuJoCo's positive `(timeconst, dampratio)` `jnt_solref` convention instead of writing negative direct-mode values. This preserves the intended unclamped force-space response while allowing MuJoCo's timestep safety clamp to soften limits that are too stiff for the step size.

The CPU mirror now uses the same `MJ_MINVAL` clamp as the Warp kernel, the focused joint-limit tests expect positive solrefs, and the MuJoCo integration docs describe the runtime conversion and export semantics. The existing Unreleased changelog entry was amended rather than duplicating the same fix.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_joint_limit_solref_conversion
uv run --extra dev -m newton.tests -k TestMuJoCoSolverInvweightScaledSolref
uv run --extra dev python newton\examples\repro_issue_3109.py
uvx pre-commit run -a
```

Also ran a local multi-mechanism issue-3109 diagnostic harness over Allegro hand, Inspire RH56, Unitree Dex5, Robotiq 2F85, Franka Panda, and Shadow Hand without tendons for 120 steps; all finished with `status=ok` and `first_nonfinite=None`.

## Bug fix

**Steps to reproduce:**

1. Run the issue #3109 Allegro hand repro using `SolverMuJoCo` with Newton default joint-limit gains.
2. Drop/contact a sphere against the low-inertia fingers.
3. On `main`, the local repro reaches non-finite constraint forces around step 98; with this PR, the same repro remains finite for the tested run.

**Minimal reproduction:**

```python
# See issue #3109 and the local repro_issue_3109.py script:
# load the Allegro hand USD, run SolverMuJoCo, drop a sphere onto
# the fingers, and track first_nonfinite / max_qfrc_constraint.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected joint-limit stiffness and damping conversion in the MuJoCo solver to use the proper positive convention, ensuring timestep safety clamping remains active.

* **Documentation**
  * Updated MuJoCo solver documentation to clarify how force-space joint-limit parameters map to MuJoCo's impedance convention and fallback behavior when parameters are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->