### PR TITLE
Adds a newton.controllers module

### DIFF
--- a/newton/_src/controllers/DESIGN_DOC.md
+++ b/newton/_src/controllers/DESIGN_DOC.md
@@ -1,0 +1,381 @@
+# Newton Controllers — Design Doc
+
+**NOTE** This is a temporary document for design review purposes only. It should be deleted
+and replaced by proper documentation before merging.
+
+## Background
+
+There are many controllers implemented across Isaac Lab/Sim. The goal of this module is to centralize them in Newton, re-implementing each so that they are completely vectorized and CUDA-graphable.
+
+Below is a table summarizing existing Isaac Sim/Lab controllers, where their implementation currently lives, and whether there is a replacement already completed in this module.
+
+| Controller | Current Repo | Completed? |
+| --- | --- | --- |
+| Differential IK | Isaac Lab | :heavy_check_mark: |
+| PID | — | :heavy_check_mark: |
+| Operational Space | Isaac Lab | :x:  |
+| Joint Impedance | Isaac Lab | :x: |
+| Differential Drive | Isaac Sim | :heavy_check_mark: |
+| Holonomic Drive | Isaac Sim | :x: |
+| Ackermann | Isaac Sim | :x: |
+
+An open question is whether to broaden this "control toolbox" beyond the controllers in the table above to include general-purpose algorithms common in robotics. For example, a linear-filter class could implement:
+
+- low-pass
+- band-pass
+- notch
+---
+
+## Architecture
+
+The module exposes a single abstract base class — `Controller(ABC)` — that every concrete control law (`ControllerPID`, `ControllerDifferentialKinematics`, `ControllerDifferentialDrive`, …) subclasses directly. There is **no framework-level composition**: callers wanting to combine multiple control laws invoke each one's `compute()` in sequence themselves.
+
+`Controller` declares the surface every law implements:
+
+- `is_graphable() -> bool` — CUDA-graph compatibility predicate.
+- `is_stateful() -> bool` — whether the law carries state between steps.
+- `state()` — allocate a fresh per-step `State` (subclass-specific `@dataclass`), or `None` for stateless laws.
+- `input_struct()` — allocate a fresh, auto-generated dataclass holding one `wp.array` field per input port.
+- `output_struct()` — same idea for write ports.
+- `compute(input_struct, output_struct, controller_state_now, controller_state_next, time_step) -> None`.
+
+Users compose laws by simply instantiating many `Controller`s and composing the outputs in whatever way they desire.
+
+---
+
+## Controller flavors
+
+Concrete controllers fall into two flavors based on **whether the control law needs a model of the robot**. This drives the constructor shape and what counts as a "goal."
+
+### Decoupled controllers (DOFs independent)
+
+`ControllerPID` is the canonical example. Each output depends only on the matching entries of its own ports: `output[i]` is a function of `joint_measured[i]`, `joint_target[i]`, the gains at `[i]`, and the state at `[i]` — nothing else. As a result it:
+
+- **Carries no robot model.** It never needs topology, mass, or geometry — only `default_dof_indices` to know which slots to read and write.
+- **Takes per-DOF goals.** A goal is a scalar target for a single controlled DOF (e.g. a target joint angle), in the same layout as every other port.
+- **Has no concept of a "robot."** `num_robots` never appears; only `num_outputs`. One DOF is indistinguishable from the next, so the law vectorizes across any mix of robots for free.
+
+### Model-based controllers (DOFs coupled, per-robot goals)
+
+`ControllerDifferentialKinematics` and `ControllerDifferentialDrive` are the canonical examples. A robot's output DOFs are coupled — they cannot be solved independently of one another — and the goal is specified once per robot rather than per DOF. Such a controller:
+
+- **Carries a model of the robot.** This can be a full `newton.ModelBuilder` of `N` topologically-identical articulations (`ControllerDifferentialKinematics`, finalized internally for FK + Jacobian evaluation) or just the handful of geometry parameters the law needs (`ControllerDifferentialDrive`'s per-robot `wheel_radius` / `wheel_base`). Either way it describes the robot the law reasons about.
+
+### Examples
+
+| | Decoupled (`PID`) | Model-based (`DifferentialKinematics`, `DifferentialDrive`) |
+| --- | --- | --- |
+| Robot model at construction | none | `ModelBuilder` or geometry parameters |
+| Goal shape | per-DOF scalar | per-robot target |
+| DOF coupling | none | within a robot |
+| Knows about "robots"? | no (`num_outputs`) | yes (`num_robots`) |
+
+---
+
+## Controller Initialization
+
+Every controller implementation declares a fixed set of inputs/outputs/parameters when it is initialized. There are two shapes for how these declarations happen:
+
+### Live ports (`*_attr` + `*_idx`)
+
+A live port connects the controller to an array that the caller supplies fresh on every step. Each live port is declared by a pair of constructor arguments: a `*_attr` string and an optional `*_idx` array.
+
+```python
+ControllerPID(
+    default_dof_indices: wp.array,
+    joint_measured_attr: str = "joint_q",
+    joint_measured_idx: wp.array | None = None,
+    joint_measured_rate_attr: str = "joint_qd",
+    joint_measured_rate_idx: wp.array | None = None,
+    joint_target_attr: str = "joint_target_q",
+    joint_target_idx: wp.array | None = None,
+    joint_target_rate_attr: str = "joint_target_qd",
+    joint_target_rate_idx: wp.array | None = None,
+    output_attr: str = "joint_f",
+    output_idx: wp.array | None = None,
+    ...
+)
+```
+
+#### `*_attr` — which array
+
+The string names an attribute on the object the caller passes to `compute()`; the controller resolves it each step via `getattr`. Different controllers default to different names, and the caller can override any of them.
+
+#### `*_idx` — which slots
+
+An optional `wp.array[wp.uint32]`. The kernel touches only `arr[idx[i]]`, leaving every other slot of the array untouched. When `*_idx` is `None`, the port falls back to `default_dof_indices`, so by default the read and write ports line up on the same slots.
+
+Passing an explicit `*_idx` lets the controller read from one layout and write into another. In `test_controllers` the controller reads `joint_target_q[1, 2]` but writes `output[5, 7]`:
+
+```python
+ControllerPID(
+    default_dof_indices=wp.array([5, 7], dtype=wp.uint32, device=device),
+    joint_target_idx=wp.array([1, 2], dtype=wp.uint32, device=device),
+    output_attr="output",
+    ...
+)
+```
+
+### Parameter ports (`wp.array | str`)
+
+Parameter ports are configuration knobs (PID gains, DLS damping, IK bandwidth, wheel geometry, …). Each accepts either a `wp.array` (*baked*) or a `str` (*live*).
+
+```python
+ControllerPID(
+    default_dof_indices: wp.array,
+    kp: wp.array | str | None = None,
+    kd: wp.array | str | None = None,
+    ki: wp.array | str | None = None,
+    integral_max: wp.array | str | None = None,
+    ...
+)
+```
+
+`ControllerPID(kp=wp.array(...))` is an example of **baked** parameters; `ControllerPID(kp="kp")` is an example of **live** parameters.
+
+#### Baked parameters (`wp.array`)
+
+The controller copies the array at construction. Mutating the user's original afterward has no effect. Length must be `num_outputs` (per-DOF) or `num_robots` (per-robot); dtype `wp.float32`. Read in natural order (`arr[i]`) — no `_idx` override.
+
+`example_pid_pendulum` bakes PID gains; `example_diff_drive_swarm` bakes per-robot `wheel_radius` / `wheel_base`:
+
+```python
+ControllerPID(
+    default_dof_indices=default_dof_indices,
+    kp=wp.array([3600.0, 1200.0], dtype=wp.float32, device=device),
+    kd=wp.array([320.0, 160.0], dtype=wp.float32, device=device),
+)
+
+ControllerDifferentialDrive(
+    num_robots=16,
+    wheel_radius=wp.full(16, 0.05, dtype=wp.float32, device=device),
+    wheel_base=wp.full(16, 0.2, dtype=wp.float32, device=device),
+    default_dof_indices=default_dof_indices,
+)
+```
+
+#### Live parameters (`str`)
+
+If a parameter is given as a string, then it is expected that the parameter is given as at every step as part of the input object. Each `compute()` resolves it with `getattr` and reads `arr[i]` in natural order. Same length/dtype rules as baked.
+
+For example, the test file `test_controllers` passes `kp="kp"` so gains can change between steps without reconstructing the controller; `ControllerDifferentialKinematics` accepts `bandwidth="my_band"` the same way:
+
+```python
+ControllerPID(
+    default_dof_indices=default_dof_indices,
+    kp="kp",
+    ...
+)
+
+ControllerDifferentialKinematics(
+    model_builder=builder,
+    controlled_site_label="tool",
+    default_dof_indices=default_dof_indices,
+    bandwidth="my_band",
+    ...
+)
+```
+
+---
+
+## State
+
+Stateful laws (PID) define a nested `@dataclass class State(Controller.State)` with their internal buffers (PID's `integral`). The abstract function `state()` allocates a fresh instance with zero-initialized fields. Users typically double-buffer:
+
+```python
+s0, s1 = controller.state(), controller.state()
+for ... :
+    controller.compute(input_struct, output_struct, s0, s1, time_step=dt)
+    s0, s1 = s1, s0
+```
+
+Stateless laws (`ControllerDifferentialKinematics`, `ControllerDifferentialDrive`) return `None` from `state()` and accept `None` for both state slots.
+
+---
+
+## Struct factories
+
+The inputs and outputs of particular controllers are highly dependent on the specific algorithm. This can be contrasted to `newton.actuators`, where the input is predictably a set of desired position/velocity/effort floats, and the output is an effort float.
+
+To simplify working with different controllers, each `Controller` implements `input_struct()` and `output_struct()` functions to auto-allocate correctly-sized struct instances which meet that controllers interface. Field names match the user's `*_attr` strings. Baked parameters are absent from either struct (they live on the controller). Each field is sized minimally for the controller's view — `max(idx)+1` for ports with an explicit `_idx`, otherwise the natural-order length (`num_outputs` / `num_robots`).
+
+Users can:
+
+- Use the returned struct as-is (each call gives a fresh allocation):
+
+```python
+inp = controller.input_struct()       # fresh wp.zeros fields
+inp.joint_target_q.assign([0.6, -1.2])
+out = controller.output_struct()
+controller.compute(inp, out, s0, s1, time_step=dt)
+```
+
+- Reassign fields to point at live sim buffers:
+
+```python
+inp = controller.input_struct()
+inp.joint_q = state.joint_q           # share the solver's array, no copy
+out = controller.output_struct()
+out.joint_f = control.joint_f         # write directly into the solver's input
+```
+
+- Skip the factory entirely and pass any duck-typed object with the right attributes:
+
+```python
+inp = SimpleNamespace(joint_q=state.joint_q, joint_qd=state.joint_qd,
+                      joint_target_q=target_q, joint_target_qd=target_qd)
+out = SimpleNamespace(joint_f=control.joint_f)
+controller.compute(inp, out, s0, s1, time_step=dt)
+```
+
+---
+
+## Concrete controllers
+
+### `ControllerPID`
+
+Per-DOF PID with symmetric anti-windup clamping. Stateful (`State.integral` shape `[num_outputs]`, float32).
+
+```python
+output[output_idx[i]] = kp[i] * (joint_target - joint_measured)
+                      + ki[i] * clamp(integral + pos_err * dt, -integral_max[i], +integral_max[i])
+                      + kd[i] * (joint_target_rate - joint_measured_rate)
+```
+
+Constructor:
+
+```python
+ControllerPID(
+    default_dof_indices: wp.array,
+    kp: wp.array | str | None = None,
+    kd: wp.array | str | None = None,
+    ki: wp.array | str | None = None,
+    integral_max: wp.array | str | None = None,
+    joint_measured_attr: str = "joint_q",
+    joint_measured_idx: wp.array | None = None,
+    joint_measured_rate_attr: str = "joint_qd",
+    joint_measured_rate_idx: wp.array | None = None,
+    joint_target_attr: str = "joint_target_q",
+    joint_target_idx: wp.array | None = None,
+    joint_target_rate_attr: str = "joint_target_qd",
+    joint_target_rate_idx: wp.array | None = None,
+    output_attr: str = "joint_f",
+    output_idx: wp.array | None = None,
+    device: Any = None,
+    requires_grad: bool = False,
+)
+```
+
+Omitted gain ports default to zero arrays of length `num_outputs`. `integral_max` defaults to `+inf` per DOF (no clamping).
+
+### `ControllerDifferentialKinematics`
+
+One-step differential IK for one end-effector per robot. The user passes a `newton.ModelBuilder` with `N` topologically-identical articulations; the controller finalizes that internally for FK + Jacobian evaluation. Stateless (`state()` returns `None`).
+
+Per-robot solve (`IkMethod.DAMPED_LEAST_SQUARES`, default):
+
+```
+e        = [target_pos - site_pos ;  2 * sign(q_err.w) * q_err.xyz]
+A        = J_site J_site^T + lambda^2 * I_6                     (6×6 SPD)
+y        = A^{-1} e                                             (tile Cholesky)
+q_dot    = bandwidth * J_site^T y
+output_q = q_current + q_dot * dt
+```
+
+With `IkMethod.TRANSPOSE`: `q_dot = bandwidth * J_site^T e`.
+
+`solver_damping` is `lambda`; `bandwidth` is the scalar multiplier on the solve output (both per-robot gain ports).
+
+**Tape-safe forward, zero-grad through the solve.** Every kernel except `_cholesky_solve_kernel` is autograd-able by default; the solve uses `wp.tile_cholesky` / `wp.tile_cholesky_solve` whose registered adjoints return zero gradients in Warp 1.14.0, so that one kernel is marked `enable_backward=False`. Revisit when upstream tile-Cholesky backward lands.
+
+Constructor:
+
+```python
+ControllerDifferentialKinematics(
+    model_builder: ModelBuilder,
+    controlled_site_label: str,
+    default_dof_indices: wp.array,
+    bandwidth: wp.array | str,
+    solver_damping: wp.array | str | None = None,
+    ik_method: IkMethod = IkMethod.DAMPED_LEAST_SQUARES,
+    target_pos_attr: str = "site_target_position",
+    target_pos_idx: wp.array | None = None,
+    target_quat_attr: str = "site_target_quaternion",
+    target_quat_idx: wp.array | None = None,
+    joint_measurement_attr: str = "joint_q",
+    joint_measurement_idx: wp.array | None = None,
+    joint_measurement_rate_attr: str = "joint_qd",
+    joint_measurement_rate_idx: wp.array | None = None,
+    joint_target_q_attr: str = "joint_target_q",
+    joint_target_q_idx: wp.array | None = None,
+    joint_target_qd_attr: str = "joint_target_qd",
+    joint_target_qd_idx: wp.array | None = None,
+    device: Any = None,
+    requires_grad: bool = False,
+)
+```
+
+`num_robots = model_builder.articulation_count`. `default_dof_indices` length is `num_robots * dofs_per_robot`, laid out `[r0_d0, r0_d1, …, r1_d0, …]`. `solver_damping` defaults to `DEFAULT_SOLVER_DAMPING` (`0.05`) per robot when `None`.
+
+### `ControllerDifferentialDrive`
+
+Vectorized unicycle differential-drive: per robot, converts body-frame `(linear_speed, angular_speed)` into left/right wheel angular velocities and writes them into a `joint_target_qd`-style output array via `default_dof_indices` (`[r0_left, r0_right, r1_left, r1_right, …]`). Commands and wheel rates are clamped per robot; parameter ports (`wheel_radius`, `wheel_base`, speed limits) are per-robot baked or live arrays. Stateless (`state()` returns `None`). Example: `python -m newton.examples diff_drive_swarm`.
+
+Constructor:
+
+```python
+ControllerDifferentialDrive(
+    num_robots: int,
+    wheel_radius: wp.array | str,
+    wheel_base: wp.array | str,
+    default_dof_indices: wp.array,
+    max_linear_speed: wp.array | str | None = None,
+    max_angular_speed: wp.array | str | None = None,
+    max_wheel_speed: wp.array | str | None = None,
+    linear_speed_attr: str = "linear_speed_command",
+    linear_speed_idx: wp.array | None = None,
+    angular_speed_attr: str = "angular_speed_command",
+    angular_speed_idx: wp.array | None = None,
+    joint_target_qd_attr: str = "joint_target_qd",
+    joint_target_qd_idx: wp.array | None = None,
+    device: Any = None,
+    requires_grad: bool = False,
+)
+```
+
+Omitted clamp ports default to `+inf` per robot (no clamping). `default_dof_indices` must be `wp.array[uint32]` with length `2 * num_robots`.
+
+---
+
+## End-to-end example
+
+A minimal PID loop driving two joints to a fixed target (condensed from `example_pid_pendulum`):
+
+```python
+controller = ControllerPID(
+    default_dof_indices=wp.array([0, 1], dtype=wp.uint32),
+    kp=wp.array([3600.0, 1200.0], dtype=wp.float32),
+    kd=wp.array([320.0, 160.0], dtype=wp.float32),
+)
+
+# Allocate an input struct for this controller:
+inp = controller.input_struct()
+inp.joint_target_q.assign([0.6, -1.2])
+
+# Allocate an output struct for this controller:
+out = controller.output_struct()
+out.joint_f = control.joint_f # reassign into the solver's array
+
+s0, s1 = controller.state(), controller.state()   # PID integral, double-buffered
+
+for _ in range(num_steps):
+    # rebind to the current sim state
+    inp.joint_q = state_0.joint_q           
+    inp.joint_qd = state_0.joint_qd
+    
+    # step the controller, then step the sim.
+    controller.compute(inp, out, s0, s1, time_step=dt)
+    s0, s1 = s1, s0
+    solver.step(state_0, state_1, control, contacts, dt)
+    state_0, state_1 = state_1, state_0
+```

--- a/newton/_src/controllers/__init__.py
+++ b/newton/_src/controllers/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from .controller import Controller
+from .impl import ControllerDifferentialDrive, ControllerDifferentialKinematics, ControllerPID
+
+__all__ = [
+    "Controller",
+    "ControllerDifferentialDrive",
+    "ControllerDifferentialKinematics",
+    "ControllerPID",
+]

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Abstract base for Newton controllers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+class Controller(ABC):
+    """Abstract interface for a single Newton control law.
+
+    Every concrete control law (PID, differential IK, gravity compensation,
+    …) subclasses :class:`Controller` directly. There is no framework-level
+    composition: users who want to combine multiple control laws call each
+    one's :meth:`compute` in sequence themselves.
+
+    Subclasses are responsible for:
+
+    - :meth:`is_graphable`, :meth:`is_stateful`: predicates the user can
+      query to decide CUDA-graph capture and double-buffered state setup.
+    - :meth:`state`: allocate a fresh :class:`State`, or return ``None``
+      for stateless laws.
+    - :meth:`input_struct`, :meth:`output_struct`: allocate fresh
+      duck-typed containers (auto-generated dataclasses) holding only the
+      live ports the user declared at construction. Baked-in arrays (gain
+      ports given a :class:`wp.array` rather than an attr name) are stored
+      on the controller and do **not** appear on the input struct.
+    - :meth:`compute`: read the input struct's live arrays, run kernels,
+      write the output struct's live arrays. Writes are slot-replacing
+      (``=``, not ``+=``); composing laws is the user's job, and the user
+      controls whether the output is zeroed beforehand.
+    """
+
+    @dataclass
+    class State:
+        """Pure data container. Subclasses declare their fields."""
+
+    @abstractmethod
+    def is_graphable(self) -> bool:
+        """Whether :meth:`compute` is safe to capture in a CUDA graph."""
+
+    @abstractmethod
+    def is_stateful(self) -> bool:
+        """Whether this controller maintains internal state between steps."""
+
+    @abstractmethod
+    def state(self) -> Controller.State | None:
+        """Allocate a fresh per-step :class:`State`, or ``None`` if stateless."""
+
+    @abstractmethod
+    def input_struct(self) -> Any:
+        """Allocate a fresh input container with one field per input port.
+
+        The returned object has attributes with
+        names that match the ``*_attr`` strings the user passed at
+        construction. Each field is a freshly :func:`wp.zeros`-allocated
+        array of the right dtype and size. The user typically reassigns
+        these fields to point at live data buffers.
+        """
+
+    @abstractmethod
+    def output_struct(self) -> Any:
+        """Allocate a fresh output container with one field per output port."""
+
+    @abstractmethod
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: Controller.State | None,
+        controller_state_next: Controller.State | None,
+        time_step: float,
+    ) -> None:
+        """Run one control step.
+
+        Args:
+            input_struct: Object whose attributes hold the live read ports.
+                Resolved via ``getattr(input_struct, attr_name)``. Any
+                duck-typed object works — :meth:`input_struct` returns a
+                pre-allocated one; the user may swap fields or pass an
+                entirely custom container (e.g. a :class:`SimpleNamespace`
+                wrapping :class:`newton.State` fields directly).
+            output_struct: Same contract as ``input_struct`` for write
+                ports. The kernel performs slot-replacing writes
+                (``arr[idx[i]] = value``) — slots outside the declared
+                port indices are left untouched.
+            controller_state_now: Current state (``None`` if stateless).
+            controller_state_next: Next-step state to populate (``None``
+                if stateless). Double-buffered against
+                ``controller_state_now``.
+            time_step: Step duration [s].
+        """

--- a/newton/_src/controllers/impl/__init__.py
+++ b/newton/_src/controllers/impl/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from .controller_diff_drive import ControllerDifferentialDrive
+from .controller_diff_ik import ControllerDifferentialKinematics
+from .controller_pid import ControllerPID
+
+__all__ = [
+    "ControllerDifferentialDrive",
+    "ControllerDifferentialKinematics",
+    "ControllerPID",
+]

--- a/newton/_src/controllers/impl/controller_diff_drive.py
+++ b/newton/_src/controllers/impl/controller_diff_drive.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""ControllerDifferentialDrive — vectorized unicycle differential-drive."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from ..controller import Controller
+from ..utils import (
+    _allocate_namespace,
+    _normalize_indices,
+    _normalize_parameter_port,
+)
+
+
+@wp.kernel
+def _diff_drive_kernel(
+    linear_speed: wp.array[float],
+    linear_speed_indices: wp.array[wp.uint32],
+    angular_speed: wp.array[float],
+    angular_speed_indices: wp.array[wp.uint32],
+    wheel_radius: wp.array[float],
+    wheel_base: wp.array[float],
+    max_linear_speed: wp.array[float],
+    max_angular_speed: wp.array[float],
+    max_wheel_speed: wp.array[float],
+    output_indices: wp.array[wp.uint32],
+    output: wp.array[float],
+):
+    """Per-robot: convert [v, omega] to (left, right) wheel angular velocities.
+
+    ``output_indices`` is laid out ``[r0_left, r0_right, r1_left, r1_right, ...]``
+    — slot ``2*r`` is robot r's left wheel, slot ``2*r + 1`` is its right wheel.
+    """
+    r = wp.tid()
+    v_max = max_linear_speed[r]
+    w_max = max_angular_speed[r]
+    v = wp.clamp(linear_speed[linear_speed_indices[r]], -v_max, v_max)
+    w = wp.clamp(angular_speed[angular_speed_indices[r]], -w_max, w_max)
+
+    radius = wheel_radius[r]
+    base = wheel_base[r]
+    # omega_L = (2V - omega*b)/(2r), omega_R = (2V + omega*b)/(2r)
+    left = (2.0 * v - w * base) / (2.0 * radius)
+    right = (2.0 * v + w * base) / (2.0 * radius)
+
+    wheel_max = max_wheel_speed[r]
+    left = wp.clamp(left, -wheel_max, wheel_max)
+    right = wp.clamp(right, -wheel_max, wheel_max)
+
+    output[output_indices[2 * r + 0]] = left
+    output[output_indices[2 * r + 1]] = right
+
+
+class ControllerDifferentialDrive(Controller):
+    """Vectorized unicycle differential-drive controller.
+
+    For each of N wheeled robots, converts a per-robot ``(linear_speed,
+    angular_speed)`` command into the pair of left / right wheel angular
+    velocities that realise it under the standard differential-drive
+    kinematic model::
+
+        omega_L = (2 * v - omega * wheel_base) / (2 * wheel_radius)
+        omega_R = (2 * v + omega * wheel_base) / (2 * wheel_radius)
+
+    The body-frame command is clamped to ``[-max_linear_speed,
+    +max_linear_speed]`` / ``[-max_angular_speed, +max_angular_speed]``
+    before the conversion; the resulting wheel rates are clamped to
+    ``[-max_wheel_speed, +max_wheel_speed]`` after.
+
+    Stateless. The output ports are slot-replacing writes (``=``) into the
+    caller's ``joint_target_qd``-style array; slots outside the controller's
+    ``2 * num_robots`` outputs are untouched.
+
+    **Parameter ports** (``wheel_radius``, ``wheel_base``, ``max_linear_speed``,
+    ``max_angular_speed``, ``max_wheel_speed``) accept either a length-N
+    :class:`wp.array` (baked; stored by copy at construction) or a ``str``
+    (live; resolved from the input struct each step). All natural per-robot
+    order; no ``_idx`` override.
+
+    Args:
+        num_robots: Number of differential-drive robots managed.
+        wheel_radius: Per-robot wheel radius [m].
+        wheel_base: Per-robot lateral wheel-to-wheel distance [m].
+        default_dof_indices: Output indices for each robot's two wheel
+            DOFs, length ``2 * num_robots``, laid out
+            ``[r0_left, r0_right, r1_left, r1_right, ...]``.
+        max_linear_speed: Per-robot forward/backward speed limit [m/s].
+            Defaults to ``+inf`` per robot.
+        max_angular_speed: Per-robot yaw-rate limit [rad/s]. Defaults to
+            ``+inf`` per robot.
+        max_wheel_speed: Per-robot wheel-rate clamp [rad/s] applied after
+            the kinematic conversion. Defaults to ``+inf`` per robot.
+        linear_speed_attr: Live read port — body-frame forward speed
+            command [m/s]. Length ``num_robots``.
+        linear_speed_idx: Override per-robot indices, or ``None`` to use
+            natural order ``wp.arange(num_robots)``.
+        angular_speed_attr: Live read port — body-frame yaw-rate command
+            [rad/s]. Length ``num_robots``.
+        angular_speed_idx: Override per-robot indices.
+        joint_target_qd_attr: Live write port — commanded wheel angular
+            velocities [rad/s].
+        joint_target_qd_idx: Override per-DOF indices, or ``None`` to use
+            ``default_dof_indices``.
+        device: Warp device for internal buffers. Defaults to
+            :func:`wp.get_device`.
+        requires_grad: If ``True``, internal buffers are allocated with
+            gradient support so :meth:`compute` is transparent to
+            :class:`wp.Tape`.
+    """
+
+    def __init__(
+        self,
+        num_robots: int,
+        wheel_radius: wp.array | str,
+        wheel_base: wp.array | str,
+        default_dof_indices: wp.array,
+        max_linear_speed: wp.array | str | None = None,
+        max_angular_speed: wp.array | str | None = None,
+        max_wheel_speed: wp.array | str | None = None,
+        linear_speed_attr: str = "linear_speed_command",
+        linear_speed_idx: wp.array | None = None,
+        angular_speed_attr: str = "angular_speed_command",
+        angular_speed_idx: wp.array | None = None,
+        joint_target_qd_attr: str = "joint_target_qd",
+        joint_target_qd_idx: wp.array | None = None,
+        device: Any = None,
+        requires_grad: bool = False,
+    ):
+        if num_robots < 1:
+            raise ValueError(f"num_robots must be >= 1, got {num_robots}.")
+        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
+            raise TypeError("default_dof_indices must be wp.array[uint32].")
+        if int(default_dof_indices.size) != 2 * num_robots:
+            raise ValueError(
+                f"default_dof_indices length {default_dof_indices.size} must equal 2 * num_robots = {2 * num_robots}."
+            )
+
+        self._num_robots = num_robots
+        self._num_outputs = 2 * num_robots
+        self._device = device if device is not None else wp.get_device()
+        self._requires_grad = requires_grad
+        self._default_dof_indices = default_dof_indices
+
+        # Per-DOF output port.
+        self._output_attr = joint_target_qd_attr
+        self._output_idx = _normalize_indices(joint_target_qd_idx, default_dof_indices, name="joint_target_qd")
+
+        # Per-robot live command ports.
+        default_robot_idx = wp.array(np.arange(num_robots, dtype=np.uint32), device=self._device)
+        self._default_robot_idx = default_robot_idx
+        self._linear_speed_attr = linear_speed_attr
+        self._linear_speed_idx = _normalize_indices(linear_speed_idx, default_robot_idx, name="linear_speed")
+        self._angular_speed_attr = angular_speed_attr
+        self._angular_speed_idx = _normalize_indices(angular_speed_idx, default_robot_idx, name="angular_speed")
+
+        # Per-robot parameter ports. Defaults: +inf for the three clamps.
+        if max_linear_speed is None:
+            max_linear_speed = wp.full(num_robots, value=wp.inf, dtype=wp.float32, device=self._device)
+        if max_angular_speed is None:
+            max_angular_speed = wp.full(num_robots, value=wp.inf, dtype=wp.float32, device=self._device)
+        if max_wheel_speed is None:
+            max_wheel_speed = wp.full(num_robots, value=wp.inf, dtype=wp.float32, device=self._device)
+
+        self._wheel_radius_attr, self._wheel_radius_baked = _normalize_parameter_port(
+            wheel_radius, num_robots, wp.float32, self._device, requires_grad, name="wheel_radius"
+        )
+        self._wheel_base_attr, self._wheel_base_baked = _normalize_parameter_port(
+            wheel_base, num_robots, wp.float32, self._device, requires_grad, name="wheel_base"
+        )
+        self._max_lin_attr, self._max_lin_baked = _normalize_parameter_port(
+            max_linear_speed, num_robots, wp.float32, self._device, requires_grad, name="max_linear_speed"
+        )
+        self._max_ang_attr, self._max_ang_baked = _normalize_parameter_port(
+            max_angular_speed, num_robots, wp.float32, self._device, requires_grad, name="max_angular_speed"
+        )
+        self._max_wheel_attr, self._max_wheel_baked = _normalize_parameter_port(
+            max_wheel_speed, num_robots, wp.float32, self._device, requires_grad, name="max_wheel_speed"
+        )
+
+        # input_struct fields: command ports + any live parameter ports.
+        self._input_specs: list[tuple[str, Any, int]] = [
+            (self._linear_speed_attr, wp.float32, _idx_max(self._linear_speed_idx)),
+            (self._angular_speed_attr, wp.float32, _idx_max(self._angular_speed_idx)),
+        ]
+        for attr in (
+            self._wheel_radius_attr,
+            self._wheel_base_attr,
+            self._max_lin_attr,
+            self._max_ang_attr,
+            self._max_wheel_attr,
+        ):
+            if attr is not None:
+                self._input_specs.append((attr, wp.float32, num_robots))
+
+        self._output_specs: list[tuple[str, Any, int]] = [
+            (self._output_attr, wp.float32, _idx_max(self._output_idx)),
+        ]
+
+    @property
+    def num_robots(self) -> int:
+        return self._num_robots
+
+    @property
+    def num_outputs(self) -> int:
+        return self._num_outputs
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
+
+    def is_stateful(self) -> bool:
+        return False
+
+    def is_graphable(self) -> bool:
+        return True
+
+    def state(self) -> None:
+        return None
+
+    def input_struct(self):
+        return _allocate_namespace(self._input_specs, self._device, self._requires_grad)
+
+    def output_struct(self):
+        return _allocate_namespace(self._output_specs, self._device, self._requires_grad)
+
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: None,
+        controller_state_next: None,
+        time_step: float,
+    ) -> None:
+        linear_speed = getattr(input_struct, self._linear_speed_attr)
+        angular_speed = getattr(input_struct, self._angular_speed_attr)
+        wheel_radius = self._wheel_radius_baked or getattr(input_struct, self._wheel_radius_attr)
+        wheel_base = self._wheel_base_baked or getattr(input_struct, self._wheel_base_attr)
+        max_lin = self._max_lin_baked or getattr(input_struct, self._max_lin_attr)
+        max_ang = self._max_ang_baked or getattr(input_struct, self._max_ang_attr)
+        max_wheel = self._max_wheel_baked or getattr(input_struct, self._max_wheel_attr)
+        out = getattr(output_struct, self._output_attr)
+
+        wp.launch(
+            _diff_drive_kernel,
+            dim=self._num_robots,
+            inputs=[
+                linear_speed,
+                self._linear_speed_idx,
+                angular_speed,
+                self._angular_speed_idx,
+                wheel_radius,
+                wheel_base,
+                max_lin,
+                max_ang,
+                max_wheel,
+                self._output_idx,
+            ],
+            outputs=[out],
+            device=self._device,
+        )
+
+
+def _idx_max(idx: wp.array) -> int:
+    return int(np.max(idx.numpy())) + 1

