### PR TITLE
Parse actuator_ctrlrange, forcerange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Fixed
 
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
+- Fix `SolverMuJoCo` dropping the authored `actuator_ctrlrange`/`actuator_ctrllimited`/`actuator_forcerange`/`actuator_forcelimited` when rebuilding USD/MJCF position/velocity actuators imported as `JOINT_TARGET`, so the compiled `mj_model` now clamps control targets and actuator forces like native MuJoCo.
 - Fix `SolverVBD` rigid contact injecting kinetic energy for yawed finite-radius contacts (e.g. small-radius cables blowing up). The normal response now acts at the geometric skeleton point rather than the rotating surface anchor, which was non-conservative under reorientation; friction still uses the surface anchor to preserve finite-radius slip. (#3125)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5497,7 +5497,9 @@ class SolverMuJoCo(SolverBase):
                         if mode == JointTargetMode.POSITION:
                             args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=name, **args)
+                            # A ball joint's authored range lives on a single source row
+                            # (keyed by the joint base DOF); apply it to every axis actuator.
+                            spec.add_actuator(target=name, **joint_target_actuator_kwargs(args, qd_start, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5508,7 +5510,7 @@ class SolverMuJoCo(SolverBase):
                         elif mode == JointTargetMode.POSITION_VELOCITY:
                             args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=name, **args)
+                            spec.add_actuator(target=name, **joint_target_actuator_kwargs(args, qd_start, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5520,7 +5522,7 @@ class SolverMuJoCo(SolverBase):
                         if mode in (JointTargetMode.VELOCITY, JointTargetMode.POSITION_VELOCITY):
                             args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=name, **args)
+                            spec.add_actuator(target=name, **joint_target_actuator_kwargs(args, qd_start, False))
                             axis_to_actuator[ai, 1] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(-(template_dof + 2))  # negative = velocity

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5264,9 +5264,8 @@ class SolverMuJoCo(SolverBase):
         # This is needed for CTRL_DIRECT actuators targeting joints within combined Newton joints.
         mjc_joint_names: list[str] = []
 
-        # Authored ctrl/force ranges to re-attach to rebuilt JOINT_TARGET actuators
-        # (the rebuild drops them otherwise; issues #2928, #3234). Keyed by
-        # (dof, is_position) so a joint's position and velocity sub-actuators can carry
+        # Saved ctrl/force ranges. The rebuild drops them, so re-attach after.
+        # Key = (dof, is_position): position and velocity sub-actuators can have
         # different ranges.
         joint_target_ranges: dict[tuple[int, bool], dict[str, Any]] = {}
         if mujoco_attrs is not None and hasattr(mujoco_attrs, "actuator_trnid"):

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1956,6 +1956,17 @@ class SolverMuJoCo(SolverBase):
                 namespace="mujoco",
             )
         )
+        # Actuator kind (position/velocity/general), classified once at import.
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="ctrl_type",
+                frequency="mujoco:actuator",
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.int32,
+                default=int(SolverMuJoCo.CtrlType.GENERAL),
+                namespace="mujoco",
+            )
+        )
         # endregion actuator attributes
 
         # region tendon attributes
@@ -5253,6 +5264,79 @@ class SolverMuJoCo(SolverBase):
         # This is needed for CTRL_DIRECT actuators targeting joints within combined Newton joints.
         mjc_joint_names: list[str] = []
 
