### PR TITLE
Clarify ShapeConfig material docs

### DIFF
--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -126,6 +126,37 @@ Supported Features
 .. experimental::
     :class:`~newton.solvers.SolverVBD`'s public API and behavior may change without prior notice.
 
+.. _Contact material support:
+
+Contact Material Support
+------------------------
+
+:class:`~newton.ModelBuilder.ShapeConfig` and the matching :class:`~newton.Model`
+shape material arrays store solver-neutral contact data. This section documents
+which fields are currently used by Newton's built-in solvers. External solvers
+may use different subsets or interpret these fields according to their own
+formulation.
+
+- ``mu``: :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`,
+  :class:`~newton.solvers.SolverXPBD`, :class:`~newton.solvers.SolverMuJoCo`,
+  :class:`~newton.solvers.SolverVBD`, :class:`~newton.solvers.SolverKamino`,
+  :class:`~newton.solvers.SolverStyle3D`, and
+  :class:`~newton.solvers.SolverImplicitMPM`.
+- ``ke`` / ``kd``: :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`,
+  :class:`~newton.solvers.SolverMuJoCo`, and
+  :class:`~newton.solvers.SolverVBD`.
+- ``kf`` / ``ka``: :class:`~newton.solvers.SolverFeatherstone` and
+  :class:`~newton.solvers.SolverSemiImplicit`.
+- ``restitution``: :class:`~newton.solvers.SolverXPBD` when restitution is
+  enabled, and :class:`~newton.solvers.SolverKamino`.
+- ``mu_torsional`` / ``mu_rolling``: :class:`~newton.solvers.SolverXPBD` and
+  :class:`~newton.solvers.SolverMuJoCo`.
+- ``kh``: consumed by hydroelastic contact generation before the solver step.
+  Any solver that consumes those generated contacts receives the resulting
+  hydroelastic contact data.
+
 .. _Joint feature support:
 
 Joint Feature Support

--- a/docs/api/newton_solvers.rst
+++ b/docs/api/newton_solvers.rst
@@ -149,13 +149,15 @@ formulation.
   :class:`~newton.solvers.SolverVBD`.
 - ``kf`` / ``ka``: :class:`~newton.solvers.SolverFeatherstone` and
   :class:`~newton.solvers.SolverSemiImplicit`.
-- ``restitution``: :class:`~newton.solvers.SolverXPBD` when restitution is
-  enabled, and :class:`~newton.solvers.SolverKamino`.
+- ``restitution``: :class:`~newton.solvers.SolverXPBD` when
+  ``enable_restitution=True``, and :class:`~newton.solvers.SolverKamino`.
 - ``mu_torsional`` / ``mu_rolling``: :class:`~newton.solvers.SolverXPBD` and
   :class:`~newton.solvers.SolverMuJoCo`.
