### PR TITLE
Clarify contact friction gain wording

### DIFF
--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1665,7 +1665,7 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
      - :attr:`~ModelBuilder.ShapeConfig.kd`
      - :attr:`~Model.shape_material_kd`
    * - ``kf``
-     - Friction damping coefficient
+     - Contact friction gain
      - SemiImplicit, Featherstone
      - 1000.0
      - :attr:`~ModelBuilder.ShapeConfig.kf`

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -262,7 +262,7 @@ class ModelBuilder:
         kd: float = 100.0
         """The contact damping coefficient [N·s/m]. Used by SemiImplicit, Featherstone, MuJoCo, VBD."""
         kf: float = 1000.0
-        """The friction damping coefficient. Used by SemiImplicit, Featherstone."""
+        """The contact friction gain [N·s/m]. Used by SemiImplicit, Featherstone."""
         ka: float = 0.0
         """The contact adhesion distance. Used by SemiImplicit, Featherstone."""
         mu: float = 1.0
@@ -962,7 +962,7 @@ class ModelBuilder:
         self.shape_material_kd: list[float] = []
         """Contact damping values accumulated for :attr:`Model.shape_material_kd`."""
         self.shape_material_kf: list[float] = []
-        """Friction stiffness values accumulated for :attr:`Model.shape_material_kf`."""
+        """Contact friction gain values [N·s/m] accumulated for :attr:`Model.shape_material_kf`."""
         self.shape_material_ka: list[float] = []
         """Adhesion distances [m] accumulated for :attr:`Model.shape_material_ka`."""
         self.shape_material_mu: list[float] = []

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -208,7 +208,7 @@ class Model:
         self.particle_kd: float = 1.0e2
         """Particle normal contact damping [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit`)."""
         self.particle_kf: float = 1.0e2
-        """Particle friction force stiffness [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit`)."""
+        """Particle contact friction gain [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit`)."""
         self.particle_mu: float = 0.5
         """Particle friction coefficient [dimensionless]."""
         self.particle_cohesion: float = 0.0
@@ -258,7 +258,7 @@ class Model:
         self.shape_material_kd: wp.array[wp.float32] | None = None
         """Shape contact damping [N·s/m], shape [shape_count], float."""
         self.shape_material_kf: wp.array[wp.float32] | None = None
-        """Shape contact friction stiffness [N·s/m], shape [shape_count], float."""
+        """Shape contact friction gain [N·s/m], shape [shape_count], float."""
         self.shape_material_ka: wp.array[wp.float32] | None = None
         """Shape contact adhesion distance [m], shape [shape_count], float."""
         self.shape_material_mu: wp.array[wp.float32] | None = None
@@ -697,7 +697,7 @@ class Model:
         self.soft_contact_kd: float = 10.0
         """Damping of soft contacts [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit` and :class:`~newton.solvers.SolverFeatherstone`)."""
         self.soft_contact_kf: float = 1.0e3
-        """Stiffness of friction force in soft contacts [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit` and :class:`~newton.solvers.SolverFeatherstone`)."""
+        """Soft contact friction gain [N·s/m] (used by :class:`~newton.solvers.SolverSemiImplicit` and :class:`~newton.solvers.SolverFeatherstone`)."""
         self.soft_contact_mu: float = 0.5
         """Friction coefficient of soft contacts [dimensionless]."""
         self.soft_contact_restitution: float = 0.0

--- a/newton/_src/solvers/semi_implicit/kernels_contact.py
+++ b/newton/_src/solvers/semi_implicit/kernels_contact.py
@@ -295,7 +295,7 @@ def eval_triangles_body_contact(
     # hard coded surface parameter tensor layout (ke, kd, kf, mu)
     ke = materials[c_mat * 4 + 0]  # restitution coefficient
     kd = materials[c_mat * 4 + 1]  # damping coefficient
-    kf = materials[c_mat * 4 + 2]  # friction coefficient
+    kf = materials[c_mat * 4 + 2]  # contact friction gain
     mu = materials[c_mat * 4 + 3]  # coulomb friction
 
     x0 = body_x[c_body]  # position of colliding body
@@ -414,7 +414,7 @@ def eval_body_contact(
     # retrieve contact margins, compute average contact material properties
     ke = 0.0  # contact normal force stiffness
     kd = 0.0  # damping coefficient
-    kf = 0.0  # friction force stiffness
+    kf = 0.0  # contact friction gain
     ka = 0.0  # adhesion distance
     mu = 0.0  # friction coefficient
     mat_nonzero = 0


### PR DESCRIPTION
## Description

Closes #2988.

- Clarify public docs and docstrings so `kf` is described as contact friction gain.
- Keep `mu` wording as the dimensionless friction coefficient.
- Do not change public API names or runtime behavior.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_generate_api
```

Result: 2 tests OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected friction parameter terminology across documentation, code comments, and configuration guides to accurately describe "contact friction gain" instead of previously inaccurate descriptions, improving clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->