### PR TITLE
[codex] Add SDF nut-bolt tunneling benchmark sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `viewer.set_picking_linear_only_bodies()` and `viewer.clear_picking_linear_only_bodies()` to mark bodies that should receive only the linear component of mouse-picking force, suppressing offset-induced torque.
 - Add opt-in `body_frame_origin="com"` to `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()` for COM-centered cable capsule body frames.
 - Add user-defined pressure laws to hydroelastic SDF contact via `HydroelasticSDF.Config.pressure_func` (a `@wp.func` mapping `(signed_depth, shape_idx, data) -> pressure`) and `pressure_data` (a `@wp.struct` carrying per-shape state). The contact patch is the iso-pressure surface `p_a == p_b`; the default linear law `pressure = -kh * signed_depth` is preserved when no callback is supplied.
+- Add an SDF nut/bolt tunneling benchmark sweep and contact-metric options to `example_nut_bolt_sdf`.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 
 ### Changed

--- a/asv/benchmarks/simulation/bench_contacts.py
+++ b/asv/benchmarks/simulation/bench_contacts.py
@@ -79,6 +79,118 @@ class FastExampleContactSdfDefaults:
         wp.synchronize_device()
 
 
+class FastExampleContactSdfTunnelingSweep:
+    """Track SDF nut-bolt tunneling sensitivity across contact settings."""
+
+    _CONFIGS = {
+        "baseline_substeps4": {
+            "sim_substeps": 4,
+        },
+        "baseline_substeps8": {
+            "sim_substeps": 8,
+        },
+        "baseline_substeps12": {
+            "sim_substeps": 12,
+        },
+        "collide_substeps4": {
+            "sim_substeps": 4,
+            "collide_every_substep": True,
+        },
+        "sticky_substeps4": {
+            "sim_substeps": 4,
+            "contact_matching": "sticky",
+        },
+        "large_hash_substeps4": {
+            "sim_substeps": 4,
+            "contact_reduction_hashtable_size_factor": 1.0,
+        },
+        "no_reduction_substeps4": {
+            "sim_substeps": 4,
+            "reduce_contacts": False,
+        },
+        "gap_10mm_substeps4": {
+            "sim_substeps": 4,
+            "shape_gap": 0.01,
+        },
+    }
+
+    params = (list(_CONFIGS),)
+    param_names = ["config"]
+    repeat = 1
+    number = 1
+    num_frames = 120
+    world_count = 4
+
+    def setup_cache(self):
+        _download_external_git_folder(ISAACGYM_ENVS_REPO_URL, ISAACGYM_NUT_BOLT_FOLDER)
+
+    def setup(self, config):
+        example_cls = _import_example_class(
+            [
+                "newton.examples.contacts.example_nut_bolt_sdf",
+            ]
+        )
+        args = newton.examples.default_args(example_cls.create_parser())
+        cfg = self._CONFIGS[config]
+        args.world_count = self.world_count
+        args.num_per_world = 1
+        args.sim_substeps = cfg["sim_substeps"]
+        args.collide_every_substep = cfg.get("collide_every_substep", False)
+        args.track_contact_metrics = True
+        args.reduce_contacts = cfg.get("reduce_contacts", True)
+        args.contact_matching = cfg.get("contact_matching", "disabled")
+        args.contact_reduction_hashtable_size_factor = cfg.get("contact_reduction_hashtable_size_factor", 0.25)
+        args.shape_gap = cfg.get("shape_gap", 0.005)
+        args.rigid_contact_max = 500 * self.world_count
+        args.max_triangle_pairs = 1_000_000
+        args.broad_phase = "sap"
+        self.example = example_cls(ViewerNull(num_frames=self.num_frames), args)
+        self._metrics = None
+
+    def _run(self):
+        if self._metrics is not None:
+            return self._metrics
+
+        for _ in range(self.num_frames):
+            self.example.step()
+        wp.synchronize_device()
+
+        metrics = self.example.get_metrics()
+        if not metrics:
+            raise RuntimeError("SDF nut-bolt metrics were not collected")
+        self._metrics = metrics
+        return metrics
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_simulate(self, config):
+        self._run()
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_tunneling_depth(self, config):
+        metrics = self._run()
+        return max(0.0, -metrics["min_nut_center_z_relative_to_bolt"])
+
+    track_tunneling_depth.unit = "m"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_max_nut_drop(self, config):
+        return self._run()["max_nut_drop"]
+
+    track_max_nut_drop.unit = "m"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_max_bolt_displacement(self, config):
+        return self._run()["max_bolt_displacement"]
+
+    track_max_bolt_displacement.unit = "m"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_max_contact_count(self, config):
+        return self._run()["max_contact_count"]
+
+    track_max_contact_count.unit = "contacts"
+
+
 class FastExampleContactHydroWorkingDefaults:
     """Benchmark the hydroelastic nut-bolt example default configuration."""
 