-- ``kh``: consumed by hydroelastic contact generation before the solver step.
-  Any solver that consumes those generated contacts receives the resulting
-  hydroelastic contact data.
+- ``kh``: consumed by hydroelastic contact generation for Newton-generated
+  contacts used by :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`, and
+  :class:`~newton.solvers.SolverMuJoCo` when ``use_mujoco_contacts=False``. See
+  :ref:`Hydroelastic Contacts`.
 
 .. _Joint feature support:
 

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1640,65 +1640,55 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
 
 .. list-table::
    :header-rows: 1
-   :widths: 10 25 18 9 19 19
+   :widths: 12 34 10 22 22
 
    * - Property
      - Description
-     - Role
      - Default
      - ShapeConfig
      - Model Array
    * - ``mu``
      - Dynamic friction coefficient
-     - Coulomb friction limit
      - 1.0
      - :attr:`~ModelBuilder.ShapeConfig.mu`
      - :attr:`~Model.shape_material_mu`
    * - ``ke``
      - Normal contact stiffness
-     - Normal contact response
      - 2.5e3
      - :attr:`~ModelBuilder.ShapeConfig.ke`
      - :attr:`~Model.shape_material_ke`
    * - ``kd``
      - Normal contact damping
-     - Normal contact response
      - 100.0
      - :attr:`~ModelBuilder.ShapeConfig.kd`
      - :attr:`~Model.shape_material_kd`
    * - ``kf``
      - Tangential friction response gain
-     - Tangential slip resistance
      - 1000.0
      - :attr:`~ModelBuilder.ShapeConfig.kf`
      - :attr:`~Model.shape_material_kf`
    * - ``ka``
      - Adhesion distance
-     - Adhesive contact response
      - 0.0
      - :attr:`~ModelBuilder.ShapeConfig.ka`
      - :attr:`~Model.shape_material_ka`
    * - ``restitution``
      - Bounciness
-     - Restitution response
      - 0.0
      - :attr:`~ModelBuilder.ShapeConfig.restitution`
      - :attr:`~Model.shape_material_restitution`
    * - ``mu_torsional``
      - Resistance to spinning at contact
-     - Torsional friction
      - 0.005
      - :attr:`~ModelBuilder.ShapeConfig.mu_torsional`
      - :attr:`~Model.shape_material_mu_torsional`
    * - ``mu_rolling``
      - Resistance to rolling motion
-     - Rolling friction
      - 0.0001
      - :attr:`~ModelBuilder.ShapeConfig.mu_rolling`
      - :attr:`~Model.shape_material_mu_rolling`
    * - ``kh``
      - Hydroelastic stiffness coefficient
-     - Hydroelastic pressure law
      - 1.0e10
      - :attr:`~ModelBuilder.ShapeConfig.kh`
      - :attr:`~Model.shape_material_kh`
@@ -1707,8 +1697,11 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
    Material properties are generic model data. Solvers and contact backends may
    use, combine, or ignore fields according to their formulation. See the
    :ref:`Contact material support` reference for built-in solver behavior, and
-   external solver documentation for third-party solvers. Some solvers require
-   enabling restitution explicitly before ``restitution`` takes effect.
+   external solver documentation for third-party solvers.
+
+.. note::
+   :class:`~newton.solvers.SolverXPBD` requires ``enable_restitution=True`` on
+   the solver constructor before ``restitution`` takes effect.
 
 Example:
 
@@ -1719,7 +1712,7 @@ Example:
         mu=0.8,           # High friction
         ke=1.0e6,         # Stiff contact
         kd=1000.0,        # Damping
-        restitution=0.5,  # Bouncy (XPBD only)
+        restitution=0.5,  # Bouncy where supported
     )
 
 .. _USD Collision:

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1059,7 +1059,9 @@ Shape collision behavior is controlled via :class:`~ModelBuilder.ShapeConfig`:
    * - ``is_hydroelastic``
      - Whether the shape uses SDF-based hydroelastic contacts. Both shapes in a pair must have this enabled. See :ref:`Hydroelastic Contacts`. Default: False.
    * - ``kh``
-     - Hydroelastic contact stiffness coefficient. Contact force scales with effective stiffness, contact area, and penetration depth. Default: 1.0e10.
+     - Hydroelastic contact stiffness coefficient. Under the default linear
+       pressure law, pressure scales with ``kh`` and penetration depth; contact
+       force also scales with contact area. Default: 1.0e10.
 
 .. _margin-gap-semantics:
 
@@ -1696,7 +1698,7 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
      - :attr:`~Model.shape_material_mu_rolling`
    * - ``kh``
      - Hydroelastic stiffness coefficient
-     - Hydroelastic contact response
+     - Hydroelastic pressure law
      - 1.0e10
      - :attr:`~ModelBuilder.ShapeConfig.kh`
      - :attr:`~Model.shape_material_kh`
@@ -1704,7 +1706,7 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
 .. note::
    Material properties are generic model data. Solvers and contact backends may
    use, combine, or ignore fields according to their formulation. See the
-   :doc:`../api/newton_solvers` API reference for built-in solver behavior, and
+   :ref:`Contact material support` reference for built-in solver behavior, and
    external solver documentation for third-party solvers. Some solvers require
    enabling restitution explicitly before ``restitution`` takes effect.
 

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1648,7 +1648,7 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
      - ShapeConfig
      - Model Array
    * - ``mu``
-     - Dynamic friction coefficient
+     - Coefficient of friction
      - 1.0
      - :attr:`~ModelBuilder.ShapeConfig.mu`
      - :attr:`~Model.shape_material_mu`

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -1059,7 +1059,7 @@ Shape collision behavior is controlled via :class:`~ModelBuilder.ShapeConfig`:
    * - ``is_hydroelastic``
      - Whether the shape uses SDF-based hydroelastic contacts. Both shapes in a pair must have this enabled. See :ref:`Hydroelastic Contacts`. Default: False.
    * - ``kh``
-     - Contact stiffness for hydroelastic collisions. Used by MuJoCo, Featherstone, SemiImplicit when ``is_hydroelastic=True``. Default: 1.0e10.
+     - Hydroelastic contact stiffness coefficient. Contact force scales with effective stiffness, contact area, and penetration depth. Default: 1.0e10.
 
 .. _margin-gap-semantics:
 
@@ -1642,70 +1642,71 @@ Shape material properties control contact resolution. Configure via :class:`~Mod
 
    * - Property
      - Description
