### PR TITLE
Fixes `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix VBD collision damping to use relative normal gap rate so uniform contact-stencil motion and tangential sliding do not create artificial normal damping.
+- Fix `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`.
 - Fix MJCF `euler` producing wrong orientations for multi-component angles by treating angles as intrinsic rotations. (#3030)
 - Fix MJCF parsing so attributes from multiple `<compiler>` elements, including `<include>`-expanded children, are merged in document order. (#3030)
 - Fix MJCF worldbody static geoms bypassing the visual/collider class filter, so `parse_visuals=False` drops visual-class geoms attached directly to `<worldbody>` too. (#3030)
@@ -285,7 +286,7 @@
 - Fix `SolverMuJoCo` passing non-zero geom/pair margins to `mujoco_warp.put_model()`, which fails when NATIVECCD is enabled. Margins are forced to zero when MuJoCo handles collisions (`use_mujoco_contacts=True`); the Newton collision pipeline (`use_mujoco_contacts=False`) is unchanged
 - Fix `SolverMuJoCo` failing to compile planar mesh colliders with MuJoCo's convex-hull path when `use_mujoco_contacts=False`; use MuJoCo contacts only with non-planar mesh colliders, primitive planes, or thick proxy geometry
 - Fix GPU illegal-memory-access in `SolverMuJoCo` Newton-contacts fast path when `notify_model_changed(BODY_INERTIAL_PROPERTIES | JOINT_DOF_PROPERTIES | MODEL_PROPERTIES)` was called between substeps (e.g. mass randomization in IsaacLab), or when the bound `Contacts` instance / MJWarp `naconmax` changed without invalidating the cached `tid_to_cid` mapping. The fast path is now invalidated on any property notify that affects cached MJWarp contact fields, and bounds-checks `cid` against `naconmax` defensively
-- Fix `State.assign` not copying namespaced extended and custom state attributes 
+- Fix `State.assign` not copying namespaced extended and custom state attributes
 - Fix mesh-convex back-face contacts generating inverted normals that trap shapes inside meshes and cause solver divergence (NaN)
 - Fix triangle-mesh-vs-convex collisions silently dropping all contacts under non-uniform (and even large uniform) mesh scale: the BVH AABB query in `mesh_vs_convex_midphase` is now performed in unscaled mesh-local space (matching the BVH built over `mesh.points`), with the per-axis contact gap converted accordingly. Previously the query was performed in scaled mesh-local space, so any convex shape whose unscaled-space AABB lay outside the BVH bounds would receive 0 triangles and 0 contacts.
 - Fix finite plane geometry 2x too large in collision, bounding sphere, and raytrace sensor
@@ -408,7 +409,7 @@
 - Deprecate `SensorContact(include_total=...)` in favor of `SensorContact(measure_total=...)`
 - Deprecate `SensorContact.sensing_objs` in favor of `SensorContact.sensing_obj_idx`
 - Deprecate `SensorContact.counterparts` and `SensorContact.reading_indices` in favor of `SensorContact.counterpart_indices`
-- Deprecate `SensorContact.shape` (use `total_force.shape` and `force_matrix.shape` instead) 
+- Deprecate `SensorContact.shape` (use `total_force.shape` and `force_matrix.shape` instead)
 - Deprecate `SensorTiledCamera.render_context`; prefer `SensorTiledCamera.utils` and `SensorTiledCamera.render_config`.
 - Deprecate `SensorTiledCamera.RenderContext`; use `SensorTiledCamera.RenderConfig` for config types and `SensorTiledCamera.render_config` / `SensorTiledCamera.utils` for runtime access.
 - Deprecate `SensorTiledCamera.Config`; prefer `SensorTiledCamera.RenderConfig` and `SensorTiledCamera.utils`.

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -219,7 +219,7 @@ class RenderContext:
         if has_shapes or has_particles or self.has_triangle_mesh or self.has_gaussians:
             if self.has_triangle_mesh:
                 if self.triangle_mesh is None:
-                    self.triangle_mesh = wp.Mesh(self.triangle_points, self.triangle_indices, device=self.device)
+                    self.triangle_mesh = wp.Mesh(self.triangle_points, self.triangle_indices)
                 else:
                     self.triangle_mesh.refit()
 

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -152,6 +152,56 @@ class TestSensorTiledCamera(unittest.TestCase):
             np.testing.assert_array_equal(packed[:3], expected_rgb)
             self.assertEqual(packed[3], 255)
 
+    def test_cloth_renders_via_triangle_mesh_construction(self) -> None:
+        """wp.Mesh must be lazily constructed on the first render call for cloth models.
+
+        Cloth models have both ``particle_q`` and ``tri_indices``, which routes rendering
+        through RenderContext's triangle-mesh path. The first ``update`` then constructs
+        a :class:`wp.Mesh` from those geometry arrays.
+        """
+        # Cloth is the minimal model with both particle_q and tri_indices. During
+        # init_from_model, RenderContext maps those to triangle_points and
+        # triangle_indices (cloth vertices live in particle_q; tri_indices are the
+        # faces). That pairing is what enables the triangle-mesh construction.
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        builder.add_cloth_grid(
+            pos=wp.vec3(0.0, 0.0, 0.0),
+            rot=wp.quat_identity(),
+            vel=wp.vec3(0.0),
+            dim_x=2,
+            dim_y=2,
+            cell_x=0.1,
+            cell_y=0.1,
+            mass=0.1,
+            fix_top=True,
+        )
+        model = builder.finalize(device="cpu")
+
+        sensor = SensorTiledCamera(model=model)
+        render_context = sensor.render_context
+
+        # init_from_model copies model.particle_q/tri_indices into triangle_points/
+        # triangle_indices but does not build wp.Mesh until the first render call.
+        self.assertTrue(render_context.has_triangle_mesh)
+        self.assertIsNone(render_context.triangle_mesh)
+
+        width, height = 8, 8
+        camera_transforms = wp.array(
+            [[wp.transformf(wp.vec3f(0.0, 0.0, 0.5), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
+            dtype=wp.transformf,
+            device="cpu",
+        )
+        camera_rays = sensor.utils.compute_pinhole_camera_rays(width, height, math.radians(60.0))
+        depth_image = sensor.utils.create_depth_image_output(width, height)
+
+        sensor.update(model.state(), camera_transforms, camera_rays, depth_image=depth_image)
+
+        # update() must construct the cloth triangle mesh on this first render call.
+        self.assertIsNotNone(render_context.triangle_mesh)
+
+        # Depth hits prove the mesh was passed into the render kernel, not just created.
+        self.assertGreater(int(np.sum(depth_image.numpy() > 0.0)), 0)
+
     @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
     def test_golden_image(self):
         model = self._shared_model


### PR DESCRIPTION
## Description

Fixes `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`.

`wp.Mesh` does not accept a `device` argument; it uses the devices of the provided points and indices arrays. Since `triangle_points` and `triangle_indices` are already allocated on the intended device, passing `device=self.device` is unnecessary and causes mesh initialization to fail.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```sh
uv run --extra dev -m newton.tests -k test_cloth_renders_via_triangle_mesh_construction
```

Verified the test fails with the pre-fix `wp.Mesh(..., device=self.device)` call and passes with the fix applied.

## Bug fix

**Minimal reproduction:**

```python
import math
import warp as wp
import newton
from newton.sensors import SensorTiledCamera
builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
builder.add_cloth_grid(
    pos=wp.vec3(0.0, 0.0, 0.0),
    rot=wp.quat_identity(),
    vel=wp.vec3(0.0),
    dim_x=2,
    dim_y=2,
    cell_x=0.1,
    cell_y=0.1,
    mass=0.1,
    fix_top=True,
)
model = builder.finalize(device="cpu")
sensor = SensorTiledCamera(model=model)
width, height = 8, 8
camera_transforms = wp.array(
    [[wp.transformf(wp.vec3f(0.0, 0.0, 0.5), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
    dtype=wp.transformf,
    device="cpu",
)
camera_rays = sensor.utils.compute_pinhole_camera_rays(width, height, math.radians(60.0))
depth_image = sensor.utils.create_depth_image_output(width, height)
sensor.update(model.state(), camera_transforms, camera_rays, depth_image=depth_image)
```

The following Python type error would pop up:
```log
if has_shapes or has_particles or self.has_triangle_mesh or self.has_gaussians:
            if self.has_triangle_mesh:
                if self.triangle_mesh is None:
>                   self.triangle_mesh = wp.Mesh(self.triangle_points, self.triangle_indices, device=self.device)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E                   TypeError: Mesh.__init__() got an unexpected keyword argument 'device'

env_isaaclab/lib/python3.12/site-packages/newton/_src/sensors/warp_raytrace/render_context.py:222: TypeError
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved triangle-mesh rendering setup to use supported mesh construction behavior, improving consistency of where mesh data lives during rendering.
  * Fixed state assignment to properly retain namespaced extended/custom attributes.
* **Tests**
  * Added coverage to confirm cloth rendering uses the triangle-mesh path and produces expected depth hits.
* **Documentation**
  * Updated release notes with a deprecation notice for `SensorContact.shape`, recommending `total_force.shape` / `force_matrix.shape` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->