@@ -152,6 +264,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastExampleContactSdfDefaults": FastExampleContactSdfDefaults,
+        "FastExampleContactSdfTunnelingSweep": FastExampleContactSdfTunnelingSweep,
         "FastExampleContactHydroWorkingDefaults": FastExampleContactHydroWorkingDefaults,
         "FastExampleContactPyramidDefaults": FastExampleContactPyramidDefaults,
     }

--- a/newton/examples/contacts/example_nut_bolt_sdf.py
+++ b/newton/examples/contacts/example_nut_bolt_sdf.py
@@ -11,6 +11,7 @@
 ###########################################################################
 
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
@@ -94,13 +95,16 @@ class Example:
         self.fps = 120
         self.frame_dt = 1.0 / self.fps
         self.sim_time = 0.0
-        self.sim_substeps = 5
+        self.sim_substeps = args.sim_substeps
         self.sim_dt = self.frame_dt / self.sim_substeps
+        self.collide_every_substep = args.collide_every_substep
 
         self.world_count = args.world_count
         self.viewer = viewer
         self.solver_type = args.solver
         self.test_mode = args.test
+        self.track_contact_metrics = args.track_contact_metrics or self.test_mode
+        self.shape_gap = args.shape_gap
 
         # XPBD contact correction (0.0 = no correction, 1.0 = full correction)
         self.xpbd_contact_relaxation = 0.8
@@ -118,10 +122,18 @@ class Example:
 
         # Maximum number of rigid contacts to allocate (limits memory usage).
         # Use a per-world budget so default world_count=100 scales appropriately.
-        self.rigid_contact_max = 500 * self.world_count
+        self.rigid_contact_max = args.rigid_contact_max or 500 * self.world_count
+        self.max_triangle_pairs = args.max_triangle_pairs
+        self.reduce_contacts = args.reduce_contacts
+        self.contact_reduction_hashtable_size_factor = args.contact_reduction_hashtable_size_factor
+        self.contact_matching = args.contact_matching
+        self.contact_matching_pos_threshold = args.contact_matching_pos_threshold
+        self.contact_matching_normal_dot_threshold = args.contact_matching_normal_dot_threshold
+        self.deterministic_contacts = args.deterministic_contacts
+        self.contact_report = args.contact_report
 
         # Broad phase mode: NXN (O(N²)), SAP (O(N log N)), EXPLICIT (precomputed pairs)
-        self.broad_phase = "sap"
+        self.broad_phase = args.broad_phase
 
         world_builder = self._build_nut_bolt_scene()
 
@@ -145,9 +157,16 @@ class Example:
 
         self.collision_pipeline = newton.CollisionPipeline(
             self.model,
-            reduce_contacts=True,
+            reduce_contacts=self.reduce_contacts,
             rigid_contact_max=self.rigid_contact_max,
             broad_phase=self.broad_phase,
+            max_triangle_pairs=self.max_triangle_pairs,
+            deterministic=self.deterministic_contacts,
+            contact_matching=self.contact_matching,
+            contact_matching_pos_threshold=self.contact_matching_pos_threshold,
+            contact_matching_normal_dot_threshold=self.contact_matching_normal_dot_threshold,
+            contact_report=self.contact_report,
+            contact_reduction_hashtable_size_factor=self.contact_reduction_hashtable_size_factor,
         )
 
         # Create solver based on user choice
@@ -204,8 +223,9 @@ class Example:
 
         bolt_file = str(asset_path / f"factory_bolt_{ASSEMBLY_STR}.obj")
         nut_file = str(asset_path / f"factory_nut_{ASSEMBLY_STR}_subdiv_3x.obj")
-        bolt_mesh, bolt_center = load_mesh_with_sdf(bolt_file, shape_cfg=SHAPE_CFG, center_origin=True)
-        nut_mesh, nut_center = load_mesh_with_sdf(nut_file, shape_cfg=SHAPE_CFG, center_origin=True)
+        shape_cfg = replace(SHAPE_CFG, gap=self.shape_gap)
+        bolt_mesh, bolt_center = load_mesh_with_sdf(bolt_file, shape_cfg=shape_cfg, center_origin=True)
+        nut_mesh, nut_center = load_mesh_with_sdf(nut_file, shape_cfg=shape_cfg, center_origin=True)
 
         # Spacing between assemblies in the grid
         spacing = 0.1 * self.scene_scale
@@ -228,7 +248,7 @@ class Example:
                     world_builder,
                     bolt_mesh,
                     bolt_xform,
-                    SHAPE_CFG,
+                    shape_cfg,
                     label=f"bolt_{i}_{j}",
                     center_vec=bolt_center * self.scene_scale,
                     scale=self.scene_scale,
