### PR TITLE
Remove deprecated SensorTiledCamera 1.1 API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Remove the deprecated `Viewer.update_shape_colors()`; write to `Model.shape_color` directly instead
 - Remove support for passing a `Gaussian` as the second positional argument to `ModelBuilder.add_shape_gaussian()` (deprecated in 1.1.0); pass it via the `gaussian=` keyword instead
 - Remove support for `worlds_per_row=0` in `SensorTiledCamera.flatten_*_to_rgba()` (deprecated in 1.2.0); pass `worlds_per_row=None` for automatic layout (values below 1 now raise `ValueError`) (#3149)
+- Remove the deprecated SensorTiledCamera 1.1 API surface: `Config`, `RenderContext`, `render_context`, image helper methods, and random color helpers; use `RenderConfig`, `render_config`, `SensorTiledCamera.utils.*`, and per-shape colors instead
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_pinhole_camera_rays()` and `create_depth_image_output()` for single-camera depth) instead
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
 
-import numpy as np
 import warp as wp
 
 from ..sim import Model, State
@@ -21,18 +19,7 @@ from .warp_raytrace import (
 )
 
 
-class _SensorTiledCameraMeta(type):
-    @property
-    def RenderContext(cls) -> type[RenderContext]:
-        warnings.warn(
-            "Access to SensorTiledCamera.RenderContext is deprecated.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return RenderContext
-
-
-class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
+class SensorTiledCamera:
     """Warp-based tiled camera sensor for raytraced rendering across multiple worlds.
 
     Renders up to six image channels per (world, camera) pair:
@@ -82,42 +69,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
     DEFAULT_CLEAR_DATA = ClearData()
     GRAY_CLEAR_DATA = ClearData(clear_color=0xFF666666, clear_albedo=0xFF000000)
 
-    @dataclass
-    class Config:
-        """Sensor configuration.
-
-        .. deprecated:: 1.1
-            Use :class:`RenderConfig` and ``SensorTiledCamera.utils.*`` instead.
-        """
-
-        checkerboard_texture: bool = False
-        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes()`` instead."""
-
-        default_light: bool = False
-        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.create_default_light()`` instead."""
-
-        default_light_shadows: bool = False
-        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.create_default_light(enable_shadows=True)`` instead."""
-
-        enable_ambient_lighting: bool = True
-        """.. deprecated:: 1.1 Use ``render_config.enable_ambient_lighting`` instead."""
-
-        colors_per_world: bool = False
-        """.. deprecated:: 1.1 Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
-
-        colors_per_shape: bool = False
-        """.. deprecated:: 1.1 Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``)."""
-
-        backface_culling: bool = True
-        """.. deprecated:: 1.1 Use ``render_config.enable_backface_culling`` instead."""
-
-        enable_textures: bool = False
-        """.. deprecated:: 1.1 Use ``render_config.enable_textures`` instead."""
-
-        enable_particles: bool = True
-        """.. deprecated:: 1.1 Use ``render_config.enable_particles`` instead."""
-
-    def __init__(self, model: Model, *, config: Config | RenderConfig | None = None, load_textures: bool = True):
+    def __init__(self, model: Model, *, config: RenderConfig | None = None, load_textures: bool = True):
         """Initialize the tiled camera sensor from a simulation model.
 
         Builds the internal :class:`RenderContext`, loads shape geometry (and
@@ -128,33 +80,15 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             model: Simulation model whose shapes will be rendered.
             config: Rendering configuration. Pass a :class:`RenderConfig` to
                 control raytrace settings directly, or ``None`` to use
-                defaults. The legacy :class:`Config` dataclass is still
-                accepted but deprecated. Use
-                ``RenderConfig.output_color_space`` to control whether packed
-                ``color`` and ``albedo`` outputs are display-encoded or left
-                linear.
+                defaults. Use ``RenderConfig.output_color_space`` to control
+                whether packed ``color`` and ``albedo`` outputs are
+                display-encoded or left linear.
             load_textures: Load texture data from the model. Set to ``False``
                 to skip texture loading when textures are not needed.
         """
         self.model = model
 
-        render_config = config
-
-        if render_config is None:
-            render_config = RenderConfig()
-
-        elif isinstance(config, SensorTiledCamera.Config):
-            warnings.warn(
-                "SensorTiledCamera.Config is deprecated, use SensorTiledCamera.RenderConfig and SensorTiledCamera.utils.* functions instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
-
-            render_config = RenderConfig()
-            render_config.enable_ambient_lighting = config.enable_ambient_lighting
-            render_config.enable_backface_culling = config.backface_culling
-            render_config.enable_textures = config.enable_textures
-            render_config.enable_particles = config.enable_particles
+        render_config = config if config is not None else RenderConfig()
 
         self.__render_context = RenderContext(
             world_count=self.model.world_count,
@@ -163,16 +97,6 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         )
 
         self.__render_context.init_from_model(self.model, load_textures)
-
-        if isinstance(config, SensorTiledCamera.Config):
-            if config.checkerboard_texture:
-                self.utils.assign_checkerboard_material_to_all_shapes()
-            if config.default_light:
-                self.utils.create_default_light(config.default_light_shadows)
-            if config.colors_per_world:
-                self.utils.assign_random_colors_per_world()
-            elif config.colors_per_shape:
-                self.utils.assign_random_colors_per_shape()
 
     def sync_transforms(self, state: State):
         """Synchronize triangle-mesh points from the simulation state.
@@ -290,310 +214,13 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
             kernel_block_dim=kernel_block_dim,
         )
 
-    def compute_pinhole_camera_rays(
-        self, width: int, height: int, camera_fovs: float | list[float] | np.ndarray | wp.array[wp.float32]
-    ) -> wp.array4d[wp.vec3f]:
-        """Compute camera-space ray directions for pinhole cameras.
-
-        Generates rays in camera space (origin at the camera center, direction normalized) for each pixel based on the
-        vertical field of view.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.compute_pinhole_camera_rays`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_fovs: Vertical FOV angles [rad], shape ``(camera_count,)``.
-
-        Returns:
-            camera_rays: Shape ``(camera_count, height, width, 2)``, dtype ``vec3f``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.compute_pinhole_camera_rays is deprecated, use SensorTiledCamera.utils.compute_pinhole_camera_rays instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return self.__render_context.utils.compute_pinhole_camera_rays(width, height, camera_fovs)
-
-    def flatten_color_image_to_rgba(
-        self,
-        image: wp.array4d[wp.uint32],
-        out_buffer: wp.array3d[wp.uint8] | None = None,
-        worlds_per_row: int | None = None,
-    ):
-        """Flatten rendered color image to a tiled RGBA buffer.
-
-        Arranges ``(world_count * camera_count)`` tiles in a grid. Each tile shows one camera's view of one world.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.flatten_color_image_to_rgba`` instead.
-
-        Args:
-            image: Color output from :meth:`update`, shape ``(world_count, camera_count, height, width)``.
-            out_buffer: Pre-allocated RGBA buffer. If None, allocates a new one.
-            worlds_per_row: Tiles per row in the grid. If None, picks a square-ish layout.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.flatten_color_image_to_rgba is deprecated, use SensorTiledCamera.utils.flatten_color_image_to_rgba instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.flatten_color_image_to_rgba(image, out_buffer, worlds_per_row)
-
-    def flatten_normal_image_to_rgba(
-        self,
-        image: wp.array4d[wp.vec3f],
-        out_buffer: wp.array3d[wp.uint8] | None = None,
-        worlds_per_row: int | None = None,
-    ):
-        """Flatten rendered normal image to a tiled RGBA buffer.
-
-        Arranges ``(world_count * camera_count)`` tiles in a grid. Each tile shows one camera's view of one world.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.flatten_normal_image_to_rgba`` instead.
-
-        Args:
-            image: Normal output from :meth:`update`, shape ``(world_count, camera_count, height, width)``.
-            out_buffer: Pre-allocated RGBA buffer. If None, allocates a new one.
-            worlds_per_row: Tiles per row in the grid. If None, picks a square-ish layout.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.flatten_normal_image_to_rgba is deprecated, use SensorTiledCamera.utils.flatten_normal_image_to_rgba instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.flatten_normal_image_to_rgba(image, out_buffer, worlds_per_row)
-
-    def flatten_depth_image_to_rgba(
-        self,
-        image: wp.array4d[wp.float32],
-        out_buffer: wp.array3d[wp.uint8] | None = None,
-        worlds_per_row: int | None = None,
-        depth_range: wp.array[wp.float32] | None = None,
-    ):
-        """Flatten rendered depth image to a tiled RGBA buffer.
-
-        Encodes depth as grayscale: inverts values (closer = brighter) and normalizes to the ``[50, 255]``
-        range. Background pixels (no hit) remain black.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.flatten_depth_image_to_rgba`` instead.
-
-        Args:
-            image: Depth output from :meth:`update`, shape ``(world_count, camera_count, height, width)``.
-            out_buffer: Pre-allocated RGBA buffer. If None, allocates a new one.
-            worlds_per_row: Tiles per row in the grid. If None, picks a square-ish layout.
-            depth_range: Depth range to normalize to, shape ``(2,)`` ``[near, far]``. If None, computes from *image*.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.flatten_depth_image_to_rgba is deprecated, use SensorTiledCamera.utils.flatten_depth_image_to_rgba instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.flatten_depth_image_to_rgba(image, out_buffer, worlds_per_row, depth_range)
-
-    def assign_random_colors_per_world(self, seed: int = 100):
-        """Assign each world a random color, applied to all its shapes.
-
-        .. deprecated:: 1.1
-            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
-
-        Args:
-            seed: Random seed.
-        """
-        warnings.warn(
-            "``SensorTiledCamera.assign_random_colors_per_world`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.utils.assign_random_colors_per_world(seed)
-
-    def assign_random_colors_per_shape(self, seed: int = 100):
-        """Assign a random color to each shape.
-
-        .. deprecated:: 1.1
-            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
-
-        Args:
-            seed: Random seed.
-        """
-        warnings.warn(
-            "``SensorTiledCamera.assign_random_colors_per_shape`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.utils.assign_random_colors_per_shape(seed)
-
-    def create_default_light(self, enable_shadows: bool = True):
-        """Create a default directional light oriented at ``(-1, 1, -1)``.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_default_light`` instead.
-
-        Args:
-            enable_shadows: Enable shadow casting for this light.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_default_light is deprecated, use SensorTiledCamera.utils.create_default_light instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.utils.create_default_light(enable_shadows)
-
-    def assign_checkerboard_material_to_all_shapes(self, resolution: int = 64, checker_size: int = 32):
-        """Assign a gray checkerboard texture material to all shapes.
-
-        Creates a gray checkerboard pattern texture and applies it to all shapes
-        in the scene.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes`` instead.
-
-        Args:
-            resolution: Texture resolution in pixels (square texture).
-            checker_size: Size of each checkerboard square in pixels.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.assign_checkerboard_material_to_all_shapes is deprecated, use SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self.utils.assign_checkerboard_material_to_all_shapes(resolution, checker_size)
-
-    def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create a color output array for :meth:`update`.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_color_image_output`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_count: Number of cameras.
-
-        Returns:
-            Array of shape ``(world_count, camera_count, height, width)``, dtype ``uint32``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_color_image_output is deprecated, use SensorTiledCamera.utils.create_color_image_output instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_color_image_output(width, height, camera_count)
-
-    def create_depth_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.float32]:
-        """Create a depth output array for :meth:`update`.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_depth_image_output`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_count: Number of cameras.
-
-        Returns:
-            Array of shape ``(world_count, camera_count, height, width)``, dtype ``float32``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_depth_image_output is deprecated, use SensorTiledCamera.utils.create_depth_image_output instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_depth_image_output(width, height, camera_count)
-
-    def create_shape_index_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create a shape-index output array for :meth:`update`.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_shape_index_image_output`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_count: Number of cameras.
-
-        Returns:
-            Array of shape ``(world_count, camera_count, height, width)``, dtype ``uint32``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_shape_index_image_output is deprecated, use SensorTiledCamera.utils.create_shape_index_image_output instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_shape_index_image_output(width, height, camera_count)
-
-    def create_normal_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
-        """Create a normal output array for :meth:`update`.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_normal_image_output`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_count: Number of cameras.
-
-        Returns:
-            Array of shape ``(world_count, camera_count, height, width)``, dtype ``vec3f``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_normal_image_output is deprecated, use SensorTiledCamera.utils.create_normal_image_output instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_normal_image_output(width, height, camera_count)
-
-    def create_albedo_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create an albedo output array for :meth:`update`.
-
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.create_albedo_image_output`` instead.
-
-        Args:
-            width: Image width [px].
-            height: Image height [px].
-            camera_count: Number of cameras.
-
-        Returns:
-            Array of shape ``(world_count, camera_count, height, width)``, dtype ``uint32``.
-        """
-        warnings.warn(
-            "Deprecated: SensorTiledCamera.create_albedo_image_output is deprecated, use SensorTiledCamera.utils.create_albedo_image_output instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_albedo_image_output(width, height, camera_count)
-
-    @property
-    def render_context(self) -> RenderContext:
-        """Internal Warp raytracing context used by :meth:`update` and buffer helpers.
-
-        .. deprecated:: 1.1
-            Direct access is deprecated and will be removed. Prefer this
-            class's public methods, or :attr:`render_config` for
-            :class:`RenderConfig` access.
-
-        Returns:
-            The shared :class:`RenderContext` instance.
-        """
-        warnings.warn(
-            "Direct access to SensorTiledCamera.render_context is deprecated and will be removed in a future release.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.__render_context
-
     @property
     def render_config(self) -> RenderConfig:
         """Low-level raytrace settings on the internal :class:`RenderContext`.
 
-        Populated at construction from :class:`Config` and from fixed defaults
-        (for example global world and shadow flags on the context). Attributes may
-        be modified to change behavior for subsequent :meth:`update` calls.
+        Populated at construction from fixed defaults (for example global
+        world and shadow flags on the context). Attributes may be modified to
+        change behavior for subsequent :meth:`update` calls.
 
         Returns:
             The live :class:`RenderConfig` instance (same object as

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -497,81 +496,3 @@ class RenderContext:
 
         self.mesh_data = wp.array(self.__mesh_data, dtype=MeshData, device=self.device)
         self.shape_mesh_data_ids = wp.array(mesh_data_ids, dtype=wp.int32, device=self.device)
-
-    def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create an output array for color rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_color_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_color_image_output is deprecated, use SensorTiledCamera.utils.create_color_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_color_image_output(width, height, camera_count)
-
-    def create_depth_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.float32]:
-        """Create an output array for depth rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_depth_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_depth_image_output is deprecated, use SensorTiledCamera.utils.create_depth_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_depth_image_output(width, height, camera_count)
-
-    def create_shape_index_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create an output array for shape-index rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_shape_index_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_shape_index_image_output is deprecated, use SensorTiledCamera.utils.create_shape_index_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_shape_index_image_output(width, height, camera_count)
-
-    def create_normal_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
-        """Create an output array for surface-normal rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_normal_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_normal_image_output is deprecated, use SensorTiledCamera.utils.create_normal_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_normal_image_output(width, height, camera_count)
-
-    def create_albedo_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
-        """Create an output array for albedo rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_albedo_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_albedo_image_output is deprecated, use SensorTiledCamera.utils.create_albedo_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_albedo_image_output(width, height, camera_count)
-
-    def create_hdr_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.vec3f]:
-        """Create an output array for linear HDR color rendering.
-
-        .. deprecated:: 1.1
-            Use :meth:`SensorTiledCamera.utils.create_hdr_color_image_output`.
-        """
-        warnings.warn(
-            "RenderContext.create_hdr_color_image_output is deprecated, use SensorTiledCamera.utils.create_hdr_color_image_output instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.utils.create_hdr_color_image_output(width, height, camera_count)

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import math
-import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -791,48 +790,6 @@ class Utils:
             device=self.__render_context.device,
         )
         return out_buffer
-
-    def assign_random_colors_per_world(self, seed: int = 100):
-        """Assign each world a random color, applied to all its shapes.
-
-        .. deprecated:: 1.1
-            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
-
-        Args:
-            seed: Random seed.
-        """
-        warnings.warn(
-            "``SensorTiledCamera.utils.assign_random_colors_per_world`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        if not self.__render_context.shape_count_total:
-            return
-        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 3)) * 0.5 + 0.5
-        self.__render_context.shape_colors = wp.array(
-            colors[self.__render_context.shape_world_index.numpy() % len(colors)],
-            dtype=wp.vec3f,
-            device=self.__render_context.device,
-        )
-
-    def assign_random_colors_per_shape(self, seed: int = 100):
-        """Assign a random color to each shape.
-
-        .. deprecated:: 1.1
-            Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).
-
-        Args:
-            seed: Random seed.
-        """
-        warnings.warn(
-            "``SensorTiledCamera.utils.assign_random_colors_per_shape`` is deprecated. Use shape colors instead (e.g. ``builder.add_shape_cylinder(..., color=(r, g, b))``).",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-
-        colors = np.random.default_rng(seed).random((self.__render_context.shape_count_total, 3)) * 0.5 + 0.5
-        self.__render_context.shape_colors = wp.array(colors, dtype=wp.vec3f, device=self.__render_context.device)
 
     def create_default_light(self, enable_shadows: bool = True, direction: wp.vec3f | None = None):
         """Create a default directional light oriented at ``(-1, 1, -1)``.

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -178,7 +178,9 @@ class TestSensorTiledCamera(unittest.TestCase):
         model = builder.finalize(device="cpu")
 
         sensor = SensorTiledCamera(model=model)
-        render_context = sensor.render_context
+        # The public render_context alias was removed; this regression test needs
+        # the internal mesh state that drives first-render construction.
+        render_context = sensor._SensorTiledCamera__render_context
 
         # init_from_model copies model.particle_q/tri_indices into triangle_points/
         # triangle_indices but does not build wp.Mesh until the first render call.


### PR DESCRIPTION
## Description

Remove the `SensorTiledCamera` / `RenderContext` API surface deprecated in 1.1.0 (all dead shims with no remaining callers):

- `SensorTiledCamera.Config` → `SensorTiledCamera.RenderConfig` + `SensorTiledCamera.utils.*`
- `SensorTiledCamera.RenderContext` / `render_context` → `RenderConfig` + `render_config` / `utils`
- the `SensorTiledCamera` and `RenderContext` image helpers (`create_*_image_output`, `flatten_*_to_rgba`, `compute_pinhole_camera_rays`, `create_default_light`, `assign_checkerboard_material_to_all_shapes`) → the `SensorTiledCamera.utils.*` equivalents
- `assign_random_colors_per_world()` / `assign_random_colors_per_shape()` → per-shape colors via `ModelBuilder.add_shape_*(color=...)`

The internal `RenderContext` class is retained; only the deprecated public accessors are removed. The `SensorTiledCamera.update(state=None, refit_bvh=...)` deprecation (1.2.0) is left untouched.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera
uv run --extra dev -m newton.tests -k test_sensor_to_rgba
uv run --extra dev -m newton.tests -k example_sensor_tiled_camera
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed**
  * Deprecated `SensorTiledCamera` legacy configuration (`SensorTiledCamera.Config`) and the `render_context` accessor/shim are removed.
  * Deprecated `SensorTiledCamera` image/color/light/material helper methods and output-buffer creation helpers are removed; use the current `RenderConfig` workflow.
  * Deprecated ray-tracing `RenderContext.create_*_image_output(...)` helpers and random color assignment utilities are removed.
* **Tests**
  * Updated `SensorTiledCamera` tests to no longer rely on the deprecated render-context alias.
* **Documentation**
  * Updated the unreleased changelog to describe the removed `SensorTiledCamera` API and suggested replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->