### PR TITLE
Use positive MuJoCo solref for force-space contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 - Honor authored `mujoco.solreflimit_mode` even when a non-zero `mujoco.solreflimit` is also present, so the explicit mode (force-space or raw) is authoritative
 - Fix `SolverMuJoCo` CPU backend overwriting `mj_model.body_iquat` with Newton's eigendecomposition result on every `BODY_INERTIAL_PROPERTIES` notify; the compiled principal-axes basis is now preserved, fixing single-contact box equilibrium (incorrect normal force) and stiff WELD-loop instabilities (`Nan, Inf or huge value in QACC`) caused by basis ambiguity on repeated eigenvalues
 - Fix `SolverMuJoCo` CPU backend dynamics for asymmetric MJCF `diaginertia` models whose principal moments are reordered during Newton/MJWarp synchronization
-- Fix `SolverMuJoCo` honoring force-space `shape_material_ke` / `shape_material_kd` for contacts (`use_mujoco_contacts=False`) using MuJoCo's positive solref convention so timestep safety clamping stays active; authored `mjc:solref` is preserved via new `mujoco.solref` / `mujoco.solref_mode` per-shape custom attributes. Force-space scaling is unsupported on `use_mujoco_contacts=True` and the MuJoCo CPU backend.
+- Fix `SolverMuJoCo` honoring force-space `shape_material_ke` / `shape_material_kd` for contacts (`use_mujoco_contacts=False`); authored `mjc:solref` is preserved via new `mujoco.solref` / `mujoco.solref_mode` per-shape custom attributes. Force-space scaling is unsupported on `use_mujoco_contacts=True` and the MuJoCo CPU backend.
 - Fix MJCF importer rejecting MuJoCo's one-value `solreflimit`/`solref` shorthand emitted by `mujoco.MjSpec.to_xml()` for default-valued joints, which broke `SolverMuJoCo(save_to_mjcf=...)` round-trips
 - Fix ground grid clipping in the Viser renderer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@
 - Honor authored `mujoco.solreflimit_mode` even when a non-zero `mujoco.solreflimit` is also present, so the explicit mode (force-space or raw) is authoritative
 - Fix `SolverMuJoCo` CPU backend overwriting `mj_model.body_iquat` with Newton's eigendecomposition result on every `BODY_INERTIAL_PROPERTIES` notify; the compiled principal-axes basis is now preserved, fixing single-contact box equilibrium (incorrect normal force) and stiff WELD-loop instabilities (`Nan, Inf or huge value in QACC`) caused by basis ambiguity on repeated eigenvalues
 - Fix `SolverMuJoCo` CPU backend dynamics for asymmetric MJCF `diaginertia` models whose principal moments are reordered during Newton/MJWarp synchronization
-- Fix `SolverMuJoCo` honoring force-space `shape_material_ke` / `shape_material_kd` for contacts (`use_mujoco_contacts=False`); authored `mjc:solref` is preserved via new `mujoco.solref` / `mujoco.solref_mode` per-shape custom attributes. Force-space scaling is unsupported on `use_mujoco_contacts=True` and the MuJoCo CPU backend.
+- Fix `SolverMuJoCo` honoring force-space `shape_material_ke` / `shape_material_kd` for contacts (`use_mujoco_contacts=False`) using MuJoCo's positive solref convention so timestep safety clamping stays active; authored `mjc:solref` is preserved via new `mujoco.solref` / `mujoco.solref_mode` per-shape custom attributes. Force-space scaling is unsupported on `use_mujoco_contacts=True` and the MuJoCo CPU backend.
 - Fix MJCF importer rejecting MuJoCo's one-value `solreflimit`/`solref` shorthand emitted by `mujoco.MjSpec.to_xml()` for default-valued joints, which broke `SolverMuJoCo(save_to_mjcf=...)` round-trips
 - Fix ground grid clipping in the Viser renderer
 

--- a/docs/integrations/mujoco.rst
+++ b/docs/integrations/mujoco.rst
@@ -213,14 +213,11 @@ Shape-material contact gains follow the same force-space contract as
 :attr:`~newton.Model.shape_material_kd` are force-space stiffness and
 damping (``N/m`` and ``N·s/m``). For the Newton-contacts path
 (``SolverMuJoCo(..., use_mujoco_contacts=False)``, the default),