-     - Solvers
+     - Role
      - Default
      - ShapeConfig
      - Model Array
    * - ``mu``
      - Dynamic friction coefficient
-     - All
+     - Coulomb friction limit
      - 1.0
      - :attr:`~ModelBuilder.ShapeConfig.mu`
      - :attr:`~Model.shape_material_mu`
    * - ``ke``
-     - Contact elastic stiffness
-     - SemiImplicit, Featherstone, MuJoCo
+     - Normal contact stiffness
+     - Normal contact response
      - 2.5e3
      - :attr:`~ModelBuilder.ShapeConfig.ke`
      - :attr:`~Model.shape_material_ke`
    * - ``kd``
-     - Contact damping
-     - SemiImplicit, Featherstone, MuJoCo
+     - Normal contact damping
+     - Normal contact response
      - 100.0
      - :attr:`~ModelBuilder.ShapeConfig.kd`
      - :attr:`~Model.shape_material_kd`
    * - ``kf``
-     - Friction damping coefficient
-     - SemiImplicit, Featherstone
+     - Tangential friction response gain
+     - Tangential slip resistance
      - 1000.0
      - :attr:`~ModelBuilder.ShapeConfig.kf`
      - :attr:`~Model.shape_material_kf`
    * - ``ka``
      - Adhesion distance
-     - SemiImplicit, Featherstone
+     - Adhesive contact response
      - 0.0
      - :attr:`~ModelBuilder.ShapeConfig.ka`
      - :attr:`~Model.shape_material_ka`
    * - ``restitution``
-     - Bounciness (requires ``enable_restitution=True`` in solver)
-     - XPBD
+     - Bounciness
+     - Restitution response
      - 0.0
      - :attr:`~ModelBuilder.ShapeConfig.restitution`
      - :attr:`~Model.shape_material_restitution`
    * - ``mu_torsional``
      - Resistance to spinning at contact
-     - XPBD, MuJoCo
+     - Torsional friction
      - 0.005
      - :attr:`~ModelBuilder.ShapeConfig.mu_torsional`
      - :attr:`~Model.shape_material_mu_torsional`
    * - ``mu_rolling``
      - Resistance to rolling motion
-     - XPBD, MuJoCo
+     - Rolling friction
      - 0.0001
      - :attr:`~ModelBuilder.ShapeConfig.mu_rolling`
      - :attr:`~Model.shape_material_mu_rolling`
    * - ``kh``
-     - Hydroelastic stiffness
-     - SemiImplicit, Featherstone, MuJoCo
+     - Hydroelastic stiffness coefficient
+     - Hydroelastic contact response
      - 1.0e10
      - :attr:`~ModelBuilder.ShapeConfig.kh`
      - :attr:`~Model.shape_material_kh`
 
 .. note::
