### PR TITLE
Reuse MuJoCo solref conversion helper

### DIFF
--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2645,10 +2645,7 @@ def update_jnt_solref_from_invweight0_kernel(
 
     direct_stiffness = wp.max(ke * factor, MJ_MINVAL)
     direct_damping = wp.max(kd * factor, MJ_MINVAL)
-    timeconst = 2.0 / direct_damping
-    dampratio = direct_damping / (2.0 * wp.sqrt(direct_stiffness))
-
-    jnt_solref[world, mjc_jnt] = wp.vec2(timeconst, dampratio)
+    jnt_solref[world, mjc_jnt] = convert_solref(direct_stiffness, direct_damping, 1.0, 1.0)
 
 
 @wp.kernel(enable_backward=False)

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7481,9 +7481,8 @@ class SolverMuJoCo(SolverBase):
                 factor = invw * (1.0 - dmax) if invw > 0.0 and dmax < 1.0 else 1.0
                 direct_stiffness = max(ke * factor, MJ_MINVAL)
                 direct_damping = max(kd * factor, MJ_MINVAL)
-                timeconst = 2.0 / direct_damping
-                dampratio = direct_damping / (2.0 * math.sqrt(direct_stiffness))
-                jnt_solref[mjc_jnt] = (timeconst, dampratio)
+                solref = convert_solref(direct_stiffness, direct_damping, 1.0, 1.0)
+                jnt_solref[mjc_jnt] = (float(solref[0]), float(solref[1]))
 
             self.mj_model.jnt_solref[:] = jnt_solref
             self.mjw_model.jnt_solref.assign(jnt_solref.reshape(1, njnt, 2))


### PR DESCRIPTION
## Description

Closes #3137.

- Replace duplicated joint-limit solref conversion math with the existing `convert_solref()` helper.
- Apply the same helper in both the Warp kernel path and the MuJoCo CPU fallback path.
- Preserve the existing gain clamping, RAW solref forwarding, and MJCF-default handling behavior.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k InvweightScaledSolref
```

Result: 20 tests OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate solver computation logic by leveraging an existing helper function, improving code maintainability without altering external behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->