-:class:`~newton.solvers.SolverMuJoCo` scales the direct stiffness/damping
-pair by ``factor = (body_invweight0[A] + body_invweight0[B]) * (1 - dmax)``
-(where ``A`` and ``B`` are the two contacting bodies and
-``dmax = solimp[1]``) and writes the per-contact ``solref`` in MuJoCo's
-positive ``(timeconst, dampratio)`` convention. This preserves the same
-unclamped force-space response while letting MuJoCo's ``refsafe`` timestep
-clamp soften contacts too stiff for the step size. The two-body inverse-mass
-sum makes the contact stiffness independent of either body's mass, so
+:class:`~newton.solvers.SolverMuJoCo` scales the stiffness/damping pair by
+``factor = (body_invweight0[A] + body_invweight0[B]) * (1 - dmax)`` (where
+``A`` and ``B`` are the two contacting bodies and ``dmax = solimp[1]``) and
+writes the resulting per-contact ``solref``. The two-body inverse-mass sum
+makes the contact stiffness independent of either body's mass, so
 :attr:`~newton.Model.shape_material_ke` behaves as a true force-space gain.
 
 ``model.mujoco.solref_mode`` (per shape) controls how

--- a/docs/integrations/mujoco.rst
+++ b/docs/integrations/mujoco.rst
@@ -213,13 +213,15 @@ Shape-material contact gains follow the same force-space contract as
 :attr:`~newton.Model.shape_material_kd` are force-space stiffness and
 damping (``N/m`` and ``N·s/m``). For the Newton-contacts path
 (``SolverMuJoCo(..., use_mujoco_contacts=False)``, the default),
-:class:`~newton.solvers.SolverMuJoCo` writes a per-contact
-``solref = (-ke * factor, -kd * factor)`` with
-``factor = (body_invweight0[A] + body_invweight0[B]) * (1 - dmax)``,
-where ``A`` and ``B`` are the two contacting bodies and
-``dmax = solimp[1]``. The two-body inverse-mass sum makes the contact
-stiffness independent of either body's mass, so :attr:`~newton.Model.shape_material_ke`
-behaves as a true force-space gain.
+:class:`~newton.solvers.SolverMuJoCo` scales the direct stiffness/damping
+pair by ``factor = (body_invweight0[A] + body_invweight0[B]) * (1 - dmax)``
+(where ``A`` and ``B`` are the two contacting bodies and
+``dmax = solimp[1]``) and writes the per-contact ``solref`` in MuJoCo's
+positive ``(timeconst, dampratio)`` convention. This preserves the same
+unclamped force-space response while letting MuJoCo's ``refsafe`` timestep
+clamp soften contacts too stiff for the step size. The two-body inverse-mass
+sum makes the contact stiffness independent of either body's mass, so
+:attr:`~newton.Model.shape_material_ke` behaves as a true force-space gain.
 
 ``model.mujoco.solref_mode`` (per shape) controls how
 ``shape_material_ke`` / ``shape_material_kd`` and ``mujoco.solref``

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -405,9 +405,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
         )
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
-        # solref averaging and write the two-body factor directly, in MuJoCo's
-        # positive ``(timeconst, dampratio)`` convention so refsafe stays active.
-        # See docs/integrations/mujoco.rst > "Shape-material contact stiffness
+        # solref averaging and write the two-body factor directly. See
+        # docs/integrations/mujoco.rst > "Shape-material contact stiffness
         # and damping" for the mechanism.
         if shape_mjc_solref_mode:
             mode_a = shape_mjc_solref_mode[shape_a]

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -405,9 +405,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
         )
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
-        # solref averaging and write the two-body factor directly, converted
-        # to MuJoCo's positive ``(timeconst, dampratio)`` convention so the
-        # ``refsafe`` clamp can soften contacts too stiff for the timestep.
+        # solref averaging and write the two-body factor directly, in MuJoCo's
+        # positive ``(timeconst, dampratio)`` convention so refsafe stays active.
         # See docs/integrations/mujoco.rst > "Shape-material contact stiffness
         # and damping" for the mechanism.
         if shape_mjc_solref_mode:

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -405,8 +405,10 @@ def convert_newton_contacts_to_mjwarp_kernel(
         )
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
-        # solref averaging and write the two-body factor directly. See
-        # docs/integrations/mujoco.rst > "Shape-material contact stiffness
+        # solref averaging and write the two-body factor directly, converted
+        # to MuJoCo's positive ``(timeconst, dampratio)`` convention so the
+        # ``refsafe`` clamp can soften contacts too stiff for the timestep.
+        # See docs/integrations/mujoco.rst > "Shape-material contact stiffness
         # and damping" for the mechanism.
         if shape_mjc_solref_mode:
             mode_a = shape_mjc_solref_mode[shape_a]