+        # Authored ctrl/force ranges to re-attach to rebuilt JOINT_TARGET actuators
+        # (the rebuild drops them otherwise; issues #2928, #3234). Keyed by
+        # (dof, is_position) so a joint's position and velocity sub-actuators can carry
+        # different ranges.
+        joint_target_ranges: dict[tuple[int, bool], dict[str, Any]] = {}
+        if mujoco_attrs is not None and hasattr(mujoco_attrs, "actuator_trnid"):
+            jt_count = model.custom_frequency_counts.get("mujoco:actuator", 0)
+            jt_trnid = get_custom_attribute("actuator_trnid")
+            jt_ctrl_source = get_custom_attribute("ctrl_source")
+            jt_trntype = get_custom_attribute("actuator_trntype")
+            jt_world = get_custom_attribute("actuator_world")
+            jt_ctrl_type = get_custom_attribute("ctrl_type")
+            jt_has_ctrlrange = get_custom_attribute("actuator_has_ctrlrange")
+            jt_ctrlrange = get_custom_attribute("actuator_ctrlrange")
+            jt_ctrllimited = get_custom_attribute("actuator_ctrllimited")
+            jt_has_forcerange = get_custom_attribute("actuator_has_forcerange")
+            jt_forcerange = get_custom_attribute("actuator_forcerange")
+            jt_forcelimited = get_custom_attribute("actuator_forcelimited")
+
+            # Which sub-actuator a row feeds (as is_position): position->position only,
+            # velocity->velocity only, unknown->both.
+            BOTH_KINDS = (True, False)
+            kinds_by_ctrl_type = {
+                int(SolverMuJoCo.CtrlType.POSITION): (True,),
+                int(SolverMuJoCo.CtrlType.VELOCITY): (False,),
+            }
+
+            def classify_joint_target_kinds(row: int) -> tuple[bool, ...]:
+                if jt_ctrl_type is None:
+                    return BOTH_KINDS
+                return kinds_by_ctrl_type.get(int(jt_ctrl_type[row]), BOTH_KINDS)
+
+            for row in range(jt_count):
+                if jt_ctrl_source is None or int(jt_ctrl_source[row]) != int(SolverMuJoCo.CtrlSource.JOINT_TARGET):
+                    continue
+                if jt_trntype is not None and int(jt_trntype[row]) != int(SolverMuJoCo.TrnType.JOINT):
+                    continue
+                if jt_world is not None:
+                    w = int(jt_world[row])
+                    if w != first_world and w != -1:
+                        continue
+                if jt_trnid is None:
+                    continue
+                dof = int(jt_trnid[row, 0])
+                if dof < 0:
+                    continue
+                info = {
+                    "has_ctrlrange": bool(jt_has_ctrlrange[row]) if jt_has_ctrlrange is not None else False,
+                    "ctrlrange": tuple(jt_ctrlrange[row]) if jt_ctrlrange is not None else None,
+                    "ctrllimited": int(jt_ctrllimited[row]) if jt_ctrllimited is not None else None,
+                    "has_forcerange": bool(jt_has_forcerange[row]) if jt_has_forcerange is not None else False,
+                    "forcerange": tuple(jt_forcerange[row]) if jt_forcerange is not None else None,
+                    "forcelimited": int(jt_forcelimited[row]) if jt_forcelimited is not None else None,
+                }
+                for is_position in classify_joint_target_kinds(row):
+                    joint_target_ranges[(dof, is_position)] = info
+
+        def joint_target_actuator_kwargs(base: dict[str, Any], dof: int, is_position: bool) -> dict[str, Any]:
+            """Merge the matching row's authored ctrl/force ranges onto a sub-actuator's kwargs."""
+            kwargs = dict(base)
+            info = joint_target_ranges.get((dof, is_position))
+            if info is None:
+                return kwargs
+            if info["ctrllimited"] is not None:
+                kwargs["ctrllimited"] = info["ctrllimited"]
+            if info["has_ctrlrange"] and info["ctrlrange"] is not None:
+                kwargs["ctrlrange"] = info["ctrlrange"]
+            if info["forcelimited"] is not None:
+                kwargs["forcelimited"] = info["forcelimited"]
+            if info["has_forcerange"] and info["forcerange"] is not None:
+                kwargs["forcerange"] = info["forcerange"]
+            return kwargs
+
         # need to keep track of current dof and joint counts to make the indexing above correct
         num_dofs = 0
         num_qpos = 0