@@ -243,7 +263,7 @@ class Example:
                     world_builder,
                     nut_mesh,
                     nut_xform,
-                    SHAPE_CFG,
+                    shape_cfg,
                     label=f"nut_{i}_{j}",
                     center_vec=nut_center * self.scene_scale,
                     scale=self.scene_scale,
@@ -261,12 +281,14 @@ class Example:
             self.graph = None
 
     def simulate(self):
-        self.collision_pipeline.collide(self.state_0, self.contacts)
+        if not self.collide_every_substep:
+            self.collision_pipeline.collide(self.state_0, self.contacts)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
 
             self.viewer.apply_forces(self.state_0)
-            # self.collision_pipeline.collide(self.state_0, self.contacts)
+            if self.collide_every_substep:
+                self.collision_pipeline.collide(self.state_0, self.contacts)
             self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
 
             self.state_0, self.state_1 = self.state_1, self.state_0
@@ -290,7 +312,7 @@ class Example:
 
     def _init_test_tracking(self):
         """Initialize tracking data for test validation."""
-        if not self.test_mode:
+        if not self.track_contact_metrics:
             self.bolt_body_indices = None
             self.nut_body_indices = None
             return
@@ -317,13 +339,15 @@ class Example:
         # Track maximum rotation change and z displacement for nuts
         self.nut_max_rotation_change = [0.0] * len(self.nut_body_indices)
         self.nut_min_z = [body_q[idx][2] for idx in self.nut_body_indices]
+        self.contact_count_max = 0
 
     def _track_test_data(self):
         """Track transforms for test validation (called each step in test mode)."""
-        if not self.test_mode:
+        if not self.track_contact_metrics:
             return
 
         body_q = self.state_0.body_q.numpy()
+        self.contact_count_max = max(self.contact_count_max, int(self.contacts.rigid_contact_count.numpy()[0]))
 
         # Track nut rotation and z position
         for i, nut_idx in enumerate(self.nut_body_indices):
@@ -341,6 +365,37 @@ class Example:
 
             # Track minimum z (nuts should move down)
             self.nut_min_z[i] = min(self.nut_min_z[i], current_q[2])