-   Material properties interact differently with each solver. ``ke``, ``kd``, ``kf``, and ``ka``
-   are used by force-based solvers (SemiImplicit, Featherstone, MuJoCo), while ``restitution``
-   only applies to XPBD. See the :doc:`../api/newton_solvers` API reference for solver-specific
-   behavior.
+   Material properties are generic model data. Solvers and contact backends may
+   use, combine, or ignore fields according to their formulation. See the
+   :doc:`../api/newton_solvers` API reference for built-in solver behavior, and
+   external solver documentation for third-party solvers. Some solvers require
+   enabling restitution explicitly before ``restitution`` takes effect.
 
 Example:
 

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -280,7 +280,11 @@ class ModelBuilder:
         mu: float = 1.0
         """The coefficient of friction."""
         restitution: float = 0.0
-        """The coefficient of restitution. Some solvers require enabling restitution explicitly."""
+        """The coefficient of restitution.
+
+        :class:`~newton.solvers.SolverXPBD` requires ``enable_restitution=True``
+        on the solver constructor for this field to take effect.
+        """
         mu_torsional: float = 0.005
         """The coefficient of torsional friction (resistance to spinning at contact point)."""
         mu_rolling: float = 0.0001
@@ -339,6 +343,11 @@ class ModelBuilder:
             not a direct force-to-penetration ratio. Solvers and contact
             backends may scale or otherwise interpret this coefficient
             according to their formulation.
+
+            For :class:`~newton.solvers.SolverMuJoCo`, stiffness values are
+            internally scaled by masses when Newton-generated contacts are
+            passed through the MuJoCo contact path. Tune ``kh`` with that
+            scaling in mind.
         """
         sdf_padding: float | None = None
         """SDF AABB padding [m] for primitive texture SDFs. Falls back to

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -259,27 +259,32 @@ class ModelBuilder:
     @dataclass
     class ShapeConfig:
         """
-        Represents the properties of a collision shape used in simulation.
+        Represents per-shape collision, material, mass, and SDF settings.
+
+        These fields are general model data, and not every field is respected
+        or needed by every solver. Solvers and contact backends may use,
+        combine, or ignore individual fields according to their formulation;
+        see solver-specific documentation for behavior.
         """
 
         density: float = 1000.0
         """The density of the shape material."""
         ke: float = 2.5e3
-        """The contact elastic stiffness [N/m]. Used by SemiImplicit, Featherstone, MuJoCo, VBD."""
+        """The normal contact stiffness [N/m]."""
         kd: float = 100.0
-        """The contact damping coefficient [N·s/m]. Used by SemiImplicit, Featherstone, MuJoCo, VBD."""
+        """The normal contact damping coefficient [N·s/m]."""
         kf: float = 1000.0
-        """The friction damping coefficient. Used by SemiImplicit, Featherstone."""
+        """The tangential friction response gain [N·s/m]."""
         ka: float = 0.0
-        """The contact adhesion distance. Used by SemiImplicit, Featherstone."""
+        """The contact adhesion distance [m]."""
         mu: float = 1.0
-        """The coefficient of friction. Used by all solvers."""
+        """The coefficient of friction."""
         restitution: float = 0.0
-        """The coefficient of restitution. Used by XPBD. To take effect, enable restitution in solver constructor via ``enable_restitution=True``."""
+        """The coefficient of restitution. Some solvers require enabling restitution explicitly."""
         mu_torsional: float = 0.005
-        """The coefficient of torsional friction (resistance to spinning at contact point). Used by XPBD, MuJoCo."""
+        """The coefficient of torsional friction (resistance to spinning at contact point)."""
         mu_rolling: float = 0.0001
-        """The coefficient of rolling friction (resistance to rolling motion). Used by XPBD, MuJoCo."""
+        """The coefficient of rolling friction (resistance to rolling motion)."""
         margin: float = 0.0
         """Outward offset from the shape's surface [m] for collision detection.
         Extends the effective collision surface outward by this amount. When two shapes collide,
@@ -325,11 +330,12 @@ class ModelBuilder:
             This flag will be automatically set to False for planes and heightfields in :meth:`ModelBuilder.add_shape`.
         """
         kh: float = 1.0e10