@@ -430,7 +432,12 @@ def convert_newton_contacts_to_mjwarp_kernel(
                 dmax = solimp[1]
                 if m_inv > 0.0 and dmax < 1.0:
                     factor = m_inv * (1.0 - dmax)
-                    solref = wp.vec2(-ke * factor, -kd * factor)
+                    solref = convert_solref(
+                        wp.max(ke * factor, MJ_MINVAL),
+                        wp.max(kd * factor, MJ_MINVAL),
+                        1.0,
+                        1.0,
+                    )
 
         # Convert Newton per-contact stiffness/damping to MuJoCo solref
         # (timeconst, dampratio). Per-contact overrides take precedence over

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -405,9 +405,9 @@ def convert_newton_contacts_to_mjwarp_kernel(
         )
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
-        # solref averaging and write the two-body factor directly. See
-        # docs/integrations/mujoco.rst > "Shape-material contact stiffness
-        # and damping" for the mechanism.
+        # solref averaging and recompute the solref from the combined
+        # two-body factor. See docs/integrations/mujoco.rst > "Shape-material
+        # contact stiffness and damping" for the mechanism.
         if shape_mjc_solref_mode:
             mode_a = shape_mjc_solref_mode[shape_a]
             mode_b = shape_mjc_solref_mode[shape_b]

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -11254,6 +11254,52 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         # instead of the ~2/MJ_MINVAL a fired override would produce.
         self.assertLess(float(actual_solref[0]), 1.0)
 
+    def test_force_space_contact_stiff_contact_stays_finite(self):
+        """A very stiff force-space contact must stay finite — the contact
+        analogue of #3109, where a too-stiff constraint diverged."""
+        # Low mass + very stiff ke make the contact too stiff for the step, so
+        # the written timeconst falls below 2*dt and refsafe must engage.
+        ke, kd, mass = 1.0e7, 1.0e3, 0.05
+        sim_dt = 1.0 / 60.0
+        model, _ = self._build_box_on_plane(mass=mass, ke=ke, kd=kd)
+        solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
+
+        contacts = model.contacts()
+        state_in, state_out, control = model.state(), model.state(), model.control()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+
+        contacted = False
+        for _ in range(120):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sim_dt)
+            state_in, state_out = state_out, state_in
+            if int(solver.mjw_data.nacon.numpy()[0]) > 0:
+                contacted = True
+                break
+        self.assertTrue(contacted, "box never contacted the plane")
+
+        # Written (unclamped) timeconst < 2*dt: the regime where the old negative
+        # direct-mode solref bypassed refsafe and diverged.
+        timeconst = float(solver.mjw_data.contact.solref.numpy()[0][0])
+        self.assertLess(timeconst, 2.0 * sim_dt)
+
+        # Step through the stiff contact; it must stay finite and bounded
+        # (the #3109 joint analogue went non-finite around step 98).
+        for _ in range(200):
+            state_in.clear_forces()
+            model.collide(state_in, contacts)
+            solver.step(state_in, state_out, control, contacts, sim_dt)
+            state_in, state_out = state_out, state_in
+
+        qvel = solver.mjw_data.qvel.numpy()
+        qfrc = solver.mjw_data.qfrc_constraint.numpy()
+        body_qd = state_in.body_qd.numpy()
+        self.assertTrue(np.all(np.isfinite(qvel)), "qvel went non-finite")
+        self.assertTrue(np.all(np.isfinite(qfrc)), "qfrc_constraint went non-finite")
+        self.assertTrue(np.all(np.isfinite(body_qd)), "body_qd went non-finite")
+        self.assertLess(float(np.max(np.abs(body_qd))), 1.0e3, "contact response blew up")
+
     def test_force_space_with_mujoco_contacts_emits_startup_warning(self):
         """Opting into FORCE_SPACE while running ``use_mujoco_contacts=True`` must warn at startup.
 

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -11054,8 +11054,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
 
     Tests use ``use_mujoco_contacts=False`` explicitly so the
     Newton-contacts kernel (where the override lives) runs. They read
-    ``mjw_data.contact.solref`` back directly and compare to the positive
-    ``(timeconst, dampratio)`` conversion of ``(ke·factor, kd·factor)`` —
+    ``mjw_data.contact.solref`` back directly and compare to the
+    ``convert_solref`` conversion of ``(ke·factor, kd·factor)`` —
     mirroring the joint-limit suite
     pattern (:meth:`TestMuJoCoSolverInvweightScaledSolref
     .test_joint_limit_solref_uses_dof_invweight0`). ``use_mujoco_contacts
@@ -11118,9 +11118,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         return float(solref[0]), float(solref[1])
 
     def test_force_space_contact_solref_uses_invweight0_and_dmax(self):
-        """Per-contact ``solref`` must equal the positive ``(timeconst, dampratio)``
-        conversion of ``(ke·factor, kd·factor)`` with
-        ``factor = (invw_a + invw_b) * (1 - dmax)``."""
+        """Per-contact ``solref`` must equal the ``convert_solref`` conversion of
+        ``(ke·factor, kd·factor)`` with ``factor = (invw_a + invw_b) * (1 - dmax)``."""
         ke, kd, mass = 1.0e4, 100.0, 5.0
         model, _ = self._build_box_on_plane(mass=mass, ke=ke, kd=kd)
         solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
@@ -11212,7 +11211,7 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         rel_tol = 1.0e-4
         self.assertAlmostEqual(float(actual_solref[0]), updated_solref_ref, delta=abs(updated_solref_ref) * rel_tol)
-        # Heavier body → smaller factor → larger timeconst (2 / (kd * factor)).
+        # Heavier body → smaller factor → larger solref[0] (2 / (kd * factor)).
         self.assertGreater(updated_solref_ref, initial_solref_ref)
 
     def test_force_space_contact_mixed_mode_falls_through_to_geom_solref(self):
@@ -11251,8 +11250,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
         self._run_to_first_contact(model, solver)
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
-        # dmax=1 zeroes the factor → override skipped; a sub-1.0 timeconst (not
-        # the clamped ~2/MJ_MINVAL) proves the guard fired.
+        # dmax=1 zeroes the factor → override skipped; solref[0] stays sub-1.0
+        # instead of the ~2/MJ_MINVAL a fired override would produce.
         self.assertLess(float(actual_solref[0]), 1.0)
 
     def test_force_space_with_mujoco_contacts_emits_startup_warning(self):
@@ -11310,15 +11309,15 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         # Per MuJoCo's solmix rule with equal priority and unit solmix on both
         # shapes, ``mix == 0.5`` exactly. Recover the mixed ke/kd, then assert
-        # ``contact.solref`` equals the positive ``(timeconst, dampratio)``
-        # conversion of the blended pair.
+        # ``contact.solref`` equals the ``convert_solref`` conversion of the
+        # blended pair.
         mix_ke = 0.5 * ke_a + 0.5 * ke_b
         mix_kd = 0.5 * kd_a + 0.5 * kd_b
         rel_tol = 1.0e-3
         expected_ref, expected_damp = self._expected_force_space_solref(solver, 0, ke=mix_ke, kd=mix_kd)
         self.assertAlmostEqual(float(actual_solref[0]), expected_ref, delta=abs(expected_ref) * rel_tol)
         self.assertAlmostEqual(float(actual_solref[1]), expected_damp, delta=abs(expected_damp) * rel_tol)
-        # Sanity: the blended timeconst (which tracks ``kd``) lies strictly
+        # Sanity: the blended solref[0] (which tracks ``kd``) lies strictly
         # between the single-material endpoints, the smoke test for ``mix``
         # actually being used.
         ref_a, _ = self._expected_force_space_solref(solver, 0, ke=ke_a, kd=kd_a)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -11053,8 +11053,11 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
 
     Tests use ``use_mujoco_contacts=False`` explicitly so the
     Newton-contacts kernel (where the override lives) runs. They read
-    ``mjw_data.contact.solref`` back directly and compare to the contact
-    direct-mode pair ``(-ke·factor, -kd·factor)``. ``use_mujoco_contacts
+    ``mjw_data.contact.solref`` back directly and compare to the positive
+    ``(timeconst, dampratio)`` conversion of ``(ke·factor, kd·factor)`` —
+    mirroring the joint-limit suite
+    pattern (:meth:`TestMuJoCoSolverInvweightScaledSolref
+    .test_joint_limit_solref_uses_dof_invweight0`). ``use_mujoco_contacts
     =True`` and the MuJoCo CPU backend remain unsupported for
     ``FORCE_SPACE``: MuJoCo's internal ``contact_params`` operates on
     per-geom ``solref`` and cannot reproduce the two-body invweight sum.
@@ -11110,10 +11113,13 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         invw_b = float(body_invweight0[0, body_b, 0]) if body_b >= 0 else 0.0
         dmax = float(solver.mjw_data.contact.solimp.numpy()[contact_idx, 1])
         factor = (invw_a + invw_b) * (1.0 - dmax)
-        return -ke * factor, -kd * factor
+        direct_stiffness = max(ke * factor, MJ_MINVAL)
+        direct_damping = max(kd * factor, MJ_MINVAL)
+        return 2.0 / direct_damping, direct_damping / (2.0 * math.sqrt(direct_stiffness))
 
     def test_force_space_contact_solref_uses_invweight0_and_dmax(self):
-        """Per-contact ``solref`` must equal ``(-ke·factor, -kd·factor)`` with
+        """Per-contact ``solref`` must equal the positive ``(timeconst, dampratio)``
+        conversion of ``(ke·factor, kd·factor)`` with
         ``factor = (invw_a + invw_b) * (1 - dmax)``."""
         ke, kd, mass = 1.0e4, 100.0, 5.0
         model, _ = self._build_box_on_plane(mass=mass, ke=ke, kd=kd)
