### PR TITLE
Preserve explicit-pair MJCF geoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fix multi-world soft contact filtering to avoid cross-world rigid-soft particle-shape pairs and VBD soft-soft triangle/edge candidates.
 - Fix `ModelBuilder.add_usd` so a stray authored joint outside any articulation root no longer suppresses base-joint (articulation) creation for unrelated floating rigid bodies in the same call. (#3002)
 - Fix `SolverSemiImplicit` ball joints to apply `joint_damping` on all three angular DOFs.
+- Preserve unclassified MJCF geoms referenced by explicit contact pairs when `parse_visuals=False`. (#3284)
 - Fix `RenderContext` triangle mesh construction by removing the unsupported `device=` keyword from `wp.Mesh(...)`.
 - Fix MJCF `euler` producing wrong orientations for multi-component angles by treating angles as intrinsic rotations. (#3030)
 - Fix `newton.eval_fk` / `newton.eval_ik` producing wrong rotations and joint velocities for `JointType.D6` with three angular DOFs whose axes form a left-handed orthonormal basis.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -331,9 +331,9 @@ def parse_mjcf(
     root, base_dir = _load_and_expand_mjcf(source, path_resolver)
     mjcf_dirname = base_dir or "."  # Backward compatible fallback for mesh paths
 
-    contact = root.find("contact")
+    contact_sections = root.findall("contact")
     explicit_pair_geom_names: set[str] = set()
-    if contact is not None:
+    for contact in contact_sections:
         for pair in contact.findall("pair"):
             for geom_key in ("geom1", "geom2"):
                 geom_name = pair.attrib.get(geom_key)
@@ -2465,9 +2465,10 @@ def parse_mjcf(
                 return idx
         return None
 
-    if contact is not None and has_pair_attrs:
+    if has_pair_attrs:
         # Parse <pair> elements - explicit contact pairs with custom properties
-        for pair in contact.findall("pair"):
+        pairs = (pair for contact in contact_sections for pair in contact.findall("pair"))
+        for pair in pairs:
             geom1_name = pair.attrib.get("geom1")
             geom2_name = pair.attrib.get("geom2")
 
@@ -2507,7 +2508,7 @@ def parse_mjcf(
                 print(f"Parsed contact pair: {geom1_name} ({geom1_idx}) <-> {geom2_name} ({geom2_idx})")
 
     # Parse <exclude> elements - body pairs to exclude from collision detection
-    if contact is not None:
+    for contact in contact_sections:
         for exclude in contact.findall("exclude"):
             body1_name = exclude.attrib.get("body1")
             body2_name = exclude.attrib.get("body2")

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1340,7 +1340,11 @@ def parse_mjcf(
             collides_with_anything = not (int(contype) == 0 and int(conaffinity) == 0)
 
             # Explicit pairs override contact masks, so their geoms must survive visual filtering.
-            if geom_name in explicit_pair_geom_names:
+            geom_label = f"{label_prefix}/{geom_name}" if label_prefix else geom_name
+            is_explicit_pair_geom = any(
+                geom_label == name or geom_label.endswith(f"/{name}") for name in explicit_pair_geom_names
+            )
+            if is_explicit_pair_geom:
                 required_colliders.append(geom)
             elif geom_class is not None:
                 neither_visual_nor_collider = True

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -331,6 +331,15 @@ def parse_mjcf(
     root, base_dir = _load_and_expand_mjcf(source, path_resolver)
     mjcf_dirname = base_dir or "."  # Backward compatible fallback for mesh paths
 
+    contact = root.find("contact")
+    explicit_pair_geom_names: set[str] = set()
+    if contact is not None:
+        for pair in contact.findall("pair"):
+            for geom_key in ("geom1", "geom2"):
+                geom_name = pair.attrib.get(geom_key)
+                if geom_name:
+                    explicit_pair_geom_names.add(geom_name)
+
     use_degrees = True  # angles are in degrees by default
     eulerseq = "xyz"  # default sequence (lowercase = intrinsic axes, per MuJoCo)
 
@@ -1303,6 +1312,7 @@ def parse_mjcf(
         """
         visuals = []
         colliders = []
+        required_colliders = []
 
         for geo_count, geom in enumerate(geoms):
             geom_defaults = defaults
@@ -1329,7 +1339,10 @@ def parse_mjcf(
             conaffinity = geom_attrib.get("conaffinity", 1)
             collides_with_anything = not (int(contype) == 0 and int(conaffinity) == 0)
 
-            if geom_class is not None:
+            # Explicit pairs override contact masks, so their geoms must survive visual filtering.
+            if geom_name in explicit_pair_geom_names:
+                required_colliders.append(geom)
+            elif geom_class is not None:
                 neither_visual_nor_collider = True
                 for pattern in visual_classes:
                     if re.match(pattern, geom_class):
@@ -1372,6 +1385,8 @@ def parse_mjcf(
                 label_prefix=label_prefix,
             )
             visual_shape_indices.extend(s)
+
+        colliders.extend(required_colliders)
 
         show_colliders = should_show_collider(
             force_show_colliders,
@@ -2441,7 +2456,6 @@ def parse_mjcf(
 
     # Only parse contact pairs if custom attributes are registered
     has_pair_attrs = "mujoco:pair_geom1" in builder.custom_attributes
-    contact = root.find("contact")
 
     def _find_shape_idx(name: str) -> int | None:
         """Look up shape index by name, supporting hierarchical labels (e.g. "prefix/geom_name")."""

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8014,6 +8014,35 @@ class TestContypeConaffinityZero(unittest.TestCase):
         solver._mujoco.mj_forward(solver.mj_model, solver.mj_data)
         self.assertGreater(solver.mj_data.ncon, 0, "Explicit <pair> should generate contacts")
 
+    def test_explicit_pair_retains_unclassified_geoms_without_visuals(self):
+        """Pair-referenced zero-mask geoms survive parse_visuals=False."""
+        mjcf = """<mujoco>
+            <default><geom contype="0" conaffinity="0"/></default>
+            <worldbody>
+                <geom name="floor_geom" type="plane" size="5 5 0.1"/>
+                <body name="ball" pos="0 0 0.05">
+                    <freejoint/>
+                    <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+                    <geom name="ball_geom" type="sphere" size="0.1"/>
+                </body>
+            </worldbody>
+            <contact>
+                <pair geom1="floor_geom" geom2="ball_geom" condim="3"/>
+            </contact>
+        </mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf, parse_visuals=False)
+
+        self.assertEqual(builder.shape_count, 2)
+        self.assertEqual(builder.shape_collision_group, [0, 0])
+
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model)
+
+        self.assertEqual(solver.mj_model.npair, 1)
+        solver._mujoco.mj_forward(solver.mj_model, solver.mj_data)
+        self.assertGreater(solver.mj_data.ncon, 0)
+
 
 class TestMjcfPlaneInfinite(unittest.TestCase):
     """Verify MJCF plane geoms are imported as infinite planes."""

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8043,6 +8043,50 @@ class TestContypeConaffinityZero(unittest.TestCase):
         solver._mujoco.mj_forward(solver.mj_model, solver.mj_data)
         self.assertGreater(solver.mj_data.ncon, 0)
 
+    def test_explicit_pairs_across_contact_sections_without_visuals(self):
+        """Pairs and excludes are parsed from every top-level contact section."""
+        mjcf = """<mujoco>
+            <default><geom contype="0" conaffinity="0"/></default>
+            <worldbody>
+                <body name="body1" pos="0 0 0">
+                    <freejoint/>
+                    <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+                    <geom name="geom1" type="sphere" size="0.1"/>
+                </body>
+                <body name="body2" pos="1 0 0">
+                    <freejoint/>
+                    <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+                    <geom name="geom2" type="sphere" size="0.1"/>
+                </body>
+                <body name="body3" pos="2 0 0">
+                    <freejoint/>
+                    <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+                    <geom name="geom3" type="sphere" size="0.1"/>
+                </body>
+            </worldbody>
+            <contact>
+                <pair geom1="geom1" geom2="geom2"/>
+            </contact>
+            <contact>
+                <pair geom1="geom2" geom2="geom3"/>
+                <exclude body1="body1" body2="body3"/>
+            </contact>
+        </mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf, parse_visuals=False)
+
+        self.assertEqual(builder.shape_count, 3)
+        self.assertEqual(builder.shape_collision_group, [0, 0, 0])
+
+        model = builder.finalize(device="cpu")
+        geom1_idx = builder.shape_label.index("worldbody/body1/geom1")
+        geom3_idx = builder.shape_label.index("worldbody/body3/geom3")
+        filter_pairs = set(model.shape_collision_filter_pairs)
+        self.assertTrue((geom1_idx, geom3_idx) in filter_pairs or (geom3_idx, geom1_idx) in filter_pairs)
+
+        solver = SolverMuJoCo(model)
+        self.assertEqual(solver.mj_model.npair, 2)
+
 
 class TestMjcfPlaneInfinite(unittest.TestCase):
     """Verify MJCF plane geoms are imported as infinite planes."""

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8087,6 +8087,41 @@ class TestContypeConaffinityZero(unittest.TestCase):
         solver = SolverMuJoCo(model)
         self.assertEqual(solver.mj_model.npair, 2)
 
+    def test_explicit_pair_hierarchical_labels_without_visuals(self):
+        """Pair-referenced geoms match their hierarchical Newton labels."""
+        mjcf = """<mujoco model="hierarchical_pair">
+            <default><geom contype="0" conaffinity="0"/></default>
+            <worldbody>
+                <body name="body1">
+                    <geom name="geom1" type="sphere" size="0.1"/>
+                </body>
+                <body name="body2">
+                    <geom name="geom2" type="sphere" size="0.1"/>
+                </body>
+            </worldbody>
+            <contact>
+                <pair
+                    geom1="hierarchical_pair/worldbody/body1/geom1"
+                    geom2="hierarchical_pair/worldbody/body2/geom2"
+                />
+            </contact>
+        </mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf, parse_visuals=False)
+
+        self.assertEqual(
+            builder.shape_label,
+            [
+                "hierarchical_pair/worldbody/body1/geom1",
+                "hierarchical_pair/worldbody/body2/geom2",
+            ],
+        )
+        self.assertEqual(builder.shape_collision_group, [0, 0])
+
+        model = builder.finalize(device="cpu")
+        solver = SolverMuJoCo(model)
+        self.assertEqual(solver.mj_model.npair, 1)
+
 
 class TestMjcfPlaneInfinite(unittest.TestCase):
     """Verify MJCF plane geoms are imported as infinite planes."""


### PR DESCRIPTION
## Description

Preserve MJCF geoms referenced by explicit `<contact><pair>` elements when visual-only geoms are filtered during import.

MuJoCo allows explicit pairs to generate contact even when both geoms use `contype="0" conaffinity="0"`. Newton previously classified unclassified zero-mask geoms as visual-only before parsing contact pairs, so `parse_visuals=False` discarded the shapes and the pair could not be exported.

The importer now pre-collects pair-referenced geom names and routes those geoms through the collider path. Their Newton collision group remains 0, which continues to disable automatic contacts while allowing the explicit pair to work. Repeated top-level `<contact>` sections are handled consistently when collecting geom references and parsing both `<pair>` and `<exclude>` elements. Early retention uses the same exact-or-suffix matching as pair lookup, so full hierarchical Newton geom labels are preserved too.

Closes #3284.

This is the final follow-up for #2492 and should merge after #3283, which preserves MJCF `geom_group` metadata. Closes #2492.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run --no-sync -m unittest newton.tests.test_import_mjcf.TestContypeConaffinityZero -v
uv run --no-sync -m unittest newton.tests.test_import_mjcf -q
uvx pre-commit run -a
```

The original regression fails on upstream `main` with `shape_count == 0`; it passes with two retained group-0 shapes, one exported pair, and a generated contact. The repeated-contact regression fails before the follow-up fix with two of three geoms retained; it now verifies three retained group-0 shapes, two exported pairs, and an exclude from the second contact section. The hierarchical-label regression fails before the review fix with no retained shapes; it now verifies two retained group-0 shapes and one exported pair. The complete MJCF importer suite passes all 222 tests.

## Bug fix

**Steps to reproduce:**

1. Define unclassified MJCF geoms with `contype="0" conaffinity="0"`.
2. Reference them from `<contact><pair>`.
3. Import with `parse_visuals=False`.
4. Observe that Newton drops both geoms before parsing the pair.

**Minimal reproduction:**

```python
import newton

mjcf = """<mujoco>
    <default><geom contype="0" conaffinity="0"/></default>
    <worldbody>
        <geom name="floor" type="plane" size="1 1 0.1"/>
        <body name="ball">
            <freejoint/>
            <geom name="ball" type="sphere" size="0.1"/>
        </body>
    </worldbody>
    <contact><pair geom1="floor" geom2="ball"/></contact>
</mujoco>"""

builder = newton.ModelBuilder()
builder.add_mjcf(mjcf, parse_visuals=False)
print(builder.shape_count)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved MJCF geoms referenced only by explicit contact pairs during import when visual parsing is disabled, preventing them from being filtered out from collision shapes.
  * Improved explicit contact-pair parsing to correctly handle multiple top-level contact sections, including related exclusions and hierarchical geom references.
* **Tests**
  * Added regression coverage for non-visual collision geoms from explicit contact pairs, including multi-section scenarios, MuJoCo pair compilation checks, and verification that contacts are generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->