-        """Contact stiffness coefficient for hydroelastic collisions. Used by MuJoCo, Featherstone, SemiImplicit when is_hydroelastic is True.
+        """Hydroelastic contact stiffness coefficient [N/m^3].
 
         .. note::
-            For MuJoCo, stiffness values will internally be scaled by masses.
-            Users should choose kh to match their desired force-to-penetration ratio.
+            Solvers may scale or otherwise interpret this coefficient according
+            to their contact model. Choose kh to match the desired
+            force-to-penetration ratio.
         """
         sdf_padding: float | None = None
         """SDF AABB padding [m] for primitive texture SDFs. Falls back to
@@ -968,7 +974,7 @@ class ModelBuilder:
         self.shape_material_kd: list[float] = []
         """Contact damping values accumulated for :attr:`Model.shape_material_kd`."""
         self.shape_material_kf: list[float] = []
-        """Friction stiffness values accumulated for :attr:`Model.shape_material_kf`."""
+        """Tangential friction response gains accumulated for :attr:`Model.shape_material_kf`."""
         self.shape_material_ka: list[float] = []
         """Adhesion distances [m] accumulated for :attr:`Model.shape_material_ka`."""
         self.shape_material_mu: list[float] = []

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -333,9 +333,12 @@ class ModelBuilder:
         """Hydroelastic contact stiffness coefficient [N/m^3].
 
         .. note::
-            Solvers may scale or otherwise interpret this coefficient according
-            to their contact model. Choose kh to match the desired
-            force-to-penetration ratio.
+            The default linear pressure law is
+            ``pressure = -kh * signed_depth``. Effective contact force scales
+            with contact area, so ``kh`` sets a pressure-to-penetration ratio,
+            not a direct force-to-penetration ratio. Solvers and contact
+            backends may scale or otherwise interpret this coefficient
+            according to their formulation.
         """
         sdf_padding: float | None = None
         """SDF AABB padding [m] for primitive texture SDFs. Falls back to
@@ -366,7 +369,7 @@ class ModelBuilder:
                     SDF generation and clears any previous max_resolution setting.
                 is_hydroelastic: Whether to use SDF-based hydroelastic contacts. Both shapes
                     in a pair must have this enabled.
-                kh: Contact stiffness coefficient for hydroelastic collisions.
+                kh: Hydroelastic contact stiffness coefficient.
                 texture_format: Subgrid texture storage format. ``"uint16"``
                     (default) uses 16-bit normalized textures. ``"float32"``
                     uses full-precision. ``"uint8"`` uses 8-bit textures.

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -258,7 +258,7 @@ class Model:
         self.shape_material_kd: wp.array[wp.float32] | None = None
         """Shape contact damping [N·s/m], shape [shape_count], float."""
         self.shape_material_kf: wp.array[wp.float32] | None = None
-        """Shape contact friction stiffness [N·s/m], shape [shape_count], float."""
+        """Shape tangential friction response gain [N·s/m], shape [shape_count], float."""
         self.shape_material_ka: wp.array[wp.float32] | None = None
         """Shape contact adhesion distance [m], shape [shape_count], float."""
         self.shape_material_mu: wp.array[wp.float32] | None = None

--- a/newton/_src/sim/model.py
+++ b/newton/_src/sim/model.py
@@ -271,7 +271,8 @@ class Model:
         """Shape rolling friction coefficient [dimensionless] (resistance to rolling motion), shape [shape_count], float."""
         self.shape_material_kh: wp.array[wp.float32] | None = None
         """Shape hydroelastic stiffness coefficient [N/m^3], shape [shape_count], float.
-        Contact stiffness is computed as ``area * kh``, yielding an effective spring constant [N/m]."""
+        Under the default linear pressure law, contact force scales with
+        contact area, ``kh``, and penetration depth."""
         self.shape_gap: wp.array[wp.float32] | None = None
         """Shape additional contact detection gap [m], shape [shape_count], float."""
 

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -124,6 +124,37 @@ Supported Features
 .. experimental::
     :class:`~newton.solvers.SolverVBD`'s public API and behavior may change without prior notice.
 
