### PR TITLE
Fix SemiImplicit ball joint damping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Fix `SolverMuJoCo` reporting incorrect `State.body_qd` angular velocity for `JointType.D6` joints with two or three angular DOFs at non-identity configurations.
 - Fix VBD collision damping to use relative normal gap rate so uniform contact-stencil motion and tangential sliding do not create artificial normal damping.
 - Fix `ModelBuilder.add_usd` so a stray authored joint outside any articulation root no longer suppresses base-joint (articulation) creation for unrelated floating rigid bodies in the same call. (#3002)
+- Fix `SolverSemiImplicit` ball joints to apply `joint_damping` on all three angular DOFs.
 - Fix `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`.
 - Fix MJCF `euler` producing wrong orientations for multi-component angles by treating angles as intrinsic rotations. (#3030)
 - Fix `newton.eval_fk` / `newton.eval_ik` producing wrong rotations and joint velocities for `JointType.D6` with three angular DOFs whose axes form a left-handed orthonormal basis.

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -242,15 +242,9 @@ def eval_body_joints(
         axis_0 = wp.transform_vector(X_wp, joint_axis[qd_start + 0])
         axis_1 = wp.transform_vector(X_wp, joint_axis[qd_start + 1])
         axis_2 = wp.transform_vector(X_wp, joint_axis[qd_start + 2])
-        t_total += axis_0 * (
-            -joint_f[qd_start + 0] + joint_damping[qd_start + 0] * wp.dot(axis_0, w_err)
-        )
-        t_total += axis_1 * (
-            -joint_f[qd_start + 1] + joint_damping[qd_start + 1] * wp.dot(axis_1, w_err)
-        )
-        t_total += axis_2 * (
-            -joint_f[qd_start + 2] + joint_damping[qd_start + 2] * wp.dot(axis_2, w_err)
-        )
+        t_total += axis_0 * (-joint_f[qd_start + 0] + joint_damping[qd_start + 0] * wp.dot(axis_0, w_err))
+        t_total += axis_1 * (-joint_f[qd_start + 1] + joint_damping[qd_start + 1] * wp.dot(axis_1, w_err))
+        t_total += axis_2 * (-joint_f[qd_start + 2] + joint_damping[qd_start + 2] * wp.dot(axis_2, w_err))
 
     if type == JointType.D6:
         pos = wp.vec3(0.0)

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -239,7 +239,18 @@ def eval_body_joints(
         # TODO expose target_kd or target_ke for ball joints
         # t_total += target_kd * w_err + target_ke * wp.transform_vector(X_wp, ang_err)
         f_total += x_err * joint_attach_ke + v_err * joint_attach_kd
-        t_total += wp.vec3(-joint_f[qd_start], -joint_f[qd_start + 1], -joint_f[qd_start + 2])
+        axis_0 = wp.transform_vector(X_wp, joint_axis[qd_start + 0])
+        axis_1 = wp.transform_vector(X_wp, joint_axis[qd_start + 1])
+        axis_2 = wp.transform_vector(X_wp, joint_axis[qd_start + 2])
+        t_total += axis_0 * (
+            -joint_f[qd_start + 0] + joint_damping[qd_start + 0] * wp.dot(axis_0, w_err)
+        )
+        t_total += axis_1 * (
+            -joint_f[qd_start + 1] + joint_damping[qd_start + 1] * wp.dot(axis_1, w_err)
+        )
+        t_total += axis_2 * (
+            -joint_f[qd_start + 2] + joint_damping[qd_start + 2] * wp.dot(axis_2, w_err)
+        )
 
     if type == JointType.D6:
         pos = wp.vec3(0.0)

--- a/newton/tests/test_joint_damping.py
+++ b/newton/tests/test_joint_damping.py
@@ -41,6 +41,29 @@ def _build_revolute_model(device, damping: float):
     return builder.finalize(device=device)
 
 
+def _build_ball_model(device, damping: float):
+    builder = newton.ModelBuilder(gravity=0.0, up_axis=newton.Axis.Y)
+    body = builder.add_link(
+        mass=1.0,
+        inertia=wp.mat33(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        lock_inertia=True,
+    )
+    joint = builder.add_joint(
+        newton.JointType.BALL,
+        parent=-1,
+        child=body,
+        angular_axes=[
+            newton.ModelBuilder.JointDofConfig(axis=newton.Axis.X, damping=damping, armature=0.0, friction=0.0),
+            newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Y, damping=damping, armature=0.0, friction=0.0),
+            newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Z, damping=damping, armature=0.0, friction=0.0),
+        ],
+    )
+    builder.add_articulation([joint])
+    builder.joint_qd[0:3] = [1.0, 0.0, 0.0]
+
+    return builder.finalize(device=device)
+
+
 def _simulate_joint_damping(device, solver_fn, damping: float, sync_joint_qd: bool) -> tuple[float, float]:
     model = _build_revolute_model(device, damping)
     solver = solver_fn(model)
@@ -60,6 +83,23 @@ def _simulate_joint_damping(device, solver_fn, damping: float, sync_joint_qd: bo
     return initial_qd, float(state_0.joint_qd.numpy()[0])
 
 
+def _simulate_ball_joint_damping(device, damping: float) -> tuple[float, float]:
+    model = _build_ball_model(device, damping)
+    solver = newton.solvers.SolverSemiImplicit(model, angular_damping=0.0)
+
+    state_0, state_1 = model.state(), model.state()
+    control = model.control()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    initial_speed = float(np.linalg.norm(state_0.joint_qd.numpy()[0:3]))
+    for _ in range(8):
+        solver.step(state_0, state_1, control, None, 0.01)
+        state_0, state_1 = state_1, state_0
+
+    newton.eval_ik(model, state_0, state_0.joint_q, state_0.joint_qd)
+    return initial_speed, float(np.linalg.norm(state_0.joint_qd.numpy()[0:3]))
+
+
 def test_revolute_joint_damping_decays_velocity(test: TestJointDamping, device, solver_fn, sync_joint_qd):
     undamped_initial, undamped_final = _simulate_joint_damping(
         device, solver_fn, damping=0.0, sync_joint_qd=sync_joint_qd
@@ -68,6 +108,14 @@ def test_revolute_joint_damping_decays_velocity(test: TestJointDamping, device, 
 
     np.testing.assert_allclose(undamped_final, undamped_initial, atol=1.0e-5, rtol=1.0e-5)
     test.assertLess(abs(damped_final), abs(damped_initial) * 0.85)
+
+
+def test_semi_implicit_ball_joint_damping_decays_velocity(test: TestJointDamping, device):
+    undamped_initial, undamped_final = _simulate_ball_joint_damping(device, damping=0.0)
+    damped_initial, damped_final = _simulate_ball_joint_damping(device, damping=3.0)
+
+    np.testing.assert_allclose(undamped_final, undamped_initial, atol=1.0e-5, rtol=1.0e-5)
+    test.assertLess(damped_final, damped_initial * 0.85)
 
 
 devices = get_test_devices()
@@ -86,6 +134,14 @@ for device in devices:
             solver_fn=solver_fn,
             sync_joint_qd=sync_joint_qd,
         )
+
+for device in devices:
+    add_function_test(
+        TestJointDamping,
+        "test_semi_implicit_ball_joint_damping_decays_velocity",
+        test_semi_implicit_ball_joint_damping_decays_velocity,
+        devices=[device],
+    )
 
 for device in get_cuda_test_devices():
     add_function_test(


### PR DESCRIPTION
## Description

Closes #2989.

- Apply `joint_damping` to all three angular DOFs in `SolverSemiImplicit` ball joints.
- Add a regression test showing SemiImplicit ball-joint angular velocity decays with nonzero passive damping.
- Update the unreleased changelog because this fixes user-facing solver behavior.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_joint_damping
```

Result: 10 tests OK.

## Bug fix

Before this PR, `SolverSemiImplicit` ignored `Model.joint_damping` for `JointType.BALL` joints. Revolute, prismatic, and D6 paths already applied passive damping through their DOF force evaluation, but the ball-joint branch only applied `joint_f`.

**Steps to reproduce:**

1. Build a one-body articulation attached to world by a ball joint.
2. Set a nonzero initial angular velocity in `joint_qd`.
3. Compare `SolverSemiImplicit` behavior with `joint_damping=0.0` and `joint_damping>0.0`.
4. Observe that angular velocity does not decay without this PR.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder(gravity=0.0)
body = builder.add_link(mass=1.0)
joint = builder.add_joint(
    newton.JointType.BALL,
    parent=-1,
    child=body,
    angular_axes=[
        newton.ModelBuilder.JointDofConfig(axis=newton.Axis.X, damping=3.0),
        newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Y, damping=3.0),
        newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Z, damping=3.0),
    ],
)
builder.add_articulation([joint])
builder.joint_qd[0:3] = [1.0, 0.0, 0.0]
model = builder.finalize()
solver = newton.solvers.SolverSemiImplicit(model, angular_damping=0.0)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ball-joint damping so it’s applied consistently across all three rotational degrees of freedom in semi-implicit solving.
* **Tests**
  * Added new automated coverage to confirm ball-joint angular velocity decays with damping enabled and stays constant when damping is zero, including updated device test wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->