### PR TITLE
Stop deploying Sphinx's .doctrees cache to gh-pages

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -41,7 +41,10 @@ jobs:
         uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e  # v1.1.1
 
       - name: Build Sphinx documentation
-        run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
+        # `-d docs/_build/doctrees` keeps Sphinx's pickled doctree cache out of
+        # the published html/ tree (GH-2726): it is build-only state, ~25 MB of
+        # non-deterministic bytes that no browser loads.
+        run: uv run --extra docs --extra sim sphinx-build -j auto -d docs/_build/doctrees -b html docs docs/_build/html
         env:
           NEWTON_REQUIRE_PANDOC: "1"
 

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -74,7 +74,10 @@ jobs:
 
       - name: Build Sphinx documentation
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'
-        run: uv run --extra docs --extra sim sphinx-build -j auto -b html docs docs/_build/html
+        # `-d docs/_build/doctrees` keeps Sphinx's pickled doctree cache out of
+        # the published html/ tree (GH-2726): it is build-only state, ~25 MB of
+        # non-deterministic bytes that no browser loads.
+        run: uv run --extra docs --extra sim sphinx-build -j auto -d docs/_build/doctrees -b html docs docs/_build/html
         env:
           NEWTON_REQUIRE_PANDOC: "1"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import docutils.nodes
+
 # Set environment variable to indicate we're in a Sphinx build.
 # This is inherited by subprocesses (e.g., Jupyter kernels run by nbsphinx).
 os.environ["NEWTON_SPHINX_BUILD"] = "1"
@@ -481,6 +483,37 @@ def _on_builder_inited(_app: Any) -> None:
     _copy_viser_client_into_output_static(outdir=outdir)
 
 
+_RE_REPR_ADDRESS = re.compile(r"<([\w.]+) object at 0x[0-9a-f]+>")
+
+
+def strip_repr_addresses(app: Any, doctree: Any, docname: str) -> None:
+    """Drop memory addresses from default-repr leaks in the resolved doctree.
+
+    When an attribute or default is documented without an explicit type
+    annotation, autodoc falls back to ``repr(obj)``.  For an object whose class
+    has no ``__repr__`` that yields ``<some.module.Class object at 0x7f...>``
+    (or ``<property object at 0x...>`` for a descriptor).  The address differs
+    every Python process (ASLR), which makes the rendered HTML byte-unstable
+    across builds -- every deploy to ``gh-pages`` then writes a different tree
+    even when the docs haven't changed (GH-2726).
+
+    ``sphinx.ext.autodoc.typehints`` injects these directly into the doctree via
+    the ``object-description-transform`` event, bypassing the
+    ``autodoc-process-signature`` / ``autodoc-process-docstring`` hooks (and not
+    covered by ``autodoc_preserve_defaults``), so the cleanup has to happen at
+    the doctree level.  Newton's public API does not currently surface such an
+    object; this runs as defense-in-depth so a future one can't silently
+    reintroduce per-build churn.
+    """
+    for text_node in list(doctree.findall(docutils.nodes.Text)):
+        original = text_node.astext()
+        if "object at 0x" not in original:
+            continue
+        cleaned = _RE_REPR_ADDRESS.sub(r"<\1 object>", original)
+        if cleaned != original:
+            text_node.parent.replace(text_node, docutils.nodes.Text(cleaned))
+
+
 def setup(app: Any) -> None:
     app.add_config_value("github_version", github_version, "env")
 
@@ -490,3 +523,4 @@ def setup(app: Any) -> None:
     generate_all()
 
     app.connect("builder-inited", _on_builder_inited)
+    app.connect("doctree-resolved", strip_repr_addresses)

--- a/docs/tutorials/01_robotics.ipynb
+++ b/docs/tutorials/01_robotics.ipynb
@@ -585,7 +585,7 @@
     "\n",
     "CUDA graph capture records the sequence of GPU operations and the device buffers they use. Replaying the graph submits that recorded sequence with less launch overhead. The contents of `state_0`, `state_1`, `control`, and `contacts` may change between replays, but the captured graph still refers to the same allocated buffers. Rebuild the graph if you reallocate those buffers or change the model structure.\n",
     "\n",
-    "<img src=\"images/cuda-graph.png\" width=\"700\">"
+    "<img src=\"images/cuda-graph.png\" width=\"700\" alt=\"CUDA graph capture of a simulation step\">"
    ]
   },
   {


### PR DESCRIPTION
## Description

Sphinx writes its pickled doctree cache to `<outdir>/.doctrees` by default, so the documentation deploy workflows were publishing the whole ~25 MB cache to the `gh-pages` branch on every build — build-only state that no browser ever loads and that regenerates with non-deterministic bytes each run.

This passes `-d docs/_build/doctrees` to `sphinx-build` in both the `docs-dev` and `docs-release` workflows, so the cache is written as a sibling of `docs/_build/html` and is no longer deployed. The published tree drops from ~50 MB to ~26 MB (excluding the Viser recordings), and two of the three files that previously churned on every build disappear.

It also makes the build a little more deterministic:
- the robotics tutorial's CUDA-graph image now has explicit `alt` text, so nbsphinx no longer renders a random per-build `uuid4` substitution name as the image's `alt` attribute;
- a `strip_repr_addresses()` `doctree-resolved` hook is added as defense-in-depth against autodoc embedding ASLR memory addresses (`<… object at 0x…>`) in default reprs (a no-op on today's API).

Addresses #2726. This is a focused first step that intentionally keeps the existing `gh-pages` orphan-reset + force-push deploy model, so the branch stays bounded exactly as it is today. The remaining per-build churn — most notably the non-deterministic Viser `.viser` recordings (~13 MB/push) regenerated by executing the tutorial notebooks — is left for a follow-up, since removing it requires either committing the recordings or moving the deploy to a commit-on-top model backed by a fully deterministic build.

## Checklist

- [ ] New or existing tests cover these changes — docs deployment has no automated tests; verified manually (see Test plan).
- [x] The documentation is up to date with these changes — CI/build-only change; no documentation content affected.
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — intentionally omitted; internal build/CI reproducibility, not a user-facing change.

## Test plan

Built the docs twice from the same commit and confirmed the doctrees cache is gone and the infra-level churn is eliminated:

```bash
uv run --extra docs --extra sim sphinx-build -j auto -d /tmp/dt1 -b html docs /tmp/h1
uv run --extra docs --extra sim sphinx-build -j auto -d /tmp/dt2 -b html docs /tmp/h2
test ! -d /tmp/h1/.doctrees           # .doctrees no longer in the published tree
du -sh /tmp/h1                         # ~26 MB (was ~50 MB)
diff -r /tmp/h1 /tmp/h2                # byte-identical with nbsphinx_execute=never
```

- `tutorials/01_robotics.html` renders the stable `alt="CUDA graph capture of a simulation step"` and no random 32-hex `alt`.
- `uvx pre-commit run --files …` passes on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced documentation consistency and output quality across builds.
  * Improved tutorial accessibility by adding descriptive alternative text for images, supporting screen readers and users with visual impairments.
  * Optimized documentation build and publication workflow for cleaner artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->