### PR TITLE
Fix inertia eigenvalue correction dtype

### DIFF
--- a/newton/_src/geometry/inertia.py
+++ b/newton/_src/geometry/inertia.py
@@ -780,7 +780,7 @@ def verify_and_correct_inertia(
 
     # Compute eigenvalues (principal moments) for validation
     try:
-        eigenvalues = np.linalg.eigvals(corrected_inertia)
+        eigenvalues = np.linalg.eigvalsh(corrected_inertia)
 
         # Check for negative or near-zero eigenvalues (ensure positive-definite).
         # The threshold is relative to the largest eigenvalue so that small but
@@ -795,7 +795,7 @@ def verify_and_correct_inertia(
             # Make positive definite by adjusting eigenvalues
             min_eig = np.min(eigenvalues)
             adjustment = eig_threshold - min_eig + _INERTIA_ABS_ADJUSTMENT
-            corrected_inertia += np.eye(3) * adjustment
+            corrected_inertia += np.eye(3, dtype=corrected_inertia.dtype) * adjustment
             eigenvalues += adjustment
             was_corrected = True
 
@@ -807,7 +807,7 @@ def verify_and_correct_inertia(
                     f"Minimum eigenvalue {min_eig} is below bound {bound_inertia}{body_id}, adjusting", stacklevel=2
                 )
                 adjustment = bound_inertia - min_eig
-                corrected_inertia += np.eye(3) * adjustment
+                corrected_inertia += np.eye(3, dtype=corrected_inertia.dtype) * adjustment
                 eigenvalues += adjustment
                 was_corrected = True
 
@@ -851,7 +851,7 @@ def verify_and_correct_inertia(
                 adjustment = deficit + _INERTIA_ABS_ADJUSTMENT
 
                 # Add scalar*I to shift all eigenvalues equally
-                corrected_inertia = corrected_inertia + np.eye(3) * adjustment
+                corrected_inertia = corrected_inertia + np.eye(3, dtype=corrected_inertia.dtype) * adjustment
                 was_corrected = True
 
                 # Update principal moments
@@ -869,7 +869,7 @@ def verify_and_correct_inertia(
     if has_violations and balance_inertia:
         # Need to recompute after balancing since we modified the matrix
         try:
-            eigenvalues = np.linalg.eigvals(corrected_inertia)
+            eigenvalues = np.linalg.eigvalsh(corrected_inertia)
         except np.linalg.LinAlgError:
             warnings.warn(f"Failed to compute eigenvalues of inertia matrix{body_id}", stacklevel=2)
             eigenvalues = np.array([0.0, 0.0, 0.0])


### PR DESCRIPTION
## Description

Use the symmetric eigenvalue solver for symmetrized inertia tensors in inertia validation. This keeps the correction path in a real dtype under the minimum dependency stack and avoids complex-valued eigenvalue adjustments being applied to float32 inertia matrices.

Refs #3210

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_inertia_validation
uvx --python 3.12 pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the minimum dependency nightly tests from issue #3210.
2. Observe `test_inertia_validation` failures where `verify_and_correct_inertia()` raises `numpy._core._exceptions._UFuncOutputCastingError` while applying eigenvalue-based diagonal adjustments.

**Minimal reproduction:**

```python
import warp as wp

from newton._src.geometry.inertia import verify_and_correct_inertia

verify_and_correct_inertia(
    1.0,
    wp.mat33([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inertia tensor validation and correction with better handling of eigenvalue computations to preserve numerical precision and ensure accurate enforcement of mathematical constraints during tensor balancing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->