### PR TITLE
Fix IndexError in collapse_fixed_joints for sparse equality constraint attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix MJCF worldbody static geoms bypassing the visual/collider class filter, so `parse_visuals=False` drops visual-class geoms attached directly to `<worldbody>` too. (#3030)
 - Fix `cable_cross_slide_table` example stability so the cable-driven table reliably tracks its rectangular path and catches drift during regression runs.
 - Fix URDF `package://` mesh fallback resolution without `resolve-robotics-uri-py` so package names only match full path components instead of unrelated directory-name substrings
+- Fix `ModelBuilder.collapse_fixed_joints()` crashing with `IndexError` when a `mujoco:equality_constraint` row omits optional fields (`anchor`, `relpose`) that carry defaults. (#3054)
 - Fix `ViewerGL.set_model()` resetting headless/interactive camera and wind state when switching between models that use the same up-axis. (#2658)
 
 ### Removed

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5742,10 +5742,11 @@ class ModelBuilder:
         self.joint_constraint_count = len(self.joint_cts)
 
         # Remap equality constraint body/joint indices and transform anchors for merged bodies.
-        # Each ``*_values`` is the dense ``list`` backing the string-frequency CustomAttribute;
-        # the ``mujoco:equality_constraint`` ``add_custom_values`` path populates all twelve in
-        # lockstep so indexed access is safe for every ``i`` in
-        # ``range(self._equality_constraint_count)``.
+        # Each ``*_values`` is the ``list`` backing the string-frequency CustomAttribute. These
+        # lists are sparse: ``add_custom_values`` only populates the fields that were supplied,
+        # so an omitted optional field can be ``None``, shorter than the row count, or absent
+        # entirely. Reads go through ``_at`` (default fallback), and writes pad the list to the
+        # row index before assignment.
         body1_attr = self._eq_attr("equality_constraint_body1")
         body2_attr = self._eq_attr("equality_constraint_body2")
         type_attr = self._eq_attr("equality_constraint_type")

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -5757,8 +5757,12 @@ class ModelBuilder:
         body1_values = body1_attr.values or []
         body2_values = body2_attr.values or []
         type_values = type_attr.values or []
-        anchor_values = anchor_attr.values or []
-        relpose_values = relpose_attr.values or []
+        if anchor_attr.values is None:
+            anchor_attr.values = []
+        anchor_values = anchor_attr.values
+        if relpose_attr.values is None:
+            relpose_attr.values = []
+        relpose_values = relpose_attr.values
         joint1_values = joint1_attr.values or []
         joint2_values = joint2_attr.values or []
         if enabled_attr.values is None:
@@ -5787,15 +5791,23 @@ class ModelBuilder:
                 merge_xform = body_merged_transform[old_body1]
                 if constraint_type == EqType.CONNECT:
                     anchor = axis_to_vec3(_at(anchor_values, i, anchor_attr.default))
+                    while len(anchor_values) <= i:
+                        anchor_values.append(None)
                     anchor_values[i] = wp.transform_point(merge_xform, anchor)
                 if constraint_type == EqType.WELD:
                     relpose = _at(relpose_values, i, relpose_attr.default)
+                    while len(relpose_values) <= i:
+                        relpose_values.append(None)
                     relpose_values[i] = merge_xform * relpose
 
             if body2_was_merged and constraint_type == EqType.WELD:
                 merge_xform = body_merged_transform[old_body2]
                 anchor = axis_to_vec3(_at(anchor_values, i, anchor_attr.default))
                 relpose = _at(relpose_values, i, relpose_attr.default)
+                while len(anchor_values) <= i:
+                    anchor_values.append(None)
+                while len(relpose_values) <= i:
+                    relpose_values.append(None)
                 anchor_values[i] = wp.transform_point(merge_xform, anchor)
                 relpose_values[i] = relpose * wp.transform_inverse(merge_xform)
 

--- a/newton/tests/test_equality_constraints.py
+++ b/newton/tests/test_equality_constraints.py
@@ -558,6 +558,44 @@ class TestEqualityConstraints(unittest.TestCase):
         self.assertEqual(model.joint_count, 3)
         self.assertEqual(model.mujoco.equality_constraint_count, 3)
 
+    def test_collapse_fixed_joints_sparse_optional_fields(self):
+        """collapse_fixed_joints must not crash when anchor/relpose are omitted (issue #3054)."""
+        builder = newton.ModelBuilder()
+        newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
+        shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0)
+
+        root = builder.add_link()
+        builder.add_shape_box(body=root, hx=0.5, hy=0.5, hz=0.5, cfg=shape_cfg)
+        root_joint = builder.add_joint_revolute(parent=-1, child=root, axis=wp.vec3(0.0, 1.0, 0.0))
+
+        merged = builder.add_link()
+        builder.add_shape_box(body=merged, hx=0.2, hy=0.2, hz=0.2, cfg=shape_cfg)
+        fixed_joint = builder.add_joint_fixed(parent=root, child=merged)
+
+        target = builder.add_link()
+        builder.add_shape_box(body=target, hx=0.5, hy=0.5, hz=0.5, cfg=shape_cfg)
+        target_joint = builder.add_joint_revolute(parent=root, child=target, axis=wp.vec3(0.0, 0.0, 1.0))
+
+        builder.add_articulation([root_joint, fixed_joint, target_joint])
+
+        builder.add_custom_values(
+            **{
+                "mujoco:equality_constraint_type": int(newton.EqType.WELD),
+                "mujoco:equality_constraint_body1": merged,
+                "mujoco:equality_constraint_body2": target,
+                "mujoco:equality_constraint_enabled": True,
+                "mujoco:equality_constraint_world": 0,
+                # anchor and relpose intentionally omitted -- they have defaults
+            }
+        )
+
+        # Must not raise IndexError
+        builder.collapse_fixed_joints(verbose=False)
+
+        # After collapse the constraint should still be present and finalizable
+        model = builder.finalize()
+        self.assertEqual(model.mujoco.equality_constraint_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Closes #3054

`ModelBuilder.collapse_fixed_joints()` crashed with `IndexError: list assignment index out of range` when an equality constraint row omitted optional fields (`anchor`, `relpose`) that carry defaults via `CustomAttribute.default`.

Two bugs combined:

1. `anchor_values = anchor_attr.values or []` created a disconnected local list when `attr.values` is `None`, so indexed assignments never reached the backing storage.
2. Even with a real but short list, `values[i] = ...` raises `IndexError` when `i >= len(values)`.

The fix mirrors the existing `enabled_attr` pattern: initialize `attr.values` to `[]` when `None`, alias the local to the real storage, and pad with `None` before each write.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_collapse_fixed_joints
```

Both `test_collapse_fixed_joints_with_equality_constraints` and the new `test_collapse_fixed_joints_sparse_optional_fields` pass. The new test was verified to fail on the unfixed code with the exact `IndexError` from the issue.

## Bug fix

**Steps to reproduce:**

1. Register MuJoCo custom attributes on a builder.
2. Add a WELD equality constraint via `add_custom_values`, omitting `anchor` and `relpose`.
3. Add a fixed joint so that one of the referenced bodies gets merged.
4. Call `collapse_fixed_joints()`.

**Minimal reproduction:**

```python
import warp as wp
import newton

builder = newton.ModelBuilder()
newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0)

root = builder.add_link()
builder.add_shape_box(body=root, hx=0.5, hy=0.5, hz=0.5, cfg=shape_cfg)
root_joint = builder.add_joint_revolute(parent=-1, child=root, axis=wp.vec3(0.0, 1.0, 0.0))

merged = builder.add_link()
builder.add_shape_box(body=merged, hx=0.2, hy=0.2, hz=0.2, cfg=shape_cfg)
fixed_joint = builder.add_joint_fixed(parent=root, child=merged)

target = builder.add_link()
builder.add_shape_box(body=target, hx=0.5, hy=0.5, hz=0.5, cfg=shape_cfg)
target_joint = builder.add_joint_revolute(parent=root, child=target, axis=wp.vec3(0.0, 0.0, 1.0))

builder.add_articulation([root_joint, fixed_joint, target_joint])
builder.add_custom_values(**{
    "mujoco:equality_constraint_type": int(newton.EqType.WELD),
    "mujoco:equality_constraint_body1": merged,
    "mujoco:equality_constraint_body2": target,
    "mujoco:equality_constraint_enabled": True,
    "mujoco:equality_constraint_world": 0,
    # anchor and relpose intentionally omitted
})

builder.collapse_fixed_joints()  # IndexError before fix
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when collapsing fixed joints on MuJoCo models where equality-constraint rows omit optional anchor/relpose data. The model builder now safely handles sparse constraint specifications using proper defaulting, preventing index-related failures.
* **Tests**
  * Added a regression test covering equality constraints with missing optional fields to ensure joint-collapsing remains stable and the constraint count is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->