### PR TITLE
Reuse convert_solref helper for joint-limit solref conversion

### DIFF
--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2645,10 +2645,7 @@ def update_jnt_solref_from_invweight0_kernel(
 
     direct_stiffness = wp.max(ke * factor, MJ_MINVAL)
     direct_damping = wp.max(kd * factor, MJ_MINVAL)
-    timeconst = 2.0 / direct_damping
-    dampratio = direct_damping / (2.0 * wp.sqrt(direct_stiffness))
-
-    jnt_solref[world, mjc_jnt] = wp.vec2(timeconst, dampratio)
+    jnt_solref[world, mjc_jnt] = convert_solref(direct_stiffness, direct_damping, 1.0, 1.0)
 
 
 @wp.kernel(enable_backward=False)

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7481,9 +7481,8 @@ class SolverMuJoCo(SolverBase):
                 factor = invw * (1.0 - dmax) if invw > 0.0 and dmax < 1.0 else 1.0
                 direct_stiffness = max(ke * factor, MJ_MINVAL)
                 direct_damping = max(kd * factor, MJ_MINVAL)
-                timeconst = 2.0 / direct_damping
-                dampratio = direct_damping / (2.0 * math.sqrt(direct_stiffness))
-                jnt_solref[mjc_jnt] = (timeconst, dampratio)
+                solref = convert_solref(direct_stiffness, direct_damping, 1.0, 1.0)
+                jnt_solref[mjc_jnt] = (float(solref[0]), float(solref[1]))
 
             self.mj_model.jnt_solref[:] = jnt_solref
             self.mjw_model.jnt_solref.assign(jnt_solref.reshape(1, njnt, 2))


### PR DESCRIPTION
## Description

Closes #3137.

Replace duplicated inline `(timeconst, dampratio)` math in `update_jnt_solref_from_invweight0_kernel` and the CPU fallback path of `_update_solref_from_invweight0` with calls to the existing `convert_solref(direct_stiffness, direct_damping, 1.0, 1.0)` helper. Pure refactor, no behavior change.

Reopens the change originally authored by @han-xudong in #3205, which was closed and had its branch deleted.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

## Test plan

```bash
uv run --extra dev -m newton.tests -k InvweightScaledSolref
```