+.. _Contact material support:
+
+Contact Material Support
+------------------------
+
+:class:`~newton.ModelBuilder.ShapeConfig` and the matching :class:`~newton.Model`
+shape material arrays store solver-neutral contact data. This section documents
+which fields are currently used by Newton's built-in solvers. External solvers
+may use different subsets or interpret these fields according to their own
+formulation.
+
+- ``mu``: :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`,
+  :class:`~newton.solvers.SolverXPBD`, :class:`~newton.solvers.SolverMuJoCo`,
+  :class:`~newton.solvers.SolverVBD`, :class:`~newton.solvers.SolverKamino`,
+  :class:`~newton.solvers.SolverStyle3D`, and
+  :class:`~newton.solvers.SolverImplicitMPM`.
+- ``ke`` / ``kd``: :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`,
+  :class:`~newton.solvers.SolverMuJoCo`, and
+  :class:`~newton.solvers.SolverVBD`.
+- ``kf`` / ``ka``: :class:`~newton.solvers.SolverFeatherstone` and
+  :class:`~newton.solvers.SolverSemiImplicit`.
+- ``restitution``: :class:`~newton.solvers.SolverXPBD` when restitution is
+  enabled, and :class:`~newton.solvers.SolverKamino`.
+- ``mu_torsional`` / ``mu_rolling``: :class:`~newton.solvers.SolverXPBD` and
+  :class:`~newton.solvers.SolverMuJoCo`.
+- ``kh``: consumed by hydroelastic contact generation before the solver step.
+  Any solver that consumes those generated contacts receives the resulting
+  hydroelastic contact data.
+
 .. _Joint feature support:
 
 Joint Feature Support

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -147,13 +147,15 @@ formulation.
   :class:`~newton.solvers.SolverVBD`.
 - ``kf`` / ``ka``: :class:`~newton.solvers.SolverFeatherstone` and
   :class:`~newton.solvers.SolverSemiImplicit`.
-- ``restitution``: :class:`~newton.solvers.SolverXPBD` when restitution is
-  enabled, and :class:`~newton.solvers.SolverKamino`.
+- ``restitution``: :class:`~newton.solvers.SolverXPBD` when
+  ``enable_restitution=True``, and :class:`~newton.solvers.SolverKamino`.
 - ``mu_torsional`` / ``mu_rolling``: :class:`~newton.solvers.SolverXPBD` and
   :class:`~newton.solvers.SolverMuJoCo`.
-- ``kh``: consumed by hydroelastic contact generation before the solver step.
-  Any solver that consumes those generated contacts receives the resulting
-  hydroelastic contact data.
+- ``kh``: consumed by hydroelastic contact generation for Newton-generated
+  contacts used by :class:`~newton.solvers.SolverFeatherstone`,
+  :class:`~newton.solvers.SolverSemiImplicit`, and
+  :class:`~newton.solvers.SolverMuJoCo` when ``use_mujoco_contacts=False``. See
+  :ref:`Hydroelastic Contacts`.
 
 .. _Joint feature support:
 


### PR DESCRIPTION
## Description

Clarifies `ModelBuilder.ShapeConfig` material documentation so these fields are described as general model data rather than an exhaustive list of built-in solver support.

This also aligns `kf` wording with the Newton USD schema terminology (`contactFrictionGain`) by describing it as a tangential friction response gain instead of friction stiffness/damping.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx --python 3.12 pre-commit run -a
```

No runtime tests were run because this is a documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified hydroelastic contact stiffness terminology for `kh`, keeping the same default and refining scaling/pressure-law wording.
  * Reworked contact-material documentation tables and descriptions for `ke/kd`, `kf/ka`, and related parameters, with more general backend/solver usage notes.
  * Added a “Contact Material Support” section mapping contact-material fields to the solvers that consume them, including when `restitution` takes effect.
  * Refreshed `ShapeConfig`/`Model` parameter wording for tangential friction response gains and `restitution` availability (“where supported”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->