@@ -11127,10 +11133,10 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         rel_tol = 1.0e-4
         self.assertAlmostEqual(float(actual_solref[0]), expected_ref, delta=abs(expected_ref) * rel_tol)
         self.assertAlmostEqual(float(actual_solref[1]), expected_damp, delta=abs(expected_damp) * rel_tol)
-        # Sign sanity: the legacy ``convert_solref(ke, kd, 1, 1)`` fallback
-        # would emit a positive ``(timeconst, dampratio)`` pair, never negative.
-        self.assertLess(float(actual_solref[0]), 0.0)
-        self.assertLess(float(actual_solref[1]), 0.0)
+        # Positive ``(timeconst, dampratio)`` convention so MuJoCo's refsafe
+        # clamp stays active for contacts too stiff for the timestep.
+        self.assertGreater(float(actual_solref[0]), 0.0)
+        self.assertGreater(float(actual_solref[1]), 0.0)
 
     def test_force_space_contact_solref_uses_two_body_invweight_sum(self):
         """Dynamic-vs-dynamic contact: factor uses the sum of both bodies' invweight0."""
@@ -11210,7 +11216,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         rel_tol = 1.0e-4
         self.assertAlmostEqual(float(actual_solref[0]), updated_solref_ref, delta=abs(updated_solref_ref) * rel_tol)
