### PR TITLE
Remove deprecated set_model max_worlds parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Removed
 
 - Remove the deprecated Style3D `CollisionHandler`; use `Collision` instead
+- Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 
 ## [1.3.0] - 2026-06-11
 

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -39,7 +39,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 - :meth:`~newton.viewer.ViewerBase.log_image` — display a single or batched image as a dockable window in :class:`~newton.viewer.ViewerGL` (no-op on other backends)
 
 **Limiting rendered worlds**: When training with many parallel environments, rendering all worlds can impact performance.
-All viewers support the ``max_worlds`` parameter to limit visualization to a subset of environments:
+All viewers support ``set_visible_worlds()`` to limit visualization to a subset of environments:
 
 .. testcode:: viewer-max-worlds
 
@@ -49,7 +49,8 @@ All viewers support the ``max_worlds`` parameter to limit visualization to a sub
 
     # Only render the first 4 environments
     viewer = newton.viewer.ViewerNull()
-    viewer.set_model(model, max_worlds=4)
+    viewer.set_model(model)
+    viewer.set_visible_worlds(range(4))
 
 Real-time Viewers
 -----------------

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -15,7 +15,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 
 **Core loop methods** — every viewer uses the same simulation loop pattern:
 
-- :meth:`~newton.viewer.ViewerBase.set_model` — assign a :class:`~newton.Model` and optionally limit the number of rendered worlds with ``max_worlds``
+- :meth:`~newton.viewer.ViewerBase.set_model` — assign a :class:`~newton.Model` (use :meth:`~newton.viewer.ViewerBase.set_visible_worlds` afterwards to limit the number of rendered worlds)
 - :meth:`~newton.viewer.ViewerBase.begin_frame` — start a new frame with the current simulation time
 - :meth:`~newton.viewer.ViewerBase.log_state` — update the viewer with the current :class:`~newton.State` (body transforms, particle positions, etc.)
 - :meth:`~newton.viewer.ViewerBase.end_frame` — finish the frame and present it

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -184,30 +184,18 @@ class ViewerBase(ABC):
             ViewerBase.SDFMarginMode, dict[int, tuple[np.ndarray, int, np.ndarray, int]]
         ] = {}
 
-    def set_model(self, model: newton.Model | None, max_worlds: int | None = None):
+    def set_model(self, model: newton.Model | None):
         """Set the model to be visualized.
 
         Args:
             model: The Newton model to visualize.
-            max_worlds: Maximum number of worlds to render (None = all).
-
-                .. deprecated:: 1.1
-                    Use :meth:`set_visible_worlds` instead.
         """
         if self.model is not None:
             self.clear_model()
 
         self.model = model
 
