### PR TITLE
Fix memory growth in the Style3D solver when CUDA Graph capture is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Fix `SolverVBD` rigid contact injecting kinetic energy for yawed finite-radius contacts (e.g. small-radius cables blowing up). The normal response now acts at the geometric skeleton point rather than the rotating surface anchor, which was non-conservative under reorientation; friction still uses the surface anchor to preserve finite-radius slip. (#3125)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
-- Fix repeated Style3D collision Hessian kernel construction during contact solves.
+- Fix memory growth in the Style3D solver when CUDA Graph capture is disabled
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix USD import so non-unit `metersPerUnit` and `kilogramsPerUnit` warn as unsupported, and stop scaling `PhysicsScene` gravity magnitude by `metersPerUnit`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Fix `SolverVBD` rigid contact injecting kinetic energy for yawed finite-radius contacts (e.g. small-radius cables blowing up). The normal response now acts at the geometric skeleton point rather than the rotating surface anchor, which was non-conservative under reorientation; friction still uses the surface anchor to preserve finite-radius slip. (#3125)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
+- Fix repeated Style3D collision Hessian kernel construction during contact solves.
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix USD import so non-unit `metersPerUnit` and `kilogramsPerUnit` warn as unsupported, and stop scaling `PhysicsScene` gravity magnitude by `metersPerUnit`.

--- a/newton/_src/solvers/style3d/collision/collision.py
+++ b/newton/_src/solvers/style3d/collision/collision.py
@@ -9,6 +9,7 @@ from newton._src.solvers.style3d.collision.kernels import (
     eval_body_contact_kernel,
     handle_edge_edge_contacts_kernel,
     handle_vertex_triangle_contacts_kernel,
+    hessian_multiply_kernel,
     solve_untangling_kernel,
 )
 
@@ -236,17 +237,6 @@ class Collision:
 
     def hessian_multiply(self, x: wp.array[wp.vec3]):
         """Computes the Hessian-vector product for implicit integration."""
-
-        @wp.kernel
-        def hessian_multiply_kernel(
-            hessian_diags: wp.array[wp.mat33],
-            x: wp.array[wp.vec3],
-            # outputs
-            Hx: wp.array[wp.vec3],
-        ):
-            tid = wp.tid()
-            Hx[tid] = hessian_diags[tid] * x[tid]
-
         wp.launch(
             hessian_multiply_kernel,
             dim=self.model.particle_count,

--- a/newton/_src/solvers/style3d/collision/kernels.py
+++ b/newton/_src/solvers/style3d/collision/kernels.py
@@ -31,6 +31,17 @@ def triangle_barycentric(A: wp.vec3, B: wp.vec3, C: wp.vec3, P: wp.vec3):
 
 
 @wp.kernel
+def hessian_multiply_kernel(
+    hessian_diags: wp.array[wp.mat33],
+    x: wp.array[wp.vec3],
+    # outputs
+    Hx: wp.array[wp.vec3],
+):
+    tid = wp.tid()
+    Hx[tid] = hessian_diags[tid] * x[tid]
+
+
+@wp.kernel
 def eval_body_contact_kernel(
     # inputs
     dt: float,


### PR DESCRIPTION
## Description

This PR moves the Style3D contact Hessian-vector multiply Warp kernel out
of `Collision.hessian_multiply()` and defines it at module scope.

`hessian_multiply()` is called from the PCG solve when collision is enabled.
Defining `@wp.kernel` inside that method constructs a new kernel object on
each call, adding Python/Warp registration and cache lookup overhead in a
hot path.

The change keeps numerical behavior unchanged: it still multiplies the
contact Hessian diagonal by the input vector and writes to the same output
buffer.

This also makes the collision solving path more friendly to non-CUDA-capture scenarios.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_solver_style3d
uvx pre-commit run -a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Fixed memory growth in the Style3D solver when CUDA Graph capture is disabled.

* **Performance / Reliability**
  * Prevented repeated kernel rebuild behavior during Style3D collision Hessian-vector computations to improve performance and consistency.

* **Refactor**
  * Streamlined Style3D collision Hessian-vector product computation by routing it through a dedicated kernel, keeping output the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->