### PR TITLE
[Kamino] Small fix to PADMM Unit Tests

### DIFF
--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -401,7 +401,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.NONE,
             use_acceleration=False,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Solve the test problem
@@ -446,7 +446,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.NONE,
             use_acceleration=True,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Solve the test problem
@@ -490,7 +490,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.INTERNAL,
             use_acceleration=False,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Initial cold-started solve
@@ -537,7 +537,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.CONTAINERS,
             use_acceleration=False,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Initial cold-started solve
@@ -586,7 +586,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.INTERNAL,
             use_acceleration=True,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Initial cold-started solve
@@ -634,7 +634,7 @@ class TestPADMMSolver(unittest.TestCase):
             config=config,
             warmstart=PADMMWarmStartMode.CONTAINERS,
             use_acceleration=True,
-            collect_info=True,
+            collect_info=self.savefig,
         )
 
         # Initial cold-started solve
@@ -666,7 +666,7 @@ class TestPADMMSolver(unittest.TestCase):
         test = TestSetup(builder_fn=basics.build_box_on_plane, max_world_contacts=1, device=self.default_device)
 
         # Create the PADMM solver
-        solver = PADMMSolver(model=test.model, collect_info=True)
+        solver = PADMMSolver(model=test.model, collect_info=self.savefig)
 
         # Solve the test problem
         test.build()

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -657,7 +657,7 @@ class TestPADMMSolver(unittest.TestCase):
             path = self.output_path / "test_07_padmm_solve_with_acceleration_and_container_warmstart.pdf"
             save_solver_info(solver=solver, path=str(path))
 
-    def test_10_padmm_solve_single_contact(self):
+    def test_08_padmm_solve_single_contact(self):
         """
         Tests the Proximal-ADMM (PADMM) solver with default config on the reference problem (no
         constraints and limits) with a single contact.
@@ -666,7 +666,7 @@ class TestPADMMSolver(unittest.TestCase):
         test = TestSetup(builder_fn=basics.build_box_on_plane, max_world_contacts=1, device=self.default_device)
 
         # Create the PADMM solver
-        solver = PADMMSolver(model=test.model)
+        solver = PADMMSolver(model=test.model, collect_info=True)
 
         # Solve the test problem
         test.build()
@@ -675,9 +675,9 @@ class TestPADMMSolver(unittest.TestCase):
         solver.solve(problem=test.problem)
 
         # Extract solver info
-        if self.savefig:
+        if self.savefig and solver.data.info is not None:
             msg.notif("Generating solver info plots...")
-            path = self.output_path / "test_10_padmm_solve.pdf"
+            path = self.output_path / "test_08_padmm_solve.pdf"
             save_solver_info(solver=solver, path=str(path))
 
         # Check solution


### PR DESCRIPTION
## Description

Fixes broken PADMM UT when verbose output and plotting are enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed the PADMM single-contact unit test and updated the saved output filename accordingly.
  * Updated PADMM test setup to collect solver information only when saving is enabled.
  * Tightened solver plot generation to run only when solver info exists and saving is turned on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->