--- a/newton/_src/controllers/impl/controller_diff_ik.py
+++ b/newton/_src/controllers/impl/controller_diff_ik.py
@@ -1,0 +1,623 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""ControllerDifferentialKinematics — one-step differential IK.
+
+Stateless. For each robot in the batch, computes a joint-velocity command
+that drives a user-defined site pose (position + orientation) toward a
+target via damped least squares or Jacobian transpose on the per-robot
+spatial Jacobian.
+
+The DLS solve is split across four kernels so that the autograd-able tile
+primitives (``wp.tile_cholesky``, ``wp.tile_cholesky_solve``) only see pure
+tile_load -> tile_cholesky -> tile_cholesky_solve -> tile_store flows — no
+element-wise mutation, which would break Warp's adjoint. All other math
+(building the site-frame Jacobian, forming A = J J^T + lambda^2 I,
+back-projecting q_dot from y) lives in per-element kernels that are
+autograd-friendly by construction.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from ...sim.articulation import eval_fk, eval_jacobian
+from ...sim.builder import ModelBuilder
+from ..controller import Controller
+from ..utils import (
+    _allocate_namespace,
+    _normalize_indices,
+    _normalize_parameter_port,
+)
+
+
+@wp.kernel
+def _gather_local_kernel(
+    global_arr: wp.array[float],
+    lookup_indices: wp.array[wp.uint32],
+    local_arr: wp.array[float],
+):
+    i = wp.tid()
+    local_arr[i] = global_arr[lookup_indices[i]]
+
+
+@wp.kernel
+def _build_site_jacobian_kernel(
+    jacobian: wp.array3d[float],
+    body_q: wp.array[wp.transform],
+    body_com: wp.array[wp.vec3],
+    target_pos: wp.array[wp.vec3],
+    target_pos_indices: wp.array[wp.uint32],
+    target_quat: wp.array[wp.quat],
+    target_quat_indices: wp.array[wp.uint32],
+    # ``global_ee_body_per_robot`` indexes the flat full-model body arrays
+    # (body_q / body_com), which concatenate every articulation's bodies.
+    # ``local_ee_body`` is the per-articulation link index used as a row
+    # offset into the per-robot Jacobian slab — the jacobian array's first
+    # axis already separates robots, so this index stays local. The
+    # consistency check in __init__ guarantees this value is identical
+    # across all articulations, so it's passed as a scalar.
+    global_ee_body_per_robot: wp.array[int],
+    local_ee_body: int,
+    site_xform_per_robot: wp.array[wp.transform],
+    dofs_per_robot: int,
+    j_site: wp.array3d[float],  # (num_robots, 6, dofs_per_robot)
+    e_buffer: wp.array2d[float],  # (num_robots, 6)
+):
+    r = wp.tid()
+
+    ee_body = global_ee_body_per_robot[r]
+    j_row = local_ee_body * 6
+    site_xform = site_xform_per_robot[r]
+
+    t_body = body_q[ee_body]
+    t_site = t_body * site_xform
+    site_pos = wp.transform_get_translation(t_site)
+    site_quat = wp.transform_get_rotation(t_site)
+    com_world = wp.transform_point(t_body, body_com[ee_body])
+    offset = site_pos - com_world
+
+    pos_err = target_pos[target_pos_indices[r]] - site_pos
+    q_err = target_quat[target_quat_indices[r]] * wp.quat_inverse(site_quat)
+    s = wp.sign(q_err[3])
+    rot_err = wp.vec3(2.0 * s * q_err[0], 2.0 * s * q_err[1], 2.0 * s * q_err[2])
+    e_buffer[r, 0] = pos_err[0]
+    e_buffer[r, 1] = pos_err[1]
+    e_buffer[r, 2] = pos_err[2]
+    e_buffer[r, 3] = rot_err[0]
+    e_buffer[r, 4] = rot_err[1]
+    e_buffer[r, 5] = rot_err[2]
+
+    for j in range(dofs_per_robot):
+        jl_x = jacobian[r, j_row + 0, j]
+        jl_y = jacobian[r, j_row + 1, j]
+        jl_z = jacobian[r, j_row + 2, j]
+        ja_x = jacobian[r, j_row + 3, j]
+        ja_y = jacobian[r, j_row + 4, j]
+        ja_z = jacobian[r, j_row + 5, j]
+        j_site[r, 0, j] = jl_x + ja_y * offset[2] - ja_z * offset[1]
+        j_site[r, 1, j] = jl_y + ja_z * offset[0] - ja_x * offset[2]
+        j_site[r, 2, j] = jl_z + ja_x * offset[1] - ja_y * offset[0]
+        j_site[r, 3, j] = ja_x
+        j_site[r, 4, j] = ja_y
+        j_site[r, 5, j] = ja_z
+
+
+@wp.kernel
+def _build_dls_matrix_kernel(
+    j_site: wp.array3d[float],
+    solver_damping: wp.array[float],
+    dofs_per_robot: int,
+    A: wp.array3d[float],
+):
+    r, i, k = wp.tid()
+    lam = solver_damping[r]
+    lam_sq = lam * lam
+    acc = float(0.0)
+    for j in range(dofs_per_robot):
+        acc += j_site[r, i, j] * j_site[r, k, j]
+    if i == k:
+        acc += lam_sq
+    A[r, i, k] = acc
+
+
+# wp.tile_cholesky*'s registered adjoints return zero gradients in Warp
+# 1.14.0; marking the solve kernel enable_backward=False makes that explicit.
+@wp.kernel(enable_backward=False)
+def _cholesky_solve_kernel(
+    A: wp.array3d[float],
+    e_buffer: wp.array2d[float],
+    y: wp.array2d[float],
+):
+    r = wp.tid()
+    A_tile = wp.tile_load(A[r], shape=(6, 6))
+    e_tile = wp.tile_load(e_buffer[r], shape=(6,))
+    L = wp.tile_cholesky(A_tile)
+    y_tile = wp.tile_cholesky_solve(L, e_tile)
+    wp.tile_store(y[r], y_tile)
+
+
+@wp.kernel
+def _qd_from_y_kernel(
+    j_site: wp.array3d[float],
+    y: wp.array2d[float],
+    bandwidth: wp.array[float],
+    qd_target_local: wp.array2d[float],
+):
+    r, j = wp.tid()
+    g = bandwidth[r]
+    val = float(0.0)
+    for i in range(6):
+        val += j_site[r, i, j] * y[r, i]
+    qd_target_local[r, j] = g * val
+
+
+@wp.kernel
+def _qd_from_jte_kernel(
+    j_site: wp.array3d[float],
+    e_buffer: wp.array2d[float],
+    bandwidth: wp.array[float],
+    qd_target_local: wp.array2d[float],
+):
+    r, j = wp.tid()
+    g = bandwidth[r]
+    val = float(0.0)
+    for i in range(6):
+        val += j_site[r, i, j] * e_buffer[r, i]
+    qd_target_local[r, j] = g * val
+
+
+@wp.kernel
+def _write_outputs_kernel(
+    qd_target_local: wp.array2d[float],
+    joint_q_local: wp.array[float],
+    dt: float,
+    dofs_per_robot: int,
+    joint_target_qd_indices: wp.array[wp.uint32],
+    joint_target_q_indices: wp.array[wp.uint32],
+    joint_target_qd: wp.array[float],
+    joint_target_q: wp.array[float],
+):
+    r, j = wp.tid()
+    flat = r * dofs_per_robot + j
+    qd = qd_target_local[r, j]
+    joint_target_qd[joint_target_qd_indices[flat]] = qd
+    joint_target_q[joint_target_q_indices[flat]] = joint_q_local[flat] + qd * dt
+
+
+class ControllerDifferentialKinematics(Controller):
+    """One-step differential IK for a single end-effector per robot.
+
+    Coupled per-robot: each robot's joint-velocity solution depends on its
+    full configuration ``q``. Stateless. Drives the **site** pose in world
+    frame toward the target. The site is identified by the ``label`` you
+    gave it when calling :meth:`newton.ModelBuilder.add_site`.
+
+    **Tape-safe, forward-only through the solve.** Every kernel in the
+    chain except the DLS solve itself is autograd-able by default; the
+    solve uses ``wp.tile_cholesky`` / ``wp.tile_cholesky_solve`` whose
+    backward path returns zero gradients in Warp 1.14.0, so that one
+    kernel is marked ``enable_backward=False``.
+
+    With :attr:`IkMethod.DAMPED_LEAST_SQUARES` (default), per robot
+    (``J_site`` is the 6xN site-frame Jacobian)::
+
+        e        = [target_pos - site_pos ;  2 * sign(q_err.w) * q_err.xyz]
+        A        = J_site J_site^T + lambda^2 * I_6                              (6x6 SPD)
+        L L^T    = A                                                            (Cholesky)
+        L L^T y  = e                                                            (solve)
+        q_dot    = bandwidth * J_site^T y
+
+    With :attr:`IkMethod.TRANSPOSE`::
+
+        q_dot    = bandwidth * J_site^T e
+
+    where ``q_err = target_quat * conj(site_quat)``. The joint_target_q
+    output is written as ``q_current + q_dot * dt``.
+
+    Construction takes a :class:`newton.ModelBuilder` containing exactly
+    ``N`` topologically-identical articulations — the N robots this
+    controller manages. The N articulations must share DOF count,
+    link/joint count, and joint types; they may differ in physical
+    parameters and per-articulation site placement. No replication: if
+    the user wants R copies of a template they call
+    :meth:`newton.ModelBuilder.replicate` themselves first.
+
+    Assumptions:
+
+    - All joints in the builder are scalar-DOF (revolute or prismatic).
+    - The intended "world frame" is the builder's base frame.
+
+    **Per-robot gain ports** (``solver_damping``, ``bandwidth``) accept
+    either a :class:`wp.array` (baked; stored by copy at construction;
+    length ``num_robots``, dtype ``wp.float32``) or a ``str`` (live;
+    resolved from the input struct each step, read in natural per-robot
+    order).
+
+    Args:
+        model_builder: Unfinalized N-articulation builder.
+            ``num_robots = model_builder.articulation_count``.
+        site: Label of the site to drive (added via
+            :meth:`newton.ModelBuilder.add_site`). The builder must contain
+            **exactly one** site with this label per articulation.
+        default_dof_indices: Default indices for any live-data per-DOF
+            port whose ``*_idx`` is ``None``. Length
+            ``num_robots * dofs_per_robot``, laid out
+            ``[r0_d0, r0_d1, ..., r1_d0, ...]``.
+        bandwidth: Scalar multiplier on the IK output (per robot).
+        ik_method: Jacobian inverse strategy.
+        solver_damping: DLS lambda per robot. Defaults to
+            :attr:`DEFAULT_SOLVER_DAMPING` when ``None``.
+        target_pos_attr: Live read port — site position target in world
+            frame. Dtype :class:`wp.vec3`.
+        target_pos_idx: Override per-robot indices for ``target_pos_attr``,
+            or ``None`` to use natural per-robot order.
+        target_quat_attr: Live read port — site orientation target. Dtype
+            :class:`wp.quat`.
+        target_quat_idx: Override per-robot indices.
+        joint_measurement_attr: Live read port — joint positions.
+        joint_measurement_idx: Override per-DOF indices.
+        joint_measurement_rate_attr: Live read port — joint velocities.
+            Consumed by ``eval_fk`` to populate ``body_qd``; the DLS solve
+            uses position-only error.
+        joint_measurement_rate_idx: Override per-DOF indices.
+        joint_target_q_attr: Live write port — commanded joint positions
+            (``q_current + q_dot * dt``).
+        joint_target_q_idx: Override per-DOF indices.
+        joint_target_qd_attr: Live write port — commanded joint
+            velocities.
+        joint_target_qd_idx: Override per-DOF indices.
+        device: Warp device for internal buffers. Defaults to
+            :func:`wp.get_device`.
+        requires_grad: If ``True``, internally-allocated buffers are
+            created with gradient support.
+    """
+
+    class IkMethod(IntEnum):
+        """Jacobian inverse strategy."""
+
+        DAMPED_LEAST_SQUARES = 0
+        TRANSPOSE = 1
+
+    DEFAULT_SOLVER_DAMPING: float = 0.05
+
+    def __init__(
+        self,
+        model_builder: ModelBuilder,
+        controlled_site_label: str,
+        default_dof_indices: wp.array,
+        bandwidth: wp.array | str,
+        solver_damping: wp.array | str | None = None,
+        ik_method: IkMethod = IkMethod.DAMPED_LEAST_SQUARES,
+        target_pos_attr: str = "site_target_position",
+        target_pos_idx: wp.array | None = None,
+        target_quat_attr: str = "site_target_quaternion",
+        target_quat_idx: wp.array | None = None,
+        joint_measurement_attr: str = "joint_q",
+        joint_measurement_idx: wp.array | None = None,
+        joint_measurement_rate_attr: str = "joint_qd",
+        joint_measurement_rate_idx: wp.array | None = None,
+        joint_target_q_attr: str = "joint_target_q",
+        joint_target_q_idx: wp.array | None = None,
+        joint_target_qd_attr: str = "joint_target_qd",
+        joint_target_qd_idx: wp.array | None = None,
+        device: Any = None,
+        requires_grad: bool = False,
+    ):
+        if not isinstance(model_builder, ModelBuilder):
+            raise TypeError(f"model_builder must be a newton.ModelBuilder, got {type(model_builder).__name__}.")
+        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
+            raise TypeError("default_dof_indices must be wp.array[uint32]")
+        articulation_count = model_builder.articulation_count
+        if articulation_count < 1:
+            raise ValueError("model_builder has no articulations.")
+        if model_builder.joint_dof_count % articulation_count != 0:
+            raise ValueError(
+                f"model_builder.joint_dof_count={model_builder.joint_dof_count} is not divisible by "
+                f"articulation_count={articulation_count}; the N articulations must share DOF count."
+            )
+        body_count = len(model_builder.body_q)
+        if body_count % articulation_count != 0:
+            raise ValueError(
+                f"template body_count={body_count} is not divisible by articulation_count={articulation_count}; "
+                f"the N articulations must share body count."
+            )
+
+        self._template = model_builder
+        self._num_robots = articulation_count
+        self._dofs_per_robot = model_builder.joint_dof_count // articulation_count
+        self._bodies_per_robot = body_count // articulation_count
+        self._num_outputs = self._num_robots * self._dofs_per_robot
+        self._device = device if device is not None else wp.get_device()
+        self._requires_grad = requires_grad
+        if not isinstance(ik_method, ControllerDifferentialKinematics.IkMethod):
+            raise TypeError(
+                f"ik_method must be ControllerDifferentialKinematics.IkMethod, got {type(ik_method).__name__}."
+            )
+        self._ik_method = ik_method
+
+        if int(default_dof_indices.size) != self._num_outputs:
+            raise ValueError(
+                f"default_dof_indices length {default_dof_indices.size} must equal "
+                f"num_robots * dofs_per_robot = {self._num_outputs}."
+            )
+        self._default_dof_indices = default_dof_indices
+
+        # Per-articulation site lookup. Bodies are assumed grouped by
+        # articulation in builder order (the natural pattern when
+        # articulations are added one at a time, or via replicate()).
+        all_site_idxs = [i for i, lbl in enumerate(model_builder.shape_label) if lbl == controlled_site_label]
+        if len(all_site_idxs) != articulation_count:
+            raise ValueError(
+                f"expected exactly {articulation_count} shapes with label '{controlled_site_label}' (one per articulation), "
+                f"found {len(all_site_idxs)} in model_builder; "
+                f"available labels: {model_builder.shape_label}."
+            )
+
+        # Each robot can carry a different site transform (the body the site
+        # rides on must be topologically identical — same per-articulation
+        # link index — but its body-local pose can differ).
+        # ``local_ee_body`` is that per-articulation link index, captured
+        # from the first site we see and consistency-checked against the
+        # rest. ``global_*`` names index into the flat full-template arrays
+        # (body_q, body_com); ``local_*`` names index within a single
+        # articulation.
+        site_xform_per_robot_dict: dict[int, wp.transform] = {}
+        local_ee_body: int | None = None
+        for shape_idx in all_site_idxs:
+            global_body = int(model_builder.shape_body[shape_idx])
+            # Bodies are assumed grouped by articulation in builder order.
+            articulation_i = global_body // self._bodies_per_robot
+            local_body_i = global_body % self._bodies_per_robot
+
+            if articulation_i in site_xform_per_robot_dict:
+                raise ValueError(
+                    f"multiple shapes labeled '{controlled_site_label}' resolved to articulation {articulation_i}; "
+                    f"each articulation must contribute exactly one site with this label."
+                )
+            if local_ee_body is None:
+                local_ee_body = local_body_i
+            elif local_body_i != local_ee_body:
+                raise ValueError(
+                    f"articulation {articulation_i} has site '{controlled_site_label}' attached at a different "
+                    f"per-articulation body (local index {local_body_i}) than previous articulations "
+                    f"(local index {local_ee_body}); robots must be topologically identical."
+                )
+            site_xform_per_robot_dict[articulation_i] = model_builder.shape_transform[shape_idx]
+
+        for r in range(articulation_count):
+            if r not in site_xform_per_robot_dict:
+                raise ValueError(f"articulation {r} has no shape labeled '{controlled_site_label}'.")
+
+        global_ee_body_per_robot = [r * self._bodies_per_robot + local_ee_body for r in range(articulation_count)]
+        site_xform_per_robot = [site_xform_per_robot_dict[r] for r in range(articulation_count)]
+
+        # Resolve all of the custom/default indices:
+        self._meas_attr = joint_measurement_attr
+        self._meas_idx = _normalize_indices(joint_measurement_idx, default_dof_indices, name="joint_measurement")
+
+        self._meas_rate_attr = joint_measurement_rate_attr
+        self._meas_rate_idx = _normalize_indices(
+            joint_measurement_rate_idx,
+            default_dof_indices,
+            name="joint_measurement_rate",
+        )
+
+        self._target_q_attr = joint_target_q_attr
+        self._target_q_idx = _normalize_indices(joint_target_q_idx, default_dof_indices, name="joint_target_q")
+        self._target_qd_attr = joint_target_qd_attr
+        self._target_qd_idx = _normalize_indices(joint_target_qd_idx, default_dof_indices, name="joint_target_qd")
+
+        # Per-robot live ports. Default natural-order = wp.arange(num_robots).
+        default_robot_idx = wp.array(np.arange(articulation_count, dtype=np.uint32), device=self._device)
+        self._default_robot_idx = default_robot_idx
+        self._target_pos_attr = target_pos_attr
+        self._target_pos_idx = _normalize_indices(target_pos_idx, default_robot_idx, name="target_pos")
+        self._target_quat_attr = target_quat_attr
+        self._target_quat_idx = _normalize_indices(target_quat_idx, default_robot_idx, name="target_quat")
+
+        # Per-robot gain ports.
+        if solver_damping is None:
+            solver_damping = wp.full(
+                articulation_count,
+                self.DEFAULT_SOLVER_DAMPING,
+                dtype=wp.float32,
+                device=self._device,
+            )
+        self._damping_attr, self._damping_baked = _normalize_parameter_port(
+            solver_damping, articulation_count, wp.float32, self._device, requires_grad, name="solver_damping"
+        )
+        self._bandwidth_attr, self._bandwidth_baked = _normalize_parameter_port(
+            bandwidth, articulation_count, wp.float32, self._device, requires_grad, name="bandwidth"
+        )
+
+        # Allocate compute-side scratch + build the internal model.
+        self._model = self._template.finalize(device=self._device, requires_grad=requires_grad)
+        self._model_state = self._model.state()
+        self._global_ee_body_per_robot = wp.array(global_ee_body_per_robot, dtype=int, device=self._device)
+        self._local_ee_body = local_ee_body
+        self._site_xform_per_robot = wp.array(site_xform_per_robot, dtype=wp.transform, device=self._device)
+        self._jacobian = wp.zeros(
+            (articulation_count, self._model.max_joints_per_articulation * 6, self._model.max_dofs_per_articulation),
+            dtype=wp.float32,
+            device=self._device,
+            requires_grad=requires_grad,
+        )
+        self._j_site = wp.zeros(
+            (articulation_count, 6, self._dofs_per_robot),
+            dtype=wp.float32,
+            device=self._device,
+            requires_grad=requires_grad,
+        )
+        self._e_buffer = wp.zeros(
+            (articulation_count, 6), dtype=wp.float32, device=self._device, requires_grad=requires_grad
+        )
+        self._A = wp.zeros(
+            (articulation_count, 6, 6), dtype=wp.float32, device=self._device, requires_grad=requires_grad
+        )
+        self._y = wp.zeros((articulation_count, 6), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+        self._qd_target_local = wp.zeros(
+            (articulation_count, self._dofs_per_robot),
+            dtype=wp.float32,
+            device=self._device,
+            requires_grad=requires_grad,
+        )
+
+        # Input ports + any live gain ports --> fields on input_struct().
+        self._input_specs: list[tuple[str, Any, int]] = [
+            (self._meas_attr, wp.float32, _idx_max(self._meas_idx)),
+            (self._meas_rate_attr, wp.float32, _idx_max(self._meas_rate_idx)),
+            (self._target_pos_attr, wp.vec3, _idx_max(self._target_pos_idx)),
+            (self._target_quat_attr, wp.quat, _idx_max(self._target_quat_idx)),
+        ]
+        for attr in (self._damping_attr, self._bandwidth_attr):
+            if attr is not None:
+                self._input_specs.append((attr, wp.float32, articulation_count))
+
+        self._output_specs: list[tuple[str, Any, int]] = [
+            (self._target_q_attr, wp.float32, _idx_max(self._target_q_idx)),
+            (self._target_qd_attr, wp.float32, _idx_max(self._target_qd_idx)),
+        ]
+
+    @property
+    def num_robots(self) -> int:
+        return self._num_robots
+
+    @property
+    def dofs_per_robot(self) -> int:
+        return self._dofs_per_robot
+
+    @property
+    def num_outputs(self) -> int:
+        return self._num_outputs
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
+
+    def is_stateful(self) -> bool:
+        return False
+
+    def is_graphable(self) -> bool:
+        return True
+
+    def state(self) -> None:
+        return None
+
+    def input_struct(self):
+        return _allocate_namespace(self._input_specs, self._device, self._requires_grad)
+
+    def output_struct(self):
+        return _allocate_namespace(self._output_specs, self._device, self._requires_grad)
+
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: None,
+        controller_state_next: None,
+        time_step: float,
+    ) -> None:
+        meas = getattr(input_struct, self._meas_attr)
+        meas_rate = getattr(input_struct, self._meas_rate_attr)
+        target_pos = getattr(input_struct, self._target_pos_attr)
+        target_quat = getattr(input_struct, self._target_quat_attr)
+        damping = self._damping_baked or getattr(input_struct, self._damping_attr)
+        bandwidth = self._bandwidth_baked or getattr(input_struct, self._bandwidth_attr)
+        out_q = getattr(output_struct, self._target_q_attr)
+        out_qd = getattr(output_struct, self._target_qd_attr)
+
+        wp.launch(
+            _gather_local_kernel,
+            dim=self._num_outputs,
+            inputs=[meas, self._meas_idx],
+            outputs=[self._model_state.joint_q],
+            device=self._device,
+        )
+        wp.launch(
+            _gather_local_kernel,
+            dim=self._num_outputs,
+            inputs=[meas_rate, self._meas_rate_idx],
+            outputs=[self._model_state.joint_qd],
+            device=self._device,
+        )
+
+        eval_fk(self._model, self._model_state.joint_q, self._model_state.joint_qd, self._model_state)
+        eval_jacobian(self._model, self._model_state, J=self._jacobian)
+
+        wp.launch(
+            _build_site_jacobian_kernel,
+            dim=self._num_robots,
+            inputs=[
+                self._jacobian,
+                self._model_state.body_q,
+                self._model.body_com,
+                target_pos,
+                self._target_pos_idx,
+                target_quat,
+                self._target_quat_idx,
+                self._global_ee_body_per_robot,
+                self._local_ee_body,
+                self._site_xform_per_robot,
+                self._dofs_per_robot,
+            ],
+            outputs=[self._j_site, self._e_buffer],
+            device=self._device,
+        )
+        if self._ik_method == ControllerDifferentialKinematics.IkMethod.TRANSPOSE:
+            wp.launch(
+                _qd_from_jte_kernel,
+                dim=(self._num_robots, self._dofs_per_robot),
+                inputs=[self._j_site, self._e_buffer, bandwidth],
+                outputs=[self._qd_target_local],
+                device=self._device,
+            )
+        else:
+            wp.launch(
+                _build_dls_matrix_kernel,
+                dim=(self._num_robots, 6, 6),
+                inputs=[self._j_site, damping, self._dofs_per_robot],
+                outputs=[self._A],
+                device=self._device,
+            )
+            wp.launch_tiled(
+                _cholesky_solve_kernel,
+                dim=[self._num_robots],
+                inputs=[self._A, self._e_buffer],
+                outputs=[self._y],
+                block_dim=32,
+                device=self._device,
+            )
+            wp.launch(
+                _qd_from_y_kernel,
+                dim=(self._num_robots, self._dofs_per_robot),
+                inputs=[self._j_site, self._y, bandwidth],
+                outputs=[self._qd_target_local],
+                device=self._device,
+            )
+        wp.launch(
+            _write_outputs_kernel,
+            dim=(self._num_robots, self._dofs_per_robot),
+            inputs=[
+                self._qd_target_local,
+                self._model_state.joint_q,
+                time_step,
+                self._dofs_per_robot,
+                self._target_qd_idx,
+                self._target_q_idx,
+            ],
+            outputs=[out_qd, out_q],
+            device=self._device,
+        )
+
+
+def _idx_max(idx: wp.array) -> int:
+    return int(np.max(idx.numpy())) + 1

