### PR TITLE
Migrate Kamino contact-sensor test off deprecated alias

### DIFF
--- a/newton/tests/test_sensor_contact.py
+++ b/newton/tests/test_sensor_contact.py
@@ -817,7 +817,7 @@ class TestSensorContactKamino(unittest.TestCase):
 
         # SensorContact requests the ``force`` contact attribute, so allocate the
         # output ``Contacts`` buffer afterwards to pick it up.
-        sensor = SensorContact(model, sensing_obj_bodies=["box"])
+        sensor = SensorContact(model, sensing_bodies=["box"])
         contacts = newton.Contacts(
             rigid_contact_max=200,
             soft_contact_max=0,


### PR DESCRIPTION
## Description

`TestSensorContactKamino.test_box_on_plane_total_force_matches_aggregation` constructs `SensorContact` with the deprecated `sensing_obj_bodies=` keyword, which emits a `DeprecationWarning`. Switch to the supported `sensing_bodies=` keyword; the constructor maps the two identically, so behavior is unchanged.

The deprecated usage was introduced by #2908 and surfaces as a hard failure under the opt-in strict-warnings test mode proposed in #3044, where Newton-emitted `DeprecationWarning`s are escalated to errors.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k "test_sensor_contact.TestSensorContactKamino"
```

Confirmed the test errors under `python -W error::DeprecationWarning` before the change and passes the full simulation after it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated regression test to use non-deprecated sensor contact API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->