### PR TITLE
Preserve MJCF geom groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix `SolverImplicitMPM` whole-step CUDA graph capture failing when the rheology inner solver is an iterative linear method such as `solver="cg"`. (#3155)
+- Preserve MJCF geom visualization groups when constructing MuJoCo models. (#2492)
 - Fix USD import so non-unit `metersPerUnit` and `kilogramsPerUnit` warn as unsupported, and stop scaling `PhysicsScene` gravity magnitude by `metersPerUnit`.
 - Fix swapped kinetic and potential energy labels in the `basic_plotting` example, and report per-world values directly so the live plot overlays match the side-panel readouts
 - Fix `SolverMuJoCo` reporting incorrect `State.body_qd` angular velocity for `JointType.D6` joints with two or three angular DOFs at non-identity configurations.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -723,6 +723,18 @@ class SolverMuJoCo(SolverBase):
         )
         builder.add_custom_attribute(
             ModelBuilder.CustomAttribute(
+                name="geom_group",
+                frequency=AttributeFrequency.SHAPE,
+                assignment=AttributeAssignment.MODEL,
+                dtype=wp.int32,
+                default=0,
+                namespace="mujoco",
+                usd_attribute_name="mjc:group",
+                mjcf_attribute_name="group",
+            )
+        )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
                 name="geom_priority",
                 frequency=AttributeFrequency.SHAPE,
                 assignment=AttributeAssignment.MODEL,
@@ -4733,6 +4745,7 @@ class SolverMuJoCo(SolverBase):
             return attr.numpy()
 
         shape_condim = get_custom_attribute("condim")
+        shape_geom_group = get_custom_attribute("geom_group")
         shape_priority = get_custom_attribute("geom_priority")
         shape_geom_solimp = get_custom_attribute("geom_solimp")
         shape_geom_solmix = get_custom_attribute("geom_solmix")
@@ -5208,6 +5221,8 @@ class SolverMuJoCo(SolverBase):
 
                 if shape_condim is not None:
                     geom_params["condim"] = shape_condim[shape]
+                if shape_geom_group is not None:
+                    geom_params["group"] = shape_geom_group[shape]
                 if shape_priority is not None:
                     geom_params["priority"] = shape_priority[shape]
                 if shape_geom_solimp is not None:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -3767,6 +3767,32 @@ class TestImportMjcfSolverParams(unittest.TestCase):
         joint_type3 = model3.joint_type.numpy()[0]
         self.assertEqual(joint_type3, newton.JointType.FREE)
 
+    def test_geom_group_parsing(self):
+        """Test parsing of geom visualization groups from MJCF."""
+        mjcf_content = """<mujoco>
+    <default>
+        <default class="group3">
+            <geom group="3"/>
+        </default>
+    </default>
+    <worldbody>
+        <body name="body">
+            <freejoint/>
+            <geom type="sphere" size="0.1" class="group3"/>
+            <geom type="box" size="0.1 0.1 0.1" group="1"/>
+            <geom type="capsule" size="0.1 0.1"/>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_content)
+        model = builder.finalize()
+
+        self.assertTrue(hasattr(model.mujoco, "geom_group"))
+        np.testing.assert_array_equal(model.mujoco.geom_group.numpy(), [3, 1, 0])
+
     def test_geom_priority_parsing(self):
         """Test parsing of geom priority from MJCF"""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -4596,6 +4596,43 @@ def Xform "Articulation" (
         self.assertTrue(np.any(geom_priority == 1))
         self.assertTrue(np.any(geom_priority == 0))
 
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_geom_group_parsing_and_conversion(self):
+        """Test USD geom groups are imported and converted to MuJoCo."""
+        from pxr import Usd
+
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(
+            """#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def Xform "Body" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI"]
+)
+{
+    def Sphere "Collision" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        double radius = 0.1
+        int mjc:group = 3
+    }
+}
+"""
+        )
+
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(stage)
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+
+        np.testing.assert_array_equal(model.mujoco.geom_group.numpy(), [3])
+        np.testing.assert_array_equal(solver.mj_model.geom_group, [3])
+        np.testing.assert_array_equal(solver.mjw_model.geom_group.numpy(), [3])
+
 
 class TestImportSampleAssetsParsing(unittest.TestCase):
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")

--- a/newton/tests/test_menagerie_mujoco.py
+++ b/newton/tests/test_menagerie_mujoco.py
@@ -349,8 +349,6 @@ DEFAULT_MODEL_SKIP_FIELDS: set[str] = {
     "qLD_all_updates",
     "qLD_level_offsets",
     "qLDiagInv_tiles",
-    # Visualization group: Newton defaults to 0, native may use other groups
-    "geom_group",
     # Collision exclusions: Newton needs to fix parent/child filtering to match MuJoCo
     "nexclude",
     # Lights: Newton doesn't parse lights from MJCF

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -2740,6 +2740,22 @@ class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):
                     msg=f"Updated rolling friction mismatch for shape {shape_idx} in world {world_idx}",
                 )
 
+    def test_geom_group_conversion(self):
+        """Test that geom_group custom attributes are converted to MuJoCo."""
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+
+        body = builder.add_link(mass=1.0, com=wp.vec3(0.0, 0.0, 0.0), inertia=wp.mat33(np.eye(3)))
+        builder.add_shape_sphere(body=body, radius=0.1, custom_attributes={"mujoco:geom_group": 3})
+        builder.add_shape_box(body=body, hx=0.1, hy=0.1, hz=0.1, custom_attributes={"mujoco:geom_group": 1})
+        joint = builder.add_joint_free(body)
+        builder.add_articulation([joint])
+
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+
+        np.testing.assert_array_equal(solver.mjw_model.geom_group.numpy(), [3, 1])
+
     def test_geom_priority_conversion(self):
         """Test that geom_priority custom attribute is properly converted to MuJoCo."""
         builder = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Preserve MuJoCo geom visualization groups when importing MJCF or USD and constructing a `SolverMuJoCo` model.

`SolverMuJoCo.register_custom_attributes()` now declares the per-shape `model.mujoco.geom_group` attribute, mapped from MJCF `group` and USD `mjc:group`. The MJCF importer uses its existing MuJoCo-attribute registration path. USD uses the existing generic custom-attribute pipeline: callers must follow the documented flow and call `SolverMuJoCo.register_custom_attributes(builder)` before `builder.add_usd(...)`. `import_usd.py` itself is unchanged.

The solver forwards the stored value to the MuJoCo geom spec instead of allowing every geom to fall back to group 0. This keeps Newton-generated MuJoCo and MJWarp models aligned without conflating visualization groups with Newton collision groups.

This addresses the remaining `geom_group` portion of #2492. The separate zero-mask explicit-pair classification edge is tracked in #3284 and fixed independently by #3285.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run --no-sync -m unittest newton.tests.test_import_mjcf.TestImportMjcfSolverParams.test_geom_group_parsing -v
uv run --no-sync -m unittest newton.tests.test_mujoco_solver.TestMuJoCoSolverGeomProperties.test_geom_group_conversion -v
uv run --no-sync -m unittest newton.tests.test_import_usd.TestImportSampleAssetsBasic.test_geom_group_parsing_and_conversion -v
uv run --no-sync -m unittest newton.tests.test_mujoco_solver.TestMuJoCoSolverGeomProperties.test_geom_priority_conversion -v
uv run --no-sync -m unittest newton.tests.test_menagerie_mujoco.TestMenagerie_Aloha -v
uvx pre-commit run -a
```

The Aloha regression covers model comparison, forward kinematics, and dynamics. The automated USD regression authors `mjc:group = 3` after pre-registering the MuJoCo custom attributes, then verifies the value in the Newton model, native MuJoCo model, and MJWarp model.

## Bug fix

**Steps to reproduce:**

1. Import an MJCF model containing geoms assigned to nonzero visualization groups.
2. Finalize the Newton model and construct `SolverMuJoCo`.
3. Compare `geom_group` with native MuJoCo; Newton previously emitted group 0 for every geom.

**Minimal reproduction:**

```python
import newton
from newton.solvers import SolverMuJoCo

builder = newton.ModelBuilder()
builder.add_mjcf(
    """<mujoco><worldbody><body name="body"><freejoint/>
    <geom type="sphere" size="0.1" group="3"/>
    <geom type="box" size="0.1 0.1 0.1" group="1"/>
    </body></worldbody></mujoco>"""
)
solver = SolverMuJoCo(builder.finalize())
print(solver.mj_model.geom_group)
```

For USD input, register the solver attributes before import:

```python
builder = newton.ModelBuilder()
SolverMuJoCo.register_custom_attributes(builder)
builder.add_usd(stage)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved MJCF/MuJoCo geom visualization group metadata during model conversion, so grouping information is retained correctly.
  * Improved attribute handling so geom group values are consistently imported and propagated, including default inheritance and explicitly set groups.

* **Tests**
  * Added new test coverage for geom group parsing and conversion for both MJCF and USD inputs.
  * Updated model comparison logic to no longer skip the geom group field during menagerie checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->