--- a/newton/_src/controllers/impl/controller_pid.py
+++ b/newton/_src/controllers/impl/controller_pid.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""ControllerPID — stateful PID with anti-windup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from ..controller import Controller
+from ..utils import (
+    _allocate_namespace,
+    _normalize_indices,
+    _normalize_parameter_port,
+)
+
+
+@wp.kernel
+def _pid_kernel(
+    measurement: wp.array[float],
+    measurement_indices: wp.array[wp.uint32],
+    measurement_rate: wp.array[float],
+    measurement_rate_indices: wp.array[wp.uint32],
+    joint_target: wp.array[float],
+    joint_target_indices: wp.array[wp.uint32],
+    joint_target_rate: wp.array[float],
+    joint_target_rate_indices: wp.array[wp.uint32],
+    kp: wp.array[float],
+    ki: wp.array[float],
+    kd: wp.array[float],
+    integral_max: wp.array[float],
+    output_indices: wp.array[wp.uint32],
+    dt: float,
+    current_integral: wp.array[float],
+    output: wp.array[float],
+    next_integral: wp.array[float],
+):
+    i = wp.tid()
+    pos_err = joint_target[joint_target_indices[i]] - measurement[measurement_indices[i]]
+    vel_err = joint_target_rate[joint_target_rate_indices[i]] - measurement_rate[measurement_rate_indices[i]]
+    imax = integral_max[i]
+    integral = wp.clamp(current_integral[i] + pos_err * dt, -imax, imax)
+    contribution = kp[i] * pos_err + ki[i] * integral + kd[i] * vel_err
+    output[output_indices[i]] = contribution
+    next_integral[i] = integral
+
+
+class ControllerPID(Controller):
+    """Stateful PID controller with symmetric anti-windup clamping.
+
+    Per-DOF: ``output[i]`` depends only on the ``i``-th entries of its
+    declared ports. Each :meth:`compute` step writes::
+
+        output[output_idx[i]] = kp[i] * (joint_target - joint_measured)
+                              + ki[i] * clamp(integral + pos_err * dt,
+                                              -integral_max[i], +integral_max[i])
+                              + kd[i] * (joint_target_rate - joint_measured_rate)
+
+    where the bracketed differences read ``arr[idx[i]]`` for each live port.
+
+    **Gain ports** (``kp``, ``kd``, ``ki``, ``integral_max``) take either:
+
+    - a :class:`wp.array` — *baked*: the controller stores its own copy at
+      construction; mutating the user's original after construction has no
+      effect. Must be length ``default_dof_indices.size`` and dtype
+      ``wp.float32``.
+    - a ``str`` — *live*: at step time the controller resolves
+      ``getattr(input_struct, value)`` and reads from that array in natural
+      order (``arr[i]``).
+
+    **Live-data ports** take an ``attr_name`` string plus an optional
+    ``_idx`` array. When ``_idx`` is ``None`` the controller's
+    ``default_dof_indices`` is used; otherwise the kernel reads
+    ``arr[_idx[i]]``.
+
+    Args:
+        kp: Proportional gain.
+        kd: Derivative gain.
+        ki: Integral gain.
+        integral_max: Symmetric integrator clamp. Use
+            ``wp.full(N, float('inf'))`` to disable clamping.
+        default_dof_indices: Default indices for any live-data port whose
+            ``*_idx`` is ``None``. Length ``num_outputs``.
+        joint_measured_attr: Live read port — process variable (joint
+            positions).
+        joint_measured_idx: Override indices for ``joint_measured_attr``,
+            or ``None`` to use ``default_dof_indices``.
+        joint_measured_rate_attr: Live read port — derivative of the
+            process variable (joint velocities).
+        joint_measured_rate_idx: Override indices.
+        joint_target_attr: Live read port — target (joint positions).
+        joint_target_idx: Override indices.
+        joint_target_rate_attr: Live read port — target derivative.
+        joint_target_rate_idx: Override indices.
+        output_attr: Live write port — controller output (effort).
+        output_idx: Override indices.
+        device: Warp device for internal buffers. Defaults to
+            :func:`wp.get_device`.
+        requires_grad: If ``True``, internally-allocated buffers are
+            created with gradient support so :meth:`compute` is
+            transparent to :class:`wp.Tape`.
+    """
+
+    @dataclass
+    class State(Controller.State):
+        integral: wp.array[float] | None = None
+        """Accumulated integral term, shape ``[num_outputs]``."""
+
+    def __init__(
+        self,
+        default_dof_indices: wp.array,
+        kp: wp.array | str | None = None,
+        kd: wp.array | str | None = None,
+        ki: wp.array | str | None = None,
+        integral_max: wp.array | str | None = None,
+        joint_measured_attr: str = "joint_q",
+        joint_measured_idx: wp.array | None = None,
+        joint_measured_rate_attr: str = "joint_qd",
+        joint_measured_rate_idx: wp.array | None = None,
+        joint_target_attr: str = "joint_target_q",
+        joint_target_idx: wp.array | None = None,
+        joint_target_rate_attr: str = "joint_target_qd",
+        joint_target_rate_idx: wp.array | None = None,
+        output_attr: str = "joint_f",
+        output_idx: wp.array | None = None,
+        device: Any = None,
+        requires_grad: bool = False,
+    ):
+        if not isinstance(default_dof_indices, wp.array):
+            raise TypeError(f"default_dof_indices must be wp.array[uint32], got {type(default_dof_indices).__name__}.")
+
+        self._device = device if device is not None else wp.get_device()
+        self._requires_grad = requires_grad
+        self._default_dof_indices = default_dof_indices
+        self._num_outputs = int(default_dof_indices.size)
+
+        # I/O-data ports.
+        self._measurement_attr = joint_measured_attr
+        self._measurement_idx = _normalize_indices(joint_measured_idx, default_dof_indices, name="joint_measured")
+
+        self._measurement_rate_attr = joint_measured_rate_attr
+        self._measurement_rate_idx = _normalize_indices(
+            joint_measured_rate_idx, default_dof_indices, name="joint_measured_rate"
+        )
+
+        self._target_attr = joint_target_attr
+        self._target_idx = _normalize_indices(joint_target_idx, default_dof_indices, name="joint_target")
+
+        self._target_rate_attr = joint_target_rate_attr
+        self._target_rate_idx = _normalize_indices(joint_target_rate_idx, default_dof_indices, name="joint_target_rate")
+
+        self._output_attr = output_attr
+        self._output_idx = _normalize_indices(output_idx, default_dof_indices, name="output")
+
+        # Gain ports (wp.array | str).
+        if not kp:
+            kp = wp.zeros(shape=self._num_outputs, dtype=float, device=self.device, requires_grad=self.requires_grad)
+        self._kp_attr, self._kp_baked = _normalize_parameter_port(
+            kp, self._num_outputs, wp.float32, self._device, requires_grad, name="kp"
+        )
+
+        if not kd:
+            kd = wp.zeros(shape=self._num_outputs, dtype=float, device=self.device, requires_grad=self.requires_grad)
+        self._kd_attr, self._kd_baked = _normalize_parameter_port(
+            kd, self._num_outputs, wp.float32, self._device, requires_grad, name="kd"
+        )
+
+        if not ki:
+            ki = wp.zeros(shape=self._num_outputs, dtype=float, device=self.device, requires_grad=self.requires_grad)
+        self._ki_attr, self._ki_baked = _normalize_parameter_port(
+            ki, self._num_outputs, wp.float32, self._device, requires_grad, name="ki"
+        )
+
+        if not integral_max:
+            # default to no max:
+            integral_max = wp.full(
+                shape=self._num_outputs, value=wp.inf, dtype=float, device=self.device, requires_grad=self.requires_grad
+            )
+        self._imax_attr, self._imax_baked = _normalize_parameter_port(
+            integral_max, self._num_outputs, wp.float32, self._device, requires_grad, name="integral_max"
+        )
+
+        # Live read ports + any live gain ports --> fields on input_struct().
+        self._input_specs: list[tuple[str, Any, int]] = [
+            (self._measurement_attr, wp.float32, _idx_max(self._measurement_idx)),
+            (self._measurement_rate_attr, wp.float32, _idx_max(self._measurement_rate_idx)),
+            (self._target_attr, wp.float32, _idx_max(self._target_idx)),
+            (self._target_rate_attr, wp.float32, _idx_max(self._target_rate_idx)),
+        ]
+        for attr in (self._kp_attr, self._kd_attr, self._ki_attr, self._imax_attr):
+            if attr is not None:
+                self._input_specs.append((attr, wp.float32, self._num_outputs))
+
+        self._output_specs: list[tuple[str, Any, int]] = [
+            (self._output_attr, wp.float32, _idx_max(self._output_idx)),
+        ]
+
+    @property
+    def num_outputs(self) -> int:
+        return self._num_outputs
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
+
+    def is_stateful(self) -> bool:
+        return True
+
+    def is_graphable(self) -> bool:
+        return True
+
+    def state(self) -> ControllerPID.State:
+        return ControllerPID.State(
+            integral=wp.zeros(
+                self._num_outputs, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad
+            ),
+        )
+
+    def input_struct(self):
+        return _allocate_namespace(self._input_specs, self._device, self._requires_grad)
+
+    def output_struct(self):
+        return _allocate_namespace(self._output_specs, self._device, self._requires_grad)
+
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: ControllerPID.State,
+        controller_state_next: ControllerPID.State,
+        time_step: float,
+    ) -> None:
+        meas = getattr(input_struct, self._measurement_attr)
+        meas_rate = getattr(input_struct, self._measurement_rate_attr)
+        target = getattr(input_struct, self._target_attr)
+        target_rate = getattr(input_struct, self._target_rate_attr)
+        out = getattr(output_struct, self._output_attr)
+
+        kp = self._kp_baked or getattr(input_struct, self._kp_attr)
+        kd = self._kd_baked or getattr(input_struct, self._kd_attr)
+        ki = self._ki_baked or getattr(input_struct, self._ki_attr)
+        imax = self._imax_baked or getattr(input_struct, self._imax_attr)
+
+        wp.launch(
+            _pid_kernel,
+            dim=self._num_outputs,
+            inputs=[
+                meas,
+                self._measurement_idx,
+                meas_rate,
+                self._measurement_rate_idx,
+                target,
+                self._target_idx,
+                target_rate,
+                self._target_rate_idx,
+                kp,
+                ki,
+                kd,
+                imax,
+                self._output_idx,
+                time_step,
+                controller_state_now.integral,
+            ],
+            outputs=[out, controller_state_next.integral],
+            device=self._device,
+        )
+
+
+def _idx_max(idx: wp.array) -> int:
+    """Smallest backing-array size that satisfies ``arr[idx[i]]`` reads.
+
+    Reads ``idx.numpy()`` once at construction — cheap relative to the rest
+    of controller setup, and lets :meth:`input_struct` size every field
+    minimally for the controller's view.
+    """
+    return int(np.max(idx.numpy())) + 1

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal helpers for :mod:`newton.controllers`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import warp as wp
+
+
+def _normalize_indices(
+    idx: Any,
+    default_idx: wp.array,
+    *,
+    name: str,
+) -> tuple[str, wp.array]:
+    """If `idx` is supplied, performs input verification.
+    Otherwise, replaces the indices with the default_idx values.
+    """
+    if idx is None:
+        return default_idx
+
+    if (not isinstance(idx, wp.array)) or (idx.dtype != wp.uint32):
+        raise TypeError(f"Port '{name}': idx must be wp.array[uint32] or None, got {type(idx).__name__}.")
+
+    if idx.size != default_idx.size:
+        raise TypeError(
+            f"Port '{name}': indices must be the same size as default_dof_indices: {idx.size} != {default_idx.size}."
+        )
+
+    # indices meet verification:
+    return idx
+
+
+def _normalize_parameter_port(
+    value: Any,
+    expected_size: int,
+    dtype: Any,
+    device: Any,
+    requires_grad: bool,
+    *,
+    name: str,
+) -> tuple[str | None, wp.array | None]:
+    """Normalize a parameter-type port. It passed a baked array,
+    verifies that the size and dtype are correct.
+
+
+    - ``str``: live — at step time the controller resolves
+      ``getattr(input, value)`` and reads that array.
+    - ``wp.array``: baked — the controller stores a copy of the supplied
+      array and reads from that copy each step. Mutating the user's
+      original after construction has no effect.
+
+    Returns ``(attr_name, baked_array)`` — exactly one
+    of the two is non-``None``.
+    """
+    if isinstance(value, str):
+        return value, None
+    if isinstance(value, wp.array):
+        if value.size != expected_size:
+            raise ValueError(f"Port '{name}': baked array length {value.size} must equal {expected_size}.")
+        if value.dtype != dtype:
+            raise TypeError(f"Port '{name}': baked array dtype {value.dtype} must equal {dtype}.")
+        baked = wp.zeros(expected_size, dtype=dtype, device=device, requires_grad=requires_grad)
+        wp.copy(baked, value)
+        return None, baked
+    raise TypeError(f"Port '{name}': must be wp.array[{dtype}] or str (attr name); got {type(value).__name__}.")
+
+
+def _allocate_namespace(
+    specs: list[tuple[str, Any, int]],
+    device: Any,
+    requires_grad: bool,
+) -> SimpleNamespace:
+    """Build a :class:`SimpleNamespace` with one zero-allocated ``wp.array``
+    per ``(attr_name, dtype, size)`` spec. Duplicate attr names take the
+    larger size (smaller views are a prefix of the larger).
+    """
+    merged: dict[str, tuple[Any, int]] = {}
+    for attr, dtype, size in specs:
+        if attr in merged:
+            prev_dtype, prev_size = merged[attr]
+            if prev_dtype != dtype:
+                raise TypeError(f"Field '{attr}': two ports declared incompatible dtypes ({prev_dtype} vs {dtype}).")
+            merged[attr] = (dtype, max(prev_size, size))
+        else:
+            merged[attr] = (dtype, size)
+    return SimpleNamespace(
+        **{
+            attr: wp.zeros(size, dtype=dtype, device=device, requires_grad=requires_grad)
+            for attr, (dtype, size) in merged.items()
+        }
+    )