-        if max_worlds is not None:
-            warnings.warn(
-                "max_worlds is deprecated, use set_visible_worlds() instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self._visible_worlds = set(range(max_worlds))
-        else:
-            self._visible_worlds = None
+        self._visible_worlds = None
 
         if model is not None:
             self.device = model.device

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -1122,14 +1122,13 @@ class ViewerFile(ViewerBase):
         self._model_recorded = False
 
     @override
-    def set_model(self, model: Model | None, max_worlds: int | None = None):
+    def set_model(self, model: Model | None):
         """Override set_model to record the model when it is set.
 
         Args:
             model: Model to bind to this viewer.
-            max_worlds: Optional cap on rendered worlds.
         """
-        super().set_model(model, max_worlds=max_worlds)
+        super().set_model(model)
 
         if model is not None and not self._model_recorded:
             self.record_model(model)

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -523,15 +523,14 @@ class ViewerGL(ViewerBase):
         super().clear_model()
 
     @override
-    def set_model(self, model: nt.Model | None, max_worlds: int | None = None):
+    def set_model(self, model: nt.Model | None):
         """
         Set the Newton model to visualize.
 
         Args:
             model: The Newton model instance.
-            max_worlds: Maximum number of worlds to render (None = all).
         """
-        super().set_model(model, max_worlds=max_worlds)
+        super().set_model(model)
 
         # ``ViewerBase.set_model`` may have switched ``self.device`` to the
         # model's device. Rebind the image logger so its GPU path tests against

--- a/newton/_src/viewer/viewer_rtx.py
+++ b/newton/_src/viewer/viewer_rtx.py
@@ -774,14 +774,13 @@ void main() {
     # ------------------------------------------------ ViewerUSD overrides
 
     @override
-    def set_model(self, model: newton.Model | None, max_worlds: int | None = None) -> None:
+    def set_model(self, model: newton.Model | None) -> None:
         """Set the Newton model to visualize.
 
         Args:
             model: The Newton model instance.
-            max_worlds: Maximum number of worlds to render (``None`` = all).
         """
-        super().set_model(model, max_worlds=max_worlds)
+        super().set_model(model)
         if model is not None:
             from pyglet.math import Vec3 as PyVec3
 

--- a/newton/examples/selection/example_selection_cartpole.py
+++ b/newton/examples/selection/example_selection_cartpole.py
@@ -102,7 +102,9 @@ class Example:
         if not isinstance(self.solver, newton.solvers.SolverMuJoCo):
             self.cartpoles.eval_fk(self.state_0)
 
-        self.viewer.set_model(self.model, max_worlds=max_worlds)
+        self.viewer.set_model(self.model)
+        if max_worlds is not None:
+            self.viewer.set_visible_worlds(range(max_worlds))
         self.viewer.set_world_offsets((1.0, 0.0, 0.0))
 
         # Set camera to view the scene

--- a/newton/tests/test_viewer_geometry_batching.py
+++ b/newton/tests/test_viewer_geometry_batching.py
@@ -31,8 +31,8 @@ class _ViewerGeometryBatchingProbe(ViewerNull):
             geo_scale = (1.0, 1.0)
         return super()._hash_geometry(geo_type, geo_scale, thickness, is_solid, geo_src, mirror)
 
-    def set_model(self, model, max_worlds=None):
-        super().set_model(model, max_worlds=max_worlds)
+    def set_model(self, model):
+        super().set_model(model)
         if self.model is None:
             return
 

--- a/newton/tests/test_viewer_visible_worlds.py
+++ b/newton/tests/test_viewer_visible_worlds.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-import warnings
 
 import numpy as np
 import warp as wp
@@ -104,19 +103,6 @@ class TestViewerVisibleWorlds(unittest.TestCase):
         # Non-visible worlds should have zero offset
         for w in [1, 2, 3, 5, 6]:
             assert_np_equal(offsets[w], np.array([0.0, 0.0, 0.0]), tol=1e-5)
-
-    def test_max_worlds_backward_compat(self):
-        """max_worlds param in set_model still works with deprecation warning."""
-        model = _build_multi_world_model(4)
-
-        viewer = ViewerNull(num_frames=1)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            viewer.set_model(model, max_worlds=2)
-            self.assertTrue(any(issubclass(x.category, DeprecationWarning) for x in w))
-
-        total = sum(len(b.scales) for b in viewer._shape_instances.values())
-        self.assertEqual(total, 2)
 
     def test_visible_worlds_mask(self):
         """Internal mask array is correctly built."""


### PR DESCRIPTION
## Description

Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()` (deprecated in 1.1.0), including the `viewer_file` / `viewer_gl` / `viewer_rtx` overrides. To restrict rendered worlds, call `set_visible_worlds()` after `set_model()`. The selection-cartpole example and the visualization guide are updated to the new pattern; the example's `--max-worlds` CLI flag is preserved and now routes through `set_visible_worlds()`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_viewer_visible_worlds
uv run --extra dev -m newton.tests -k test_viewer_geometry_batching
uv run --extra dev -m newton.tests -k selection_cartpole
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated max_worlds parameter from the viewer set_model(); call set_visible_worlds() after set_model() to limit rendered environments.

* **Documentation**
  * Guides updated to show calling set_model() followed by set_visible_worlds(); references to the old parameter removed.

* **Examples**
  * Example code updated to call set_model() then set_visible_worlds() when needed.

* **Tests**
  * Backward-compatibility test for the removed parameter removed; visible-worlds tests retained and adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->