### PR TITLE
Remove deprecated SolverVBD rigid_enable_dahl_friction arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_pinhole_camera_rays()` and `create_depth_image_output()` for single-camera depth) instead
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead
+- Remove the deprecated and ignored `rigid_enable_dahl_friction` argument of `SolverVBD`; Dahl friction is auto-detected from `model.vbd.dahl_eps_max` / `model.vbd.dahl_tau`
 
 ## [1.3.0] - 2026-06-11
 

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -238,7 +238,6 @@ class SolverVBD(SolverBase):
         rigid_joint_angular_k_start: float = 1.0e1,  # Angular penalty seed (used when angular beta > 0)
         rigid_joint_linear_kd: float = 0.0,  # Absolute damping for non-cable linear joint constraints
         rigid_joint_angular_kd: float = 0.0,  # Absolute damping for non-cable angular joint constraints
-        rigid_enable_dahl_friction: bool | None = None,  # Deprecated: controlled by model attributes
     ):
         """
         Args:
@@ -346,8 +345,6 @@ class SolverVBD(SolverBase):
                 Negative values are clamped to 0.
             rigid_joint_angular_kd: Damping coefficient for non-cable angular joint constraints [N·m·s/rad].
                 Negative values are clamped to 0.
-            rigid_enable_dahl_friction: Deprecated and ignored. Dahl friction is controlled
-                by ``model.vbd.dahl_eps_max`` / ``model.vbd.dahl_tau``.
 
         Note:
             - The `integrate_with_external_rigid_solver` argument enables one-way coupling between rigid body and soft body
@@ -365,16 +362,6 @@ class SolverVBD(SolverBase):
               enabled only when positive Dahl parameters are authored.
 
         """
-        if rigid_enable_dahl_friction is not None:
-            warnings.warn(
-                "rigid_enable_dahl_friction is deprecated and ignored. "
-                "Dahl friction is now controlled by model attributes "
-                "(model.vbd.dahl_eps_max / model.vbd.dahl_tau). "
-                "It is enabled only where both values are positive.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         if rigid_avbd_beta < 0:
             raise ValueError(f"rigid_avbd_beta must be >= 0, got {rigid_avbd_beta}")
         rigid_avbd_linear_beta = rigid_avbd_linear_beta if rigid_avbd_linear_beta is not None else rigid_avbd_beta


### PR DESCRIPTION
## Description

Remove the deprecated and ignored `rigid_enable_dahl_friction` argument of `SolverVBD` (deprecated in 1.2.0). Dahl friction is auto-detected from the model attributes `model.vbd.dahl_eps_max` / `model.vbd.dahl_tau`, so the argument had no effect.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_vbd
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Removed**
  * Removed the deprecated `rigid_enable_dahl_friction` parameter from the solver API.
  * Dahl friction enablement is now automatically determined from model attributes (`model.vbd.dahl_eps_max` / `model.vbd.dahl_tau`), without any manual override.
* **Documentation**
  * Updated the changelog entry under **Unreleased** to reflect this removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->