### PR TITLE
Remove deprecated body armature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,12 @@
 - Remove the deprecated `newton-actuators` package dependency; all actuator functionality is built into `newton.actuators`
 - Remove the deprecated implicit MPM `collider_velocity_mode` aliases `'finite_difference'` and `'instantaneous'` (deprecated in 1.1.0); use `'backward'` and `'forward'` instead
 - Remove the deprecated `Viewer.update_shape_colors()`; write to `Model.shape_color` directly instead
+- Remove body armature: drop `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` and `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. All `add_link()` and `add_body()` parameters are now keyword-only
 - Remove support for passing a `Gaussian` as the second positional argument to `ModelBuilder.add_shape_gaussian()` (deprecated in 1.1.0); pass it via the `gaussian=` keyword instead
 - Remove support for `worlds_per_row=0` in `SensorTiledCamera.flatten_*_to_rgba()` (deprecated in 1.2.0); pass `worlds_per_row=None` for automatic layout (values below 1 now raise `ValueError`) (#3149)
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_pinhole_camera_rays()` and `create_depth_image_output()` for single-camera depth) instead
-- Remove body armature — `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. All `add_link()` / `add_body()` parameters are now keyword-only
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead
-- Remove body armature — `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. The remaining `add_link()` / `add_body()` parameters after `xform` are now keyword-only
 
 ## [1.3.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Remove support for passing a `Gaussian` as the second positional argument to `ModelBuilder.add_shape_gaussian()` (deprecated in 1.1.0); pass it via the `gaussian=` keyword instead
 - Remove support for `worlds_per_row=0` in `SensorTiledCamera.flatten_*_to_rgba()` (deprecated in 1.2.0); pass `worlds_per_row=None` for automatic layout (values below 1 now raise `ValueError`) (#3149)
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_pinhole_camera_rays()` and `create_depth_image_output()` for single-camera depth) instead
+- Remove body armature — `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. All `add_link()` / `add_body()` parameters are now keyword-only
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead
 - Remove body armature — `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. The remaining `add_link()` / `add_body()` parameters after `xform` are now keyword-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_pinhole_camera_rays()` and `create_depth_image_output()` for single-camera depth) instead
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead
+- Remove body armature — `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. The remaining `add_link()` / `add_body()` parameters after `xform` are now keyword-only
 
 ## [1.3.0] - 2026-06-11
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -3860,8 +3860,8 @@ class ModelBuilder:
 
     def add_link(
         self,
-        xform: Transform | None = None,
         *,
+        xform: Transform | None = None,
         com: Vec3 | None = None,
         inertia: Mat33 | None = None,
         mass: float = 0.0,
@@ -3945,8 +3945,8 @@ class ModelBuilder:
 
     def add_body(
         self,
-        xform: Transform | None = None,
         *,
+        xform: Transform | None = None,
         com: Vec3 | None = None,
         inertia: Mat33 | None = None,
         mass: float = 0.0,

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import copy
 import ctypes
-import inspect
 import math
 import warnings
 from collections import Counter, deque
@@ -189,15 +188,6 @@ class ModelBuilder:
         "will change from 'start' to 'com' in a future release. Pass body_frame_origin='start' to "
         "preserve the existing start-node body frame, or body_frame_origin='com' to opt into "
         "COM-centered capsule body frames."
-    )
-    _BODY_ARMATURE_ARG_DEPRECATION_MESSAGE = (
-        "ModelBuilder.add_link(..., armature=...) and ModelBuilder.add_body(..., armature=...) "
-        "are deprecated and will be removed in a future release. "
-        "Add any isotropic artificial inertia directly to 'inertia' instead."
-    )
-    _DEFAULT_BODY_ARMATURE_DEPRECATION_MESSAGE = (
-        "ModelBuilder.default_body_armature is deprecated and will be removed in a future release. "
-        "Add any isotropic artificial inertia directly to 'inertia' instead."
     )
 
     @staticmethod
@@ -888,7 +878,6 @@ class ModelBuilder:
         self.default_tet_density = 1.0
         """Default density [kg/m^3] for tetrahedral soft bodies."""
 
-        self._default_body_armature = 0.0
         # endregion
 
         # region compiler settings (similar to MuJoCo)
@@ -3869,57 +3858,10 @@ class ModelBuilder:
 
         return wp.mat33(*value)
 
-    @staticmethod
-    def _external_warning_stacklevel() -> int:
-        frame = inspect.currentframe()
-        if frame is None:
-            return 2
-
-        frame = frame.f_back
-        stacklevel = 1
-        try:
-            while frame is not None and frame.f_code.co_filename == __file__:
-                frame = frame.f_back
-                stacklevel += 1
-            return stacklevel
-        finally:
-            del frame
-
-    @classmethod
-    def _warn_body_armature_arg_deprecated(cls) -> None:
-        warnings.warn(
-            cls._BODY_ARMATURE_ARG_DEPRECATION_MESSAGE,
-            DeprecationWarning,
-            stacklevel=cls._external_warning_stacklevel(),
-        )
-
-    @classmethod
-    def _warn_default_body_armature_deprecated(cls) -> None:
-        warnings.warn(
-            cls._DEFAULT_BODY_ARMATURE_DEPRECATION_MESSAGE,
-            DeprecationWarning,
-            stacklevel=cls._external_warning_stacklevel(),
-        )
-
-    @property
-    def default_body_armature(self) -> float:
-        """Deprecated default body armature.
-
-        .. deprecated:: 1.1
-            Add any isotropic artificial inertia directly to ``inertia`` instead.
-        """
-        self._warn_default_body_armature_deprecated()
-        return self._default_body_armature
-
-    @default_body_armature.setter
-    def default_body_armature(self, value: float) -> None:
-        self._warn_default_body_armature_deprecated()
-        self._default_body_armature = value
-
     def add_link(
         self,
         xform: Transform | None = None,
-        armature: float | None = None,
+        *,
         com: Vec3 | None = None,
         inertia: Mat33 | None = None,
         mass: float = 0.0,
@@ -3936,15 +3878,8 @@ class ModelBuilder:
 
         After calling this method and one of the joint methods, ensure that an articulation is created using :meth:`add_articulation`.
 
-        .. deprecated:: 1.1
-            The ``armature`` parameter is deprecated. Add any isotropic artificial
-            inertia directly to ``inertia`` instead.
-
         Args:
             xform: The location of the body in the world frame.
-            armature: Deprecated. Artificial inertia added to the body. If ``None``,
-                the deprecated default value from :attr:`default_body_armature` is used.
-                Add any isotropic artificial inertia directly to ``inertia`` instead.
             com: The center of mass of the body w.r.t its origin. If None, the center of mass is assumed to be at the origin.
             inertia: The 3x3 inertia tensor of the body (specified relative to the center of mass). If None, the inertia tensor is assumed to be zero.
             mass: Mass of the body.
@@ -3960,8 +3895,6 @@ class ModelBuilder:
             The index of the body in the model.
 
         """
-        if armature is not None and armature != 0.0:
-            self._warn_body_armature_arg_deprecated()
         if xform is None:
             xform = wp.transform()
         else:
@@ -3978,9 +3911,6 @@ class ModelBuilder:
         body_id = len(self.body_mass)
 
         # body data
-        if armature is None:
-            armature = self._default_body_armature
-        inertia = inertia + wp.mat33(np.eye(3, dtype=np.float32)) * armature
         self.body_inertia.append(inertia)
         self.body_mass.append(mass)
         self.body_com.append(com)
@@ -4016,7 +3946,7 @@ class ModelBuilder:
     def add_body(
         self,
         xform: Transform | None = None,
-        armature: float | None = None,
+        *,
         com: Vec3 | None = None,
         inertia: Mat33 | None = None,
         mass: float = 0.0,
@@ -4037,15 +3967,8 @@ class ModelBuilder:
         For creating articulations with multiple linked bodies, use :meth:`add_link`,
         the appropriate joint methods, and :meth:`add_articulation` directly.
 
-        .. deprecated:: 1.1
-            The ``armature`` parameter is deprecated. Add any isotropic artificial
-            inertia directly to ``inertia`` instead.
-
         Args:
             xform: The location of the body in the world frame.
-            armature: Deprecated. Artificial inertia added to the body. If ``None``,
-                the deprecated default value from :attr:`default_body_armature` is used.
-                Add any isotropic artificial inertia directly to ``inertia`` instead.
             com: The center of mass of the body w.r.t its origin. If None, the center of mass is assumed to be at the origin.
             inertia: The 3x3 inertia tensor of the body (specified relative to the center of mass). If None, the inertia tensor is assumed to be zero.
             mass: Mass of the body.
@@ -4063,7 +3986,6 @@ class ModelBuilder:
         """
         body_id = self.add_link(
             xform=xform,
-            armature=armature,
             com=com,
             inertia=inertia,
             mass=mass,

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import copy
 import ctypes
+import inspect
 import math
 import warnings
 from collections import Counter, deque
@@ -200,6 +201,22 @@ class ModelBuilder:
         if color is None:
             return None
         return (float(color[0]), float(color[1]), float(color[2]))
+
+    @staticmethod
+    def _external_warning_stacklevel() -> int:
+        frame = inspect.currentframe()
+        if frame is None:
+            return 2
+
+        frame = frame.f_back
+        stacklevel = 1
+        try:
+            while frame is not None and frame.f_code.co_filename == __file__:
+                frame = frame.f_back
+                stacklevel += 1
+            return stacklevel
+        finally:
+            del frame
 
     @classmethod
     def _resolve_rod_body_frame_origin(

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import collections
 import copy
 import datetime
-import inspect
 import itertools
 import logging
 import math
@@ -50,24 +49,6 @@ from .import_utils import should_show_collider
 logger = logging.getLogger("newton")
 
 AttributeFrequency = Model.AttributeFrequency
-
-_NEWTON_SRC_DIR = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pardir)) + os.sep
-
-
-def _external_stacklevel() -> int:
-    """Return a ``stacklevel`` that points past all ``newton._src`` frames."""
-    frame = inspect.currentframe()
-    if frame is None:
-        return 2
-    frame = frame.f_back
-    stacklevel = 1
-    try:
-        while frame is not None and os.path.normpath(frame.f_code.co_filename).startswith(_NEWTON_SRC_DIR):
-            frame = frame.f_back
-            stacklevel += 1
-        return stacklevel
-    finally:
-        del frame
 
 
 def parse_usd(
@@ -759,7 +740,6 @@ def parse_usd(
         return imageable.ComputeVisibility() != UsdGeom.Tokens.invisible
 
     bodies_with_visual_shapes: set[int] = set()
-    warned_deprecated_body_armature_paths: set[str] = set()
 
     def _get_prim_world_mat(prim, articulation_root_xform, incoming_world_xform):
         prim_world_mat = usd.get_transform_matrix(prim, local=False, xform_cache=xform_cache)
@@ -997,7 +977,6 @@ def parse_usd(
         prim: Usd.Prim,
         xform: wp.transform,
         label: str,
-        armature: float | None,
         articulation_root_xform: wp.transform | None = None,
         is_kinematic: bool = False,
     ) -> int:
@@ -1006,13 +985,10 @@ def parse_usd(
         body_custom_attrs = usd.get_custom_attribute_values(
             prim, builder_custom_attr_body, context={"builder": builder}
         )
-        body_inertia = wp.mat33(np.eye(3, dtype=np.float32)) * armature if armature is not None else None
 
         b = builder.add_link(
             xform=xform,
             label=label,
-            inertia=body_inertia,
-            armature=0.0 if armature is not None else None,
             is_kinematic=is_kinematic,
             custom_attributes=body_custom_attrs,
         )
@@ -1044,28 +1020,6 @@ def parse_usd(
             origin = wp.mul(incoming_xform, origin)
         path = str(prim.GetPath())
 
-        body_armature_source_path: str | None = None
-        body_armature = usd.get_float(prim, "newton:armature", None)
-        if body_armature is not None:
-            body_armature_source_path = path
-        if body_armature is None and physics_scene_prim:
-            body_armature = usd.get_float(physics_scene_prim, "newton:armature", None)
-            if body_armature is not None:
-                body_armature_source_path = str(physics_scene_prim.GetPath())
-
-        if (
-            body_armature_source_path is not None
-            and body_armature_source_path not in warned_deprecated_body_armature_paths
-        ):
-            warnings.warn(
-                f"USD-authored 'newton:armature' on {body_armature_source_path} is deprecated and will be "
-                "removed in a future release. Add any isotropic artificial inertia directly to the body's "
-                "inertia instead.",
-                DeprecationWarning,
-                stacklevel=_external_stacklevel(),
-            )
-            warned_deprecated_body_armature_paths.add(body_armature_source_path)
-
         is_kinematic = rigid_body_desc.kinematicBody
 
         if add_body_to_builder:
@@ -1073,7 +1027,6 @@ def parse_usd(
                 prim,
                 origin,
                 path,
-                body_armature,
                 articulation_root_xform=articulation_root_xform,
                 is_kinematic=is_kinematic,
             )
@@ -1082,7 +1035,6 @@ def parse_usd(
                 "prim": prim,
                 "xform": origin,
                 "label": path,
-                "armature": body_armature,
                 "is_kinematic": is_kinematic,
             }
             if articulation_root_xform is not None:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -114,7 +114,10 @@ def Xform "Root" (
         self.assertEqual(len(collision_shapes), 13)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
-    def test_import_body_newton_armature_warns_deprecated(self):
+    def test_import_body_newton_armature_ignored(self):
+        # Body-level newton:armature was removed: an authored value must be
+        # ignored without warning and contribute nothing to body inertia.
+        # (Joint-level newton:armature is a separate, supported attribute.)
         from pxr import Sdf, Usd, UsdGeom, UsdPhysics
 
         stage = Usd.Stage.CreateInMemory()
@@ -133,17 +136,15 @@ def Xform "Root" (
             warnings.simplefilter("always")
             builder.add_usd(stage)
 
-        deprecations = [item for item in caught if issubclass(item.category, DeprecationWarning)]
-        self.assertEqual(len(deprecations), 1)
-        message = str(deprecations[0].message)
-        self.assertIn("newton:armature", message)
-        self.assertIn("/World/Body", message)
-        self.assertNotIn("add_link(..., armature=...)", message)
+        self.assertFalse(
+            any("newton:armature" in str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)),
+            "body newton:armature should be ignored silently",
+        )
 
-        # Verify the armature was applied to body inertia (default cube: half-extents
-        # (1,1,1), density 1000 → mass 8000, diagonal = 16000/3; plus armature 0.125)
+        # Authored armature is ignored: inertia is shape-only (default cube:
+        # half-extents (1,1,1), density 1000 → mass 8000, diagonal = 16000/3).
         inertia = builder.body_inertia[0]
-        expected_diag = 16000.0 / 3.0 + 0.125
+        expected_diag = 16000.0 / 3.0
         for j in range(3):
             self.assertAlmostEqual(float(inertia[j, j]), expected_diag, places=2)
 

--- a/newton/tests/test_joint_controllers.py
+++ b/newton/tests/test_joint_controllers.py
@@ -31,7 +31,7 @@ def test_revolute_controller(
     box_mass = 1.0
     box_inertia = wp.mat33((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
     # easy case: identity transform, zero center of mass
-    b = builder.add_link(armature=0.0, inertia=box_inertia, mass=box_mass)
+    b = builder.add_link(inertia=box_inertia, mass=box_mass)
     builder.add_shape_box(body=b, hx=0.2, hy=0.2, hz=0.2, cfg=newton.ModelBuilder.ShapeConfig(density=1))
 
     # Create a revolute joint
@@ -105,7 +105,7 @@ def test_ball_controller(
         box_mass = 1.0
         box_inertia = wp.mat33((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
         # easy case: identity transform, zero center of mass
-        b = builder.add_link(armature=0.0, inertia=box_inertia, mass=box_mass)
+        b = builder.add_link(inertia=box_inertia, mass=box_mass)
         builder.add_shape_box(body=b, hx=0.2, hy=0.2, hz=0.2, cfg=newton.ModelBuilder.ShapeConfig(density=1))
 
         # Create a ball joint
@@ -201,7 +201,7 @@ def test_ball_controller_coord_layout(
     try:
         builder = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
         box_inertia = wp.mat33((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
-        b = builder.add_link(armature=0.0, inertia=box_inertia, mass=1.0)
+        b = builder.add_link(inertia=box_inertia, mass=1.0)
         builder.add_shape_box(body=b, hx=0.2, hy=0.2, hz=0.2, cfg=newton.ModelBuilder.ShapeConfig(density=1))
         j = builder.add_joint_ball(
             parent=-1,
@@ -277,11 +277,11 @@ def test_ball_controller_coord_layout_rotated_anchor(
         builder = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
         box_inertia = wp.mat33((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
 
-        base = builder.add_link(armature=0.0, inertia=box_inertia, mass=1.0)
+        base = builder.add_link(inertia=box_inertia, mass=1.0)
         j_free = builder.add_joint_free(child=base)
         builder.add_articulation([j_free])
 
-        b = builder.add_link(armature=0.0, inertia=box_inertia, mass=1.0)
+        b = builder.add_link(inertia=box_inertia, mass=1.0)
         builder.add_shape_box(body=b, hx=0.2, hy=0.2, hz=0.2, cfg=newton.ModelBuilder.ShapeConfig(density=1))
         j = builder.add_joint_ball(
             parent=-1,
@@ -364,11 +364,11 @@ def test_free_plus_revolute_position_target(
         builder = newton.ModelBuilder(up_axis=newton.Axis.Z, gravity=0.0)
         newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
 
-        base = builder.add_link(armature=0.0, inertia=wp.mat33(np.eye(3) * 0.1), mass=1.0)
+        base = builder.add_link(inertia=wp.mat33(np.eye(3) * 0.1), mass=1.0)
         builder.add_shape_box(body=base, hx=0.1, hy=0.1, hz=0.1, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
         j_free = builder.add_joint_free(child=base)
 
-        child = builder.add_link(armature=0.0, inertia=wp.mat33(np.eye(3) * 0.1), mass=1.0)
+        child = builder.add_link(inertia=wp.mat33(np.eye(3) * 0.1), mass=1.0)
         builder.add_shape_box(body=child, hx=0.1, hy=0.1, hz=0.1, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
         target_pos = wp.pi / 4.0
         target_ke = 100.0
@@ -430,7 +430,7 @@ def test_effort_limit_clamping(
     box_mass = 1.0
     inertia_value = 0.1
     box_inertia = wp.mat33((inertia_value, 0.0, 0.0), (0.0, inertia_value, 0.0), (0.0, 0.0, inertia_value))
-    b = builder.add_link(armature=0.0, inertia=box_inertia, mass=box_mass)
+    b = builder.add_link(inertia=box_inertia, mass=box_mass)
     builder.add_shape_box(body=b, hx=0.1, hy=0.1, hz=0.1, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
 
     # High PD gains should be clamped by low effort_limit
@@ -517,7 +517,7 @@ def test_qfrc_actuator(
     box_mass = 1.0
     inertia_value = 0.1
     box_inertia = wp.mat33((inertia_value, 0.0, 0.0), (0.0, inertia_value, 0.0), (0.0, 0.0, inertia_value))
-    b = builder.add_link(armature=0.0, inertia=box_inertia, mass=box_mass)
+    b = builder.add_link(inertia=box_inertia, mass=box_mass)
     builder.add_shape_box(body=b, hx=0.1, hy=0.1, hz=0.1, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
 
     kp = 100.0
@@ -584,7 +584,7 @@ def test_qfrc_actuator(
 
     # Verify that qfrc_actuator is NOT allocated when not requested
     builder2 = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
-    b2 = builder2.add_link(armature=0.0, inertia=box_inertia, mass=box_mass)
+    b2 = builder2.add_link(inertia=box_inertia, mass=box_mass)
     builder2.add_shape_box(body=b2, hx=0.1, hy=0.1, hz=0.1, cfg=newton.ModelBuilder.ShapeConfig(density=0.0))
     j2 = builder2.add_joint_revolute(
         parent=-1,

--- a/newton/tests/test_joint_drive.py
+++ b/newton/tests/test_joint_drive.py
@@ -95,7 +95,7 @@ class TestJointDrive(unittest.TestCase):
             # Create a single body jointed to the world with a prismatic joint
             # Make sure that we use the mass properties specified here by setting shape density to 0.0
             world_builder = newton.ModelBuilder(gravity=g, up_axis=world_up_axis)
-            bodyIndex = world_builder.add_link(mass=body_mass, inertia=body_inertia, armature=0.0, com=body_com)
+            bodyIndex = world_builder.add_link(mass=body_mass, inertia=body_inertia, com=body_com)
             world_builder.add_shape_sphere(
                 radius=1.0, body=bodyIndex, cfg=newton.ModelBuilder.ShapeConfig(density=0.0, has_shape_collision=False)
             )

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -119,28 +119,6 @@ class TestModelBuilderDeprecations(unittest.TestCase):
         self.assertEqual(len(caught), 1)
         self.assertEqual(model.mujoco.equality_constraint_count, 3)
 
-    def test_body_armature_removed(self):
-        # Body armature was removed: the `armature` argument of add_link/add_body
-        # and the `default_body_armature` attribute no longer exist. Add any
-        # isotropic artificial inertia directly to `inertia` instead.
-        builder = ModelBuilder()
-        inertia = np.diag([1.0, 2.0, 3.0]).astype(np.float32)
-
-        with self.assertRaises(TypeError):
-            builder.add_link(mass=1.0, inertia=inertia, armature=0.5)
-        with self.assertRaises(TypeError):
-            builder.add_body(mass=1.0, inertia=inertia, armature=0.25)
-        with self.assertRaises(AttributeError):
-            _ = builder.default_body_armature
-
-        # `inertia` is honored as-is, with no armature contribution.
-        body = builder.add_link(mass=1.0, inertia=inertia)
-        np.testing.assert_allclose(
-            np.asarray(builder.body_inertia[body]).reshape(3, 3),
-            inertia,
-            atol=1e-6,
-        )
-
     def test_joint_target_pos_vel_aliases_warn(self):
         """Legacy ``joint_target_pos`` / ``joint_target_vel`` warn under the
         default flag and raise under ``use_coord_layout_targets=True``;

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -1821,11 +1821,11 @@ class TestModelJoints(unittest.TestCase):
     def test_add_base_joint_fixed_to_parent(self):
         """Test that add_base_joint with parent creates fixed joint."""
         builder = ModelBuilder()
-        parent_body = builder.add_body(wp.transform((0, 0, 0), wp.quat_identity()), mass=1.0)
+        parent_body = builder.add_body(xform=wp.transform((0, 0, 0), wp.quat_identity()), mass=1.0)
         parent_joint = builder.add_joint_fixed(parent=-1, child=parent_body)
         builder.add_articulation([parent_joint])  # Register parent body into an articulation
 
-        child_body = builder.add_body(wp.transform((1, 0, 0), wp.quat_identity()), mass=0.5)
+        child_body = builder.add_body(xform=wp.transform((1, 0, 0), wp.quat_identity()), mass=0.5)
         joint_id = builder._add_base_joint(child_body, parent=parent_body, floating=False)
 
         self.assertEqual(builder.joint_type[joint_id], newton.JointType.FIXED)

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -119,74 +119,25 @@ class TestModelBuilderDeprecations(unittest.TestCase):
         self.assertEqual(len(caught), 1)
         self.assertEqual(model.mujoco.equality_constraint_count, 3)
 
-    def test_default_body_armature_get_and_set_warn(self):
-        builder = ModelBuilder()
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            builder.default_body_armature = 0.25
-            value = builder.default_body_armature
-
-        self.assertAlmostEqual(value, 0.25)
-        self.assertEqual(len(caught), 2)
-        self.assertTrue(all(issubclass(item.category, DeprecationWarning) for item in caught))
-        self.assertTrue(all("default_body_armature" in str(item.message) for item in caught))
-        self.assertTrue(all(item.filename.endswith("test_model.py") for item in caught))
-
-    def test_add_link_armature_warns_and_preserves_inertia(self):
+    def test_body_armature_removed(self):
+        # Body armature was removed: the `armature` argument of add_link/add_body
+        # and the `default_body_armature` attribute no longer exist. Add any
+        # isotropic artificial inertia directly to `inertia` instead.
         builder = ModelBuilder()
         inertia = np.diag([1.0, 2.0, 3.0]).astype(np.float32)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            body = builder.add_link(mass=1.0, inertia=inertia, armature=0.5)
+        with self.assertRaises(TypeError):
+            builder.add_link(mass=1.0, inertia=inertia, armature=0.5)
+        with self.assertRaises(TypeError):
+            builder.add_body(mass=1.0, inertia=inertia, armature=0.25)
+        with self.assertRaises(AttributeError):
+            _ = builder.default_body_armature
 
-        self.assertEqual(body, 0)
-        self.assertEqual(len(caught), 1)
-        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
-        self.assertIn("add_link(..., armature=...)", str(caught[0].message))
-        self.assertTrue(caught[0].filename.endswith("test_model.py"))
+        # `inertia` is honored as-is, with no armature contribution.
+        body = builder.add_link(mass=1.0, inertia=inertia)
         np.testing.assert_allclose(
             np.asarray(builder.body_inertia[body]).reshape(3, 3),
-            inertia + np.eye(3, dtype=np.float32) * 0.5,
-            atol=1e-6,
-        )
-
-    def test_add_body_armature_warns_and_preserves_inertia(self):
-        builder = ModelBuilder()
-        inertia = np.diag([1.5, 2.5, 3.5]).astype(np.float32)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            body = builder.add_body(mass=1.0, inertia=inertia, armature=0.25)
-
-        self.assertEqual(body, 0)
-        self.assertEqual(len(caught), 1)
-        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
-        self.assertIn("add_body(..., armature=...)", str(caught[0].message))
-        self.assertTrue(caught[0].filename.endswith("test_model.py"))
-        np.testing.assert_allclose(
-            np.asarray(builder.body_inertia[body]).reshape(3, 3),
-            inertia + np.eye(3, dtype=np.float32) * 0.25,
-            atol=1e-6,
-        )
-
-    def test_add_link_uses_default_body_armature_without_extra_warning(self):
-        builder = ModelBuilder()
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            builder.default_body_armature = 0.125
-            body = builder.add_link()
-
-        self.assertEqual(body, 0)
-        self.assertEqual(len(caught), 1)
-        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
-        self.assertIn("default_body_armature", str(caught[0].message))
-        self.assertTrue(caught[0].filename.endswith("test_model.py"))
-        np.testing.assert_allclose(
-            np.asarray(builder.body_inertia[body]).reshape(3, 3),
-            np.eye(3, dtype=np.float32) * 0.125,
+            inertia,
             atol=1e-6,
         )
 

--- a/newton/tests/test_state_assign.py
+++ b/newton/tests/test_state_assign.py
@@ -12,7 +12,7 @@ import newton
 def _build_model(*, custom_attrs: tuple[str, ...] = ()):
     builder = newton.ModelBuilder(up_axis=newton.Axis.Y, gravity=0.0)
     inertia = wp.mat33((0.1, 0.0, 0.0), (0.0, 0.1, 0.0), (0.0, 0.0, 0.1))
-    body = builder.add_link(armature=0.0, inertia=inertia, mass=1.0)
+    body = builder.add_link(inertia=inertia, mass=1.0)
     joint = builder.add_joint_revolute(
         parent=-1,
         child=body,


### PR DESCRIPTION
## Description

Remove body armature, deprecated since 1.1.0. This drops `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` / `add_body()`, and the body-level USD-authored `newton:armature` read. Add any isotropic artificial inertia directly to `inertia` instead.

The remaining `add_link()` / `add_body()` parameters after `xform` are now keyword-only. Joint armature and the joint-level `newton:armature` schema mapping are unaffected.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_body_armature_removed
uv run --extra dev -m newton.tests -k test_import_body_newton_armature_ignored
uv run --extra dev -m newton.tests -k test_joint_controllers
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed deprecated “armature” support from rigid-body creation; provide `mass` and `inertia` explicitly.
  * Removed the `default_body_armature` property.
  * After the initial transform, body configuration parameters are now keyword-only.
  * USD-authored `newton:armature` at the body level is now ignored silently (no inertia contribution); use `inertia` instead.

* **Tests**
  * Updated USD import and model/joint controller tests to stop using `armature`, and adjusted inertia expectations accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->