### PR TITLE
Add targeted checkerboard material utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `viewer.set_picking_linear_only_bodies()` and `viewer.clear_picking_linear_only_bodies()` to mark bodies that should receive only the linear component of mouse-picking force, suppressing offset-induced torque.
 - Add opt-in `body_frame_origin="com"` to `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()` for COM-centered cable capsule body frames.
 - Add user-defined pressure laws to hydroelastic SDF contact via `HydroelasticSDF.Config.pressure_func` (a `@wp.func` mapping `(signed_depth, shape_idx, data) -> pressure`) and `pressure_data` (a `@wp.struct` carrying per-shape state). The contact patch is the iso-pressure surface `p_a == p_b`; the default linear law `pressure = -kh * signed_depth` is preserved when no callback is supplied.
+- Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` for applying the checkerboard texture to selected shapes.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 
 ### Changed
@@ -125,6 +126,7 @@
 
 - Users of joint target aliases should migrate `Model.joint_target_pos` / `Control.joint_target_pos` and `Model.joint_target_vel` / `Control.joint_target_vel` to `joint_target_q` / `joint_target_qd`. The legacy names emit a `DeprecationWarning` and raise `AttributeError` when `newton.use_coord_layout_targets = True`. Set that flag before building a model to switch `joint_target_q` to `joint_coord_count` shape (matching `joint_q`); the default `False` keeps the legacy `joint_dof_count` layout. `ModelBuilder.joint_target_pos` / `ModelBuilder.joint_target_vel` are now read-only deprecated aliases (the writable attributes are removed) — set per-axis targets via `JointDofConfig.target_pos` / `target_vel` or write directly to `ModelBuilder.joint_target_q` / `joint_target_qd`. (#2965)
 - Actuator users should pass `control_target_pos_attr="joint_target_q"` (and the velocity counterpart) explicitly to adopt the future default now. The implicit `Actuator` default that resolves `control_target_pos_attr` / `control_target_vel_attr` to legacy `joint_target_pos` / `joint_target_vel` when `newton.use_coord_layout_targets` is `False` is deprecated and will switch to `joint_target_q` / `joint_target_qd` in a future release. (#2965)
+- Deprecate `SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes()` in favor of `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)`.
 - Deprecate `SolverNotifyFlags` in favor of `ModelFlags`; migrate calls such as `SolverNotifyFlags.MODEL_PROPERTIES` to `ModelFlags.MODEL_PROPERTIES`. (#2657)
 - `SolverVBD.register_custom_attributes()` users who want Dahl cable friction should pass `dahl_defaults_enabled=False` and explicitly author positive `model.vbd.dahl_eps_max` and `model.vbd.dahl_tau` values instead of relying on registered default values. Implicit positive Dahl defaults are deprecated. (#2921)
 - Deprecate `Model.mujoco.dof_passive_damping` in favor of `Model.joint_damping`; MuJoCo `damping` import now populates `Model.joint_damping` and the old namespaced attribute remains a warning alias. (#2304)

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -91,7 +91,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         """
 
         checkerboard_texture: bool = False
-        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes()`` instead."""
+        """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)`` instead."""
 
         default_light: bool = False
         """.. deprecated:: 1.1 Use ``SensorTiledCamera.utils.create_default_light()`` instead."""
@@ -166,7 +166,7 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
 
         if isinstance(config, SensorTiledCamera.Config):
             if config.checkerboard_texture:
-                self.utils.assign_checkerboard_material_to_all_shapes()
+                self.utils.assign_checkerboard_material(shape_indices=np.arange(self.model.shape_count, dtype=np.int32))
             if config.default_light:
                 self.utils.create_default_light(config.default_light_shadows)
             if config.colors_per_world:
@@ -449,19 +449,25 @@ class SensorTiledCamera(metaclass=_SensorTiledCameraMeta):
         Creates a gray checkerboard pattern texture and applies it to all shapes
         in the scene.
 
-        .. deprecated:: 1.1
-            Use ``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes`` instead.
+        .. deprecated:: 1.4
+            Use ``SensorTiledCamera.utils.assign_checkerboard_material`` with
+            explicit shape indices instead.
 
         Args:
             resolution: Texture resolution in pixels (square texture).
             checker_size: Size of each checkerboard square in pixels.
         """
         warnings.warn(
-            "Deprecated: SensorTiledCamera.assign_checkerboard_material_to_all_shapes is deprecated, use SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes instead.",
+            "``SensorTiledCamera.assign_checkerboard_material_to_all_shapes`` is deprecated as of Newton 1.4. "
+            "Use ``SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)`` instead.",
             category=DeprecationWarning,
             stacklevel=2,
         )
-        self.utils.assign_checkerboard_material_to_all_shapes(resolution, checker_size)
+        self.utils.assign_checkerboard_material(
+            shape_indices=np.arange(self.model.shape_count, dtype=np.int32),
+            resolution=resolution,
+            checker_size=checker_size,
+        )
 
     def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create a color output array for :meth:`update`.

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -857,22 +858,33 @@ class Utils:
             device=self.__render_context.device,
         )
 
-    def assign_checkerboard_material_to_all_shapes(self, resolution: int = 64, checker_size: int = 32):
-        """Assign a gray checkerboard texture material to all shapes.
-        Creates a gray checkerboard pattern texture and applies it to all shapes
-        in the scene.
+    def assign_checkerboard_material(
+        self,
+        *,
+        shape_indices: Sequence[int] | np.ndarray,
+        resolution: int = 64,
+        checker_size: int = 32,
+    ):
+        """Assign a gray checkerboard texture material to selected shapes.
 
         Args:
+            shape_indices: Shape indices that should use the checkerboard texture.
             resolution: Texture resolution in pixels (square texture).
             checker_size: Size of each checkerboard square in pixels.
         """
+        shape_indices = np.asarray(shape_indices, dtype=np.int64).reshape(-1)
+        invalid = (shape_indices < 0) | (shape_indices >= self.__render_context.shape_count_total)
+        if invalid.any():
+            raise ValueError("shape_indices contains an out-of-range shape index")
+
         checkerboard = (
             (np.arange(resolution) // checker_size)[:, None] + (np.arange(resolution) // checker_size)
         ) % 2 == 0
 
         pixels = np.where(checkerboard, 0xFF808080, 0xFFBFBFBF).astype(np.uint32)
 
-        texture_ids = np.full(self.__render_context.shape_count_total, fill_value=0, dtype=np.int32)
+        texture_ids = np.full(self.__render_context.shape_count_total, fill_value=-1, dtype=np.int32)
+        texture_ids[shape_indices] = 0
 
         self.__checkerboard_data = TextureData()
         self.__checkerboard_data.texture = wp.Texture2D(
@@ -893,6 +905,29 @@ class Utils:
         )
         self.__render_context.shape_texture_ids = wp.array(
             texture_ids, dtype=wp.int32, device=self.__render_context.device
+        )
+
+    def assign_checkerboard_material_to_all_shapes(self, resolution: int = 64, checker_size: int = 32):
+        """Assign a gray checkerboard texture material to all shapes.
+
+        .. deprecated:: 1.4
+            Use :meth:`assign_checkerboard_material` with explicit shape
+            indices instead.
+
+        Args:
+            resolution: Texture resolution in pixels (square texture).
+            checker_size: Size of each checkerboard square in pixels.
+        """
+        warnings.warn(
+            "``SensorTiledCamera.utils.assign_checkerboard_material_to_all_shapes`` is deprecated as of Newton 1.4. "
+            "Use ``SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)`` instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.assign_checkerboard_material(
+            shape_indices=np.arange(self.__render_context.shape_count_total, dtype=np.int32),
+            resolution=resolution,
+            checker_size=checker_size,
         )
 
     def __reshape_buffer_for_flatten(

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -103,6 +103,7 @@ class Example:
         builder = newton.ModelBuilder()
 
         semantic_colors = []
+        robot_shape_indices: list[int] = []
 
         rng = random.Random(1234)
         for _ in range(self.world_count_total):
@@ -155,15 +156,19 @@ class Example:
                 )
                 semantic_colors.append(SEMANTIC_COLOR_GAUSSIAN)
 
+            robot_shape_start = builder.shape_count
             builder.add_builder(robot_builder, xform=wp.transform(p=wp.vec3(2.0, 0.0, 0.0), q=wp.quat_identity()))
+            robot_shape_indices.extend(range(robot_shape_start, robot_shape_start + robot_builder.shape_count))
             semantic_colors.extend([SEMANTIC_COLOR_ROBOT] * robot_builder.shape_count)
             builder.end_world()
 
-        builder.add_ground_plane(color=(0.6, 0.6, 0.6))
+        ground_shape_index = builder.add_ground_plane(color=(0.6, 0.6, 0.6))
         semantic_colors.append(SEMANTIC_COLOR_GROUND_PLANE)
 
         self.model = builder.finalize()
         self.state = self.model.state()
+        self.robot_shape_indices = np.asarray(robot_shape_indices, dtype=np.uint32)
+        self.ground_shape_indices = np.asarray([ground_shape_index], dtype=np.uint32)
 
         # Build per-DOF home pose and oscillation radius for animate_franka.
         # Joints not listed in _FRANKA_HOME_AND_ALPHA keep radius=0 and stay put.
@@ -195,7 +200,7 @@ class Example:
         # Setup Tiled Camera Sensor
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
         self.tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
-        self.tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
+        self.tiled_camera_sensor.utils.assign_checkerboard_material(shape_indices=self.ground_shape_indices)
 
         fov = 45.0
         if isinstance(self.viewer, ViewerGL):
@@ -344,6 +349,21 @@ class Example:
         shape_index_image = self.tiled_camera_sensor_shape_index_image.numpy()
         assert shape_index_image.shape == expected_shape
         assert shape_index_image.dtype == np.uint32
+
+        albedo_rgba = albedo_image.view(np.uint8).reshape(
+            self.world_count_total * self.camera_count, self.sensor_render_height, self.sensor_render_width, 4
+        )
+        ground_shape_mask = np.isin(shape_index_image.reshape(albedo_rgba.shape[:3]), self.ground_shape_indices)
+        ground_albedo = albedo_rgba[..., :3][ground_shape_mask]
+        assert ground_albedo.size > 0
+        assert np.unique(ground_albedo, axis=0).shape[0] > 1
+
+        robot_shape_mask = np.isin(shape_index_image.reshape(albedo_rgba.shape[:3]), self.robot_shape_indices)
+        robot_albedo = albedo_rgba[..., :3][robot_shape_mask]
+        assert robot_albedo.size > 0
+        checker_swatches = np.array([[128, 128, 128], [191, 191, 191]], dtype=np.uint8)
+        checker_swatch_mask = (robot_albedo[:, None, :] == checker_swatches[None, :, :]).all(axis=2).any(axis=1)
+        assert not checker_swatch_mask.any()
 
     def gui(self, ui):
         show_compile_kernel_info = False

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -202,6 +202,13 @@ class TestSensorTiledCamera(unittest.TestCase):
         # Depth hits prove the mesh was passed into the render kernel, not just created.
         self.assertGreater(int(np.sum(depth_image.numpy() > 0.0)), 0)
 
+    def test_checkerboard_material_requires_keyword_arguments(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        sensor = SensorTiledCamera(model=model)
+
+        with self.assertRaises(TypeError):
+            sensor.utils.assign_checkerboard_material([0])
+
     @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
     def test_golden_image(self):
         model = self._shared_model
@@ -216,7 +223,9 @@ class TestSensorTiledCamera(unittest.TestCase):
 
         tiled_camera_sensor = SensorTiledCamera(model=model)
         tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
-        tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
+        tiled_camera_sensor.utils.assign_checkerboard_material(
+            shape_indices=np.arange(model.shape_count, dtype=np.int32)
+        )
 
         camera_rays = tiled_camera_sensor.utils.compute_pinhole_camera_rays(width, height, math.radians(45.0))
         color_image = tiled_camera_sensor.utils.create_color_image_output(width, height, camera_count)
@@ -236,6 +245,14 @@ class TestSensorTiledCamera(unittest.TestCase):
 
         self.__compare_images(color_image.numpy(), golden_color_data, allowed_difference=0.1)
         self.__compare_images(depth_image.numpy(), golden_depth_data, allowed_difference=0.1)
+
+    @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
+    def test_deprecated_checkerboard_material_to_all_shapes_warns(self):
+        model = self._shared_model
+        tiled_camera_sensor = SensorTiledCamera(model=model)
+
+        with self.assertWarnsRegex(DeprecationWarning, "assign_checkerboard_material"):
+            tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
 
     @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
     def test_output_image_parameters(self):

--- a/newton/tests/test_sensor_tiled_camera_heightfield.py
+++ b/newton/tests/test_sensor_tiled_camera_heightfield.py
@@ -28,7 +28,7 @@ class TestSensorTiledCameraHeightfield(unittest.TestCase):
         res = 16
         sensor = SensorTiledCamera(model=model)
         sensor.utils.create_default_light(enable_shadows=False)
-        sensor.utils.assign_checkerboard_material_to_all_shapes()
+        sensor.utils.assign_checkerboard_material(shape_indices=[0])
         # 30-deg fov: footprint half-extent at depth 4 is 4*tan(15)=1.07 < 2,
         # so the terrain robustly fills the whole frame.
         rays = sensor.utils.compute_pinhole_camera_rays(res, res, math.radians(30.0))


### PR DESCRIPTION
## Summary

- Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` so checkerboard material can be applied to explicit shapes only.
- Deprecate `assign_checkerboard_material_to_all_shapes()` as of Newton 1.4 and route legacy all-shapes behavior through the new API.
- Update `sensor_tiled_camera` so only the ground plane receives the checkerboard texture, preserving the Franka robot's imported visual materials.

