### PR TITLE
Remove SolverVBD damping migration warning

### DIFF
--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -85,9 +85,6 @@ from .tri_mesh_collision import (
 __all__ = ["SolverVBD"]
 
 
-_vbd_damping_migration_warned = {"value": False}
-
-
 class SolverVBD(SolverBase):
     """An implicit solver using Vertex Block Descent (VBD) for particles and Augmented VBD (AVBD) for rigid bodies.
 
@@ -377,22 +374,6 @@ class SolverVBD(SolverBase):
                 DeprecationWarning,
                 stacklevel=2,
             )
-
-        # TODO: Remove this temporary warning after the Newton 1.4 migration window.
-        if (
-            model.particle_count > 0 or (model.body_count > 0 and not integrate_with_external_rigid_solver)
-        ) and not _vbd_damping_migration_warned["value"]:
-            warnings.warn(
-                "SolverVBD damping behavior changed in Newton 1.4.0:\n"
-                "  - Damping coefficients are interpreted as absolute physical coefficients, "
-                "not stiffness-relative multipliers.\n"
-                "To preserve previous behavior, compute the new damping coefficient as "
-                "kd_new = kd_old * k, where kd_old is the old relative damping value and k is "
-                "the stiffness or penalty coefficient for the same constraint, contact, or material.",
-                UserWarning,
-                stacklevel=2,
-            )
-            _vbd_damping_migration_warned["value"] = True
 
         if rigid_avbd_beta < 0:
             raise ValueError(f"rigid_avbd_beta must be >= 0, got {rigid_avbd_beta}")


### PR DESCRIPTION
## Description

Remove the runtime `UserWarning` (and its module-global once-per-process latch) that #2877 added to `SolverVBD.__init__` to announce the absolute-damping behavior change.

A runtime warning is the wrong mechanism for an already-shipped behavior change. Newton communicates behavior/default changes through CHANGELOG "Changed" entries with migration guidance (e.g. the `SensorTiledCamera` color-space default, the MPM `solver`/`collider_basis` defaults); `warnings.warn` is otherwise reserved for API deprecations (`DeprecationWarning`) and runtime input validation. The breaking-change entry added in #2877 already carries the full migration instructions, and `SolverVBD` is experimental.

The warning also can't distinguish a stale old-convention coefficient from a correctly migrated one — both are the same `kd=X` assignment — so it fires identically on correct usage (the basic VBD examples set the new absolute values and still tripped it). No call site has the signal to make it meaningful, and the global latch bypasses `warnings.filterwarnings` and breaks `assertWarns`-based testing.

The damping change is unreleased (last release 1.3.0), so the warning never shipped; no CHANGELOG change is needed and the existing breaking-change entry remains accurate. This also lets the strict output contract in #2874 pass without an allow-regex workaround.

## Checklist

- [x] New or existing tests cover these changes (no test depended on the warning; removal verified by constructing a `SolverVBD` and confirming no warning)
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` updated — N/A (unreleased; the #2877 breaking-change entry already covers it)

## Test plan

```
uvx pre-commit run --files newton/_src/solvers/vbd/solver_vbd.py
# Constructed SolverVBD on CPU; confirmed no "damping behavior changed" warning is emitted.
```
