### PR TITLE
Allow release-assets host in license check egress

### DIFF
--- a/.github/workflows/pr_license_check.yml
+++ b/.github/workflows/pr_license_check.yml
@@ -28,6 +28,7 @@ jobs:
             api.github.com:443
             github.com:443
             proxy.golang.org:443
+            release-assets.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1


### PR DESCRIPTION
## Description

The `check-licenses` job started failing with `connect ECONNREFUSED` during `actions/setup-go`, which is run by the `apache/skywalking-eyes/header` composite action (it builds `license-eye` from Go source on every run). The Go toolchain tarball is downloaded from `release-assets.githubusercontent.com`, which was missing from this job's harden-runner allowlist.

While that host resolved into GitHub's Fastly CDN range it was implicitly trusted, but release assets are now also served from AWS addresses that harden-runner drops — so the download fails before any license header is checked. This is why the job is flaky: it only fails when the host resolves to an AWS address.

This adds `release-assets.githubusercontent.com:443` to `allowed-endpoints`, matching `ci.yml` and `pr.yml` which already list it.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

CI-only change; verified by the `License Check` workflow passing on this PR. The `ci.yml` and `pr.yml` workflows already allowlist this host and pass.

## Bug fix

**Steps to reproduce:**

1. Run the `License Check` workflow on a runner where `release-assets.githubusercontent.com` resolves to an AWS address (e.g. `54.185.253.63`).
2. `actions/setup-go` attempts to download the Go 1.23 toolchain from `https://github.com/actions/go-versions/releases/download/...`, which redirects to `release-assets.githubusercontent.com`.
3. harden-runner drops the connection (`domain not allowed`), `setup-go` fails with `connect ECONNREFUSED`, and the job errors before checking any license header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a pull request check workflow to allow access to an additional required endpoint, helping the check run successfully and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->