## Root Cause

The tiled camera example used the old all-shapes checkerboard helper as a stand-in for ViewerGL's checker floor. That helper also textured the robot, so parts of the Franka rendered with checkerboard albedo instead of their imported visual colors.

Links: https://github.com/newton-physics/newton/issues/3213

## Validation

- `uv run python docs\generate_api.py`
- `uv run -m newton.examples sensor_tiled_camera --viewer null --test --quiet --num-frames 1`
- `$env:WARP_CACHE_PATH = Join-Path $env:TEMP 'warp-newton-checkerboard-pr-cache'; uv run --extra dev -m unittest newton.tests.test_sensor_tiled_camera newton.tests.test_sensor_tiled_camera_heightfield`
- `uvx ruff check CHANGELOG.md newton\_src\sensors\warp_raytrace\utils.py newton\_src\sensors\sensor_tiled_camera.py newton\examples\sensors\example_sensor_tiled_camera.py newton\tests\test_sensor_tiled_camera.py newton\tests\test_sensor_tiled_camera_heightfield.py`
- `uvx ruff format --check newton\_src\sensors\warp_raytrace\utils.py newton\_src\sensors\sensor_tiled_camera.py newton\examples\sensors\example_sensor_tiled_camera.py newton\tests\test_sensor_tiled_camera.py newton\tests\test_sensor_tiled_camera_heightfield.py`
- `uvx pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selective checkerboard texture application—users can now apply checkerboard materials to specific shapes rather than all shapes.

* **Deprecations**
  * Deprecated the method that applies checkerboard textures to all shapes. Use the new selective API instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->