+
+    def get_metrics(self) -> dict[str, float | int]:
+        """Return stability metrics for focused contact benchmarks."""
+        if not self.bolt_body_indices or not self.nut_body_indices:
+            return {}
+
+        body_q = self.state_0.body_q.numpy()
+
+        max_bolt_displacement = 0.0
+        for i, bolt_idx in enumerate(self.bolt_body_indices):
+            current_pos = body_q[bolt_idx][:3]
+            initial_pos = self.bolt_initial_transforms[i][:3]
+            max_bolt_displacement = max(max_bolt_displacement, float(np.linalg.norm(current_pos - initial_pos)))
+
+        min_nut_center_z = min(float(z) for z in self.nut_min_z)
+        min_bolt_initial_z = min(float(q[2]) for q in self.bolt_initial_transforms)
+        max_nut_drop = max(
+            float(initial_q[2] - min_z)
+            for initial_q, min_z in zip(self.nut_initial_transforms, self.nut_min_z, strict=True)
+        )
+        max_nut_rotation = max(float(angle) for angle in self.nut_max_rotation_change)
+
+        return {
+            "max_bolt_displacement": max_bolt_displacement,
+            "max_nut_drop": max_nut_drop,
+            "max_nut_rotation": max_nut_rotation,
+            "min_nut_center_z": min_nut_center_z,
+            "min_nut_center_z_relative_to_bolt": min_nut_center_z - min_bolt_initial_z,
+            "max_contact_count": self.contact_count_max,
+            "final_contact_count": int(self.contacts.rigid_contact_count.numpy()[0]),
+        }
 
     def test_final(self):
         """Verify simulation state after example completes.
@@ -381,9 +436,12 @@ class Example:
 
     @staticmethod
     def create_parser():
+        import argparse  # noqa: PLC0415
+
         parser = newton.examples.create_parser()
         newton.examples.add_world_count_arg(parser)
-        parser.set_defaults(world_count=100)
+        newton.examples.add_broad_phase_arg(parser)
+        parser.set_defaults(world_count=100, broad_phase="sap")
         parser.add_argument(
             "--solver",
             type=str,
@@ -392,6 +450,80 @@ class Example:
             help="Solver to use: 'xpbd' (Extended Position-Based Dynamics) or 'mujoco' (MuJoCo constraint solver).",
         )
         parser.add_argument("--num-per-world", type=int, default=1, help="Number of assemblies per world.")
+        parser.add_argument("--sim-substeps", type=int, default=5, help="Number of solver substeps per frame.")
+        parser.add_argument(
+            "--collide-every-substep",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Refresh Newton contacts before every solver substep instead of once per frame.",
+        )
+        parser.add_argument(
+            "--track-contact-metrics",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Track nut/bolt contact stability metrics for tests and benchmarks.",
+        )
+        parser.add_argument(
+            "--shape-gap",
+            type=float,
+            default=SHAPE_CFG.gap,
+            help="Additional SDF mesh contact detection gap [m].",
+        )
+        parser.add_argument(
+            "--rigid-contact-max",
+            type=int,
+            default=None,
+            help="Maximum rigid contacts allocated by the collision pipeline.",
+        )
+        parser.add_argument(
+            "--max-triangle-pairs",
+            type=int,
+            default=1_000_000,
+            help="Maximum mesh triangle pairs allocated by the narrow phase.",
+        )
+        parser.add_argument(
+            "--reduce-contacts",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Reduce mesh contacts before passing them to the solver.",
+        )
+        parser.add_argument(
+            "--contact-reduction-hashtable-size-factor",
+            type=float,
+            default=0.25,
+            help="Hashtable size factor used by global contact reduction.",
+        )
+        parser.add_argument(
+            "--contact-matching",
+            type=str,
+            choices=["disabled", "latest", "sticky"],
+            default="disabled",
+            help="Frame-to-frame contact matching mode.",
+        )
+        parser.add_argument(
+            "--contact-matching-pos-threshold",
+            type=float,
+            default=0.0005,
+            help="World-space contact matching position threshold [m].",
+        )
+        parser.add_argument(
+            "--contact-matching-normal-dot-threshold",
+            type=float,
+            default=0.995,
+            help="Contact matching normal dot-product threshold.",
+        )
+        parser.add_argument(
+            "--deterministic-contacts",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Sort rigid contacts deterministically after narrow phase.",
+        )
+        parser.add_argument(
+            "--contact-report",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+            help="Track new and broken contacts when contact matching is enabled.",
+        )
         return parser
 
 


### PR DESCRIPTION
## Description

Related to #3188.

This PR does **not** claim to fix the SDF nut/bolt tunneling behavior yet. It adds a focused Newton-only benchmark/repro harness around the existing `example_nut_bolt_sdf` example so the issue can be investigated without the full Isaac Lab replay bundle.

What changed:

- Expose SDF nut/bolt example knobs for substeps, contact refresh cadence, shape gap, contact reduction, reduction hashtable sizing, contact matching, deterministic sorting, and contact metric tracking.
- Add `Example.get_metrics()` for nut drop, a tunneling-depth proxy, bolt displacement, and contact counts.
- Add `FastExampleContactSdfTunnelingSweep` ASV coverage for baseline 4/8/12 substeps plus collide-every-substep, sticky matching, larger reduction hashtable, disabled reduction, and a larger gap.

Important validation caveat:

I could not reproduce or behaviorally validate the CUDA SDF contact case on my MacBook. Local Warp reports CUDA unavailable, Docker has no NVIDIA runtime, and the direct CPU attempt fails because `SDF.create_from_mesh` requires CUDA/`wp.Texture3D`. This PR is therefore a focused benchmark/repro addition, not a verified solver fix. The next step is to run the new sweep on an NVIDIA CUDA machine and use the metrics to decide which contact path needs the actual fix.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_contacts.example_nut_bolt_sdf
uv run --extra dev python - <<'PY'
import importlib.util
from pathlib import Path
path = Path('asv/benchmarks/simulation/bench_contacts.py').resolve()
spec = importlib.util.spec_from_file_location('bench_contacts_local', path)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
cls = module.FastExampleContactSdfTunnelingSweep
print(cls.param_names)
print(cls.params)
PY
uv run python -m py_compile newton/examples/contacts/example_nut_bolt_sdf.py asv/benchmarks/simulation/bench_contacts.py
```

Local result notes:

- The targeted example test resolves but skips locally because no CUDA device is available.
- A direct CPU run of `example_nut_bolt_sdf` fails before simulation with `SDF.create_from_mesh requires a CUDA device`, confirming the actual SDF contact repro cannot be run on this MacBook.
- Docker GPU execution is unavailable locally: Docker reports no NVIDIA runtime/capability provider.

CUDA validation still needed:

```bash
uvx --with virtualenv asv run --launch-method spawn --bench FastExampleContactSdfTunnelingSweep main^!
```

## New feature / API change

```bash
python -m newton.examples.contacts.example_nut_bolt_sdf \
  --viewer null \
  --world-count 4 \
  --sim-substeps 4 \
  --track-contact-metrics \
  --contact-matching sticky
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark sweep for SDF nut-bolt tunneling scenarios with multiple contact and tunneling configuration options.
  * Enhanced example with parameterized simulation behavior including configurable collision detection timing and metrics collection for contact stability analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->