### PR TITLE
Remove deprecated add_shape_ellipsoid a/b/c params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Removed
 
 - Remove the deprecated Style3D `CollisionHandler`; use `Collision` instead
+- Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead
 
 ## [1.3.0] - 2026-06-11
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -6423,16 +6423,11 @@ class ModelBuilder:
         color: Vec3 | None = None,
         label: str | None = None,
         custom_attributes: dict[str, Any] | None = None,
-        **kwargs,
     ) -> int:
         """Adds an ellipsoid collision shape or site to a body.
 
         The ellipsoid is centered at its local origin as defined by `xform`, with semi-axes
         `rx`, `ry`, `rz` along the local X, Y, Z axes respectively.
-
-        .. deprecated:: 1.1
-            The ``a``, ``b``, ``c`` parameter names are deprecated; use
-            ``rx``, ``ry``, ``rz`` instead.
 
         Note:
             Ellipsoid collision is handled by the GJK/MPR collision pipeline,
@@ -6472,26 +6467,6 @@ class ModelBuilder:
                 # A sphere is a special case where rx = ry = rz
                 builder.add_shape_ellipsoid(body=body, rx=0.5, ry=0.5, rz=0.5)
         """
-        # Backward compat: accept deprecated a, b, c parameter names
-        _deprecated_map = {"a": ("rx", rx, 1.0), "b": ("ry", ry, 0.75), "c": ("rz", rz, 0.5)}
-        for old_name, (new_name, new_val, default) in _deprecated_map.items():
-            if old_name in kwargs:
-                if new_val != default:
-                    raise TypeError(f"Cannot specify both '{old_name}' and '{new_name}'")
-                warnings.warn(
-                    f"Parameter '{old_name}' is deprecated, use '{new_name}' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-        if "a" in kwargs:
-            rx = kwargs.pop("a")
-        if "b" in kwargs:
-            ry = kwargs.pop("b")
-        if "c" in kwargs:
-            rz = kwargs.pop("c")
-        if kwargs:
-            raise TypeError(f"Unexpected keyword arguments: {set(kwargs)}")
-
         if cfg is None:
             cfg = self.default_site_cfg if as_site else self.default_shape_cfg
         elif as_site:


### PR DESCRIPTION
## Description

Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()`, deprecated in 1.1.0. The `**kwargs` shim that accepted the old names is gone; use `rx`, `ry`, `rz` instead. Passing `a`/`b`/`c` now raises `TypeError`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_negative_scaling
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Deprecated parameters `a`, `b`, `c` for ellipsoid shape configuration have been removed. Update your code to use `rx`, `ry`, `rz` parameters instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->