--- a/newton/controllers.py
+++ b/newton/controllers.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Control blocks for Newton.
+
+A :class:`Controller` is a single self-contained control law (PID,
+differential IK, differential drive, …). There is no framework-level
+composition: callers wanting to combine multiple control laws invoke each
+one's :meth:`Controller.compute` in sequence themselves. Controllers
+typically run *before* actuators in a simulation step — a controller
+produces a desired joint position, velocity, or force; downstream
+actuators turn that target into effort.
+"""
+
+from ._src.controllers import (
+    Controller,
+    ControllerDifferentialDrive,
+    ControllerDifferentialKinematics,
+    ControllerPID,
+)
+
+__all__ = [
+    "Controller",
+    "ControllerDifferentialDrive",
+    "ControllerDifferentialKinematics",
+    "ControllerPID",
+]

--- a/newton/examples/controllers/example_diff_drive_swarm.py
+++ b/newton/examples/controllers/example_diff_drive_swarm.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# Example Controllers — A swarm of differential-drive robots
+#
+# A single ControllerDifferentialDrive drives the wheels of N two-wheel
+# differential-drive robots. Each robot receives a constant
+# (linear_speed, angular_speed) command — most go straight at different
+# speeds, the last few spin in place. MuJoCo's velocity actuators track
+# the wheel-velocity targets the controller writes each substep.
+#
+# Command: python -m newton.examples diff_drive_swarm
+###########################################################################
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.examples
+from newton import JointTargetMode
+from newton.controllers import ControllerDifferentialDrive
+
+ROBOT_COUNT = 16
+ROBOT_SPACING = 0.3
+WHEEL_RADIUS = 0.05
+WHEEL_BASE = 0.2
+
+
+def dof_starts_per_world(
+    model: newton.Model,
+    template: newton.ModelBuilder,
+    *joint_ids: int,
+) -> list[int]:
+    """Global ``joint_qd`` indices for template joint IDs across replicated worlds.
+
+    Each world is laid out like the unfinalized *template*. Use
+    ``template.joint_qd_start[joint_id]`` for the DOF offset within a world
+    (not the raw joint index returned by ``add_joint_*``).
+    """
+    dof_world_start = model.joint_dof_world_start.numpy()
+    flat: list[int] = []
+    for world in range(model.world_count):
+        world_dof_base = int(dof_world_start[world])
+        flat += [world_dof_base + template.joint_qd_start[j] for j in joint_ids]
+    return flat
+
+
+def _build_robot_template():
+    """One chassis fixed to the world + two revolute wheels."""
+    builder = newton.ModelBuilder()
+
+    chassis = builder.add_link(xform=wp.transform(p=wp.vec3(0.0, 0.0, 0.2)))
+    builder.add_shape_box(chassis, hx=0.15, hy=0.10, hz=0.04)
+    # add_shape_cylinder is fixed along Z; rotate the shape so its length
+    # aligns with the wheel rotation axis (Y).
+    wheel_xform = wp.transform(p=wp.vec3(0.0, 0.0, 0.0), q=wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), -wp.pi / 2))
+    left = builder.add_link()
+    builder.add_shape_cylinder(left, xform=wheel_xform, radius=WHEEL_RADIUS, half_height=0.01)
+    right = builder.add_link()
+    builder.add_shape_cylinder(right, xform=wheel_xform, radius=WHEEL_RADIUS, half_height=0.01)
+
+    j_base = builder.add_joint_free(
+        parent=-1,
+        child=chassis,
+    )
+    j_left = builder.add_joint_revolute(
+        parent=chassis,
+        child=left,
+        axis=wp.vec3(0.0, 1.0, 0.0),
+        parent_xform=wp.transform(p=wp.vec3(0.0, -WHEEL_BASE / 2, -0.05)),
+        label="wheel_left",
+    )
+    j_right = builder.add_joint_revolute(
+        parent=chassis,
+        child=right,
+        axis=wp.vec3(0.0, 1.0, 0.0),
+        parent_xform=wp.transform(p=wp.vec3(0.0, +WHEEL_BASE / 2, -0.05)),
+        label="wheel_right",
+    )
+    builder.add_articulation([j_base, j_left, j_right], label="diff_drive_robot")
+
+    # MuJoCo velocity actuators on the two wheel DOFs (the fixed joint has no
+    # actuator). ke = 0 means no position term; kd is the velocity gain.
+    for i in range(len(builder.joint_target_kd)):
+        builder.joint_target_ke[i] = 0.0
+        builder.joint_target_kd[i] = 20.0
+        builder.joint_target_mode[i] = int(JointTargetMode.VELOCITY)
+    return builder, j_left, j_right
+
+
+class Example:
+    def __init__(self, viewer, args):
+        # joint_target_qd is the canonical coord-layout array MuJoCo's
+        # velocity actuators read from.
+        newton.use_coord_layout_targets = True
+
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_substeps = 4
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.sim_time = 0.0
+        self.viewer = viewer
+        self.device = wp.get_device()
+
+        template, j_left, j_right = _build_robot_template()
+        scene = newton.ModelBuilder()
+        scene.replicate(template, ROBOT_COUNT)
+        scene.add_ground_plane()
+        self.model = scene.finalize()
+
+        self.solver = newton.solvers.SolverMuJoCo(self.model)
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+        self.control = self.model.control()
+        self.contacts = self.model.contacts()
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
+
+        # 2 wheel DOFs per robot, laid out [r0_L, r0_R, r1_L, r1_R, ...].
+        wheel_dof_idx = dof_starts_per_world(self.model, template, j_left, j_right)
+        self._wheel_dof_idx = np.array(wheel_dof_idx, dtype=np.int32)
+        default_dof_indices = wp.array(wheel_dof_idx, dtype=wp.uint32, device=self.device)
+
+        self.controller = ControllerDifferentialDrive(
+            num_robots=ROBOT_COUNT,
+            wheel_radius=wp.full(ROBOT_COUNT, WHEEL_RADIUS, dtype=wp.float32, device=self.device),
+            wheel_base=wp.full(ROBOT_COUNT, WHEEL_BASE, dtype=wp.float32, device=self.device),
+            default_dof_indices=default_dof_indices,
+            device=self.device,
+        )
+
+        # robots all go in a circle:
+        omega = 0.05  # speed at which they will circle.
+        linear_cmd = np.linspace(
+            ROBOT_SPACING * omega, ROBOT_COUNT * ROBOT_SPACING * omega, ROBOT_COUNT, dtype=np.float32
+        )
+        angular_cmd = np.full(shape=ROBOT_COUNT, fill_value=omega, dtype=np.float32)
+        self._input = self.controller.input_struct()
+        self._input.linear_speed_command.assign(linear_cmd)
+        self._input.angular_speed_command.assign(angular_cmd)
+        self._linear_cmd = linear_cmd
+        self._angular_cmd = angular_cmd
+
+        # Controller writes directly into control.joint_target_qd so MuJoCo's
+        # velocity actuators read the freshest target each substep.
+        self._output = self.controller.output_struct()
+        self._output.joint_target_qd = self.control.joint_target_qd
+
+        self.viewer.set_model(self.model)
+        self.viewer.set_world_offsets((0.0, ROBOT_SPACING, 0.0))
+        self.graph = None
+        if self.device.is_cuda:
+            with wp.ScopedCapture() as capture:
+                self._simulate()
+            self.graph = capture.graph
+
+    def _simulate(self):
+        for _ in range(self.sim_substeps):
+            self.state_0.clear_forces()
+            self.model.collide(
+                state=self.state_0,
+                contacts=self.contacts,
+            )
+            self.controller.compute(self._input, self._output, None, None, time_step=self.sim_dt)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.state_0, self.state_1 = self.state_1, self.state_0
+
+    def step(self):
+        if self.graph:
+            wp.capture_launch(self.graph)
+        else:
+            self._simulate()
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        self.viewer.begin_frame(self.sim_time)
+        self.viewer.log_state(self.state_0)
+        self.viewer.end_frame()
+
+    def test_final(self):
+        # Verify the controller produced the analytical wheel velocities.
+        # omega_L = (2v - omega*b) / (2r); omega_R = (2v + omega*b) / (2r).
+        expected_left = (2.0 * self._linear_cmd - self._angular_cmd * WHEEL_BASE) / (2.0 * WHEEL_RADIUS)
+        expected_right = (2.0 * self._linear_cmd + self._angular_cmd * WHEEL_BASE) / (2.0 * WHEEL_RADIUS)
+        out = self.control.joint_target_qd.numpy()[self._wheel_dof_idx]
+        np.testing.assert_allclose(out[0::2], expected_left, atol=1e-4)
+        np.testing.assert_allclose(out[1::2], expected_right, atol=1e-4)
+
+
+if __name__ == "__main__":
+    viewer, args = newton.examples.init()
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/controllers/example_diff_ik_panda.py
+++ b/newton/examples/controllers/example_diff_ik_panda.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# Example Controllers — Differential IK driving four Franka Panda arms
+#
+# A ControllerDifferentialIK manages four Franka Panda (fr3 + hand) robots
+# arranged in a row. Each robot has its own 6DOF draggable gizmo in the
+# viewer; the controller drives every arm's TCP toward its gizmo every
+# step. The MuJoCo solver applies the controller's commanded q-targets
+# via its built-in joint-position PD.
+#
+# Command: python -m newton.examples diff_ik_panda
+###########################################################################
+
+from __future__ import annotations
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.examples
+import newton.solvers
+import newton.utils
+from newton.controllers import ControllerDifferentialKinematics
+
+ROBOT_COUNT = 4
+ROBOT_SPACING_Y = 1.2
+ARM_DOF_COUNT = 7
+FINGER_DOF_COUNT = 2
+DOFS_PER_ROBOT = ARM_DOF_COUNT + FINGER_DOF_COUNT
+# fr3_link7 → fr3_link8 (z=+0.107) → fr3_hand (id) → fr3_hand_tcp (z=+0.1034).
+# These fixed joints are collapsed into fr3_link7 at load time, so the TCP
+# expressed in fr3_link7's body-local frame is the sum.
+TCP_OFFSET = wp.vec3(0.0, 0.0, 0.2104)
+
+
+@wp.kernel
+def _scatter_kernel(
+    src: wp.array[float],
+    indices: wp.array[int],
+    dst: wp.array[float],
+):
+    """Copy ``src[indices[i]] → dst[indices[i]]`` — used to push only the arm
+    DOFs of the controller's q-buffer into ``control.joint_target_q``,
+    leaving finger entries (initialized to home once) undisturbed.
+    """
+    i = wp.tid()
+    idx = indices[i]
+    dst[idx] = src[idx]
+
+
+class Example:
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument(
+            "--transpose-solver",
+            type=bool,
+            default=False,
+            help="Use Jacobian-transpose solver instead of damped-least-squares solver.",
+        )
+        return parser
+
+    def __init__(self, viewer, args):
+        # joint_target_q / joint_target_qd are the canonical coord-layout
+        # arrays MuJoCo's joint-target PD reads from.
+        newton.use_coord_layout_targets = True
+
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_substeps = 10
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.sim_time = 0.0
+        self.viewer = viewer
+        self.device = wp.get_device()
+
+        # ------------------------------------------------------------------
+        # Template — one Franka with MuJoCo PD attrs + a TCP site
+        # ------------------------------------------------------------------
+
+        template = newton.ModelBuilder()
+        urdf_path = newton.utils.download_asset("franka_emika_panda") / "urdf" / "fr3_franka_hand.urdf"
+        template.add_urdf(
+            str(urdf_path),
+            floating=False,
+            collapse_fixed_joints=True,
+        )
+
+        # After collapse_fixed_joints, the hand/TCP fixed-joint chain folds
+        # into fr3_link7 — that's the body the IK site rides on.
+        ee_body_in_template = template.body_label.index("fr3/fr3_link7")
+        self._ee_body_in_template = ee_body_in_template
+
+        template.add_site(
+            ee_body_in_template,
+            label="ee",
+            xform=wp.transform(p=TCP_OFFSET, q=wp.quat_identity()),
+            visible=True,
+            scale=(0.02, 0.02, 0.02),
+        )
+
+        # Reasonable initial pose: arm folded forward-up, gripper fingers open.
+        home_q = np.array(
+            [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785, 0.04, 0.04],
+            dtype=np.float32,
+        )
+        template.joint_q = home_q.tolist()
+        self.home_q_per_robot = home_q
+
+        for i in range(len(template.joint_target_ke)):
+            template.joint_target_ke[i] = 3000.0
+            template.joint_target_kd[i] = 100.0
+
+        # ------------------------------------------------------------------
+        # Scene — replicate 4, add ground plane.
+        # ------------------------------------------------------------------
+        scene = newton.ModelBuilder()
+        scene.replicate(template, ROBOT_COUNT)
+        scene.add_ground_plane()
+        self.model = scene.finalize()
+
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+        self.control = self.model.control()
+        self.contacts = None
+
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
+
+        # disable_contacts: the arms shouldn't be colliding with anything in
+        # this demo, and turning contacts off keeps the simulation fast and
+        # focused on tracking behavior.
+        self.solver = newton.solvers.SolverMuJoCo(self.model, disable_contacts=True)
+
+        # ------------------------------------------------------------------
+        # DiffIK setup
+        # ------------------------------------------------------------------
+        total_dofs = ROBOT_COUNT * DOFS_PER_ROBOT
+        dof_indices = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self.device)
+
+        bodies_per_robot = self.model.body_count // ROBOT_COUNT
+        self._bodies_per_robot = bodies_per_robot
+        body_q_np = self.state_0.body_q.numpy()
+
+        target_frames_init: list[wp.transform] = []
+        for r in range(ROBOT_COUNT):
+            ee_scene_idx = r * bodies_per_robot + ee_body_in_template
+            ee_world = wp.transform(*body_q_np[ee_scene_idx])
+            target_frames_init.append(ee_world * wp.transform(p=TCP_OFFSET, q=wp.quat_identity()))
+
+        # ------------------------------------------------------------------
+        # DiffIK template — N articulations at the origin (no ground plane).
+        # Target poses live in each robot's own base frame; viewer offsets
+        # only affect gizmo display via _target_frames_to_gizmos().
+        # ------------------------------------------------------------------
+        diffik_template = newton.ModelBuilder()
+        diffik_template.replicate(template, ROBOT_COUNT)
+
+        ik_method = ControllerDifferentialKinematics.IkMethod.DAMPED_LEAST_SQUARES
+        if args.transpose_solver:
+            ik_method = ControllerDifferentialKinematics.IkMethod.TRANSPOSE
+
+        self.controller = ControllerDifferentialKinematics(
+            model_builder=diffik_template,
+            controlled_site_label="ee",
+            default_dof_indices=dof_indices,
+            bandwidth=wp.full(ROBOT_COUNT, 20.0, dtype=wp.float32, device=self.device),
+            device=self.device,
+            ik_method=ik_method,
+        )
+
+        # input_struct() / output_struct() return fresh dataclasses with one
+        # wp.zeros field per live port. We seed the per-robot target fields
+        # with the home TCPs, then reassign joint_q / joint_qd each frame to
+        # point at the current sim state.
+        self._input = self.controller.input_struct()
+        self._input.joint_q = self.state_0.joint_q
+        self._input.joint_qd = self.state_0.joint_qd
+        self._assign_target_frames(target_frames_init)
+        self._output = self.controller.output_struct()
+
+        # Seed control.joint_target_q with the home pose for every robot.
+        # The arm slots get overwritten every substep by the scatter; the
+        # finger slots persist (PD holds them open).
+        home_tile = np.tile(self.home_q_per_robot, ROBOT_COUNT).astype(np.float32)
+        wp.copy(
+            self.control.joint_target_q,
+            wp.array(home_tile, dtype=wp.float32, device=self.device),
+        )
+
+        # Arm DOF indices in the scene's per-robot layout. The DiffIK's
+        # dof_indices is arange(total_dofs), so q_buffer flat index equals
+        # the scene's joint_target_q index — we just pick out the 7 arm
+        # slots per robot for the scatter.
+        arm_indices = []
+        for r in range(ROBOT_COUNT):
+            base = r * DOFS_PER_ROBOT
+            arm_indices.extend(range(base, base + ARM_DOF_COUNT))
+        self._arm_indices = wp.array(arm_indices, dtype=wp.int32, device=self.device)
+
+        self.viewer.set_model(self.model)
+        self.viewer.set_world_offsets((0.0, ROBOT_SPACING_Y, 0.0))
+        self._visual_offsets = self.viewer.world_offsets.numpy()
+        self.gizmo_tfs = self._target_frames_to_gizmos(target_frames_init)
+        self.viewer.set_camera(
+            pos=wp.vec3(2.5, 0.0, 1.3),
+            pitch=-15.0,
+            yaw=180.0,
+        )
+
+        # CUDA graph capture skipped: _push_gizmos mutates wp.arrays from the
+        # Python side each frame to follow gizmo drags, which isn't capturable.
+        self.graph = None
+
+    def _assign_target_frames(self, frames: list[wp.transform]) -> None:
+        pos = np.zeros((ROBOT_COUNT, 3), dtype=np.float32)
+        quat = np.zeros((ROBOT_COUNT, 4), dtype=np.float32)
+        for r, tf in enumerate(frames):
+            p = wp.transform_get_translation(tf)
+            q = wp.transform_get_rotation(tf)
+            pos[r] = [p[0], p[1], p[2]]
+            quat[r] = [q[0], q[1], q[2], q[3]]
+        self._input.site_target_position.assign(pos)
+        self._input.site_target_quaternion.assign(quat)
+
+    def _push_gizmos(self) -> None:
+        self._assign_target_frames(self._gizmos_to_target_frames(self.gizmo_tfs))
+
+    def _scatter_arm_targets(self) -> None:
+        wp.launch(
+            _scatter_kernel,
+            dim=len(self._arm_indices),
+            inputs=[self._output.joint_target_q, self._arm_indices],
+            outputs=[self.control.joint_target_q],
+            device=self.device,
+        )
+
+    def _gizmos_to_target_frames(self, frames: list[wp.transform]) -> list[wp.transform]:
+        """Gizmo (viewer) frame → per-robot target frame (strip visual offsets)."""
+        return [
+            wp.transform(
+                p=wp.transform_get_translation(tf) - wp.vec3(*self._visual_offsets[r]),
+                q=wp.transform_get_rotation(tf),
+            )
+            for r, tf in enumerate(frames)
+        ]
+
+    def _target_frames_to_gizmos(self, frames: list[wp.transform]) -> list[wp.transform]:
+        """Per-robot target frame → gizmo (viewer) frame (apply visual offsets)."""
+        return [
+            wp.transform(
+                p=wp.transform_get_translation(tf) + wp.vec3(*self._visual_offsets[r]),
+                q=wp.transform_get_rotation(tf),
+            )
+            for r, tf in enumerate(frames)
+        ]
+
+    def step(self) -> None:
+        self._push_gizmos()
+        # Rebind the live joint_q / joint_qd to whichever State buffer the
+        # substep swap left at ``self.state_0`` after the previous frame.
+        # SimpleNamespace's attributes are just Python refs, so this is
+        # cheap; we do it every frame for robustness regardless of the
+        # substep parity.
+        self._input.joint_q = self.state_0.joint_q
+        self._input.joint_qd = self.state_0.joint_qd
+        # One controller step per frame. DiffIK's output_q is current_q +
+        # q_dot * frame_dt — a position target one frame ahead. The MuJoCo PD
+        # then tracks that fixed target for all ``sim_substeps`` physics
+        # substeps; running DiffIK inside the substep loop would refresh the
+        # target against the drifted current_q on every substep, leaving PD
+        # with no restoring signal against gravity.
+        self.controller.compute(self._input, self._output, None, None, time_step=self.frame_dt)
+        self._scatter_arm_targets()
+        for _ in range(self.sim_substeps):
+            self.state_0.clear_forces()
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.state_0, self.state_1 = self.state_1, self.state_0
+        self.sim_time += self.frame_dt
+
+    def render(self) -> None:
+        self.viewer.begin_frame(self.sim_time)
+
+        body_q_np = self.state_0.body_q.numpy()
+        target_frames = []
+        for r in range(ROBOT_COUNT):
+            ee_scene_idx = r * self._bodies_per_robot + self._ee_body_in_template
+            ee_world = wp.transform(*body_q_np[ee_scene_idx])
+            target_frames.append(ee_world * wp.transform(p=TCP_OFFSET, q=wp.quat_identity()))
+        snap_gizmos = self._target_frames_to_gizmos(target_frames)
+        for r, tf in enumerate(self.gizmo_tfs):
+            self.viewer.log_gizmo(f"target_{r}", tf, snap_to=snap_gizmos[r])
+
+        self.viewer.log_state(self.state_0)
+        self.viewer.end_frame()
+        wp.synchronize()
+
+    def test_final(self) -> None:
+        # Gizmos aren't touched in headless test mode, so every arm should
+        # remain near its home pose under MuJoCo's joint-position PD.
+        joint_q = self.state_0.joint_q.numpy()
+        for r in range(ROBOT_COUNT):
+            base = r * DOFS_PER_ROBOT
+            arm_q = joint_q[base : base + ARM_DOF_COUNT]
+            assert np.all(np.isfinite(arm_q)), f"Robot {r} joint_q has NaN/Inf: {arm_q}"
+            assert np.allclose(arm_q, self.home_q_per_robot[:ARM_DOF_COUNT], atol=0.1), (
+                f"Robot {r} drifted from home pose: {arm_q}"
+            )
+
+
+if __name__ == "__main__":
+    parser = Example.create_parser()
+    viewer, args = newton.examples.init(parser)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/controllers/example_pid_pendulum.py
+++ b/newton/examples/controllers/example_pid_pendulum.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# Example Controllers — PID swinging a double pendulum to a setpoint.
+#
+# A ControllerPID drives both joints of a planar 2-link pendulum to fixed
+# target angles by writing joint efforts into control.joint_f, which the
+# XPBD solver applies each substep.
+#
+# Command: python -m newton.examples pid_pendulum
+###########################################################################
+
+import warp as wp
+
+import newton
+import newton.examples
+from newton.controllers import ControllerPID
+
+
+class Example:
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        parser.add_argument(
+            "--j1-target",
+            type=float,
+            default=0.6,
+            help="Target angle for joint 1 [rad].",
+        )
+        parser.add_argument(
+            "--j2-target",
+            type=float,
+            default=-1.2,
+            help="Target angle for joint 2 [rad].",
+        )
+        return parser
+
+    def __init__(self, viewer, args):
+        self.fps = 200
+        self.frame_dt = 1.0 / self.fps
+        self.sim_substeps = 10
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.sim_time = 0.0
+        self.viewer = viewer
+        self.device = wp.get_device()
+
+        # Two-link planar pendulum, one revolute joint per link.
+        builder = newton.ModelBuilder()
+        link_0 = builder.add_link()
+        builder.add_shape_box(link_0, hx=0.5, hy=0.05, hz=0.05)
+        link_1 = builder.add_link()
+        builder.add_shape_box(link_1, hx=0.5, hy=0.05, hz=0.05)
+
+        j0 = builder.add_joint_revolute(
+            parent=-1,
+            child=link_0,
+            axis=wp.vec3(0.0, 1.0, 0.0),
+            parent_xform=wp.transform(p=wp.vec3(0.0, 0.0, 3.0)),
+            child_xform=wp.transform(p=wp.vec3(-0.5, 0.0, 0.0)),
+        )
+        j1 = builder.add_joint_revolute(
+            parent=link_0,
+            child=link_1,
+            axis=wp.vec3(0.0, 1.0, 0.0),
+            parent_xform=wp.transform(p=wp.vec3(0.5, 0.0, 0.0)),
+            child_xform=wp.transform(p=wp.vec3(-0.5, 0.0, 0.0)),
+        )
+        builder.add_articulation([j0, j1], label="pendulum")
+        self.model = builder.finalize()
+
+        self.solver = newton.solvers.SolverMuJoCo(self.model)
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+        self.control = self.model.control()
+        self.contacts = None
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
+
+        # PID with all defaults: reads joint_q / joint_qd / joint_target_q /
+        # joint_target_qd from the input struct and writes joint_f to the
+        # output struct. Gains baked in as wp.arrays.
+        default_dof_indices = wp.array([0, 1], dtype=wp.uint32, device=self.device)
+        self.controller = ControllerPID(
+            kp=wp.array([3600.0, 1200.0], dtype=wp.float32, device=self.device),
+            kd=wp.array([320.0, 160.0], dtype=wp.float32, device=self.device),
+            default_dof_indices=default_dof_indices,
+            device=self.device,
+        )
+
+        # The input struct's joint_q / joint_qd / joint_target_q / joint_target_qd
+        # fields default to wp.zeros; we rebind joint_q/qd each frame to the
+        # current sim state, and seed the setpoint once.
+        self._input = self.controller.input_struct()
+        self.j1_target = args.j1_target
+        self.j2_target = args.j2_target
+
+        self._input.joint_target_q.assign([self.j1_target, self.j2_target])  # target angles [rad]
+
+        # The output struct's joint_f field is what the solver consumes — wire it
+        # straight into control.joint_f so the PID writes directly into the
+        # arrays the solver reads.
+        self._output = self.controller.output_struct()
+        self._output.joint_f = self.control.joint_f
+
+        # Double-buffered controller state — PID's integral state lives here.
+        self._cs0 = self.controller.state()
+        self._cs1 = self.controller.state()
+
+        self.viewer.set_model(self.model)
+        self.graph = None
+        if self.device.is_cuda:
+            with wp.ScopedCapture() as capture:
+                self._simulate()
+            self.graph = capture.graph
+
+    def _simulate(self):
+        for _ in range(self.sim_substeps):
+            self.state_0.clear_forces()
+            # Rebind to whichever buffer the swap last left at state_0; SimpleNamespace
+            # attribute assignment is a Python ref so this is free.
+            self._input.joint_q = self.state_0.joint_q
+            self._input.joint_qd = self.state_0.joint_qd
+            self.controller.compute(self._input, self._output, self._cs0, self._cs1, time_step=self.sim_dt)
+            self._cs0, self._cs1 = self._cs1, self._cs0
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.state_0, self.state_1 = self.state_1, self.state_0
+
+    def step(self):
+        if self.graph:
+            wp.capture_launch(self.graph)
+        else:
+            self._simulate()
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        self.viewer.begin_frame(self.sim_time)
+        self.viewer.log_state(self.state_0)
+        self.viewer.end_frame()
+
+    def test_final(self):
+        # After enough sim time the PID should hold the joints near the targets.
+        joint_q = self.state_0.joint_q.numpy()
+        assert abs(joint_q[0] - self.j1_target) < 0.1, f"joint 0 = {joint_q[0]:.3f}, expected ~{self.j1_target}"
+        assert abs(joint_q[1] - self.j2_target) < 0.1, f"joint 1 = {joint_q[1]:.3f}, expected ~{self.j2_target}"
+
+
+if __name__ == "__main__":
+    parser = Example.create_parser()
+    viewer, args = newton.examples.init(parser)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/tests/test_controllers.py
+++ b/newton/tests/test_controllers.py
@@ -1,0 +1,734 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for newton.controllers."""
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.controllers import ControllerDifferentialKinematics, ControllerPID
+
+
+# Tape-aware scalar sum (wp.utils.array_sum calls a native C reducer, so it
+# isn't recorded by wp.Tape; we need a real Warp kernel for the grad tests).
+@wp.kernel
+def _sum_kernel(values: wp.array[float], out: wp.array[float]):
+    i = wp.tid()
+    wp.atomic_add(out, 0, values[i])
+
+
+def _idx(values, device):
+    return wp.array(values, dtype=wp.uint32, device=device)
+
+
+def _iota(n, device):
+    return wp.array(np.arange(n, dtype=np.uint32), device=device)
+
+
+# ----------------------------------------------------------------------------
+# ControllerPID
+# ----------------------------------------------------------------------------
+
+
+class TestControllerPID(unittest.TestCase):
+    def test_proportional_only(self):
+        device = wp.get_device()
+        default_idx = _iota(3, device)
+        output_arr = wp.zeros(3, dtype=wp.float32, device=device)
+
+        pid = ControllerPID(
+            kp=wp.array([2.0, 2.0, 2.0], dtype=wp.float32, device=device),
+            kd=wp.zeros(3, dtype=wp.float32, device=device),
+            ki=wp.zeros(3, dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf, np.inf, np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            joint_measured_attr="joint_q",
+            joint_target_attr="joint_target_q",
+            output_attr="output",
+            device=device,
+        )
+
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(3, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(3, dtype=wp.float32, device=device),
+            joint_target_q=wp.array([1.0, 2.0, -1.0], dtype=wp.float32, device=device),
+            joint_target_qd=wp.zeros(3, dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+
+        s0, s1 = pid.state(), pid.state()
+        pid.compute(input_struct, output_struct, s0, s1, time_step=0.01)
+
+        np.testing.assert_allclose(output_arr.numpy(), [2.0, 4.0, -2.0], atol=1e-6)
+
+    def test_integral_accumulates(self):
+        device = wp.get_device()
+        default_idx = _iota(1, device)
+        output_arr = wp.zeros(1, dtype=wp.float32, device=device)
+
+        pid = ControllerPID(
+            kp=wp.zeros(1, dtype=wp.float32, device=device),
+            kd=wp.zeros(1, dtype=wp.float32, device=device),
+            ki=wp.array([0.5], dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            output_attr="output",
+            device=device,
+        )
+
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_target_q=wp.array([1.0], dtype=wp.float32, device=device),
+            joint_target_qd=wp.zeros(1, dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+
+        s0, s1 = pid.state(), pid.state()
+        dt = 0.1
+        running_integral = 0.0
+        for step_i in range(5):
+            running_integral += dt
+            pid.compute(input_struct, output_struct, s0, s1, time_step=dt)
+            s0, s1 = s1, s0
+            self.assertAlmostEqual(
+                float(output_arr.numpy()[0]),
+                0.5 * running_integral,
+                places=5,
+                msg=f"step {step_i}: integral should be {running_integral:.3f}",
+            )
+
+    def test_anti_windup_clamps_integral(self):
+        device = wp.get_device()
+        default_idx = _iota(1, device)
+        output_arr = wp.zeros(1, dtype=wp.float32, device=device)
+
+        pid = ControllerPID(
+            kp=wp.zeros(1, dtype=wp.float32, device=device),
+            kd=wp.zeros(1, dtype=wp.float32, device=device),
+            ki=wp.array([1.0], dtype=wp.float32, device=device),
+            integral_max=wp.array([0.3], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            output_attr="output",
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_target_q=wp.array([1.0], dtype=wp.float32, device=device),
+            joint_target_qd=wp.zeros(1, dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+
+        s0, s1 = pid.state(), pid.state()
+        for _ in range(21):
+            pid.compute(input_struct, output_struct, s0, s1, time_step=0.1)
+            s0, s1 = s1, s0
+
+        self.assertAlmostEqual(float(output_arr.numpy()[0]), 0.3, places=5)
+        self.assertAlmostEqual(float(s0.integral.numpy()[0]), 0.3, places=5)
+
+    def test_gradient_flows_with_requires_grad(self):
+        """Gradient from a loss on the output flows back to a requires_grad
+        joint_target_q. Live ports resolve via getattr at step time, so
+        autograd sees the user-supplied requires_grad array."""
+        device = wp.get_device()
+        default_idx = _iota(3, device)
+        output_arr = wp.zeros(3, dtype=wp.float32, device=device, requires_grad=True)
+        target = wp.array([1.0, 2.0, -1.0], dtype=wp.float32, device=device, requires_grad=True)
+
+        pid = ControllerPID(
+            kp=wp.array([2.0, 2.0, 2.0], dtype=wp.float32, device=device),
+            kd=wp.zeros(3, dtype=wp.float32, device=device),
+            ki=wp.zeros(3, dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf, np.inf, np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            output_attr="output",
+            device=device,
+            requires_grad=True,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(3, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(3, dtype=wp.float32, device=device),
+            joint_target_q=target,
+            joint_target_qd=wp.zeros(3, dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+        s0, s1 = pid.state(), pid.state()
+
+        loss = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
+        tape = wp.Tape()
+        with tape:
+            pid.compute(input_struct, output_struct, s0, s1, time_step=0.01)
+            wp.launch(_sum_kernel, dim=len(output_arr), inputs=[output_arr, loss])
+        tape.backward(loss=loss)
+
+        np.testing.assert_allclose(target.grad.numpy(), [2.0, 2.0, 2.0], atol=1e-5)
+
+    def test_live_idx_diverges_from_default(self):
+        """A per-port `_idx` override lets a live input port read from a
+        differently-laid-out source array than the output writes to."""
+        device = wp.get_device()
+        default_idx = _idx([5, 7], device)  # output slots
+        output_arr = wp.zeros(10, dtype=wp.float32, device=device)
+        # joint_target is laid out across a length-5 source; the controller's
+        # two outputs read joint_target[1] and joint_target[2].
+        target = wp.array([99.0, 1.0, 1.0, 99.0, 99.0], dtype=wp.float32, device=device)
+        target_idx = _idx([1, 2], device)
+
+        pid = ControllerPID(
+            kp=wp.array([2.0, 2.0], dtype=wp.float32, device=device),
+            kd=wp.zeros(2, dtype=wp.float32, device=device),
+            ki=wp.zeros(2, dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf, np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            joint_target_attr="joint_target_q",
+            joint_target_idx=target_idx,
+            output_attr="output",
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(10, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(10, dtype=wp.float32, device=device),
+            joint_target_q=target,
+            joint_target_qd=wp.zeros(10, dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+        s0, s1 = pid.state(), pid.state()
+        pid.compute(input_struct, output_struct, s0, s1, time_step=0.01)
+
+        result = output_arr.numpy()
+        self.assertAlmostEqual(float(result[5]), 2.0, places=5)
+        self.assertAlmostEqual(float(result[7]), 2.0, places=5)
+        for i in (0, 1, 2, 3, 4, 6, 8, 9):
+            self.assertEqual(float(result[i]), 0.0)
+
+    def test_live_gain_from_input_struct(self):
+        """A gain passed as a string lives on the input struct; the
+        controller reads it at step time. Equivalent semantics to the baked
+        form for natural-order indexing."""
+        device = wp.get_device()
+        default_idx = _iota(2, device)
+        output_arr = wp.zeros(2, dtype=wp.float32, device=device)
+
+        pid = ControllerPID(
+            kp="kp",
+            kd=wp.zeros(2, dtype=wp.float32, device=device),
+            ki=wp.zeros(2, dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf, np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            output_attr="output",
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_target_q=wp.array([1.0, 2.0], dtype=wp.float32, device=device),
+            joint_target_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            kp=wp.array([3.0, 4.0], dtype=wp.float32, device=device),
+        )
+        output_struct = SimpleNamespace(output=output_arr)
+        s0, s1 = pid.state(), pid.state()
+        pid.compute(input_struct, output_struct, s0, s1, time_step=0.01)
+
+        np.testing.assert_allclose(output_arr.numpy(), [3.0, 8.0], atol=1e-6)
+
+    def test_baked_gain_copied_not_referenced(self):
+        """Mutating the user's baked gain array after construction has no
+        effect on the controller — baked arrays are stored by copy."""
+        device = wp.get_device()
+        default_idx = _iota(2, device)
+        kp_user = wp.array([2.0, 2.0], dtype=wp.float32, device=device)
+
+        pid = ControllerPID(
+            kp=kp_user,
+            kd=wp.zeros(2, dtype=wp.float32, device=device),
+            ki=wp.zeros(2, dtype=wp.float32, device=device),
+            integral_max=wp.array([np.inf, np.inf], dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            output_attr="output",
+            device=device,
+        )
+        # Mutate the user's kp_user post-construction — controller should not see this.
+        kp_user.assign(np.array([100.0, 100.0], dtype=np.float32))
+
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_target_q=wp.array([1.0, 1.0], dtype=wp.float32, device=device),
+            joint_target_qd=wp.zeros(2, dtype=wp.float32, device=device),
+        )
+        output_arr = wp.zeros(2, dtype=wp.float32, device=device)
+        output_struct = SimpleNamespace(output=output_arr)
+        s0, s1 = pid.state(), pid.state()
+        pid.compute(input_struct, output_struct, s0, s1, time_step=0.01)
+
+        np.testing.assert_allclose(output_arr.numpy(), [2.0, 2.0], atol=1e-6)
+
+    def test_input_struct_factory(self):
+        """`input_struct()` allocates a fresh dataclass with one field per
+        live read port, sized for the controller's view."""
+        device = wp.get_device()
+        default_idx = _iota(3, device)
+        pid = ControllerPID(
+            kp="my_kp",
+            kd=wp.zeros(3, dtype=wp.float32, device=device),
+            ki=wp.zeros(3, dtype=wp.float32, device=device),
+            integral_max=wp.full(3, value=float(np.inf), dtype=wp.float32, device=device),
+            default_dof_indices=default_idx,
+            device=device,
+        )
+        s = pid.input_struct()
+        # Live ports + live gain (kp).
+        self.assertTrue(hasattr(s, "joint_q"))
+        self.assertTrue(hasattr(s, "joint_qd"))
+        self.assertTrue(hasattr(s, "joint_target_q"))
+        self.assertTrue(hasattr(s, "joint_target_qd"))
+        self.assertTrue(hasattr(s, "my_kp"))
+        # Baked gains (kd, ki, integral_max) do NOT appear on the input struct.
+        self.assertFalse(hasattr(s, "kd"))
+        self.assertFalse(hasattr(s, "ki"))
+        self.assertFalse(hasattr(s, "integral_max"))
+        self.assertEqual(s.joint_q.shape, (3,))
+        self.assertEqual(s.my_kp.shape, (3,))
+
+
+# ----------------------------------------------------------------------------
+# ControllerDifferentialKinematics
+# ----------------------------------------------------------------------------
+
+
+def _build_planar_arm_one_link():
+    builder = newton.ModelBuilder()
+    link0 = builder.add_link()
+    j0 = builder.add_joint_revolute(
+        parent=-1,
+        child=link0,
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([j0], label="arm")
+    builder.add_site(link0, label="tool", xform=wp.transform(p=wp.vec3(1.0, 0.0, 0.0), q=wp.quat_identity()))
+    return builder
+
+
+def _build_planar_arm_two_link():
+    builder = newton.ModelBuilder()
+    link0 = builder.add_link()
+    link1 = builder.add_link()
+    j0 = builder.add_joint_revolute(
+        parent=-1,
+        child=link0,
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    j1 = builder.add_joint_revolute(
+        parent=link0,
+        child=link1,
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        parent_xform=wp.transform(p=wp.vec3(1.0, 0.0, 0.0)),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([j0, j1], label="arm")
+    builder.add_site(link1, label="tip", xform=wp.transform(p=wp.vec3(1.0, 0.0, 0.0), q=wp.quat_identity()))
+    return builder
+
+
+def _make_diffik(builder, site, default_idx, device, **overrides):
+    return ControllerDifferentialKinematics(
+        model_builder=builder,
+        controlled_site_label=site,
+        default_dof_indices=default_idx,
+        bandwidth=wp.array([1.0], dtype=wp.float32, device=device),
+        device=device,
+        **overrides,
+    )
+
+
+class TestControllerDifferentialKinematics(unittest.TestCase):
+    def test_target_equals_current_gives_zero_velocity(self):
+        device = wp.get_device()
+        builder = _build_planar_arm_two_link()
+        default_idx = _iota(2, device)
+        out_q = wp.zeros(2, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(2, dtype=wp.float32, device=device)
+
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tip",
+            default_dof_indices=default_idx,
+            bandwidth=wp.array([1.0], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(2.0, 0.0, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        np.testing.assert_allclose(out_qd.numpy(), [0.0, 0.0], atol=1e-5)
+        np.testing.assert_allclose(out_q.numpy(), [0.0, 0.0], atol=1e-5)
+
+    def test_pulls_first_joint_toward_offset_target(self):
+        device = wp.get_device()
+        builder = _build_planar_arm_two_link()
+        default_idx = _iota(2, device)
+        out_q = wp.zeros(2, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(2, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tip",
+            default_dof_indices=default_idx,
+            bandwidth=wp.array([1.0], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(2.0, 0.1, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        self.assertGreater(float(out_qd.numpy()[0]), 0.0)
+
+    def test_output_q_equals_current_q_plus_qdot_dt(self):
+        device = wp.get_device()
+        builder = _build_planar_arm_two_link()
+        default_idx = _iota(2, device)
+        joint_q = wp.array([0.2, -0.3], dtype=wp.float32, device=device)
+        out_q = wp.zeros(2, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(2, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tip",
+            default_dof_indices=default_idx,
+            bandwidth=wp.array([1.0], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=joint_q,
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(1.5, 0.2, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        dt = 0.02
+        diffik.compute(input_struct, output_struct, None, None, time_step=dt)
+
+        expected_q = joint_q.numpy() + out_qd.numpy() * dt
+        np.testing.assert_allclose(out_q.numpy(), expected_q, atol=1e-5)
+
+    def test_one_dof_matches_analytical_dls(self):
+        device = wp.get_device()
+        ERR_Y = 0.1
+        LAMBDA = 0.5
+        BAND = 2.0
+        builder = _build_planar_arm_one_link()
+        default_idx = _iota(1, device)
+        out_q = wp.zeros(1, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(1, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA], dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(1, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(1.0, ERR_Y, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        expected_qd = BAND * ERR_Y / (2.0 + LAMBDA**2)
+        self.assertAlmostEqual(float(out_qd.numpy()[0]), expected_qd, places=5)
+
+    def test_one_dof_matches_analytical_transpose(self):
+        device = wp.get_device()
+        ERR_Y = 0.1
+        BAND = 2.0
+        builder = _build_planar_arm_one_link()
+        default_idx = _iota(1, device)
+        out_q = wp.zeros(1, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(1, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            bandwidth=wp.array([BAND], dtype=wp.float32, device=device),
+            ik_method=ControllerDifferentialKinematics.IkMethod.TRANSPOSE,
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(1, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(1.0, ERR_Y, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        expected_qd = BAND * ERR_Y
+        self.assertAlmostEqual(float(out_qd.numpy()[0]), expected_qd, places=5)
+
+    def test_default_solver_damping(self):
+        device = wp.get_device()
+        builder = _build_planar_arm_one_link()
+        default_idx = _iota(1, device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            bandwidth=wp.array([1.0], dtype=wp.float32, device=device),
+            device=device,
+        )
+        self.assertAlmostEqual(
+            float(diffik._damping_baked.numpy()[0]),
+            ControllerDifferentialKinematics.DEFAULT_SOLVER_DAMPING,
+        )
+
+    def test_runs_inside_wp_tape_without_crashing(self):
+        device = wp.get_device()
+        LAMBDA = 0.5
+        BAND = 1.5
+        builder = _build_planar_arm_one_link()
+        default_idx = _iota(1, device)
+        out_q = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
+        out_qd = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
+        target_pos = wp.array([wp.vec3(1.0, 0.1, 0.0)], dtype=wp.vec3, device=device, requires_grad=True)
+
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA], dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND], dtype=wp.float32, device=device),
+            device=device,
+            requires_grad=True,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(1, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(1, dtype=wp.float32, device=device),
+            site_target_position=target_pos,
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+
+        loss = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
+        tape = wp.Tape()
+        with tape:
+            diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+            wp.launch(_sum_kernel, dim=len(out_qd), inputs=[out_qd, loss])
+        tape.backward(loss=loss)
+
+        expected_qd = BAND * 0.1 / (2.0 + LAMBDA**2)
+        self.assertAlmostEqual(float(out_qd.numpy()[0]), expected_qd, places=5)
+        np.testing.assert_allclose(target_pos.grad.numpy()[0], [0.0, 0.0, 0.0], atol=1e-7)
+
+    def test_parallel_robots(self):
+        device = wp.get_device()
+        LAMBDA = 0.5
+        BAND = 1.0
+        N = 4
+        template = _build_planar_arm_one_link()
+        builder = newton.ModelBuilder()
+        builder.replicate(template, world_count=N)
+        default_idx = _iota(N, device)
+        target_ys = [0.10, 0.20, 0.05, -0.15]
+        out_q = wp.zeros(N, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(N, dtype=wp.float32, device=device)
+
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA] * N, dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND] * N, dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(N, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(N, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(1.0, y, 0.0) for y in target_ys], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)] * N, dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        expected_qd = np.array([BAND * y / (2.0 + LAMBDA**2) for y in target_ys], dtype=np.float32)
+        np.testing.assert_allclose(out_qd.numpy(), expected_qd, atol=1e-5)
+
+    def test_robot_is_subset_of_scene(self):
+        """Live per-DOF idx routes writes to arbitrary sim slots."""
+        device = wp.get_device()
+        LAMBDA = 0.5
+        BAND = 1.5
+        ERR_Y = 0.1
+        sim_n_dofs = 2  # arm dof 0 + pendulum dof 1
+        builder = _build_planar_arm_one_link()
+        default_idx = _idx([0], device)
+        out_q = wp.zeros(sim_n_dofs, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(sim_n_dofs, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA], dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(sim_n_dofs, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(sim_n_dofs, dtype=wp.float32, device=device),
+            site_target_position=wp.array([wp.vec3(1.0, ERR_Y, 0.0)], dtype=wp.vec3, device=device),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)], dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        dt = 0.01
+        diffik.compute(input_struct, output_struct, None, None, time_step=dt)
+
+        expected_qd_arm = BAND * ERR_Y / (2.0 + LAMBDA**2)
+        np.testing.assert_allclose(out_qd.numpy(), [expected_qd_arm, 0.0], atol=1e-5)
+        np.testing.assert_allclose(out_q.numpy(), [expected_qd_arm * dt, 0.0], atol=1e-5)
+
+    def test_two_articulations_different_site_offsets(self):
+        device = wp.get_device()
+        LAMBDA = 0.5
+        BAND = 1.0
+        ERR_Y = 0.1
+        builder = newton.ModelBuilder()
+
+        v0_link = builder.add_link()
+        v0_joint = builder.add_joint_revolute(
+            parent=-1,
+            child=v0_link,
+            axis=wp.vec3(0.0, 0.0, 1.0),
+            parent_xform=wp.transform_identity(),
+            child_xform=wp.transform_identity(),
+        )
+        builder.add_articulation([v0_joint], label="arm_v0")
+        builder.add_site(v0_link, label="tool", xform=wp.transform(p=wp.vec3(1.0, 0.0, 0.0), q=wp.quat_identity()))
+
+        v1_link = builder.add_link()
+        v1_joint = builder.add_joint_revolute(
+            parent=-1,
+            child=v1_link,
+            axis=wp.vec3(0.0, 0.0, 1.0),
+            parent_xform=wp.transform_identity(),
+            child_xform=wp.transform_identity(),
+        )
+        builder.add_articulation([v1_joint], label="arm_v1")
+        builder.add_site(v1_link, label="tool", xform=wp.transform(p=wp.vec3(2.0, 0.0, 0.0), q=wp.quat_identity()))
+
+        default_idx = _iota(2, device)
+        out_q = wp.zeros(2, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(2, dtype=wp.float32, device=device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA, LAMBDA], dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND, BAND], dtype=wp.float32, device=device),
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(2, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(2, dtype=wp.float32, device=device),
+            site_target_position=wp.array(
+                [wp.vec3(1.0, ERR_Y, 0.0), wp.vec3(2.0, ERR_Y, 0.0)],
+                dtype=wp.vec3,
+                device=device,
+            ),
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)] * 2, dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        expected_qd_v0 = BAND * ERR_Y / (2.0 + LAMBDA**2)
+        expected_qd_v1 = BAND * 2.0 * ERR_Y / (5.0 + LAMBDA**2)
+        np.testing.assert_allclose(out_qd.numpy(), [expected_qd_v0, expected_qd_v1], atol=1e-5)
+
+    def test_per_robot_idx_share_target_across_robots(self):
+        """Per-robot live-port idx lets multiple robots share a single source slot."""
+        device = wp.get_device()
+        LAMBDA = 0.5
+        BAND = 1.0
+        N = 4
+        template = _build_planar_arm_one_link()
+        builder = newton.ModelBuilder()
+        builder.replicate(template, world_count=N)
+
+        target_pos_short = wp.array(
+            [wp.vec3(1.0, 0.10, 0.0), wp.vec3(1.0, 0.20, 0.0)],
+            dtype=wp.vec3,
+            device=device,
+        )
+        target_pos_idx = _idx([0, 0, 1, 1], device)
+        default_idx = _iota(N, device)
+        out_q = wp.zeros(N, dtype=wp.float32, device=device)
+        out_qd = wp.zeros(N, dtype=wp.float32, device=device)
+
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            solver_damping=wp.array([LAMBDA] * N, dtype=wp.float32, device=device),
+            bandwidth=wp.array([BAND] * N, dtype=wp.float32, device=device),
+            target_pos_idx=target_pos_idx,
+            device=device,
+        )
+        input_struct = SimpleNamespace(
+            joint_q=wp.zeros(N, dtype=wp.float32, device=device),
+            joint_qd=wp.zeros(N, dtype=wp.float32, device=device),
+            site_target_position=target_pos_short,
+            site_target_quaternion=wp.array([wp.quat(0.0, 0.0, 0.0, 1.0)] * N, dtype=wp.quat, device=device),
+        )
+        output_struct = SimpleNamespace(joint_target_q=out_q, joint_target_qd=out_qd)
+        diffik.compute(input_struct, output_struct, None, None, time_step=0.01)
+
+        qd_0 = BAND * 0.10 / (2.0 + LAMBDA**2)
+        qd_1 = BAND * 0.20 / (2.0 + LAMBDA**2)
+        np.testing.assert_allclose(out_qd.numpy(), [qd_0, qd_0, qd_1, qd_1], atol=1e-5)
+
+    def test_struct_factories(self):
+        device = wp.get_device()
+        builder = _build_planar_arm_one_link()
+        default_idx = _iota(1, device)
+        diffik = ControllerDifferentialKinematics(
+            model_builder=builder,
+            controlled_site_label="tool",
+            default_dof_indices=default_idx,
+            bandwidth="my_band",  # live
+            device=device,
+        )
+        i = diffik.input_struct()
+        self.assertTrue(hasattr(i, "joint_q"))
+        self.assertTrue(hasattr(i, "joint_qd"))
+        self.assertTrue(hasattr(i, "site_target_position"))
+        self.assertTrue(hasattr(i, "site_target_quaternion"))
+        self.assertTrue(hasattr(i, "my_band"))
+        self.assertFalse(hasattr(i, "solver_damping"))  # baked
+        self.assertEqual(i.site_target_position.dtype, wp.vec3)
+        self.assertEqual(i.site_target_quaternion.dtype, wp.quat)
+        o = diffik.output_struct()
+        self.assertTrue(hasattr(o, "joint_target_q"))
+        self.assertTrue(hasattr(o, "joint_target_qd"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -915,5 +915,33 @@ add_example_test(
 )
 
 
+class TestControllerExamples(unittest.TestCase):
+    pass
+
+
+add_example_test(
+    TestControllerExamples,
+    name="controllers.example_pid_pendulum",
+    devices=test_devices,
+    use_viewer=True,
+    test_options={"num-frames": 120},
+)
+
+add_example_test(
+    TestControllerExamples,
+    name="controllers.example_diff_ik_panda",
+    devices=cuda_test_devices,  # or test_devices with low num-frames on CPU
+    use_viewer=True,
+    test_options={"num-frames": 120},
+)
+
+add_example_test(
+    TestControllerExamples,
+    name="controllers.example_diff_drive_swarm",
+    devices=test_devices,
+    use_viewer=True,
+    test_options={"num-frames": 120},
+)
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Please see the temporary `DESIGN_DOC.md` in the file diffs. This PR is for early review of design ideas with some sample controllers implemented. DO NOT MERGE.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->
```
# runs both unittests, and tests on the added `Example` classes.
uv run --extra dev -m newton.tests -k controllers
```
## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

A short snippet to show using a `Controller` is given below. There are more details in the `DESIGN_DOC.md`.

```python
controller = ControllerPID(
    default_dof_indices=wp.array([0, 1], dtype=wp.uint32),
    kp=wp.array([3600.0, 1200.0], dtype=wp.float32),
    kd=wp.array([320.0, 160.0], dtype=wp.float32),
)

# Allocate an input struct for this controller:
inp = controller.input_struct()
inp.joint_target_q.assign([0.6, -1.2])

# Allocate an output struct for this controller:
out = controller.output_struct()
out.joint_f = control.joint_f # reassign into the solver's array

s0, s1 = controller.state(), controller.state()   # PID integral, double-buffered

for _ in range(num_steps):
    # rebind to the current sim state
    inp.joint_q = state_0.joint_q           
    inp.joint_qd = state_0.joint_qd
    
    # step the controller, then step the sim.
    controller.compute(inp, out, s0, s1, time_step=dt)
    s0, s1 = s1, s0
    solver.step(state_0, state_1, control, contacts, dt)
    state_0, state_1 = state_1, state_0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added a new controllers API with a shared `Controller` interface and per-step input/output struct lifecycle.
  * Introduced `ControllerPID` (stateful, with anti-windup integral clamping).
  * Introduced `ControllerDifferentialDrive` and `ControllerDifferentialKinematics` (one-step IK with DLS or transpose).
  * Added a public controllers entry point and new controller examples (diff-drive swarm, Diff IK Panda, PID pendulum).
* **Documentation**
  * Added a temporary design document for the controllers architecture.
* **Tests**
  * Added unit tests (including gradient checks) and example-run integration tests for the new examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->