-        # Heavier body → smaller invweight0 → smaller |factor| → less-negative solref[0].
+        # Heavier body → smaller invweight0 → smaller factor → larger timeconst
+        # (solref[0] = 2 / (kd * factor)).
         self.assertGreater(updated_solref_ref, initial_solref_ref)
 
     def test_force_space_contact_mixed_mode_falls_through_to_geom_solref(self):
@@ -11229,10 +11236,18 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
         self._run_to_first_contact(model, solver)
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
-        # Per-geom mixing produces a positive ``(timeconst, dampratio)`` pair;
-        # the force-space override would have produced negatives.
+        # Both the override and per-geom mixing now emit positive
+        # ``(timeconst, dampratio)``, so discriminate by value: the actual
+        # ``solref`` must differ from the two-body force-space conversion the
+        # override would have written, proving the override was bypassed.
+        override_ref, override_damp = self._expected_force_space_solref(solver, 0, ke=ke, kd=kd)
         self.assertGreater(float(actual_solref[0]), 0.0)
         self.assertGreater(float(actual_solref[1]), 0.0)
+        self.assertFalse(
+            np.isclose(float(actual_solref[0]), override_ref, rtol=1e-3)
+            and np.isclose(float(actual_solref[1]), override_damp, rtol=1e-3),
+            "mixed-mode contact must not use the force-space override solref",
+        )
 
     def test_force_space_contact_solref_dmax_one_disables_override(self):
         """Guard boundary: ``dmax >= 1`` must skip the override (factor would be zero)."""
