### PR TITLE
Fix ViewerFile running state after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+- Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Fix `SolverVBD` rigid contact injecting kinetic energy for yawed finite-radius contacts (e.g. small-radius cables blowing up). The normal response now acts at the geometric skeleton point rather than the rotating surface anchor, which was non-conservative under reorientation; friction still uses the surface anchor to preserve finite-radius slip. (#3125)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.

--- a/newton/_src/viewer/viewer_file.py
+++ b/newton/_src/viewer/viewer_file.py
@@ -1120,6 +1120,7 @@ class ViewerFile(ViewerBase):
 
         self._frame_count = 0
         self._model_recorded = False
+        self._running = True
 
     @override
     def set_model(self, model: Model | None):
@@ -1150,6 +1151,15 @@ class ViewerFile(ViewerBase):
         # Auto-save if enabled
         if self.auto_save and self._frame_count % self.save_interval == 0:
             self._save_recording()
+
+    @override
+    def is_running(self) -> bool:
+        """Report whether the file viewer should continue recording.
+
+        Returns:
+            bool: False after :meth:`close` has been called.
+        """
+        return self._running
 
     def save_recording(self, file_path: str | None = None, verbose: bool = False):
         """Save the recorded data to file.
@@ -1426,6 +1436,7 @@ class ViewerFile(ViewerBase):
         """Save final recording and cleanup."""
         if self._frame_count > 0:
             self._save_recording()
+        self._running = False
         print(f"ViewerFile closed. Total frames recorded: {self._frame_count}")
 
     def load_recording(self, file_path: str | None = None, verbose: bool = False):

--- a/newton/tests/test_recorder.py
+++ b/newton/tests/test_recorder.py
@@ -22,7 +22,15 @@ from newton.viewer import ViewerFile
 
 
 class TestRecorder(unittest.TestCase):
-    pass
+    def test_viewer_file_is_running_reflects_close(self):
+        """ViewerFile loop lifecycle matches interactive viewers."""
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=True) as tmp:
+            viewer_file = ViewerFile(tmp.name, auto_save=False)
+
+            self.assertTrue(viewer_file.is_running())
+
+            viewer_file.close()
+            self.assertFalse(viewer_file.is_running())
 
 
 def test_ringbuffer_basic(test: TestRecorder, device):
@@ -225,8 +233,9 @@ def test_viewer_file_playback(test: TestRecorder, device):
         viewer_file_record.set_model(model)
         for state in states:
             viewer_file_record.log_state(state)
-        viewer_file_record.save_recording()
+
         viewer_file_record.close()
+        test.assertFalse(viewer_file_record.is_running())
 
         # Playback via ViewerFile
         viewer_file_play = ViewerFile(file_path)


### PR DESCRIPTION
## Description

Fixes #3094.

`ViewerFile.close()` already saves recorded snapshots, but `ViewerFile` did not implement `is_running()`, so it inherited `ViewerBase.is_running()` and continued to report `True` after close.

This change adds a `ViewerFile` running-state flag, makes `is_running()` report that flag, and marks the recorder as no longer running after `close()` saves the final recording.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests.test_recorder -k test_viewer_file
```

Verified:
- `test_viewer_file_is_running_reflects_close`
- `test_viewer_file_playback_cpu`

## Bug fix

**Steps to reproduce:**

1. Create a `ViewerFile`.
2. Check `viewer.is_running()`.
3. Call `viewer.close()`.
4. Check `viewer.is_running()` again.
5. Without this PR, it still returns `True`.

**Minimal reproduction:**

```python
import tempfile

import newton

with tempfile.NamedTemporaryFile(suffix=".json") as tmp:
    viewer = newton.viewer.ViewerFile(tmp.name, auto_save=False)

    print(viewer.is_running())  # True

    viewer.close()

    print(viewer.is_running())  # True before this PR, False after this PR
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed headless recording loops so they reliably stop: the viewer file now reports a stopped running state immediately after it is closed.

* **Tests**
  * Added a test to verify `is_running()` returns `False` immediately following `close()`.
  * Updated the recorder test flow to close the viewer file and assert the stopped state before validating outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->