@@ -5540,7 +5624,7 @@ class SolverMuJoCo(SolverBase):
                         if mode == JointTargetMode.POSITION:
                             actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5551,7 +5635,7 @@ class SolverMuJoCo(SolverBase):
                         elif mode == JointTargetMode.POSITION_VELOCITY:
                             actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5563,7 +5647,7 @@ class SolverMuJoCo(SolverBase):
                         if mode in (JointTargetMode.VELOCITY, JointTargetMode.POSITION_VELOCITY):
                             actuator_args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, False))
                             axis_to_actuator[ai, 1] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(-(template_dof + 2))  # negative = velocity
@@ -5652,7 +5736,7 @@ class SolverMuJoCo(SolverBase):
                         if mode == JointTargetMode.POSITION:
                             actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, -kp, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5663,7 +5747,7 @@ class SolverMuJoCo(SolverBase):
                         elif mode == JointTargetMode.POSITION_VELOCITY:
                             actuator_args["gainprm"] = [kp, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, -kp, 0, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, True))
                             axis_to_actuator[ai, 0] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(template_dof)  # positive = position
@@ -5675,7 +5759,7 @@ class SolverMuJoCo(SolverBase):
                         if mode in (JointTargetMode.VELOCITY, JointTargetMode.POSITION_VELOCITY):
                             actuator_args["gainprm"] = [kd, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                             actuator_args["biasprm"] = [0, 0, -kd, 0, 0, 0, 0, 0, 0, 0]
-                            spec.add_actuator(target=axname, **actuator_args)
+                            spec.add_actuator(target=axname, **joint_target_actuator_kwargs(actuator_args, ai, False))
                             axis_to_actuator[ai, 1] = actuator_count
                             mjc_actuator_ctrl_source_list.append(0)  # JOINT_TARGET
                             mjc_actuator_to_newton_idx_list.append(-(template_dof + 2))  # negative = velocity

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -2972,11 +2972,20 @@ def parse_mjcf(
                 if key not in parsed_attrs:
                     parsed_attrs[key] = value
 
+            # Intrinsic actuator kind, known directly from the MJCF shortcut tag.
+            if actuator_type == "position":
+                ctrl_type_val = int(SolverMuJoCo.CtrlType.POSITION)
+            elif actuator_type == "velocity":
+                ctrl_type_val = int(SolverMuJoCo.CtrlType.VELOCITY)
+            else:
+                ctrl_type_val = int(SolverMuJoCo.CtrlType.GENERAL)
+
             # Build full values dict
             actuator_values: dict[str, Any] = {}
             for attr in builder_custom_attr_actuator:
                 if attr.key in (
                     "mujoco:ctrl_source",
+                    "mujoco:ctrl_type",
                     "mujoco:actuator_trntype",
                     "mujoco:actuator_gainprm",
                     "mujoco:actuator_biasprm",
@@ -2986,6 +2995,7 @@ def parse_mjcf(
                 actuator_values[attr.key] = parsed_attrs.get(attr.key, attr.default)
 
             actuator_values["mujoco:ctrl_source"] = ctrl_source_val
+            actuator_values["mujoco:ctrl_type"] = ctrl_type_val
             actuator_values["mujoco:actuator_gainprm"] = gainprm
             actuator_values["mujoco:actuator_biasprm"] = biasprm
             actuator_values["mujoco:actuator_trnid"] = wp.vec2i(target_idx, 0)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4278,11 +4278,9 @@ def parse_usd(
             # actuators with default dyntype/gaintype/biastype/gear, so non-default
             # values for those force the actuator to stay CTRL_DIRECT.
             #
-            # Authored ctrlrange/forcerange are not gating: the solver re-attaches both
-            # to the rebuilt actuator (see joint_target_ranges in _init_actuators), so
-            # they map to actuator_ctrlrange/actuator_forcerange just like native MJCF.
-            # The joint-level effort limit (jnt_actfrcrange) is left to the joint's own
-            # forceLimit/actuatorfrcrange, not the actuator's forcerange.
+            # ctrlrange/forcerange don't gate: the rebuild re-attaches them
+            # (see joint_target_ranges in _init_actuators). Effort limit
+            # (jnt_actfrcrange) comes from the joint, not the actuator.
             if (
                 int(_row("mujoco:actuator_biastype", row)) != biastype_affine
                 or int(_row("mujoco:actuator_dyntype", row)) != dyntype_none

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4265,7 +4265,6 @@ def parse_usd(
             value = attr.values[row] if row < len(attr.values) else None
             return attr.default if value is None else value
 
-        autolimits = bool(_row("mujoco:autolimits", 0))
         converted = 0
 
         for row in range(mjc_actuator_count):
@@ -4279,9 +4278,11 @@ def parse_usd(
             # actuators with default dyntype/gaintype/biastype/gear, so non-default
             # values for those force the actuator to stay CTRL_DIRECT.
             #
-            # Authored ctrlrange/forcerange are not gating: ctrlrange has no
-            # equivalent under Control.joint_target_q/qd (matching MJCF's
-            # behavior), and forcerange is propagated below into joint_effort_limit.
+            # Authored ctrlrange/forcerange are not gating: the solver re-attaches both
+            # to the rebuilt actuator (see joint_target_ranges in _init_actuators), so
+            # they map to actuator_ctrlrange/actuator_forcerange just like native MJCF.
+            # The joint-level effort limit (jnt_actfrcrange) is left to the joint's own
+            # forceLimit/actuatorfrcrange, not the actuator's forcerange.
             if (
                 int(_row("mujoco:actuator_biastype", row)) != biastype_affine
                 or int(_row("mujoco:actuator_dyntype", row)) != dyntype_none
@@ -4326,21 +4327,10 @@ def parse_usd(
             # so _init_actuators routes through MuJoCo's joint_target_mode actuators.
             builder.custom_attributes["mujoco:ctrl_source"].values[row] = ctrl_source_joint_target
             builder.custom_attributes["mujoco:actuator_trnid"].values[row] = wp.vec2i(dof, 0)
-
-            # Tighten the joint effort limit when the actuator authored a forceRange.
-            if bool(_row("mujoco:actuator_has_forcerange", row)):
-                limited = int(_row("mujoco:actuator_forcelimited", row))
-                if limited == 1 or (limited == 2 and autolimits):
-                    force_range = list(_row("mujoco:actuator_forcerange", row))
-                    limit = max(abs(force_range[0]), abs(force_range[1]))
-                    current = builder.joint_effort_limit[dof]
-                    if not np.isfinite(current) or limit < current:
-                        if np.isfinite(current) and verbose:
-                            print(
-                                f"MuJoCo USD actuator {row} narrows joint DOF {dof} "
-                                f"effort limit from {current} to {limit}"
-                            )
-                        builder.joint_effort_limit[dof] = limit
+            # Record the kind classified above so the solver doesn't re-derive it.
+            builder.custom_attributes["mujoco:ctrl_type"].values[row] = int(
+                SolverMuJoCo.CtrlType.POSITION if is_position else SolverMuJoCo.CtrlType.VELOCITY
+            )
 
             converted += 1
 

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1319,15 +1319,11 @@ class TestMenagerieUSD(TestMenagerieBase):
         "actuator_lengthrange",
     }
 
-    # Per-joint fields the USD parser doesn't populate to match native MJCF
-    # compilation, but which step-response dynamics depends on. Empirically
-    # pinned down on ShadowHand: without these, qfrc_constraint diverges at
-    # step 1+ (joint-limit solref + actfrc).
-    #
-    # Per-actuator clipping fields (actuator_ctrlrange/ctrllimited/forcerange/
-    # forcelimited) no longer need backfilling: SolverMuJoCo now re-attaches the
-    # authored ctrl/force ranges when rebuilding JOINT_TARGET actuators from USD
-    # MjcActuator rows (issues #2928, #3234).
+    # Per-joint fields the USD parser doesn't populate to match native MJCF, but
+    # which step-response dynamics depend on (joint-limit solref + actfrc range).
+    # Without them, qfrc_constraint diverges from step 1 onward.
+    # Actuator ctrl/force ranges are not listed: the solver re-attaches them when
+    # rebuilding JOINT_TARGET actuators, so no backfill is needed.
     usd_joint_backfill_fields: ClassVar[list[str]] = [
         "jnt_solref",
         "jnt_actfrclimited",

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1882,11 +1882,6 @@ class TestMenagerieUSD_UR5e(TestMenagerieUSD):
     usd_asset_folder = "universal_robots_ur5e"
     usd_scene_file = "usd_structured/ur5e.usda"
 
-    # UR5e USD MjcActuator rows match the position-shortcut pattern, so they're
-    # imported as JOINT_TARGET (see parse_usd's MjcActuator post-process).
-    # _init_actuators now re-attaches the authored per-actuator forcerange (and
-    # ctrlrange) when rebuilding these actuators, matching native MJCF's clipping
-    # path (issues #2928, #3234), so step-response dynamics are enabled again.
     num_steps = 20
     fk_enabled = True
     backfill_model = True

--- a/newton/tests/test_menagerie_usd_mujoco.py
+++ b/newton/tests/test_menagerie_usd_mujoco.py
@@ -1319,17 +1319,15 @@ class TestMenagerieUSD(TestMenagerieBase):
         "actuator_lengthrange",
     }
 
-    # Per-actuator and per-joint fields the USD parser doesn't populate to match
-    # native MJCF compilation, but which step-response dynamics depends on.
-    # Empirically pinned down on ShadowHand: without these, qfrc_actuator
-    # diverges at step 0 (actuator clipping fields), and qfrc_constraint
-    # diverges at step 1+ (joint-limit solref + actfrc).
-    usd_actuator_backfill_fields: ClassVar[list[str]] = [
-        "actuator_ctrlrange",
-        "actuator_ctrllimited",
-        "actuator_forcerange",
-        "actuator_forcelimited",
-    ]
+    # Per-joint fields the USD parser doesn't populate to match native MJCF
+    # compilation, but which step-response dynamics depends on. Empirically
+    # pinned down on ShadowHand: without these, qfrc_constraint diverges at
+    # step 1+ (joint-limit solref + actfrc).
+    #
+    # Per-actuator clipping fields (actuator_ctrlrange/ctrllimited/forcerange/
+    # forcelimited) no longer need backfilling: SolverMuJoCo now re-attaches the
+    # authored ctrl/force ranges when rebuilding JOINT_TARGET actuators from USD
+    # MjcActuator rows (issues #2928, #3234).
     usd_joint_backfill_fields: ClassVar[list[str]] = [
         "jnt_solref",
         "jnt_actfrclimited",
@@ -1380,8 +1378,6 @@ class TestMenagerieUSD(TestMenagerieBase):
                     out[nw] = m[ni]
             getattr(newton_mjw, field).assign(out)
 
-        for field in self.usd_actuator_backfill_fields:
-            _backfill_permuted(field, self._actuator_map)
         for field in self.usd_joint_backfill_fields:
             _backfill_permuted(field, self._jnt_map)
         for field in self.usd_body_backfill_fields:
@@ -1886,18 +1882,12 @@ class TestMenagerieUSD_UR5e(TestMenagerieUSD):
     usd_asset_folder = "universal_robots_ur5e"
     usd_scene_file = "usd_structured/ur5e.usda"
 
-    # TODO(#2420): re-enable step-response dynamics. UR5e USD MjcActuator rows
-    # match the position-shortcut pattern, so they're imported as JOINT_TARGET
-    # (see parse_usd's MjcActuator post-process). _init_actuators rebuilds
-    # JOINT_TARGET actuators with no per-actuator forcerange and instead clamps
-    # at the joint via jnt_actfrcrange. Native MJCF UR5e uses per-actuator
-    # forcerange. Both clip at the same magnitude, but mujoco-warp routes them
-    # through different code paths (joint-level becomes a solver constraint),
-    # producing small qpos diffs (~1e-3) at step 0 that exceed the 1e-6
-    # tolerance. The fix is to also set actuator_forcerange on JOINT_TARGET-
-    # built actuators in _init_actuators so the clipping path matches native;
-    # that affects the MJCF JOINT_TARGET path too and is out of scope here.
-    num_steps = 0
+    # UR5e USD MjcActuator rows match the position-shortcut pattern, so they're
+    # imported as JOINT_TARGET (see parse_usd's MjcActuator post-process).
+    # _init_actuators now re-attaches the authored per-actuator forcerange (and
+    # ctrlrange) when rebuilding these actuators, matching native MJCF's clipping
+    # path (issues #2928, #3234), so step-response dynamics are enabled again.
+    num_steps = 20
     fk_enabled = True
     backfill_model = True
 

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -465,6 +465,37 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertTrue(seen_position, "no position sub-actuator found")
         self.assertTrue(seen_velocity, "no velocity sub-actuator found")
 
+    def test_ball_joint_target_ranges_applied_to_all_axes(self):
+        """A ball-joint position actuator is rebuilt as three per-axis MuJoCo actuators.
+        The single authored ctrl/force range must be applied to every axis, not dropped
+        (the ball path mirrors the hinge/slide range plumbing)."""
+        mjcf = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="ball">
+    <option gravity="0 0 0"/>
+    <worldbody>
+        <body name="link" pos="0 0 0">
+            <joint name="bj" type="ball"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+        </body>
+    </worldbody>
+    <actuator>
+        <position name="p" joint="bj" kp="100" forcerange="-7 7" forcelimited="true" ctrlrange="-2 2" ctrllimited="true"/>
+    </actuator>
+</mujoco>
+"""
+        builder = ModelBuilder()
+        builder.add_mjcf(mjcf, ctrl_direct=False)
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mj_model = solver.mj_model
+        self.assertEqual(mj_model.nu, 3)  # one actuator per ball DOF
+        for mj_idx in range(mj_model.nu):
+            np.testing.assert_allclose(mj_model.actuator_forcerange[mj_idx], [-7.0, 7.0], atol=1e-5)
+            np.testing.assert_allclose(mj_model.actuator_ctrlrange[mj_idx], [-2.0, 2.0], atol=1e-5)
+            self.assertTrue(bool(mj_model.actuator_forcelimited[mj_idx]))
+            self.assertTrue(bool(mj_model.actuator_ctrllimited[mj_idx]))
+
     def test_parsing_ctrl_direct_true(self):
         """Test parsing with ctrl_direct=True."""
         builder = ModelBuilder()

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -180,6 +180,7 @@ def assert_solver_actuator_mapping(test, model, expected_indices):
         [SolverMuJoCo.CtrlSource.JOINT_TARGET] * len(expected_indices),
     )
     np.testing.assert_array_equal(solver.mjc_actuator_to_newton_idx.numpy(), expected_indices)
+    return solver
 
 
 def find_joint_by_name(builder, joint_name):
@@ -207,7 +208,8 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertEqual(builder.joint_target_mode[dof], int(JointTargetMode.POSITION))
         self.assertEqual(builder.joint_target_ke[dof], 12.0)
         self.assertEqual(builder.joint_target_kd[dof], 0.0)
-        self.assertEqual(builder.joint_effort_limit[dof], 5.0)
+        # forceRange maps to the actuator's forcerange, not the joint effort limit (matches MJCF).
+        self.assertEqual(builder.joint_effort_limit[dof], builder.default_joint_cfg.effort_limit)
 
         model = builder.finalize()
         self.assertEqual(model.custom_frequency_counts.get("mujoco:actuator", 0), 1)
@@ -215,7 +217,8 @@ class TestMuJoCoActuators(unittest.TestCase):
         np.testing.assert_array_equal(model.mujoco.ctrl_source.numpy(), [SolverMuJoCo.CtrlSource.JOINT_TARGET])
         np.testing.assert_array_equal(model.mujoco.actuator_trnid.numpy(), [[dof, 0]])
 
-        assert_solver_actuator_mapping(self, model, [dof])
+        solver = assert_solver_actuator_mapping(self, model, [dof])
+        np.testing.assert_allclose(solver.mj_model.actuator_forcerange[0], [-5.0, 5.0], atol=1e-5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_usd_mjc_velocity_actuator_sets_velocity_target(self):
@@ -244,7 +247,9 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertEqual(builder.joint_target_mode[dof], int(JointTargetMode.POSITION_VELOCITY))
         self.assertEqual(builder.joint_target_ke[dof], 12.0)
         self.assertEqual(builder.joint_target_kd[dof], 4.0)
-        self.assertEqual(builder.joint_effort_limit[dof], 5.0)
+        # Only the position actuator authored a forceRange; it maps to that sub-actuator's
+        # forcerange (below), not the joint effort limit (matches MJCF).
+        self.assertEqual(builder.joint_effort_limit[dof], builder.default_joint_cfg.effort_limit)
 
         model = builder.finalize()
         self.assertEqual(model.custom_frequency_counts.get("mujoco:actuator", 0), 2)
@@ -255,7 +260,11 @@ class TestMuJoCoActuators(unittest.TestCase):
         )
         np.testing.assert_array_equal(model.mujoco.actuator_trnid.numpy(), [[dof, 0], [dof, 0]])
 
-        assert_solver_actuator_mapping(self, model, [dof, -(dof + 2)])
+        solver = assert_solver_actuator_mapping(self, model, [dof, -(dof + 2)])
+        mjc_to_newton = solver.mjc_actuator_to_newton_idx.numpy()
+        for mj_idx in range(solver.mj_model.nu):
+            if mjc_to_newton[mj_idx] >= 0:  # position sub-actuator carries the authored forceRange
+                np.testing.assert_allclose(solver.mj_model.actuator_forcerange[mj_idx], [-5.0, 5.0], atol=1e-5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_usd_mjc_direct_actuator_stays_ctrl_direct(self):
@@ -401,6 +410,60 @@ class TestMuJoCoActuators(unittest.TestCase):
                     kd = joint_target_kd[dof_idx]
                     np.testing.assert_allclose(mj_model.actuator_gainprm[mj_idx, 0], kd, atol=1e-5)
                     np.testing.assert_allclose(mj_model.actuator_biasprm[mj_idx, 2], -kd, atol=1e-5)
+
+    def test_joint_target_distinct_position_velocity_ranges(self):
+        """A joint driven by both a position and a velocity actuator (merged into
+        POSITION_VELOCITY) must keep each sub-actuator's own ctrl/force range in the
+        compiled mj_model, even when they differ (issues #2928, #3234)."""
+        mjcf = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="dual_actuator">
+    <option gravity="0 0 0"/>
+    <worldbody>
+        <body name="link" pos="0 0 0">
+            <joint name="j" axis="0 0 1" type="hinge"/>
+            <geom type="box" size="0.1 0.1 0.1" mass="1"/>
+        </body>
+    </worldbody>
+    <actuator>
+        <position name="p" joint="j" kp="100" forcerange="-7 7" forcelimited="true" ctrlrange="-2 2" ctrllimited="true"/>
+        <velocity name="v" joint="j" kv="10" forcerange="-3 3" forcelimited="true" ctrlrange="-5 5" ctrllimited="true"/>
+    </actuator>
+</mujoco>
+"""
+        builder = ModelBuilder()
+        builder.add_mjcf(mjcf, ctrl_direct=False)
+        model = builder.finalize()
+
+        self.assertEqual(
+            model.joint_target_mode.numpy()[get_qd_start(builder, "j")],
+            int(JointTargetMode.POSITION_VELOCITY),
+        )
+
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+        mj_model = solver.mj_model
+        self.assertEqual(mj_model.nu, 2)
+
+        mjc_ctrl_source = solver.mjc_actuator_ctrl_source.numpy()
+        mjc_to_newton = solver.mjc_actuator_to_newton_idx.numpy()
+
+        seen_position = False
+        seen_velocity = False
+        for mj_idx in range(mj_model.nu):
+            self.assertEqual(mjc_ctrl_source[mj_idx], SolverMuJoCo.CtrlSource.JOINT_TARGET)
+            # JOINT_TARGET: idx >= 0 is a position sub-actuator, idx <= -2 is velocity.
+            if mjc_to_newton[mj_idx] >= 0:
+                seen_position = True
+                np.testing.assert_allclose(mj_model.actuator_forcerange[mj_idx], [-7.0, 7.0], atol=1e-5)
+                np.testing.assert_allclose(mj_model.actuator_ctrlrange[mj_idx], [-2.0, 2.0], atol=1e-5)
+            else:
+                seen_velocity = True
+                np.testing.assert_allclose(mj_model.actuator_forcerange[mj_idx], [-3.0, 3.0], atol=1e-5)
+                np.testing.assert_allclose(mj_model.actuator_ctrlrange[mj_idx], [-5.0, 5.0], atol=1e-5)
+            self.assertTrue(bool(mj_model.actuator_forcelimited[mj_idx]))
+            self.assertTrue(bool(mj_model.actuator_ctrllimited[mj_idx]))
+
+        self.assertTrue(seen_position, "no position sub-actuator found")
+        self.assertTrue(seen_velocity, "no velocity sub-actuator found")
 
     def test_parsing_ctrl_direct_true(self):
         """Test parsing with ctrl_direct=True."""

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -411,9 +411,11 @@ class TestMuJoCoActuators(unittest.TestCase):
                     np.testing.assert_allclose(mj_model.actuator_biasprm[mj_idx, 2], -kd, atol=1e-5)
 
     def test_joint_target_distinct_position_velocity_ranges(self):
-        """A joint driven by both a position and a velocity actuator (merged into
-        POSITION_VELOCITY) must keep each sub-actuator's own ctrl/force range in the
-        compiled mj_model, even when they differ (issues #2928, #3234)."""
+        """Position + velocity actuators on one joint keep separate ctrl/force ranges.
+
+        The two are merged into a single POSITION_VELOCITY joint target, then rebuilt
+        as two mj_model actuators; each must carry its own authored range.
+        """
         mjcf = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="dual_actuator">
     <option gravity="0 0 0"/>
@@ -465,9 +467,10 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertTrue(seen_velocity, "no velocity sub-actuator found")
 
     def test_ball_joint_target_ranges_applied_to_all_axes(self):
-        """A ball-joint position actuator is rebuilt as three per-axis MuJoCo actuators.
-        The single authored ctrl/force range must be applied to every axis, not dropped
-        (the ball path mirrors the hinge/slide range plumbing)."""
+        """A ball-joint position actuator expands to one mj_model actuator per axis.
+
+        The single authored ctrl/force range must apply to every per-axis actuator.
+        """
         mjcf = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="ball">
     <option gravity="0 0 0"/>

--- a/newton/tests/test_mujoco_general_actuators.py
+++ b/newton/tests/test_mujoco_general_actuators.py
@@ -208,7 +208,6 @@ class TestMuJoCoActuators(unittest.TestCase):
         self.assertEqual(builder.joint_target_mode[dof], int(JointTargetMode.POSITION))
         self.assertEqual(builder.joint_target_ke[dof], 12.0)
         self.assertEqual(builder.joint_target_kd[dof], 0.0)
-        # forceRange maps to the actuator's forcerange, not the joint effort limit (matches MJCF).
         self.assertEqual(builder.joint_effort_limit[dof], builder.default_joint_cfg.effort_limit)
 
         model = builder.finalize()


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve authored `JOINT_TARGET` actuator `ctrlrange`/`forcerange` and `ctrllimited`/`forcelimited` when rebuilding actuators from USD/MJCF, ensuring compiled behavior matches native MuJoCo.
  * Improve joint-target control-type handling (position vs velocity vs general) so merged position/velocity sub-actuators keep their distinct ranges/limits.
  * Remove incorrect ctrl/force backfilling and avoid unintended joint-level effort-limit tightening during import.

* **Tests**
  * Expanded/adjusted assertions for preserved actuator ranges and enabled the UR5e step-response equivalence test.
  * Added a unit test covering distinct authored position vs velocity ranges on the same joint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->