### PR TITLE
Map PhysX gravity disable to MuJoCo gravcomp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix USD import so non-unit `metersPerUnit` and `kilogramsPerUnit` warn as unsupported, and stop scaling `PhysicsScene` gravity magnitude by `metersPerUnit`.
+- Fix USD import of body-level `physxRigidBody:disableGravity` for `SolverMuJoCo` by mapping it to `mujoco:gravcomp` when MuJoCo custom attributes are registered.
 - Fix `SolverMuJoCo` reporting incorrect `State.body_qd` angular velocity for `JointType.D6` joints with two or three angular DOFs at non-identity configurations.
 - Fix VBD collision damping to use relative normal gap rate so uniform contact-stencil motion and tangential sliding do not create artificial normal damping.
 - Fix `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`.

--- a/docs/integrations/mujoco.rst
+++ b/docs/integrations/mujoco.rst
@@ -595,8 +595,11 @@ Caveats
   body-level ``physxRigidBody:disableGravity = true`` is imported as
   ``mujoco:gravcomp = 1.0``. An explicit ``mjc:gravcomp`` value on the same
   body takes precedence. This mapping affects MuJoCo gravity compensation; it
-  does not add a solver-independent per-body gravity flag to Newton's core
-  model.
+  does not add a solver-independent per-body gravity flag to Newton's core model.
+  It matches PhysX gravity disable only when the MuJoCo body has finite,
+  correct mass properties, because MuJoCo implements ``gravcomp`` as a
+  counter-force proportional to body mass rather than by removing the body
+  from gravity integration.
 
 **Kinematic-root armature override.**
   DOFs of kinematic articulation roots have their

--- a/docs/integrations/mujoco.rst
+++ b/docs/integrations/mujoco.rst
@@ -590,6 +590,14 @@ Caveats
   Newton's :attr:`~newton.Model.joint_velocity_limit` has no MuJoCo equivalent and is
   ignored.
 
+**Per-body gravity disable maps to MuJoCo gravcomp.**
+  When MuJoCo custom attributes are registered before USD import, authored
+  body-level ``physxRigidBody:disableGravity = true`` is imported as
+  ``mujoco:gravcomp = 1.0``. An explicit ``mjc:gravcomp`` value on the same
+  body takes precedence. This mapping affects MuJoCo gravity compensation; it
+  does not add a solver-independent per-body gravity flag to Newton's core
+  model.
+
 **Kinematic-root armature override.**
   DOFs of kinematic articulation roots have their
   :attr:`~newton.Model.joint_armature` replaced with a very large

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -677,6 +677,20 @@ class SolverMuJoCo(SolverBase):
                 return SOLREF_MODE_RAW
             return SOLREF_MODE_MJCF_DEFAULT
 
+        def parse_body_gravcomp_usd(_value: Any, context: dict[str, Any]) -> float | None:
+            prim = context.get("prim")
+            if prim is None:
+                return None
+
+            gravcomp_attr = prim.GetAttribute("mjc:gravcomp")
+            if gravcomp_attr is not None and gravcomp_attr.HasAuthoredValue():
+                return float(gravcomp_attr.Get())
+
+            disable_gravity_attr = prim.GetAttribute("physxRigidBody:disableGravity")
+            if disable_gravity_attr is not None and disable_gravity_attr.HasAuthoredValue():
+                return 1.0 if bool(disable_gravity_attr.Get()) else None
+            return None
+
         # region custom frequencies
         builder.add_custom_frequency(ModelBuilder.CustomFrequency(name="pair", namespace="mujoco"))
         builder.add_custom_frequency(
@@ -878,7 +892,8 @@ class SolverMuJoCo(SolverBase):
                 dtype=wp.float32,
                 default=0.0,
                 namespace="mujoco",
-                usd_attribute_name="mjc:gravcomp",
+                usd_attribute_name="*",
+                usd_value_transformer=parse_body_gravcomp_usd,
                 mjcf_attribute_name="gravcomp",
             )
         )

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -678,6 +678,7 @@ class SolverMuJoCo(SolverBase):
             return SOLREF_MODE_MJCF_DEFAULT
 
         def parse_body_gravcomp_usd(_value: Any, context: dict[str, Any]) -> float | None:
+            """Map USD body gravity controls to MuJoCo body ``gravcomp``."""
             prim = context.get("prim")
             if prim is None:
                 return None

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4331,6 +4331,57 @@ def Xform "NotPSD" (
         self.assertAlmostEqual(float(gravcomp_by_body["/Body3"]), 0.25)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_usd_articulation_disable_gravity_as_gravcomp(self):
+        """Test disableGravity mapping on an articulated child body through one MuJoCo step."""
+        from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        robot = UsdGeom.Xform.Define(stage, "/Robot")
+        UsdPhysics.ArticulationRootAPI.Apply(robot.GetPrim())
+
+        bodies = {}
+        for name in ("Base", "Link"):
+            body = UsdGeom.Xform.Define(stage, f"/Robot/{name}")
+            prim = body.GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(prim)
+            mass_api = UsdPhysics.MassAPI.Apply(prim)
+            mass_api.CreateMassAttr().Set(1.0)
+            mass_api.CreateDiagonalInertiaAttr().Set((1.0, 1.0, 1.0))
+            bodies[name] = body
+
+        bodies["Link"].GetPrim().CreateAttribute("physxRigidBody:disableGravity", Sdf.ValueTypeNames.Bool).Set(True)
+
+        joint = UsdPhysics.RevoluteJoint.Define(stage, "/Robot/Joint")
+        joint.CreateBody0Rel().SetTargets([bodies["Base"].GetPath()])
+        joint.CreateBody1Rel().SetTargets([bodies["Link"].GetPath()])
+        joint.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint.CreateAxisAttr().Set("Z")
+
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(stage)
+        model = builder.finalize()
+
+        gravcomp_by_body = dict(zip(model.body_label, model.mujoco.gravcomp.numpy(), strict=True))
+        self.assertAlmostEqual(float(gravcomp_by_body["/Robot/Base"]), 0.0)
+        self.assertAlmostEqual(float(gravcomp_by_body["/Robot/Link"]), 1.0)
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mj_body_id = solver.mj_model.body(model.body_label[model.body_label.index("/Robot/Link")].replace("/", "_")).id
+        self.assertAlmostEqual(float(solver.mj_model.body_gravcomp[mj_body_id]), 1.0)
+
+        state_in = model.state()
+        state_out = model.state()
+        solver.step(state_in, state_out, model.control(), model.contacts(), 1.0 / 60.0)
+        self.assertTrue(np.all(np.isfinite(state_out.body_q.numpy())))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_stiffness_damping(self):
         """Test that joint stiffness and damping are parsed correctly from USD."""
         from pxr import Usd

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4325,9 +4325,10 @@ def Xform "NotPSD" (
 
         gravcomp = model.mujoco.gravcomp.numpy()
         self.assertEqual(len(gravcomp), 3)
-        self.assertTrue(np.any(np.isclose(gravcomp, 1.0)))
-        self.assertTrue(np.any(np.isclose(gravcomp, 0.0)))
-        self.assertTrue(np.any(np.isclose(gravcomp, 0.25)))
+        gravcomp_by_body = dict(zip(model.body_label, gravcomp, strict=True))
+        self.assertAlmostEqual(float(gravcomp_by_body["/Body1"]), 1.0)
+        self.assertAlmostEqual(float(gravcomp_by_body["/Body2"]), 0.0)
+        self.assertAlmostEqual(float(gravcomp_by_body["/Body3"]), 0.25)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_stiffness_damping(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4298,6 +4298,38 @@ def Xform "NotPSD" (
         self.assertTrue(np.any(np.isclose(gravcomp, 0.0)))
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_usd_physx_disable_gravity_as_gravcomp(self):
+        """Test that body-level PhysX disableGravity maps to MuJoCo gravcomp."""
+        from pxr import Sdf, Usd, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        prim1 = stage.DefinePrim("/Body1", "Xform")
+        UsdPhysics.RigidBodyAPI.Apply(prim1)
+        prim1.CreateAttribute("physxRigidBody:disableGravity", Sdf.ValueTypeNames.Bool).Set(True)
+
+        prim2 = stage.DefinePrim("/Body2", "Xform")
+        UsdPhysics.RigidBodyAPI.Apply(prim2)
+        prim2.CreateAttribute("physxRigidBody:disableGravity", Sdf.ValueTypeNames.Bool).Set(False)
+
+        prim3 = stage.DefinePrim("/Body3", "Xform")
+        UsdPhysics.RigidBodyAPI.Apply(prim3)
+        prim3.CreateAttribute("physxRigidBody:disableGravity", Sdf.ValueTypeNames.Bool).Set(True)
+        prim3.CreateAttribute("mjc:gravcomp", Sdf.ValueTypeNames.Float).Set(0.25)
+
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(stage)
+        model = builder.finalize()
+
+        gravcomp = model.mujoco.gravcomp.numpy()
+        self.assertEqual(len(gravcomp), 3)
+        self.assertTrue(np.any(np.isclose(gravcomp, 1.0)))
+        self.assertTrue(np.any(np.isclose(gravcomp, 0.0)))
+        self.assertTrue(np.any(np.isclose(gravcomp, 0.25)))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_stiffness_damping(self):
         """Test that joint stiffness and damping are parsed correctly from USD."""
         from pxr import Usd


### PR DESCRIPTION
## Description

USD import already supports MuJoCo per-body gravity compensation through `mujoco:gravcomp`, but body-level PhysX `physxRigidBody:disableGravity` was not translated into that path. This PR imports authored `physxRigidBody:disableGravity = true` as `mujoco:gravcomp = 1.0` when MuJoCo custom attributes are registered, while preserving explicit `mjc:gravcomp` precedence.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools PRE_COMMIT_HOME=/tmp/pre-commit-cache uvx --python 3.12 pre-commit run ruff-format --files newton/_src/solvers/mujoco/solver_mujoco.py newton/tests/test_import_usd.py
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools PRE_COMMIT_HOME=/tmp/pre-commit-cache uvx --python 3.12 pre-commit run ruff --files newton/_src/solvers/mujoco/solver_mujoco.py newton/tests/test_import_usd.py
UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev -m newton.tests -k test_import_usd_physx_disable_gravity_as_gravcomp
git diff --check
```

## Bug fix

**Steps to reproduce:**

1. Register MuJoCo custom attributes on a `ModelBuilder`.
2. Import a USD rigid body with `physxRigidBody:disableGravity = true` and no explicit `mjc:gravcomp`.
3. Observe that `model.mujoco.gravcomp` keeps the default `0.0`, so `SolverMuJoCo` does not cancel gravity for that body.

**Minimal reproduction:**

```python
from pxr import Sdf, Usd, UsdPhysics
import newton
from newton.solvers import SolverMuJoCo

stage = Usd.Stage.CreateInMemory()
UsdPhysics.Scene.Define(stage, "/physicsScene")
body = stage.DefinePrim("/Body", "Xform")
UsdPhysics.RigidBodyAPI.Apply(body)
body.CreateAttribute("physxRigidBody:disableGravity", Sdf.ValueTypeNames.Bool).Set(True)

builder = newton.ModelBuilder()
SolverMuJoCo.register_custom_attributes(builder)
builder.add_usd(stage)
model = builder.finalize()
assert model.mujoco.gravcomp.numpy()[0] == 1.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD import so per-body PhysX `disableGravity` is mapped to MuJoCo gravity-compensation.
  * Ensured an explicitly authored `mjc:gravcomp` on the same body takes precedence over any imported `disableGravity`.
* **Documentation**
  * Added a caveat documenting the per-body gravity-compensation mapping behavior during USD import.
* **Tests**
  * Added regression coverage for mixed per-body gravity settings, including articulated robots and explicit override cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->