@@ -11247,9 +11262,12 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         self._run_to_first_contact(model, solver)
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         # With dmax=1 the override's ``factor = m_inv * (1 - dmax) = 0`` is
-        # discarded; per-geom mixing keeps positive (timeconst, dampratio).
+        # discarded; per-geom mixing keeps a normal positive (timeconst,
+        # dampratio). Had the override fired, the ``MJ_MINVAL``-clamped factor
+        # would yield a degenerate ~``2 / MJ_MINVAL`` timeconst.
         self.assertGreater(float(actual_solref[0]), 0.0)
         self.assertGreater(float(actual_solref[1]), 0.0)
+        self.assertLess(float(actual_solref[0]), 1.0)
 
     def test_force_space_with_mujoco_contacts_emits_startup_warning(self):
         """Opting into FORCE_SPACE while running ``use_mujoco_contacts=True`` must warn at startup.
@@ -11306,26 +11324,22 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         # Per MuJoCo's solmix rule with equal priority and unit solmix on both
         # shapes, ``mix == 0.5`` exactly. Recover the mixed ke/kd, then assert
-        # ``contact.solref == -mix_ke * factor`` etc. The blended values fall
-        # strictly between the two endpoints, which is the smoke test for
-        # ``mix`` actually being used.
-        geom_pair = solver.mjw_data.contact.geom.numpy()[0]
-        geom_bodyid = solver.mjw_model.geom_bodyid.numpy()
-        body_a = int(geom_bodyid[int(geom_pair[0])])
-        body_b = int(geom_bodyid[int(geom_pair[1])])
-        body_invweight0 = solver.mjw_model.body_invweight0.numpy()
-        invw_a = float(body_invweight0[0, body_a, 0]) if body_a >= 0 else 0.0
-        invw_b = float(body_invweight0[0, body_b, 0]) if body_b >= 0 else 0.0
-        dmax = float(solver.mjw_data.contact.solimp.numpy()[0, 1])
-        factor = (invw_a + invw_b) * (1.0 - dmax)
+        # ``contact.solref`` equals the positive ``(timeconst, dampratio)``
+        # conversion of the blended pair.
         mix_ke = 0.5 * ke_a + 0.5 * ke_b
         mix_kd = 0.5 * kd_a + 0.5 * kd_b
         rel_tol = 1.0e-3
-        self.assertAlmostEqual(float(actual_solref[0]), -mix_ke * factor, delta=abs(mix_ke * factor) * rel_tol)
-        self.assertAlmostEqual(float(actual_solref[1]), -mix_kd * factor, delta=abs(mix_kd * factor) * rel_tol)
-        # Sanity: blended value is between the two extremes, neither endpoint matches.
-        self.assertNotAlmostEqual(float(actual_solref[0]), -ke_a * factor, delta=abs(ke_a * factor) * 0.05)
-        self.assertNotAlmostEqual(float(actual_solref[0]), -ke_b * factor, delta=abs(ke_b * factor) * 0.05)
+        expected_ref, expected_damp = self._expected_force_space_solref(solver, 0, ke=mix_ke, kd=mix_kd)
+        self.assertAlmostEqual(float(actual_solref[0]), expected_ref, delta=abs(expected_ref) * rel_tol)
+        self.assertAlmostEqual(float(actual_solref[1]), expected_damp, delta=abs(expected_damp) * rel_tol)
+        # Sanity: the blended timeconst (which tracks ``kd``) lies strictly
+        # between the single-material endpoints, the smoke test for ``mix``
+        # actually being used.
+        ref_a, _ = self._expected_force_space_solref(solver, 0, ke=ke_a, kd=kd_a)
+        ref_b, _ = self._expected_force_space_solref(solver, 0, ke=ke_b, kd=kd_b)
+        lo, hi = sorted((ref_a, ref_b))
+        self.assertGreater(float(actual_solref[0]), lo)
+        self.assertLess(float(actual_solref[0]), hi)
 
     def test_mjcf_default_mode_preserved(self):
         """Unauthored MJCF geoms stay in ``SOLREF_MODE_MJCF_DEFAULT``.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -25,6 +25,7 @@ from newton._src.solvers.mujoco.constants import (
     SOLREF_MODE_RAW,
 )
 from newton._src.solvers.mujoco.equality import _add_equality_constraint
