### PR TITLE
Tolerate TorchScript deprecation in neural actuator tests

### DIFF
--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import types
 import unittest
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -73,6 +74,24 @@ def _write_dof_values(model, array, dof_indices, values):
     for dof, val in zip(dof_indices, values, strict=True):
         arr_np[dof] = val
     wp.copy(array, wp.array(arr_np, dtype=float, device=model.device))
+
+
+def _ignore_torchscript_deprecation(test_case):
+    """Tolerate torch's TorchScript-family deprecation notices for one test.
+
+    The neural-controller tests deliberately exercise the TorchScript checkpoint
+    path (``torch.jit.script``/``save``/``load``), which PyTorch now deprecates in
+    favor of ``torch.export``. Ignore just those advisories, scoped to the calling
+    test, so strict-warnings mode still surfaces everything else.
+    """
+    ctx = warnings.catch_warnings()
+    ctx.__enter__()
+    test_case.addCleanup(ctx.__exit__, None, None, None)
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*torch\.jit\..* is deprecated",
+        category=DeprecationWarning,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +214,7 @@ class TestControllerNeuralMLP(unittest.TestCase):
             self.skipTest(f"{e}")
 
         self.torch = torch
+        _ignore_torchscript_deprecation(self)
         self.device = wp.get_device()
         self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
         self._tmp_dir = tempfile.mkdtemp()
@@ -319,6 +339,7 @@ class TestControllerNeuralLSTM(unittest.TestCase):
             self.skipTest(f"{e}")
 
         self.torch = torch
+        _ignore_torchscript_deprecation(self)
         self.device = wp.get_device()
         self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
         self._tmp_dir = tempfile.mkdtemp()
@@ -1414,6 +1435,7 @@ class TestNeuralActuatorUsdParsing(unittest.TestCase):
             self.skipTest(f"{e}")
 
         self.torch = torch
+        _ignore_torchscript_deprecation(self)
         self._tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):


### PR DESCRIPTION
## Description

The neural-actuator tests build TorchScript checkpoint fixtures (`torch.jit.script`/`torch.jit.save`) and load them through the actuator runtime (`torch.jit.load`). Current PyTorch deprecates the `torch.jit` TorchScript API in favor of `torch.export`, so the test runner's `--strict-warnings` mode (added in #3044) promotes those `DeprecationWarning`s to errors and fails the neural-controller tests.

This scopes a `warnings` filter to each neural test (via `setUp`) that ignores only torch's TorchScript-family deprecation notices, leaving every other warning to surface and the production loader untouched (so end users still see torch's advisory). Migrating the loader off the deprecated API is tracked in #3250.

Prerequisite for #3044, matching #3058–#3061.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — N/A, test-only

## Test plan

```
uv run --extra dev --extra torch-cu13 -m newton.tests --strict-warnings -k Neural
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced noisy deprecation warnings during neural controller test runs.
  * Test execution is now cleaner and less likely to surface expected TorchScript warnings as failures or distractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->