+from newton._src.solvers.mujoco.kernels import convert_solref
 from newton._src.solvers.mujoco.utils import MJC_OBJ_BODY, MJC_OBJ_JOINT, MjcEqualityTargetKind
 from newton.solvers import SolverMuJoCo
 from newton.tests.unittest_utils import USD_AVAILABLE, assert_np_equal
@@ -11113,9 +11114,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         invw_b = float(body_invweight0[0, body_b, 0]) if body_b >= 0 else 0.0
         dmax = float(solver.mjw_data.contact.solimp.numpy()[contact_idx, 1])
         factor = (invw_a + invw_b) * (1.0 - dmax)
-        direct_stiffness = max(ke * factor, MJ_MINVAL)
-        direct_damping = max(kd * factor, MJ_MINVAL)
-        return 2.0 / direct_damping, direct_damping / (2.0 * math.sqrt(direct_stiffness))
+        solref = convert_solref(max(ke * factor, MJ_MINVAL), max(kd * factor, MJ_MINVAL), 1.0, 1.0)
+        return float(solref[0]), float(solref[1])
 
     def test_force_space_contact_solref_uses_invweight0_and_dmax(self):
         """Per-contact ``solref`` must equal the positive ``(timeconst, dampratio)``
@@ -11133,10 +11133,6 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         rel_tol = 1.0e-4
         self.assertAlmostEqual(float(actual_solref[0]), expected_ref, delta=abs(expected_ref) * rel_tol)
         self.assertAlmostEqual(float(actual_solref[1]), expected_damp, delta=abs(expected_damp) * rel_tol)
-        # Positive ``(timeconst, dampratio)`` convention so MuJoCo's refsafe
-        # clamp stays active for contacts too stiff for the timestep.
-        self.assertGreater(float(actual_solref[0]), 0.0)
-        self.assertGreater(float(actual_solref[1]), 0.0)
 
     def test_force_space_contact_solref_uses_two_body_invweight_sum(self):
         """Dynamic-vs-dynamic contact: factor uses the sum of both bodies' invweight0."""
@@ -11216,8 +11212,7 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
         rel_tol = 1.0e-4
         self.assertAlmostEqual(float(actual_solref[0]), updated_solref_ref, delta=abs(updated_solref_ref) * rel_tol)
-        # Heavier body → smaller invweight0 → smaller factor → larger timeconst
-        # (solref[0] = 2 / (kd * factor)).
+        # Heavier body → smaller factor → larger timeconst (2 / (kd * factor)).
         self.assertGreater(updated_solref_ref, initial_solref_ref)
 
     def test_force_space_contact_mixed_mode_falls_through_to_geom_solref(self):
@@ -11236,13 +11231,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
         self._run_to_first_contact(model, solver)
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
-        # Both the override and per-geom mixing now emit positive
-        # ``(timeconst, dampratio)``, so discriminate by value: the actual
-        # ``solref`` must differ from the two-body force-space conversion the
-        # override would have written, proving the override was bypassed.
+        # Override bypassed: solref must differ from the force-space conversion.
         override_ref, override_damp = self._expected_force_space_solref(solver, 0, ke=ke, kd=kd)
-        self.assertGreater(float(actual_solref[0]), 0.0)
-        self.assertGreater(float(actual_solref[1]), 0.0)
         self.assertFalse(
             np.isclose(float(actual_solref[0]), override_ref, rtol=1e-3)
             and np.isclose(float(actual_solref[1]), override_damp, rtol=1e-3),
@@ -11261,12 +11251,8 @@ class TestMuJoCoSolverForceSpaceContactSolref(unittest.TestCase):
         solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=20, nconmax=20, iterations=10)
         self._run_to_first_contact(model, solver)
         actual_solref = solver.mjw_data.contact.solref.numpy()[0]
-        # With dmax=1 the override's ``factor = m_inv * (1 - dmax) = 0`` is
-        # discarded; per-geom mixing keeps a normal positive (timeconst,
-        # dampratio). Had the override fired, the ``MJ_MINVAL``-clamped factor
-        # would yield a degenerate ~``2 / MJ_MINVAL`` timeconst.
-        self.assertGreater(float(actual_solref[0]), 0.0)
-        self.assertGreater(float(actual_solref[1]), 0.0)
+        # dmax=1 zeroes the factor → override skipped; a sub-1.0 timeconst (not
+        # the clamped ~2/MJ_MINVAL) proves the guard fired.
         self.assertLess(float(actual_solref[0]), 1.0)
 
     def test_force_space_with_mujoco_contacts_emits_startup_warning(self):


### PR DESCRIPTION
## Description

Follow-up to #3132 (joint limits), found while reviewing it.

The shape-material force-space contact override in `convert_newton_contacts_to_mjwarp_kernel` writes per-contact `solref` in MuJoCo's negative direct-mode convention `(-ke * factor, -kd * factor)`. Direct mode bypasses MuJoCo's `refsafe` clamp (`timeconst >= 2*dt`) — the exact same latent failure mode #3109 hit for joint limits. Confirmed in `mujoco_warp`'s `constraint.py`: the shared `_update_efc_row` applies `refsafe` only to the positive `(timeconst, dampratio)` branch; the negative direct-mode branch discards the clamped `timeconst`. Contacts flow through that same function via `d.contact.solref`.

This PR converts the scaled stiffness/damping pair to the positive convention via the existing `convert_solref` helper. The conversion reproduces the same unclamped force-space response while letting `refsafe` soften contacts too stiff for the step.

Scope/severity notes:

- This path is **opt-in**: shapes default to `SOLREF_MODE_MJCF_DEFAULT`, and the override only fires when both shapes in a contact are explicitly `SOLREF_MODE_FORCE_SPACE`. (Joint limits, which default to `FORCE_SPACE`, were the broad #3109 trigger.) The blow-up here is therefore **latent** — not independently reproduced as non-finite, unlike #3109.
- Marked **draft** pending team review of two open points: (1) whether to also add a finiteness regression test exercising the `refsafe`-clamping regime (same gap noted on #3132), and (2) the separate question of whether joint limits should keep defaulting to `FORCE_SPACE` at all.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A: internal convention fix to the already-listed (unreleased) force-space contact entry

## Test plan

```
uv run --extra dev -m newton.tests -k "test_mujoco_solver.TestMuJoCoSolverForceSpaceContactSolref"
```

All 11 tests in the class pass on GPU. The sign-based discriminators in `mixed_mode` / `dmax_one` were replaced with value-based checks, since both the override and the per-geom fall-through now emit positive `solref`.

## Bug fix

**Steps to reproduce (latent — same class as #3109):**

1. Build a model with two shapes both set to `mujoco.solref_mode == SOLREF_MODE_FORCE_SPACE` and large `shape_material_ke`, run with `SolverMuJoCo(use_mujoco_contacts=False)`.
2. The per-contact `solref` is written negative (direct mode), so MuJoCo's `refsafe` timestep clamp never engages.
3. A contact stiff enough for the timestep can diverge, mirroring #3109's joint-limit blow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified SolverMuJoCo contact-material docs to explain positive stiffness/damping (time-constant, dampratio) convention and per-contact solref calculation.

* **Bug Fixes**
  * Ensured per-contact solref uses clamped positive stiffness/damping values and the proper positive (timeconstant, dampratio) mapping for consistent solver behavior.

* **Tests**
  * Updated and tightened contact-solver tests and assertions to validate the positive solref convention, bounds, and mixed-material behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
