### PR TITLE
Sanitize type annotations and docstrings in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/bodies.py
+++ b/newton/_src/solvers/kamino/_src/core/bodies.py
@@ -83,13 +83,13 @@ class RigidBodyDescriptor(Descriptor):
 
     wid: int = -1
     """
-    Index of the world to which the body belongs.\n
+    Index of the world to which the body belongs.
     Defaults to `-1`, indicating that the body has not yet been added to a world.
     """
 
     bid: int = -1
     """
-    Index of the body w.r.t. its world.\n
+    Index of the body w.r.t. its world.
     Defaults to `-1`, indicating that the body has not yet been added to a world.
     """
 
@@ -117,21 +117,21 @@ class RigidBodiesModel:
 
     Attributes:
         num_bodies: The total number of body elements in the model (host-side).
-        wid: World index of each body.\n
+        wid: World index of each body.
             Shape of ``(num_bodies,)``.
-        bid: Body index of each body w.r.t. its world.\n
+        bid: Body index of each body w.r.t. its world.
             Shape of ``(num_bodies,)``.
-        m_i: Mass of each body.\n
+        m_i: Mass of each body.
             Shape of ``(num_bodies,)``.
-        inv_m_i: Inverse mass (1/m_i) of each body.\n
+        inv_m_i: Inverse mass (1/m_i) of each body.
             Shape of ``(num_bodies,)``.
-        i_I_i: Local moment of inertia of each body.\n
+        i_I_i: Local moment of inertia of each body.
             Shape of ``(num_bodies,)``.
-        inv_i_I_i: Inverse of the local moment of inertia of each body.\n
+        inv_i_I_i: Inverse of the local moment of inertia of each body.
             Shape of ``(num_bodies,)``.
-        q_i_0: Initial pose of each body.\n
+        q_i_0: Initial pose of each body.
             Shape of ``(num_bodies,)``.
-        u_i_0: Initial twist of each body.\n
+        u_i_0: Initial twist of each body.
             Shape of ``(num_bodies,)``.
     """
 
@@ -144,7 +144,7 @@ class RigidBodiesModel:
 
     label: list[str] | None = None
     """
-    A list containing the label of each body.\n
+    A list containing the label of each body.
     Length of ``num_bodies``.
     """
 
@@ -154,13 +154,13 @@ class RigidBodiesModel:
 
     wid: wp.array[wp.int32] | None = None
     """
-    World index each body.\n
+    World index each body.
     Shape of ``(num_bodies,)``.
     """
 
     bid: wp.array[wp.int32] | None = None
     """
-    Body index of each body w.r.t it's world.\n
+    Body index of each body w.r.t it's world.
     Shape of ``(num_bodies,)``.
     """
 
@@ -170,31 +170,31 @@ class RigidBodiesModel:
 
     i_r_com_i: wp.array[wp.vec3f] | None = None
     """
-    Translational offset of the center of mass w.r.t the body's reference frame.\n
+    Translational offset of the center of mass w.r.t the body's reference frame.
     Shape of ``(num_bodies,)``.
     """
 
     m_i: wp.array[wp.float32] | None = None
     """
-    Mass of each body.\n
+    Mass of each body.
     Shape of ``(num_bodies,)``.
     """
 
     inv_m_i: wp.array[wp.float32] | None = None
     """
-    Inverse mass (1/m_i) of each body.\n
+    Inverse mass (1/m_i) of each body.
     Shape of ``(num_bodies,)``.
     """
 
     i_I_i: wp.array[wp.mat33f] | None = None
     """
-    Local moment of inertia of each body.\n
+    Local moment of inertia of each body.
     Shape of ``(num_bodies,)``.
     """
 
     inv_i_I_i: wp.array[wp.mat33f] | None = None
     """
-    Inverse of the local moment of inertia of each body.\n
+    Inverse of the local moment of inertia of each body.
     Shape of ``(num_bodies,)``.
     """
 
@@ -204,13 +204,13 @@ class RigidBodiesModel:
 
     q_i_0: wp.array[wp.transformf] | None = None
     """
-    Initial pose of each body.\n
+    Initial pose of each body.
     Shape of ``(num_bodies,)``.
     """
 
     u_i_0: wp.array[wp.spatial_vectorf] | None = None
     """
-    Initial twist of each body.\n
+    Initial twist of each body.
     Shape of ``(num_bodies,)``.
     """
 
@@ -226,61 +226,61 @@ class RigidBodiesData:
 
     q_i: wp.array[wp.transformf] | None = None
     """
-    Absolute poses of each body (in world coordinates).\n
+    Absolute poses of each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     u_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Absolute twists of each body (in world coordinates).\n
+    Absolute twists of each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     I_i: wp.array[wp.mat33f] | None = None
     """
-    Moment of inertia (in world coordinates) of each body.\n
+    Moment of inertia (in world coordinates) of each body.
     Shape of ``(num_bodies,)``.
     """
 
     inv_I_i: wp.array[wp.mat33f] | None = None
     """
-    Inverse moment of inertia (in world coordinates) of each body.\n
+    Inverse moment of inertia (in world coordinates) of each body.
     Shape of ``(num_bodies,)``.
     """
 
     w_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Total wrench applied to each body (in world coordinates).\n
+    Total wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     w_a_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Joint actuation wrench applied to each body (in world coordinates).\n
+    Joint actuation wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     w_j_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Joint constraint wrench applied to each body (in world coordinates).\n
+    Joint constraint wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     w_l_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Joint limit wrench applied to each body (in world coordinates).\n
+    Joint limit wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     w_c_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Contact wrench applied to each body (in world coordinates).\n
+    Contact wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 
     w_e_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    External wrench applied to each body (in world coordinates).\n
+    External wrench applied to each body (in world coordinates).
     Shape of ``(num_bodies,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/bodies.py
+++ b/newton/_src/solvers/kamino/_src/core/bodies.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, field
 
 import warp as wp
 
-from .types import Descriptor, int32, mat33f, override, transformf, vec3f, vec6f
+from .....core.types import override
+from .types import Descriptor
 
 ###
 # Module interface
@@ -46,15 +47,15 @@ class RigidBodyDescriptor(Descriptor):
     A container to describe a single rigid body in the model builder.
 
     Attributes:
-        name (str): The name of the body.
-        uid (str): The unique identifier of the body.
-        m_i (float): Mass of the body (in kg).
-        i_r_com_i (vec3f): Translational offset of the body center of mass (in meters).
-        i_I_i (mat33f): Moment of inertia matrix (in local coordinates) of the body (in kg*m^2).
-        q_i_0 (transformf): Initial absolute pose of the body (in world coordinates).
-        u_i_0 (vec6f): Initial absolute twist of the body (in world coordinates).
-        wid (int): Index of the world to which the body belongs.
-        bid (int): Index of the body w.r.t. its world.
+        name: The name of the body.
+        uid: The unique identifier of the body.
+        m_i: Mass of the body [kg].
+        i_r_com_i: Translational offset of the body center of mass [m].
+        i_I_i: Moment of inertia matrix in local coordinates [kg·m²].
+        q_i_0: Initial absolute pose of the body in world coordinates.
+        u_i_0: Initial absolute twist of the body in world coordinates.
+        wid: Index of the world to which the body belongs.
+        bid: Index of the body w.r.t. its world.
     """
 
     ###
@@ -64,16 +65,16 @@ class RigidBodyDescriptor(Descriptor):
     m_i: float = 0.0
     """Mass of the body."""
 
-    i_r_com_i: vec3f = field(default_factory=vec3f)
+    i_r_com_i: wp.vec3f = field(default_factory=wp.vec3f)
     """Translational offset of the body center of mass w.r.t the reference frame expressed in local coordinates."""
 
-    i_I_i: mat33f = field(default_factory=mat33f)
+    i_I_i: wp.mat33f = field(default_factory=wp.mat33f)
     """Moment of inertia matrix of the body expressed in local coordinates."""
 
-    q_i_0: transformf = field(default_factory=transformf)
+    q_i_0: wp.transformf = field(default_factory=wp.transformf)
     """Initial absolute pose of the body expressed in world coordinates."""
 
-    u_i_0: vec6f = field(default_factory=vec6f)
+    u_i_0: wp.spatial_vectorf = field(default_factory=wp.spatial_vectorf)
     """Initial absolute twist of the body expressed in world coordinates."""
 
     ###
@@ -115,23 +116,23 @@ class RigidBodiesModel:
     An SoA-based container to hold time-invariant model data of a set of rigid body elements.
 
     Attributes:
-        num_bodies (int): The total number of body elements in the model (host-side).
-        wid (wp.array | None): World index each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`int`.
-        bid (wp.array | None): Body index of each body w.r.t it's world.\n
-            Shape of ``(num_bodies,)`` and type :class:`int`.
-        m_i (wp.array | None): Mass of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`float`.
-        inv_m_i (wp.array | None): Inverse mass (1/m_i) of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`float`.
-        i_I_i (wp.array | None): Local moment of inertia of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`mat33`.
-        inv_i_I_i (wp.array | None): Inverse of the local moment of inertia of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`mat33`.
-        q_i_0 (wp.array | None): Initial pose of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`transform`.
-        u_i_0 (wp.array | None): Initial twist of each body.\n
-            Shape of ``(num_bodies,)`` and type :class:`vec6`.
+        num_bodies: The total number of body elements in the model (host-side).
+        wid: World index of each body.\n
+            Shape of ``(num_bodies,)``.
+        bid: Body index of each body w.r.t. its world.\n
+            Shape of ``(num_bodies,)``.
+        m_i: Mass of each body.\n
+            Shape of ``(num_bodies,)``.
+        inv_m_i: Inverse mass (1/m_i) of each body.\n
+            Shape of ``(num_bodies,)``.
+        i_I_i: Local moment of inertia of each body.\n
+            Shape of ``(num_bodies,)``.
+        inv_i_I_i: Inverse of the local moment of inertia of each body.\n
+            Shape of ``(num_bodies,)``.
+        q_i_0: Initial pose of each body.\n
+            Shape of ``(num_bodies,)``.
+        u_i_0: Initial twist of each body.\n
+            Shape of ``(num_bodies,)``.
     """
 
     ###
@@ -144,73 +145,73 @@ class RigidBodiesModel:
     label: list[str] | None = None
     """
     A list containing the label of each body.\n
-    Length of ``num_bodies`` and type :class:`str`.
+    Length of ``num_bodies``.
     """
 
     ###
     # Identifiers
     ###
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     World index each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`int`.
+    Shape of ``(num_bodies,)``.
     """
 
-    bid: wp.array | None = None
+    bid: wp.array[wp.int32] | None = None
     """
     Body index of each body w.r.t it's world.\n
-    Shape of ``(num_bodies,)`` and type :class:`int`.
+    Shape of ``(num_bodies,)``.
     """
 
     ###
     # Parameterization
     ###
 
-    i_r_com_i: wp.array | None = None
+    i_r_com_i: wp.array[wp.vec3f] | None = None
     """
     Translational offset of the center of mass w.r.t the body's reference frame.\n
-    Shape of ``(num_bodies,)`` and type :class:`vec3`.
+    Shape of ``(num_bodies,)``.
     """
 
-    m_i: wp.array | None = None
+    m_i: wp.array[wp.float32] | None = None
     """
     Mass of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`float`.
+    Shape of ``(num_bodies,)``.
     """
 
-    inv_m_i: wp.array | None = None
+    inv_m_i: wp.array[wp.float32] | None = None
     """
     Inverse mass (1/m_i) of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`float`.
+    Shape of ``(num_bodies,)``.
     """
 
-    i_I_i: wp.array | None = None
+    i_I_i: wp.array[wp.mat33f] | None = None
     """
     Local moment of inertia of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`mat33`.
+    Shape of ``(num_bodies,)``.
     """
 
-    inv_i_I_i: wp.array | None = None
+    inv_i_I_i: wp.array[wp.mat33f] | None = None
     """
     Inverse of the local moment of inertia of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`mat33`.
+    Shape of ``(num_bodies,)``.
     """
 
     ###
     # Initial State
     ###
 
-    q_i_0: wp.array | None = None
+    q_i_0: wp.array[wp.transformf] | None = None
     """
     Initial pose of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`transform`.
+    Shape of ``(num_bodies,)``.
     """
 
-    u_i_0: wp.array | None = None
+    u_i_0: wp.array[wp.spatial_vectorf] | None = None
     """
     Initial twist of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
 
@@ -223,64 +224,64 @@ class RigidBodiesData:
     num_bodies: int = 0
     """Total number of body entities in the model (host-side)."""
 
-    q_i: wp.array | None = None
+    q_i: wp.array[wp.transformf] | None = None
     """
     Absolute poses of each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`transform`.
+    Shape of ``(num_bodies,)``.
     """
 
-    u_i: wp.array | None = None
+    u_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Absolute twists of each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    I_i: wp.array | None = None
+    I_i: wp.array[wp.mat33f] | None = None
     """
     Moment of inertia (in world coordinates) of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`mat33`.
+    Shape of ``(num_bodies,)``.
     """
 
-    inv_I_i: wp.array | None = None
+    inv_I_i: wp.array[wp.mat33f] | None = None
     """
     Inverse moment of inertia (in world coordinates) of each body.\n
-    Shape of ``(num_bodies,)`` and type :class:`mat33`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_i: wp.array | None = None
+    w_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Total wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_a_i: wp.array | None = None
+    w_a_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Joint actuation wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_j_i: wp.array | None = None
+    w_j_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Joint constraint wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_l_i: wp.array | None = None
+    w_l_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Joint limit wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_c_i: wp.array | None = None
+    w_c_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Contact wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_e_i: wp.array | None = None
+    w_e_i: wp.array[wp.spatial_vectorf] | None = None
     """
     External wrench applied to each body (in world coordinates).\n
-    Shape of ``(num_bodies,)`` and type :class:`vec6`.
+    Shape of ``(num_bodies,)``.
     """
 
     def clear_all_wrenches(self):
@@ -320,39 +321,38 @@ class RigidBodiesData:
 ###
 
 
-# TODO: Use Warp generics to be applicable to other numeric types
 @wp.func
-def make_symmetric(A: mat33f) -> mat33f:
+def make_symmetric(A: wp.mat33f) -> wp.mat33f:
     """
     Makes a given matrix symmetric by averaging it with its transpose.
 
     Args:
-        A (mat33f): The input matrix.
+        A: The input matrix.
 
     Returns:
-        mat33f: The symmetric matrix.
+        The symmetrized matrix.
     """
     return 0.5 * (A + wp.transpose(A))
 
 
 @wp.func
 def transform_body_inertial_properties(
-    p_i: transformf,
-    i_I_i: mat33f,
-    inv_i_I_i: mat33f,
-) -> tuple[mat33f, mat33f]:
+    p_i: wp.transformf,
+    i_I_i: wp.mat33f,
+    inv_i_I_i: wp.mat33f,
+) -> tuple[wp.mat33f, wp.mat33f]:
     """
     Transforms the inertial properties of a rigid body, specified in
     local coordinates, to world coordinates given its pose. The inertial
     properties include the moment of inertia matrix and its inverse.
 
     Args:
-        p_i (transformf): The absolute pose of the body in world coordinates.
-        i_I_i (mat33f): The local moment of inertia of the body.
-        inv_i_I_i (mat33f): The inverse of the local moment of inertia of the body.
+        p_i: The absolute pose of the body in world coordinates.
+        i_I_i: The local moment of inertia of the body.
+        inv_i_I_i: The inverse of the local moment of inertia of the body.
 
     Returns:
-        tuple[mat33f, mat33f]: The moment of inertia and its inverse in world coordinates.
+        The moment of inertia and its inverse in world coordinates.
     """
     # Compute the moment of inertia matrices in world coordinates
     R_i = wp.quat_to_matrix(wp.transform_get_rotation(p_i))
@@ -375,12 +375,12 @@ def transform_body_inertial_properties(
 @wp.kernel
 def _update_body_inertias(
     # Inputs:
-    model_bodies_i_I_i_in: wp.array[mat33f],
-    model_bodies_inv_i_I_i_in: wp.array[mat33f],
-    state_bodies_q_i_in: wp.array[transformf],
+    model_bodies_i_I_i_in: wp.array[wp.mat33f],
+    model_bodies_inv_i_I_i_in: wp.array[wp.mat33f],
+    state_bodies_q_i_in: wp.array[wp.transformf],
     # Outputs:
-    state_bodies_I_i_out: wp.array[mat33f],
-    state_bodies_inv_I_i_out: wp.array[mat33f],
+    state_bodies_I_i_out: wp.array[wp.mat33f],
+    state_bodies_inv_I_i_out: wp.array[wp.mat33f],
 ):
     # Retrieve the thread index as the body index
     bid = wp.tid()
@@ -401,13 +401,13 @@ def _update_body_inertias(
 @wp.kernel
 def _update_body_wrenches(
     # Inputs
-    state_bodies_w_a_i_in: wp.array[vec6f],
-    state_bodies_w_j_i_in: wp.array[vec6f],
-    state_bodies_w_l_i_in: wp.array[vec6f],
-    state_bodies_w_c_i_in: wp.array[vec6f],
-    state_bodies_w_e_i_in: wp.array[vec6f],
+    state_bodies_w_a_i_in: wp.array[wp.spatial_vectorf],
+    state_bodies_w_j_i_in: wp.array[wp.spatial_vectorf],
+    state_bodies_w_l_i_in: wp.array[wp.spatial_vectorf],
+    state_bodies_w_c_i_in: wp.array[wp.spatial_vectorf],
+    state_bodies_w_e_i_in: wp.array[wp.spatial_vectorf],
     # Outputs
-    state_bodies_w_i_out: wp.array[vec6f],
+    state_bodies_w_i_out: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index as the body index
     bid = wp.tid()
@@ -429,12 +429,12 @@ def _update_body_wrenches(
 @wp.kernel
 def _convert_body_origin_to_com(
     # Inputs
-    world_mask: wp.array[bool],
-    body_wid: wp.array[int32],
-    body_com: wp.array[vec3f],
-    body_q: wp.array[transformf],
+    world_mask: wp.array[wp.bool],  # None also supported
+    body_wid: wp.array[wp.int32],  # None also supported
+    body_com: wp.array[wp.vec3f],
+    body_q: wp.array[wp.transformf],
     # Outputs
-    body_q_com: wp.array[transformf],
+    body_q_com: wp.array[wp.transformf],
 ):
     bid = wp.tid()
 
@@ -450,18 +450,18 @@ def _convert_body_origin_to_com(
     body_rot = wp.transform_get_rotation(q)
     r_com = wp.quat_rotate(body_rot, com)
 
-    body_q_com[bid] = transformf(body_r + r_com, body_rot)
+    body_q_com[bid] = wp.transformf(body_r + r_com, body_rot)
 
 
 @wp.kernel
 def _convert_body_com_to_origin(
     # Inputs
-    world_mask: wp.array[bool],
-    body_wid: wp.array[int32],
-    body_com: wp.array[vec3f],
-    body_q_com: wp.array[transformf],
+    world_mask: wp.array[wp.bool],  # None also supported
+    body_wid: wp.array[wp.int32],  # None also supported
+    body_com: wp.array[wp.vec3f],
+    body_q_com: wp.array[wp.transformf],
     # Outputs
-    body_q: wp.array[transformf],
+    body_q: wp.array[wp.transformf],
 ):
     bid = wp.tid()
 
@@ -477,18 +477,18 @@ def _convert_body_com_to_origin(
     body_rot = wp.transform_get_rotation(q)
     r_com = wp.quat_rotate(body_rot, com)
 
-    body_q[bid] = transformf(body_r_com - r_com, body_rot)
+    body_q[bid] = wp.transformf(body_r_com - r_com, body_rot)
 
 
 @wp.kernel
 def _convert_base_origin_to_com(
     # Inputs
-    base_joint_index: wp.array[int32],
-    base_body_index: wp.array[int32],
-    body_com: wp.array[vec3f],
-    base_q: wp.array[transformf],
+    base_joint_index: wp.array[wp.int32],
+    base_body_index: wp.array[wp.int32],
+    body_com: wp.array[wp.vec3f],
+    base_q: wp.array[wp.transformf],
     # Outputs
-    base_q_com: wp.array[transformf],
+    base_q_com: wp.array[wp.transformf],
 ):
     wid = wp.tid()
     base_jid = base_joint_index[wid]
@@ -502,17 +502,17 @@ def _convert_base_origin_to_com(
         com = body_com[base_bid]
         rot = wp.transform_get_rotation(q)
         r_com = wp.quat_rotate(rot, com)
-        base_q_com[wid] = transformf(wp.transform_get_translation(q) + r_com, rot)
+        base_q_com[wid] = wp.transformf(wp.transform_get_translation(q) + r_com, rot)
 
 
 @wp.kernel
 def _convert_geom_offset_origin_to_com(
     # Inputs
-    body_com: wp.array[vec3f],
-    geom_bid: wp.array[int32],
-    geom_offset: wp.array[transformf],
+    body_com: wp.array[wp.vec3f],
+    geom_bid: wp.array[wp.int32],
+    geom_offset: wp.array[wp.transformf],
     # Outputs
-    geom_offset_com: wp.array[transformf],
+    geom_offset_com: wp.array[wp.transformf],
 ):
     gid = wp.tid()
     bid = geom_bid[gid]
@@ -521,7 +521,7 @@ def _convert_geom_offset_origin_to_com(
         X = geom_offset[gid]
         pos = wp.transform_get_translation(X)
         rot = wp.transform_get_rotation(X)
-        geom_offset_com[gid] = transformf(pos - com, rot)
+        geom_offset_com[gid] = wp.transformf(pos - com, rot)
     else:
         geom_offset_com[gid] = geom_offset[gid]
 
@@ -532,10 +532,10 @@ def _convert_geom_offset_origin_to_com(
 
 
 def convert_geom_offset_origin_to_com(
-    body_com: wp.array,
-    geom_bid: wp.array,
-    geom_offset: wp.array,
-    geom_offset_com: wp.array,
+    body_com: wp.array[wp.vec3f],
+    geom_bid: wp.array[wp.int32],
+    geom_offset: wp.array[wp.transformf],
+    geom_offset_com: wp.array[wp.transformf],
 ):
     wp.launch(
         _convert_geom_offset_origin_to_com,
@@ -582,11 +582,11 @@ def update_body_wrenches(model: RigidBodiesModel, data: RigidBodiesData):
 
 
 def convert_body_origin_to_com(
-    body_com: wp.array,
-    body_q: wp.array,
-    body_q_com: wp.array,
-    body_wid: wp.array | None = None,
-    world_mask: wp.array | None = None,
+    body_com: wp.array[wp.vec3f],
+    body_q: wp.array[wp.transformf],
+    body_q_com: wp.array[wp.transformf],
+    body_wid: wp.array[wp.int32] | None = None,
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     wp.launch(
         _convert_body_origin_to_com,
@@ -598,11 +598,11 @@ def convert_body_origin_to_com(
 
 
 def convert_body_com_to_origin(
-    body_com: wp.array,
-    body_q_com: wp.array,
-    body_q: wp.array,
-    body_wid: wp.array | None = None,
-    world_mask: wp.array | None = None,
+    body_com: wp.array[wp.vec3f],
+    body_q_com: wp.array[wp.transformf],
+    body_q: wp.array[wp.transformf],
+    body_wid: wp.array[wp.int32] | None = None,
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     wp.launch(
         _convert_body_com_to_origin,
@@ -614,11 +614,11 @@ def convert_body_com_to_origin(
 
 
 def convert_base_origin_to_com(
-    base_joint_index: wp.array,
-    base_body_index: wp.array,
-    body_com: wp.array,
-    base_q: wp.array,
-    base_q_com: wp.array,
+    base_joint_index: wp.array[wp.int32],
+    base_body_index: wp.array[wp.int32],
+    body_com: wp.array[wp.vec3f],
+    base_q: wp.array[wp.transformf],
+    base_q_com: wp.array[wp.transformf],
 ):
     wp.launch(
         _convert_base_origin_to_com,

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable
 import numpy as np
 import warp as wp
 
+from .....core.types import Axis
 from .....geometry import ShapeFlags
 from .bodies import RigidBodiesModel, RigidBodyDescriptor
 from .geometry import GeometriesModel, GeometryDescriptor
@@ -29,7 +30,7 @@ from .model import ModelKamino, ModelKaminoInfo
 from .shapes import ShapeDescriptorType, max_contacts_for_shape_pair
 from .size import SizeKamino
 from .time import TimeModel
-from .types import Axis, float32, mat33f, to_warp_int32_array, transformf, vec2i, vec3f, vec4f, vec6f
+from .types import to_warp_int32_array
 from .world import WorldDescriptor
 
 ###
@@ -63,7 +64,7 @@ class ModelBuilderKamino:
         Initializes a new empty model builder.
 
         Args:
-            default_world (bool): Whether to create a default world upon initialization.
+            default_world: Whether to create a default world upon initialization.
                 If True, a default world will be created. Defaults to False.
         """
         # Meta-data
@@ -265,16 +266,16 @@ class ModelBuilderKamino:
         Add a new world to the model.
 
         Args:
-            name (str): The name of the world.
-            uid (str | None): The unique identifier of the world.\n
+            name: The name of the world.
+            uid: The unique identifier of the world.
                 If None, a UUID will be generated.
-            up_axis (Axis | None): The up axis of the world.\n
+            up_axis: The up axis of the world.
                 If None, Axis.Z will be used.
-            gravity (GravityDescriptor | None): The gravity descriptor of the world.\n
+            gravity: The gravity descriptor of the world.
                 If None, a default gravity descriptor will be used.
 
         Returns:
-            int: The index of the newly added world.
+            The index of the newly added world.
         """
         # Create a new world descriptor
         self._worlds.append(WorldDescriptor(name=name, uid=uid, wid=self._num_worlds))
@@ -306,9 +307,9 @@ class ModelBuilderKamino:
     def add_rigid_body(
         self,
         m_i: float,
-        i_I_i: mat33f,
-        q_i_0: transformf,
-        u_i_0: vec6f | None = None,
+        i_I_i: wp.mat33f,
+        q_i_0: wp.transformf,
+        u_i_0: wp.spatial_vectorf | None = None,
         name: str | None = None,
         uid: str | None = None,
         world_index: int = 0,
@@ -317,17 +318,17 @@ class ModelBuilderKamino:
         Add a rigid body entity to the model using explicit specifications.
 
         Args:
-            m_i (float): The mass of the body.
-            i_I_i (mat33f): The inertia tensor of the body.
-            q_i_0 (transformf): The initial pose of the body.
-            u_i_0 (vec6f): The initial velocity of the body.
-            name (str | None): The name of the body.
-            uid (str | None): The unique identifier of the body.
-            world_index (int): The index of the world to which the body will be added.\n
+            m_i: The mass of the body.
+            i_I_i: The inertia tensor of the body.
+            q_i_0: The initial pose of the body.
+            u_i_0: The initial velocity of the body.
+            name: The name of the body.
+            uid: The unique identifier of the body.
+            world_index: The index of the world to which the body will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The index of the newly added body.
+            The index of the newly added body.
         """
         # Create a rigid body descriptor from the provided specifications
         # NOTE: Specifying a name is required by the base descriptor class,
@@ -339,7 +340,7 @@ class ModelBuilderKamino:
             m_i=m_i,
             i_I_i=i_I_i,
             q_i_0=q_i_0,
-            u_i_0=u_i_0 if u_i_0 is not None else vec6f(0.0),
+            u_i_0=u_i_0 if u_i_0 is not None else wp.spatial_vectorf(0.0),
         )
 
         # Add the body descriptor to the model
@@ -350,12 +351,12 @@ class ModelBuilderKamino:
         Add a rigid body entity to the model using a descriptor object.
 
         Args:
-            body (RigidBodyDescriptor): The body descriptor to be added.
-            world_index (int): The index of the world to which the body will be added.\n
+            body: The body descriptor to be added.
+            world_index: The index of the world to which the body will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The body index of the newly added body w.r.t its world.
+            The body index of the newly added body w.r.t its world.
         """
         # Check if the descriptor is valid
         if not isinstance(body, RigidBodyDescriptor):
@@ -385,10 +386,10 @@ class ModelBuilderKamino:
         dof_type: JointDoFType,
         bid_B: int,
         bid_F: int,
-        B_r_Bj: vec3f,
-        F_r_Fj: vec3f,
-        X_Bj: mat33f,
-        X_Fj: mat33f | None = None,
+        B_r_Bj: wp.vec3f,
+        F_r_Fj: wp.vec3f,
+        X_Bj: wp.mat33f,
+        X_Fj: wp.mat33f | None = None,
         q_j_min: list[float] | float | None = None,
         q_j_max: list[float] | float | None = None,
         dq_j_max: list[float] | float | None = None,
@@ -405,29 +406,29 @@ class ModelBuilderKamino:
         Add a joint entity to the model using explicit specifications.
 
         Args:
-            act_type (JointActuationType): The actuation type of the joint.
-            dof_type (JointDoFType): The degree of freedom type of the joint.
-            bid_B (int): The index of the body on the "base" side of the joint.
-            bid_F (int): The index of the body on the "follower" side of the joint.
-            B_r_Bj (vec3f): The position of the joint in the base body frame.
-            F_r_Fj (vec3f): The position of the joint in the follower body frame.
+            act_type: The actuation type of the joint.
+            dof_type: The degree of freedom type of the joint.
+            bid_B: The index of the body on the "base" side of the joint.
+            bid_F: The index of the body on the "follower" side of the joint.
+            B_r_Bj: The position of the joint in the base body frame.
+            F_r_Fj: The position of the joint in the follower body frame.
             X_Bj: The orientation of the joint frame relative to the base body frame.
             X_Fj: The orientation of the joint frame relative to the follower body frame.
-            q_j_min (list[float] | float | None): The minimum joint coordinate limits.
-            q_j_max (list[float] | float | None): The maximum joint coordinate limits.
-            dq_j_max (list[float] | float | None): The maximum joint velocity limits.
-            tau_j_max (list[float] | float | None): The maximum joint effort limits.
-            a_j (list[float] | float | None): The joint armature along each DoF.
-            b_j (list[float] | float | None): The joint damping along each DoF.
-            k_p_j (list[float] | float | None): The joint proportional gain along each DoF.
-            k_d_j (list[float] | float | None): The joint derivative gain along each DoF.
-            name (str | None): The name of the joint.
-            uid (str | None): The unique identifier of the joint.
-            world_index (int): The index of the world to which the joint will be added.
+            q_j_min: The minimum joint coordinate limits.
+            q_j_max: The maximum joint coordinate limits.
+            dq_j_max: The maximum joint velocity limits.
+            tau_j_max: The maximum joint effort limits.
+            a_j: The joint armature along each DoF.
+            b_j: The joint damping along each DoF.
+            k_p_j: The joint proportional gain along each DoF.
+            k_d_j: The joint derivative gain along each DoF.
+            name: The name of the joint.
+            uid: The unique identifier of the joint.
+            world_index: The index of the world to which the joint will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The index of the newly added joint.
+            The index of the newly added joint.
         """
         # Check if the actuation type is valid
         if not isinstance(act_type, JointActuationType):
@@ -470,14 +471,14 @@ class ModelBuilderKamino:
         Add a joint entity to the model by descriptor.
 
         Args:
-            joint (JointDescriptor):
+            joint:
                 The joint descriptor to be added.
-            world_index (int):
-                The index of the world to which the joint will be added.\n
+            world_index:
+                The index of the world to which the joint will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The joint index of the newly added joint w.r.t its world.
+            The joint index of the newly added joint w.r.t its world.
         """
         # Check if the descriptor is valid
         if not isinstance(joint, JointDescriptor):
@@ -509,7 +510,7 @@ class ModelBuilderKamino:
         self,
         body: int = -1,
         shape: ShapeDescriptorType | None = None,
-        offset: transformf | None = None,
+        offset: wp.transformf | None = None,
         material: str | int | None = None,
         group: int = 1,
         collides: int = 1,
@@ -524,42 +525,30 @@ class ModelBuilderKamino:
         Add a geometry entity to the model using explicit specifications.
 
         Args:
-            body (int):
-                The index of the body to which the geometry will be attached.\n
+            body: The index of the body to which the geometry will be attached.
                 Defaults to -1 (world).
-            shape (ShapeDescriptorType | None):
-                The shape descriptor of the geometry.
-            offset (transformf | None):
-                The local offset of the geometry relative to the body frame.
-            material (str | int | None):
-                The name or index of the material assigned to the geometry.
-            max_contacts (int):
-                The maximum number of contact points for the geometry.\n
+            shape: The shape descriptor of the geometry.
+            offset: The local offset of the geometry relative to the body frame.
+            material: The name or index of the material assigned to the geometry.
+            max_contacts: The maximum number of contact points for the geometry.
                 Defaults to 0 (unlimited).
-            group (int):
-                The collision group of the geometry.\n
+            group: The collision group of the geometry.
                 Defaults to 1.
-            collides (int):
-                The collision mask of the geometry.\n
+            collides: The collision mask of the geometry.
                 Defaults to 1.
-            gap (float):
-                The collision detection gap of the geometry.\n
+            gap: The collision detection gap of the geometry.
                 Defaults to 0.0.
-            margin (float):
-                The artificial surface margin of the geometry.\n
+            margin: The artificial surface margin of the geometry.
                 Defaults to 0.0.
-            name (str | None):
-                The name of the geometry.\n
+            name: The name of the geometry.
                 If `None`, a default name will be generated based on the current number of geometries in the model.
-            uid (str | None):
-                The unique identifier of the geometry.\n
+            uid: The unique identifier of the geometry.
                 If `None`, a UUID will be generated.
-            world_index (int):
-                The index of the world to which the geometry will be added.\n
+            world_index: The index of the world to which the geometry will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The index of the newly added collision geometry.
+            The index of the newly added collision geometry.
         """
         # Set the default material if not provided
         if material is None:
@@ -588,7 +577,7 @@ class ModelBuilderKamino:
             name=name if name is not None else f"cgeom_{self._num_geoms}",
             uid=uid,
             body=body,
-            offset=offset if offset is not None else transformf(),
+            offset=offset if offset is not None else wp.transformf(),
             shape=shape,
             material=self._materials[material],
             mid=self._materials.index(material),
@@ -607,14 +596,12 @@ class ModelBuilderKamino:
         Add a geometry to the model by descriptor.
 
         Args:
-            geom (GeometryDescriptor):
-                The geometry descriptor to be added.
-            world_index (int):
-                The index of the world to which the geometry will be added.\n
+            geom: The geometry descriptor to be added.
+            world_index: The index of the world to which the geometry will be added.
                 Defaults to the first world with index `0`.
 
         Returns:
-            int: The geometry index of the newly added geometry w.r.t its world.
+            The geometry index of the newly added geometry w.r.t its world.
         """
         # Check if the descriptor is valid
         if not isinstance(geom, GeometryDescriptor):
@@ -649,8 +636,8 @@ class ModelBuilderKamino:
         Add a material to the model.
 
         Args:
-            material (MaterialDescriptor): The material descriptor to be added.
-            world_index (int): The index of the world to which the material will be added.\n
+            material: The material descriptor to be added.
+            world_index: The index of the world to which the material will be added.
                 Defaults to the first world with index `0`.
         """
         # Check if the world index is valid
@@ -677,8 +664,8 @@ class ModelBuilderKamino:
         indices of the elements in the other builder are adjusted to account for the
         existing elements in the current builder, preventing any index conflicts.
 
-        Arguments:
-            other (ModelBuilderKamino): The other ModelBuilderKamino whose contents are to be added to the current.
+        Args:
+            other: The other ModelBuilderKamino whose contents are to be added to the current.
 
         Raises:
             ValueError: If the provided builder is not of type `ModelBuilderKamino`.
@@ -747,8 +734,8 @@ class ModelBuilderKamino:
         Set the up axis for a specific world.
 
         Args:
-            axis (Axis): The new up axis to be set.
-            world_index (int): The index of the world for which to set the up axis.\n
+            axis: The new up axis to be set.
+            world_index: The index of the world for which to set the up axis.
                 Defaults to the first world with index `0`.
 
         Raises:
@@ -769,8 +756,8 @@ class ModelBuilderKamino:
         Set the gravity descriptor for a specific world.
 
         Args:
-            gravity (GravityDescriptor): The new gravity descriptor to be set.
-            world_index (int): The index of the world for which to set the gravity descriptor.\n
+            gravity: The new gravity descriptor to be set.
+            world_index: The index of the world for which to set the gravity descriptor.
                 Defaults to the first world with index `0`.
 
         Raises:
@@ -815,10 +802,10 @@ class ModelBuilderKamino:
         Sets the material pair properties for two materials.
 
         Args:
-            first (int | str | MaterialDescriptor): The first material (by index, name, or descriptor).
-            second (int | str | MaterialDescriptor): The second material (by index, name, or descriptor).
-            material_pair (MaterialPairProperties): The material pair properties to be set.
-            world_index (int): The index of the world for which to set the material pair properties.\n
+            first: The first material (by index, name, or descriptor).
+            second: The second material (by index, name, or descriptor).
+            material_pair: The material pair properties to be set.
+            world_index: The index of the world for which to set the material pair properties.
                 Defaults to the first world with index `0`.
         """
         # Check if the world index is valid
@@ -836,9 +823,9 @@ class ModelBuilderKamino:
         Set the base body for a specific world specified either by name or by index.
 
         Args:
-            body_key (int | str): Identifier of the body to be set as the base body.
+            body_key: Identifier of the body to be set as the base body.
                 Can be either the body's index (within the world) or its name.
-            world_index (int): The index of the world for which to set the base body.\n
+            world_index: The index of the world for which to set the base body.
                 Defaults to the first world with index `0`.
         """
         # Check if the world index is valid
@@ -860,9 +847,9 @@ class ModelBuilderKamino:
         Set the base joint for a specific world specified either by name or by index.
 
         Args:
-            joint_key (int | str): Identifier of the joint to be set as the base joint.
+            joint_key: Identifier of the joint to be set as the base joint.
                 Can be either the joint's index (within the world) or its name.
-            world_index (int): The index of the world for which to set the base joint.\n
+            world_index: The index of the world for which to set the base joint.
                 Defaults to the first world with index `0`.
         """
         # Check if the world index is valid
@@ -893,15 +880,15 @@ class ModelBuilderKamino:
         object, allocating the necessary data structures on the target device.
 
         Args:
-            device (wp.DeviceLike): The target device for the model data.\n
+            device: The target device for the model data.
                 If None, the default/preferred device will determined by Warp.
-            requires_grad (bool): Whether the model data should support gradients.\n
+            requires_grad: Whether the model data should support gradients.
                 Defaults to False.
-            base_auto (bool): Whether to automatically select a base body,
+            base_auto: Whether to automatically select a base body,
                 and if possible, a base joint, if neither was set.
 
         Returns:
-            ModelKamino: The constructed ModelKamino object containing the time-invariant simulation data.
+            The constructed ModelKamino object containing the time-invariant simulation data.
         """
         # Number of model worlds
         num_worlds = len(self._worlds)
@@ -1349,19 +1336,21 @@ class ModelBuilderKamino:
                 joint_kinematic_cts_offset=to_warp_int32_array(info_jkcio),
                 base_body_index=to_warp_int32_array(info_base_bid),
                 base_joint_index=to_warp_int32_array(info_base_jid),
-                mass_min=wp.array(info_mass_min, dtype=float32),
-                mass_max=wp.array(info_mass_max, dtype=float32),
-                mass_total=wp.array(info_mass_total, dtype=float32),
-                inertia_total=wp.array(info_inertia_total, dtype=float32),
+                mass_min=wp.array(info_mass_min, dtype=wp.float32),
+                mass_max=wp.array(info_mass_max, dtype=wp.float32),
+                mass_total=wp.array(info_mass_total, dtype=wp.float32),
+                inertia_total=wp.array(info_inertia_total, dtype=wp.float32),
             )
 
             # Create the model time data
-            model_time = TimeModel(dt=wp.zeros(num_worlds, dtype=float32), inv_dt=wp.zeros(num_worlds, dtype=float32))
+            model_time = TimeModel(
+                dt=wp.zeros(num_worlds, dtype=wp.float32), inv_dt=wp.zeros(num_worlds, dtype=wp.float32)
+            )
 
             # Construct model gravity data
             model_gravity = GravityModel(
-                g_dir_acc=wp.array(gravity_g_dir_acc, dtype=vec4f),
-                vector=wp.array(gravity_vector, dtype=vec4f, requires_grad=requires_grad),
+                g_dir_acc=wp.array(gravity_g_dir_acc, dtype=wp.vec4f),
+                vector=wp.array(gravity_vector, dtype=wp.vec4f, requires_grad=requires_grad),
             )
 
             # Create the bodies model
@@ -1370,13 +1359,13 @@ class ModelBuilderKamino:
                 label=bodies_label,
                 wid=to_warp_int32_array(bodies_wid),
                 bid=to_warp_int32_array(bodies_bid),
-                i_r_com_i=wp.array(bodies_i_r_com_i, dtype=vec3f, requires_grad=requires_grad),
-                m_i=wp.array(bodies_m_i, dtype=float32, requires_grad=requires_grad),
-                inv_m_i=wp.array(bodies_inv_m_i, dtype=float32, requires_grad=requires_grad),
-                i_I_i=wp.array(bodies_i_I_i, dtype=mat33f, requires_grad=requires_grad),
-                inv_i_I_i=wp.array(bodies_inv_i_I_i, dtype=mat33f, requires_grad=requires_grad),
-                q_i_0=wp.array(bodies_q_i_0, dtype=transformf, requires_grad=requires_grad),
-                u_i_0=wp.array(bodies_u_i_0, dtype=vec6f, requires_grad=requires_grad),
+                i_r_com_i=wp.array(bodies_i_r_com_i, dtype=wp.vec3f, requires_grad=requires_grad),
+                m_i=wp.array(bodies_m_i, dtype=wp.float32, requires_grad=requires_grad),
+                inv_m_i=wp.array(bodies_inv_m_i, dtype=wp.float32, requires_grad=requires_grad),
+                i_I_i=wp.array(bodies_i_I_i, dtype=wp.mat33f, requires_grad=requires_grad),
+                inv_i_I_i=wp.array(bodies_inv_i_I_i, dtype=wp.mat33f, requires_grad=requires_grad),
+                q_i_0=wp.array(bodies_q_i_0, dtype=wp.transformf, requires_grad=requires_grad),
+                u_i_0=wp.array(bodies_u_i_0, dtype=wp.spatial_vectorf, requires_grad=requires_grad),
             )
 
             # Create the joints model
@@ -1389,20 +1378,20 @@ class ModelBuilderKamino:
                 act_type=to_warp_int32_array(joints_actid),
                 bid_B=to_warp_int32_array(joints_bid_B),
                 bid_F=to_warp_int32_array(joints_bid_F),
-                B_r_Bj=wp.array(joints_B_r_Bj, dtype=vec3f, requires_grad=requires_grad),
-                F_r_Fj=wp.array(joints_F_r_Fj, dtype=vec3f, requires_grad=requires_grad),
-                X_Bj=wp.array(joints_X_Bj, dtype=mat33f, requires_grad=requires_grad),
-                X_Fj=wp.array(joints_X_Fj, dtype=mat33f, requires_grad=requires_grad),
-                q_j_min=wp.array(joints_q_j_min, dtype=float32, requires_grad=requires_grad),
-                q_j_max=wp.array(joints_q_j_max, dtype=float32, requires_grad=requires_grad),
-                dq_j_max=wp.array(joints_qd_j_max, dtype=float32, requires_grad=requires_grad),
-                tau_j_max=wp.array(joints_tau_j_max, dtype=float32, requires_grad=requires_grad),
-                a_j=wp.array(joints_a_j, dtype=float32, requires_grad=requires_grad),
-                b_j=wp.array(joints_b_j, dtype=float32, requires_grad=requires_grad),
-                k_p_j=wp.array(joints_k_p_j, dtype=float32, requires_grad=requires_grad),
-                k_d_j=wp.array(joints_k_d_j, dtype=float32, requires_grad=requires_grad),
-                q_j_0=wp.array(joints_q_j_0, dtype=float32, requires_grad=requires_grad),
-                dq_j_0=wp.array(joints_dq_j_0, dtype=float32, requires_grad=requires_grad),
+                B_r_Bj=wp.array(joints_B_r_Bj, dtype=wp.vec3f, requires_grad=requires_grad),
+                F_r_Fj=wp.array(joints_F_r_Fj, dtype=wp.vec3f, requires_grad=requires_grad),
+                X_Bj=wp.array(joints_X_Bj, dtype=wp.mat33f, requires_grad=requires_grad),
+                X_Fj=wp.array(joints_X_Fj, dtype=wp.mat33f, requires_grad=requires_grad),
+                q_j_min=wp.array(joints_q_j_min, dtype=wp.float32, requires_grad=requires_grad),
+                q_j_max=wp.array(joints_q_j_max, dtype=wp.float32, requires_grad=requires_grad),
+                dq_j_max=wp.array(joints_qd_j_max, dtype=wp.float32, requires_grad=requires_grad),
+                tau_j_max=wp.array(joints_tau_j_max, dtype=wp.float32, requires_grad=requires_grad),
+                a_j=wp.array(joints_a_j, dtype=wp.float32, requires_grad=requires_grad),
+                b_j=wp.array(joints_b_j, dtype=wp.float32, requires_grad=requires_grad),
+                k_p_j=wp.array(joints_k_p_j, dtype=wp.float32, requires_grad=requires_grad),
+                k_d_j=wp.array(joints_k_d_j, dtype=wp.float32, requires_grad=requires_grad),
+                q_j_0=wp.array(joints_q_j_0, dtype=wp.float32, requires_grad=requires_grad),
+                dq_j_0=wp.array(joints_dq_j_0, dtype=wp.float32, requires_grad=requires_grad),
                 num_coords=to_warp_int32_array(joints_ncoords_j),
                 num_dofs=to_warp_int32_array(joints_ndofs_j),
                 num_cts=to_warp_int32_array(joints_ncts_j),
@@ -1434,30 +1423,30 @@ class ModelBuilderKamino:
                 type=to_warp_int32_array(geoms_type),
                 flags=to_warp_int32_array(geoms_flags),
                 ptr=wp.array(geoms_ptr, dtype=wp.uint64),
-                params=wp.array(geoms_params, dtype=vec3f),
-                offset=wp.array(geoms_offset, dtype=transformf),
+                params=wp.array(geoms_params, dtype=wp.vec3f),
+                offset=wp.array(geoms_offset, dtype=wp.transformf),
                 material=to_warp_int32_array(geoms_material),
                 group=to_warp_int32_array(geoms_group),
-                gap=wp.array(geoms_gap, dtype=float32),
-                margin=wp.array(geoms_margin, dtype=float32),
-                collidable_pairs=wp.array(np.array(model_collidable_pairs), dtype=vec2i),
-                excluded_pairs=wp.array(np.array(model_excluded_pairs), dtype=vec2i),
+                gap=wp.array(geoms_gap, dtype=wp.float32),
+                margin=wp.array(geoms_margin, dtype=wp.float32),
+                collidable_pairs=wp.array(np.array(model_collidable_pairs), dtype=wp.vec2i),
+                excluded_pairs=wp.array(np.array(model_excluded_pairs), dtype=wp.vec2i),
             )
 
             # Create the material pairs model
             model_materials = MaterialsModel(
                 num_materials=model_size.sum_of_num_materials,
-                restitution=wp.array(materials_rest[0], dtype=float32),
-                static_friction=wp.array(materials_static_fric[0], dtype=float32),
-                dynamic_friction=wp.array(materials_dynamic_fric[0], dtype=float32),
+                restitution=wp.array(materials_rest[0], dtype=wp.float32),
+                static_friction=wp.array(materials_static_fric[0], dtype=wp.float32),
+                dynamic_friction=wp.array(materials_dynamic_fric[0], dtype=wp.float32),
             )
 
             # Create the material pairs model
             model_material_pairs = MaterialPairsModel(
                 num_material_pairs=model_size.sum_of_num_material_pairs,
-                restitution=wp.array(mpairs_rest[0], dtype=float32),
-                static_friction=wp.array(mpairs_static_fric[0], dtype=float32),
-                dynamic_friction=wp.array(mpairs_dynamic_fric[0], dtype=float32),
+                restitution=wp.array(mpairs_rest[0], dtype=wp.float32),
+                static_friction=wp.array(mpairs_static_fric[0], dtype=wp.float32),
+                dynamic_friction=wp.array(mpairs_dynamic_fric[0], dtype=wp.float32),
             )
 
         # Construct and return the complete model container
@@ -1492,8 +1481,7 @@ class ModelBuilderKamino:
             6. (optional) filter out neighbor collisions for joints w/ DoFs
 
         Args:
-            allow_neighbors (bool, optional):
-                If True, includes geom-pairs with corresponding
+            allow_neighbors: If True, includes geom-pairs with corresponding
                 bodies that are neighbors via joints with DoF.
 
         Returns:
@@ -1594,8 +1582,7 @@ class ModelBuilderKamino:
         pairs that should **not** collide.
 
         Args:
-            allow_neighbors (bool, optional):
-                If True, does not exclude geom-pairs with corresponding
+            allow_neighbors: If True, does not exclude geom-pairs with corresponding
                 bodies that are neighbors via joints with DoF.
 
         Returns:
@@ -1678,12 +1665,10 @@ class ModelBuilderKamino:
         Computes the number of unique collidable geometries from the provided list of collidable geometry pairs.
 
         Args:
-            collidable_geom_pairs (list[tuple[int, int]], optional):
-                A list of geom-pair indices `(gid1, gid2)` (absolute w.r.t the model).\n
+            collidable_geom_pairs: A list of geom-pair indices `(gid1, gid2)` (absolute w.r.t the model).
                 If `None`, the number of collidable geometries will
                 be extracted by exhaustively checking all geometries.
-            collidable_pairs_offset: (list[int], optional):
-                A list of per-world offsets into collidable_geom_pairs (with one
+            collidable_pairs_offset: A list of per-world offsets into collidable_geom_pairs (with one
                 extra entry giving the total length of collidable_geom_pairs).
                 Cannot be `None` if collidable_geom_pairs is provided.
 
@@ -1779,7 +1764,7 @@ class ModelBuilderKamino:
         Checks if the provided world index is valid.
 
         Args:
-            world_index (int): The index of the world to be checked.
+            world_index: The index of the world to be checked.
 
         Raises:
             ValueError: If the world index is out of range.
@@ -1858,12 +1843,12 @@ class ModelBuilderKamino:
     """A type alias for model entity descriptors."""
 
     @staticmethod
-    def _check_body_inertia(m_i: float, i_I_i: mat33f):
+    def _check_body_inertia(m_i: float, i_I_i: wp.mat33f):
         """
         Checks if the body inertia is valid.
 
         Args:
-            i_I_i (mat33f): The inertia matrix to be checked.
+            i_I_i: The inertia matrix to be checked.
 
         Raises:
             ValueError: If the inertia matrix is not symmetric of positive definite.
@@ -1880,18 +1865,18 @@ class ModelBuilderKamino:
             raise ValueError(f"Invalid body inertia matrix:\n{i_I_i}\nMust be positive definite.")
 
     @staticmethod
-    def _check_body_pose(q_i: transformf):
+    def _check_body_pose(q_i: wp.transformf):
         """
         Checks if the body pose is valid.
 
         Args:
-            q_i_0 (transformf): The pose of the body to be checked.
+            q_i_0: The pose of the body to be checked.
 
         Raises:
             ValueError: If the body pose is not a valid transformation.
         """
-        if not isinstance(q_i, transformf):
-            raise TypeError(f"Invalid body pose type: {type(q_i)}. Must be `transformf`.")
+        if not isinstance(q_i, wp.transformf):
+            raise TypeError(f"Invalid body pose type: {type(q_i)}. Must be `wp.transformf`.")
 
         # Extract the orientation quaternion
         if not np.isclose(wp.length(q_i.q), 1.0, atol=float(FLOAT32_EPS)):

--- a/newton/_src/solvers/kamino/_src/core/control.py
+++ b/newton/_src/solvers/kamino/_src/core/control.py
@@ -43,25 +43,25 @@ class ControlKamino:
 
     tau_j: wp.array[wp.float32] | None = None
     """
-    Array of generalized joint actuation forces.\n
+    Array of generalized joint actuation forces.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     q_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference generalized joint coordinates for implicit PD control.\n
+    Array of reference generalized joint coordinates for implicit PD control.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     dq_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference generalized joint velocities for implicit PD control.\n
+    Array of reference generalized joint velocities for implicit PD control.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     tau_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference feed-forward generalized joint forces for implicit PD control.\n
+    Array of reference feed-forward generalized joint forces for implicit PD control.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/control.py
+++ b/newton/_src/solvers/kamino/_src/core/control.py
@@ -12,7 +12,6 @@ import warp as wp
 
 from .....sim.control import Control
 from .conversions import convert_target_coords_to_target_dofs, convert_target_dofs_to_target_coords
-from .types import float32
 
 if TYPE_CHECKING:
     from .model import ModelKamino
@@ -42,32 +41,28 @@ class ControlKamino:
     # Attributes
     ###
 
-    tau_j: wp.array | None = None
+    tau_j: wp.array[wp.float32] | None = None
     """
     Array of generalized joint actuation forces.\n
-    Shape is ``(sum(d_j),)`` and dtype is :class:`float32`,\n
-    where ``d_j`` is the number of DoFs of each joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    q_j_ref: wp.array | None = None
+    q_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference generalized joint coordinates for implicit PD control.\n
-    Shape of ``(sum(c_j),)`` and type :class:`float`,
-    where ``c_j`` is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    dq_j_ref: wp.array | None = None
+    dq_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference generalized joint velocities for implicit PD control.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    tau_j_ref: wp.array | None = None
+    tau_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference feed-forward generalized joint forces for implicit PD control.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
@@ -77,7 +72,7 @@ class ControlKamino:
     _needs_coord_conversion: bool = False
     """Whether dofs-to-coords conversion is required for this model."""
 
-    _q_j_ref_coords_space: wp.array | None = None
+    _q_j_ref_coords_space: wp.array[wp.float32] | None = None
     """Owned coords-space reference buffer used when ``dofs != coords``."""
 
     ###
@@ -141,7 +136,7 @@ class ControlKamino:
             and model.size.sum_of_num_joint_dofs != model.size.sum_of_num_joint_coords
         )
         self._q_j_ref_coords_space = (
-            wp.zeros(shape=model.size.sum_of_num_joint_coords, dtype=float32, device=device)
+            wp.zeros(shape=model.size.sum_of_num_joint_coords, dtype=wp.float32, device=device)
             if self._needs_coord_conversion
             else None
         )

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -30,7 +30,7 @@ from .joints import (
 from .materials import MaterialDescriptor, MaterialManager
 from .shapes import max_contacts_for_shape_pair
 from .size import SizeKamino
-from .types import float32, int32, mat33f, mat63f, to_warp_int32_array, transformf, vec2i, vec3f, vec6f
+from .types import mat63f, to_warp_int32_array, vec6f
 
 if TYPE_CHECKING:
     from ..core.model import ModelKamino, ModelKaminoInfo
@@ -58,11 +58,11 @@ __all__ = [
 def world_max_contacts_kernel(
     # Inputs:
     max_contacts_per_pair: int,
-    model_shape_type: wp.array[int32],
-    model_shape_world: wp.array[int32],
-    model_shape_contact_pair: wp.array[vec2i],
+    model_shape_type: wp.array[wp.int32],
+    model_shape_world: wp.array[wp.int32],
+    model_shape_contact_pair: wp.array[wp.vec2i],
     # Outputs:
-    world_max_contacts: wp.array[int32],
+    world_max_contacts: wp.array[wp.int32],
 ):
     # Retrieve the shape pair index from the thread grid
     shape_pair_id = wp.tid()
@@ -96,16 +96,16 @@ def world_max_contacts_kernel(
 @wp.kernel
 def rigid_bodies_indexing_kernel(
     # Inputs:
-    model_body_world_start: wp.array[int32],
-    model_shape_world_start: wp.array[int32],
+    model_body_world_start: wp.array[wp.int32],
+    model_shape_world_start: wp.array[wp.int32],
     # Outputs:
-    body_bid: wp.array[int32],
-    num_bodies: wp.array[int32],
-    num_shapes: wp.array[int32],
-    num_body_dofs: wp.array[int32],
-    world_body_offset: wp.array[int32],
-    world_shape_offset: wp.array[int32],
-    world_body_dof_offset: wp.array[int32],
+    body_bid: wp.array[wp.int32],
+    num_bodies: wp.array[wp.int32],
+    num_shapes: wp.array[wp.int32],
+    num_body_dofs: wp.array[wp.int32],
+    world_body_offset: wp.array[wp.int32],
+    world_shape_offset: wp.array[wp.int32],
+    world_body_dof_offset: wp.array[wp.int32],
 ):
     # Retrieve the world index
     world_id = wp.tid()
@@ -130,14 +130,14 @@ def rigid_bodies_indexing_kernel(
 @wp.kernel
 def mass_prop_accumulation_kernel(
     # Inputs:
-    model_body_world_start: wp.array[int32],
-    model_body_mass: wp.array[float32],
-    body_inertia: wp.array[mat33f],
+    model_body_world_start: wp.array[wp.int32],
+    model_body_mass: wp.array[wp.float32],
+    body_inertia: wp.array[wp.mat33f],
     # Outputs:
-    mass_total: wp.array[float32],
-    mass_min: wp.array[float32],
-    mass_max: wp.array[float32],
-    inertia_total: wp.array[float32],
+    mass_total: wp.array[wp.float32],
+    mass_min: wp.array[wp.float32],
+    mass_max: wp.array[wp.float32],
+    inertia_total: wp.array[wp.float32],
 ):
     # Retrieve the world index
     world_id = wp.tid()
@@ -145,10 +145,10 @@ def mass_prop_accumulation_kernel(
     body_id_start = model_body_world_start[world_id]
     body_id_end = model_body_world_start[world_id + 1] - 1
 
-    mass = float32(0.0)
-    m_min = float32(1e10)
-    m_max = float32(0.0)
-    inertia = float32(0.0)
+    mass = wp.float32(0.0)
+    m_min = wp.float32(1e10)
+    m_max = wp.float32(0.0)
+    inertia = wp.float32(0.0)
 
     for body_id in range(body_id_start, body_id_end + 1):
         mass_b = model_body_mass[body_id]
@@ -169,30 +169,30 @@ def mass_prop_accumulation_kernel(
 @wp.kernel
 def joint_conversion_kernel(
     # Inputs:
-    model_joint_world: wp.array[int32],
-    model_joint_world_start: wp.array[int32],
-    model_joint_type: wp.array[int32],
-    model_joint_target_mode: wp.array[int32],
-    model_joint_dof_dim: wp.array2d[int32],
-    model_joint_q_start: wp.array[int32],
-    model_joint_qd_start: wp.array[int32],
-    model_joint_armature: wp.array[float32],
-    model_joint_friction: wp.array[float32],
-    model_joint_target_ke: wp.array[float32],
-    model_joint_target_kd: wp.array[float32],
-    joint_limit_lower: wp.array[float32],
-    joint_limit_upper: wp.array[float32],
-    joint_velocity_limit: wp.array[float32],
-    joint_effort_limit: wp.array[float32],
+    model_joint_world: wp.array[wp.int32],
+    model_joint_world_start: wp.array[wp.int32],
+    model_joint_type: wp.array[wp.int32],
+    model_joint_target_mode: wp.array[wp.int32],
+    model_joint_dof_dim: wp.array2d[wp.int32],
+    model_joint_q_start: wp.array[wp.int32],
+    model_joint_qd_start: wp.array[wp.int32],
+    model_joint_armature: wp.array[wp.float32],
+    model_joint_friction: wp.array[wp.float32],
+    model_joint_target_ke: wp.array[wp.float32],
+    model_joint_target_kd: wp.array[wp.float32],
+    joint_limit_lower: wp.array[wp.float32],
+    joint_limit_upper: wp.array[wp.float32],
+    joint_velocity_limit: wp.array[wp.float32],
+    joint_effort_limit: wp.array[wp.float32],
     # Outputs:
-    joint_jid: wp.array[int32],
-    joint_dof_type: wp.array[int32],
-    joint_act_type: wp.array[int32],
-    joint_num_coords: wp.array[int32],
-    joint_num_dofs: wp.array[int32],
-    joint_num_cts: wp.array[int32],
-    joint_num_dynamic_cts: wp.array[int32],
-    joint_num_kinematic_cts: wp.array[int32],
+    joint_jid: wp.array[wp.int32],
+    joint_dof_type: wp.array[wp.int32],
+    joint_act_type: wp.array[wp.int32],
+    joint_num_coords: wp.array[wp.int32],
+    joint_num_dofs: wp.array[wp.int32],
+    joint_num_cts: wp.array[wp.int32],
+    joint_num_dynamic_cts: wp.array[wp.int32],
+    joint_num_kinematic_cts: wp.array[wp.int32],
 ):
     # Retrieve the joint index
     joint_id = wp.tid()
@@ -202,7 +202,7 @@ def joint_conversion_kernel(
 
     # Determine Kamino joint type
     type_j = model_joint_type[joint_id]
-    dof_dim_j = vec2i(model_joint_dof_dim[joint_id, 0], model_joint_dof_dim[joint_id, 1])
+    dof_dim_j = wp.vec2i(model_joint_dof_dim[joint_id, 0], model_joint_dof_dim[joint_id, 1])
     q_count_j = model_joint_q_start[joint_id + 1] - model_joint_q_start[joint_id]
     dofs_start_j = model_joint_qd_start[joint_id]
     qd_count_j = model_joint_qd_start[joint_id + 1] - dofs_start_j
@@ -263,20 +263,20 @@ def joint_conversion_kernel(
 @wp.kernel
 def joint_frame_conversion_kernel(
     # Inputs:
-    model_joint_parent: wp.array[int32],
-    model_joint_child: wp.array[int32],
-    model_joint_qd_start: wp.array[int32],
-    model_joint_axis: wp.array[vec3f],
-    model_body_com: wp.array[vec3f],
-    model_joint_X_p: wp.array[transformf],
-    model_joint_X_c: wp.array[transformf],
-    joint_dof_type: wp.array[int32],
-    joint_num_dofs: wp.array[int32],
+    model_joint_parent: wp.array[wp.int32],
+    model_joint_child: wp.array[wp.int32],
+    model_joint_qd_start: wp.array[wp.int32],
+    model_joint_axis: wp.array[wp.vec3f],
+    model_body_com: wp.array[wp.vec3f],
+    model_joint_X_p: wp.array[wp.transformf],
+    model_joint_X_c: wp.array[wp.transformf],
+    joint_dof_type: wp.array[wp.int32],
+    joint_num_dofs: wp.array[wp.int32],
     # Outputs:
-    joint_B_r_B: wp.array[vec3f],
-    joint_F_r_F: wp.array[vec3f],
-    joint_X_B: wp.array[mat33f],
-    joint_X_F: wp.array[mat33f],
+    joint_B_r_B: wp.array[wp.vec3f],
+    joint_F_r_F: wp.array[wp.vec3f],
+    joint_X_B: wp.array[wp.mat33f],
+    joint_X_F: wp.array[wp.mat33f],
 ):
     # Retrieve the joint index
     joint_id = wp.tid()
@@ -287,8 +287,8 @@ def joint_frame_conversion_kernel(
 
     # Get Newton joint transforms and joint axes
     parent_bid = model_joint_parent[joint_id]
-    p_r_p_com = vec3f(model_body_com[parent_bid]) if parent_bid >= 0 else vec3f(0.0, 0.0, 0.0)
-    c_r_c_com = vec3f(model_body_com[model_joint_child[joint_id]])
+    p_r_p_com = wp.vec3f(model_body_com[parent_bid]) if parent_bid >= 0 else wp.vec3f(0.0, 0.0, 0.0)
+    c_r_c_com = wp.vec3f(model_body_com[model_joint_child[joint_id]])
     T_X_p_j = model_joint_X_p[joint_id]
     T_X_c_j = model_joint_X_c[joint_id]
     q_p_j = wp.transform_get_rotation(T_X_p_j)
@@ -319,34 +319,34 @@ def joint_frame_conversion_kernel(
 @wp.kernel
 def joint_indexing_kernel(
     # Inputs:
-    model_joint_world_start: wp.array[int32],
-    joint_act_type: wp.array[int32],
-    joint_num_coords: wp.array[int32],
-    joint_num_dofs: wp.array[int32],
-    joint_num_kinematic_cts: wp.array[int32],
-    joint_num_dynamic_cts: wp.array[int32],
+    model_joint_world_start: wp.array[wp.int32],
+    joint_act_type: wp.array[wp.int32],
+    joint_num_coords: wp.array[wp.int32],
+    joint_num_dofs: wp.array[wp.int32],
+    joint_num_kinematic_cts: wp.array[wp.int32],
+    joint_num_dynamic_cts: wp.array[wp.int32],
     # Outputs:
-    num_passive_joints: wp.array[int32],
-    num_actuated_joints: wp.array[int32],
-    num_dynamic_joints: wp.array[int32],
-    num_joint_coords: wp.array[int32],
-    num_joint_dofs: wp.array[int32],
-    num_joint_passive_coords: wp.array[int32],
-    num_joint_passive_dofs: wp.array[int32],
-    num_joint_actuated_coords: wp.array[int32],
-    num_joint_actuated_dofs: wp.array[int32],
-    num_joint_cts: wp.array[int32],
-    num_joint_dynamic_cts: wp.array[int32],
-    num_joint_kinematic_cts: wp.array[int32],
-    joint_coord_start: wp.array[int32],
-    joint_dofs_start: wp.array[int32],
-    joint_actuated_coord_start: wp.array[int32],
-    joint_actuated_dofs_start: wp.array[int32],
-    joint_passive_coord_start: wp.array[int32],
-    joint_passive_dofs_start: wp.array[int32],
-    joint_cts_start: wp.array[int32],
-    joint_dynamic_cts_start: wp.array[int32],
-    joint_kinematic_cts_start: wp.array[int32],
+    num_passive_joints: wp.array[wp.int32],
+    num_actuated_joints: wp.array[wp.int32],
+    num_dynamic_joints: wp.array[wp.int32],
+    num_joint_coords: wp.array[wp.int32],
+    num_joint_dofs: wp.array[wp.int32],
+    num_joint_passive_coords: wp.array[wp.int32],
+    num_joint_passive_dofs: wp.array[wp.int32],
+    num_joint_actuated_coords: wp.array[wp.int32],
+    num_joint_actuated_dofs: wp.array[wp.int32],
+    num_joint_cts: wp.array[wp.int32],
+    num_joint_dynamic_cts: wp.array[wp.int32],
+    num_joint_kinematic_cts: wp.array[wp.int32],
+    joint_coord_start: wp.array[wp.int32],
+    joint_dofs_start: wp.array[wp.int32],
+    joint_actuated_coord_start: wp.array[wp.int32],
+    joint_actuated_dofs_start: wp.array[wp.int32],
+    joint_passive_coord_start: wp.array[wp.int32],
+    joint_passive_dofs_start: wp.array[wp.int32],
+    joint_cts_start: wp.array[wp.int32],
+    joint_dynamic_cts_start: wp.array[wp.int32],
+    joint_kinematic_cts_start: wp.array[wp.int32],
 ):
     world_id = wp.tid()
 
@@ -428,26 +428,26 @@ def joint_indexing_kernel(
 @wp.kernel
 def _globalize_joint_offsets(
     # Inputs:
-    joint_world: wp.array[int32],
-    world_coord_offset: wp.array[int32],
-    world_dof_offset: wp.array[int32],
-    world_passive_coord_offset: wp.array[int32],
-    world_passive_dof_offset: wp.array[int32],
-    world_actuated_coord_offset: wp.array[int32],
-    world_actuated_dof_offset: wp.array[int32],
-    world_cts_offset: wp.array[int32],
-    world_dynamic_cts_offset: wp.array[int32],
-    world_kinematic_cts_offset: wp.array[int32],
+    joint_world: wp.array[wp.int32],
+    world_coord_offset: wp.array[wp.int32],
+    world_dof_offset: wp.array[wp.int32],
+    world_passive_coord_offset: wp.array[wp.int32],
+    world_passive_dof_offset: wp.array[wp.int32],
+    world_actuated_coord_offset: wp.array[wp.int32],
+    world_actuated_dof_offset: wp.array[wp.int32],
+    world_cts_offset: wp.array[wp.int32],
+    world_dynamic_cts_offset: wp.array[wp.int32],
+    world_kinematic_cts_offset: wp.array[wp.int32],
     # Outputs:
-    joint_coord_start: wp.array[int32],
-    joint_dofs_start: wp.array[int32],
-    joint_passive_coord_start: wp.array[int32],
-    joint_passive_dofs_start: wp.array[int32],
-    joint_actuated_coord_start: wp.array[int32],
-    joint_actuated_dofs_start: wp.array[int32],
-    joint_cts_start: wp.array[int32],
-    joint_dynamic_cts_start: wp.array[int32],
-    joint_kinematic_cts_start: wp.array[int32],
+    joint_coord_start: wp.array[wp.int32],
+    joint_dofs_start: wp.array[wp.int32],
+    joint_passive_coord_start: wp.array[wp.int32],
+    joint_passive_dofs_start: wp.array[wp.int32],
+    joint_actuated_coord_start: wp.array[wp.int32],
+    joint_actuated_dofs_start: wp.array[wp.int32],
+    joint_cts_start: wp.array[wp.int32],
+    joint_dynamic_cts_start: wp.array[wp.int32],
+    joint_kinematic_cts_start: wp.array[wp.int32],
 ):
     jid = wp.tid()
     w = joint_world[jid]
@@ -465,14 +465,14 @@ def _globalize_joint_offsets(
 @wp.kernel
 def geometry_conversion_kernel(
     # Inputs:
-    model_shape_world: wp.array[int32],
-    model_shape_world_start: wp.array[int32],
-    model_shape_flags: wp.array[int32],
-    model_shape_collision_groups: wp.array[int32],
-    geom_material: wp.array[int32],
+    model_shape_world: wp.array[wp.int32],
+    model_shape_world_start: wp.array[wp.int32],
+    model_shape_flags: wp.array[wp.int32],
+    model_shape_collision_groups: wp.array[wp.int32],
+    geom_material: wp.array[wp.int32],
     # Outputs:
-    geom_gid: wp.array[int32],
-    model_num_collidable_geoms: wp.array[int32],
+    geom_gid: wp.array[wp.int32],
+    model_num_collidable_geoms: wp.array[wp.int32],
 ):
     # Retrieve the geom/shape index from the thread grid
     shape_id = wp.tid()
@@ -502,12 +502,12 @@ def geometry_conversion_kernel(
 @wp.kernel
 def target_dofs_to_coords_conversion_kernel(
     # Inputs
-    model_joints_dof_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_coords_offset: wp.array[int32],
-    joint_target_dofs: wp.array[float32],
+    model_joints_dof_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_coords_offset: wp.array[wp.int32],
+    joint_target_dofs: wp.array[wp.float32],
     # Outputs
-    joint_target_coords: wp.array[float32],
+    joint_target_coords: wp.array[wp.float32],
 ):
     # Read thread id (= joint id)
     jid = wp.tid()
@@ -532,7 +532,7 @@ def target_dofs_to_coords_conversion_kernel(
     # Convert Euler angles to unit quaternion if needed
     if orientation_dofs_offset >= 0:
         angles_offset = dof_offset + orientation_dofs_offset
-        angles = vec3f(
+        angles = wp.vec3f(
             joint_target_dofs[angles_offset],
             joint_target_dofs[angles_offset + 1],
             joint_target_dofs[angles_offset + 2],
@@ -546,12 +546,12 @@ def target_dofs_to_coords_conversion_kernel(
 @wp.kernel
 def target_coords_to_dofs_conversion_kernel(
     # Inputs
-    model_joints_dof_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_coords_offset: wp.array[int32],
-    joint_target_coords: wp.array[float32],
+    model_joints_dof_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_coords_offset: wp.array[wp.int32],
+    joint_target_coords: wp.array[wp.float32],
     # Outputs
-    joint_target_dofs: wp.array[float32],
+    joint_target_dofs: wp.array[wp.float32],
 ):
     # Read thread id (= joint id)
     jid = wp.tid()
@@ -589,7 +589,7 @@ def target_coords_to_dofs_conversion_kernel(
 
 
 @wp.kernel
-def write_coeff_kernel(a: wp.array[int32], idx: int, v: int):
+def write_coeff_kernel(a: wp.array[wp.int32], idx: int, v: int):
     """Helper kernel writing a single array coefficient"""
     a[idx] = v
 
@@ -611,13 +611,10 @@ def compute_required_contact_capacity(
     to be allocated, according to the shapes present in the model.
 
     Args:
-        model (Model):
-            The Newton model for which to compute the required contact capacity.
-        max_contacts_per_pair (int, optional):
-            Optional maximum number of contacts to allocate per shape pair.
+        model: The Newton model for which to compute the required contact capacity.
+        max_contacts_per_pair: Optional maximum number of contacts to allocate per shape pair.
             If `None`, no per-pair limit is applied.
-        max_contacts_per_world (int, optional):
-            Optional maximum number of contacts to allocate per world.
+        max_contacts_per_world: Optional maximum number of contacts to allocate per world.
             If `None`, no per-world limit is applied, otherwise it will
             override the computed per-world requirements if it is larger.
 
@@ -637,7 +634,7 @@ def compute_required_contact_capacity(
         return 0, [0] * model.world_count
 
     # Compute maximum contacts per world
-    world_max_contacts_wp = wp.zeros((model.world_count,), dtype=int32, device=model.device)
+    world_max_contacts_wp = wp.zeros((model.world_count,), dtype=wp.int32, device=model.device)
     wp.launch(
         kernel=world_max_contacts_kernel,
         dim=model.shape_contact_pair_count,
@@ -669,9 +666,9 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     transforms and writes them in-place into ``joints``.
 
     Args:
-    - model (Model):
+    - model:
         The input Newton model containing the joint information to be converted.
-    - joints (JointsModel):
+    - joints:
         The output JointsModel instance where the converted joint data will be stored.
         This function modifies the `joints` object in-place.
     """
@@ -721,13 +718,13 @@ def convert_rigid_bodies(
 
     # Compute the offsets and number of entities per world
     with wp.ScopedDevice(model.device):
-        body_bid = wp.zeros((model.body_count,), dtype=int32)
-        num_bodies = wp.zeros((model.world_count,), dtype=int32)
-        num_shapes = wp.zeros((model.world_count,), dtype=int32)
-        num_body_dofs = wp.zeros((model.world_count,), dtype=int32)
-        world_body_offset = wp.zeros((model.world_count + 1,), dtype=int32)
-        world_shape_offset = wp.zeros((model.world_count,), dtype=int32)
-        world_body_dof_offset = wp.zeros((model.world_count,), dtype=int32)
+        body_bid = wp.zeros((model.body_count,), dtype=wp.int32)
+        num_bodies = wp.zeros((model.world_count,), dtype=wp.int32)
+        num_shapes = wp.zeros((model.world_count,), dtype=wp.int32)
+        num_body_dofs = wp.zeros((model.world_count,), dtype=wp.int32)
+        world_body_offset = wp.zeros((model.world_count + 1,), dtype=wp.int32)
+        world_shape_offset = wp.zeros((model.world_count,), dtype=wp.int32)
+        world_body_dof_offset = wp.zeros((model.world_count,), dtype=wp.int32)
     wp.launch(
         kernel=rigid_bodies_indexing_kernel,
         dim=model.world_count,
@@ -749,10 +746,10 @@ def convert_rigid_bodies(
 
     # Construct per-world inertial summaries
     with wp.ScopedDevice(model.device):
-        mass_total = wp.empty((model.world_count,), dtype=float32)
-        mass_min = wp.empty((model.world_count,), dtype=float32)
-        mass_max = wp.empty((model.world_count,), dtype=float32)
-        inertia_total = wp.empty((model.world_count,), dtype=float32)
+        mass_total = wp.empty((model.world_count,), dtype=wp.float32)
+        mass_min = wp.empty((model.world_count,), dtype=wp.float32)
+        mass_max = wp.empty((model.world_count,), dtype=wp.float32)
+        inertia_total = wp.empty((model.world_count,), dtype=wp.float32)
     wp.launch(
         kernel=mass_prop_accumulation_kernel,
         dim=model.world_count,
@@ -772,7 +769,7 @@ def convert_rigid_bodies(
 
     # model.body_q stores body-origin world poses, but Kamino expects
     # COM world poses (joint attachment vectors are COM-relative).
-    q_i_0 = wp.empty((model.body_count,), dtype=transformf, device=model.device)
+    q_i_0 = wp.empty((model.body_count,), dtype=wp.transformf, device=model.device)
     convert_body_origin_to_com(model.body_com, model.body_q, q_i_0)
 
     # Fill in size data for bodies
@@ -844,18 +841,18 @@ def convert_joints(
 
     # Create joint property arrays
     with wp.ScopedDevice(model.device):
-        joint_jid = wp.empty(shape=(model.joint_count,), dtype=int32)
-        joint_dof_type = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_act_type = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_num_coords = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_num_dofs = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_num_cts = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_num_dynamic_cts = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_num_kinematic_cts = wp.zeros(shape=(model.joint_count,), dtype=int32)
-        joint_B_r_B = wp.empty(shape=(model.joint_count,), dtype=vec3f)
-        joint_F_r_F = wp.empty(shape=(model.joint_count,), dtype=vec3f)
-        joint_X_B = wp.empty(shape=(model.joint_count,), dtype=mat33f)
-        joint_X_F = wp.empty(shape=(model.joint_count,), dtype=mat33f)
+        joint_jid = wp.empty(shape=(model.joint_count,), dtype=wp.int32)
+        joint_dof_type = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_act_type = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_num_coords = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_num_dofs = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_num_cts = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_num_dynamic_cts = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_num_kinematic_cts = wp.zeros(shape=(model.joint_count,), dtype=wp.int32)
+        joint_B_r_B = wp.empty(shape=(model.joint_count,), dtype=wp.vec3f)
+        joint_F_r_F = wp.empty(shape=(model.joint_count,), dtype=wp.vec3f)
+        joint_X_B = wp.empty(shape=(model.joint_count,), dtype=wp.mat33f)
+        joint_X_F = wp.empty(shape=(model.joint_count,), dtype=wp.mat33f)
 
     # Copy limit arrays
     joint_limit_lower = wp.clone(model.joint_limit_lower)
@@ -921,27 +918,27 @@ def convert_joints(
 
     # Compute sizes and indices for all joint properties
     with wp.ScopedDevice(model.device):
-        num_passive_joints = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_actuated_joints = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_dynamic_joints = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_coords = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_dofs = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_passive_coords = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_passive_dofs = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_actuated_coords = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_actuated_dofs = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_cts = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_dynamic_cts = wp.zeros(shape=(model.world_count,), dtype=int32)
-        num_joint_kinematic_cts = wp.zeros(shape=(model.world_count,), dtype=int32)
-        joint_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_actuated_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_actuated_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_passive_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_passive_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_dynamic_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
-        joint_kinematic_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=int32)
+        num_passive_joints = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_actuated_joints = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_dynamic_joints = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_passive_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_passive_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_actuated_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_actuated_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_dynamic_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_kinematic_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        joint_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_actuated_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_actuated_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_passive_coord_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_passive_dofs_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_dynamic_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
+        joint_kinematic_cts_start = wp.zeros(shape=(model.joint_count + 1,), dtype=wp.int32)
 
     wp.launch(
         kernel=joint_indexing_kernel,
@@ -1324,9 +1321,9 @@ def convert_geometries(
 
     # Convert shapes to the Kamino data structure
     with wp.ScopedDevice(model.device):
-        geom_gid = wp.zeros((model.shape_count,), dtype=int32)
+        geom_gid = wp.zeros((model.shape_count,), dtype=wp.int32)
         geom_material = to_warp_int32_array(geom_material_np)
-        model_num_collidable_geoms = wp.zeros((1,), dtype=int32)
+        model_num_collidable_geoms = wp.zeros((1,), dtype=wp.int32)
 
     wp.launch(
         kernel=geometry_conversion_kernel,
@@ -1363,7 +1360,7 @@ def convert_geometries(
     )
 
     # Create additional collision detection meta-data
-    excluded_pairs = wp.array(sorted(model.shape_collision_filter_pairs), dtype=vec2i, device=model.device)
+    excluded_pairs = wp.array(sorted(model.shape_collision_filter_pairs), dtype=wp.vec2i, device=model.device)
 
     # Construct and return the converted geometries model
     return GeometriesModel(
@@ -1399,7 +1396,7 @@ def convert_geometries(
 
 
 def convert_target_dofs_to_target_coords(
-    joint_target_dofs: wp.array, joint_target_coords: wp.array, model: ModelKamino
+    joint_target_dofs: wp.array[wp.float32], joint_target_coords: wp.array[wp.float32], model: ModelKamino
 ):
     wp.launch(
         target_dofs_to_coords_conversion_kernel,
@@ -1416,7 +1413,7 @@ def convert_target_dofs_to_target_coords(
 
 
 def convert_target_coords_to_target_dofs(
-    joint_target_coords: wp.array, joint_target_dofs: wp.array, model: ModelKamino
+    joint_target_coords: wp.array[wp.float32], joint_target_dofs: wp.array[wp.float32], model: ModelKamino
 ):
     wp.launch(
         target_coords_to_dofs_conversion_kernel,

--- a/newton/_src/solvers/kamino/_src/core/data.py
+++ b/newton/_src/solvers/kamino/_src/core/data.py
@@ -45,54 +45,54 @@ class DataKaminoInfo:
     # Total Constraints
     ###
 
-    num_total_cts: wp.array | None = None
+    num_total_cts: wp.array[wp.int32] | None = None
     """
     The total number of active constraints.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Limits
     ###
 
-    num_limits: wp.array | None = None
+    num_limits: wp.array[wp.int32] | None = None
     """
     The number of active limits in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_limit_cts: wp.array | None = None
+    num_limit_cts: wp.array[wp.int32] | None = None
     """
     The number of active limit constraints.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    limit_cts_group_offset: wp.array | None = None
+    limit_cts_group_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the limit constraints group within the constraints block of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Contacts
     ###
 
-    num_contacts: wp.array | None = None
+    num_contacts: wp.array[wp.int32] | None = None
     """
     The number of active contacts in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_contact_cts: wp.array | None = None
+    num_contact_cts: wp.array[wp.int32] | None = None
     """
     The number of active contact constraints.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    contact_cts_group_offset: wp.array | None = None
+    contact_cts_group_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the contact constraints group within the constraints block of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
@@ -161,8 +161,7 @@ class DataKamino:
         - Body twists
 
         Args:
-            state (StateKamino):
-                The state container holding time-varying state of the simulation.
+            state: The state container holding time-varying state of the simulation.
         """
         # Ensure bodies data has been allocated
         if self.bodies is None:
@@ -182,8 +181,7 @@ class DataKamino:
         - Body wrenches
 
         Args:
-            state (StateKamino):
-                The state container holding time-varying state of the simulation.
+            state: The state container holding time-varying state of the simulation.
         """
         # Ensure bodies data has been allocated
         if self.bodies is None:
@@ -203,8 +201,7 @@ class DataKamino:
         - Joint velocities
 
         Args:
-            state (StateKamino):
-                The state container holding time-varying state of the simulation.
+            state: The state container holding time-varying state of the simulation.
         """
         # Ensure joints data has been allocated
         if self.joints is None:
@@ -225,8 +222,7 @@ class DataKamino:
         - Joint constraint reactions
 
         Args:
-            state (StateKamino):
-                The state container holding time-varying state of the simulation.
+            state: The state container holding time-varying state of the simulation.
         """
         # Ensure joints data has been allocated
         if self.joints is None:

--- a/newton/_src/solvers/kamino/_src/core/data.py
+++ b/newton/_src/solvers/kamino/_src/core/data.py
@@ -47,7 +47,7 @@ class DataKaminoInfo:
 
     num_total_cts: wp.array[wp.int32] | None = None
     """
-    The total number of active constraints.\n
+    The total number of active constraints.
     Shape of ``(num_worlds,)``.
     """
 
@@ -57,19 +57,19 @@ class DataKaminoInfo:
 
     num_limits: wp.array[wp.int32] | None = None
     """
-    The number of active limits in each world.\n
+    The number of active limits in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_limit_cts: wp.array[wp.int32] | None = None
     """
-    The number of active limit constraints.\n
+    The number of active limit constraints.
     Shape of ``(num_worlds,)``.
     """
 
     limit_cts_group_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the limit constraints group within the constraints block of each world.\n
+    The index offset of the limit constraints group within the constraints block of each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -79,19 +79,19 @@ class DataKaminoInfo:
 
     num_contacts: wp.array[wp.int32] | None = None
     """
-    The number of active contacts in each world.\n
+    The number of active contacts in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_contact_cts: wp.array[wp.int32] | None = None
     """
-    The number of active contact constraints.\n
+    The number of active contact constraints.
     Shape of ``(num_worlds,)``.
     """
 
     contact_cts_group_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the contact constraints group within the constraints block of each world.\n
+    The index offset of the contact constraints group within the constraints block of each world.
     Shape of ``(num_worlds,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/geometry.py
+++ b/newton/_src/solvers/kamino/_src/core/geometry.py
@@ -5,14 +5,21 @@
 KAMINO: Geometry Model Types & Containers
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING
 
 import warp as wp
 
 # TODO: from .....sim.builder import ModelBuilder
+from .....core.types import override
 from .....geometry.flags import ShapeFlags
 from .shapes import ShapeDescriptorType
-from .types import Descriptor, float32, int32, override, transformf
+from .types import Descriptor
+
+if TYPE_CHECKING:
+    from .....utils.heightfield import HeightfieldData
 
 ###
 # Module interface
@@ -63,8 +70,8 @@ class GeometryDescriptor(Descriptor):
     shape: ShapeDescriptorType | None = None
     """Definition of the shape of the geometry entity of type :class:`ShapeDescriptorType`."""
 
-    offset: transformf = field(default_factory=wp.transform_identity)
-    """Offset pose of the geometry entity w.r.t. its corresponding body, of type :class:`transformf`."""
+    offset: wp.transformf = field(default_factory=wp.transform_identity)
+    """Offset pose of the geometry entity w.r.t. its corresponding body, of type :class:`wp.transformf`."""
 
     # TODO: Use Model.ShapeConfig instead of all these individual fields
     # config: ModelBuilder.ShapeConfig = field(default_factory=ModelBuilder.ShapeConfig)
@@ -191,7 +198,7 @@ class GeometryDescriptor(Descriptor):
         )
 
     @staticmethod
-    def copy_without_shape(geom: "GeometryDescriptor") -> "GeometryDescriptor":
+    def copy_without_shape(geom: GeometryDescriptor) -> GeometryDescriptor:
         """Returns a copy of a descriptor, but with the shape field set to None"""
         return replace(geom, shape=None)
 
@@ -230,135 +237,135 @@ class GeometriesModel:
     label: list[str] | None = None
     """
     A list containing the label of each geometry.\n
-    Length of ``num_geoms`` and type :class:`str`.
+    Length of ``num_geoms``.
     """
 
     ###
     # Identifiers
     ###
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     World index of each geometry entity.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    gid: wp.array | None = None
+    gid: wp.array[wp.int32] | None = None
     """
     Geometry index of each geometry entity w.r.t its world.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    bid: wp.array | None = None
+    bid: wp.array[wp.int32] | None = None
     """
     Body index of each geometry entity.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
     ###
     # Parameterization
     ###
 
-    type: wp.array | None = None
+    type: wp.array[wp.int32] | None = None
     """
     Shape index of each geometry entity.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    flags: wp.array | None = None
+    flags: wp.array[wp.int32] | None = None
     """
     Shape flags of each geometry entity.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    ptr: wp.array | None = None
+    ptr: wp.array[wp.uint64] | None = None
     """
     Pointer to the source data of the shape.\n
     For primitive shapes this is `0` indicating NULL, otherwise it points to
     the shape data, which can correspond to a mesh, heightfield, or SDF.\n
-    Shape of ``(num_geoms,)`` and type :class:`uint64`.
+    Shape of ``(num_geoms,)``.
     """
 
-    params: wp.array | None = None
+    params: wp.array[wp.vec3f] | None = None
     """
     Shape parameters of each geometry entity if they are shape primitives.\n
-    Shape of ``(num_geoms,)`` and type :class:`vec3f`.
+    Shape of ``(num_geoms,)``.
     """
 
-    offset: wp.array | None = None
+    offset: wp.array[wp.transformf] | None = None
     """
     Offset poses of the geometry elements w.r.t. their corresponding bodies.\n
-    Shape of ``(num_geoms,)`` and type :class:`transformf`.
+    Shape of ``(num_geoms,)``.
     """
 
     ###
     # Collisions
     ###
 
-    material: wp.array | None = None
+    material: wp.array[wp.int32] | None = None
     """
     Material index assigned to each collision geometry.\n
-    Shape of ``(num_geoms,)`` and type :class:`int32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    group: wp.array | None = None
+    group: wp.array[wp.int32] | None = None
     """
     Collision group assigned to each collision geometry.\n
-    Shape of ``(num_geoms,)`` and type :class:`uint32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    gap: wp.array | None = None
+    gap: wp.array[wp.float32] | None = None
     """
     Additional detection threshold [m] for each collision geometry.\n
     Pairwise additive.  Used by both broadphase (AABB expansion) and
     narrowphase (contact retention).\n
-    Shape of ``(num_geoms,)`` and type :class:`float32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    margin: wp.array | None = None
+    margin: wp.array[wp.float32] | None = None
     """
     Surface offset [m] for each collision geometry.\n
     Pairwise additive.  Determines resting separation between shapes.\n
-    Shape of ``(num_geoms,)`` and type :class:`float32`.
+    Shape of ``(num_geoms,)``.
     """
 
-    collidable_pairs: wp.array | None = None
+    collidable_pairs: wp.array[wp.vec2i] | None = None
     """
     Geometry-pair indices that are explicitly considered for collision detection.
     This array is used in broad-phase collision detection.\n
-    Shape of ``(num_collidable_pairs,)`` and type :class:`vec2i`.
+    Shape of ``(num_collidable_pairs,)``.
     """
 
-    excluded_pairs: wp.array | None = None
+    excluded_pairs: wp.array[wp.vec2i] | None = None
     """
     Geometry-pair indices that are explicitly excluded from collision detection.\n
     This array is used in broad-phase collision detection.\n
-    Shape of ``(num_excluded_geom_pairs,)`` and type :class:`vec2i`.
+    Shape of ``(num_excluded_geom_pairs,)``.
     """
 
     ###
     # Mesh / Heightfield Data
     ###
 
-    heightfield_index: wp.array | None = None
+    heightfield_index: wp.array[wp.int32] | None = None
     """Per-shape heightfield index (``-1`` for non-heightfield shapes)."""
 
-    heightfield_data: wp.array | None = None
+    heightfield_data: wp.array[HeightfieldData] | None = None
     """Concatenated :class:`HeightfieldData` structs for all heightfields."""
 
-    heightfield_elevations: wp.array | None = None
+    heightfield_elevations: wp.array[wp.float32] | None = None
     """Concatenated elevation samples for all heightfields."""
 
-    collision_aabb_lower: wp.array | None = None
+    collision_aabb_lower: wp.array[wp.vec3f] | None = None
     """Per-shape local-space collision AABB lower bounds."""
 
-    collision_aabb_upper: wp.array | None = None
+    collision_aabb_upper: wp.array[wp.vec3f] | None = None
     """Per-shape local-space collision AABB upper bounds."""
 
-    collision_radius: wp.array | None = None
+    collision_radius: wp.array[wp.float32] | None = None
     """Per-shape bounding-sphere radius for broadphase AABB computation."""
 
-    voxel_resolution: wp.array | None = None
+    voxel_resolution: wp.array[wp.vec3i] | None = None
     """Per-shape voxel resolution for mesh contact reduction."""
 
 
@@ -368,18 +375,18 @@ class GeometriesData:
     An SoA-based container to hold time-varying data of a set of generic geometry entities.
 
     Attributes:
-        num_geoms (int32): The total number of geometry entities in the model (host-side).
-        pose (wp.array | None): The poses of the geometry entities in world coordinates.\n
-            Shape of ``(num_geoms,)`` and type :class:`transformf`.
+        num_geoms: The total number of geometry entities in the model (host-side).
+        pose: The poses of the geometry entities in world coordinates.\n
+            Shape of ``(num_geoms,)``.
     """
 
     num_geoms: int = 0
     """Total number of geometry entities in the model (host-side)."""
 
-    pose: wp.array | None = None
+    pose: wp.array[wp.transformf] | None = None
     """
     The poses of the geometry entities in world coordinates.\n
-    Shape of ``(num_geoms,)`` and type :class:`transformf`.
+    Shape of ``(num_geoms,)``.
     """
 
 
@@ -391,31 +398,27 @@ class GeometriesData:
 @wp.kernel
 def _update_geometries_state(
     # Inputs:
-    geom_bid: wp.array[int32],
-    geom_offset: wp.array[transformf],
-    body_pose: wp.array[transformf],
+    geom_bid: wp.array[wp.int32],
+    geom_offset: wp.array[wp.transformf],
+    body_pose: wp.array[wp.transformf],
     # Outputs:
-    geom_pose: wp.array[transformf],
+    geom_pose: wp.array[wp.transformf],
 ):
     """
     A kernel to update poses of geometry entities in world
     coordinates from the poses of their associated bodies.
 
-    **Inputs**:
-        body_pose (wp.array):
-            Array of per-body poses in world coordinates.\n
-            Shape of ``(num_bodies,)`` and type :class:`transformf`.
-        geom_bid (wp.array):
-            Array of per-geom body indices.\n
-            Shape of ``(num_geoms,)`` and type :class:`int32`.
-        geom_offset (wp.array):
-            Array of per-geom pose offsets w.r.t. their associated bodies.\n
-            Shape of ``(num_geoms,)`` and type :class:`transformf`.
+    Inputs:
+        geom_bid: Array of per-geom body indices.\n
+            Shape of ``(num_geoms,)``.
+        geom_offset: Array of per-geom pose offsets w.r.t. their associated bodies.\n
+            Shape of ``(num_geoms,)``.
+        body_pose: Array of per-body poses in world coordinates.\n
+            Shape of ``(num_bodies,)``.
 
-    **Outputs**:
-        geom_pose (wp.array):
-            Array of per-geom poses in world coordinates.\n
-            Shape of ``(num_geoms,)`` and type :class:`transformf`.
+    Outputs:
+        geom_pose: Array of per-geom poses in world coordinates.\n
+            Shape of ``(num_geoms,)``.
     """
     # Retrieve the geometry index from the thread grid
     gid = wp.tid()
@@ -424,7 +427,7 @@ def _update_geometries_state(
     bid = geom_bid[gid]
 
     # Retrieve the pose of the corresponding body
-    X_b = wp.transform_identity(dtype=float32)
+    X_b = wp.transform_identity(dtype=wp.float32)
     if bid > -1:
         X_b = body_pose[bid]
 
@@ -444,7 +447,7 @@ def _update_geometries_state(
 
 
 def update_geometries_state(
-    body_poses: wp.array,
+    body_poses: wp.array[wp.transformf],
     geom_model: GeometriesModel,
     geom_data: GeometriesData,
 ):
@@ -453,13 +456,10 @@ def update_geometries_state(
     world coordinates from the poses of their associated bodies.
 
     Args:
-        body_poses (wp.array):
-            The poses of the bodies in world coordinates.\n
-            Shape of ``(num_bodies,)`` and type :class:`transformf`.
-        geom_model (GeometriesModel):
-            The model container holding time-invariant geometry data.
-        geom_data (GeometriesData):
-            The data container of the geometry elements.
+        body_poses: The poses of the bodies in world coordinates.
+            Shape of ``(num_bodies,)``.
+        geom_model: The model container holding time-invariant geometry data.
+        geom_data: The data container of the geometry elements.
     """
     wp.launch(
         _update_geometries_state,

--- a/newton/_src/solvers/kamino/_src/core/geometry.py
+++ b/newton/_src/solvers/kamino/_src/core/geometry.py
@@ -62,8 +62,8 @@ class GeometryDescriptor(Descriptor):
 
     body: int = -1
     """
-    Index of the body to which the geometry entity is attached.\n
-    Defaults to `-1`, indicating that the geometry has not yet been assigned to a body.\n
+    Index of the body to which the geometry entity is attached.
+    Defaults to `-1`, indicating that the geometry has not yet been assigned to a body.
     The value `-1` also indicates that the geometry, by default, is statically attached to the world.
     """
 
@@ -82,27 +82,27 @@ class GeometryDescriptor(Descriptor):
 
     material: str | int | None = None
     """
-    The material assigned to the collision geometry instance.\n
-    Can be specified either as a string name or an integer index.\n
+    The material assigned to the collision geometry instance.
+    Can be specified either as a string name or an integer index.
     Defaults to `None`, indicating the default material.
     """
 
     group: int = 1
     """
-    The collision group assigned to the collision geometry.\n
+    The collision group assigned to the collision geometry.
     Defaults to the default group with value `1`.
     """
 
     collides: int = 1
     """
-    The collision groups with which the collision geometry can collide.\n
+    The collision groups with which the collision geometry can collide.
     Defaults to enabling collisions with the default group with value `1`.
     """
 
     max_contacts: int = 0
     """
-    The maximum number of contacts to generate for the collision geometry.\n
-    This value provides a hint to the model builder when allocating memory for contacts.\n
+    The maximum number of contacts to generate for the collision geometry.
+    This value provides a hint to the model builder when allocating memory for contacts.
     Defaults to `0`, indicating no limit is imposed on the number of contacts generated for this geometry.
     """
 
@@ -134,25 +134,25 @@ class GeometryDescriptor(Descriptor):
 
     wid: int = -1
     """
-    Index of the world to which the body belongs.\n
+    Index of the world to which the body belongs.
     Defaults to `-1`, indicating that the body has not yet been added to a world.
     """
 
     gid: int = -1
     """
-    Index of the geometry w.r.t. its world.\n
+    Index of the geometry w.r.t. its world.
     Defaults to `-1`, indicating that the geometry has not yet been added to a world.
     """
 
     mid: int = -1
     """
-    The material index assigned to the collision geometry.\n
+    The material index assigned to the collision geometry.
     Defaults to `-1` indicating that the default material will be assigned.
     """
 
     flags: int = ShapeFlags.VISIBLE | ShapeFlags.COLLIDE_SHAPES | ShapeFlags.COLLIDE_PARTICLES
     """
-    Shape flags of the geometry entity, used to specify additional properties of the geometry.\n
+    Shape flags of the geometry entity, used to specify additional properties of the geometry.
     Defaults to `ShapeFlags.VISIBLE | ShapeFlags.COLLIDE_SHAPES | ShapeFlags.COLLIDE_PARTICLES`,
     indicating that the geometry is visible and can collide with shapes and particles.
     """
@@ -230,13 +230,13 @@ class GeometriesModel:
 
     world_minimum_contacts: list[int] | None = None
     """
-    List of the minimum number of contacts required for each world in the model (host-side).\n
+    List of the minimum number of contacts required for each world in the model (host-side).
     The sum of all elements in `world_minimum_contacts` should equal `model_minimum_contacts`.
     """
 
     label: list[str] | None = None
     """
-    A list containing the label of each geometry.\n
+    A list containing the label of each geometry.
     Length of ``num_geoms``.
     """
 
@@ -246,19 +246,19 @@ class GeometriesModel:
 
     wid: wp.array[wp.int32] | None = None
     """
-    World index of each geometry entity.\n
+    World index of each geometry entity.
     Shape of ``(num_geoms,)``.
     """
 
     gid: wp.array[wp.int32] | None = None
     """
-    Geometry index of each geometry entity w.r.t its world.\n
+    Geometry index of each geometry entity w.r.t its world.
     Shape of ``(num_geoms,)``.
     """
 
     bid: wp.array[wp.int32] | None = None
     """
-    Body index of each geometry entity.\n
+    Body index of each geometry entity.
     Shape of ``(num_geoms,)``.
     """
 
@@ -268,33 +268,33 @@ class GeometriesModel:
 
     type: wp.array[wp.int32] | None = None
     """
-    Shape index of each geometry entity.\n
+    Shape index of each geometry entity.
     Shape of ``(num_geoms,)``.
     """
 
     flags: wp.array[wp.int32] | None = None
     """
-    Shape flags of each geometry entity.\n
+    Shape flags of each geometry entity.
     Shape of ``(num_geoms,)``.
     """
 
     ptr: wp.array[wp.uint64] | None = None
     """
-    Pointer to the source data of the shape.\n
+    Pointer to the source data of the shape.
     For primitive shapes this is `0` indicating NULL, otherwise it points to
-    the shape data, which can correspond to a mesh, heightfield, or SDF.\n
+    the shape data, which can correspond to a mesh, heightfield, or SDF.
     Shape of ``(num_geoms,)``.
     """
 
     params: wp.array[wp.vec3f] | None = None
     """
-    Shape parameters of each geometry entity if they are shape primitives.\n
+    Shape parameters of each geometry entity if they are shape primitives.
     Shape of ``(num_geoms,)``.
     """
 
     offset: wp.array[wp.transformf] | None = None
     """
-    Offset poses of the geometry elements w.r.t. their corresponding bodies.\n
+    Offset poses of the geometry elements w.r.t. their corresponding bodies.
     Shape of ``(num_geoms,)``.
     """
 
@@ -304,42 +304,42 @@ class GeometriesModel:
 
     material: wp.array[wp.int32] | None = None
     """
-    Material index assigned to each collision geometry.\n
+    Material index assigned to each collision geometry.
     Shape of ``(num_geoms,)``.
     """
 
     group: wp.array[wp.int32] | None = None
     """
-    Collision group assigned to each collision geometry.\n
+    Collision group assigned to each collision geometry.
     Shape of ``(num_geoms,)``.
     """
 
     gap: wp.array[wp.float32] | None = None
     """
-    Additional detection threshold [m] for each collision geometry.\n
+    Additional detection threshold [m] for each collision geometry.
     Pairwise additive.  Used by both broadphase (AABB expansion) and
-    narrowphase (contact retention).\n
+    narrowphase (contact retention).
     Shape of ``(num_geoms,)``.
     """
 
     margin: wp.array[wp.float32] | None = None
     """
-    Surface offset [m] for each collision geometry.\n
-    Pairwise additive.  Determines resting separation between shapes.\n
+    Surface offset [m] for each collision geometry.
+    Pairwise additive.  Determines resting separation between shapes.
     Shape of ``(num_geoms,)``.
     """
 
     collidable_pairs: wp.array[wp.vec2i] | None = None
     """
     Geometry-pair indices that are explicitly considered for collision detection.
-    This array is used in broad-phase collision detection.\n
+    This array is used in broad-phase collision detection.
     Shape of ``(num_collidable_pairs,)``.
     """
 
     excluded_pairs: wp.array[wp.vec2i] | None = None
     """
-    Geometry-pair indices that are explicitly excluded from collision detection.\n
-    This array is used in broad-phase collision detection.\n
+    Geometry-pair indices that are explicitly excluded from collision detection.
+    This array is used in broad-phase collision detection.
     Shape of ``(num_excluded_geom_pairs,)``.
     """
 
@@ -376,7 +376,7 @@ class GeometriesData:
 
     Attributes:
         num_geoms: The total number of geometry entities in the model (host-side).
-        pose: The poses of the geometry entities in world coordinates.\n
+        pose: The poses of the geometry entities in world coordinates.
             Shape of ``(num_geoms,)``.
     """
 
@@ -385,7 +385,7 @@ class GeometriesData:
 
     pose: wp.array[wp.transformf] | None = None
     """
-    The poses of the geometry entities in world coordinates.\n
+    The poses of the geometry entities in world coordinates.
     Shape of ``(num_geoms,)``.
     """
 
@@ -409,15 +409,15 @@ def _update_geometries_state(
     coordinates from the poses of their associated bodies.
 
     Inputs:
-        geom_bid: Array of per-geom body indices.\n
+        geom_bid: Array of per-geom body indices.
             Shape of ``(num_geoms,)``.
-        geom_offset: Array of per-geom pose offsets w.r.t. their associated bodies.\n
+        geom_offset: Array of per-geom pose offsets w.r.t. their associated bodies.
             Shape of ``(num_geoms,)``.
-        body_pose: Array of per-body poses in world coordinates.\n
+        body_pose: Array of per-body poses in world coordinates.
             Shape of ``(num_bodies,)``.
 
     Outputs:
-        geom_pose: Array of per-geom poses in world coordinates.\n
+        geom_pose: Array of per-geom poses in world coordinates.
             Shape of ``(num_geoms,)``.
     """
     # Retrieve the geometry index from the thread grid

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -155,21 +155,21 @@ class GravityModel:
     A container to hold the time-invariant gravity model data.
 
     Attributes:
-        g_dir_acc: The gravity direction and acceleration vector as ``[g_dir_x, g_dir_y, g_dir_z, g_accel]``.\n
+        g_dir_acc: The gravity direction and acceleration vector as ``[g_dir_x, g_dir_y, g_dir_z, g_accel]``.
             Shape of ``(num_worlds,)``.
-        vector: The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.\n
+        vector: The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.
             Shape of ``(num_worlds,)``.
     """
 
     g_dir_acc: wp.array[wp.vec4f] | None = None
     """
-    The gravity direction and acceleration vector.\n
+    The gravity direction and acceleration vector.
     Shape of ``(num_worlds,)``.
     """
 
     vector: wp.array[wp.vec4f] | None = None
     """
-    The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.\n
+    The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.
     Shape of ``(num_worlds,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -135,9 +135,9 @@ class GravityDescriptor(Descriptor):
         return self._direction
 
     @direction.setter
-    def direction(self, dir: wp.vec3f):
+    def direction(self, direction: wp.vec3f):
         """Sets the normalized direction vector of gravity."""
-        self._direction = wp.normalize(dir)
+        self._direction = wp.normalize(direction)
 
     def dir_accel(self) -> wp.vec4f:
         """Returns the gravity direction and acceleration as compactly as a :class:`wp.vec4f`."""

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -10,9 +10,10 @@ from dataclasses import dataclass
 import numpy as np
 import warp as wp
 
+from .....core.types import override
 from .....sim.model import Model
 from ..utils import logger as msg
-from .types import ArrayLike, Descriptor, override, vec3f, vec4f
+from .types import ArrayLike, Descriptor
 
 ###
 # Module interface
@@ -62,11 +63,11 @@ class GravityDescriptor(Descriptor):
     A container to describe a world's gravity.
 
     Attributes:
-        name (str): The name of the gravity descriptor.
-        uid (str): The unique identifier of the gravity descriptor.
-        enabled (bool): Whether gravity is enabled.
-        acceleration (float): The gravitational acceleration magnitude in m/s^2.
-        direction (vec3f): The normalized direction vector of gravity.
+        name: The name of the gravity descriptor.
+        uid: The unique identifier of the gravity descriptor.
+        enabled: Whether gravity is enabled.
+        acceleration: The gravitational acceleration magnitude [m/s²].
+        direction: The normalized direction vector of gravity.
     """
 
     def __init__(
@@ -81,19 +82,19 @@ class GravityDescriptor(Descriptor):
         Initialize the gravity descriptor.
 
         Args:
-            enabled (bool): Whether gravity is enabled.\n
+            enabled: Whether gravity is enabled.
                 Defaults to `True` to enable gravity by default.
-            acceleration (float): The gravitational acceleration magnitude in m/s^2.\n
+            acceleration: The gravitational acceleration magnitude in m/s^2.
                 Defaults to 9.8067 m/s^2 (Earth's gravity).
-            direction (vec3f): The normalized direction vector of gravity.\n
+            direction: The normalized direction vector of gravity.
                 Defaults to pointing down the -Z axis.
-            name (str): The name of the gravity descriptor.
-            uid (str | None): Optional unique identifier of the gravity descriptor.
+            name: The name of the gravity descriptor.
+            uid: Optional unique identifier of the gravity descriptor.
         """
         super().__init__(name, uid)
         self._enabled: bool = enabled
         self._acceleration: float = acceleration
-        self._direction: vec3f = wp.normalize(vec3f(direction))
+        self._direction: wp.vec3f = wp.normalize(wp.vec3f(direction))
 
     @override
     def __repr__(self):
@@ -129,23 +130,23 @@ class GravityDescriptor(Descriptor):
         self._acceleration = g
 
     @property
-    def direction(self) -> vec3f:
+    def direction(self) -> wp.vec3f:
         """Returns the normalized direction vector of gravity."""
         return self._direction
 
     @direction.setter
-    def direction(self, dir: vec3f):
+    def direction(self, dir: wp.vec3f):
         """Sets the normalized direction vector of gravity."""
         self._direction = wp.normalize(dir)
 
-    def dir_accel(self) -> vec4f:
-        """Returns the gravity direction and acceleration as compactly as a :class:`vec4f`."""
-        return vec4f([self.direction[0], self.direction[1], self.direction[2], self.acceleration])
+    def dir_accel(self) -> wp.vec4f:
+        """Returns the gravity direction and acceleration as compactly as a :class:`wp.vec4f`."""
+        return wp.vec4f([self.direction[0], self.direction[1], self.direction[2], self.acceleration])
 
-    def vector(self) -> vec4f:
-        """Returns the effective gravity vector and enabled flag compactly as a :class:`vec4f`."""
-        g = vec3f(self.acceleration * self.direction)
-        return vec4f([g[0], g[1], g[2], float(self.enabled)])
+    def vector(self) -> wp.vec4f:
+        """Returns the effective gravity vector and enabled flag compactly as a :class:`wp.vec4f`."""
+        g = wp.vec3f(self.acceleration * self.direction)
+        return wp.vec4f([g[0], g[1], g[2], float(self.enabled)])
 
 
 @dataclass
@@ -154,20 +155,22 @@ class GravityModel:
     A container to hold the time-invariant gravity model data.
 
     Attributes:
-        g_dir_acc (wp.array): The gravity direction and acceleration vector as ``[g_dir_x, g_dir_y, g_dir_z, g_accel]``.
-        vector (wp.array): The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.
+        g_dir_acc: The gravity direction and acceleration vector as ``[g_dir_x, g_dir_y, g_dir_z, g_accel]``.\n
+            Shape of ``(num_worlds,)``.
+        vector: The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.\n
+            Shape of ``(num_worlds,)``.
     """
 
-    g_dir_acc: wp.array | None = None
+    g_dir_acc: wp.array[wp.vec4f] | None = None
     """
     The gravity direction and acceleration vector.\n
-    Shape of ``(num_worlds,)`` and type :class:`vec4f`.
+    Shape of ``(num_worlds,)``.
     """
 
-    vector: wp.array | None = None
+    vector: wp.array[wp.vec4f] | None = None
     """
     The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.\n
-    Shape of ``(num_worlds,)`` and type :class:`vec4f`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
@@ -190,11 +193,9 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
     Converts the gravity representation from the Newton model to the Kamino format.
 
     Args:
-        model_in (Model):
-            The input Newton model containing the gravity information to be converted.
-        gravity_out (GravityModel, optional):
-            The output GravityModel instance where the converted gravity data will be stored.\n
-            If `None`, a new GravityModel instance will be created and returned.\n
+        model_in: The input Newton model containing the gravity information to be converted.
+        gravity_out: The output GravityModel instance where the converted gravity data will be stored.
+            If `None`, a new GravityModel instance will be created and returned.
             If the arrays within `gravity_out` are not already allocated
             with the appropriate shapes, this function will allocate them.
     """
@@ -223,8 +224,8 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
     if gravity_out is None:
         with wp.ScopedDevice(model_in.device):
             gravity_out = GravityModel(
-                g_dir_acc=wp.array(g_dir_acc_np, dtype=vec4f),
-                vector=wp.array(vector_np, dtype=vec4f),
+                g_dir_acc=wp.array(g_dir_acc_np, dtype=wp.vec4f),
+                vector=wp.array(vector_np, dtype=wp.vec4f),
             )
 
     # Otherwise, ensure the provided model has allocated arrays of the
@@ -233,12 +234,12 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
         # Ensure that the output GravityModel has allocated arrays of the correct shape and type
         if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.g_dir_acc` array does not have matching shape. Allocating a new array.")
-            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=vec4f, device=model_in.device)
+            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=wp.vec4f, device=model_in.device)
         else:
             gravity_out.g_dir_acc.assign(g_dir_acc_np)
         if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.vector` array does not have matching shape. Allocating a new array.")
-            gravity_out.vector = wp.array(vector_np, dtype=vec4f, device=model_in.device)
+            gravity_out.vector = wp.array(vector_np, dtype=wp.vec4f, device=model_in.device)
         else:
             gravity_out.vector.assign(vector_np)
 

--- a/newton/_src/solvers/kamino/_src/core/inertia.py
+++ b/newton/_src/solvers/kamino/_src/core/inertia.py
@@ -6,7 +6,7 @@ Provides functions to compute moments
 of inertia for solid geometric bodies.
 """
 
-from .types import mat33f
+import warp as wp
 
 ###
 # Module interface
@@ -26,37 +26,37 @@ __all__ = [
 ###
 
 
-def solid_sphere_body_moment_of_inertia(m: float, r: float) -> mat33f:
+def solid_sphere_body_moment_of_inertia(m: float, r: float) -> wp.mat33f:
     Ia = 0.4 * m * r * r
-    i_I_i = mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ia]])
+    i_I_i = wp.mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ia]])
     return i_I_i
 
 
-def solid_cylinder_body_moment_of_inertia(m: float, r: float, h: float) -> mat33f:
+def solid_cylinder_body_moment_of_inertia(m: float, r: float, h: float) -> wp.mat33f:
     Ia = 1.0 / 12.0 * m * (3.0 * r * r + h * h)
     Ib = 0.5 * m * r * r
-    i_I_i = mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
+    i_I_i = wp.mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
     return i_I_i
 
 
-def solid_cone_body_moment_of_inertia(m: float, r: float, h: float) -> mat33f:
+def solid_cone_body_moment_of_inertia(m: float, r: float, h: float) -> wp.mat33f:
     Ia = 0.15 * m * (r * r + 0.25 * h * h)
     Ib = 0.3 * m * r * r
-    i_I_i = mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
+    i_I_i = wp.mat33f([[Ia, 0.0, 0.0], [0.0, Ia, 0.0], [0.0, 0.0, Ib]])
     return i_I_i
 
 
-def solid_ellipsoid_body_moment_of_inertia(m: float, a: float, b: float, c: float) -> mat33f:
+def solid_ellipsoid_body_moment_of_inertia(m: float, a: float, b: float, c: float) -> wp.mat33f:
     Ia = 0.2 * m * (b * b + c * c)
     Ib = 0.2 * m * (a * a + c * c)
     Ic = 0.2 * m * (a * a + b * b)
-    i_I_i = mat33f([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ic]])
+    i_I_i = wp.mat33f([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ic]])
     return i_I_i
 
 
-def solid_cuboid_body_moment_of_inertia(m: float, w: float, h: float, d: float) -> mat33f:
+def solid_cuboid_body_moment_of_inertia(m: float, w: float, h: float, d: float) -> wp.mat33f:
     Ia = (1.0 / 12.0) * m * (h * h + d * d)
     Ib = (1.0 / 12.0) * m * (w * w + d * d)
     Ic = (1.0 / 12.0) * m * (w * w + h * h)
-    i_I_i = mat33f([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ic]])
+    i_I_i = wp.mat33f([[Ia, 0.0, 0.0], [0.0, Ib, 0.0], [0.0, 0.0, Ic]])
     return i_I_i

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -13,27 +13,15 @@ import numpy as np
 import warp as wp
 from warp._src.types import Any, Int, Vector
 
-from .....core.types import MAXVAL
+from .....core.types import MAXVAL, override
 from .....sim import JointTargetMode, JointType
 from .math import FLOAT32_MAX, FLOAT32_MIN, PI, TWO_PI
 from .types import (
     ArrayLike,
     Descriptor,
-    float32,
-    int32,
-    mat33f,
     mat63f,
-    override,
-    quatf,
-    transformf,
     vec1f,
     vec1i,
-    vec2f,
-    vec2i,
-    vec3f,
-    vec3i,
-    vec4f,
-    vec4i,
     vec5i,
     vec6f,
     vec6i,
@@ -126,11 +114,10 @@ class JointActuationType(IntEnum):
         Converts a `JointActuationType` to the corresponding `JointTargetMode`.
 
         Args:
-            type (JointActuationType): The joint actuation type to convert.
+            type: The joint actuation type to convert.
 
         Returns:
-            JointTargetMode:
-                The corresponding Newton joint target mode, or None if not applicable.
+            The corresponding Newton joint target mode, or None if not applicable.
         """
         _MAP_TO_NEWTON: dict[JointActuationType, JointTargetMode | None] = {
             JointActuationType.PASSIVE: JointTargetMode.NONE,
@@ -153,11 +140,10 @@ class JointActuationType(IntEnum):
         Converts a `JointTargetMode` to the corresponding `JointActuationType`.
 
         Args:
-            mode (JointTargetMode): The Newton joint target mode to convert.
+            mode: The Newton joint target mode to convert.
 
         Returns:
-            JointActuationType | None:
-                The corresponding joint actuation type, or None if not applicable.
+            The corresponding joint actuation type, or None if not applicable.
         """
         _MAP_FROM_NEWTON: dict[JointTargetMode, JointActuationType] = {
             JointTargetMode.NONE: JointActuationType.PASSIVE,
@@ -272,12 +258,12 @@ class JointCorrectionMode(IntEnum):
 
 
 @wp.func
-def _axis_rotmatn_from_vec3f(vec: vec3f) -> mat33f:
+def _axis_rotmatn_from_vec3f(vec: wp.vec3f) -> wp.mat33f:
     n = wp.norm_l2(vec)
     assert n >= 1e-12, "Joint axis cannot have near-zero length"
     ax = vec / n
-    dominant = int32(wp.argmax(wp.abs(ax)))
-    ref = vec3f(0.0, 0.0, 0.0)
+    dominant = wp.int32(wp.argmax(wp.abs(ax)))
+    ref = wp.vec3f(0.0, 0.0, 0.0)
     ref[(dominant + 2) % 3] = 1.0
     ay = wp.cross(ref, ax)
     ay = wp.normalize(ay)
@@ -544,15 +530,15 @@ class JointDoFType(IntEnum):
         elif self.value == self.PRISMATIC:
             return wp.constant(vec5i(1, 2, 3, 4, 5))
         elif self.value == self.CYLINDRICAL:
-            return wp.constant(vec4i(1, 2, 4, 5))
+            return wp.constant(wp.vec4i(1, 2, 4, 5))
         elif self.value == self.UNIVERSAL:
-            return wp.constant(vec4i(0, 1, 2, 5))
+            return wp.constant(wp.vec4i(0, 1, 2, 5))
         elif self.value == self.SPHERICAL:
-            return wp.constant(vec3i(0, 1, 2))
+            return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.GIMBAL:
-            return wp.constant(vec3i(0, 1, 2))
+            return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.CARTESIAN:
-            return wp.constant(vec3i(3, 4, 5))
+            return wp.constant(wp.vec3i(3, 4, 5))
         elif self.value == self.FIXED:
             return wp.constant(vec6i(0, 1, 2, 3, 4, 5))
         else:
@@ -570,15 +556,15 @@ class JointDoFType(IntEnum):
         elif self.value == self.PRISMATIC:
             return wp.constant(vec1i(0))
         elif self.value == self.CYLINDRICAL:
-            return wp.constant(vec2i(0, 3))
+            return wp.constant(wp.vec2i(0, 3))
         elif self.value == self.UNIVERSAL:
-            return wp.constant(vec2i(3, 4))
+            return wp.constant(wp.vec2i(3, 4))
         elif self.value == self.SPHERICAL:
-            return wp.constant(vec3i(3, 4, 5))
+            return wp.constant(wp.vec3i(3, 4, 5))
         elif self.value == self.GIMBAL:
-            return wp.constant(vec3i(3, 4, 5))
+            return wp.constant(wp.vec3i(3, 4, 5))
         elif self.value == self.CARTESIAN:
-            return wp.constant(vec3i(0, 1, 2))
+            return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.FIXED:
             return []  # Empty vector (TODO: wp.constant(vec0i()))
         else:
@@ -596,15 +582,15 @@ class JointDoFType(IntEnum):
         elif self.value == self.PRISMATIC:
             return vec1f
         elif self.value == self.CYLINDRICAL:
-            return vec2f
+            return wp.vec2f
         elif self.value == self.UNIVERSAL:
-            return vec2f
+            return wp.vec2f
         elif self.value == self.SPHERICAL:
-            return vec4f
+            return wp.vec4f
         elif self.value == self.GIMBAL:
-            return vec3f
+            return wp.vec3f
         elif self.value == self.CARTESIAN:
-            return vec3f
+            return wp.vec3f
         elif self.value == self.FIXED:
             return None
         else:
@@ -616,21 +602,21 @@ class JointDoFType(IntEnum):
         Returns the data type required to represent the joint's generalized coordinates.
         """
         if self.value == self.FREE:
-            return transformf
+            return wp.transformf
         elif self.value == self.REVOLUTE:
             return vec1f
         elif self.value == self.PRISMATIC:
             return vec1f
         elif self.value == self.CYLINDRICAL:
-            return vec2f
+            return wp.vec2f
         elif self.value == self.UNIVERSAL:
-            return vec2f
+            return wp.vec2f
         elif self.value == self.SPHERICAL:
-            return quatf
+            return wp.quatf
         elif self.value == self.GIMBAL:
-            return vec3f
+            return wp.vec3f
         elif self.value == self.CARTESIAN:
-            return vec3f
+            return wp.vec3f
         elif self.value == self.FIXED:
             return None
         else:
@@ -696,10 +682,10 @@ class JointDoFType(IntEnum):
         Converts a `JointDoFType` to the corresponding `JointType`.
 
         Args:
-            dof_type (JointDoFType): The joint DoF type to convert.
+            dof_type: The joint DoF type to convert.
 
         Returns:
-            JointType | None: The corresponding Newton joint type, or None if unsupported.
+            The corresponding Newton joint type, or None if unsupported.
         """
         _MAP_TO_NEWTON: dict[JointDoFType, JointType] = {
             # All trivially supported DoF types map directly
@@ -733,10 +719,10 @@ class JointDoFType(IntEnum):
         Converts a `JointType` to the corresponding `JointDoFType`.
 
         Args:
-            type (JointType): The Newton joint type to convert.
+            type: The Newton joint type to convert.
 
         Returns:
-            JointDoFType: The corresponding joint DoF type.
+            The corresponding joint DoF type.
         """
         # First try directly mapping the trivially supported types
         _MAP_TO_KAMINO: dict[JointType, JointDoFType | None] = {
@@ -833,10 +819,10 @@ class JointDoFType(IntEnum):
         joint_type: int,
         q_count: int,
         qd_count: int,
-        dof_dim: vec2i,
+        dof_dim: wp.vec2i,
         limit_lower: vec6f,
         limit_upper: vec6f,
-    ) -> int32:
+    ) -> wp.int32:
         """
         Converts a Newton `JointType` to the corresponding Kamino `JointDoFType`.
 
@@ -864,22 +850,22 @@ class JointDoFType(IntEnum):
 
         # If the type is not directly supported, attempt to infer the DoF type based
         # on the dimensions of the joint and number of DoFs.
-        if q_count == 0 and qd_count == 0 and dof_dim == vec2i(0, 0):
+        if q_count == 0 and qd_count == 0 and dof_dim == wp.vec2i(0, 0):
             return JointDoFType.FIXED
-        elif q_count == 1 and qd_count == 1 and dof_dim == vec2i(1, 0):
+        elif q_count == 1 and qd_count == 1 and dof_dim == wp.vec2i(1, 0):
             return JointDoFType.PRISMATIC
-        elif q_count == 1 and qd_count == 1 and dof_dim == vec2i(0, 1):
+        elif q_count == 1 and qd_count == 1 and dof_dim == wp.vec2i(0, 1):
             return JointDoFType.REVOLUTE
-        elif q_count == 2 and qd_count == 2 and dof_dim == vec2i(0, 2):
+        elif q_count == 2 and qd_count == 2 and dof_dim == wp.vec2i(0, 2):
             return JointDoFType.UNIVERSAL
-        elif q_count == 2 and qd_count == 2 and dof_dim == vec2i(1, 1):
+        elif q_count == 2 and qd_count == 2 and dof_dim == wp.vec2i(1, 1):
             return JointDoFType.CYLINDRICAL
-        elif q_count == 3 and qd_count == 3 and dof_dim == vec2i(3, 0):
+        elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(3, 0):
             return JointDoFType.CARTESIAN
-        elif q_count == 3 and qd_count == 3 and dof_dim == vec2i(0, 3):
+        elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
             # TODO: dof_type = JointDoFType.GIMBAL
             return -1
-        elif q_count == 4 and qd_count == 3 and dof_dim == vec2i(0, 3):
+        elif q_count == 4 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
             return JointDoFType.SPHERICAL
         elif q_count == 7 and qd_count == 6:
             for i in range(qd_count):
@@ -1001,10 +987,8 @@ class JointDoFType(IntEnum):
         specified joint DoF type, based on the provided DoF axes.
 
         Args:
-            dof_type:
-                The joint DoF type for which to compute the axes matrix.
-            dof_axes:
-                A 2D array of shape `(6, 3)`, of which the initial block of
+            dof_type: The joint DoF type for which to compute the axes matrix.
+            dof_axes: A 2D array of shape `(6, 3)`, of which the initial block of
                 shape `(num_dofs, 3)` contains the local axes of the joint's
                 DoFs in the order they are defined.
 
@@ -1013,7 +997,7 @@ class JointDoFType(IntEnum):
             identity matrix if the joint type does not require an axes matrix.
         """
         # Initialize the joint axes rotation matrix to identity by default
-        R_axis_j = wp.identity(3, dtype=float32)
+        R_axis_j = wp.identity(3, dtype=wp.float32)
 
         # Determine the joint axes matrix based on the DoF type and axes
         if dof_type == JointDoFType.FIXED:
@@ -1076,16 +1060,16 @@ class JointDescriptor(Descriptor):
     Defaults to `-1`, indicating that the joint has not been assigned a follower body.
     """
 
-    B_r_Bj: vec3f = field(default_factory=vec3f)
+    B_r_Bj: wp.vec3f = field(default_factory=wp.vec3f)
     """The relative position of the joint in the base body coordinates."""
 
-    F_r_Fj: vec3f = field(default_factory=vec3f)
+    F_r_Fj: wp.vec3f = field(default_factory=wp.vec3f)
     """The relative position of the joint in the follower body coordinates."""
 
-    X_Bj: mat33f = field(default_factory=mat33f)
+    X_Bj: wp.mat33f = field(default_factory=wp.mat33f)
     """The orientation of the joint frame on the base body, in the base body coordinates."""
 
-    X_Fj: mat33f | None = None
+    X_Fj: wp.mat33f | None = None
     """
     The orientation of the joint frame on the follower body, in the follower body coordinates.
 
@@ -1466,7 +1450,7 @@ class JointDescriptor(Descriptor):
         # Default the follower-side joint frame to the base-side one, which
         # is the convention for joints with aligned base/follower frames.
         if self.X_Fj is None:
-            self.X_Fj = mat33f(self.X_Bj)
+            self.X_Fj = wp.mat33f(self.X_Bj)
 
         # Set default values for joint limits if not provided
         self.q_j_min = self._check_dofs_array(self.q_j_min, self.num_dofs, float(JOINT_QMIN))
@@ -1580,7 +1564,11 @@ class JointDescriptor(Descriptor):
     ###
 
     @staticmethod
-    def _check_dofs_array(x: ArrayLike | float | None, size: int, default: float = float(FLOAT32_MAX)) -> list[float]:
+    def _check_dofs_array(
+        x: ArrayLike | float | None,
+        size: int,
+        default: float = float(FLOAT32_MAX),
+    ) -> list[float]:
         """
         Processes a specified limit value to ensure it is a list of floats.
 
@@ -1592,12 +1580,12 @@ class JointDescriptor(Descriptor):
             contains only floats and matches the specified length.
 
         Args:
-            x (List[float] | float | None): The DOF array to be processed.
-            size (int): The number of degrees of freedom to determine the length of the output list.
-            default (float): The default value to use if DOF array is None or an empty list.
+            x: The DOF array to be processed.
+            size: The number of degrees of freedom to determine the length of the output list.
+            default: The default value to use if DOF array is None or an empty list.
 
         Returns:
-            List[float]: The processed list of DOF values.
+            The processed list of DOF values.
 
         Raises:
             ValueError: If the length of the DOF array does not match num_dofs.
@@ -1682,84 +1670,84 @@ class JointsModel:
     label: list[str] | None = None
     """
     A list containing the label of each joint entity.\n
-    Length of ``num_joints`` and type :class:`str`.
+    Length of ``num_joints``.
     """
 
     ###
     # Identifiers
     ###
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     Index each the world in which each joint is defined.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    jid: wp.array | None = None
+    jid: wp.array[wp.int32] | None = None
     """
     Index of each joint w.r.t the world.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
     ###
     # Parameterization
     ###
 
-    dof_type: wp.array | None = None
+    dof_type: wp.array[wp.int32] | None = None
     """
     Joint DoF type ID of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    act_type: wp.array | None = None
+    act_type: wp.array[wp.int32] | None = None
     """
     Joint actuation type ID of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    bid_B: wp.array | None = None
+    bid_B: wp.array[wp.int32] | None = None
     """
     Base body index of each joint w.r.t the model.\n
     Equals `-1` for world, `>=0` for bodies.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    bid_F: wp.array | None = None
+    bid_F: wp.array[wp.int32] | None = None
     """
     Follower body index of each joint w.r.t the model.\n
     Equals `-1` for world, `>=0` for bodies.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    B_r_Bj: wp.array | None = None
+    B_r_Bj: wp.array[wp.vec3f] | None = None
     """
     Relative position of the joint, expressed in and w.r.t the base body coordinate frame.\n
-    Shape of ``(num_joints,)`` and type :class:`vec3`.
+    Shape of ``(num_joints,)``.
     """
 
-    F_r_Fj: wp.array | None = None
+    F_r_Fj: wp.array[wp.vec3f] | None = None
     """
     Relative position of the joint, expressed in and w.r.t the follower body coordinate frame.\n
-    Shape of ``(num_joints,)`` and type :class:`vec3`.
+    Shape of ``(num_joints,)``.
     """
 
-    X_Bj: wp.array | None = None
+    X_Bj: wp.array[wp.mat33f] | None = None
     """
     Orientation of the joint frame on the base body, expressed in the base body coordinate frame.\n
-    Shape of ``(num_joints,)`` and type :class:`mat33`.
+    Shape of ``(num_joints,)``.
     """
 
-    X_Fj: wp.array | None = None
+    X_Fj: wp.array[wp.mat33f] | None = None
     """
     Orientation of the joint frame on the follower body, expressed in the follower body coordinate frame.\n
-    Shape of ``(num_joints,)`` and type :class:`mat33`.
+    Shape of ``(num_joints,)``.
     """
 
     ###
     # Limits
     ###
 
-    q_j_min: wp.array | None = None
+    q_j_min: wp.array[wp.float32] | None = None
     """
     Minimum (a.k.a. lower) joint DoF limits of each joint (as flat array).\n
 
@@ -1767,12 +1755,10 @@ class JointsModel:
     as opposed to the number of coordinates in order to handle cases such
     where joints have more coordinates than DoFs (e.g. spherical joints).\n
 
-    Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_dofs := sum(d_j)`, and ``d_j``
-    is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    q_j_max: wp.array | None = None
+    q_j_max: wp.array[wp.float32] | None = None
     """
     Maximum (a.k.a. upper) joint DoF limits of each joint (as flat array).\n
 
@@ -1780,62 +1766,54 @@ class JointsModel:
     as opposed to the number of coordinates in order to handle cases such
     where joints have more coordinates than DoFs (e.g. spherical joints).\n
 
-    Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_dofs := sum(d_j)`, and ``d_j``
-    is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    dq_j_max: wp.array | None = None
+    dq_j_max: wp.array[wp.float32] | None = None
     """
     Maximum joint velocity limits of each joint (as flat array).\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    tau_j_max: wp.array | None = None
+    tau_j_max: wp.array[wp.float32] | None = None
     """
     Maximum joint torque limits of each joint (as flat array).\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
     # Dynamics
     ###
 
-    a_j: wp.array | None = None
+    a_j: wp.array[wp.float32] | None = None
     """
     Internal inertia of each joint (as flat array), used for implicit integration of joint dynamics.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    b_j: wp.array | None = None
+    b_j: wp.array[wp.float32] | None = None
     """
     Internal damping of each joint (as flat array) used for implicit integration of joint dynamics.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    k_p_j: wp.array | None = None
+    k_p_j: wp.array[wp.float32] | None = None
     """
     Implicit PD-control proportional gain of each joint (as flat array).\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    k_d_j: wp.array | None = None
+    k_d_j: wp.array[wp.float32] | None = None
     """
     Implicit PD-control derivative gain of each joint (as flat array).\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,\n
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
     # Initial State
     ###
 
-    q_j_0: wp.array | None = None
+    q_j_0: wp.array[wp.float32] | None = None
     """
     The initial coordinates of each joint (as flat array),
     indicating the "rest" or "neutral" position of each joint.
@@ -1843,11 +1821,10 @@ class JointsModel:
     These are used for resetting joint positions when multi-turn
     correction for revolute DoFs is enabled in the simulation.
 
-    Shape of ``(sum(c_j),)`` and type :class:`float`,\n
-    where ``c_j`` is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    dq_j_0: wp.array | None = None
+    dq_j_0: wp.array[wp.float32] | None = None
     """
     The initial velocities of each joint (as flat array),
     indicating the "rest" or "neutral" velocity of each joint.
@@ -1855,47 +1832,46 @@ class JointsModel:
     These are used for resetting joint velocities when multi-turn
     correction for revolute DoFs is enabled in the simulation.
 
-    Shape of ``(sum(c_j),)`` and type :class:`float`,\n
-    where ``c_j`` is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
     # Metadata
     ###
 
-    num_coords: wp.array | None = None
+    num_coords: wp.array[wp.int32] | None = None
     """
     Number of coordinates of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    num_dofs: wp.array | None = None
+    num_dofs: wp.array[wp.int32] | None = None
     """
     Number of DoFs of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    # TODO: Consider making this a vec2i containing
+    # TODO: Consider making this a wp.vec2i containing
     # both dynamic and kinematic constraint counts
-    num_cts: wp.array | None = None
+    num_cts: wp.array[wp.int32] | None = None
     """
     Number of total constraints of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    num_dynamic_cts: wp.array | None = None
+    num_dynamic_cts: wp.array[wp.int32] | None = None
     """
     Number of dynamic constraints of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    num_kinematic_cts: wp.array | None = None
+    num_kinematic_cts: wp.array[wp.int32] | None = None
     """
     Number of kinematic constraints of each joint.\n
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    coords_offset: wp.array | None = None
+    coords_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's coordinates block, in model-wide
     flattened joint coordinates arrays.
@@ -1905,13 +1881,13 @@ class JointsModel:
     - array of joint generalized coordinates :attr:`JointsData.q_j`
     - array of previous joint generalized coordinates :attr:`JointsData.q_j_p`
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total coordinates count, so that the per-joint
     coordinates count is encoded as ``coords_offset[j+1] - coords_offset[j]``.
     """
 
-    dofs_offset: wp.array | None = None
+    dofs_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's DoFs block, in model-wide
     flattened joint DoFs arrays.
@@ -1921,68 +1897,68 @@ class JointsModel:
     - array of joint generalized velocities :attr:`JointsData.dq_j`
     - array of joint generalized forces :attr:`JointsData.tau_j`
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total DoFs count, so that the per-joint
     DoFs count is encoded as ``dofs_offset[j+1] - dofs_offset[j]``.
     """
 
-    passive_coords_offset: wp.array | None = None
+    passive_coords_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's passive coordinates block, in model-wide
     flattened passive joint coordinates arrays.
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total passive coordinates count, so that the per-joint
     passive coordinates count is encoded as ``passive_coords_offset[j+1] - passive_coords_offset[j]``.
     """
 
-    passive_dofs_offset: wp.array | None = None
+    passive_dofs_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's passive DoFs block, in model-wide
     flattened passive joint DoFs arrays.
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total passive DoFs count, so that the per-joint
     passive DoFs count is encoded as ``passive_dofs_offset[j+1] - passive_dofs_offset[j]``.
     """
 
-    actuated_coords_offset: wp.array | None = None
+    actuated_coords_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's actuated coordinates block, in model-wide
     flattened actuated joint coordinates arrays.
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total actuated coordinates count, so that the per-joint
     actuated coordinates count is encoded as ``actuated_coords_offset[j+1] - actuated_coords_offset[j]``.
     """
 
-    actuated_dofs_offset: wp.array | None = None
+    actuated_dofs_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's actuated DoFs block, in model-wide
     flattened actuated joint DoFs arrays.
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total actuated DoFs count, so that the per-joint
     actuated DoFs count is encoded as ``actuated_dofs_offset[j+1] - actuated_dofs_offset[j]``.
     """
 
-    cts_offset: wp.array | None = None
+    cts_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's constraints block, in model-wide
     flattened joint constraints arrays (dynamic + kinematic).
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total joint constraints count, so that the per-joint
     constraints count is encoded as ``cts_offset[j+1] - cts_offset[j]``.
     """
 
-    dynamic_cts_offset: wp.array | None = None
+    dynamic_cts_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's dynamic constraints block, in model-wide
     flattened joint dynamic constraints arrays.
@@ -1993,13 +1969,13 @@ class JointsModel:
     - array of joint-space P gains :attr:`JointsData.k_p_j`
     - array of joint-space D gains :attr:`JointsData.k_d_j`
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total joint dynamic constraints count, so that the per-joint
     dynamic constraints count is encoded as ``dynamic_cts_offset[j+1] - dynamic_cts_offset[j]``.
     """
 
-    kinematic_cts_offset: wp.array | None = None
+    kinematic_cts_offset: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's kinematic constraints block, in model-wide
     flattened joint kinematic constraints arrays.
@@ -2008,42 +1984,42 @@ class JointsModel:
     - array of joint constraint residuals :attr:`JointsData.r_j`
     - array of joint constraint residual time-derivatives :attr:`JointsData.dr_j`
 
-    Shape of ``(num_joints + 1,)`` and type :class:`int`.
+    Shape of ``(num_joints + 1,)``.
 
     The last entry is the total joint kinematic constraints count, so that the per-joint
     kinematic constraints count is encoded as ``kinematic_cts_offset[j+1] - kinematic_cts_offset[j]``.
     """
 
-    dynamic_cts_offset_joint_cts: wp.array | None = None
+    dynamic_cts_offset_joint_cts: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's dynamic constraints block, in model-wide
     flattened joint constraints arrays.
 
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    kinematic_cts_offset_joint_cts: wp.array | None = None
+    kinematic_cts_offset_joint_cts: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's kinematic constraints block, in model-wide
     flattened joint constraints arrays.
 
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    dynamic_cts_offset_total_cts: wp.array | None = None
+    dynamic_cts_offset_total_cts: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's dynamic constraints block, in model-wide
     flattened total constraints arrays (joints + limits + contacts).
 
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
-    kinematic_cts_offset_total_cts: wp.array | None = None
+    kinematic_cts_offset_total_cts: wp.array[wp.int32] | None = None
     """
     Index offset of each joint's kinematic constraints block, in model-wide
     flattened total constraints arrays (joints + limits + contacts).
 
-    Shape of ``(num_joints,)`` and type :class:`int`.
+    Shape of ``(num_joints,)``.
     """
 
 
@@ -2060,49 +2036,41 @@ class JointsData:
     # State
     ###
 
-    p_j: wp.array | None = None
+    p_j: wp.array[wp.transformf] | None = None
     """
     Array of joint frame pose transforms in world coordinates.\n
-    Shape of ``(num_joints,)`` and type :class:`transform`.
+    Shape of ``(num_joints,)``.
     """
 
-    q_j: wp.array | None = None
+    q_j: wp.array[wp.float32] | None = None
     """
     Flat array of generalized coordinates of the joints.\n
-    Shape of ``(sum_of_num_joint_coords,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_coords := sum(c_j)`, and ``c_j``
-    is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    q_j_p: wp.array | None = None
+    q_j_p: wp.array[wp.float32] | None = None
     """
     Flat array of previous generalized coordinates of the joints.\n
-    Shape of ``(sum_of_num_joint_coords,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_coords := sum(c_j)`, and ``c_j``
-    is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    dq_j: wp.array | None = None
+    dq_j: wp.array[wp.float32] | None = None
     """
     Flat array of generalized velocities of the joints.\n
-    Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_dofs := sum(d_j)`, and ``d_j``
-    is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    tau_j: wp.array | None = None
+    tau_j: wp.array[wp.float32] | None = None
     """
     Flat array of generalized forces of the joints.\n
-    Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`,
-    where `sum_of_num_joint_dofs := sum(d_j)`, and ``d_j``
-    is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
     # Constraints
     ###
 
-    r_j: wp.array | None = None
+    r_j: wp.array[wp.float32] | None = None
     """
     Flat array of joint kinematic constraint residuals.
 
@@ -2110,12 +2078,10 @@ class JointsData:
     - to get the start index: ``model.info.joint_kinematic_cts_offset[w]``
     - to get the size: ``model.info.num_joint_kinematic_cts[w]``
 
-    Shape of ``(sum_of_num_kinematic_joint_cts,)`` and type :class:`float`,\n
-    where `sum_of_num_kinematic_joint_cts := sum(f_j)`, and ``f_j``
-    is the number of kinematic constraints of joint ``j``.
+    Shape of ``(sum_of_num_kinematic_joint_cts,)``.
     """
 
-    dr_j: wp.array | None = None
+    dr_j: wp.array[wp.float32] | None = None
     """
     Flat array of joint kinematic constraint residual time-derivatives.
 
@@ -2123,12 +2089,10 @@ class JointsData:
     - to get the start index: ``model.info.joint_kinematic_cts_offset[w]``
     - to get the size: ``model.info.num_joint_kinematic_cts[w]``
 
-    Shape of ``(sum_of_num_kinematic_joint_cts,)`` and type :class:`float`,\n
-    where `sum_of_num_kinematic_joint_cts := sum(f_j)`, and ``f_j``
-    is the number of kinematic constraints of joint ``j``.
+    Shape of ``(sum_of_num_kinematic_joint_cts,)``.
     """
 
-    lambda_j: wp.array | None = None
+    lambda_j: wp.array[wp.float32] | None = None
     """
     Flat array of joint constraint Lagrange multipliers.
 
@@ -2142,16 +2106,14 @@ class JointsData:
     - kinematic constraints:
         ``model.info.joint_kinematic_cts_group_offset[w]`` and ``model.info.num_joint_kinematic_cts[w]``
 
-    Shape of ``(sum_of_num_joint_cts,)`` and type :class:`float`,\n
-    where `sum_of_num_joint_cts := sum(e_j) + sum(f_j)`, and ``e_j`` and ``f_j``
-    are the number of dynamic and kinematic constraints of joint ``j``, respectively.
+    Shape of ``(sum_of_num_joint_cts,)``.
     """
 
     ###
     # Dynamics
     ###
 
-    m_j: wp.array | None = None
+    m_j: wp.array[wp.float32] | None = None
     """
     Internal effective inertia of each joint (as flat array),
     used for implicit integration of joint dynamics.
@@ -2159,14 +2121,13 @@ class JointsData:
     ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,\n
     where dt is the simulation time step.
 
-    A non-zero minimum mass is enforced to avoid a\n
+    A non-zero minimum mass is enforced to avoid a
     division-by-zero failure.
 
-    Shape of ``(sum(e_j),)`` and type :class:`float`,\n
-    where ``e_j`` is the number of dynamic constraints of joint ``j``.
+    Shape of ``(sum_of_num_dynamic_joint_cts,)``.
     """
 
-    inv_m_j: wp.array | None = None
+    inv_m_j: wp.array[wp.float32] | None = None
     """
     Internal effective inverse inertia of each joint (as flat
     array), used for implicit integration of joint dynamics.
@@ -2175,14 +2136,13 @@ class JointsData:
     where ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,
     and dt is the simulation time step.
 
-    Note that all ``inv_m_j>0`` due to a minimum non-zero mass\n
+    Note that all ``inv_m_j>0`` due to a minimum non-zero mass
     being enforced.
 
-    Shape of ``(sum(e_j),)`` and type :class:`float`,
-    where ``e_j`` is the number of dynamic constraints of joint ``j``.
+    Shape of ``(sum_of_num_dynamic_joint_cts,)``.
     """
 
-    dq_b_j: wp.array | None = None
+    dq_b_j: wp.array[wp.float32] | None = None
     """
     The velocity bias of the joint dynamic constraints (as flat array).
 
@@ -2190,7 +2150,7 @@ class JointsData:
     ```
     m_j * dq_j^{+} = a_j * dq_j^{-} + dt * h_j
     ```
-    and it contributes to the dynamics of the system through the constraint equation:\n
+    and it contributes to the dynamics of the system through the constraint equation:
     ```
     dq_j^{+} = J_q_j * u^{+}
     ```
@@ -2215,83 +2175,79 @@ class JointsData:
     ```
     where dt is the simulation time step.
 
-    Shape of ``(sum(e_j),)`` and type :class:`float`,
-    where ``e_j`` is the number of dynamic constraints of joint ``j``.
+    Shape of ``(sum_of_num_dynamic_joint_cts,)``.
     """
 
     ###
     # Reference State
     ###
 
-    q_j_ref: wp.array | None = None
+    q_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference generalized joint coordinates for implicit PD control.\n
-    Shape of ``(sum(c_j),)`` and type :class:`float`,
-    where ``c_j`` is the number of coordinates of joint ``j``.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    dq_j_ref: wp.array | None = None
+    dq_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference generalized joint velocities for implicit PD control.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    tau_j_ref: wp.array | None = None
+    tau_j_ref: wp.array[wp.float32] | None = None
     """
     Array of reference feed-forward generalized joint forces for implicit PD control.\n
-    Shape of ``(sum(d_j),)`` and type :class:`float`,
-    where ``d_j`` is the number of DoFs of joint ``j``.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     ###
     # Per-Body Wrenches
     ###
 
-    j_w_j: wp.array | None = None
+    j_w_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Total wrench applied by each joint, expressed
     in and about the corresponding joint frame.\n
     Its direction follows the convention that
     joints act on the follower by the base body.\n
-    Shape of ``(num_joints,)`` and type :class:`vec6`.
+    Shape of ``(num_joints,)``.
     """
 
-    j_w_a_j: wp.array | None = None
+    j_w_a_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Actuation wrench applied by each joint, expressed
     in and about the corresponding joint frame.\n
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
     twist of the follower body relative to the base body.\n
-    Shape of ``(num_joints,)`` and type :class:`vec6`.
+    Shape of ``(num_joints,)``.
     """
 
-    j_w_c_j: wp.array | None = None
+    j_w_c_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Constraint wrench applied by each joint, expressed
     in and about the corresponding joint frame.\n
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
     twist of the follower body relative to the base body.\n
-    Shape of ``(num_joints,)`` and type :class:`vec6`.
+    Shape of ``(num_joints,)``.
     """
 
-    j_w_l_j: wp.array | None = None
+    j_w_l_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Joint-limit wrench applied by each joint, expressed
     in and about the corresponding joint frame.\n
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
     twist of the follower body relative to the base body.\n
-    Shape of ``(num_joints,)`` and type :class:`vec6`.
+    Shape of ``(num_joints,)``.
     """
 
     ###
     # Operations
     ###
 
-    def reset_state(self, q_j_0: wp.array | None = None):
+    def reset_state(self, q_j_0: wp.array[wp.float32] | None = None):
         """
         Resets all generalized joint coordinates to either zero or the provided
         reference coordinates and all generalized joint velocities to zero.
@@ -2307,17 +2263,19 @@ class JointsData:
         self.dq_j.zero_()
 
     def reset_references(
-        self, q_j_ref: wp.array | None = None, dq_j_ref: wp.array | None = None, joints: JointsModel | None = None
+        self,
+        q_j_ref: wp.array[wp.float32] | None = None,
+        dq_j_ref: wp.array[wp.float32] | None = None,
+        joints: JointsModel | None = None,
     ):
         """
         Resets all reference coordinates and velocities to either the provided reference values,
         or the initial values stored in the model.
 
         Args:
-            q_j_ref (wp.array, optional): New reference joint coordinates to set.
-            dq_j_ref (wp.array, optional): New reference joint velocities to set.
-            joints (JointsModel, optional): Joints model, to read initial joint coords/velocities
-                                            to use as reference if not provided.
+            q_j_ref: New reference joint coordinates to set.
+            dq_j_ref: New reference joint velocities to set.
+            joints: Joints model, to read initial joint coords/velocities to use as reference if not provided.
         """
         if q_j_ref is None and joints is None:
             raise ValueError("Either q_j_ref or joints must be provided to reset reference coordinates.")

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -196,20 +196,20 @@ class JointCorrectionMode(IntEnum):
 
     TWOPI = 0
     """
-    Rotational joint coordinates are computed to always lie within ``[-2*pi, 2*pi]``.\n
+    Rotational joint coordinates are computed to always lie within ``[-2*pi, 2*pi]``.
     This is the default correction mode for all joints with rotational DoFs.
     """
 
     CONTINUOUS = 1
     """
-    Rotational joint coordinates are continuously accumulated and thus unbounded.\n
+    Rotational joint coordinates are continuously accumulated and thus unbounded.
     This means that joint coordinates can increase/decrease indefinitely over time,
     but are limited to numerical precision limits (i.e. ``[JOINT_QMIN, JOINT_QMAX]``).
     """
 
     NONE = -1
     """
-    No joint coordinate correction is applied.\n
+    No joint coordinate correction is applied.
     Rotational joint coordinates are computed to lie within ``[-pi, pi]``.
     """
 
@@ -1050,13 +1050,13 @@ class JointDescriptor(Descriptor):
 
     bid_B: int = -1
     """
-    The Base body index of the joint (-1 for world, >=0 for bodies).\n
+    The Base body index of the joint (-1 for world, >=0 for bodies).
     Defaults to `-1`, indicating that the joint has not been assigned a base body.
     """
 
     bid_F: int = -1
     """
-    The Follower body index of the joint (must always be >=0 to index a body).\n
+    The Follower body index of the joint (must always be >=0 to index a body).
     Defaults to `-1`, indicating that the joint has not been assigned a follower body.
     """
 
@@ -1222,13 +1222,13 @@ class JointDescriptor(Descriptor):
 
     wid: int = -1
     """
-    Index of the world to which the joint belongs.\n
+    Index of the world to which the joint belongs.
     Defaults to `-1`, indicating that the joint has not yet been added to a world.
     """
 
     jid: int = -1
     """
-    Index of the joint w.r.t. its world.\n
+    Index of the joint w.r.t. its world.
     Defaults to `-1`, indicating that the joint has not yet been added to a world.
     """
 
@@ -1669,7 +1669,7 @@ class JointsModel:
 
     label: list[str] | None = None
     """
-    A list containing the label of each joint entity.\n
+    A list containing the label of each joint entity.
     Length of ``num_joints``.
     """
 
@@ -1679,13 +1679,13 @@ class JointsModel:
 
     wid: wp.array[wp.int32] | None = None
     """
-    Index each the world in which each joint is defined.\n
+    Index each the world in which each joint is defined.
     Shape of ``(num_joints,)``.
     """
 
     jid: wp.array[wp.int32] | None = None
     """
-    Index of each joint w.r.t the world.\n
+    Index of each joint w.r.t the world.
     Shape of ``(num_joints,)``.
     """
 
@@ -1695,51 +1695,51 @@ class JointsModel:
 
     dof_type: wp.array[wp.int32] | None = None
     """
-    Joint DoF type ID of each joint.\n
+    Joint DoF type ID of each joint.
     Shape of ``(num_joints,)``.
     """
 
     act_type: wp.array[wp.int32] | None = None
     """
-    Joint actuation type ID of each joint.\n
+    Joint actuation type ID of each joint.
     Shape of ``(num_joints,)``.
     """
 
     bid_B: wp.array[wp.int32] | None = None
     """
-    Base body index of each joint w.r.t the model.\n
-    Equals `-1` for world, `>=0` for bodies.\n
+    Base body index of each joint w.r.t the model.
+    Equals `-1` for world, `>=0` for bodies.
     Shape of ``(num_joints,)``.
     """
 
     bid_F: wp.array[wp.int32] | None = None
     """
-    Follower body index of each joint w.r.t the model.\n
-    Equals `-1` for world, `>=0` for bodies.\n
+    Follower body index of each joint w.r.t the model.
+    Equals `-1` for world, `>=0` for bodies.
     Shape of ``(num_joints,)``.
     """
 
     B_r_Bj: wp.array[wp.vec3f] | None = None
     """
-    Relative position of the joint, expressed in and w.r.t the base body coordinate frame.\n
+    Relative position of the joint, expressed in and w.r.t the base body coordinate frame.
     Shape of ``(num_joints,)``.
     """
 
     F_r_Fj: wp.array[wp.vec3f] | None = None
     """
-    Relative position of the joint, expressed in and w.r.t the follower body coordinate frame.\n
+    Relative position of the joint, expressed in and w.r.t the follower body coordinate frame.
     Shape of ``(num_joints,)``.
     """
 
     X_Bj: wp.array[wp.mat33f] | None = None
     """
-    Orientation of the joint frame on the base body, expressed in the base body coordinate frame.\n
+    Orientation of the joint frame on the base body, expressed in the base body coordinate frame.
     Shape of ``(num_joints,)``.
     """
 
     X_Fj: wp.array[wp.mat33f] | None = None
     """
-    Orientation of the joint frame on the follower body, expressed in the follower body coordinate frame.\n
+    Orientation of the joint frame on the follower body, expressed in the follower body coordinate frame.
     Shape of ``(num_joints,)``.
     """
 
@@ -1749,35 +1749,35 @@ class JointsModel:
 
     q_j_min: wp.array[wp.float32] | None = None
     """
-    Minimum (a.k.a. lower) joint DoF limits of each joint (as flat array).\n
+    Minimum (a.k.a. lower) joint DoF limits of each joint (as flat array).
 
     Limits are dimensioned according to the number of DoFs of each joint,
     as opposed to the number of coordinates in order to handle cases such
-    where joints have more coordinates than DoFs (e.g. spherical joints).\n
+    where joints have more coordinates than DoFs (e.g. spherical joints).
 
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     q_j_max: wp.array[wp.float32] | None = None
     """
-    Maximum (a.k.a. upper) joint DoF limits of each joint (as flat array).\n
+    Maximum (a.k.a. upper) joint DoF limits of each joint (as flat array).
 
     Limits are dimensioned according to the number of DoFs of each joint,
     as opposed to the number of coordinates in order to handle cases such
-    where joints have more coordinates than DoFs (e.g. spherical joints).\n
+    where joints have more coordinates than DoFs (e.g. spherical joints).
 
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     dq_j_max: wp.array[wp.float32] | None = None
     """
-    Maximum joint velocity limits of each joint (as flat array).\n
+    Maximum joint velocity limits of each joint (as flat array).
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     tau_j_max: wp.array[wp.float32] | None = None
     """
-    Maximum joint torque limits of each joint (as flat array).\n
+    Maximum joint torque limits of each joint (as flat array).
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
@@ -1787,25 +1787,25 @@ class JointsModel:
 
     a_j: wp.array[wp.float32] | None = None
     """
-    Internal inertia of each joint (as flat array), used for implicit integration of joint dynamics.\n
+    Internal inertia of each joint (as flat array), used for implicit integration of joint dynamics.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     b_j: wp.array[wp.float32] | None = None
     """
-    Internal damping of each joint (as flat array) used for implicit integration of joint dynamics.\n
+    Internal damping of each joint (as flat array) used for implicit integration of joint dynamics.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     k_p_j: wp.array[wp.float32] | None = None
     """
-    Implicit PD-control proportional gain of each joint (as flat array).\n
+    Implicit PD-control proportional gain of each joint (as flat array).
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     k_d_j: wp.array[wp.float32] | None = None
     """
-    Implicit PD-control derivative gain of each joint (as flat array).\n
+    Implicit PD-control derivative gain of each joint (as flat array).
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
@@ -1841,13 +1841,13 @@ class JointsModel:
 
     num_coords: wp.array[wp.int32] | None = None
     """
-    Number of coordinates of each joint.\n
+    Number of coordinates of each joint.
     Shape of ``(num_joints,)``.
     """
 
     num_dofs: wp.array[wp.int32] | None = None
     """
-    Number of DoFs of each joint.\n
+    Number of DoFs of each joint.
     Shape of ``(num_joints,)``.
     """
 
@@ -1855,19 +1855,19 @@ class JointsModel:
     # both dynamic and kinematic constraint counts
     num_cts: wp.array[wp.int32] | None = None
     """
-    Number of total constraints of each joint.\n
+    Number of total constraints of each joint.
     Shape of ``(num_joints,)``.
     """
 
     num_dynamic_cts: wp.array[wp.int32] | None = None
     """
-    Number of dynamic constraints of each joint.\n
+    Number of dynamic constraints of each joint.
     Shape of ``(num_joints,)``.
     """
 
     num_kinematic_cts: wp.array[wp.int32] | None = None
     """
-    Number of kinematic constraints of each joint.\n
+    Number of kinematic constraints of each joint.
     Shape of ``(num_joints,)``.
     """
 
@@ -2038,31 +2038,31 @@ class JointsData:
 
     p_j: wp.array[wp.transformf] | None = None
     """
-    Array of joint frame pose transforms in world coordinates.\n
+    Array of joint frame pose transforms in world coordinates.
     Shape of ``(num_joints,)``.
     """
 
     q_j: wp.array[wp.float32] | None = None
     """
-    Flat array of generalized coordinates of the joints.\n
+    Flat array of generalized coordinates of the joints.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     q_j_p: wp.array[wp.float32] | None = None
     """
-    Flat array of previous generalized coordinates of the joints.\n
+    Flat array of previous generalized coordinates of the joints.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     dq_j: wp.array[wp.float32] | None = None
     """
-    Flat array of generalized velocities of the joints.\n
+    Flat array of generalized velocities of the joints.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     tau_j: wp.array[wp.float32] | None = None
     """
-    Flat array of generalized forces of the joints.\n
+    Flat array of generalized forces of the joints.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
@@ -2118,7 +2118,7 @@ class JointsData:
     Internal effective inertia of each joint (as flat array),
     used for implicit integration of joint dynamics.
 
-    ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,\n
+    ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,
     where dt is the simulation time step.
 
     A non-zero minimum mass is enforced to avoid a
@@ -2132,7 +2132,7 @@ class JointsData:
     Internal effective inverse inertia of each joint (as flat
     array), used for implicit integration of joint dynamics.
 
-    ``inv_m_j := 1 / m_j``, computed element-wise,\n
+    ``inv_m_j := 1 / m_j``, computed element-wise,
     where ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,
     and dt is the simulation time step.
 
@@ -2146,11 +2146,11 @@ class JointsData:
     """
     The velocity bias of the joint dynamic constraints (as flat array).
 
-    Each joint has local actuation and PD control dynamics:\n
+    Each joint has local actuation and PD control dynamics:
     ```
     m_j * dq_j^{+} = a_j * dq_j^{-} + dt * h_j
     ```
-    and it contributes to the dynamics of the system through the constraint equation:
+    and is contributes to the dynamics of the system through the constraint equation:
     ```
     dq_j^{+} = J_q_j * u^{+}
     ```
@@ -2167,7 +2167,7 @@ class JointsData:
     dq_j^{+} + m_j^{-1} * lambda_q_j = dq_b_j
     J_q_j * u^{+} + m_j^{-1} * lambda_q_j = dq_b_j
     ```
-    and thus the velocity bias term of the joint-space dynamics of each joint `j` is computed as:\n
+    and thus the velocity bias term of the joint-space dynamics of each joint `j` is computed as:
     ```
     tau_j_tot := dt * ( tau_j + tau_j_ff + k_p_j * (q_j_ref - q_j^{-} ) + k_d_j * dq_j_ref )
     h_j := a_j * dq_j^{-} + dt * tau_j_tot
@@ -2184,19 +2184,19 @@ class JointsData:
 
     q_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference generalized joint coordinates for implicit PD control.\n
+    Array of reference generalized joint coordinates for implicit PD control.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     dq_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference generalized joint velocities for implicit PD control.\n
+    Array of reference generalized joint velocities for implicit PD control.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     tau_j_ref: wp.array[wp.float32] | None = None
     """
-    Array of reference feed-forward generalized joint forces for implicit PD control.\n
+    Array of reference feed-forward generalized joint forces for implicit PD control.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
@@ -2207,39 +2207,39 @@ class JointsData:
     j_w_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Total wrench applied by each joint, expressed
-    in and about the corresponding joint frame.\n
+    in and about the corresponding joint frame.
     Its direction follows the convention that
-    joints act on the follower by the base body.\n
+    joints act on the follower by the base body.
     Shape of ``(num_joints,)``.
     """
 
     j_w_a_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Actuation wrench applied by each joint, expressed
-    in and about the corresponding joint frame.\n
+    in and about the corresponding joint frame.
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
-    twist of the follower body relative to the base body.\n
+    twist of the follower body relative to the base body.
     Shape of ``(num_joints,)``.
     """
 
     j_w_c_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Constraint wrench applied by each joint, expressed
-    in and about the corresponding joint frame.\n
+    in and about the corresponding joint frame.
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
-    twist of the follower body relative to the base body.\n
+    twist of the follower body relative to the base body.
     Shape of ``(num_joints,)``.
     """
 
     j_w_l_j: wp.array[wp.spatial_vectorf] | None = None
     """
     Joint-limit wrench applied by each joint, expressed
-    in and about the corresponding joint frame.\n
+    in and about the corresponding joint frame.
     Its direction is defined by the convention that positive wrenches
     in the joint frame are those inducing a positive change in the
-    twist of the follower body relative to the base body.\n
+    twist of the follower body relative to the base body.
     Shape of ``(num_joints,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -114,10 +114,13 @@ class JointActuationType(IntEnum):
         Converts a `JointActuationType` to the corresponding `JointTargetMode`.
 
         Args:
-            type: The joint actuation type to convert.
+            act_type: The joint actuation type to convert.
 
         Returns:
-            The corresponding Newton joint target mode, or None if not applicable.
+            The corresponding Newton joint target mode.
+
+        Raises:
+            ValueError: if the joint actuation type is not supported.
         """
         _MAP_TO_NEWTON: dict[JointActuationType, JointTargetMode | None] = {
             JointActuationType.PASSIVE: JointTargetMode.NONE,
@@ -140,10 +143,13 @@ class JointActuationType(IntEnum):
         Converts a `JointTargetMode` to the corresponding `JointActuationType`.
 
         Args:
-            mode: The Newton joint target mode to convert.
+            target_mode: The Newton joint target mode to convert.
 
         Returns:
-            The corresponding joint actuation type, or None if not applicable.
+            The corresponding joint actuation type.
+
+        Raises:
+            ValueError: if the Newton joint target mode is not supported.
         """
         _MAP_FROM_NEWTON: dict[JointTargetMode, JointActuationType] = {
             JointTargetMode.NONE: JointActuationType.PASSIVE,
@@ -677,7 +683,7 @@ class JointDoFType(IntEnum):
             raise ValueError(f"Unknown joint DoF type: {self.value}")
 
     @staticmethod
-    def to_newton(dof_type: JointDoFType) -> JointType | None:
+    def to_newton(dof_type: JointDoFType) -> JointType:
         """
         Converts a `JointDoFType` to the corresponding `JointType`.
 
@@ -685,7 +691,10 @@ class JointDoFType(IntEnum):
             dof_type: The joint DoF type to convert.
 
         Returns:
-            The corresponding Newton joint type, or None if unsupported.
+            The corresponding Newton joint type.
+
+        Raises:
+            ValueError: if the joint dof type is not supported.
         """
         _MAP_TO_NEWTON: dict[JointDoFType, JointType] = {
             # All trivially supported DoF types map directly
@@ -720,9 +729,17 @@ class JointDoFType(IntEnum):
 
         Args:
             type: The Newton joint type to convert.
+            q_count: The Newton coordinates count for this joint.
+            qd_count: The Newton dofs count for this joint.
+            dof_dim: The Newton dof dimension (linear/angular dof counts) for this joint.
+            limit_lower: The lower position limits from Newton for this joint (in dof space).
+            limit_upper: The upper position limits from Newton for this joint (in dof space).
 
         Returns:
             The corresponding joint DoF type.
+
+        Raises:
+            ValueError: if the Newton joint type is not supported.
         """
         # First try directly mapping the trivially supported types
         _MAP_TO_KAMINO: dict[JointType, JointDoFType | None] = {
@@ -830,7 +847,12 @@ class JointDoFType(IntEnum):
             This is the warp-compatible equivalent to `from_newton()`.
 
         Args:
-            type: The Newton joint type to convert, see `JointType`.
+            joint_type: The Newton joint type to convert, see `JointType`.
+            q_count: The Newton coordinates count for this joint.
+            qd_count: The Newton dofs count for this joint.
+            dof_dim: The Newton dof dimension (linear/angular dof counts) for this joint.
+            limit_lower: The lower position limits from Newton for this joint (in dof space).
+            limit_upper: The upper position limits from Newton for this joint (in dof space).
 
         Returns:
             The corresponding joint DoF type, or -1 if the joint type is not

--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -20,15 +20,18 @@ material properties that can be queried at simulation runtime. It includes:
 - :class:`MaterialPairsModel`: A container to hold and manage per-material-pair properties.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import IntEnum
 
 import numpy as np
 import warp as wp
 
+from .....core.types import override
 from ..utils import logger as msg
 from .math import tril_index
-from .types import Descriptor, float32, int32, override
+from .types import Descriptor
 
 ###
 # Module interface
@@ -103,27 +106,19 @@ class MaterialDescriptor(Descriptor):
     currently do not support material-pair definitions.
 
     Attributes:
-        name (`str`):
-            The name of the material.
-        uid (`str`):
-            The unique identifier (UUID) of the material.
-        density (`float`):
-            The density of the material, in kg/m^3.\n
-            Defaults to the global default of ``1000.0`` kg/m^3.
-        restitution (`float`):
-            The coefficient of restitution, according to the Newtonian impact model.\n
+        name: The name of the material.
+        uid: The unique identifier (UUID) of the material.
+        density: The density of the material [kg/m³].\n
+            Defaults to the global default of ``1000.0`` kg/m³.
+        restitution: The coefficient of restitution, according to the Newtonian impact model.\n
             Defaults to the global default of ``0.0``.
-        static_friction (`float`):
-            The coefficient of static friction, according to the Coulomb friction model.\n
+        static_friction: The coefficient of static friction, according to the Coulomb friction model.\n
             Defaults to the global default of ``0.7``.
-        dynamic_friction (`float`):
-            The coefficient of dynamic friction, according to the Coulomb friction model.\n
+        dynamic_friction: The coefficient of dynamic friction, according to the Coulomb friction model.\n
             Defaults to the global default of ``0.7``.
-        wid (`int`):
-            Index of the world to which the material belongs.\n
+        wid: Index of the world to which the material belongs.\n
             Defaults to `-1`, indicating that the material has not yet been added to a world.
-        mid (`int`):
-            Index of the material w.r.t. the world.\n
+        mid: Index of the material w.r.t. the world.\n
             Defaults to `-1`, indicating that the material has not yet been added to a world.
     """
 
@@ -194,14 +189,11 @@ class MaterialPairProperties:
     A container to represent the properties of a pair of materials, including friction and restitution coefficients.
 
     Attributes:
-        restitution (`float`):
-            The coefficient of restitution, according to the Newtonian impact model.\n
+        restitution: The coefficient of restitution, according to the Newtonian impact model.\n
             Defaults to the global default of ``0.0``.
-        static_friction (`float`):
-            The coefficient of static surface friction, according to the Coulomb friction model.\n
+        static_friction: The coefficient of static surface friction, according to the Coulomb friction model.\n
             Defaults to the global default of ``0.7``.
-        dynamic_friction (`float`):
-            The coefficient of dynamic surface friction, according to the Coulomb friction model.\n
+        dynamic_friction: The coefficient of dynamic surface friction, according to the Coulomb friction model.\n
             Defaults to the global default of ``0.7``.
     """
 
@@ -238,46 +230,44 @@ class MaterialsModel:
     to the material index (`mid`) defined by the MaterialManager.
 
     Attributes:
-        num_pairs (int):
-            Total number of material pairs in the model.
-        restitution (wp.array):
-            Array of restitution coefficients for each registered material.\n
-            Shape of ``(num_materials, num_materials)`` and type :class:`float`.
-        static_friction (wp.array):
-            Array of static friction coefficients for each registered material.\n
-            Shape of ``(num_materials, num_materials)`` and type :class:`float`.
-        dynamic_friction (wp.array):
-            Array of dynamic friction coefficients for each registered material.\n
-            Shape of ``(num_materials, num_materials)`` and type :class:`float`.
+        num_materials: Total number of materials represented in the model.
+        density: Array of material density values of each registered material.\n
+            Shape of ``(num_materials,)``.
+        restitution: Array of restitution coefficients for each registered material.\n
+            Shape of ``(num_materials,)``.
+        static_friction: Array of static friction coefficients for each registered material.\n
+            Shape of ``(num_materials,)``.
+        dynamic_friction: Array of dynamic friction coefficients for each registered material.\n
+            Shape of ``(num_materials,)``.
     """
 
     num_materials: int = 0
     """Total number of materials represented in the model."""
 
-    density: wp.array | None = None
+    density: wp.array[wp.float32] | None = None
     """
     Array of material density values of each registered material.\n
-    Shape of ``(num_materials,)`` and type :class:`float`.
+    Shape of ``(num_materials,)``.
     """
 
-    restitution: wp.array | None = None
+    restitution: wp.array[wp.float32] | None = None
     """
     Array of restitution coefficients for each registered material.\n
-    Shape of ``(num_materials,)`` and type :class:`float`.
+    Shape of ``(num_materials,)``.
     """
 
-    # TODO: Switch to vec3f for anisotropic+torsional friction?
-    static_friction: wp.array | None = None
+    # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
+    static_friction: wp.array[wp.float32] | None = None
     """
     Array of static friction coefficients for each registered material.\n
-    Shape of ``(num_materials,)`` and type :class:`float`.
+    Shape of ``(num_materials,)``.
     """
 
-    # TODO: Switch to vec3f for anisotropic+torsional friction?
-    dynamic_friction: wp.array | None = None
+    # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
+    dynamic_friction: wp.array[wp.float32] | None = None
     """
     Array of dynamic friction coefficients for each registered material.\n
-    Shape of ``(num_materials,)`` and type :class:`float`.
+    Shape of ``(num_materials,)``.
     """
 
 
@@ -292,40 +282,36 @@ class MaterialPairsModel:
     `i,j` correspond to the material indices (`mid`) defined by the MaterialManager.
 
     Attributes:
-        num_material_pairs (int):
-            Total number of material pairs represented in the model.
-        restitution (wp.array):
-            Lower-triangular matrix of material-pair restitution coefficients.\n
-            Shape of ``(num_material_pairs,)`` and type :class:`float`.
-        static_friction (wp.array):
-            Lower-triangular matrix of material-pair static friction coefficients.\n
-            Shape of ``(num_material_pairs,)`` and type :class:`float`.
-        dynamic_friction (wp.array):
-            Lower-triangular matrix of material-pair dynamic friction coefficients.\n
-            Shape of ``(num_material_pairs,)`` and type :class:`float`.
+        num_material_pairs: Total number of material pairs represented in the model.
+        restitution: Lower-triangular matrix of material-pair restitution coefficients.\n
+            Shape of ``(num_material_pairs,)``.
+        static_friction: Lower-triangular matrix of material-pair static friction coefficients.\n
+            Shape of ``(num_material_pairs,)``.
+        dynamic_friction: Lower-triangular matrix of material-pair dynamic friction coefficients.\n
+            Shape of ``(num_material_pairs,)``.
     """
 
     num_material_pairs: int = 0
     """Total number of material pairs represented in the model."""
 
-    restitution: wp.array | None = None
+    restitution: wp.array[wp.float32] | None = None
     """
     Lower-triangular matrix of material-pair restitution coefficients.\n
-    Shape of ``(num_material_pairs,)`` and type :class:`float`.
+    Shape of ``(num_material_pairs,)``.
     """
 
-    # TODO: Switch to vec3f for anisotropic+torsional friction?
-    static_friction: wp.array | None = None
+    # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
+    static_friction: wp.array[wp.float32] | None = None
     """
     Lower-triangular matrix of material-pair static friction coefficients.\n
-    Shape of ``(num_material_pairs,)`` and type :class:`float`.
+    Shape of ``(num_material_pairs,)``.
     """
 
-    # TODO: Switch to vec3f for anisotropic+torsional friction?
-    dynamic_friction: wp.array | None = None
+    # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
+    dynamic_friction: wp.array[wp.float32] | None = None
     """
     Lower-triangular matrix of material-pair dynamic friction coefficients.\n
-    Shape of ``(num_material_pairs,)`` and type :class:`float`.
+    Shape of ``(num_material_pairs,)``.
     """
 
 
@@ -336,54 +322,54 @@ class MaterialPairsModel:
 
 @wp.func
 def material_average(
-    value1: float32,
-    value2: float32,
-) -> float32:
+    value1: wp.float32,
+    value2: wp.float32,
+) -> wp.float32:
     """
     Computes the average of two material property values.
 
     Args:
-        value1 (float32): The first material property value.
-        value2 (float32): The second material property value.
+        value1: The first material property value.
+        value2: The second material property value.
 
     Returns:
-        float32: The average of the two material property values.
+        The average of the two material property values.
     """
     return 0.5 * (value1 + value2)
 
 
 @wp.func
 def material_max(
-    value1: float32,
-    value2: float32,
-) -> float32:
+    value1: wp.float32,
+    value2: wp.float32,
+) -> wp.float32:
     """
     Computes the maximum of two material property values.
 
     Args:
-        value1 (float32): The first material property value.
-        value2 (float32): The second material property value.
+        value1: The first material property value.
+        value2: The second material property value.
 
     Returns:
-        float32: The maximum of the two material property values.
+        The maximum of the two material property values.
     """
     return wp.max(value1, value2)
 
 
 @wp.func
 def material_min(
-    value1: float32,
-    value2: float32,
-) -> float32:
+    value1: wp.float32,
+    value2: wp.float32,
+) -> wp.float32:
     """
     Computes the maximinimum of two material property values.
 
     Args:
-        value1 (float32): The first material property value.
-        value2 (float32): The second material property value.
+        value1: The first material property value.
+        value2: The second material property value.
 
     Returns:
-        float32: The minimum of the two material property values.
+        The minimum of the two material property values.
     """
     return wp.min(value1, value2)
 
@@ -394,10 +380,10 @@ def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode
     properties based on the specified muxing mode.
 
     Args:
-        muxmode (MaterialMuxMode): The muxing mode to use for material pair properties.
+        muxmode: The muxing mode to use for material pair properties.
 
     Returns:
-        function: A Warp function that retrieves material pair properties.
+        A Warp function that retrieves material pair properties.
     """
     # Select the appropriate muxing function based on the muxing mode
     match muxmode:
@@ -413,15 +399,15 @@ def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode
     # Define the Warp function to retrieve material pair properties
     @wp.func
     def _get_material_pair_properties(
-        mid1: int32,
-        mid2: int32,
-        material_restitution: wp.array[float32],
-        material_static_friction: wp.array[float32],
-        material_dynamic_friction: wp.array[float32],
-        material_pair_restitution: wp.array[float32],
-        material_pair_static_friction: wp.array[float32],
-        material_pair_dynamic_friction: wp.array[float32],
-    ) -> tuple[float32, float32, float32]:
+        mid1: wp.int32,
+        mid2: wp.int32,
+        material_restitution: wp.array[wp.float32],
+        material_static_friction: wp.array[wp.float32],
+        material_dynamic_friction: wp.array[wp.float32],
+        material_pair_restitution: wp.array[wp.float32],
+        material_pair_static_friction: wp.array[wp.float32],
+        material_pair_dynamic_friction: wp.array[wp.float32],
+    ) -> tuple[wp.float32, wp.float32, wp.float32]:
         """
         Retrieves the properties of a material pair given their material indices.
 
@@ -430,18 +416,17 @@ def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode
         materials using the configured muxing method.
 
         Args:
-            mid1 (int32): The index of the first material.
-            mid2 (int32): The index of the second material.
-            material_restitution (wp.array): The per-material restitution coefficients.
-            material_static_friction (wp.array): The per-material static friction coefficients.
-            material_dynamic_friction (wp.array): The per-material dynamic friction coefficients.
-            material_pair_restitution (wp.array): The per-material-pair restitution coefficients.
-            material_pair_static_friction (wp.array): The per-material-pair static friction coefficients.
-            material_pair_dynamic_friction (wp.array): The per-material-pair dynamic friction coefficients.
+            mid1: The index of the first material.
+            mid2: The index of the second material.
+            material_restitution: The per-material restitution coefficients.
+            material_static_friction: The per-material static friction coefficients.
+            material_dynamic_friction: The per-material dynamic friction coefficients.
+            material_pair_restitution: The per-material-pair restitution coefficients.
+            material_pair_static_friction: The per-material-pair static friction coefficients.
+            material_pair_dynamic_friction: The per-material-pair dynamic friction coefficients.
 
         Returns:
-            tuple: A tuple containing the restitution, static friction,
-            and dynamic friction coefficients for the material pair.
+            The restitution, static friction, and dynamic friction coefficients for the material pair.
         """
         # Compute the index in the flattened lower-triangular matrix
         mid_tril_idx = tril_index(mid1, mid2)
@@ -476,10 +461,10 @@ class MaterialManager:
     A class to manage materials used in simulations, including their properties and pairwise interactions.
 
     Attributes:
-        num_materials (int): The number of materials managed by this MaterialManager.
-        materials (list[MaterialDescriptor]): A list of materials managed by this MaterialManager.
-        pairs (list[list[MaterialPairProperties]]): A 2D list representing the properties of material pairs.
-        default (MaterialDescriptor): The default material managed by this MaterialManager.
+        num_materials: The number of materials managed by this MaterialManager.
+        materials: A list of materials managed by this MaterialManager.
+        pairs: A 2D list representing the properties of material pairs.
+        default: The default material managed by this MaterialManager.
     """
 
     def __init__(
@@ -493,12 +478,14 @@ class MaterialManager:
         Initializes the MaterialManager with an optional default material and its properties.
 
         Args:
-            default_material (MaterialDescriptor, optional): The default material to register.\n
+            default_material: The default material to register.\n
                 If None, a default material with the name 'default' will be created.
-            default_static_friction (float): The default friction coefficient for material pairs.\n
-                Defaults to `DEFAULT_FRICTION`.
-            default_dynamic_friction (float): The default restitution coefficient for material pairs.\n
-                Defaults to `DEFAULT_RESTITUTION`.
+            default_restitution: The default restitution coefficient for material pairs.\n
+                Defaults to ``DEFAULT_RESTITUTION``.
+            default_static_friction: The default static friction coefficient for material pairs.\n
+                Defaults to ``DEFAULT_FRICTION``.
+            default_dynamic_friction: The default dynamic friction coefficient for material pairs.\n
+                Defaults to ``DEFAULT_FRICTION``.
         """
         # Declare the materials and material-pairs lists
         self._materials: list[MaterialDescriptor] = []
@@ -564,7 +551,7 @@ class MaterialManager:
         Sets the default material to the provided material descriptor.
 
         Args:
-            material (`MaterialDescriptor`): The material to set as the default.
+            material: The material to set as the default.
 
         Raises:
             TypeError: If the provided material is not an instance of MaterialDescriptor.
@@ -585,10 +572,10 @@ class MaterialManager:
         Checks if a material with the given name exists in the manager.
 
         Args:
-            name (str): The name of the material to check.
+            name: The name of the material to check.
 
         Returns:
-            bool: True if the material exists, False otherwise.
+            True if the material exists, False otherwise.
         """
         for m in self._materials:
             if m.name == name:
@@ -600,10 +587,10 @@ class MaterialManager:
         Registers a new material with the manager.
 
         Args:
-            material (MaterialDescriptor): The material descriptor to register.
+            material: The material descriptor to register.
 
         Returns:
-            int: The index of the newly registered material.
+            The index of the newly registered material.
 
         Raises:
             ValueError: If a material with the same name or UID already exists.
@@ -637,9 +624,9 @@ class MaterialManager:
         Registers a new material pair with the manager.
 
         Args:
-            first (MaterialDescriptor): The first material in the pair.
-            second (MaterialDescriptor): The second material in the pair.
-            material_pair (MaterialPairProperties): The properties of the material pair.
+            first: The first material in the pair.
+            second: The second material in the pair.
+            material_pair: The properties of the material pair.
 
         Raises:
             ValueError: If either material is not already registered.
@@ -661,9 +648,9 @@ class MaterialManager:
         Configures the properties of an existing material pair.
 
         Args:
-            first (int | str): The index or name of the first material in the pair.
-            second (int | str): The index or name of the second material in the pair.
-            material_pair (MaterialPairProperties): The properties to set for the material pair.
+            first: The index or name of the first material in the pair.
+            second: The index or name of the second material in the pair.
+            material_pair: The properties to set for the material pair.
 
         Raises:
             ValueError: If either material is not found.
@@ -676,12 +663,12 @@ class MaterialManager:
         self._pair_properties[mid1][mid2] = self._pair_properties[mid2][mid1] = material_pair
         msg.debug("Configured material pair: %s - %s", self.materials[mid1].name, self.materials[mid2].name)
 
-    def merge(self, other: "MaterialManager"):
+    def merge(self, other: MaterialManager):
         """
         Merges another MaterialManager into this one, combining their materials and material-pair properties.
 
         Args:
-            other (MaterialManager): The other MaterialManager to merge.
+            other: The other MaterialManager to merge.
 
         Raises:
             ValueError: If there are conflicting material names or UIDs.
@@ -705,10 +692,10 @@ class MaterialManager:
         Retrieves a material descriptor by its index or name.
 
         Args:
-            key (str | int): The name or index of the material.
+            key: The name or index of the material.
 
         Returns:
-            MaterialDescriptor: The material descriptor.
+            The material descriptor.
 
         Raises:
             IndexError: If the index is out of range.
@@ -736,10 +723,10 @@ class MaterialManager:
         Retrieves the index of a material by its name or index.
 
         Args:
-            key (str | int): The name or index of the material.
+            key: The name or index of the material.
 
         Returns:
-            int: The index of the material.
+            The index of the material.
 
         Raises:
             ValueError: If the material is not found.
@@ -769,7 +756,7 @@ class MaterialManager:
         Generates a vector of restitution coefficients over all materials.
 
         Returns:
-            np.ndarray: A 1D numpy array containing per-material restitution coefficients.
+            A 1D numpy array containing per-material restitution coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -789,7 +776,7 @@ class MaterialManager:
         Generates a matrix of restitution coefficients for all material pairs.
 
         Returns:
-            np.ndarray: A 2D numpy array containing restitution coefficients.
+            A 2D numpy array containing restitution coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -819,7 +806,7 @@ class MaterialManager:
         Generates a vector of static friction coefficients over all materials.
 
         Returns:
-            np.ndarray: A 1D numpy array containing per-material static friction coefficients.
+            A 1D numpy array containing per-material static friction coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -839,7 +826,7 @@ class MaterialManager:
         Generates a matrix of friction coefficients for all material pairs.
 
         Returns:
-            np.ndarray: A 2D numpy array containing static friction coefficients.
+            A 2D numpy array containing static friction coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -869,7 +856,7 @@ class MaterialManager:
         Generates a vector of dynamic friction coefficients over all materials.
 
         Returns:
-            np.ndarray: A 1D numpy array containing per-material dynamic friction coefficients.
+            A 1D numpy array containing per-material dynamic friction coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -889,7 +876,7 @@ class MaterialManager:
         Generates a matrix of friction coefficients for all material pairs.
 
         Returns:
-            np.ndarray: A 2D numpy array containing dynamic friction coefficients.
+            A 2D numpy array containing dynamic friction coefficients.
         """
         # Get the number of materials
         num_materials = len(self._materials)
@@ -925,9 +912,9 @@ class MaterialManager:
         materials_dynamic_fric = [self.dynamic_friction_vector()]
         return MaterialsModel(
             num_materials=self.num_materials,
-            restitution=wp.array(materials_rest[0], dtype=float32),
-            static_friction=wp.array(materials_static_fric[0], dtype=float32),
-            dynamic_friction=wp.array(materials_dynamic_fric[0], dtype=float32),
+            restitution=wp.array(materials_rest[0], dtype=wp.float32),
+            static_friction=wp.array(materials_static_fric[0], dtype=wp.float32),
+            dynamic_friction=wp.array(materials_dynamic_fric[0], dtype=wp.float32),
         )
 
     def make_material_pairs_model(self) -> MaterialPairsModel:
@@ -937,7 +924,7 @@ class MaterialManager:
         mpairs_dynamic_fric = [self.dynamic_friction_matrix()]
         return MaterialPairsModel(
             num_material_pairs=self.num_material_pairs,
-            restitution=wp.array(mpairs_rest[0], dtype=float32),
-            static_friction=wp.array(mpairs_static_fric[0], dtype=float32),
-            dynamic_friction=wp.array(mpairs_dynamic_fric[0], dtype=float32),
+            restitution=wp.array(mpairs_rest[0], dtype=wp.float32),
+            static_friction=wp.array(mpairs_static_fric[0], dtype=wp.float32),
+            dynamic_friction=wp.array(mpairs_dynamic_fric[0], dtype=wp.float32),
         )

--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -54,7 +54,7 @@ __all__ = [
 
 DEFAULT_DENSITY = 1000.0
 """
-The global default density for materials, in kg/m^3.\n
+The global default density for materials, in kg/m^3.
 Equals ``1000.0`` kg/m^3.
 """
 
@@ -108,17 +108,17 @@ class MaterialDescriptor(Descriptor):
     Attributes:
         name: The name of the material.
         uid: The unique identifier (UUID) of the material.
-        density: The density of the material [kg/m³].\n
+        density: The density of the material [kg/m³].
             Defaults to the global default of ``1000.0`` kg/m³.
-        restitution: The coefficient of restitution, according to the Newtonian impact model.\n
+        restitution: The coefficient of restitution, according to the Newtonian impact model.
             Defaults to the global default of ``0.0``.
-        static_friction: The coefficient of static friction, according to the Coulomb friction model.\n
+        static_friction: The coefficient of static friction, according to the Coulomb friction model.
             Defaults to the global default of ``0.7``.
-        dynamic_friction: The coefficient of dynamic friction, according to the Coulomb friction model.\n
+        dynamic_friction: The coefficient of dynamic friction, according to the Coulomb friction model.
             Defaults to the global default of ``0.7``.
-        wid: Index of the world to which the material belongs.\n
+        wid: Index of the world to which the material belongs.
             Defaults to `-1`, indicating that the material has not yet been added to a world.
-        mid: Index of the material w.r.t. the world.\n
+        mid: Index of the material w.r.t. the world.
             Defaults to `-1`, indicating that the material has not yet been added to a world.
     """
 
@@ -128,25 +128,25 @@ class MaterialDescriptor(Descriptor):
 
     density: float = DEFAULT_DENSITY
     """
-    The density of the material, in kg/m^3.\n
+    The density of the material, in kg/m^3.
     Defaults to the global default of ``1000.0`` kg/m^3.
     """
 
     restitution: float = DEFAULT_RESTITUTION
     """
-    The coefficient of restitution, according to the Newtonian impact model.\n
+    The coefficient of restitution, according to the Newtonian impact model.
     Defaults to the global default of ``0.0``.
     """
 
     static_friction: float = DEFAULT_FRICTION
     """
-    The coefficient of static friction, according to the isotropic Coulomb friction model.\n
+    The coefficient of static friction, according to the isotropic Coulomb friction model.
     Defaults to the global default of ``0.7``.
     """
 
     dynamic_friction: float = DEFAULT_FRICTION
     """
-    The coefficient of dynamic friction, according to the isotropicCoulomb friction model.\n
+    The coefficient of dynamic friction, according to the isotropicCoulomb friction model.
     Defaults to the global default of ``0.7``.
     """
 
@@ -156,13 +156,13 @@ class MaterialDescriptor(Descriptor):
 
     wid: int = -1
     """
-    Index of the world to which the material belongs.\n
+    Index of the world to which the material belongs.
     Defaults to `-1`, indicating that the material has not yet been added to a world.
     """
 
     mid: int = -1
     """
-    Index of the material w.r.t. the world.\n
+    Index of the material w.r.t. the world.
     Defaults to `-1`, indicating that the material has not yet been added to a world.
     """
 
@@ -189,29 +189,29 @@ class MaterialPairProperties:
     A container to represent the properties of a pair of materials, including friction and restitution coefficients.
 
     Attributes:
-        restitution: The coefficient of restitution, according to the Newtonian impact model.\n
+        restitution: The coefficient of restitution, according to the Newtonian impact model.
             Defaults to the global default of ``0.0``.
-        static_friction: The coefficient of static surface friction, according to the Coulomb friction model.\n
+        static_friction: The coefficient of static surface friction, according to the Coulomb friction model.
             Defaults to the global default of ``0.7``.
-        dynamic_friction: The coefficient of dynamic surface friction, according to the Coulomb friction model.\n
+        dynamic_friction: The coefficient of dynamic surface friction, according to the Coulomb friction model.
             Defaults to the global default of ``0.7``.
     """
 
     restitution: float = DEFAULT_RESTITUTION
     """
-    The coefficient of restitution, according to the Newtonian impact model.\n
+    The coefficient of restitution, according to the Newtonian impact model.
     Defaults to the global default of ``0.0``.
     """
 
     static_friction: float = DEFAULT_FRICTION
     """
-    The coefficient of static surface friction, according to the Coulomb friction model.\n
+    The coefficient of static surface friction, according to the Coulomb friction model.
     Defaults to the global default of ``0.7``.
     """
 
     dynamic_friction: float = DEFAULT_FRICTION
     """
-    The coefficient of dynamic surface friction, according to the Coulomb friction model.\n
+    The coefficient of dynamic surface friction, according to the Coulomb friction model.
     Defaults to the global default of ``0.7``.
     """
 
@@ -231,13 +231,13 @@ class MaterialsModel:
 
     Attributes:
         num_materials: Total number of materials represented in the model.
-        density: Array of material density values of each registered material.\n
+        density: Array of material density values of each registered material.
             Shape of ``(num_materials,)``.
-        restitution: Array of restitution coefficients for each registered material.\n
+        restitution: Array of restitution coefficients for each registered material.
             Shape of ``(num_materials,)``.
-        static_friction: Array of static friction coefficients for each registered material.\n
+        static_friction: Array of static friction coefficients for each registered material.
             Shape of ``(num_materials,)``.
-        dynamic_friction: Array of dynamic friction coefficients for each registered material.\n
+        dynamic_friction: Array of dynamic friction coefficients for each registered material.
             Shape of ``(num_materials,)``.
     """
 
@@ -246,27 +246,27 @@ class MaterialsModel:
 
     density: wp.array[wp.float32] | None = None
     """
-    Array of material density values of each registered material.\n
+    Array of material density values of each registered material.
     Shape of ``(num_materials,)``.
     """
 
     restitution: wp.array[wp.float32] | None = None
     """
-    Array of restitution coefficients for each registered material.\n
+    Array of restitution coefficients for each registered material.
     Shape of ``(num_materials,)``.
     """
 
     # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
     static_friction: wp.array[wp.float32] | None = None
     """
-    Array of static friction coefficients for each registered material.\n
+    Array of static friction coefficients for each registered material.
     Shape of ``(num_materials,)``.
     """
 
     # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
     dynamic_friction: wp.array[wp.float32] | None = None
     """
-    Array of dynamic friction coefficients for each registered material.\n
+    Array of dynamic friction coefficients for each registered material.
     Shape of ``(num_materials,)``.
     """
 
@@ -283,11 +283,11 @@ class MaterialPairsModel:
 
     Attributes:
         num_material_pairs: Total number of material pairs represented in the model.
-        restitution: Lower-triangular matrix of material-pair restitution coefficients.\n
+        restitution: Lower-triangular matrix of material-pair restitution coefficients.
             Shape of ``(num_material_pairs,)``.
-        static_friction: Lower-triangular matrix of material-pair static friction coefficients.\n
+        static_friction: Lower-triangular matrix of material-pair static friction coefficients.
             Shape of ``(num_material_pairs,)``.
-        dynamic_friction: Lower-triangular matrix of material-pair dynamic friction coefficients.\n
+        dynamic_friction: Lower-triangular matrix of material-pair dynamic friction coefficients.
             Shape of ``(num_material_pairs,)``.
     """
 
@@ -296,21 +296,21 @@ class MaterialPairsModel:
 
     restitution: wp.array[wp.float32] | None = None
     """
-    Lower-triangular matrix of material-pair restitution coefficients.\n
+    Lower-triangular matrix of material-pair restitution coefficients.
     Shape of ``(num_material_pairs,)``.
     """
 
     # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
     static_friction: wp.array[wp.float32] | None = None
     """
-    Lower-triangular matrix of material-pair static friction coefficients.\n
+    Lower-triangular matrix of material-pair static friction coefficients.
     Shape of ``(num_material_pairs,)``.
     """
 
     # TODO: Switch to wp.vec3f for anisotropic+torsional friction?
     dynamic_friction: wp.array[wp.float32] | None = None
     """
-    Lower-triangular matrix of material-pair dynamic friction coefficients.\n
+    Lower-triangular matrix of material-pair dynamic friction coefficients.
     Shape of ``(num_material_pairs,)``.
     """
 
@@ -478,13 +478,13 @@ class MaterialManager:
         Initializes the MaterialManager with an optional default material and its properties.
 
         Args:
-            default_material: The default material to register.\n
+            default_material: The default material to register.
                 If None, a default material with the name 'default' will be created.
-            default_restitution: The default restitution coefficient for material pairs.\n
+            default_restitution: The default restitution coefficient for material pairs.
                 Defaults to ``DEFAULT_RESTITUTION``.
-            default_static_friction: The default static friction coefficient for material pairs.\n
+            default_static_friction: The default static friction coefficient for material pairs.
                 Defaults to ``DEFAULT_FRICTION``.
-            default_dynamic_friction: The default dynamic friction coefficient for material pairs.\n
+            default_dynamic_friction: The default dynamic friction coefficient for material pairs.
                 Defaults to ``DEFAULT_FRICTION``.
         """
         # Declare the materials and material-pairs lists

--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -146,7 +146,7 @@ class MaterialDescriptor(Descriptor):
 
     dynamic_friction: float = DEFAULT_FRICTION
     """
-    The coefficient of dynamic friction, according to the isotropicCoulomb friction model.
+    The coefficient of dynamic friction, according to the isotropic Coulomb friction model.
     Defaults to the global default of ``0.7``.
     """
 
@@ -362,7 +362,7 @@ def material_min(
     value2: wp.float32,
 ) -> wp.float32:
     """
-    Computes the maximinimum of two material property values.
+    Computes the minimum of two material property values.
 
     Args:
         value1: The first material property value.

--- a/newton/_src/solvers/kamino/_src/core/math.py
+++ b/newton/_src/solvers/kamino/_src/core/math.py
@@ -11,19 +11,10 @@ import numpy as np
 import warp as wp
 from warp._src.types import Any, Float
 
+from .....core.types import Axis, AxisType
 from .types import (
-    float32,
-    mat22f,
-    mat33f,
     mat34f,
-    mat44f,
     mat63f,
-    mat66f,
-    quatf,
-    transformf,
-    vec3f,
-    vec4f,
-    vec6f,
 )
 
 ###
@@ -37,22 +28,22 @@ wp.set_module_options({"enable_backward": False})
 # Constants
 ###
 
-FLOAT32_MIN = wp.constant(float32(np.finfo(np.float32).min))
+FLOAT32_MIN = wp.constant(wp.float32(np.finfo(np.float32).min))
 """The lowest 32-bit floating-point value."""
 
-FLOAT32_MAX = wp.constant(float32(np.finfo(np.float32).max))
+FLOAT32_MAX = wp.constant(wp.float32(np.finfo(np.float32).max))
 """The highest 32-bit floating-point value."""
 
-FLOAT32_EPS = wp.constant(float32(np.finfo(np.float32).eps))
+FLOAT32_EPS = wp.constant(wp.float32(np.finfo(np.float32).eps))
 """Machine epsilon for 32-bit float: the smallest value such that 1.0 + eps != 1.0."""
 
-UNIT_X = wp.constant(vec3f(1.0, 0.0, 0.0))
+UNIT_X = wp.constant(wp.vec3f(1.0, 0.0, 0.0))
 """ 3D unit vector for the X axis """
 
-UNIT_Y = wp.constant(vec3f(0.0, 1.0, 0.0))
+UNIT_Y = wp.constant(wp.vec3f(0.0, 1.0, 0.0))
 """ 3D unit vector for the Y axis """
 
-UNIT_Z = wp.constant(vec3f(0.0, 0.0, 1.0))
+UNIT_Z = wp.constant(wp.vec3f(0.0, 0.0, 1.0))
 """ 3D unit vector for the Z axis """
 
 PI = wp.constant(3.141592653589793)
@@ -67,17 +58,19 @@ HALF_PI = wp.constant(1.5707963267948966)
 COS_PI_6 = wp.constant(0.8660254037844387)
 """Convenience constant for cos(PI / 6)"""
 
-I_2 = wp.constant(mat22f(1, 0, 0, 1))
+I_2 = wp.constant(wp.mat22f(1, 0, 0, 1))
 """ The 2x2 identity matrix."""
 
-I_3 = wp.constant(mat33f(1, 0, 0, 0, 1, 0, 0, 0, 1))
+I_3 = wp.constant(wp.mat33f(1, 0, 0, 0, 1, 0, 0, 0, 1))
 """ The 3x3 identity matrix."""
 
-I_4 = wp.constant(mat44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
+I_4 = wp.constant(wp.mat44f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1))
 """ The 4x4 identity matrix."""
 
 I_6 = wp.constant(
-    mat66f(1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1)
+    wp.spatial_matrixf(
+        1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1
+    )
 )
 """ The 6x6 identity matrix."""
 
@@ -97,66 +90,84 @@ def squared_norm(x: Any) -> Float:
 ###
 
 
+def axis_to_mat33(axis: AxisType) -> wp.mat33f:
+    """Return a 3x3 frame matrix whose first column is the unit vector for ``axis``.
+
+    The remaining two columns are the standard basis vectors cycled so the matrix
+    is a permutation of the identity (i.e. a proper rotation).
+
+    Args:
+        axis: Axis identifier (:class:`Axis`, string, or int) to use as the first
+            column of the output matrix.
+    """
+    a = Axis.from_any(axis)
+    if a == Axis.X:
+        return wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    if a == Axis.Y:
+        return wp.mat33f(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+    return wp.mat33f(0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
+
+
 @wp.func
-def R_x(theta: float32) -> mat33f:
+def R_x(theta: wp.float32) -> wp.mat33f:
     """
     Computes the rotation matrix around the X axis.
 
     Args:
-        theta (float32): The angle in radians.
+        theta: The angle in radians.
 
     Returns:
-        mat33f: The rotation matrix.
+        The rotation matrix.
     """
     c = wp.cos(theta)
     s = wp.sin(theta)
-    return mat33f(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c)
+    return wp.mat33f(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c)
 
 
 @wp.func
-def R_y(theta: float32) -> mat33f:
+def R_y(theta: wp.float32) -> wp.mat33f:
     """
     Computes the rotation matrix around the Y axis.
 
     Args:
-        theta (float32): The angle in radians.
+        theta: The angle in radians.
 
     Returns:
-        mat33f: The rotation matrix.
+        The rotation matrix.
     """
     c = wp.cos(theta)
     s = wp.sin(theta)
-    return mat33f(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c)
+    return wp.mat33f(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c)
 
 
 @wp.func
-def R_z(theta: float32) -> mat33f:
+def R_z(theta: wp.float32) -> wp.mat33f:
     """
     Computes the rotation matrix around the Z axis.
 
     Args:
-        theta (float32): The angle in radians.
+        theta: The angle in radians.
 
     Returns:
-        mat33f: The rotation matrix.
+        The rotation matrix.
     """
     c = wp.cos(theta)
     s = wp.sin(theta)
-    return mat33f(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0)
+    return wp.mat33f(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0)
 
 
 @wp.func
-def unskew(S: mat33f) -> vec3f:
+def unskew(S: wp.mat33f) -> wp.vec3f:
     """
     Extracts the 3D vector from a 3x3 skew-symmetric matrix.
 
     Args:
-        S (mat33f): The 3x3 skew-symmetric matrix.
+        S: The 3x3 skew-symmetric matrix.
 
     Returns:
-        vec3f: The vector extracted from the skew-symmetric matrix.
+        The vector extracted from the skew-symmetric matrix.
     """
-    return vec3f(S[2, 1], S[0, 2], S[1, 0])
+    return wp.vec3f(S[2, 1], S[0, 2], S[1, 0])
 
 
 ###
@@ -165,15 +176,15 @@ def unskew(S: mat33f) -> vec3f:
 
 
 @wp.func
-def G_of(q: quatf) -> mat34f:
+def G_of(q: wp.quatf) -> mat34f:
     """
     Computes the G matrix from a quaternion.
 
     Args:
-        q (quatf): The quaternion.
+        q: The quaternion.
 
     Returns:
-        mat34f: The G matrix.
+        The G matrix.
     """
     G = mat34f(0.0)
     G[0, 0] = q.w
@@ -192,15 +203,15 @@ def G_of(q: quatf) -> mat34f:
 
 
 @wp.func
-def H_of(q: quatf) -> mat34f:
+def H_of(q: wp.quatf) -> mat34f:
     """
     Computes the H matrix from a quaternion.
 
     Args:
-        q (quatf): The quaternion.
+        q: The quaternion.
 
     Returns:
-        mat34f: The H matrix.
+        The H matrix.
     """
     H = mat34f(0.0)
     H[0, 0] = q.w
@@ -219,32 +230,32 @@ def H_of(q: quatf) -> mat34f:
 
 
 @wp.func
-def quat_from_vec4(v: vec4f) -> quatf:
+def quat_from_vec4(v: wp.vec4f) -> wp.quatf:
     """
-    Convert a vec4f to a quaternion type.
+    Convert a wp.vec4f to a quaternion type.
     """
-    return quatf(v[0], v[1], v[2], v[3])
+    return wp.quatf(v[0], v[1], v[2], v[3])
 
 
 @wp.func
-def quat_to_vec4(q: quatf) -> vec4f:
+def quat_to_vec4(q: wp.quatf) -> wp.vec4f:
     """
-    Convert a quaternion type to a vec4f.
+    Convert a quaternion type to a wp.vec4f.
     """
-    return vec4f(q.x, q.y, q.z, q.w)
+    return wp.vec4f(q.x, q.y, q.z, q.w)
 
 
 @wp.func
-def quat_conj(q: quatf) -> quatf:
+def quat_conj(q: wp.quatf) -> wp.quatf:
     """
     Compute the conjugate of a quaternion.
     The conjugate of a quaternion q = (x, y, z, w) is defined as: q_conj = (x, y, z, -w)
     """
-    return quatf(q.x, q.y, q.z, -q.w)
+    return wp.quatf(q.x, q.y, q.z, -q.w)
 
 
 @wp.func
-def quat_positive(q: quatf) -> quatf:
+def quat_positive(q: wp.quatf) -> wp.quatf:
     """
     Compute the positive representation of a quaternion.
     The positive representation is defined as the quaternion with a non-negative scalar part.
@@ -257,16 +268,16 @@ def quat_positive(q: quatf) -> quatf:
 
 
 @wp.func
-def quat_imaginary(q: quatf) -> vec3f:
+def quat_imaginary(q: wp.quatf) -> wp.vec3f:
     """
     Extract the imaginary part of a quaternion.
     The imaginary part is defined as the vector part of the quaternion (x, y, z).
     """
-    return vec3f(q.x, q.y, q.z)
+    return wp.vec3f(q.x, q.y, q.z)
 
 
 @wp.func
-def quat_apply(q: quatf, v: vec3f) -> vec3f:
+def quat_apply(q: wp.quatf, v: wp.vec3f) -> wp.vec3f:
     """
     Apply a quaternion to a vector.
     The quaternion is applied to the vector using the formula:
@@ -279,24 +290,24 @@ def quat_apply(q: quatf, v: vec3f) -> vec3f:
 
 
 @wp.func
-def quat_derivative(q: quatf, omega: vec3f) -> quatf:
+def quat_derivative(q: wp.quatf, omega: wp.vec3f) -> wp.quatf:
     """
     Computes the quaternion derivative from a quaternion and angular velocity.
 
     Args:
-        q (quatf): The quaternion of the current pose of the body.
-        omega (vec3f): The angular velocity of the body.
+        q: The quaternion of the current pose of the body.
+        omega: The angular velocity of the body.
 
     Returns:
-        quatf: The quaternion derivative.
+        The quaternion derivative.
     """
     vdq = 0.5 * wp.transpose(G_of(q)) * omega
-    dq = wp.quaternion(vdq.x, vdq.y, vdq.z, vdq.w, dtype=float32)
+    dq = wp.quaternion(vdq.x, vdq.y, vdq.z, vdq.w, dtype=wp.float32)
     return dq
 
 
 @wp.func
-def quat_log(q: quatf) -> vec3f:
+def quat_log(q: wp.quatf) -> wp.vec3f:
     """
     Computes the logarithm of a quaternion using the stable
     `4 * atan()` formulation to render a rotation vector.
@@ -324,12 +335,12 @@ def quat_log(q: quatf) -> vec3f:
 
 
 @wp.func
-def quat_log_decomposed(q: quatf) -> vec4f:
+def quat_log_decomposed(q: wp.quatf) -> wp.vec4f:
     """
     Computes the logarithm of a quaternion using the stable
     `4 * atan()` formulation to render an angle-axis vector.
 
-    The output is a vec4f with the following format:
+    The output is a wp.vec4f with the following format:
         - `a = [x, y, z, c]` is the angle-axis output
         - `[x, y, z]` is the axis of rotation
         - `c` is the angle.
@@ -353,24 +364,24 @@ def quat_log_decomposed(q: quatf) -> vec4f:
         c = (2.0 - wp.static(2.0 / 3.0) * (pv_norm_sq / pw_sq)) / p.w
 
     # Return the scaled imaginary part of the quaternion
-    return vec4f(pv.x, pv.y, pv.z, c)
+    return wp.vec4f(pv.x, pv.y, pv.z, c)
 
 
 @wp.func
-def quat_exp(v: vec3f) -> quatf:
+def quat_exp(v: wp.vec3f) -> wp.quatf:
     """
     Computes the exponential map of a 3D vector as a quaternion.
     using Rodrigues' formula: R = I + sin(θ)*K (1-cos(θ)*K^2),
     were q = quat(R).
 
     Args:
-        v (vec3f): The 3D rotation vector to be mapped to quaternion space.
+        v: The 3D rotation vector to be mapped to quaternion space.
 
     Returns:
-        quatf: The quaternion resulting from the exponential map of the input rotation vector.
+        The quaternion resulting from the exponential map of the input rotation vector.
     """
     eps = FLOAT32_EPS
-    q = wp.quat_identity(dtype=float32)
+    q = wp.quat_identity(dtype=wp.float32)
     vn = wp.length(v)
     if vn > eps:
         a = 0.5 * vn
@@ -390,18 +401,18 @@ def quat_exp(v: vec3f) -> quatf:
 
 
 @wp.func
-def quat_product(q1: quatf, q2: quatf) -> quatf:
+def quat_product(q1: wp.quatf, q2: wp.quatf) -> wp.quatf:
     """
     Computes the quaternion product of two quaternions.
 
     Args:
-        q1 (quatf): The first quaternion.
-        q2 (quatf): The second quaternion.
+        q1: The first quaternion.
+        q2: The second quaternion.
 
     Returns:
-        quatf: The result of the quaternion product.
+        The result of the quaternion product.
     """
-    q3 = wp.quat_identity(dtype=float32)
+    q3 = wp.quat_identity(dtype=wp.float32)
     q3.x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y
     q3.y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z * q2.x
     q3.z = q1.w * q2.z + q1.x * q2.y - q1.y * q2.x + q1.z * q2.w
@@ -410,23 +421,23 @@ def quat_product(q1: quatf, q2: quatf) -> quatf:
 
 
 @wp.func
-def quat_box_plus(q: quatf, v: vec3f) -> quatf:
+def quat_box_plus(q: wp.quatf, v: wp.vec3f) -> wp.quatf:
     """
     Computes the box-plus operation for a quaternion and a vector:
         R(q) [+] v == exp(v) * R(q), where R(q) is the rotation matrix of the quaternion q.
 
     Args:
-        q (vec3f): The quaternion.
-        v (vec3f): The vector.
+        q: The quaternion.
+        v: The vector.
 
     Returns:
-        quatf: The result of the box-plus operation.
+        The result of the box-plus operation.
     """
     return quat_product(quat_exp(v), q)
 
 
 @wp.func
-def quat_from_x_rot(angle_rad: float32) -> quatf:
+def quat_from_x_rot(angle_rad: wp.float32) -> wp.quatf:
     """
     Computes a unit quaternion corresponding to rotation by given angle about the x axis
     """
@@ -434,7 +445,7 @@ def quat_from_x_rot(angle_rad: float32) -> quatf:
 
 
 @wp.func
-def quat_from_y_rot(angle_rad: float32) -> quatf:
+def quat_from_y_rot(angle_rad: wp.float32) -> wp.quatf:
     """
     Computes a unit quaternion corresponding to rotation by given angle about the y axis
     """
@@ -442,7 +453,7 @@ def quat_from_y_rot(angle_rad: float32) -> quatf:
 
 
 @wp.func
-def quat_from_z_rot(angle_rad: float32) -> quatf:
+def quat_from_z_rot(angle_rad: wp.float32) -> wp.quatf:
     """
     Computes a unit quaternion corresponding to rotation by given angle about the z axis
     """
@@ -450,11 +461,11 @@ def quat_from_z_rot(angle_rad: float32) -> quatf:
 
 
 @wp.func
-def quat_to_euler_xyz(q: quatf) -> vec3f:
+def quat_to_euler_xyz(q: wp.quatf) -> wp.vec3f:
     """
     Converts a unit quaternion to XYZ Euler angles (also known as Cardan angles).
     """
-    rpy = vec3f(0.0)
+    rpy = wp.vec3f(0.0)
     R_20 = -2.0 * (q.x * q.z - q.w * q.y)
     if wp.abs(R_20) < 1.0:
         rpy[1] = wp.asin(-R_20)
@@ -468,7 +479,7 @@ def quat_to_euler_xyz(q: quatf) -> vec3f:
 
 
 @wp.func
-def quat_from_euler_xyz(rpy: vec3f) -> quatf:
+def quat_from_euler_xyz(rpy: wp.vec3f) -> wp.quatf:
     """
     Converts XYZ Euler angles (also known as Cardan angles) to a unit quaternion.
     """
@@ -476,7 +487,7 @@ def quat_from_euler_xyz(rpy: vec3f) -> quatf:
 
 
 @wp.func
-def quat_left_jacobian_inverse(q: quatf) -> mat33f:
+def quat_left_jacobian_inverse(q: wp.quatf) -> wp.mat33f:
     """
     Computes the left-Jacobian inverse of the quaternion log map
     """
@@ -496,11 +507,11 @@ def quat_left_jacobian_inverse(q: quatf) -> mat33f:
         c1 = wp.static(1.0 / 3.0) / pw_sq
         c0 = (1.0 - c1 * pv_norm_sq) / p.w
 
-    return wp.identity(3, dtype=float32) - wp.skew(c0 * pv) + wp.skew(c1 * pv) * wp.skew(pv)
+    return wp.identity(3, dtype=wp.float32) - wp.skew(c0 * pv) + wp.skew(c1 * pv) * wp.skew(pv)
 
 
 @wp.func
-def quat_normalized_apply(q: quatf, v: vec3f) -> vec3f:
+def quat_normalized_apply(q: wp.quatf, v: wp.vec3f) -> wp.vec3f:
     """
     Combines quaternion normalization and applying a unit quaternion to a vector
     """
@@ -511,7 +522,7 @@ def quat_normalized_apply(q: quatf, v: vec3f) -> vec3f:
 
 
 @wp.func
-def quat_conj_normalized_apply(q: quatf, v: vec3f) -> vec3f:
+def quat_conj_normalized_apply(q: wp.quatf, v: wp.vec3f) -> wp.vec3f:
     """
     Combines quaternion conjugation, normalization and applying a unit quaternion to a vector
     """
@@ -522,7 +533,7 @@ def quat_conj_normalized_apply(q: quatf, v: vec3f) -> vec3f:
 
 
 @wp.func
-def quat_twist_angle(q: quatf, axis: vec3f) -> wp.float32:
+def quat_twist_angle(q: wp.quatf, axis: wp.vec3f) -> wp.float32:
     """
     Computes the twist angle of a quaternion around a specific axis.
 
@@ -543,7 +554,7 @@ def quat_twist_angle(q: quatf, axis: vec3f) -> wp.float32:
 
 
 @wp.func
-def unit_quat_apply(q: quatf, v: vec3f) -> vec3f:
+def unit_quat_apply(q: wp.quatf, v: wp.vec3f) -> wp.vec3f:
     """
     Applies a unit quaternion to a vector (making use of the unit norm assumption to simplify the result)
     """
@@ -553,7 +564,7 @@ def unit_quat_apply(q: quatf, v: vec3f) -> vec3f:
 
 
 @wp.func
-def unit_quat_conj_apply(q: quatf, v: vec3f) -> vec3f:
+def unit_quat_conj_apply(q: wp.quatf, v: wp.vec3f) -> wp.vec3f:
     """
     Applies the conjugate of a unit quaternion to a vector (making use of the unit norm assumption to simplify
     the result)
@@ -564,7 +575,7 @@ def unit_quat_conj_apply(q: quatf, v: vec3f) -> vec3f:
 
 
 @wp.func
-def unit_quat_to_rotation_matrix(q: quatf) -> mat33f:
+def unit_quat_to_rotation_matrix(q: wp.quatf) -> wp.mat33f:
     """
     Converts a unit quaternion to a rotation matrix (making use of the unit norm assumption to simplify the result)
     """
@@ -577,11 +588,11 @@ def unit_quat_to_rotation_matrix(q: quatf) -> mat33f:
     wy = 2.0 * q.w * q.y
     zz = 2.0 * q.z * q.z
     wz = 2.0 * q.w * q.z
-    return mat33f(1.0 - yy - zz, xy - wz, xz + wy, xy + wz, 1.0 - xx - zz, yz - wx, xz - wy, yz + wx, 1.0 - xx - yy)
+    return wp.mat33f(1.0 - yy - zz, xy - wz, xz + wy, xy + wz, 1.0 - xx - zz, yz - wx, xz - wy, yz + wx, 1.0 - xx - yy)
 
 
 @wp.func
-def unit_quat_conj_to_rotation_matrix(q: quatf) -> mat33f:
+def unit_quat_conj_to_rotation_matrix(q: wp.quatf) -> wp.mat33f:
     """
     Converts the conjugate of a unit quaternion to a rotation matrix (making use of the unit norm assumption
     to simplify the result); this is simply the transpose of unit_quat_to_rotation_matrix(q)
@@ -595,11 +606,11 @@ def unit_quat_conj_to_rotation_matrix(q: quatf) -> mat33f:
     wy = 2.0 * q.w * q.y
     zz = 2.0 * q.z * q.z
     wz = 2.0 * q.w * q.z
-    return mat33f(1.0 - yy - zz, xy + wz, xz - wy, xy - wz, 1.0 - xx - zz, yz + wx, xz + wy, yz - wx, 1.0 - xx - yy)
+    return wp.mat33f(1.0 - yy - zz, xy + wz, xz - wy, xy - wz, 1.0 - xx - zz, yz + wx, xz + wy, yz - wx, 1.0 - xx - yy)
 
 
 @wp.func
-def unit_quat_apply_jacobian(q: quatf, v: vec3f) -> mat34f:
+def unit_quat_apply_jacobian(q: wp.quatf, v: wp.vec3f) -> mat34f:
     """
     Returns the Jacobian of unit_quat_apply(q, v) with respect to q
     """
@@ -632,7 +643,7 @@ def unit_quat_apply_jacobian(q: quatf, v: vec3f) -> mat34f:
 
 
 @wp.func
-def unit_quat_conj_apply_jacobian(q: quatf, v: vec3f) -> mat34f:
+def unit_quat_conj_apply_jacobian(q: wp.quatf, v: wp.vec3f) -> mat34f:
     """
     Returns the Jacobian of unit_quat_conj_apply(q, v) with respect to q
     """
@@ -670,50 +681,50 @@ def unit_quat_conj_apply_jacobian(q: quatf, v: vec3f) -> mat34f:
 
 
 @wp.func
-def screw(linear: vec3f, angular: vec3f) -> vec6f:
+def screw(linear: wp.vec3f, angular: wp.vec3f) -> wp.spatial_vectorf:
     """
-    Constructs a 6D screw (as `vec6f`) from 3D linear and angular components.
+    Constructs a 6D screw (as `wp.spatial_vectorf`) from 3D linear and angular components.
 
     Args:
-        linear (vec3f): The linear component of the screw.
-        angular (vec3f): The angular component of the screw.
+        linear: The linear component of the screw.
+        angular: The angular component of the screw.
 
     Returns:
-        vec6f: The resulting screw represented as a 6D vector.
+        The resulting screw represented as a 6D vector.
     """
-    return vec6f(linear[0], linear[1], linear[2], angular[0], angular[1], angular[2])
+    return wp.spatial_vectorf(linear[0], linear[1], linear[2], angular[0], angular[1], angular[2])
 
 
 @wp.func
-def screw_linear(s: vec6f) -> vec3f:
+def screw_linear(s: wp.spatial_vectorf) -> wp.vec3f:
     """
     Extracts the linear component from a 6D screw vector.
 
     Args:
-        s (vec6f): The 6D screw vector.
+        s: The 6D screw vector.
 
     Returns:
-        vec3f: The linear component of the screw.
+        The linear component of the screw.
     """
-    return vec3f(s[0], s[1], s[2])
+    return wp.vec3f(s[0], s[1], s[2])
 
 
 @wp.func
-def screw_angular(s: vec6f) -> vec3f:
+def screw_angular(s: wp.spatial_vectorf) -> wp.vec3f:
     """
     Extracts the angular component from a 6D screw vector.
 
     Args:
-        s (vec6f): The 6D screw vector.
+        s: The 6D screw vector.
 
     Returns:
-        vec3f: The angular component of the screw.
+        The angular component of the screw.
     """
-    return vec3f(s[3], s[4], s[5])
+    return wp.vec3f(s[3], s[4], s[5])
 
 
 @wp.func
-def screw_transform_matrix_from_points(r_A: vec3f, r_B: vec3f) -> mat66f:
+def screw_transform_matrix_from_points(r_A: wp.vec3f, r_B: wp.vec3f) -> wp.spatial_matrixf:
     """
     Generates a 6x6 screw transformation matrix given the starting (`r_A`)
     and ending (`r_B`) positions defining the line-of-action of the screw.
@@ -729,11 +740,11 @@ def screw_transform_matrix_from_points(r_A: vec3f, r_B: vec3f) -> mat66f:
     where `S_BA` is the skew-symmetric matrix of the vector `r_BA = r_A - r_B`.
 
     Args:
-        r_A (vec3f): The starting position of the line-of-action in world coordinates.
-        r_B (vec3f): The ending position of the line-of-action in world coordinates.
+        r_A: The starting position of the line-of-action in world coordinates.
+        r_B: The ending position of the line-of-action in world coordinates.
 
     Returns:
-        mat66f: The 6x6 screw transformation matrix.
+        The 6x6 screw transformation matrix.
     """
     # Initialize the wrench matrix
     W_BA = I_6
@@ -758,7 +769,7 @@ W_C_I = wp.constant(mat63f(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 
 @wp.func
-def contact_wrench_matrix_from_points(r_k: vec3f, r_i: vec3f) -> mat63f:
+def contact_wrench_matrix_from_points(r_k: wp.vec3f, r_i: wp.vec3f) -> mat63f:
     """
     Generates a 6x3 screw transformation matrix given the contact (`r_k`)
     and body CoM (`r_i`) positions defining the line-of-action of the force.
@@ -774,11 +785,11 @@ def contact_wrench_matrix_from_points(r_k: vec3f, r_i: vec3f) -> mat63f:
     where `S_ki` is the skew-symmetric matrix of the vector `r_ki = r_k - r_i`.
 
     Args:
-        r_k (vec3f): The position of the contact point in world coordinates.
-        r_i (vec3f): The position of the body CoM in world coordinates.
+        r_k: The position of the contact point in world coordinates.
+        r_i: The position of the body CoM in world coordinates.
 
     Returns:
-        mat66f: The 6x6 screw transformation matrix.
+        The 6x6 screw transformation matrix.
     """
     # Initialize the wrench matrix
     W_ki = W_C_I
@@ -794,19 +805,19 @@ def contact_wrench_matrix_from_points(r_k: vec3f, r_i: vec3f) -> mat63f:
 
 
 @wp.func
-def expand6d(X: mat33f) -> mat66f:
+def expand6d(X: wp.mat33f) -> wp.spatial_matrixf:
     """
     Expands a 3x3 rotation matrix to a 6x6 matrix operator by filling
     the upper left and lower right blocks with the input matrix.
 
     Args:
-        X (mat33f): The 3x3 matrix to be expanded.
+        X: The 3x3 matrix to be expanded.
 
     Returns:
-        mat66: The expanded 6x6 matrix.
+        The expanded 6x6 matrix.
     """
     # Initialize the 6D matrix
-    X_6d = mat66f(0.0)
+    X_6d = wp.spatial_matrixf(0.0)
 
     # Fill the upper left 3x3 block with the input matrix
     for i in range(3):
@@ -819,19 +830,19 @@ def expand6d(X: mat33f) -> mat66f:
 
 
 @wp.func
-def concat6d(X1: mat33f, X2: mat33f) -> mat66f:
+def concat6d(X1: wp.mat33f, X2: wp.mat33f) -> wp.spatial_matrixf:
     """
     Concatenates two 3x3 rotation matrix as diagonal blocks of a 6x6 matrix.
 
     Args:
-        X1 (mat33f): The 3x3 top-left matrix.
-        X2 (mat33f): The 3x3 bottom-right matrix.
+        X1: The 3x3 top-left matrix.
+        X2: The 3x3 bottom-right matrix.
 
     Returns:
-        mat66: The 6x6 matrix concatenating X1, X2 along the diagonal.
+        The 6x6 matrix concatenating X1 and X2 along the diagonal.
     """
     # Initialize the 6D matrix
-    X_6d = mat66f(0.0)
+    X_6d = wp.spatial_matrixf(0.0)
 
     # Fill the upper left 3x3 block with the input matrix
     for i in range(3):
@@ -850,14 +861,14 @@ def concat6d(X1: mat33f, X2: mat33f) -> mat66f:
 
 @wp.func
 def compute_body_twist_update_with_eom(
-    dt: float32,
-    g: vec3f,
-    inv_m_i: float32,
-    I_i: mat33f,
-    inv_I_i: mat33f,
-    u_i: vec6f,
-    w_i: vec6f,
-) -> tuple[vec3f, vec3f]:
+    dt: wp.float32,
+    g: wp.vec3f,
+    inv_m_i: wp.float32,
+    I_i: wp.mat33f,
+    inv_I_i: wp.mat33f,
+    u_i: wp.spatial_vectorf,
+    w_i: wp.spatial_vectorf,
+) -> tuple[wp.vec3f, wp.vec3f]:
     # Extract linear and angular parts
     v_i = screw_linear(u_i)
     omega_i = screw_angular(u_i)
@@ -875,11 +886,11 @@ def compute_body_twist_update_with_eom(
 
 @wp.func
 def compute_body_pose_update_with_logmap(
-    dt: float32,
-    p_i: transformf,
-    v_i: vec3f,
-    omega_i: vec3f,
-) -> transformf:
+    dt: wp.float32,
+    p_i: wp.transformf,
+    v_i: wp.vec3f,
+    omega_i: wp.vec3f,
+) -> wp.transformf:
     # Extract linear and angular parts
     r_i = wp.transform_get_translation(p_i)
     q_i = wp.transform_get_rotation(p_i)
@@ -887,7 +898,7 @@ def compute_body_pose_update_with_logmap(
     # Compute configuration update equations
     r_i_n = r_i + dt * v_i
     q_i_n = quat_box_plus(q_i, dt * omega_i)
-    p_i_n = transformf(r_i_n, q_i_n)
+    p_i_n = wp.transformf(r_i_n, q_i_n)
 
     # Return the new pose and twist
     return p_i_n
@@ -904,10 +915,10 @@ def tril_index(row: Any, col: Any) -> Any:
     Computes the index in a flattened lower-triangular matrix.
 
     Args:
-        row (Any): The row index.
-        col (Any): The column index.
+        row: The row index.
+        col: The column index.
 
     Returns:
-        Any: The index in the flattened lower-triangular matrix.
+        The index in the flattened lower-triangular matrix.
     """
     return (row * (row + 1)) // 2 + col

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -32,7 +32,6 @@ from .materials import MaterialManager, MaterialPairsModel, MaterialsModel
 from .size import SizeKamino
 from .state import StateKamino
 from .time import TimeData, TimeModel
-from .types import float32, int32, mat33f, transformf, vec6f
 
 ###
 # Module interface
@@ -73,260 +72,260 @@ class ModelKaminoInfo:
     # Entity Counts
     ###
 
-    num_bodies: wp.array | None = None
+    num_bodies: wp.array[wp.int32] | None = None
     """
     The number of bodies in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_joints: wp.array | None = None
+    num_joints: wp.array[wp.int32] | None = None
     """
     The number of joints in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_passive_joints: wp.array | None = None
+    num_passive_joints: wp.array[wp.int32] | None = None
     """
     The number of passive joints in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_actuated_joints: wp.array | None = None
+    num_actuated_joints: wp.array[wp.int32] | None = None
     """
     The number of actuated joints in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_dynamic_joints: wp.array | None = None
+    num_dynamic_joints: wp.array[wp.int32] | None = None
     """
     The number of dynamic joints in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_geoms: wp.array | None = None
+    num_geoms: wp.array[wp.int32] | None = None
     """
     The number of geometries in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    max_limits: wp.array | None = None
+    max_limits: wp.array[wp.int32] | None = None
     """
     The maximum number of limits in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    max_contacts: wp.array | None = None
+    max_contacts: wp.array[wp.int32] | None = None
     """
     The maximum number of contacts in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # DoF Counts
     ###
 
-    num_body_dofs: wp.array | None = None
+    num_body_dofs: wp.array[wp.int32] | None = None
     """
     The number of body DoFs of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_joint_coords: wp.array | None = None
+    num_joint_coords: wp.array[wp.int32] | None = None
     """
     The number of joint coordinates of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_joint_dofs: wp.array | None = None
+    num_joint_dofs: wp.array[wp.int32] | None = None
     """
     The number of joint DoFs of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_passive_joint_coords: wp.array | None = None
+    num_passive_joint_coords: wp.array[wp.int32] | None = None
     """
     The number of passive joint coordinates of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_passive_joint_dofs: wp.array | None = None
+    num_passive_joint_dofs: wp.array[wp.int32] | None = None
     """
     The number of passive joint DoFs of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_actuated_joint_coords: wp.array | None = None
+    num_actuated_joint_coords: wp.array[wp.int32] | None = None
     """
     The number of actuated joint coordinates of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_actuated_joint_dofs: wp.array | None = None
+    num_actuated_joint_dofs: wp.array[wp.int32] | None = None
     """
     The number of actuated joint DoFs of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Constraint Counts
     ###
 
-    # TODO: We could make this a vec2i to store dynamic
+    # TODO: We could make this a wp.vec2i to store dynamic
     # and kinematic joint constraint counts separately
-    num_joint_cts: wp.array | None = None
+    num_joint_cts: wp.array[wp.int32] | None = None
     """
     The number of joint constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_joint_dynamic_cts: wp.array | None = None
+    num_joint_dynamic_cts: wp.array[wp.int32] | None = None
     """
     The number of dynamic joint constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    num_joint_kinematic_cts: wp.array | None = None
+    num_joint_kinematic_cts: wp.array[wp.int32] | None = None
     """
     The number of kinematic joint constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    max_limit_cts: wp.array | None = None
+    max_limit_cts: wp.array[wp.int32] | None = None
     """
     The maximum number of active limit constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    max_contact_cts: wp.array | None = None
+    max_contact_cts: wp.array[wp.int32] | None = None
     """
     The maximum number of active contact constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    max_total_cts: wp.array | None = None
+    max_total_cts: wp.array[wp.int32] | None = None
     """
     The maximum total number of active constraints of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Entity Offsets
     ###
 
-    bodies_offset: wp.array | None = None
+    bodies_offset: wp.array[wp.int32] | None = None
     """
     The body index offset of each world w.r.t the model.\n
-    Shape of ``(num_worlds + 1,)`` and type :class:`int`.
+    Shape of ``(num_worlds + 1,)``.
     The last entry is the total bodies count, so that the per-world
     bodies count is encoded as ``bodies_offset[w+1] - bodies_offset[w]``.
     """
 
-    joints_offset: wp.array | None = None
+    joints_offset: wp.array[wp.int32] | None = None
     """
     The joint index offset of each world w.r.t the model.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    geoms_offset: wp.array | None = None
+    geoms_offset: wp.array[wp.int32] | None = None
     """
     The geom index offset of each world w.r.t. the model.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    limits_offset: wp.array | None = None
+    limits_offset: wp.array[wp.int32] | None = None
     """
     The limit index offset of each world w.r.t the model.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    contacts_offset: wp.array | None = None
+    contacts_offset: wp.array[wp.int32] | None = None
     """
     The contact index offset of world w.r.t the model.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    unilaterals_offset: wp.array | None = None
+    unilaterals_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the unilaterals (limits + contacts) block of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # DoF Offsets
     ###
 
-    body_dofs_offset: wp.array | None = None
+    body_dofs_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the body DoF block of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_coords_offset: wp.array | None = None
+    joint_coords_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the joint coordinates block of each world.\n
     Used to index into arrays that contain flattened joint coordinate-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_dofs_offset: wp.array | None = None
+    joint_dofs_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the joint DoF block of each world.\n
     Used to index into arrays that contain flattened joint DoF-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_passive_coords_offset: wp.array | None = None
+    joint_passive_coords_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the passive joint coordinates block of each world.\n
     Used to index into arrays that contain flattened passive joint coordinate-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_passive_dofs_offset: wp.array | None = None
+    joint_passive_dofs_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the passive joint DoF block of each world.\n
     Used to index into arrays that contain flattened passive joint DoF-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_actuated_coords_offset: wp.array | None = None
+    joint_actuated_coords_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the actuated joint coordinates block of each world.\n
     Used to index into arrays that contain flattened actuated joint coordinate-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_actuated_dofs_offset: wp.array | None = None
+    joint_actuated_dofs_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the actuated joint DoF block of each world.\n
     Used to index into arrays that contain flattened actuated joint DoF-sized data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Constraint Offsets
     ###
 
-    joint_cts_offset: wp.array | None = None
+    joint_cts_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the joint constraints block of each world.\n
     Used to index into arrays that contain flattened and
     concatenated dynamic and kinematic joint constraint data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_dynamic_cts_offset: wp.array | None = None
+    joint_dynamic_cts_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the dynamic joint constraints block of each world.\n
     Used to index into arrays that contain flattened dynamic joint constraint data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_kinematic_cts_offset: wp.array | None = None
+    joint_kinematic_cts_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the kinematic joint constraints block of each world.\n
     Used to index into arrays that contain flattened kinematic joint constraint data.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     # TODO: We could make this an array of vec5i and store the absolute
@@ -337,7 +336,7 @@ class ModelKaminoInfo:
     # - [3]: limit_cts_group_offset
     # - [4]: contact_cts_group_offset
     # TODO: We could then provide helper functions to get the start-end of each block
-    total_cts_offset: wp.array | None = None
+    total_cts_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the total constraints block of each world.\n
     Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
@@ -364,67 +363,67 @@ class ModelKaminoInfo:
     world_contact_cts_start = world_cts_start + local_contact_cts_start
     ```
 
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_dynamic_cts_group_offset: wp.array | None = None
+    joint_dynamic_cts_group_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the dynamic joint constraints group within the constraints block of each world.\n
     Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    joint_kinematic_cts_group_offset: wp.array | None = None
+    joint_kinematic_cts_group_offset: wp.array[wp.int32] | None = None
     """
     The index offset of the kinematic joint constraints group within the constraints block of each world.\n
     Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Base Properties
     ###
 
-    base_body_index: wp.array | None = None
+    base_body_index: wp.array[wp.int32] | None = None
     """
     The index of the base body assigned in each world w.r.t the model.
     If a base joint is also assigned, must be the follower body of that joint.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    base_joint_index: wp.array | None = None
+    base_joint_index: wp.array[wp.int32] | None = None
     """
     The index of the base joint assigned in each world w.r.t the model (-1 if not assigned).
     If assigned, must be a unary, non-universal, joint.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
     ###
     # Inertial Properties
     ###
 
-    mass_min: wp.array | None = None
+    mass_min: wp.array[wp.float32] | None = None
     """
     Smallest mass amongst all bodies in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
-    mass_max: wp.array | None = None
+    mass_max: wp.array[wp.float32] | None = None
     """
     Largest mass amongst all bodies in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
-    mass_total: wp.array | None = None
+    mass_total: wp.array[wp.float32] | None = None
     """
     Total mass over all bodies in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
-    inertia_total: wp.array | None = None
+    inertia_total: wp.array[wp.float32] | None = None
     """
     Total diagonal inertia over all bodies in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
 
@@ -521,16 +520,12 @@ class ModelKamino:
         """
         Creates a model data container with the initial state of the model entities.
 
-        Parameters:
-            unilateral_cts (`bool`, optional):
-                Whether to include unilateral constraints (limits and contacts) in the model data. Defaults to `True`.
-            joint_wrenches (`bool`, optional):
-                Whether to include joint wrenches in the model data. Defaults to `False`.
-            requires_grad (`bool`, optional):
-                Whether the model data should require gradients. Defaults to `False`.
-            device (`wp.DeviceLike`, optional):
-                The device to create the model data on. If not specified, the model's device is used.
-                Defaults to `None`. If not specified, the model's device is used.
+        Args:
+            unilateral_cts: Whether to include unilateral constraints (limits and contacts) in the model data.
+                Defaults to ``True``.
+            joint_wrenches: Whether to include joint wrenches in the model data. Defaults to ``False``.
+            requires_grad: Whether the model data should require gradients. Defaults to ``False``.
+            device: The device to create the model data on. If not specified, the model's device is used.
         """
         # If no device is specified, use the model's device
         if device is None:
@@ -555,25 +550,25 @@ class ModelKamino:
             # counts initialized to the joint constraints count
             info = DataKaminoInfo(
                 num_total_cts=wp.clone(self.info.num_joint_cts),
-                num_limits=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
-                num_contacts=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
-                num_limit_cts=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
-                num_contact_cts=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
-                limit_cts_group_offset=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
-                contact_cts_group_offset=wp.zeros(shape=nw, dtype=int32) if unilateral_cts else None,
+                num_limits=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
+                num_contacts=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
+                num_limit_cts=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
+                num_contact_cts=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
+                limit_cts_group_offset=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
+                contact_cts_group_offset=wp.zeros(shape=nw, dtype=wp.int32) if unilateral_cts else None,
             )
 
             # Construct the time data with the initial step and time set to zero for all worlds
             time = TimeData(
-                steps=wp.zeros(shape=nw, dtype=int32, requires_grad=requires_grad),
-                time=wp.zeros(shape=nw, dtype=float32, requires_grad=requires_grad),
+                steps=wp.zeros(shape=nw, dtype=wp.int32, requires_grad=requires_grad),
+                time=wp.zeros(shape=nw, dtype=wp.float32, requires_grad=requires_grad),
             )
 
             # Construct the rigid bodies data from the model's initial state
             bodies = RigidBodiesData(
                 num_bodies=nb,
-                I_i=wp.zeros(shape=nb, dtype=mat33f, requires_grad=requires_grad),
-                inv_I_i=wp.zeros(shape=nb, dtype=mat33f, requires_grad=requires_grad),
+                I_i=wp.zeros(shape=nb, dtype=wp.mat33f, requires_grad=requires_grad),
+                inv_I_i=wp.zeros(shape=nb, dtype=wp.mat33f, requires_grad=requires_grad),
                 q_i=wp.clone(self.bodies.q_i_0, requires_grad=requires_grad),
                 u_i=wp.clone(self.bodies.u_i_0, requires_grad=requires_grad),
                 w_i=wp.zeros_like(self.bodies.u_i_0, requires_grad=requires_grad),
@@ -587,31 +582,39 @@ class ModelKamino:
             # Construct the joints data from the model's initial state
             joints = JointsData(
                 num_joints=nj,
-                p_j=wp.zeros(shape=nj, dtype=transformf, requires_grad=requires_grad),
-                q_j=wp.zeros(shape=njcoords, dtype=float32, requires_grad=requires_grad),
-                q_j_p=wp.zeros(shape=njcoords, dtype=float32, requires_grad=requires_grad),
-                dq_j=wp.zeros(shape=njdofs, dtype=float32, requires_grad=requires_grad),
-                tau_j=wp.zeros(shape=njdofs, dtype=float32, requires_grad=requires_grad),
-                r_j=wp.zeros(shape=njkincts, dtype=float32, requires_grad=requires_grad),
-                dr_j=wp.zeros(shape=njkincts, dtype=float32, requires_grad=requires_grad),
-                lambda_j=wp.zeros(shape=njcts, dtype=float32, requires_grad=requires_grad),
-                m_j=wp.zeros(shape=njdyncts, dtype=float32, requires_grad=requires_grad),
-                inv_m_j=wp.zeros(shape=njdyncts, dtype=float32, requires_grad=requires_grad),
-                dq_b_j=wp.zeros(shape=njdyncts, dtype=float32, requires_grad=requires_grad),
+                p_j=wp.zeros(shape=nj, dtype=wp.transformf, requires_grad=requires_grad),
+                q_j=wp.zeros(shape=njcoords, dtype=wp.float32, requires_grad=requires_grad),
+                q_j_p=wp.zeros(shape=njcoords, dtype=wp.float32, requires_grad=requires_grad),
+                dq_j=wp.zeros(shape=njdofs, dtype=wp.float32, requires_grad=requires_grad),
+                tau_j=wp.zeros(shape=njdofs, dtype=wp.float32, requires_grad=requires_grad),
+                r_j=wp.zeros(shape=njkincts, dtype=wp.float32, requires_grad=requires_grad),
+                dr_j=wp.zeros(shape=njkincts, dtype=wp.float32, requires_grad=requires_grad),
+                lambda_j=wp.zeros(shape=njcts, dtype=wp.float32, requires_grad=requires_grad),
+                m_j=wp.zeros(shape=njdyncts, dtype=wp.float32, requires_grad=requires_grad),
+                inv_m_j=wp.zeros(shape=njdyncts, dtype=wp.float32, requires_grad=requires_grad),
+                dq_b_j=wp.zeros(shape=njdyncts, dtype=wp.float32, requires_grad=requires_grad),
                 # TODO: Should we make these optional and only include them when implicit joints are present?
                 q_j_ref=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
                 dq_j_ref=wp.clone(self.joints.dq_j_0, requires_grad=requires_grad),
-                tau_j_ref=wp.zeros(shape=njdofs, dtype=float32, requires_grad=requires_grad),
-                j_w_j=wp.zeros(shape=nj, dtype=vec6f, requires_grad=requires_grad) if joint_wrenches else None,
-                j_w_c_j=wp.zeros(shape=nj, dtype=vec6f, requires_grad=requires_grad) if joint_wrenches else None,
-                j_w_a_j=wp.zeros(shape=nj, dtype=vec6f, requires_grad=requires_grad) if joint_wrenches else None,
-                j_w_l_j=wp.zeros(shape=nj, dtype=vec6f, requires_grad=requires_grad) if joint_wrenches else None,
+                tau_j_ref=wp.zeros(shape=njdofs, dtype=wp.float32, requires_grad=requires_grad),
+                j_w_j=wp.zeros(shape=nj, dtype=wp.spatial_vectorf, requires_grad=requires_grad)
+                if joint_wrenches
+                else None,
+                j_w_c_j=wp.zeros(shape=nj, dtype=wp.spatial_vectorf, requires_grad=requires_grad)
+                if joint_wrenches
+                else None,
+                j_w_a_j=wp.zeros(shape=nj, dtype=wp.spatial_vectorf, requires_grad=requires_grad)
+                if joint_wrenches
+                else None,
+                j_w_l_j=wp.zeros(shape=nj, dtype=wp.spatial_vectorf, requires_grad=requires_grad)
+                if joint_wrenches
+                else None,
             )
 
             # Construct the geometries data from the model's initial state
             geoms = GeometriesData(
                 num_geoms=ng,
-                pose=wp.zeros(shape=ng, dtype=transformf, requires_grad=requires_grad),
+                pose=wp.zeros(shape=ng, dtype=wp.transformf, requires_grad=requires_grad),
             )
 
         # Assemble and return the new data container
@@ -627,11 +630,9 @@ class ModelKamino:
         """
         Creates state container initialized to the initial body state defined in the model.
 
-        Parameters:
-            requires_grad (`bool`, optional):
-                Whether the state should require gradients. Defaults to `False`.
-            device (`wp.DeviceLike`, optional):
-                The device to create the state on. If not specified, the model's device is used.
+        Args:
+            requires_grad: Whether the state should require gradients. Defaults to ``False``.
+            device: The device to create the state on. If not specified, the model's device is used.
         """
         # If no device is specified, use the model's device
         if device is None:
@@ -646,8 +647,8 @@ class ModelKamino:
                 w_i_e=wp.zeros_like(self.bodies.u_i_0, requires_grad=requires_grad),
                 q_j=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
                 q_j_p=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
-                dq_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
-                lambda_j=wp.zeros(shape=self.size.sum_of_num_joint_cts, dtype=float32, requires_grad=requires_grad),
+                dq_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=wp.float32, requires_grad=requires_grad),
+                lambda_j=wp.zeros(shape=self.size.sum_of_num_joint_cts, dtype=wp.float32, requires_grad=requires_grad),
             )
 
         # Return the constructed state container
@@ -657,11 +658,9 @@ class ModelKamino:
         """
         Creates a control container with all values initialized to zeros.
 
-        Parameters:
-            requires_grad (`bool`, optional):
-                Whether the control container should require gradients. Defaults to `False`.
-            device (`wp.DeviceLike`, optional):
-                The device to create the control container on. If not specified, the model's device is used.
+        Args:
+            requires_grad: Whether the control container should require gradients. Defaults to ``False``.
+            device: The device to create the control container on. If not specified, the model's device is used.
         """
         # If no device is specified, use the model's device
         if device is None:
@@ -670,10 +669,12 @@ class ModelKamino:
         # Create a new control container on the specified device
         with wp.ScopedDevice(device=device):
             control = ControlKamino(
-                tau_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
+                tau_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=wp.float32, requires_grad=requires_grad),
                 q_j_ref=wp.clone(self.joints.q_j_0, requires_grad=requires_grad),
                 dq_j_ref=wp.clone(self.joints.dq_j_0, requires_grad=requires_grad),
-                tau_j_ref=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
+                tau_j_ref=wp.zeros(
+                    shape=self.size.sum_of_num_joint_dofs, dtype=wp.float32, requires_grad=requires_grad
+                ),
             )
 
         # Post-processing to finalize the control container
@@ -740,8 +741,8 @@ class ModelKamino:
 
             # Per-world time
             model_time = TimeModel(
-                dt=wp.zeros(shape=(model.world_count,), dtype=float32),
-                inv_dt=wp.zeros(shape=(model.world_count,), dtype=float32),
+                dt=wp.zeros(shape=(model.world_count,), dtype=wp.float32),
+                inv_dt=wp.zeros(shape=(model.world_count,), dtype=wp.float32),
             )
 
             # Per-world gravity

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -74,49 +74,49 @@ class ModelKaminoInfo:
 
     num_bodies: wp.array[wp.int32] | None = None
     """
-    The number of bodies in each world.\n
+    The number of bodies in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_joints: wp.array[wp.int32] | None = None
     """
-    The number of joints in each world.\n
+    The number of joints in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_passive_joints: wp.array[wp.int32] | None = None
     """
-    The number of passive joints in each world.\n
+    The number of passive joints in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_actuated_joints: wp.array[wp.int32] | None = None
     """
-    The number of actuated joints in each world.\n
+    The number of actuated joints in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_dynamic_joints: wp.array[wp.int32] | None = None
     """
-    The number of dynamic joints in each world.\n
+    The number of dynamic joints in each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_geoms: wp.array[wp.int32] | None = None
     """
-    The number of geometries in each world.\n
+    The number of geometries in each world.
     Shape of ``(num_worlds,)``.
     """
 
     max_limits: wp.array[wp.int32] | None = None
     """
-    The maximum number of limits in each world.\n
+    The maximum number of limits in each world.
     Shape of ``(num_worlds,)``.
     """
 
     max_contacts: wp.array[wp.int32] | None = None
     """
-    The maximum number of contacts in each world.\n
+    The maximum number of contacts in each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -126,43 +126,43 @@ class ModelKaminoInfo:
 
     num_body_dofs: wp.array[wp.int32] | None = None
     """
-    The number of body DoFs of each world.\n
+    The number of body DoFs of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_joint_coords: wp.array[wp.int32] | None = None
     """
-    The number of joint coordinates of each world.\n
+    The number of joint coordinates of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_joint_dofs: wp.array[wp.int32] | None = None
     """
-    The number of joint DoFs of each world.\n
+    The number of joint DoFs of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_passive_joint_coords: wp.array[wp.int32] | None = None
     """
-    The number of passive joint coordinates of each world.\n
+    The number of passive joint coordinates of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_passive_joint_dofs: wp.array[wp.int32] | None = None
     """
-    The number of passive joint DoFs of each world.\n
+    The number of passive joint DoFs of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_actuated_joint_coords: wp.array[wp.int32] | None = None
     """
-    The number of actuated joint coordinates of each world.\n
+    The number of actuated joint coordinates of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_actuated_joint_dofs: wp.array[wp.int32] | None = None
     """
-    The number of actuated joint DoFs of each world.\n
+    The number of actuated joint DoFs of each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -174,37 +174,37 @@ class ModelKaminoInfo:
     # and kinematic joint constraint counts separately
     num_joint_cts: wp.array[wp.int32] | None = None
     """
-    The number of joint constraints of each world.\n
+    The number of joint constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_joint_dynamic_cts: wp.array[wp.int32] | None = None
     """
-    The number of dynamic joint constraints of each world.\n
+    The number of dynamic joint constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
     num_joint_kinematic_cts: wp.array[wp.int32] | None = None
     """
-    The number of kinematic joint constraints of each world.\n
+    The number of kinematic joint constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
     max_limit_cts: wp.array[wp.int32] | None = None
     """
-    The maximum number of active limit constraints of each world.\n
+    The maximum number of active limit constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
     max_contact_cts: wp.array[wp.int32] | None = None
     """
-    The maximum number of active contact constraints of each world.\n
+    The maximum number of active contact constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
     max_total_cts: wp.array[wp.int32] | None = None
     """
-    The maximum total number of active constraints of each world.\n
+    The maximum total number of active constraints of each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -214,7 +214,7 @@ class ModelKaminoInfo:
 
     bodies_offset: wp.array[wp.int32] | None = None
     """
-    The body index offset of each world w.r.t the model.\n
+    The body index offset of each world w.r.t the model.
     Shape of ``(num_worlds + 1,)``.
     The last entry is the total bodies count, so that the per-world
     bodies count is encoded as ``bodies_offset[w+1] - bodies_offset[w]``.
@@ -222,31 +222,31 @@ class ModelKaminoInfo:
 
     joints_offset: wp.array[wp.int32] | None = None
     """
-    The joint index offset of each world w.r.t the model.\n
+    The joint index offset of each world w.r.t the model.
     Shape of ``(num_worlds,)``.
     """
 
     geoms_offset: wp.array[wp.int32] | None = None
     """
-    The geom index offset of each world w.r.t. the model.\n
+    The geom index offset of each world w.r.t. the model.
     Shape of ``(num_worlds,)``.
     """
 
     limits_offset: wp.array[wp.int32] | None = None
     """
-    The limit index offset of each world w.r.t the model.\n
+    The limit index offset of each world w.r.t the model.
     Shape of ``(num_worlds,)``.
     """
 
     contacts_offset: wp.array[wp.int32] | None = None
     """
-    The contact index offset of world w.r.t the model.\n
+    The contact index offset of world w.r.t the model.
     Shape of ``(num_worlds,)``.
     """
 
     unilaterals_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the unilaterals (limits + contacts) block of each world.\n
+    The index offset of the unilaterals (limits + contacts) block of each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -256,49 +256,49 @@ class ModelKaminoInfo:
 
     body_dofs_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the body DoF block of each world.\n
+    The index offset of the body DoF block of each world.
     Shape of ``(num_worlds,)``.
     """
 
     joint_coords_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the joint coordinates block of each world.\n
-    Used to index into arrays that contain flattened joint coordinate-sized data.\n
+    The index offset of the joint coordinates block of each world.
+    Used to index into arrays that contain flattened joint coordinate-sized data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_dofs_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the joint DoF block of each world.\n
-    Used to index into arrays that contain flattened joint DoF-sized data.\n
+    The index offset of the joint DoF block of each world.
+    Used to index into arrays that contain flattened joint DoF-sized data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_passive_coords_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the passive joint coordinates block of each world.\n
-    Used to index into arrays that contain flattened passive joint coordinate-sized data.\n
+    The index offset of the passive joint coordinates block of each world.
+    Used to index into arrays that contain flattened passive joint coordinate-sized data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_passive_dofs_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the passive joint DoF block of each world.\n
-    Used to index into arrays that contain flattened passive joint DoF-sized data.\n
+    The index offset of the passive joint DoF block of each world.
+    Used to index into arrays that contain flattened passive joint DoF-sized data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_actuated_coords_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the actuated joint coordinates block of each world.\n
-    Used to index into arrays that contain flattened actuated joint coordinate-sized data.\n
+    The index offset of the actuated joint coordinates block of each world.
+    Used to index into arrays that contain flattened actuated joint coordinate-sized data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_actuated_dofs_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the actuated joint DoF block of each world.\n
-    Used to index into arrays that contain flattened actuated joint DoF-sized data.\n
+    The index offset of the actuated joint DoF block of each world.
+    Used to index into arrays that contain flattened actuated joint DoF-sized data.
     Shape of ``(num_worlds,)``.
     """
 
@@ -308,23 +308,23 @@ class ModelKaminoInfo:
 
     joint_cts_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the joint constraints block of each world.\n
+    The index offset of the joint constraints block of each world.
     Used to index into arrays that contain flattened and
-    concatenated dynamic and kinematic joint constraint data.\n
+    concatenated dynamic and kinematic joint constraint data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_dynamic_cts_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the dynamic joint constraints block of each world.\n
-    Used to index into arrays that contain flattened dynamic joint constraint data.\n
+    The index offset of the dynamic joint constraints block of each world.
+    Used to index into arrays that contain flattened dynamic joint constraint data.
     Shape of ``(num_worlds,)``.
     """
 
     joint_kinematic_cts_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the kinematic joint constraints block of each world.\n
-    Used to index into arrays that contain flattened kinematic joint constraint data.\n
+    The index offset of the kinematic joint constraints block of each world.
+    Used to index into arrays that contain flattened kinematic joint constraint data.
     Shape of ``(num_worlds,)``.
     """
 
@@ -338,8 +338,8 @@ class ModelKaminoInfo:
     # TODO: We could then provide helper functions to get the start-end of each block
     total_cts_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the total constraints block of each world.\n
-    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
+    The index offset of the total constraints block of each world.
+    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.
 
     This offset should be used together with:
     - joint_dynamic_cts_group_offset
@@ -368,15 +368,15 @@ class ModelKaminoInfo:
 
     joint_dynamic_cts_group_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the dynamic joint constraints group within the constraints block of each world.\n
-    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
+    The index offset of the dynamic joint constraints group within the constraints block of each world.
+    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.
     Shape of ``(num_worlds,)``.
     """
 
     joint_kinematic_cts_group_offset: wp.array[wp.int32] | None = None
     """
-    The index offset of the kinematic joint constraints group within the constraints block of each world.\n
-    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.\n
+    The index offset of the kinematic joint constraints group within the constraints block of each world.
+    Used to index into constraint-space arrays, e.g. constraint residuals and reactions.
     Shape of ``(num_worlds,)``.
     """
 
@@ -387,14 +387,14 @@ class ModelKaminoInfo:
     base_body_index: wp.array[wp.int32] | None = None
     """
     The index of the base body assigned in each world w.r.t the model.
-    If a base joint is also assigned, must be the follower body of that joint.\n
+    If a base joint is also assigned, must be the follower body of that joint.
     Shape of ``(num_worlds,)``.
     """
 
     base_joint_index: wp.array[wp.int32] | None = None
     """
     The index of the base joint assigned in each world w.r.t the model (-1 if not assigned).
-    If assigned, must be a unary, non-universal, joint.\n
+    If assigned, must be a unary, non-universal, joint.
     Shape of ``(num_worlds,)``.
     """
 
@@ -404,25 +404,25 @@ class ModelKaminoInfo:
 
     mass_min: wp.array[wp.float32] | None = None
     """
-    Smallest mass amongst all bodies in each world.\n
+    Smallest mass amongst all bodies in each world.
     Shape of ``(num_worlds,)``.
     """
 
     mass_max: wp.array[wp.float32] | None = None
     """
-    Largest mass amongst all bodies in each world.\n
+    Largest mass amongst all bodies in each world.
     Shape of ``(num_worlds,)``.
     """
 
     mass_total: wp.array[wp.float32] | None = None
     """
-    Total mass over all bodies in each world.\n
+    Total mass over all bodies in each world.
     Shape of ``(num_worlds,)``.
     """
 
     inertia_total: wp.array[wp.float32] | None = None
     """
-    Total diagonal inertia over all bodies in each world.\n
+    Total diagonal inertia over all bodies in each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -444,7 +444,7 @@ class ModelKamino:
 
     size: SizeKamino | None = None
     """
-    Host-side cache of the model summary sizes.\n
+    Host-side cache of the model summary sizes.
     This is used for memory allocations and kernel thread dimensions.
     """
 
@@ -468,13 +468,13 @@ class ModelKamino:
 
     materials: MaterialsModel | None = None
     """
-    The materials model container holding all material entities in the model.\n
+    The materials model container holding all material entities in the model.
     The materials data is currently defined globally to be shared by all worlds.
     """
 
     material_pairs: MaterialPairsModel | None = None
     """
-    The material pairs model container holding all material pairs in the model.\n
+    The material pairs model container holding all material pairs in the model.
     The material-pairs data is currently defined globally to be shared by all worlds.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -522,7 +522,7 @@ class ModelKamino:
 
         Args:
             unilateral_cts: Whether to include unilateral constraints (limits and contacts) in the model data.
-                Defaults to ``True``.
+                Defaults to ``False``.
             joint_wrenches: Whether to include joint wrenches in the model data. Defaults to ``False``.
             requires_grad: Whether the model data should require gradients. Defaults to ``False``.
             device: The device to create the model data on. If not specified, the model's device is used.

--- a/newton/_src/solvers/kamino/_src/core/shapes.py
+++ b/newton/_src/solvers/kamino/_src/core/shapes.py
@@ -11,9 +11,9 @@ from collections.abc import Sequence
 import numpy as np
 import warp as wp
 
-from .....core.types import Vec2, Vec3
+from .....core.types import Vec2, Vec3, override
 from .....geometry.types import GeoType, Heightfield, Mesh
-from .types import Descriptor, override, vec3f
+from .types import Descriptor
 
 ###
 # Module interface
@@ -92,8 +92,8 @@ class ShapeDescriptor(ABC, Descriptor):
 
     @property
     @abstractmethod
-    def paramsvec(self) -> vec3f:
-        return vec3f(0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(0.0)
 
     @property
     @abstractmethod
@@ -126,8 +126,8 @@ class EmptyShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(0.0)
 
     @property
     @override
@@ -159,8 +159,8 @@ class SphereShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.radius, 0.0, 0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.radius, 0.0, 0.0)
 
     @property
     @override
@@ -194,8 +194,8 @@ class CylinderShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.radius, self.half_height, 0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.radius, self.half_height, 0.0)
 
     @property
     @override
@@ -229,8 +229,8 @@ class ConeShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.radius, self.half_height, 0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.radius, self.half_height, 0.0)
 
     @property
     @override
@@ -264,8 +264,8 @@ class CapsuleShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.radius, self.half_height, 0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.radius, self.half_height, 0.0)
 
     @property
     @override
@@ -301,8 +301,8 @@ class BoxShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.hx, self.hy, self.hz)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.hx, self.hy, self.hz)
 
     @property
     @override
@@ -340,8 +340,8 @@ class EllipsoidShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.rx, self.ry, self.rz)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.rx, self.ry, self.rz)
 
     @property
     @override
@@ -391,8 +391,8 @@ class PlaneShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(self.width, self.length, 0.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(self.width, self.length, 0.0)
 
     @property
     @override
@@ -418,13 +418,13 @@ class MeshShape(ShapeDescriptor):
     that provides the necessary interfacing to be used with the Kamino solver.
 
     Attributes:
-        vertices (np.ndarray): The vertices of the mesh.
-        indices (np.ndarray): The triangle indices of the mesh.
-        normals (np.ndarray | None): The vertex normals of the mesh.
-        uvs (np.ndarray | None): The texture coordinates of the mesh.
-        color (Vec3 | None): The color of the mesh.
-        is_solid (bool): Whether the mesh is solid.
-        is_convex (bool): Whether the mesh is convex.
+        vertices: The vertices of the mesh.
+        indices: The triangle indices of the mesh.
+        normals: The vertex normals of the mesh.
+        uvs: The texture coordinates of the mesh.
+        color: The color of the mesh.
+        is_solid: Whether the mesh is solid.
+        is_convex: Whether the mesh is convex.
     """
 
     MAX_HULL_VERTICES = Mesh.MAX_HULL_VERTICES
@@ -448,17 +448,17 @@ class MeshShape(ShapeDescriptor):
         Initialize the mesh shape descriptor.
 
         Args:
-            vertices (Sequence[Vec3] | np.ndarray): The vertices of the mesh.
-            indices (Sequence[int] | np.ndarray): The triangle indices of the mesh.
-            normals (Sequence[Vec3] | np.ndarray | None): The vertex normals of the mesh.
-            uvs (Sequence[Vec2] | np.ndarray | None): The texture coordinates of the mesh.
-            color (Vec3 | None): The color of the mesh.
-            maxhullvert (int): The maximum number of hull vertices for convex shapes.
-            compute_inertia (bool): Whether to compute inertia for the mesh.
-            is_solid (bool): Whether the mesh is solid.
-            is_convex (bool): Whether the mesh is convex.
-            name (str): The name of the shape descriptor.
-            uid (str | None): Optional unique identifier of the shape descriptor.
+            vertices: The vertices of the mesh.
+            indices: The triangle indices of the mesh.
+            normals: The vertex normals of the mesh.
+            uvs: The texture coordinates of the mesh.
+            color: The color of the mesh.
+            maxhullvert: The maximum number of hull vertices for convex shapes.
+            compute_inertia: Whether to compute inertia for the mesh.
+            is_solid: Whether the mesh is solid.
+            is_convex: Whether the mesh is convex.
+            name: The name of the shape descriptor.
+            uid: Optional unique identifier of the shape descriptor.
         """
         # Determine the mesh shape type, and adapt default name if necessary
         if is_convex:
@@ -504,8 +504,8 @@ class MeshShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(1.0, 1.0, 1.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(1.0, 1.0, 1.0)
 
     @property
     @override
@@ -568,8 +568,8 @@ class HFieldShape(ShapeDescriptor):
 
     @property
     @override
-    def paramsvec(self) -> vec3f:
-        return vec3f(1.0, 1.0, 1.0)
+    def paramsvec(self) -> wp.vec3f:
+        return wp.vec3f(1.0, 1.0, 1.0)
 
     @property
     @override
@@ -627,7 +627,7 @@ def max_contacts_for_shape_pair(type_a: int, type_b: int) -> tuple[int, int]:
         type_b: Second shape type as :class:`GeoType` integer value.
 
     Returns:
-        tuple[int, int]: Number of contact points for collisions between A->B and B->A.
+        Number of contact points for collisions between A->B and B->A.
     """
     # Ensure the shape types are ordered canonically
     if type_a > type_b:

--- a/newton/_src/solvers/kamino/_src/core/state.py
+++ b/newton/_src/solvers/kamino/_src/core/state.py
@@ -67,53 +67,53 @@ class StateKamino:
 
     q_i: wp.array[wp.transformf] | None = None
     """
-    Array of absolute body CoM poses expressed in world coordinates.\n
-    Each element is a 7D transform consisting of a 3D position + 4D unit quaternion.\n
+    Array of absolute body CoM poses expressed in world coordinates.
+    Each element is a 7D transform consisting of a 3D position + 4D unit quaternion.
     Shape of ``(num_bodies,)``.
     """
 
     u_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Array of absolute body CoM twists expressed in world coordinates.\n
-    Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
+    Array of absolute body CoM twists expressed in world coordinates.
+    Each element is a 6D vector comprising a 3D linear + 3D angular components.
     Shape of ``(num_bodies,)``.
     """
 
     w_i: wp.array[wp.spatial_vectorf] | None = None
     """
-    Array of total body CoM wrenches expressed in world coordinates.\n
-    Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
+    Array of total body CoM wrenches expressed in world coordinates.
+    Each element is a 6D vector comprising a 3D linear + 3D angular components.
     Shape of ``(num_bodies,)``.
     """
 
     w_i_e: wp.array[wp.spatial_vectorf] | None = None
     """
-    Array of external body CoM wrenches expressed in world coordinates.\n
-    Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
+    Array of external body CoM wrenches expressed in world coordinates.
+    Each element is a 6D vector comprising a 3D linear + 3D angular components.
     Shape of ``(num_bodies,)``.
     """
 
     q_j: wp.array[wp.float32] | None = None
     """
-    Array of generalized joint coordinates.\n
+    Array of generalized joint coordinates.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     q_j_p: wp.array[wp.float32] | None = None
     """
-    Array of previous generalized joint coordinates.\n
+    Array of previous generalized joint coordinates.
     Shape of ``(sum_of_num_joint_coords,)``.
     """
 
     dq_j: wp.array[wp.float32] | None = None
     """
-    Array of generalized joint velocities.\n
+    Array of generalized joint velocities.
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
     lambda_j: wp.array[wp.float32] | None = None
     """
-    Array of generalized joint constraint forces.\n
+    Array of generalized joint constraint forces.
     Shape of ``(sum_of_num_joint_cts,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/state.py
+++ b/newton/_src/solvers/kamino/_src/core/state.py
@@ -12,7 +12,6 @@ import warp as wp
 from .....sim import Model, State
 from .bodies import convert_body_com_to_origin, convert_body_origin_to_com
 from .size import SizeKamino
-from .types import vec6f
 
 ###
 # Module interface
@@ -66,56 +65,56 @@ class StateKamino:
     # Attributes
     ###
 
-    q_i: wp.array | None = None
+    q_i: wp.array[wp.transformf] | None = None
     """
     Array of absolute body CoM poses expressed in world coordinates.\n
     Each element is a 7D transform consisting of a 3D position + 4D unit quaternion.\n
-    Shape is ``(num_bodies,)`` and dtype is :class:`transformf`.
+    Shape of ``(num_bodies,)``.
     """
 
-    u_i: wp.array | None = None
+    u_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Array of absolute body CoM twists expressed in world coordinates.\n
     Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
-    Shape is ``(num_bodies,)`` and dtype is :class:`vec6f`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_i: wp.array | None = None
+    w_i: wp.array[wp.spatial_vectorf] | None = None
     """
     Array of total body CoM wrenches expressed in world coordinates.\n
     Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
-    Shape is ``(num_bodies,)`` and dtype is :class:`vec6f`.
+    Shape of ``(num_bodies,)``.
     """
 
-    w_i_e: wp.array | None = None
+    w_i_e: wp.array[wp.spatial_vectorf] | None = None
     """
     Array of external body CoM wrenches expressed in world coordinates.\n
     Each element is a 6D vector comprising a 3D linear + 3D angular components.\n
-    Shape is ``(num_bodies,)`` and dtype is :class:`vec6f`.
+    Shape of ``(num_bodies,)``.
     """
 
-    q_j: wp.array | None = None
+    q_j: wp.array[wp.float32] | None = None
     """
     Array of generalized joint coordinates.\n
-    Shape is ``(sum_of_num_joint_coords,)`` and dtype is :class:`float32`.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    q_j_p: wp.array | None = None
+    q_j_p: wp.array[wp.float32] | None = None
     """
     Array of previous generalized joint coordinates.\n
-    Shape is ``(sum_of_num_joint_coords,)`` and dtype is :class:`float32`.
+    Shape of ``(sum_of_num_joint_coords,)``.
     """
 
-    dq_j: wp.array | None = None
+    dq_j: wp.array[wp.float32] | None = None
     """
     Array of generalized joint velocities.\n
-    Shape is ``(sum_of_num_joint_dofs,)`` and dtype is :class:`float32`.
+    Shape of ``(sum_of_num_joint_dofs,)``.
     """
 
-    lambda_j: wp.array | None = None
+    lambda_j: wp.array[wp.float32] | None = None
     """
     Array of generalized joint constraint forces.\n
-    Shape is ``(sum_of_num_joint_cts,)`` and dtype is :class:`float32`.
+    Shape of ``(sum_of_num_joint_cts,)``.
     """
 
     ###
@@ -162,18 +161,17 @@ class StateKamino:
     def convert_to_body_com_state(
         self,
         model: Model,
-        world_mask: wp.array | None = None,
-        body_wid: wp.array | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
+        body_wid: wp.array[wp.int32] | None = None,
     ) -> None:
         """
         Convert the body-frame state to body center-of-mass (CoM)
         state using the provided body center-of-mass offsets.
 
         Args:
-            model (Model):
-                The model container holding the time-invariant parameters of the simulation.
-            world_mask: optional per-world mask selecting which worlds to process.
-            body_wid: body-to-world index mapping, required when ``world_mask`` is given.
+            model: The model container holding the time-invariant parameters of the simulation.
+            world_mask: Optional per-world mask selecting which worlds to process.
+            body_wid: Body-to-world index mapping, required when ``world_mask`` is given.
         """
         # Ensure the model is valid
         if model is None:
@@ -194,18 +192,17 @@ class StateKamino:
     def convert_to_body_frame_state(
         self,
         model: Model,
-        world_mask: wp.array | None = None,
-        body_wid: wp.array | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
+        body_wid: wp.array[wp.int32] | None = None,
     ) -> None:
         """
         Convert the body center-of-mass (CoM) state to body-frame
         state using the provided body center-of-mass offsets.
 
         Args:
-            model (Model):
-                The model container holding the time-invariant parameters of the simulation.
-            world_mask: optional per-world mask selecting which worlds to process.
-            body_wid: body-to-world index mapping, required when ``world_mask`` is given.
+            model: The model container holding the time-invariant parameters of the simulation.
+            world_mask: Optional per-world mask selecting which worlds to process.
+            body_wid: Body-to-world index mapping, required when ``world_mask`` is given.
         """
         # Ensure the model is valid
         if model is None:
@@ -238,16 +235,14 @@ class StateKamino:
         :class:`newton.State`, effectively creating an alias without copying data.
 
         Args:
-            state (State):
-                The source :class:`newton.State` object to be adapted.
-            initialize_state_prev (bool):
-                If True, initialize the `joint_q_prev` attribute to
-                match the current `joint_q` from the newton.State.
-            convert_to_com_frame (bool):
-                If True, convert body poses to local center-of-mass frames.
+            size: Kamino size metadata for the model.
+            model: The source Newton model.
+            state: The source :class:`newton.State` object to be adapted.
+            initialize_state_prev: If True, initialize ``joint_q_prev`` to match the current ``joint_q``.
+            convert_to_com_frame: If True, convert body poses to local center-of-mass frames.
 
         Returns:
-            A :class:`kamino.StateKamino` object that aliases the data of the input :class:`newton.State` object.
+            A :class:`StateKamino` object that aliases the data of the input :class:`newton.State`.
         """
         # Ensure the state is valid
         if state is None:
@@ -300,9 +295,9 @@ class StateKamino:
         # Create a new StateKamino object, aliasing the relevant data from the input newton.State
         state_kamino = StateKamino(
             q_i=state.body_q,
-            u_i=state.body_qd.view(dtype=vec6f),  # TODO: change to wp.spatial_vector
-            w_i=body_f_total.view(dtype=vec6f),  # TODO: change to wp.spatial_vector
-            w_i_e=state.body_f.view(dtype=vec6f),  # TODO: change to wp.spatial_vector
+            u_i=state.body_qd.view(dtype=wp.spatial_vectorf),
+            w_i=body_f_total.view(dtype=wp.spatial_vectorf),
+            w_i_e=state.body_f.view(dtype=wp.spatial_vectorf),
             q_j=state.joint_q,
             q_j_p=joint_q_prev,
             dq_j=state.joint_qd,
@@ -326,13 +321,12 @@ class StateKamino:
         :class:`kamino.StateKamino`, effectively creating an alias without copying data.
 
         Args:
-            state (StateKamino):
-                The source :class:`kamino.StateKamino` object to be adapted.
-            convert_to_body_frame (bool):
-                If True, convert body poses to body-local frames.
+            model: The Newton model associated with the state.
+            state: The source :class:`StateKamino` object to be adapted.
+            convert_to_body_frame: If True, convert body poses to body-local frames.
 
         Returns:
-            A :class:`newton.State` object that aliases the data of the input :class:`kamino.StateKamino` object.
+            A :class:`newton.State` object that aliases the data of the input :class:`StateKamino`.
         """
         # Ensure the model is valid
         if model is None:

--- a/newton/_src/solvers/kamino/_src/core/time.py
+++ b/newton/_src/solvers/kamino/_src/core/time.py
@@ -41,21 +41,21 @@ class TimeModel:
     A container to hold heterogeneous model time-step.
 
     Attributes:
-        dt: The discrete time-step size of each world.\n
+        dt: The discrete time-step size of each world.
             Shape of ``(num_worlds,)``.
-        inv_dt: The inverse of the discrete time-step size of each world.\n
+        inv_dt: The inverse of the discrete time-step size of each world.
             Shape of ``(num_worlds,)``.
     """
 
     dt: wp.array[wp.float32] | None = None
     """
-    The discrete time-step size of each world.\n
+    The discrete time-step size of each world.
     Shape of ``(num_worlds,)``.
     """
 
     inv_dt: wp.array[wp.float32] | None = None
     """
-    The inverse of the discrete time-step size of each world.\n
+    The inverse of the discrete time-step size of each world.
     Shape of ``(num_worlds,)``.
     """
 
@@ -110,21 +110,21 @@ class TimeData:
     A container to hold heterogeneous model time-keeping data.
 
     Attributes:
-        steps: The current number of simulation steps of each world.\n
+        steps: The current number of simulation steps of each world.
             Shape of ``(num_worlds,)``.
-        time: The current simulation time of each world.\n
+        time: The current simulation time of each world.
             Shape of ``(num_worlds,)``.
     """
 
     steps: wp.array[wp.int32] | None = None
     """
-    The current number of simulation steps of each world.\n
+    The current number of simulation steps of each world.
     Shape of ``(num_worlds,)``.
     """
 
     time: wp.array[wp.float32] | None = None
     """
-    The current simulation time of each world.\n
+    The current simulation time of each world.
     Shape of ``(num_worlds,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/time.py
+++ b/newton/_src/solvers/kamino/_src/core/time.py
@@ -5,12 +5,12 @@
 Defines containers for time-keeping across heterogeneous worlds simulated in parallel.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import numpy as np
 import warp as wp
-
-from .types import float32, int32
 
 ###
 # Module interface
@@ -41,22 +41,22 @@ class TimeModel:
     A container to hold heterogeneous model time-step.
 
     Attributes:
-        dt (wp.array | None): The discrete time-step size of each world.\n
-            Shape of ``(num_worlds,)`` and type :class:`float`.
-        inv_dt (wp.array | None): The inverse of the discrete time-step size of each world.\n
-            Shape of ``(num_worlds,)`` and type :class:`float`.
+        dt: The discrete time-step size of each world.\n
+            Shape of ``(num_worlds,)``.
+        inv_dt: The inverse of the discrete time-step size of each world.\n
+            Shape of ``(num_worlds,)``.
     """
 
-    dt: wp.array | None = None
+    dt: wp.array[wp.float32] | None = None
     """
     The discrete time-step size of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
-    inv_dt: wp.array | None = None
+    inv_dt: wp.array[wp.float32] | None = None
     """
     The inverse of the discrete time-step size of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
     def set_uniform_timestep(self, dt: float):
@@ -64,7 +64,7 @@ class TimeModel:
         Sets a uniform discrete time-step for all worlds.
 
         Args:
-            dt (float): The time-step size to set.
+            dt: The time-step size to set.
         """
         # Ensure that the provided time-step is a floating-point value
         if not isinstance(dt, float):
@@ -83,7 +83,7 @@ class TimeModel:
         Sets the discrete time-step of each world explicitly.
 
         Args:
-            dt (list[float] | np.ndarray): An iterable collection of time-steps over all worlds.
+            dt: An iterable collection of time-steps over all worlds.
         """
         # Ensure that the length of the input matches the number of worlds
         if len(dt) != self.dt.size:
@@ -110,22 +110,22 @@ class TimeData:
     A container to hold heterogeneous model time-keeping data.
 
     Attributes:
-        steps (wp.array | None): The current number of simulation steps of each world.\n
-            Shape of ``(num_worlds,)`` and type :class:`int`.
-        time (wp.array | None): The current simulation time of each world.\n
-            Shape of ``(num_worlds,)`` and type :class:`float`.
+        steps: The current number of simulation steps of each world.\n
+            Shape of ``(num_worlds,)``.
+        time: The current simulation time of each world.\n
+            Shape of ``(num_worlds,)``.
     """
 
-    steps: wp.array | None = None
+    steps: wp.array[wp.int32] | None = None
     """
     The current number of simulation steps of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int`.
+    Shape of ``(num_worlds,)``.
     """
 
-    time: wp.array | None = None
+    time: wp.array[wp.float32] | None = None
     """
     The current simulation time of each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`float`.
+    Shape of ``(num_worlds,)``.
     """
 
     def reset(self):
@@ -144,10 +144,10 @@ class TimeData:
 @wp.kernel
 def _advance_time(
     # Inputs
-    dt: wp.array[float32],
+    dt: wp.array[wp.float32],
     # Outputs
-    steps: wp.array[int32],  # TODO: Make this uint64
-    time: wp.array[float32],
+    steps: wp.array[wp.int32],  # TODO: Make this wp.uint64
+    time: wp.array[wp.float32],
 ):
     """
     Advances the time-keeping state of each world by one time-step.
@@ -178,10 +178,8 @@ def advance_time(model: TimeModel, data: TimeData):
     by the corresponding time increment ``dt[wid]``.
 
     Args:
-        model (TimeModel):
-            The time model containing the time-step information.
-        data (TimeData):
-            The time data containing the current time-keeping state.
+        model: The time model containing the time-step information.
+        data: The time data containing the current time-keeping state.
     """
     # Ensure the model is valid
     if model is None:

--- a/newton/_src/solvers/kamino/_src/core/types.py
+++ b/newton/_src/solvers/kamino/_src/core/types.py
@@ -1,29 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""The core data types used throughout Kamino."""
+"""A module defining several core types and aliases specific to Kamino."""
 
 from __future__ import annotations
 
-import sys
 import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass
-from enum import IntEnum
-from typing import Literal
 
 import numpy as np
 import warp as wp
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    try:
-        from typing_extensions import override
-    except ImportError:
-        # Fallback no-op decorator if typing_extensions is not available
-        def override(func):
-            return func
 
 ###
 # Module configs
@@ -33,304 +20,75 @@ wp.set_module_options({"enable_backward": False})
 
 
 ###
-# Generics
-###
-
-Vec3 = list[float]
-Vec4 = list[float]
-Vec6 = list[float]
-Quat = list[float]
-Mat33 = list[float]
-Transform = tuple[Vec3, Quat]
-
-
-###
-# Scalars
-###
-
-uint8 = wp.uint8
-uint16 = wp.uint16
-uint32 = wp.uint32
-uint64 = wp.uint64
-
-int8 = wp.int8
-int16 = wp.int16
-int32 = wp.int32
-int64 = wp.int64
-
-float16 = wp.float16
-float32 = wp.float32
-float64 = wp.float64
-
-
-###
 # Unions
 ###
 
 
-FloatType = float16 | float32 | float64
-IntType = int16 | int32 | int64
+FloatType = wp.float16 | wp.float32 | wp.float64
+IntType = wp.int16 | wp.int32 | wp.int64
 VecIntType = wp.vec2s | wp.vec2i | wp.vec2l
 
-
-###
-# Vectors
-###
+ArrayLike = np.ndarray | list | tuple | Iterable
+"""An Array-like structure for aliasing various data types compatible with numpy."""
 
 
-class vec1i(wp.types.vector(length=1, dtype=int32)):
-    pass
+FloatArrayLike = np.ndarray | list[float] | list[list[float]]
+"""An Array-like structure for aliasing various floating-point data types compatible with numpy."""
 
 
-class vec1f(wp.types.vector(length=1, dtype=float32)):
-    pass
-
-
-class vec2i(wp.types.vector(length=2, dtype=int32)):
-    pass
-
-
-class vec2f(wp.types.vector(length=2, dtype=float32)):
-    pass
-
-
-class vec3i(wp.types.vector(length=3, dtype=int32)):
-    pass
-
-
-class vec3f(wp.types.vector(length=3, dtype=float32)):
-    pass
-
-
-class vec4i(wp.types.vector(length=4, dtype=int32)):
-    pass
-
-
-class vec4f(wp.types.vector(length=4, dtype=float32)):
-    pass
-
-
-class vec5i(wp.types.vector(length=5, dtype=int32)):
-    pass
-
-
-class vec5f(wp.types.vector(length=5, dtype=float32)):
-    pass
-
-
-class vec6i(wp.types.vector(length=6, dtype=int32)):
-    pass
-
-
-class vec6f(wp.types.vector(length=6, dtype=float32)):
-    pass
-
-
-class vec7f(wp.types.vector(length=7, dtype=float32)):
-    pass
-
-
-class vec8f(wp.types.vector(length=8, dtype=float32)):
-    pass
-
-
-class vec14f(wp.types.vector(length=14, dtype=float32)):
-    pass
+IntArrayLike = np.ndarray | list[int] | list[list[int]]
+"""An Array-like structure for aliasing various integer data types compatible with numpy."""
 
 
 ###
-# Matrices
+# Vectors & Matrices
 ###
 
+# Aliases for vector/matrix sizes without a warp built-in, but that we use in Kamino
 
-class mat22f(wp.types.matrix(shape=(2, 2), dtype=float32)):
+
+class vec1i(wp.types.vector(length=1, dtype=wp.int32)):
     pass
 
 
-class mat33f(wp.types.matrix(shape=(3, 3), dtype=float32)):
+class vec5i(wp.types.vector(length=5, dtype=wp.int32)):
     pass
 
 
-class mat44f(wp.types.matrix(shape=(4, 4), dtype=float32)):
+class vec6i(wp.types.vector(length=6, dtype=wp.int32)):
     pass
 
 
-class mat61f(wp.types.matrix(shape=(6, 1), dtype=float32)):
+class vec1f(wp.types.vector(length=1, dtype=wp.float32)):
     pass
 
 
-class mat16f(wp.types.matrix(shape=(1, 6), dtype=float32)):
+class vec6f(wp.types.vector(length=6, dtype=wp.float32)):
     pass
 
 
-class mat62f(wp.types.matrix(shape=(6, 2), dtype=float32)):
+class vec7f(wp.types.vector(length=7, dtype=wp.float32)):
     pass
 
 
-class mat26f(wp.types.matrix(shape=(2, 6), dtype=float32)):
+class vec8f(wp.types.vector(length=8, dtype=wp.float32)):
     pass
 
 
-class mat63f(wp.types.matrix(shape=(6, 3), dtype=float32)):
+class mat63f(wp.types.matrix(shape=(6, 3), dtype=wp.float32)):
     pass
 
 
-class mat36f(wp.types.matrix(shape=(3, 6), dtype=float32)):
+class mat34f(wp.types.matrix(shape=(3, 4), dtype=wp.float32)):
     pass
 
 
-class mat64f(wp.types.matrix(shape=(6, 4), dtype=float32)):
+class mat36f(wp.types.matrix(shape=(3, 6), dtype=wp.float32)):
     pass
 
 
-class mat46f(wp.types.matrix(shape=(4, 6), dtype=float32)):
+class mat66f(wp.types.matrix(shape=(6, 6), dtype=wp.float32)):
     pass
-
-
-class mat65f(wp.types.matrix(shape=(6, 5), dtype=float32)):
-    pass
-
-
-class mat56f(wp.types.matrix(shape=(5, 6), dtype=float32)):
-    pass
-
-
-class mat66f(wp.types.matrix(shape=(6, 6), dtype=float32)):
-    pass
-
-
-class mat34f(wp.types.matrix(shape=(3, 4), dtype=float32)):
-    pass
-
-
-class mat43f(wp.types.matrix(shape=(4, 3), dtype=float32)):
-    pass
-
-
-class mat38f(wp.types.matrix(shape=(3, 8), dtype=float32)):
-    pass
-
-
-class mat83f(wp.types.matrix(shape=(8, 3), dtype=float32)):
-    pass
-
-
-###
-# Quaternions
-###
-
-
-class quatf(wp.types.quaternion(dtype=float32)):
-    pass
-
-
-###
-# Transforms
-###
-
-
-class transformf(wp.types.transformation(dtype=float32)):
-    pass
-
-
-###
-# Axis
-###
-
-
-class Axis(IntEnum):
-    """Enum for representing the three axes in 3D space."""
-
-    X = 0
-    Y = 1
-    Z = 2
-
-    @classmethod
-    def from_string(cls, axis_str: str) -> Axis:
-        axis_str = axis_str.lower()
-        if axis_str == "x":
-            return cls.X
-        elif axis_str == "y":
-            return cls.Y
-        elif axis_str == "z":
-            return cls.Z
-        raise ValueError(f"Invalid axis string: {axis_str}")
-
-    @classmethod
-    def from_any(cls, value: AxisType) -> Axis:
-        if isinstance(value, cls):
-            return value
-        if isinstance(value, str):
-            return cls.from_string(value)
-        if type(value) in {int, wp.int32, wp.int64, np.int32, np.int64}:
-            return cls(value)
-        raise TypeError(f"Cannot convert {type(value)} to Axis")
-
-    @override
-    def __str__(self):
-        return self.name.capitalize()
-
-    @override
-    def __repr__(self):
-        return f"Axis.{self.name.capitalize()}"
-
-    @override
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return self.name.lower() == other.lower()
-        if type(other) in {int, wp.int32, wp.int64, np.int32, np.int64}:
-            return self.value == int(other)
-        return NotImplemented
-
-    @override
-    def __hash__(self):
-        return hash(self.name)
-
-    def to_vector(self) -> tuple[float, float, float]:
-        if self == Axis.X:
-            return (1.0, 0.0, 0.0)
-        elif self == Axis.Y:
-            return (0.0, 1.0, 0.0)
-        else:
-            return (0.0, 0.0, 1.0)
-
-    def to_matrix(self) -> Mat33:
-        if self == Axis.X:
-            return [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
-        elif self == Axis.Y:
-            return [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-        else:
-            return [0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
-
-    def to_vec3(self) -> vec3f:
-        return vec3f(*self.to_vector())
-
-    def to_mat33(self) -> mat33f:
-        return mat33f(*self.to_matrix())
-
-
-AxisType = Axis | Literal["X", "Y", "Z"] | Literal[0, 1, 2] | int | str
-"""Type that can be used to represent an axis, including the enum, string, and integer representations."""
-
-
-def axis_to_vec3(axis: AxisType | Vec3) -> vec3f:
-    """Convert an axis representation to a 3D vector."""
-    if isinstance(axis, list | tuple | np.ndarray):
-        return vec3f(*axis)
-    elif wp.types.type_is_vector(type(axis)):
-        return vec3f(*axis)
-    else:
-        return Axis.from_any(axis).to_vec3()
-
-
-def axis_to_mat33(axis: AxisType | Vec3) -> mat33f:
-    """Convert an axis representation to a 3x3 matrix."""
-    if isinstance(axis, list | tuple | np.ndarray):
-        return mat33f(*axis)
-    elif wp.types.type_is_vector(type(axis)):
-        return mat33f(*axis)
-    else:
-        return Axis.from_any(axis).to_mat33()
 
 
 ###
@@ -358,10 +116,10 @@ class Descriptor:
         Check if a given UID string is valid.
 
         Args:
-            uid (str): The UID string to validate.
+            uid: The UID string to validate.
 
         Returns:
-            str: The validated UID string.
+            The validated UID string.
 
         Raises:
             ValueError: If the UID string is not valid.
@@ -391,22 +149,6 @@ class Descriptor:
 
 
 ###
-# Utilities
-###
-
-ArrayLike = np.ndarray | list | tuple | Iterable
-"""An Array-like structure for aliasing various data types compatible with numpy."""
-
-
-FloatArrayLike = np.ndarray | list[float] | list[list[float]]
-"""An Array-like structure for aliasing various floating-point data types compatible with numpy."""
-
-
-IntArrayLike = np.ndarray | list[int] | list[list[int]]
-"""An Array-like structure for aliasing various integer data types compatible with numpy."""
-
-
-###
 # Array constructors
 ###
 
@@ -430,10 +172,10 @@ def _check_int32_range(data: IntArrayLike, func_name: str) -> np.ndarray:
 def to_warp_int32_array(
     data: IntArrayLike,
     device: wp.DeviceLike | None = None,
-) -> wp.array:
+) -> wp.array[wp.int32]:
     """Convert ``data`` to a Warp ``int32`` array, asserting all values fit in ``int32``.
 
-    Use this helper in place of ``wp.array(data, dtype=int32)`` and
+    Use this helper in place of ``wp.array(data, dtype=wp.int32)`` and
     ``wp.from_numpy(data, dtype=wp.int32)`` whenever ``data`` originates from
     Python ints or NumPy integers. Direct ``wp.array`` / ``wp.from_numpy`` calls
     silently truncate values that do not fit in ``int32``; this helper raises
@@ -444,7 +186,7 @@ def to_warp_int32_array(
         device: Warp device to allocate on. Defaults to the current scoped device.
 
     Returns:
-        A Warp array with dtype :data:`int32` containing the values of ``data``.
+        A Warp array with dtype :class:`wp.int32` containing the values of ``data``.
 
     Raises:
         TypeError: if ``data`` is not integer-typed.
@@ -454,7 +196,7 @@ def to_warp_int32_array(
     return wp.array(arr.astype(np.int32, copy=False), dtype=wp.int32, device=device)
 
 
-def assign_to_warp_int32_array(dst: wp.array, data: IntArrayLike) -> None:
+def assign_to_warp_int32_array(dst: wp.array[wp.int32], data: IntArrayLike) -> None:
     """Assign ``data`` into an existing Warp ``int32`` array ``dst``, asserting no overflow.
 
     Use this helper in place of ``dst.assign(data)`` whenever ``dst`` is an
@@ -463,11 +205,11 @@ def assign_to_warp_int32_array(dst: wp.array, data: IntArrayLike) -> None:
     the target dtype; this helper raises instead.
 
     Args:
-        dst: Pre-allocated Warp array with dtype :data:`int32`.
+        dst: Pre-allocated Warp array with dtype :class:`wp.int32`.
         data: Integer array-like (Python list, tuple, numpy array, or scalar).
 
     Raises:
-        TypeError: if ``dst`` does not have dtype :data:`int32`, or if ``data``
+        TypeError: if ``dst`` does not have dtype :class:`wp.int32`, or if ``data``
             is not integer-typed.
         OverflowError: if any value falls outside ``[-2**31, 2**31 - 1]``.
     """

--- a/newton/_src/solvers/kamino/_src/core/world.py
+++ b/newton/_src/solvers/kamino/_src/core/world.py
@@ -41,7 +41,7 @@ class WorldDescriptor(Descriptor):
 
     wid: int = 0
     """
-    Index of the world w.r.t. the entire model. Defaults to `0`.\n
+    Index of the world w.r.t. the entire model. Defaults to `0`.
     Used to identify the world in construction of multi-world models.
     """
 
@@ -61,19 +61,19 @@ class WorldDescriptor(Descriptor):
 
     num_passive_joints: int = 0
     """
-    The number of joints that are passive.\n
+    The number of joints that are passive.
     This is less than or equal to `num_joints`.
     """
 
     num_actuated_joints: int = 0
     """
-    The number of joints that are actuated.\n
+    The number of joints that are actuated.
     This is less than or equal to `num_joints`.
     """
 
     num_dynamic_joints: int = 0
     """
-    The number of joints that are dynamic.\n
+    The number of joints that are dynamic.
     This is less than or equal to `num_joints`.
     """
 
@@ -93,128 +93,128 @@ class WorldDescriptor(Descriptor):
 
     num_body_coords: int = 0
     """
-    The total number of body coordinates.\n
+    The total number of body coordinates.
     This is always equal to `7 * num_bodies`.
     """
 
     num_body_dofs: int = 0
     """
-    The total number of body DoFs.\n
+    The total number of body DoFs.
     This is always equal to `6 * num_bodies`.
     """
 
     num_joint_coords: int = 0
     """
-    The total number of joint coordinates.\n
+    The total number of joint coordinates.
     This is equal to the sum of the coordinates of all joints in the world.
     """
 
     num_joint_dofs: int = 0
     """
-    The total number of joint DoFs.\n
+    The total number of joint DoFs.
     This is equal to the sum of the DoFs of all joints in the world.
     """
 
     num_passive_joint_coords: int = 0
     """
-    The number of passive joint coordinates.\n
+    The number of passive joint coordinates.
     This is equal to the sum of the coordinates of all passive joints defined
-    in the world, and is always less than or equal to `num_joint_coords`.\n
+    in the world, and is always less than or equal to `num_joint_coords`.
     """
 
     num_passive_joint_dofs: int = 0
     """
-    The number of passive joint DoFs.\n
+    The number of passive joint DoFs.
     This is equal to the sum of the DoFs of all passive joints defined
-    in the world, and is always less than or equal to `num_joint_dofs`.\n
+    in the world, and is always less than or equal to `num_joint_dofs`.
     """
 
     num_actuated_joint_coords: int = 0
     """
-    The number of actuated joint coordinates.\n
+    The number of actuated joint coordinates.
     This is equal to the sum of the coordinates of all actuated joints defined
-    in the world, and is always less than or equal to `num_joint_coords`.\n
+    in the world, and is always less than or equal to `num_joint_coords`.
     """
 
     num_actuated_joint_dofs: int = 0
     """
-    The number of actuated joint DoFs.\n
+    The number of actuated joint DoFs.
     This is equal to the sum of the DoFs of all actuated joints defined
-    in the world, and is always less than or equal to `num_joint_dofs`.\n
+    in the world, and is always less than or equal to `num_joint_dofs`.
     """
 
     num_joint_cts: int = 0
     """
-    The total number of joint constraints.\n
+    The total number of joint constraints.
     This is equal to the sum of the constraints of all dynamic joints defined in the world.
     """
 
     num_dynamic_joint_cts: int = 0
     """
-    The total number of joint dynamics constraints.\n
+    The total number of joint dynamics constraints.
     This is equal to the sum of the dynamic constraints of all dynamic joints defined in the world.
     """
 
     num_kinematic_joint_cts: int = 0
     """
-    The total number of joint kinematics constraints.\n
+    The total number of joint kinematics constraints.
     This is equal to the sum of the kinematics constraints of all joints defined in the world.
     """
 
     joint_coords: list[int] = field(default_factory=list)
     """
-    The list of all joint coordinates.\n
+    The list of all joint coordinates.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_joint_coords`.\n
+    and the sum of all elements is equal to `num_joint_coords`.
     """
 
     joint_dofs: list[int] = field(default_factory=list)
     """
-    The list of all joint DoFs.\n
+    The list of all joint DoFs.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_joint_dofs`.\n
+    and the sum of all elements is equal to `num_joint_dofs`.
     """
 
     joint_passive_coords: list[int] = field(default_factory=list)
     """
-    The list of all passive joint coordinates.\n
+    The list of all passive joint coordinates.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_passive_joint_coords`.\n
+    and the sum of all elements is equal to `num_passive_joint_coords`.
     """
 
     joint_passive_dofs: list[int] = field(default_factory=list)
     """
-    The list of all passive joint DoFs.\n
+    The list of all passive joint DoFs.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_passive_joint_dofs`.\n
+    and the sum of all elements is equal to `num_passive_joint_dofs`.
     """
 
     joint_actuated_coords: list[int] = field(default_factory=list)
     """
-    The list of all actuated joint coordinates.\n
+    The list of all actuated joint coordinates.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_actuated_joint_coords`.\n
+    and the sum of all elements is equal to `num_actuated_joint_coords`.
     """
 
     joint_actuated_dofs: list[int] = field(default_factory=list)
     """
-    The list of all actuated joint DoFs.\n
+    The list of all actuated joint DoFs.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_actuated_joint_dofs`.\n
+    and the sum of all elements is equal to `num_actuated_joint_dofs`.
     """
 
     joint_dynamic_cts: list[int] = field(default_factory=list)
     """
-    The list of all joint dynamics constraints.\n
+    The list of all joint dynamics constraints.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_dynamic_joint_cts`.\n
+    and the sum of all elements is equal to `num_dynamic_joint_cts`.
     """
 
     joint_kinematic_cts: list[int] = field(default_factory=list)
     """
-    The list of all joint kinematics constraints.\n
+    The list of all joint kinematics constraints.
     This list is ordered according the joint indices in the world,
-    and the sum of all elements is equal to `num_kinematic_joint_cts`.\n
+    and the sum of all elements is equal to `num_kinematic_joint_cts`.
     """
 
     ###
@@ -317,13 +317,13 @@ class WorldDescriptor(Descriptor):
     base_body_idx: int | None = None
     """
     Index of the `base body` w.r.t. the world, i.e., index of the central node of the
-    body-joint connectivity graph.\n
+    body-joint connectivity graph.
 
     The `base body` is connected to the world through a `base joint`, which, if not specified
     is considered to be an implicit 6D free joint, indicating a floating-base system.
-    Otherwise, the `base joint` must be a unary joint connecting the base body to the world.\n
+    Otherwise, the `base joint` must be a unary joint connecting the base body to the world.
 
-    For articulated systems, the base body is the root body of the kinematic tree.\n
+    For articulated systems, the base body is the root body of the kinematic tree.
 
     For general mechanical assemblies, e.g. particle systems, rigid clusters or overconstrained
     multi-body systems, the base body serves only as a reference body for managing the system's
@@ -332,7 +332,7 @@ class WorldDescriptor(Descriptor):
 
     base_joint_idx: int | None = None
     """
-    Index of the base joint w.r.t. the world, i.e. the joint connecting the base body to the world.\n
+    Index of the base joint w.r.t. the world, i.e. the joint connecting the base body to the world.
     See `base_body_idx` for more details.
     """
 
@@ -380,7 +380,7 @@ class WorldDescriptor(Descriptor):
 
     inertia_total: float = 0.0
     """
-    Total diagonal inertia over all bodies in the world.\n
+    Total diagonal inertia over all bodies in the world.
     Equals the trace of the maximal-coordinate generalized mass matrix of the world.
     """
 

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -60,6 +60,8 @@ Typical usage example:
     delassus.solve(b=rhs, x=solution)
 """
 
+from __future__ import annotations
+
 import copy
 import functools
 from typing import Any
@@ -70,7 +72,7 @@ import warp as wp
 from ..core.data import DataKamino
 from ..core.model import ModelKamino
 from ..core.size import SizeKamino
-from ..core.types import FloatType, float32, int32, mat33f, to_warp_int32_array, vec3f, vec6f
+from ..core.types import FloatType, to_warp_int32_array, vec6f
 from ..geometry.contacts import ContactsKamino
 from ..kinematics.constraints import get_max_constraints_per_world
 from ..kinematics.jacobians import ColMajorSparseConstraintJacobians, DenseSystemJacobians, SparseSystemJacobians
@@ -125,10 +127,10 @@ def upper_triangular_indices_from_index(index: int, mat_size: int):
     if index < 0 or index >= mat_size * (mat_size + 1) // 2:
         return -1, -1
 
-    # Recover row i: largest i such that f(i) <= index (integer binary search; avoids float32 sqrt)
-    lo = int32(0)
-    hi = mat_size - int32(1)
-    i = int32(0)
+    # Recover row i: largest i such that f(i) <= index (integer binary search; avoids wp.float32 sqrt)
+    lo = wp.int32(0)
+    hi = mat_size - wp.int32(1)
+    i = wp.int32(0)
     while lo <= hi:
         mid = lo + (hi - lo) // 2
         fi = mid * mat_size - mid * (mid - 1) // 2
@@ -152,15 +154,15 @@ def upper_triangular_indices_from_index(index: int, mat_size: int):
 @wp.kernel
 def _build_delassus_elementwise_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_bodies_inv_m_i: wp.array[float32],
-    data_bodies_inv_I_i: wp.array[mat33f],
-    jacobians_cts_offset: wp.array[int32],
-    jacobians_cts_data: wp.array[float32],
-    delassus_dim: wp.array[int32],
-    delassus_mio: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_bodies_inv_m_i: wp.array[wp.float32],
+    data_bodies_inv_I_i: wp.array[wp.mat33f],
+    jacobians_cts_offset: wp.array[wp.int32],
+    jacobians_cts_data: wp.array[wp.float32],
+    delassus_dim: wp.array[wp.int32],
+    delassus_mio: wp.array[wp.int32],
     # Outputs:
-    delassus_D: wp.array[float32],
+    delassus_D: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index and upper-triangle element index
     wid, tid = wp.tid()
@@ -190,11 +192,11 @@ def _build_delassus_elementwise_dense(
     nbd = 6 * nb
 
     # Buffers
-    Jv_i = vec3f(0.0)
-    Jv_j = vec3f(0.0)
-    Jw_i = vec3f(0.0)
-    Jw_j = vec3f(0.0)
-    D_ij = float32(0.0)
+    Jv_i = wp.vec3f(0.0)
+    Jv_j = wp.vec3f(0.0)
+    Jw_i = wp.vec3f(0.0)
+    Jw_j = wp.vec3f(0.0)
+    D_ij = wp.float32(0.0)
 
     # Loop over rigid body blocks
     # NOTE: k is the body index w.r.t the world
@@ -232,17 +234,17 @@ def _build_delassus_elementwise_dense(
 @wp.kernel
 def _build_delassus_elementwise_sparse(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_bodies_inv_m_i: wp.array[float32],
-    data_bodies_inv_I_i: wp.array[mat33f],
-    jacobian_cts_num_nzb: wp.array[int32],
-    jacobian_cts_nzb_start: wp.array[int32],
-    jacobian_cts_nzb_coords: wp.array2d[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_bodies_inv_m_i: wp.array[wp.float32],
+    data_bodies_inv_I_i: wp.array[wp.mat33f],
+    jacobian_cts_num_nzb: wp.array[wp.int32],
+    jacobian_cts_nzb_start: wp.array[wp.int32],
+    jacobian_cts_nzb_coords: wp.array2d[wp.int32],
     jacobian_cts_nzb_values: wp.array[vec6f],
-    delassus_dim: wp.array[int32],
-    delassus_mio: wp.array[int32],
+    delassus_dim: wp.array[wp.int32],
+    delassus_mio: wp.array[wp.int32],
     # Outputs:
-    delassus_D: wp.array[float32],
+    delassus_D: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index and Jacobian block index pair
     wid, tid = wp.tid()
@@ -297,10 +299,10 @@ def _build_delassus_elementwise_sparse(
     dmio = delassus_mio[wid]
 
     # Load the Jacobian blocks components for body
-    Jv_i = vec3f(block_i[0], block_i[1], block_i[2])
-    Jv_j = vec3f(block_j[0], block_j[1], block_j[2])
-    Jw_i = vec3f(block_i[3], block_i[4], block_i[5])
-    Jw_j = vec3f(block_j[3], block_j[4], block_j[5])
+    Jv_i = wp.vec3f(block_i[0], block_i[1], block_i[2])
+    Jv_j = wp.vec3f(block_j[0], block_j[1], block_j[2])
+    Jw_i = wp.vec3f(block_i[3], block_i[4], block_i[5])
+    Jw_j = wp.vec3f(block_j[3], block_j[4], block_j[5])
 
     # Linear term: inv_m_k * dot(Jv_i, Jv_j)
     # Angular term: dot(Jw_i, inv_I_k @ Jw_j)
@@ -317,13 +319,13 @@ def _build_delassus_elementwise_sparse(
 @wp.kernel
 def _add_joint_armature_diagonal_regularization_dense(
     # Inputs:
-    model_info_num_joint_dynamic_cts: wp.array[int32],
-    model_info_joint_dynamic_cts_offset: wp.array[int32],
-    model_joint_inv_m_j: wp.array[float32],
-    delassus_dim: wp.array[int32],
-    delassus_mio: wp.array[int32],
+    model_info_num_joint_dynamic_cts: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_offset: wp.array[wp.int32],
+    model_joint_inv_m_j: wp.array[wp.float32],
+    delassus_dim: wp.array[wp.int32],
+    delassus_mio: wp.array[wp.int32],
     # Outputs:
-    delassus_D: wp.array[float32],
+    delassus_D: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index and Delassus element index
     wid, tid = wp.tid()
@@ -352,12 +354,12 @@ def _add_joint_armature_diagonal_regularization_dense(
 @wp.kernel
 def _regularize_delassus_diagonal_dense(
     # Inputs:
-    delassus_dim: wp.array[int32],
-    delassus_vio: wp.array[int32],
-    delassus_mio: wp.array[int32],
-    eta: wp.array[float32],
+    delassus_dim: wp.array[wp.int32],
+    delassus_vio: wp.array[wp.int32],
+    delassus_mio: wp.array[wp.int32],
+    eta: wp.array[wp.float32],
     # Outputs:
-    delassus_D: wp.array[float32],
+    delassus_D: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -377,12 +379,12 @@ def _regularize_delassus_diagonal_dense(
 
 @wp.kernel
 def _merge_inv_mass_matrix_kernel(
-    model_info_bodies_offset: wp.array[int32],
-    model_bodies_inv_m_i: wp.array[float32],
-    data_bodies_inv_I_i: wp.array[mat33f],
-    num_nzb: wp.array[int32],
-    nzb_start: wp.array[int32],
-    nzb_coords: wp.array2d[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_bodies_inv_m_i: wp.array[wp.float32],
+    data_bodies_inv_I_i: wp.array[wp.mat33f],
+    num_nzb: wp.array[wp.int32],
+    nzb_start: wp.array[wp.int32],
+    nzb_coords: wp.array2d[wp.int32],
     nzb_values: wp.array[vec6f],
 ):
     """
@@ -409,8 +411,8 @@ def _merge_inv_mass_matrix_kernel(
     inv_I = data_bodies_inv_I_i[global_body_id]
 
     # Apply inverse mass matrices to Jacobian block
-    v = inv_m * vec3f(block[0], block[1], block[2])
-    w = inv_I @ vec3f(block[3], block[4], block[5])
+    v = inv_m * wp.vec3f(block[0], block[1], block[2])
+    w = inv_I @ wp.vec3f(block[3], block[4], block[5])
 
     # Write back values
     block[0] = v[0]
@@ -437,16 +439,15 @@ def _make_merge_preconditioner_kernel(block_type: BlockDType):
     elif len(block_shape) == 1:
         block_shape = (1, block_shape[0])
 
-    @wp.kernel
     def merge_preconditioner_kernel(
         # Inputs:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
-        row_start: wp.array[int32],
-        preconditioner: wp.array[float32],
+        num_nzb,  # wp.array[wp.int32],
+        nzb_start,  # wp.array[wp.int32],
+        nzb_coords,  # wp.array2d[wp.int32],
+        row_start,  # wp.array[wp.int32],
+        preconditioner,  # wp.array[wp.float32],
         # Outputs:
-        nzb_values: wp.array[block_type.warp_type],
+        nzb_values,  # wp.array[block_type.warp_type],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -475,18 +476,28 @@ def _make_merge_preconditioner_kernel(block_type: BlockDType):
 
         nzb_values[global_block_idx] = block
 
-    return merge_preconditioner_kernel
+    # Set type annotations manually (else block_type fails to resolve)
+    merge_preconditioner_kernel.__annotations__ = {
+        "num_nzb": wp.array[wp.int32],
+        "nzb_start": wp.array[wp.int32],
+        "nzb_coords": wp.array2d[wp.int32],
+        "row_start": wp.array[wp.int32],
+        "preconditioner": wp.array[wp.float32],
+        "nzb_values": wp.array[block_type.warp_type],
+    }
+
+    return wp.kernel(merge_preconditioner_kernel)
 
 
 @wp.kernel
 def _add_armature_regularization_sparse(
     # Inputs:
-    model_info_num_joint_dynamic_cts: wp.array[int32],
-    model_info_joint_dynamic_cts_offset: wp.array[int32],
-    row_start: wp.array[int32],
-    model_joint_inv_m_j: wp.array[float32],
+    model_info_num_joint_dynamic_cts: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_offset: wp.array[wp.int32],
+    row_start: wp.array[wp.int32],
+    model_joint_inv_m_j: wp.array[wp.float32],
     # Outputs:
-    combined_regularization: wp.array[float32],
+    combined_regularization: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index and joint dynamics index
     wid, tid = wp.tid()
@@ -514,13 +525,13 @@ def _add_armature_regularization_sparse(
 @wp.kernel
 def _add_armature_regularization_preconditioned_sparse(
     # Inputs:
-    model_info_num_joint_dynamic_cts: wp.array[int32],
-    model_info_joint_dynamic_cts_offset: wp.array[int32],
-    model_joint_inv_m_j: wp.array[float32],
-    row_start: wp.array[int32],
-    preconditioner: wp.array[float32],
+    model_info_num_joint_dynamic_cts: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_offset: wp.array[wp.int32],
+    model_joint_inv_m_j: wp.array[wp.float32],
+    row_start: wp.array[wp.int32],
+    preconditioner: wp.array[wp.float32],
     # Outputs:
-    combined_regularization: wp.array[float32],
+    combined_regularization: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index and joint dynamics index
     wid, tid = wp.tid()
@@ -551,16 +562,16 @@ def _add_armature_regularization_preconditioned_sparse(
 @wp.kernel
 def _compute_block_sparse_delassus_diagonal(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_bodies_inv_m_i: wp.array[float32],
-    data_bodies_inv_I_i: wp.array[mat33f],
-    bsm_nzb_start: wp.array[int32],
-    bsm_num_nzb: wp.array[int32],
-    bsm_nzb_coords: wp.array2d[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_bodies_inv_m_i: wp.array[wp.float32],
+    data_bodies_inv_I_i: wp.array[wp.mat33f],
+    bsm_nzb_start: wp.array[wp.int32],
+    bsm_num_nzb: wp.array[wp.int32],
+    bsm_nzb_coords: wp.array2d[wp.int32],
     bsm_nzb_values: wp.array[vec6f],
-    vec_start: wp.array[int32],
+    vec_start: wp.array[wp.int32],
     # Outputs:
-    diag: wp.array[float32],
+    diag: wp.array[wp.float32],
 ):
     """
     Computes the diagonal entries of the Delassus matrix by summing up the contributions of each
@@ -610,13 +621,13 @@ def _compute_block_sparse_delassus_diagonal(
 
 @wp.kernel
 def _add_matrix_diag_product(
-    model_data_num_total_cts: wp.array[int32],
-    row_start: wp.array[int32],
-    d: wp.array[float32],
-    x: wp.array[float32],
-    y: wp.array[float32],
+    model_data_num_total_cts: wp.array[wp.int32],
+    row_start: wp.array[wp.int32],
+    d: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
     alpha: float,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Adds the product of a vector with a diagonal matrix to another vector: y += alpha * diag(d) @ x
@@ -636,14 +647,14 @@ def _add_matrix_diag_product(
 @wp.kernel
 def _scale_row_vector_kernel(
     # Matrix data:
-    matrix_dims: wp.array2d[int32],
+    matrix_dims: wp.array2d[wp.int32],
     # Vector block offsets:
-    row_start: wp.array[int32],
+    row_start: wp.array[wp.int32],
     # Inputs:
     x: wp.array[Any],
     beta: Any,
     # Mask:
-    matrix_mask: wp.array[bool],
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     Computes a vector scaling for all active entries: y = beta * y
@@ -659,28 +670,28 @@ def _scale_row_vector_kernel(
 
 
 @functools.cache
-def _make_block_sparse_gemv_regularization_kernel(alpha: float32):
+def _make_block_sparse_gemv_regularization_kernel(alpha: wp.float32):
     # Note: this kernel factory allows to optimize for the common case alpha = 1.0. In use cases where
     # alpha changes over time, this would need to be revisited (to avoid multiple recompilations)
     @wp.kernel
     def _block_sparse_gemv_regularization_kernel(
         # Matrix data:
-        dims: wp.array2d[int32],
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        dims: wp.array2d[wp.int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[vec6f],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Regularization:
-        eta: wp.array[float32],
+        eta: wp.array[wp.float32],
         # Vector:
-        x: wp.array[float32],
-        y: wp.array[float32],
-        z: wp.array[float32],
+        x: wp.array[wp.float32],
+        y: wp.array[wp.float32],
+        z: wp.array[wp.float32],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         """
         Computes a generalized matrix-vector product with an added diagonal regularization component:
@@ -703,7 +714,7 @@ def _make_block_sparse_gemv_regularization_kernel(alpha: float32):
 
         # Perform block matrix-vector multiplication: z += alpha * A_block @ x_block
         x_idx_base = col_start[mat_id] + block_coord[1]
-        acc = float32(0.0)
+        acc = wp.float32(0.0)
 
         for j in range(6):
             acc += block[j] * x[x_idx_base + j]
@@ -755,11 +766,12 @@ class DelassusOperator:
         the maximum number of constraints that can be active in each world.
 
         Args:
-            model (ModelKamino): The model container for which the Delassus operator is built.
-            data (DataKamino, optional): The model data container holding the state info and data.
-            limits (LimitsKamino, optional): The container holding the allocated joint-limit data.
-            contacts (ContactsKamino, optional): The container holding the allocated contacts data.
-            factorizer (CholeskyFactorizer, optional): An optional Cholesky factorization object. Defaults to None.
+            model: The model container for which the Delassus operator is built.
+            data: The model data container holding the state info and data.
+            limits: The container holding the allocated joint-limit data.
+            contacts: The container holding the allocated contacts data.
+            solver: The solver type to use for linear systems defined by the Delassus operator.
+            solver_kwargs: Additional keyword arguments to pass to the solver constructor.
         """
         # Declare and initialize the host-side cache of the necessary memory allocations
         self._num_worlds: int = 0
@@ -839,7 +851,7 @@ class DelassusOperator:
         return self._operator.info
 
     @property
-    def D(self) -> wp.array:
+    def D(self) -> wp.array[wp.float32]:
         """
         Returns a reference to the flat Delassus matrix array.
         """
@@ -857,10 +869,13 @@ class DelassusOperator:
         """
         Allocates the Delassus operator with the specified dimensions.
 
-        Args
-        ----
-            dims (List[int]): The dimensions of the Delassus matrix for each world.
-            factorizer (CholeskyFactorizer, optional): An optional Cholesky factorization object. Defaults to None.
+        Args:
+            model: The model container for which the Delassus operator is built.
+            data: The model data container holding the state info and data.
+            limits: The container holding the allocated joint-limit data.
+            contacts: The container holding the allocated contacts data.
+            solver: The solver type to use for linear systems defined by the Delassus operator.
+            solver_kwargs: Additional keyword arguments to pass to the solver constructor.
         """
 
         # Ensure the model container is valid
@@ -909,7 +924,7 @@ class DelassusOperator:
         # Construct the Delassus operator data structure
         self._operator = DenseLinearOperatorData()
         self._operator.info = DenseSquareMultiLinearInfo()
-        self._operator.mat = wp.zeros(shape=(self._model_maxsize,), dtype=float32, device=self._device)
+        self._operator.mat = wp.zeros(shape=(self._model_maxsize,), dtype=wp.float32, device=self._device)
         if (model.info is not None) and (data.info is not None):
             mat_offsets = [0] + [sum(self._world_maxsize[:i]) for i in range(1, self._num_worlds + 1)]
             self._operator.info.assign(
@@ -917,11 +932,11 @@ class DelassusOperator:
                 dim=data.info.num_total_cts,
                 vio=model.info.total_cts_offset,
                 mio=to_warp_int32_array(mat_offsets[: self._num_worlds], device=self._device),
-                dtype=float32,
+                dtype=wp.float32,
                 device=self._device,
             )
         else:
-            self._operator.info.finalize(dimensions=maxdims, dtype=float32, itype=int32, device=self._device)
+            self._operator.info.finalize(dimensions=maxdims, dtype=wp.float32, itype=wp.int32, device=self._device)
 
         # Optionally initialize the linear system solver if one is specified
         if solver is not None:
@@ -948,10 +963,10 @@ class DelassusOperator:
         Builds the Delassus matrix using the provided ModelKamino, DataKamino, and constraint Jacobians.
 
         Args:
-            model (ModelKamino): The model for which the Delassus operator is built.
-            data (DataKamino): The current data of the model.
-            jacobians (DenseSystemJacobians | SparseSystemJacobians): The current Jacobians of the model.
-            reset_to_zero (bool, optional): If True (default), resets the Delassus matrix to zero before building.
+            model: The model for which the Delassus operator is built.
+            data: The current data of the model.
+            jacobians: The current Jacobians of the model.
+            reset_to_zero: If True (default), resets the Delassus matrix to zero before building.
 
         Raises:
             ValueError: If the model, data, or Jacobians are not valid.
@@ -1046,14 +1061,14 @@ class DelassusOperator:
                 device=self._device,
             )
 
-    def regularize(self, eta: wp.array):
+    def regularize(self, eta: wp.array[wp.float32]):
         """
         Adds diagonal regularization to each matrix block of the Delassus operator.
 
         Args:
-            eta (wp.array): The regularization values to add to the diagonal of each matrix block.
-            This should be an array of shape `(maxdims,)` and type :class:`float32`.
+            eta: The regularization values to add to the diagonal of each matrix block.
             Each value in `eta` corresponds to the regularization along each constraint.
+            Shape of ``(sum_of_max_total_cts,)``.
         """
         wp.launch(
             kernel=_regularize_delassus_diagonal_dense,
@@ -1070,8 +1085,7 @@ class DelassusOperator:
         pre-computation, e.g. Cholesky factorization for direct solvers.
 
         Args:
-            reset_to_zero (bool):
-                If True, resets the Delassus matrix to zero.\n
+            reset_to_zero: If True, resets the Delassus matrix to zero.\n
                 This is useful for ensuring that the matrix is in a clean state before pre-computation.
         """
         # Ensure the Delassus matrix is allocated
@@ -1089,13 +1103,13 @@ class DelassusOperator:
         # Perform the Cholesky factorization
         self._solver.compute(A=self._operator.mat)
 
-    def solve(self, v: wp.array, x: wp.array):
+    def solve(self, v: wp.array[wp.float32], x: wp.array[wp.float32]):
         """
         Solves the linear system D * x = v using the Cholesky factorization.
 
         Args:
-            v (wp.array): The right-hand side vector of the linear system.
-            x (wp.array): The array to hold the solution.
+            v: The right-hand side vector of the linear system.
+            x: The array to hold the solution.
 
         Raises:
             ValueError: If the Delassus matrix is not allocated or the factorizer is not available.
@@ -1112,13 +1126,13 @@ class DelassusOperator:
         # Solve the linear system using the factorized matrix
         return self._solver.solve(b=v, x=x)
 
-    def solve_inplace(self, x: wp.array):
+    def solve_inplace(self, x: wp.array[wp.float32]):
         """
         Solves the linear system D * x = v in-place.\n
         This modifies the input array x to contain the solution assuming it is initialized as x=v.
 
         Args:
-            x (wp.array): The array to hold the solution. It should be initialized with the right-hand side vector v.
+            x: The array to hold the solution. It should be initialized with the right-hand side vector v.
 
         Raises:
             ValueError: If the Delassus matrix is not allocated or the factorizer is not available.
@@ -1212,21 +1226,14 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         be active in each world.
 
         Args:
-            model (ModelKamino, optional):
-                The model container for which the Delassus operator is built.
-            data (DataKamino, optional):
-                The model data container holding the state info and data.
-            limits (LimitsKamino, optional):
-                Limits data container for joint limit constraints.
-            contacts (ContactsKamino, optional):
-                Contacts data container for contact constraints.
-            jacobians (SparseSystemJacobians, optional):
-                The sparse Jacobians container.
-            solver (LinearSolverType, optional):
-                The linear solver class to use for solving linear systems.
+            model: The model container for which the Delassus operator is built.
+            data: The model data container holding the state info and data.
+            limits: Limits data container for joint limit constraints.
+            contacts: Contacts data container for contact constraints.
+            jacobians: The sparse Jacobians container.
+            solver: The solver type to use for linear systems defined by the Delassus operator.
                 Must be a subclass of `IterativeSolver`.
-            solver_kwargs (dict, optional):
-                Additional keyword arguments to pass to the solver constructor.
+            solver_kwargs: Additional keyword arguments to pass to the solver constructor.
         """
         super().__init__()
 
@@ -1235,8 +1242,8 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         self._data: DataKamino | None = None
         self._limits: LimitsKamino | None = None
         self._contacts: ContactsKamino | None = None
-        self._preconditioner: wp.array | None = None
-        self._eta: wp.array | None = None
+        self._preconditioner: wp.array[wp.float32] | None = None
+        self._eta: wp.array[wp.float32] | None = None
 
         self._jacobians: SparseSystemJacobians | None = None
 
@@ -1254,13 +1261,13 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         self._needs_update: bool = False
 
         # Temporary vector to store results, sized to the number of body dofs in a model.
-        self._vec_temp_body_space: wp.array | None = None
+        self._vec_temp_body_space: wp.array[wp.float32] | None = None
 
         self._col_major_jacobian: ColMajorSparseConstraintJacobians | None = None
         self._transpose_op_matrix: BlockSparseMatrices | None = None
 
         # Combined regularization vector for implicit joint dynamics
-        self._combined_regularization: wp.array | None = None
+        self._combined_regularization: wp.array[wp.float32] | None = None
 
         # Allocate the Delassus operator data if at least the model is provided
         if model is not None:
@@ -1288,21 +1295,14 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         Allocates the Delassus operator with the specified dimensions and device.
 
         Args:
-            model (ModelKamino):
-                The model container for which the Delassus operator is built.
-            data (DataKamino):
-                The model data container holding the state info and data.
-            jacobians (SparseSystemJacobians):
-                The sparse Jacobians container.
-            limits (LimitsKamino, optional):
-                Limits data container for joint limit constraints.
-            contacts (ContactsKamino, optional):
-                Contacts data container for contact constraints.
-            solver (LinearSolverType, optional):
-                The linear solver class to use for solving linear systems.
+            model: The model container for which the Delassus operator is built.
+            data: The model data container holding the state info and data.
+            jacobians: The sparse Jacobians container.
+            limits: Limits data container for joint limit constraints.
+            contacts: Contacts data container for contact constraints.
+            solver: The solver type to use for linear systems defined by the Delassus operator.
                 Must be a subclass of `IterativeSolver`.
-            solver_kwargs (dict, optional):
-                Additional keyword arguments to pass to the solver constructor.
+            solver_kwargs: Additional keyword arguments to pass to the solver constructor.
         """
         # Ensure the model container is valid
         if model is None:
@@ -1342,15 +1342,15 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
                 maxdim=model.info.max_total_cts,
                 dim=data.info.num_total_cts,
                 vio=model.info.total_cts_offset,
-                mio=wp.empty((self.num_matrices,), dtype=int32, device=self._device),
-                dtype=float32,
+                mio=wp.empty((self.num_matrices,), dtype=wp.int32, device=self._device),
+                dtype=wp.float32,
                 device=self._device,
             )
         else:
             self._info.finalize(
                 dimensions=model.info.max_total_cts.numpy(),
-                dtype=float32,
-                itype=int32,
+                dtype=wp.float32,
+                itype=wp.int32,
                 device=self._device,
             )
 
@@ -1369,13 +1369,13 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
 
         # Initialize temporary memory
         self._vec_temp_body_space = wp.empty(
-            (self._model.size.sum_of_num_body_dofs,), dtype=float32, device=self._device
+            (self._model.size.sum_of_num_body_dofs,), dtype=wp.float32, device=self._device
         )
 
         # Initialize memory for combined regularization, if necessary
         if self._model.size.max_of_num_dynamic_joint_cts > 0:
             self._combined_regularization = wp.empty(
-                (self._model.size.sum_of_max_total_cts,), dtype=float32, device=self._device
+                (self._model.size.sum_of_max_total_cts,), dtype=wp.float32, device=self._device
             )
 
         # Check whether any of the maximum row dimensions of the Jacobians is smaller than six.
@@ -1542,7 +1542,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
 
         self._needs_update = False
 
-    def set_regularization(self, eta: wp.array | None):
+    def set_regularization(self, eta: wp.array[wp.float32] | None):
         """
         Adds diagonal regularization to each matrix block of the Delassus operator, replacing any
         previously set regularization.
@@ -1550,15 +1550,15 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         The regularized Delassus matrix is defined as D = J @ M^-1 @ J^T + diag(eta)
 
         Args:
-            eta (wp.array): The regularization values to add to the diagonal of each matrix block,
+            eta: The regularization values to add to the diagonal of each matrix block,
                 with each value corresponding to the regularization along a constraint.
-                This should be an array of shape `(sum_of_max_total_cts,)` and type :class:`float32`,
                 or `None` if no regularization should be applied.
+                Shape of ``(sum_of_max_total_cts,)``.
         """
         self._eta = eta
         self.set_needs_update()
 
-    def set_preconditioner(self, preconditioner: wp.array | None):
+    def set_preconditioner(self, preconditioner: wp.array[wp.float32] | None):
         """
         Sets the diagonal preconditioner for the Delassus operator, replacing any previously set
         preconditioner.
@@ -1566,15 +1566,15 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         With preconditioning, the effective operator becomes P @ D @ P, where P = diag(preconditioner).
 
         Args:
-            preconditioner (wp.array): The diagonal preconditioner values to apply to the Delassus
+            preconditioner: The diagonal preconditioner values to apply to the Delassus
                 operator, with each value corresponding to a constraint. This should be an array of
-                shape `(sum_of_max_total_cts,)` and type :class:`float32`, or `None` to disable
-                preconditioning.
+                or `None` to disable preconditioning.
+                Shape of ``(sum_of_max_total_cts,)``.
         """
         self._preconditioner = preconditioner
         self.set_needs_update()
 
-    def diagonal(self, diag: wp.array):
+    def diagonal(self, diag: wp.array[wp.float32]):
         """Stores the diagonal of the Delassus matrix in the given array.
 
         Note:
@@ -1582,8 +1582,8 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
             preconditioning.
 
         Args:
-            diag (wp.array): Output vector for the Delassus matrix diagonal entries.
-                Shape `(sum_of_max_total_cts,)` and type :class:`float32`.
+            diag: Output vector for the Delassus matrix diagonal entries.
+                Shape of ``(sum_of_max_total_cts,)``.
         """
         if self._model is None or self._data is None:
             raise RuntimeError("ModelKamino and data must be assigned before computing diagonal.")
@@ -1633,8 +1633,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         Depending on the configured solver type, this may perform different pre-computation.
 
         Args:
-            reset_to_zero (bool):
-                If True, resets the Delassus matrix to zero.\n
+            reset_to_zero: If True, resets the Delassus matrix to zero.\n
                 This is useful for ensuring that the matrix is in a clean state before pre-computation.
         """
         # Ensure that `finalize()` was called
@@ -1660,13 +1659,13 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         # Perform the pre-computation
         self._solver.compute()
 
-    def solve(self, v: wp.array, x: wp.array):
+    def solve(self, v: wp.array[wp.float32], x: wp.array[wp.float32]):
         """
         Solves the linear system D * x = v using the assigned solver.
 
         Args:
-            v (wp.array): The right-hand side vector of the linear system.
-            x (wp.array): The array to hold the solution.
+            v: The right-hand side vector of the linear system.
+            x: The array to hold the solution.
 
         Raises:
             ValueError: If the Delassus matrix is not allocated or the solver is not available.
@@ -1690,13 +1689,13 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         # Solve the linear system
         return self._solver.solve(b=v, x=x)
 
-    def solve_inplace(self, x: wp.array):
+    def solve_inplace(self, x: wp.array[wp.float32]):
         """
         Solves the linear system D * x = v in-place.\n
         This modifies the input array x to contain the solution assuming it is initialized as x=v.
 
         Args:
-            x (wp.array): The array to hold the solution. It should be initialized with the right-hand side vector v.
+            x: The array to hold the solution. It should be initialized with the right-hand side vector v.
 
         Raises:
             ValueError: If the Delassus matrix is not allocated or the solver is not available.
@@ -1769,7 +1768,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
     # Operations
     ###
 
-    def matvec(self, x: wp.array, y: wp.array, world_mask: wp.array):
+    def matvec(self, x: wp.array[wp.float32], y: wp.array[wp.float32], world_mask: wp.array[wp.bool]):
         """
         Performs the sparse matrix-vector product `y = D @ x`, applying regularization and
         preconditioning if configured.
@@ -1815,7 +1814,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
                 device=self.device,
             )
 
-    def matvec_transpose(self, y: wp.array, x: wp.array, world_mask: wp.array):
+    def matvec_transpose(self, y: wp.array[wp.float32], x: wp.array[wp.float32], world_mask: wp.array[wp.bool]):
         """
         Performs the sparse matrix-transpose-vector product `x = D^T @ y`.
 
@@ -1828,7 +1827,14 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
 
         self.matvec(x, y, world_mask)
 
-    def gemv(self, x: wp.array, y: wp.array, world_mask: wp.array, alpha: float = 1.0, beta: float = 0.0):
+    def gemv(
+        self,
+        x: wp.array[wp.float32],
+        y: wp.array[wp.float32],
+        world_mask: wp.array[wp.bool],
+        alpha: float = 1.0,
+        beta: float = 0.0,
+    ):
         """
         Performs a BLAS-like generalized sparse matrix-vector product `y = alpha * D @ x + beta * y`,
         applying regularization and preconditioning if configured.
@@ -1882,7 +1888,14 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
                 device=self.device,
             )
 
-    def gemv_transpose(self, y: wp.array, x: wp.array, world_mask: wp.array, alpha: float = 1.0, beta: float = 0.0):
+    def gemv_transpose(
+        self,
+        y: wp.array[wp.float32],
+        x: wp.array[wp.float32],
+        world_mask: wp.array[wp.bool],
+        alpha: float = 1.0,
+        beta: float = 0.0,
+    ):
         """
         Performs a BLAS-like generalized sparse matrix-transpose-vector product
         `x = alpha * D^T @ y + beta * x`.

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -439,15 +439,16 @@ def _make_merge_preconditioner_kernel(block_type: BlockDType):
     elif len(block_shape) == 1:
         block_shape = (1, block_shape[0])
 
+    @wp.kernel
     def merge_preconditioner_kernel(
         # Inputs:
-        num_nzb,  # wp.array[wp.int32],
-        nzb_start,  # wp.array[wp.int32],
-        nzb_coords,  # wp.array2d[wp.int32],
-        row_start,  # wp.array[wp.int32],
-        preconditioner,  # wp.array[wp.float32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
+        row_start: wp.array[wp.int32],
+        preconditioner: wp.array[wp.float32],
         # Outputs:
-        nzb_values,  # wp.array[block_type.warp_type],
+        nzb_values: wp.array[Any],  # wp.array[block_type.warp_type]
     ):
         mat_id, block_idx = wp.tid()
 
@@ -476,17 +477,7 @@ def _make_merge_preconditioner_kernel(block_type: BlockDType):
 
         nzb_values[global_block_idx] = block
 
-    # Set type annotations manually (else block_type fails to resolve)
-    merge_preconditioner_kernel.__annotations__ = {
-        "num_nzb": wp.array[wp.int32],
-        "nzb_start": wp.array[wp.int32],
-        "nzb_coords": wp.array2d[wp.int32],
-        "row_start": wp.array[wp.int32],
-        "preconditioner": wp.array[wp.float32],
-        "nzb_values": wp.array[block_type.warp_type],
-    }
-
-    return wp.kernel(merge_preconditioner_kernel)
+    return merge_preconditioner_kernel
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -1085,7 +1085,7 @@ class DelassusOperator:
         pre-computation, e.g. Cholesky factorization for direct solvers.
 
         Args:
-            reset_to_zero: If True, resets the Delassus matrix to zero.\n
+            reset_to_zero: If True, resets the Delassus matrix to zero.
                 This is useful for ensuring that the matrix is in a clean state before pre-computation.
         """
         # Ensure the Delassus matrix is allocated
@@ -1128,7 +1128,7 @@ class DelassusOperator:
 
     def solve_inplace(self, x: wp.array[wp.float32]):
         """
-        Solves the linear system D * x = v in-place.\n
+        Solves the linear system D * x = v in-place.
         This modifies the input array x to contain the solution assuming it is initialized as x=v.
 
         Args:
@@ -1633,7 +1633,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         Depending on the configured solver type, this may perform different pre-computation.
 
         Args:
-            reset_to_zero: If True, resets the Delassus matrix to zero.\n
+            reset_to_zero: If True, resets the Delassus matrix to zero.
                 This is useful for ensuring that the matrix is in a clean state before pre-computation.
         """
         # Ensure that `finalize()` was called
@@ -1691,7 +1691,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
 
     def solve_inplace(self, x: wp.array[wp.float32]):
         """
-        Solves the linear system D * x = v in-place.\n
+        Solves the linear system D * x = v in-place.
         This modifies the input array x to contain the solution assuming it is initialized as x=v.
 
         Args:

--- a/newton/_src/solvers/kamino/_src/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/dual.py
@@ -129,7 +129,7 @@ class DualProblemData:
 
     config: wp.array[DualProblemConfigStruct] | None = None
     """
-    Problem configuration parameters for each world.\n
+    Problem configuration parameters for each world.
     Shape of `(num_worlds,)`.
     """
 
@@ -139,50 +139,50 @@ class DualProblemData:
 
     njc: wp.array[wp.int32] | None = None
     """
-    The number of active joint constraints in each world.\n
+    The number of active joint constraints in each world.
     Shape of `(num_worlds,)`.
     """
 
     nl: wp.array[wp.int32] | None = None
     """
-    The number of active limit constraints in each world.\n
+    The number of active limit constraints in each world.
     Shape of `(num_worlds,)`.
     """
 
     nc: wp.array[wp.int32] | None = None
     """
-    The number of active contact constraints in each world.\n
+    The number of active contact constraints in each world.
     Shape of `(num_worlds,)`.
     """
 
     lio: wp.array[wp.int32] | None = None
     """
-    The limit index offset of each world.\n
-    Shape of `(num_worlds,)`.\n
+    The limit index offset of each world.
+    Shape of `(num_worlds,)`.
     """
 
     cio: wp.array[wp.int32] | None = None
     """
-    The contact index offset of each world.\n
-    Shape of `(num_worlds,)`.\n
+    The contact index offset of each world.
+    Shape of `(num_worlds,)`.
     """
 
     uio: wp.array[wp.int32] | None = None
     """
-    The unilateral index offset of each world.\n
-    Shape of `(num_worlds,)`.\n
+    The unilateral index offset of each world.
+    Shape of `(num_worlds,)`.
     """
 
     lcgo: wp.array[wp.int32] | None = None
     """
-    The limit constraint group offset of each world.\n
-    Shape of `(num_worlds,)`.\n
+    The limit constraint group offset of each world.
+    Shape of `(num_worlds,)`.
     """
 
     ccgo: wp.array[wp.int32] | None = None
     """
-    The contact constraint group offset of each world.\n
-    Shape of `(num_worlds,)`.\n
+    The contact constraint group offset of each world.
+    Shape of `(num_worlds,)`.
     """
 
     ###
@@ -191,39 +191,39 @@ class DualProblemData:
 
     maxdim: wp.array[wp.int32] | None = None
     """
-    The maximum number of dual problem dimensions of each world.\n
+    The maximum number of dual problem dimensions of each world.
     Shape of `(num_worlds,)`.
     """
 
     dim: wp.array[wp.int32] | None = None
     """
-    The active number of dual problem dimensions of each world.\n
+    The active number of dual problem dimensions of each world.
     Shape of `(num_worlds,)`.
     """
 
     mio: wp.array[wp.int32] | None = None
     """
-    The matrix index offset of each Delassus matrix block.\n
-    This is applicable to `D` as well as to its (optional) factorizations.\n
+    The matrix index offset of each Delassus matrix block.
+    This is applicable to `D` as well as to its (optional) factorizations.
     Shape of `(num_worlds,)`.
     """
 
     vio: wp.array[wp.int32] | None = None
     """
-    The vector index offset of each constraint dimension vector block.\n
-    This is applicable to `v_b`, `v_i` and `v_f`.\n
+    The vector index offset of each constraint dimension vector block.
+    This is applicable to `v_b`, `v_i` and `v_f`.
     Shape of `(num_worlds,)`.
     """
 
     D: wp.array[wp.float32] | None = None
     """
-    The flat array of Delassus matrix blocks (constraint-space apparent inertia).\n
+    The flat array of Delassus matrix blocks (constraint-space apparent inertia).
     Shape of `(sum_of_max_total_delassus_size,)`.
     """
 
     P: wp.array[wp.float32] | None = None
     """
-    The flat array of Delassus diagonal preconditioner blocks.\n
+    The flat array of Delassus diagonal preconditioner blocks.
     Shape of `(sum_of_max_total_cts,)`.
     """
 
@@ -233,7 +233,7 @@ class DualProblemData:
 
     h: wp.array[wp.spatial_vectorf] | None = None
     """
-    Stack of non-linear generalized forces vectors of each world.\n
+    Stack of non-linear generalized forces vectors of each world.
 
     Computed as:
     `h = dt * (w_e + w_gc + w_a)`
@@ -253,7 +253,7 @@ class DualProblemData:
 
     u_f: wp.array[wp.spatial_vectorf] | None = None
     """
-    Stack of unconstrained generalized velocity vectors.\n
+    Stack of unconstrained generalized velocity vectors.
 
     Computed as:
     `u_f = u_minus + dt * M^{-1} @ h`
@@ -268,7 +268,7 @@ class DualProblemData:
 
     v_b: wp.array[wp.float32] | None = None
     """
-    Stack of free-velocity constraint bias vectors (in constraint-space).\n
+    Stack of free-velocity constraint bias vectors (in constraint-space).
 
     Computed as:
     `v_b = [ v_b_dynamics;
@@ -290,7 +290,7 @@ class DualProblemData:
 
     v_i: wp.array[wp.float32] | None = None
     """
-    The stack of free-velocity impact biases vector (in constraint-space).\n
+    The stack of free-velocity impact biases vector (in constraint-space).
 
     Computed as:
     `v_i = epsilon @ (J_cts @ u_minus)`
@@ -305,7 +305,7 @@ class DualProblemData:
 
     v_f: wp.array[wp.float32] | None = None
     """
-    Stack of free-velocity vectors (constraint-space unconstrained velocity).\n
+    Stack of free-velocity vectors (constraint-space unconstrained velocity).
 
     Computed as:
     `v_f = J_cts @ u_f + v_b + v_i`
@@ -321,7 +321,7 @@ class DualProblemData:
 
     mu: wp.array[wp.float32] | None = None
     """
-    Stack of per-contact constraint friction coefficient vectors.\n
+    Stack of per-contact constraint friction coefficient vectors.
     Shape of `(sum_of_max_contacts,)`.
     """
 
@@ -1076,11 +1076,11 @@ class DualProblem:
             contacts: The contacts container to use for the dual problem.
             jacobians: The constraints Jacobians for this model. Must be provided if model is provided.
             solver: The linear solver to use for the Delassus operator. Defaults to None.
-            config: The config for the dual problem.\n
+            config: The config for the dual problem.
                 If a single `DualProblem.Config` object is provided, it will be replicated for all worlds.
                 Defaults to `None`, indicating that default config will be used for all worlds.
             compute_h: Set to `True` to enable the computation of the nonlinear
-                generalized forces vectors in construction of the dual problem.\n
+                generalized forces vectors in construction of the dual problem.
                 Defaults to `False`.
         """
         # Ensure Jacobians are given if model is provided.
@@ -1202,13 +1202,13 @@ class DualProblem:
             model: The model to build the dual problem for.
             jacobians: The constraints Jacobians for this model.
             contacts: The contacts container to use for the dual problem.
-            solver: The linear solver to use for the Delassus operator.\n
+            solver: The linear solver to use for the Delassus operator.
                 Defaults to `None`.
-            config: The config for the dual problem.\n
+            config: The config for the dual problem.
                 If a single `DualProblem.Config` object is provided, it will be replicated for all worlds.
                 Defaults to `None`, indicating that default config will be used for all worlds.
             compute_h: Set to `True` to enable the computation of the nonlinear
-                generalized forces vectors in construction of the dual problem.\n
+                generalized forces vectors in construction of the dual problem.
                 Defaults to `False`.
         """
         # Ensure the model is valid

--- a/newton/_src/solvers/kamino/_src/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/dual.py
@@ -64,7 +64,7 @@ from ..core.data import DataKamino
 from ..core.math import FLOAT32_EPS, screw, screw_angular, screw_linear
 from ..core.model import ModelKamino
 from ..core.size import SizeKamino
-from ..core.types import float32, int32, mat33f, vec2f, vec3f, vec4f, vec6f
+from ..core.types import vec6f
 from ..dynamics.delassus import BlockSparseMatrixFreeDelassusOperator, DelassusOperator
 from ..geometry.contacts import ContactsKamino
 from ..kinematics.jacobians import DenseSystemJacobians, SparseSystemJacobians
@@ -99,13 +99,13 @@ class DualProblemConfigStruct:
     A Warp struct to hold on-device configuration parameters of a dual problem.
     """
 
-    alpha: float32
+    alpha: wp.float32
     """Baumgarte stabilization parameter for bilateral joint constraints."""
-    beta: float32
+    beta: wp.float32
     """Baumgarte stabilization parameter for unilateral joint limit constraints."""
-    gamma: float32
+    gamma: wp.float32
     """Baumgarte stabilization parameter for unilateral contact constraints."""
-    delta: float32
+    delta: wp.float32
     """Contact penetration margin used for unilateral contact constraints"""
     preconditioning: wp.bool
     """Flag to enable preconditioning of the dual problem."""
@@ -127,111 +127,111 @@ class DualProblemData:
     # Problem configurations
     ###
 
-    config: wp.array | None = None
+    config: wp.array[DualProblemConfigStruct] | None = None
     """
     Problem configuration parameters for each world.\n
-    Shape of `(num_worlds,)` and type :class:`DualProblemConfigStruct`.
+    Shape of `(num_worlds,)`.
     """
 
     ###
     # Constraints info
     ###
 
-    njc: wp.array | None = None
+    njc: wp.array[wp.int32] | None = None
     """
     The number of active joint constraints in each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    nl: wp.array | None = None
+    nl: wp.array[wp.int32] | None = None
     """
     The number of active limit constraints in each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    nc: wp.array | None = None
+    nc: wp.array[wp.int32] | None = None
     """
     The number of active contact constraints in each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    lio: wp.array | None = None
+    lio: wp.array[wp.int32] | None = None
     """
     The limit index offset of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.\n
+    Shape of `(num_worlds,)`.\n
     """
 
-    cio: wp.array | None = None
+    cio: wp.array[wp.int32] | None = None
     """
     The contact index offset of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.\n
+    Shape of `(num_worlds,)`.\n
     """
 
-    uio: wp.array | None = None
+    uio: wp.array[wp.int32] | None = None
     """
     The unilateral index offset of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.\n
+    Shape of `(num_worlds,)`.\n
     """
 
-    lcgo: wp.array | None = None
+    lcgo: wp.array[wp.int32] | None = None
     """
     The limit constraint group offset of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.\n
+    Shape of `(num_worlds,)`.\n
     """
 
-    ccgo: wp.array | None = None
+    ccgo: wp.array[wp.int32] | None = None
     """
     The contact constraint group offset of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.\n
+    Shape of `(num_worlds,)`.\n
     """
 
     ###
     # Delassus operator
     ###
 
-    maxdim: wp.array | None = None
+    maxdim: wp.array[wp.int32] | None = None
     """
     The maximum number of dual problem dimensions of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    dim: wp.array | None = None
+    dim: wp.array[wp.int32] | None = None
     """
     The active number of dual problem dimensions of each world.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    mio: wp.array | None = None
+    mio: wp.array[wp.int32] | None = None
     """
     The matrix index offset of each Delassus matrix block.\n
     This is applicable to `D` as well as to its (optional) factorizations.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    vio: wp.array | None = None
+    vio: wp.array[wp.int32] | None = None
     """
     The vector index offset of each constraint dimension vector block.\n
     This is applicable to `v_b`, `v_i` and `v_f`.\n
-    Shape of `(num_worlds,)` and type :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
-    D: wp.array | None = None
+    D: wp.array[wp.float32] | None = None
     """
     The flat array of Delassus matrix blocks (constraint-space apparent inertia).\n
-    Shape of `(sum_of_max_total_delassus_size,)` and type :class:`float32`.
+    Shape of `(sum_of_max_total_delassus_size,)`.
     """
 
-    P: wp.array | None = None
+    P: wp.array[wp.float32] | None = None
     """
     The flat array of Delassus diagonal preconditioner blocks.\n
-    Shape of `(sum_of_max_total_cts,)` and type :class:`float32`.
+    Shape of `(sum_of_max_total_cts,)`.
     """
 
     ###
     # Problem vectors
     ###
 
-    h: wp.array | None = None
+    h: wp.array[wp.spatial_vectorf] | None = None
     """
     Stack of non-linear generalized forces vectors of each world.\n
 
@@ -248,10 +248,10 @@ class DualProblemData:
     incorporated in the computation of the generalized free-velocity `u_f`.
     It is can be optionally built for analysis or debugging purposes.
 
-    Shape of `(sum_of_num_body_dofs,)` and type :class:`vec6f`.
+    Shape of `(sum_of_num_body_dofs,)`.
     """
 
-    u_f: wp.array | None = None
+    u_f: wp.array[wp.spatial_vectorf] | None = None
     """
     Stack of unconstrained generalized velocity vectors.\n
 
@@ -263,10 +263,10 @@ class DualProblemData:
     - `M^{-1}` is the block-diagonal inverse generalized mass matrix
     - `h` is the stack of non-linear generalized forces vectors
 
-    Shape of `(sum_of_num_body_dofs,)` and type :class:`vec6f`.
+    Shape of `(sum_of_num_body_dofs,)`.
     """
 
-    v_b: wp.array | None = None
+    v_b: wp.array[wp.float32] | None = None
     """
     Stack of free-velocity constraint bias vectors (in constraint-space).\n
 
@@ -285,10 +285,10 @@ class DualProblemData:
     - `alpha`, `beta`, `gamma` are the Baumgarte stabilization
         parameters for joints, limits and contacts, respectively
 
-    Shape of `(sum_of_max_total_cts,)` and type :class:`float32`.
+    Shape of `(sum_of_max_total_cts,)`.
     """
 
-    v_i: wp.array | None = None
+    v_i: wp.array[wp.float32] | None = None
     """
     The stack of free-velocity impact biases vector (in constraint-space).\n
 
@@ -300,10 +300,10 @@ class DualProblemData:
     - `J_cts` is the constraint Jacobian matrix
     - `u_minus` is the stack of per-body generalized velocities at the beginning of the time step
 
-    Shape of `(sum_of_max_total_cts,)` and type :class:`float32`.
+    Shape of `(sum_of_max_total_cts,)`.
     """
 
-    v_f: wp.array | None = None
+    v_f: wp.array[wp.float32] | None = None
     """
     Stack of free-velocity vectors (constraint-space unconstrained velocity).\n
 
@@ -316,13 +316,13 @@ class DualProblemData:
     - `v_b` is the stack of free-velocity stabilization biases vectors
     - `v_i` is the stack of free-velocity impact biases vectors
 
-    Shape of `(sum_of_max_total_cts,)` and type :class:`float32`.
+    Shape of `(sum_of_max_total_cts,)`.
     """
 
-    mu: wp.array | None = None
+    mu: wp.array[wp.float32] | None = None
     """
     Stack of per-contact constraint friction coefficient vectors.\n
-    Shape of `(sum_of_max_contacts,)` and type :class:`float32`.
+    Shape of `(sum_of_max_contacts,)`.
     """
 
 
@@ -333,11 +333,11 @@ class DualProblemData:
 
 @wp.func
 def gravity_plus_coriolis_wrench(
-    g: vec3f,
-    m_i: float32,
-    I_i: mat33f,
-    omega_i: vec3f,
-) -> vec6f:
+    g: wp.vec3f,
+    m_i: wp.float32,
+    I_i: wp.mat33f,
+    omega_i: wp.vec3f,
+) -> wp.spatial_vectorf:
     """
     Compute the gravitational + Coriolis wrench acting on a body.
     """
@@ -348,11 +348,11 @@ def gravity_plus_coriolis_wrench(
 
 @wp.func
 def gravity_plus_coriolis_wrench_split(
-    g: vec3f,
-    m_i: float32,
-    I_i: mat33f,
-    omega_i: vec3f,
-):
+    g: wp.vec3f,
+    m_i: wp.float32,
+    I_i: wp.mat33f,
+    omega_i: wp.vec3f,
+) -> tuple[wp.vec3f, wp.vec3f]:
     """
     Compute the gravitational+inertial wrench on a body.
     """
@@ -369,16 +369,16 @@ def gravity_plus_coriolis_wrench_split(
 @wp.kernel
 def _build_nonlinear_generalized_force(
     # Inputs:
-    model_time_dt: wp.array[float32],
-    model_gravity_vector: wp.array[vec4f],
-    model_bodies_wid: wp.array[int32],
-    model_bodies_m_i: wp.array[float32],
-    state_bodies_u_i: wp.array[vec6f],
-    state_bodies_I_i: wp.array[mat33f],
-    state_bodies_w_e_i: wp.array[vec6f],
-    state_bodies_w_a_i: wp.array[vec6f],
+    model_time_dt: wp.array[wp.float32],
+    model_gravity_vector: wp.array[wp.vec4f],
+    model_bodies_wid: wp.array[wp.int32],
+    model_bodies_m_i: wp.array[wp.float32],
+    state_bodies_u_i: wp.array[wp.spatial_vectorf],
+    state_bodies_I_i: wp.array[wp.mat33f],
+    state_bodies_w_e_i: wp.array[wp.spatial_vectorf],
+    state_bodies_w_a_i: wp.array[wp.spatial_vectorf],
     # Outputs:
-    problem_h: wp.array[vec6f],
+    problem_h: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the body index as the thread index
     bid = wp.tid()
@@ -396,7 +396,7 @@ def _build_nonlinear_generalized_force(
     gv = model_gravity_vector[wid]
 
     # Extract the effective gravity vector
-    g = gv.w * vec3f(gv.x, gv.y, gv.z)
+    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
 
     # Extract the linear and angular components of the generalized velocity
     omega_i = screw_angular(u_i)
@@ -411,18 +411,18 @@ def _build_nonlinear_generalized_force(
 @wp.kernel
 def _build_generalized_free_velocity(
     # Inputs:
-    model_time_dt: wp.array[float32],
-    model_gravity_vector: wp.array[vec4f],
-    model_bodies_wid: wp.array[int32],
-    model_bodies_m_i: wp.array[float32],
-    model_bodies_inv_m_i: wp.array[float32],
-    state_bodies_u_i: wp.array[vec6f],
-    state_bodies_I_i: wp.array[mat33f],
-    state_bodies_inv_I_i: wp.array[mat33f],
-    state_bodies_w_e_i: wp.array[vec6f],
-    state_bodies_w_a_i: wp.array[vec6f],
+    model_time_dt: wp.array[wp.float32],
+    model_gravity_vector: wp.array[wp.vec4f],
+    model_bodies_wid: wp.array[wp.int32],
+    model_bodies_m_i: wp.array[wp.float32],
+    model_bodies_inv_m_i: wp.array[wp.float32],
+    state_bodies_u_i: wp.array[wp.spatial_vectorf],
+    state_bodies_I_i: wp.array[wp.mat33f],
+    state_bodies_inv_I_i: wp.array[wp.mat33f],
+    state_bodies_w_e_i: wp.array[wp.spatial_vectorf],
+    state_bodies_w_a_i: wp.array[wp.spatial_vectorf],
     # Outputs:
-    problem_u_f: wp.array[vec6f],
+    problem_u_f: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the body index as the thread index
     bid = wp.tid()
@@ -442,7 +442,7 @@ def _build_generalized_free_velocity(
     gv = model_gravity_vector[wid]
 
     # Extract the effective gravity vector
-    g = gv.w * vec3f(gv.x, gv.y, gv.z)
+    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
 
     # Extract the linear and angular components of the generalized velocity
     v_i = screw_linear(u_i)
@@ -464,12 +464,12 @@ def _build_generalized_free_velocity(
 @wp.kernel
 def _build_free_velocity_bias_joint_dynamics(
     # Inputs:
-    model_joints_wid: wp.array[int32],
-    model_joints_dynamic_cts_offset: wp.array[int32],
-    model_joints_dynamic_cts_offset_total_cts: wp.array[int32],
-    data_joints_dq_b_j: wp.array[float32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset_total_cts: wp.array[wp.int32],
+    data_joints_dq_b_j: wp.array[wp.float32],
     # Outputs:
-    problem_v_b: wp.array[float32],
+    problem_v_b: wp.array[wp.float32],
 ):
     # Retrieve the joint index as the thread index
     jid = wp.tid()
@@ -493,14 +493,14 @@ def _build_free_velocity_bias_joint_dynamics(
 @wp.kernel
 def _build_free_velocity_bias_joint_kinematics(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_joints_wid: wp.array[int32],
-    model_joints_kinematic_cts_offset: wp.array[int32],
-    model_joints_kinematic_cts_offset_total_cts: wp.array[int32],
-    data_joints_r_j: wp.array[float32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset_total_cts: wp.array[wp.int32],
+    data_joints_r_j: wp.array[wp.float32],
     problem_config: wp.array[DualProblemConfigStruct],
     # Outputs:
-    problem_v_b: wp.array[float32],
+    problem_v_b: wp.array[wp.float32],
 ):
     # Retrieve the joint index as the thread index
     jid = wp.tid()
@@ -532,17 +532,17 @@ def _build_free_velocity_bias_joint_kinematics(
 @wp.kernel
 def _build_free_velocity_bias_limits(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    limits_model_max: int32,
-    limits_model_num: wp.array[int32],
-    limits_wid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_r_q: wp.array[float32],
+    model_time_inv_dt: wp.array[wp.float32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    limits_model_max: wp.int32,
+    limits_model_num: wp.array[wp.int32],
+    limits_wid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_r_q: wp.array[wp.float32],
     problem_config: wp.array[DualProblemConfigStruct],
-    problem_vio: wp.array[int32],
+    problem_vio: wp.array[wp.int32],
     # Outputs:
-    problem_v_b: wp.array[float32],
+    problem_v_b: wp.array[wp.float32],
 ):
     # Retrieve the limit index as the thread index
     tid = wp.tid()
@@ -575,21 +575,21 @@ def _build_free_velocity_bias_limits(
 @wp.kernel
 def _build_free_velocity_bias_contacts(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_info_contacts_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    contacts_model_max: int32,
-    contacts_model_num: wp.array[int32],
-    contacts_wid: wp.array[int32],
-    contacts_cid: wp.array[int32],
-    contacts_gapfunc: wp.array[vec4f],
-    contacts_material: wp.array[vec2f],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_info_contacts_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    contacts_model_max: wp.int32,
+    contacts_model_num: wp.array[wp.int32],
+    contacts_wid: wp.array[wp.int32],
+    contacts_cid: wp.array[wp.int32],
+    contacts_gapfunc: wp.array[wp.vec4f],
+    contacts_material: wp.array[wp.vec2f],
     problem_config: wp.array[DualProblemConfigStruct],
-    problem_vio: wp.array[int32],
+    problem_vio: wp.array[wp.int32],
     # Outputs:
-    problem_v_b: wp.array[float32],
-    problem_v_i: wp.array[float32],
-    problem_mu: wp.array[float32],
+    problem_v_b: wp.array[wp.float32],
+    problem_v_i: wp.array[wp.float32],
+    problem_mu: wp.array[wp.float32],
 ):
     # Retrieve the contact index as the thread index
     tid = wp.tid()
@@ -663,17 +663,17 @@ def _build_free_velocity_bias_contacts(
 @wp.kernel
 def _build_free_velocity(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    data_bodies_u_i: wp.array[vec6f],
-    jacobians_J_cts_offsets: wp.array[int32],
-    jacobians_J_cts_data: wp.array[float32],
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_u_f: wp.array[vec6f],
-    problem_v_b: wp.array[float32],
-    problem_v_i: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    data_bodies_u_i: wp.array[wp.spatial_vectorf],
+    jacobians_J_cts_offsets: wp.array[wp.int32],
+    jacobians_J_cts_data: wp.array[wp.float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_u_f: wp.array[wp.spatial_vectorf],
+    problem_v_b: wp.array[wp.float32],
+    problem_v_i: wp.array[wp.float32],
     # Outputs:
-    problem_v_f: wp.array[float32],
+    problem_v_f: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -710,7 +710,7 @@ def _build_free_velocity(
 
     # Buffers
     J_i = vec6f(0.0)
-    v_f_j = float32(0.0)
+    v_f_j = wp.float32(0.0)
 
     # Iterate over each body to accumulate velocity contributions
     for i in range(nb):
@@ -739,17 +739,17 @@ def _build_free_velocity(
 @wp.kernel
 def _build_free_velocity_sparse(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    state_bodies_u_i: wp.array[vec6f],
-    jac_num_nzb: wp.array[int32],
-    jac_nzb_start: wp.array[int32],
-    jac_nzb_coords: wp.array2d[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    state_bodies_u_i: wp.array[wp.spatial_vectorf],
+    jac_num_nzb: wp.array[wp.int32],
+    jac_nzb_start: wp.array[wp.int32],
+    jac_nzb_coords: wp.array2d[wp.int32],
     jac_nzb_values: wp.array[vec6f],
-    problem_vio: wp.array[int32],
-    problem_u_f: wp.array[vec6f],
-    problem_v_i: wp.array[float32],
+    problem_vio: wp.array[wp.int32],
+    problem_u_f: wp.array[wp.spatial_vectorf],
+    problem_v_i: wp.array[wp.float32],
     # Outputs:
-    problem_v_f: wp.array[float32],
+    problem_v_f: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, nzb_id = wp.tid()
@@ -776,7 +776,7 @@ def _build_free_velocity_sparse(
     epsilon_j = problem_v_i[thread_offset]
 
     # Buffers
-    v_f_j = float32(0.0)
+    v_f_j = wp.float32(0.0)
 
     # Iterate over each body to accumulate velocity contributions
     bid = jac_block_coord[1] // 6
@@ -799,14 +799,14 @@ def _build_free_velocity_sparse(
 def _build_dual_preconditioner_all_constraints(
     # Inputs:
     problem_config: wp.array[DualProblemConfigStruct],
-    problem_dim: wp.array[int32],
-    problem_mio: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_njc: wp.array[int32],
-    problem_nl: wp.array[int32],
-    problem_D: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_mio: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_njc: wp.array[wp.int32],
+    problem_nl: wp.array[wp.int32],
+    problem_D: wp.array[wp.float32],
     # Outputs:
-    problem_P: wp.array[float32],
+    problem_P: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -850,8 +850,8 @@ def _build_dual_preconditioner_all_constraints(
             D_kk_2 = problem_D[mio + ncts * (tid + 2) + (tid + 2)]
             # Compute the effective diagonal entry
             # D_kk = (D_kk_0 + D_kk_1 + D_kk_2) / 3.0
-            # D_kk = wp.min(vec3f(D_kk_0, D_kk_1, D_kk_2))
-            D_kk = wp.max(vec3f(D_kk_0, D_kk_1, D_kk_2))
+            # D_kk = wp.min(wp.vec3f(D_kk_0, D_kk_1, D_kk_2))
+            D_kk = wp.max(wp.vec3f(D_kk_0, D_kk_1, D_kk_2))
             # Compute the corresponding Jacobi preconditioner entry
             P_k = wp.sqrt(1.0 / (wp.abs(D_kk) + FLOAT32_EPS))
             problem_P[vio + tid] = P_k
@@ -863,12 +863,12 @@ def _build_dual_preconditioner_all_constraints(
 def _build_dual_preconditioner_all_constraints_sparse(
     # Inputs:
     problem_config: wp.array[DualProblemConfigStruct],
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_njc: wp.array[int32],
-    problem_nl: wp.array[int32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_njc: wp.array[wp.int32],
+    problem_nl: wp.array[wp.int32],
     # Outputs:
-    problem_P: wp.array[float32],
+    problem_P: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -909,8 +909,8 @@ def _build_dual_preconditioner_all_constraints_sparse(
             D_kk_2 = problem_P[vio + tid + 2]
             # Compute the effective diagonal entry
             # D_kk = (D_kk_0 + D_kk_1 + D_kk_2) / 3.0
-            # D_kk = wp.min(vec3f(D_kk_0, D_kk_1, D_kk_2))
-            D_kk = wp.max(vec3f(D_kk_0, D_kk_1, D_kk_2))
+            # D_kk = wp.min(wp.vec3f(D_kk_0, D_kk_1, D_kk_2))
+            D_kk = wp.max(wp.vec3f(D_kk_0, D_kk_1, D_kk_2))
             # Compute the corresponding Jacobi preconditioner entry
             P_k = wp.sqrt(1.0 / (wp.abs(D_kk) + FLOAT32_EPS))
             problem_P[vio + tid] = P_k
@@ -921,12 +921,12 @@ def _build_dual_preconditioner_all_constraints_sparse(
 @wp.kernel
 def _apply_dual_preconditioner_to_matrix(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_mio: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_P: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_mio: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    X: wp.array[float32],
+    X: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -969,11 +969,11 @@ def _apply_dual_preconditioner_to_matrix(
 @wp.kernel
 def _apply_dual_preconditioner_to_vector(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_P: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    x: wp.array[float32],
+    x: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -1072,20 +1072,14 @@ class DualProblem:
         by calling the `finalize()` method at a later point.
 
         Args:
-            model (ModelKamino, optional):
-                The model to build the dual problem for.
-            contacts (ContactsKamino, optional):
-                The contacts container to use for the dual problem.
-            jacobians (SparseSystemJacobians | DenseSystemJacobians, optional):
-                The constraints Jacobians for this model. Must be provided if model is provided.
-            solver (LinearSolverType, optional):
-                The linear solver to use for the Delassus operator. Defaults to None.
-            config (List[DualProblem.Config] | DualProblem.Config, optional):
-                The config for the dual problem.\n
+            model: The model to build the dual problem for.
+            contacts: The contacts container to use for the dual problem.
+            jacobians: The constraints Jacobians for this model. Must be provided if model is provided.
+            solver: The linear solver to use for the Delassus operator. Defaults to None.
+            config: The config for the dual problem.\n
                 If a single `DualProblem.Config` object is provided, it will be replicated for all worlds.
                 Defaults to `None`, indicating that default config will be used for all worlds.
-            compute_h (bool, optional):
-                Set to `True` to enable the computation of the nonlinear
+            compute_h: Set to `True` to enable the computation of the nonlinear
                 generalized forces vectors in construction of the dual problem.\n
                 Defaults to `False`.
         """
@@ -1205,21 +1199,15 @@ class DualProblem:
         for the given model, limits, contacts and Jacobians.
 
         Args:
-            model (ModelKamino):
-                The model to build the dual problem for.
-            jacobians (SparseSystemJacobians | DenseSystemJacobians):
-                The constraints Jacobians for this model.
-            contacts (ContactsKamino, optional):
-                The contacts container to use for the dual problem.
-            solver (LinearSolverType, optional):
-                The linear solver to use for the Delassus operator.\n
+            model: The model to build the dual problem for.
+            jacobians: The constraints Jacobians for this model.
+            contacts: The contacts container to use for the dual problem.
+            solver: The linear solver to use for the Delassus operator.\n
                 Defaults to `None`.
-            config (List[DualProblem.Config] | DualProblem.Config, optional):
-                The config for the dual problem.\n
+            config: The config for the dual problem.\n
                 If a single `DualProblem.Config` object is provided, it will be replicated for all worlds.
                 Defaults to `None`, indicating that default config will be used for all worlds.
-            compute_nonlinear_forces (bool, optional):
-                Set to `True` to enable the computation of the nonlinear
+            compute_h: Set to `True` to enable the computation of the nonlinear
                 generalized forces vectors in construction of the dual problem.\n
                 Defaults to `False`.
         """
@@ -1274,7 +1262,7 @@ class DualProblem:
             self._delassus.set_regularization(
                 wp.zeros(
                     (model.size.sum_of_max_total_cts,),
-                    dtype=float32,
+                    dtype=wp.float32,
                     device=self._device,
                 )
             )
@@ -1312,13 +1300,15 @@ class DualProblem:
                     D=None,
                     # Allocate new memory for the remaining dual problem quantities
                     config=wp.array([c.to_struct() for c in self.config], dtype=DualProblemConfigStruct),
-                    h=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=vec6f) if self._compute_h else None,
-                    u_f=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=vec6f),
-                    v_b=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=float32),
-                    v_i=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=float32),
-                    v_f=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=float32),
-                    mu=wp.zeros(shape=(model_max_contacts_host,), dtype=float32),
-                    P=wp.ones(shape=(self._delassus.sum_of_max_dims,), dtype=float32),
+                    h=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf)
+                    if self._compute_h
+                    else None,
+                    u_f=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf),
+                    v_b=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=wp.float32),
+                    v_i=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=wp.float32),
+                    v_f=wp.zeros(shape=(self._delassus.sum_of_max_dims,), dtype=wp.float32),
+                    mu=wp.zeros(shape=(model_max_contacts_host,), dtype=wp.float32),
+                    P=wp.ones(shape=(self._delassus.sum_of_max_dims,), dtype=wp.float32),
                 )
                 # Connect Delassus preconditioner to data array
                 self._delassus.set_preconditioner(self._data.P)
@@ -1344,13 +1334,15 @@ class DualProblem:
                     D=self._delassus.D,
                     # Allocate new memory for the remaining dual problem quantities
                     config=wp.array([c.to_struct() for c in self.config], dtype=DualProblemConfigStruct),
-                    h=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=vec6f) if self._compute_h else None,
-                    u_f=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=vec6f),
-                    v_b=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=float32),
-                    v_i=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=float32),
-                    v_f=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=float32),
-                    mu=wp.zeros(shape=(model_max_contacts_host,), dtype=float32),
-                    P=wp.ones(shape=(self._delassus.num_maxdims,), dtype=float32),
+                    h=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf)
+                    if self._compute_h
+                    else None,
+                    u_f=wp.zeros(shape=(model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf),
+                    v_b=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=wp.float32),
+                    v_i=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=wp.float32),
+                    v_f=wp.zeros(shape=(self._delassus.num_maxdims,), dtype=wp.float32),
+                    mu=wp.zeros(shape=(model_max_contacts_host,), dtype=wp.float32),
+                    P=wp.ones(shape=(self._delassus.num_maxdims,), dtype=wp.float32),
                 )
 
     def zero(self):
@@ -1724,7 +1716,7 @@ class DualProblem:
             device=self.device,
         )
 
-    def _apply_dual_preconditioner_to_matrix(self, X: wp.array):
+    def _apply_dual_preconditioner_to_matrix(self, X: wp.array[wp.float32]):
         """
         Applies the diagonal preconditioner 'P' to a given matrix.
         """
@@ -1743,7 +1735,7 @@ class DualProblem:
             device=self.device,
         )
 
-    def _apply_dual_preconditioner_to_vector(self, x: wp.array):
+    def _apply_dual_preconditioner_to_vector(self, x: wp.array[wp.float32]):
         """
         Applies the diagonal preconditioner 'P' to a given vector.
         """

--- a/newton/_src/solvers/kamino/_src/dynamics/wrenches.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/wrenches.py
@@ -5,11 +5,13 @@
 KAMINO: Dynamics: Wrenches
 """
 
+from __future__ import annotations
+
 import warp as wp
 
 from ..core.data import DataKamino
 from ..core.model import ModelKamino
-from ..core.types import float32, int32, mat63f, vec2i, vec3f, vec6f
+from ..core.types import mat63f, vec6f
 from ..geometry.contacts import ContactsKamino
 from ..kinematics.jacobians import DenseSystemJacobians, SparseSystemJacobians
 from ..kinematics.limits import LimitsKamino
@@ -39,18 +41,18 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _compute_joint_dof_body_wrenches_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_info_joint_dofs_offset: wp.array[int32],
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_wid: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    model_joints_bid_F: wp.array[int32],
-    data_joints_tau_j: wp.array[float32],
-    jacobian_dofs_offsets: wp.array[int32],
-    jacobian_dofs_data: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_info_joint_dofs_offset: wp.array[wp.int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    model_joints_bid_F: wp.array[wp.int32],
+    data_joints_tau_j: wp.array[wp.float32],
+    jacobian_dofs_offsets: wp.array[wp.int32],
+    jacobian_dofs_data: wp.array[wp.float32],
     # Outputs:
-    data_bodies_w_a: wp.array[vec6f],
+    data_bodies_w_a: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index as the joint index
     jid = wp.tid()
@@ -85,7 +87,7 @@ def _compute_joint_dof_body_wrenches_dense(
     vio = dio_j
 
     # Compute and store the joint actuation wrench for the Follower body
-    w_j_F = vec6f(0.0)
+    w_j_F = wp.spatial_vectorf(0.0)
     dio_F = 6 * (bid_F_j - bio)
     for j in range(d_j):
         mio_j = mio + nbd * j + dio_F
@@ -97,7 +99,7 @@ def _compute_joint_dof_body_wrenches_dense(
 
     # Compute and store the joint actuation wrench for the Base body if bid_B >= 0
     if bid_B_j >= 0:
-        w_j_B = vec6f(0.0)
+        w_j_B = wp.spatial_vectorf(0.0)
         dio_B = 6 * (bid_B_j - bio)
         for j in range(d_j):
             mio_j = mio + nbd * j + dio_B
@@ -111,16 +113,16 @@ def _compute_joint_dof_body_wrenches_dense(
 @wp.kernel
 def _compute_joint_dof_body_wrenches_sparse(
     # Inputs:
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_num_dofs: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    model_joints_bid_F: wp.array[int32],
-    data_joints_tau_j: wp.array[float32],
-    jac_joint_nzb_offsets: wp.array[int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_num_dofs: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    model_joints_bid_F: wp.array[wp.int32],
+    data_joints_tau_j: wp.array[wp.float32],
+    jac_joint_nzb_offsets: wp.array[wp.int32],
     jac_nzb_values: wp.array[vec6f],
     # Outputs:
-    data_bodies_w_a: wp.array[vec6f],
+    data_bodies_w_a: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index as the joint index
     jid = wp.tid()
@@ -142,7 +144,7 @@ def _compute_joint_dof_body_wrenches_sparse(
     jac_j_nzb_start = jac_joint_nzb_offsets[jid]
 
     # Compute and store the joint actuation wrench for the Follower body
-    w_j_F = vec6f(0.0)
+    w_j_F = wp.spatial_vectorf(0.0)
     for j in range(d_j):
         jac_block = jac_nzb_values[jac_j_nzb_start + j]
         vio_j = dio_j + j
@@ -152,7 +154,7 @@ def _compute_joint_dof_body_wrenches_sparse(
 
     # Compute and store the joint actuation wrench for the Base body if bid_B >= 0
     if bid_B_j >= 0:
-        w_j_B = vec6f(0.0)
+        w_j_B = wp.spatial_vectorf(0.0)
         for j in range(d_j):
             jac_block = jac_nzb_values[jac_j_nzb_start + d_j + j]
             vio_j = dio_j + j
@@ -164,23 +166,23 @@ def _compute_joint_dof_body_wrenches_sparse(
 @wp.kernel
 def _compute_joint_cts_body_wrenches_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_info_joint_dynamic_cts_offset: wp.array[int32],
-    model_info_joint_kinematic_cts_offset: wp.array[int32],
-    model_info_joint_dynamic_cts_group_offset: wp.array[int32],
-    model_info_joint_kinematic_cts_group_offset: wp.array[int32],
-    model_time_inv_dt: wp.array[float32],
-    model_joints_wid: wp.array[int32],
-    model_joints_dynamic_cts_offset: wp.array[int32],
-    model_joints_kinematic_cts_offset: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    model_joints_bid_F: wp.array[int32],
-    jacobian_cts_offset: wp.array[int32],
-    jacobian_cts_data: wp.array[float32],
-    lambdas_offsets: wp.array[int32],
-    lambdas_data: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_offset: wp.array[wp.int32],
+    model_info_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_group_offset: wp.array[wp.int32],
+    model_info_joint_kinematic_cts_group_offset: wp.array[wp.int32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    model_joints_bid_F: wp.array[wp.int32],
+    jacobian_cts_offset: wp.array[wp.int32],
+    jacobian_cts_data: wp.array[wp.float32],
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     # Outputs:
-    data_bodies_w_j: wp.array[vec6f],
+    data_bodies_w_j: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index as the joint index
     jid = wp.tid()
@@ -223,7 +225,7 @@ def _compute_joint_cts_body_wrenches_dense(
 
     # Compute and store the joint constraint wrench for the Follower body
     # NOTE: We need to scale by the time-step because the lambdas are impulses
-    w_j_F = vec6f(0.0)
+    w_j_F = wp.spatial_vectorf(0.0)
     col_F_start = 6 * (bid_F_j - bio)
     for j in range(num_dyn_cts_j):
         row_j = world_jdcgo + local_dyn_cts_start_j + j
@@ -244,7 +246,7 @@ def _compute_joint_cts_body_wrenches_dense(
     # Compute and store the joint constraint wrench for the Base body if bid_B >= 0
     # NOTE: We need to scale by the time-step because the lambdas are impulses
     if bid_B_j >= 0:
-        w_j_B = vec6f(0.0)
+        w_j_B = wp.spatial_vectorf(0.0)
         col_B_start = 6 * (bid_B_j - bio)
         for j in range(num_dyn_cts_j):
             row_j = world_jdcgo + local_dyn_cts_start_j + j
@@ -266,20 +268,20 @@ def _compute_joint_cts_body_wrenches_dense(
 @wp.kernel
 def _compute_limit_cts_body_wrenches_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    model_time_inv_dt: wp.array[float32],
-    limits_model_num: wp.array[int32],
-    limits_model_max: int32,
-    limits_wid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    jacobian_cts_offset: wp.array[int32],
-    jacobian_cts_data: wp.array[float32],
-    lambdas_offsets: wp.array[int32],
-    lambdas_data: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    model_time_inv_dt: wp.array[wp.float32],
+    limits_model_num: wp.array[wp.int32],
+    limits_model_max: wp.int32,
+    limits_wid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    jacobian_cts_offset: wp.array[wp.int32],
+    jacobian_cts_data: wp.array[wp.float32],
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     # Outputs:
-    data_bodies_w_l: wp.array[vec6f],
+    data_bodies_w_l: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -353,20 +355,20 @@ def _compute_limit_cts_body_wrenches_dense(
 @wp.kernel
 def _compute_contact_cts_body_wrenches_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    model_time_inv_dt: wp.array[float32],
-    contacts_model_num: wp.array[int32],
-    contacts_model_max: int32,
-    contacts_wid: wp.array[int32],
-    contacts_cid: wp.array[int32],
-    contacts_bid_AB: wp.array[vec2i],
-    jacobian_cts_offset: wp.array[int32],
-    jacobian_cts_data: wp.array[float32],
-    lambdas_offsets: wp.array[int32],
-    lambdas_data: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    model_time_inv_dt: wp.array[wp.float32],
+    contacts_model_num: wp.array[wp.int32],
+    contacts_model_max: wp.int32,
+    contacts_wid: wp.array[wp.int32],
+    contacts_cid: wp.array[wp.int32],
+    contacts_bid_AB: wp.array[wp.vec2i],
+    jacobian_cts_offset: wp.array[wp.int32],
+    jacobian_cts_data: wp.array[wp.float32],
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     # Outputs:
-    data_bodies_w_c: wp.array[vec6f],
+    data_bodies_w_c: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -407,7 +409,7 @@ def _compute_contact_cts_body_wrenches_dense(
 
     # Extract the 3D contact force
     # NOTE: We need to scale by the time-step because the lambdas are impulses
-    lambda_c = inv_dt * vec3f(lambdas_data[vio_k], lambdas_data[vio_k + 1], lambdas_data[vio_k + 2])
+    lambda_c = inv_dt * wp.vec3f(lambdas_data[vio_k], lambdas_data[vio_k + 1], lambdas_data[vio_k + 2])
 
     # Extract the contact constraint Jacobian for body B
     JT_c_B = mat63f(0.0)
@@ -443,20 +445,20 @@ def _compute_contact_cts_body_wrenches_dense(
 @wp.kernel
 def _compute_cts_body_wrenches_sparse(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_info_bodies_offset: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    jac_num_nzb: wp.array[int32],
-    jac_nzb_start: wp.array[int32],
-    jac_nzb_coords: wp.array2d[int32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    jac_num_nzb: wp.array[wp.int32],
+    jac_nzb_start: wp.array[wp.int32],
+    jac_nzb_coords: wp.array2d[wp.int32],
     jac_nzb_values: wp.array[vec6f],
-    lambdas_offsets: wp.array[int32],
-    lambdas_data: wp.array[float32],
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     # Outputs:
-    data_bodies_w_j_i: wp.array[vec6f],
-    data_bodies_w_l_i: wp.array[vec6f],
-    data_bodies_w_c_i: wp.array[vec6f],
+    data_bodies_w_j_i: wp.array[wp.spatial_vectorf],
+    data_bodies_w_l_i: wp.array[wp.spatial_vectorf],
+    data_bodies_w_c_i: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the world and non-zero
     # block indices from the thread grid
@@ -608,8 +610,8 @@ def compute_constraint_body_wrenches_dense(
     model: ModelKamino,
     data: DataKamino,
     jacobians: DenseSystemJacobians,
-    lambdas_offsets: wp.array,
-    lambdas_data: wp.array,
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     limits: LimitsKamino | None = None,
     contacts: ContactsKamino | None = None,
     reset_to_zero: bool = True,
@@ -709,8 +711,8 @@ def compute_constraint_body_wrenches_sparse(
     model: ModelKamino,
     data: DataKamino,
     jacobians: SparseSystemJacobians,
-    lambdas_offsets: wp.array,
-    lambdas_data: wp.array,
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     reset_to_zero: bool = True,
 ):
     """
@@ -757,8 +759,8 @@ def compute_constraint_body_wrenches(
     model: ModelKamino,
     data: DataKamino,
     jacobians: DenseSystemJacobians | SparseSystemJacobians,
-    lambdas_offsets: wp.array,
-    lambdas_data: wp.array,
+    lambdas_offsets: wp.array[wp.int32],
+    lambdas_data: wp.array[wp.float32],
     limits: LimitsKamino | None = None,
     contacts: ContactsKamino | None = None,
     reset_to_zero: bool = True,

--- a/newton/_src/solvers/kamino/_src/geometry/aggregation.py
+++ b/newton/_src/solvers/kamino/_src/geometry/aggregation.py
@@ -331,7 +331,7 @@ class ContactAggregationData:
 
     body_net_contact_force: wp.array3d[wp.float32] | None = None
     """
-    Net contact force per body (world frame).\n
+    Net contact force per body (world frame).
     Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
@@ -343,7 +343,7 @@ class ContactAggregationData:
 
     body_static_contact_flag: wp.array2d[wp.int32] | None = None
     """
-    Static contact flag per body (contact with static geoms, 0 or 1).\n
+    Static contact flag per body (contact with static geoms, 0 or 1).
     Shape `(num_worlds, max_bodies_per_world)`.
     """
 
@@ -351,7 +351,7 @@ class ContactAggregationData:
 
     geom_net_contact_force: wp.array3d[wp.float32] | None = None
     """
-    Net contact force per geometry (world frame).\n
+    Net contact force per geometry (world frame).
     Shape `(num_worlds, max_geoms_per_world, 3)`.
     """
 
@@ -365,19 +365,19 @@ class ContactAggregationData:
 
     body_contact_position: wp.array3d[wp.float32] | None = None
     """
-    Average contact position per body (world frame).\n
+    Average contact position per body (world frame).
     Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
     body_contact_normal: wp.array3d[wp.float32] | None = None
     """
-    Average contact normal per body (world frame).\n
+    Average contact normal per body (world frame).
     Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
     body_num_contacts: wp.array2d[wp.int32] | None = None
     """
-    Number of contacts per body.\n
+    Number of contacts per body.
     Shape `(num_worlds, max_bodies_per_world)`.
     """
 
@@ -385,7 +385,7 @@ class ContactAggregationData:
 
     body_pair_contact_flag: wp.array[wp.int32] | None = None
     """
-    Per-world flag indicating contact between a specific body pair (0 or 1).\n
+    Per-world flag indicating contact between a specific body pair (0 or 1).
     Shape `(num_worlds,)`.
     """
 
@@ -535,7 +535,7 @@ class ContactAggregation:
 
         Args:
             skip_if_no_contacts:
-                If True, check for zero contacts and return early.\n
+                If True, check for zero contacts and return early.
                 Set to False when using CUDA graphs to avoid GPU-to-CPU copies.
         """
 

--- a/newton/_src/solvers/kamino/_src/geometry/aggregation.py
+++ b/newton/_src/solvers/kamino/_src/geometry/aggregation.py
@@ -9,12 +9,13 @@ ContactsKaminoData into per-body and per-geom summaries suitable for RL observat
 The aggregation is performed on GPU using efficient atomic operations.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import warp as wp
 
 from ..core.model import ModelKamino
-from ..core.types import int32, quatf, vec2i, vec3f
 from .contacts import ContactMode, ContactsKamino
 
 ###
@@ -41,16 +42,16 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _aggregate_contact_force_per_body(
     # Inputs:
-    model_info_bodies_start: wp.array[int32],  # Per-world bodies start index
-    model_active_contacts: wp.array[int32],  # contacts over all worlds
-    contact_wid: wp.array[int32],  # world index per contact
-    contact_bid_AB: wp.array[vec2i],  # body pair per contact (global body indices)
-    contact_reaction: wp.array[vec3f],  # force in local contact frame
-    contact_frame: wp.array[quatf],  # contact frame (rotation quaternion)
-    contact_mode: wp.array[int32],  # contact mode
+    model_info_bodies_start: wp.array[wp.int32],  # Per-world bodies start index
+    model_active_contacts: wp.array[wp.int32],  # contacts over all worlds
+    contact_wid: wp.array[wp.int32],  # world index per contact
+    contact_bid_AB: wp.array[wp.vec2i],  # body pair per contact (global body indices)
+    contact_reaction: wp.array[wp.vec3f],  # force in local contact frame
+    contact_frame: wp.array[wp.quatf],  # contact frame (rotation quaternion)
+    contact_mode: wp.array[wp.int32],  # contact mode
     # Outputs:
     body_net_force: wp.array3d[wp.float32],  # [num_worlds, max_bodies, 3]
-    body_contact_flag: wp.array2d[int32],  # [num_worlds, max_bodies]
+    body_contact_flag: wp.array2d[wp.int32],  # [num_worlds, max_bodies]
 ):
     """
     Aggregate contact force and flags per body across all contacts.
@@ -103,25 +104,25 @@ def _aggregate_contact_force_per_body(
         body_A_in_world = global_body_A - bodies_start  # Convert to per-world index
         for i in range(3):
             wp.atomic_add(body_net_force, world_idx, body_A_in_world, i, -force_world[i])
-        wp.atomic_max(body_contact_flag, world_idx, body_A_in_world, int32(1))
+        wp.atomic_max(body_contact_flag, world_idx, body_A_in_world, wp.int32(1))
 
     if global_body_B >= 0:
         body_B_in_world = global_body_B - bodies_start  # Convert to per-world index
         for i in range(3):
             wp.atomic_add(body_net_force, world_idx, body_B_in_world, i, force_world[i])
-        wp.atomic_max(body_contact_flag, world_idx, body_B_in_world, int32(1))
+        wp.atomic_max(body_contact_flag, world_idx, body_B_in_world, wp.int32(1))
 
 
 @wp.kernel
 def _aggregate_static_contact_flag_per_body(
     # Inputs:
-    model_info_bodies_start: wp.array[int32],  # Per-world bodies start index
-    model_active_contacts: wp.array[int32],  # contacts over all worlds
-    contact_wid: wp.array[int32],  # world index per contact
-    contact_bid_AB: wp.array[vec2i],  # body pair per contact (global body indices)
-    contact_mode: wp.array[int32],  # contact mode
+    model_info_bodies_start: wp.array[wp.int32],  # Per-world bodies start index
+    model_active_contacts: wp.array[wp.int32],  # contacts over all worlds
+    contact_wid: wp.array[wp.int32],  # world index per contact
+    contact_bid_AB: wp.array[wp.vec2i],  # body pair per contact (global body indices)
+    contact_mode: wp.array[wp.int32],  # contact mode
     # Outputs:
-    static_contact_flag: wp.array2d[int32],  # [num_worlds, max_bodies]
+    static_contact_flag: wp.array2d[wp.int32],  # [num_worlds, max_bodies]
 ):
     """
     Identify which bodies are in contact with static geometries.
@@ -164,27 +165,27 @@ def _aggregate_static_contact_flag_per_body(
     if global_body_B < 0 and global_body_A >= 0:
         # Body A is in contact with static (geom B)
         body_A_in_world = global_body_A - bodies_start
-        wp.atomic_max(static_contact_flag, world_idx, body_A_in_world, int32(1))
+        wp.atomic_max(static_contact_flag, world_idx, body_A_in_world, wp.int32(1))
     if global_body_A < 0 and global_body_B >= 0:
         # Body B is in contact with static (geom A)
         body_B_in_world = global_body_B - bodies_start
-        wp.atomic_max(static_contact_flag, world_idx, body_B_in_world, int32(1))
+        wp.atomic_max(static_contact_flag, world_idx, body_B_in_world, wp.int32(1))
 
 
 @wp.kernel
 def _aggregate_contact_force_per_body_geom(
     # Inputs:
-    model_info_geoms_start: wp.array[int32],  # Offset to convert global geom ID to per-world index
-    model_active_contacts: wp.array[int32],  # contacts over all worlds
-    contact_wid: wp.array[int32],  # world index per contact
-    contact_gid_AB: wp.array[vec2i],  # geometry pair per contact
-    contact_bid_AB: wp.array[vec2i],  # geometry pair per contact
-    contact_reaction: wp.array[vec3f],  # force in local contact frame
-    contact_frame: wp.array[quatf],  # contact frame (rotation quaternion)
-    contact_mode: wp.array[int32],  # contact mode
+    model_info_geoms_start: wp.array[wp.int32],  # Offset to convert global geom ID to per-world index
+    model_active_contacts: wp.array[wp.int32],  # contacts over all worlds
+    contact_wid: wp.array[wp.int32],  # world index per contact
+    contact_gid_AB: wp.array[wp.vec2i],  # geometry pair per contact
+    contact_bid_AB: wp.array[wp.vec2i],  # geometry pair per contact
+    contact_reaction: wp.array[wp.vec3f],  # force in local contact frame
+    contact_frame: wp.array[wp.quatf],  # contact frame (rotation quaternion)
+    contact_mode: wp.array[wp.int32],  # contact mode
     # Outputs:
     geom_net_force: wp.array3d[wp.float32],  # [num_worlds, max_geoms, 3]
-    geom_contact_flag: wp.array2d[int32],  # [num_worlds, max_geoms]
+    geom_contact_flag: wp.array2d[wp.int32],  # [num_worlds, max_geoms]
 ):
     """
     Aggregate contact force and flags per geometry across all contacts.
@@ -237,29 +238,29 @@ def _aggregate_contact_force_per_body_geom(
         world_geom_A = global_geom_A - world_geom_start  # Convert to per-world index
         for i in range(3):
             wp.atomic_add(geom_net_force, world_idx, world_geom_A, i, force_world[i])
-        wp.atomic_max(geom_contact_flag, world_idx, world_geom_A, int32(1))
+        wp.atomic_max(geom_contact_flag, world_idx, world_geom_A, wp.int32(1))
     if global_body_B >= 0:
         world_geom_B = global_geom_B - world_geom_start  # Convert to per-world index
         for i in range(3):
             wp.atomic_add(geom_net_force, world_idx, world_geom_B, i, force_world[i])
-        wp.atomic_max(geom_contact_flag, world_idx, world_geom_B, int32(1))
+        wp.atomic_max(geom_contact_flag, world_idx, world_geom_B, wp.int32(1))
 
 
 @wp.kernel
 def _aggregate_body_pair_contact_flag_per_world(
     # Input: Kamino ContactsData
-    wid: wp.array[int32],  # world index per contact
-    bid_AB: wp.array[vec2i],  # body pair per contact (global body indices)
-    mode: wp.array[int32],  # contact mode
-    world_active_contacts: wp.array[int32],  # contacts per world
+    wid: wp.array[wp.int32],  # world index per contact
+    bid_AB: wp.array[wp.vec2i],  # body pair per contact (global body indices)
+    mode: wp.array[wp.int32],  # contact mode
+    world_active_contacts: wp.array[wp.int32],  # contacts per world
     # Model data for global to per-world body ID conversion
-    model_body_bid: wp.array[int32],  # Per-world body ID for each global body
+    model_body_bid: wp.array[wp.int32],  # Per-world body ID for each global body
     num_worlds: int,
     # Target body pair (per-world body indices)
     target_body_a: int,
     target_body_b: int,
     # Output
-    body_pair_contact_flag: wp.array[int32],  # [num_worlds]
+    body_pair_contact_flag: wp.array[wp.int32],  # [num_worlds]
 ):
     """
     Detect contact between a specific pair of bodies across all worlds.
@@ -281,7 +282,7 @@ def _aggregate_body_pair_contact_flag_per_world(
     contact_idx = wp.tid()
 
     # Calculate total active contacts across all worlds
-    total_contacts = int32(0)
+    total_contacts = wp.int32(0)
     for w in range(num_worlds):
         total_contacts += world_active_contacts[w]
 
@@ -311,7 +312,7 @@ def _aggregate_body_pair_contact_flag_per_world(
     if (body_A_in_world == target_body_a and body_B_in_world == target_body_b) or (
         body_A_in_world == target_body_b and body_B_in_world == target_body_a
     ):
-        wp.atomic_max(body_pair_contact_flag, world_idx, int32(1))
+        wp.atomic_max(body_pair_contact_flag, world_idx, wp.int32(1))
 
 
 ###
@@ -328,64 +329,64 @@ class ContactAggregationData:
 
     # === Per-Body Aggregated Data (for RL interface) ===
 
-    body_net_contact_force: wp.array | None = None
+    body_net_contact_force: wp.array3d[wp.float32] | None = None
     """
     Net contact force per body (world frame).\n
-    Shape `(num_worlds, max_bodies_per_world)` and dtype=:class:`vec3f`.
+    Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
-    body_contact_flag: wp.array | None = None
+    body_contact_flag: wp.array2d[wp.int32] | None = None
     """
-    Binary contact flag per body (any contact).
-    Shape `(num_worlds, max_bodies_per_world)` and dtype=:class:`int32` (0 or 1).
+    Binary contact flag per body (any contact, 0 or 1).
+    Shape `(num_worlds, max_bodies_per_world)`.
     """
 
-    body_static_contact_flag: wp.array | None = None
+    body_static_contact_flag: wp.array2d[wp.int32] | None = None
     """
-    Static contact flag per body (contact with static geoms).\n
-    Shape `(num_worlds, max_bodies_per_world)` and dtype=:class:`int32` (0 or 1).
+    Static contact flag per body (contact with static geoms, 0 or 1).\n
+    Shape `(num_worlds, max_bodies_per_world)`.
     """
 
     # === Per-Geom Detailed Data (for advanced RL) ===
 
-    geom_net_contact_force: wp.array | None = None
+    geom_net_contact_force: wp.array3d[wp.float32] | None = None
     """
     Net contact force per geometry (world frame).\n
-    Shape `(num_worlds, max_geoms_per_world, 3)` and dtype=:class:`float32`.
+    Shape `(num_worlds, max_geoms_per_world, 3)`.
     """
 
-    geom_contact_flag: wp.array | None = None
+    geom_contact_flag: wp.array2d[wp.int32] | None = None
     """
-    Contact flags per geometry.
-    Shape `(num_worlds, max_geoms_per_world)` and dtype=:class:`int32` (0 or 1).
+    Contact flags per geometry (0 or 1).
+    Shape `(num_worlds, max_geoms_per_world)`.
     """
 
     # === Contact Position/Normal Data (optional, for visualization) ===
 
-    body_contact_position: wp.array | None = None
+    body_contact_position: wp.array3d[wp.float32] | None = None
     """
     Average contact position per body (world frame).\n
-    Shape `(num_worlds, max_bodies_per_world, 3)` and dtype=:class:`float32`.
+    Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
-    body_contact_normal: wp.array | None = None
+    body_contact_normal: wp.array3d[wp.float32] | None = None
     """
     Average contact normal per body (world frame).\n
-    Shape `(num_worlds, max_bodies_per_world, 3)` and dtype=:class:`float32`.
+    Shape `(num_worlds, max_bodies_per_world, 3)`.
     """
 
-    body_num_contacts: wp.array | None = None
+    body_num_contacts: wp.array2d[wp.int32] | None = None
     """
     Number of contacts per body.\n
-    Shape `(num_worlds, max_bodies_per_world)` and dtype=:class:`int32`.
+    Shape `(num_worlds, max_bodies_per_world)`.
     """
 
     # === Body-Pair Contact Detection ===
 
-    body_pair_contact_flag: wp.array | None = None
+    body_pair_contact_flag: wp.array[wp.int32] | None = None
     """
-    Per-world flag indicating contact between a specific body pair.\n
-    Shape `(num_worlds,)` and dtype=:class:`int32` (0 or 1).
+    Per-world flag indicating contact between a specific body pair (0 or 1).\n
+    Shape `(num_worlds,)`.
     """
 
 
@@ -420,14 +421,11 @@ class ContactAggregation:
         """Initialize contact aggregation.
 
         Args:
-            model (ModelKamino | None):
-                The model container describing the system to be simulated.
+            model: The model container describing the system to be simulated.
                 If None, call ``finalize()`` later.
-            contacts (ContactsKamino | None):
-                The contacts container with per-contact data.
+            contacts: The contacts container with per-contact data.
                 If None, call ``finalize()`` later.
-            enable_positions_normals:
-                Whether to compute average contact positions and normals per body.
+            enable_positions_normals: Whether to compute average contact positions and normals per body.
         """
         # Declare the device cache
         self._device: wp.DeviceLike = None
@@ -451,32 +449,32 @@ class ContactAggregation:
     ###
 
     @property
-    def body_net_force(self) -> wp.array:
+    def body_net_force(self) -> wp.array3d[wp.float32]:
         """Net force per body [num_worlds, max_bodies, 3]"""
         return self._data.body_net_contact_force
 
     @property
-    def body_contact_flag(self) -> wp.array:
+    def body_contact_flag(self) -> wp.array2d[wp.int32]:
         """Contact flags per body [num_worlds, max_bodies]"""
         return self._data.body_contact_flag
 
     @property
-    def body_static_contact_flag(self) -> wp.array:
+    def body_static_contact_flag(self) -> wp.array2d[wp.int32]:
         """Static contact flag per body [num_worlds, max_bodies]"""
         return self._data.body_static_contact_flag
 
     @property
-    def geom_net_force(self) -> wp.array:
+    def geom_net_force(self) -> wp.array3d[wp.float32]:
         """Net force per geom [num_worlds, max_geoms, 3]"""
         return self._data.geom_net_contact_force
 
     @property
-    def geom_contact_flag(self) -> wp.array:
+    def geom_contact_flag(self) -> wp.array2d[wp.int32]:
         """Contact flags per geom [num_worlds, max_geoms]"""
         return self._data.geom_contact_flag
 
     @property
-    def body_pair_contact_flag(self) -> wp.array:
+    def body_pair_contact_flag(self) -> wp.array[wp.int32]:
         """Per-world body-pair contact flag [num_worlds]."""
         return self._data.body_pair_contact_flag
 
@@ -493,8 +491,9 @@ class ContactAggregation:
         """Finalizes memory allocations for the contact aggregation data.
 
         Args:
-            model (ModelKamino): The model container describing the system to be simulated.
-            contacts (ContactsKamino): The contacts container with per-contact data.
+            model: The model container describing the system to be simulated.
+            contacts: The contacts container with per-contact data.
+            enable_positions_normals: Whether to compute average contact positions and normals per body.
         """
         # Use the model's device
         self._device = model.device

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -37,13 +37,7 @@ from .....sim.state import State
 from ..core.math import COS_PI_6, UNIT_X, UNIT_Y
 from ..core.model import ModelKamino
 from ..core.types import (
-    int32,
-    quatf,
     to_warp_int32_array,
-    vec2f,
-    vec2i,
-    vec3f,
-    vec4f,
 )
 from ..utils import logger as msg
 from .keying import build_pair_key2
@@ -170,10 +164,10 @@ class ContactMode(IntEnum):
             Computes the discrete contact mode based on the contact velocity.
 
             Args:
-                v (vec3f): The contact velocity expressed in the local contact frame.
+                v: The contact velocity expressed in the local contact frame.
 
             Returns:
-                int32: The discrete contact mode as an integer value.
+                The discrete contact mode as an integer value.
             """
             # Decompose the velocity into the normal and tangential components
             v_N = v.z
@@ -221,61 +215,61 @@ class ContactsKaminoData:
     model_max_contacts: wp.array[wp.int32] | None = None
     """
     The number of contacts pre-allocated across all worlds in the model.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
     model_active_contacts: wp.array[wp.int32] | None = None
     """
     The number of active contacts detected across all worlds in the model.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
     world_max_contacts: wp.array[wp.int32] | None = None
     """
     The maximum number of contacts pre-allocated for each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
     world_active_contacts: wp.array[wp.int32] | None = None
     """
     The number of active contacts detected in each world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
     wid: wp.array[wp.int32] | None = None
     """
     The world index of each active contact.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     cid: wp.array[wp.int32] | None = None
     """
     The contact index of each active contact w.r.t its world.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     gid_AB: wp.array[wp.vec2i] | None = None
     """
     The geometry indices of the geometry-pair AB associated with each active contact.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec2i`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     bid_AB: wp.array[wp.vec2i] | None = None
     """
     The body indices of the body-pair AB associated with each active contact.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec2i`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     position_A: wp.array[wp.vec3f] | None = None
     """
     The position of each active contact on the associated body-A in world coordinates.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     position_B: wp.array[wp.vec3f] | None = None
     """
     The position of each active contact on the associated body-B in world coordinates.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     gapfunc: wp.array[wp.vec4f] | None = None
@@ -284,25 +278,25 @@ class ContactsKaminoData:
     The ``w`` component stores the signed distance between margin-shifted surfaces:
     negative means penetration past the resting separation, positive means separation
     within the detection gap.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec4f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     frame: wp.array[wp.quatf] | None = None
     """
     The coordinate frame of each active contact as a rotation quaternion w.r.t the world.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`quatf`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     material: wp.array[wp.vec2f] | None = None
     """
     The material properties of each active contact with format `(0: friction, 1: restitution)`.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec2f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     margins: wp.array[wp.vec2f] | None = None
     """
     The shape-pair margins of each active contact.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec2f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     key: wp.array[wp.uint64] | None = None
@@ -313,21 +307,21 @@ class ContactsKaminoData:
     - the triangle index
     - shape-specific topological data
     - contact index w.r.t the geom-pair\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`uint64`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     reaction: wp.array[wp.vec3f] | None = None
     """
     The 3D contact reaction (force/impulse) expressed in the respective local contact frame.\n
     This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     velocity: wp.array[wp.vec3f] | None = None
     """
     The 3D contact velocity expressed in the respective local contact frame.\n
     This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     mode: wp.array[wp.int32] | None = None
@@ -335,13 +329,13 @@ class ContactsKaminoData:
     The discrete contact mode expressed as an integer value.\n
     The possible values correspond to those of the :class:`ContactMode`.\n
     This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_contacts_host,)``.
     """
 
     remap: wp.array[wp.int32] | None = None
     """
     Per-contact mapping back to the source contact index when converted from Newton :class:`Contacts`.\n
-    Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_contacts_host,)``.
 
     Populated by :func:`convert_contacts_newton_to_kamino` so that each Kamino
     contact knows which original Newton contact it was generated from; entries
@@ -488,7 +482,7 @@ class ContactsKamino:
         Sets the default maximum number of contacts per world.
 
         Args:
-            max_contacts (int): The maximum number of contacts per world.
+            max_contacts: The maximum number of contacts per world.
         """
         if max_contacts < 0:
             raise ValueError("max_contacts must be a non-negative integer")
@@ -531,7 +525,7 @@ class ContactsKamino:
     def model_max_contacts(self) -> wp.array[wp.int32]:
         """
         Returns the maximum number contacts pre-allocated across all worlds in the model.\n
-        Shape of ``(1,)`` and type :class:`int32`.
+        Shape of ``(1,)``.
         """
         self._assert_has_data()
         return self._data.model_max_contacts
@@ -540,7 +534,7 @@ class ContactsKamino:
     def model_active_contacts(self) -> wp.array[wp.int32]:
         """
         Returns the number of active contacts detected across all worlds in the model.\n
-        Shape of ``(1,)`` and type :class:`int32`.
+        Shape of ``(1,)``.
         """
         self._assert_has_data()
         return self._data.model_active_contacts
@@ -549,7 +543,7 @@ class ContactsKamino:
     def world_max_contacts(self) -> wp.array[wp.int32]:
         """
         Returns the maximum number of contacts pre-allocated for each world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.
+        Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
         return self._data.world_max_contacts
@@ -558,7 +552,7 @@ class ContactsKamino:
     def world_active_contacts(self) -> wp.array[wp.int32]:
         """
         Returns the number of active contacts detected in each world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.
+        Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
         return self._data.world_active_contacts
@@ -567,7 +561,7 @@ class ContactsKamino:
     def wid(self) -> wp.array[wp.int32]:
         """
         Returns the world index of each active contact.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.wid
@@ -576,7 +570,7 @@ class ContactsKamino:
     def cid(self) -> wp.array[wp.int32]:
         """
         Returns the contact index of each active contact w.r.t its world.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.cid
@@ -585,7 +579,7 @@ class ContactsKamino:
     def gid_AB(self) -> wp.array[wp.vec2i]:
         """
         Returns the geometry indices of the geometry-pair AB associated with each active contact.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec2i`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.gid_AB
@@ -594,7 +588,7 @@ class ContactsKamino:
     def bid_AB(self) -> wp.array[wp.vec2i]:
         """
         Returns the body indices of the body-pair AB associated with each active contact.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec2i`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.bid_AB
@@ -603,7 +597,7 @@ class ContactsKamino:
     def position_A(self) -> wp.array[wp.vec3f]:
         """
         Returns the position of each active contact on the associated body-A in world coordinates.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.position_A
@@ -612,7 +606,7 @@ class ContactsKamino:
     def position_B(self) -> wp.array[wp.vec3f]:
         """
         Returns the position of each active contact on the associated body-B in world coordinates.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.position_B
@@ -621,7 +615,7 @@ class ContactsKamino:
     def gapfunc(self) -> wp.array[wp.vec4f]:
         """
         Returns the gap-function of each active contact, packed as``(xyz: normal, w: distance)``.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec4f`.
+        Shape of ``(model_max_contacts_host,)``.
 
         The ``w`` component stores the signed ``distance`` between margin-shifted surfaces:
         - ``w < 0`` means penetration past the resting separation defined by the margin
@@ -634,7 +628,7 @@ class ContactsKamino:
     def frame(self) -> wp.array[wp.quatf]:
         """
         Returns the coordinate frame of each active contact as a rotation quaternion w.r.t the world.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`quatf`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.frame
@@ -643,7 +637,7 @@ class ContactsKamino:
     def material(self) -> wp.array[wp.vec2f]:
         """
         Returns the material properties of each active contact with format `(0: friction, 1: restitution)`.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec2f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.material
@@ -652,7 +646,7 @@ class ContactsKamino:
     def margins(self) -> wp.array[wp.vec2f]:
         """
         Returns the effective shape-pair margins of each active contact.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec2f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.margins
@@ -666,7 +660,7 @@ class ContactsKamino:
         - the triangle index
         - shape-specific topological data
         - contact index w.r.t the geom-pair\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`uint64`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.key
@@ -676,7 +670,7 @@ class ContactsKamino:
         """
         Returns the 3D contact reaction (force/impulse) expressed in the respective local contact frame.\n
         This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.reaction
@@ -686,7 +680,7 @@ class ContactsKamino:
         """
         Returns the 3D contact velocity expressed in the respective local contact frame.\n
         This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`vec3f`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.velocity
@@ -697,7 +691,7 @@ class ContactsKamino:
         Returns the discrete contact mode expressed as an integer value.\n
         The possible values correspond to those of the :class:`ContactMode`.\n
         This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
-        Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.mode
@@ -706,7 +700,7 @@ class ContactsKamino:
     def remap(self) -> wp.array[wp.int32] | None:
         """
         Returns the remapped contact index of each active contact.
-        Shape of ``(model_max_contacts_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
         return self._data.remap
@@ -804,18 +798,18 @@ class ContactsKamino:
                 model_max_contacts_host=model_max_contacts,
                 world_max_contacts_host=world_max_contacts,
                 model_max_contacts=to_warp_int32_array([model_max_contacts]),
-                model_active_contacts=wp.zeros(shape=1, dtype=int32),
+                model_active_contacts=wp.zeros(shape=1, dtype=wp.int32),
                 world_max_contacts=to_warp_int32_array(world_max_contacts),
-                world_active_contacts=wp.zeros(shape=len(world_max_contacts), dtype=int32),
-                wid=wp.full(value=-1, shape=(model_max_contacts,), dtype=int32),
-                cid=wp.full(value=-1, shape=(model_max_contacts,), dtype=int32),
-                gid_AB=wp.full(value=vec2i(-1, -1), shape=(model_max_contacts,), dtype=vec2i),
-                bid_AB=wp.full(value=vec2i(-1, -1), shape=(model_max_contacts,), dtype=vec2i),
-                position_A=wp.zeros(shape=(model_max_contacts,), dtype=vec3f),
-                position_B=wp.zeros(shape=(model_max_contacts,), dtype=vec3f),
-                gapfunc=wp.zeros(shape=(model_max_contacts,), dtype=vec4f),
-                frame=wp.zeros(shape=(model_max_contacts,), dtype=quatf),
-                material=wp.zeros(shape=(model_max_contacts,), dtype=vec2f),
+                world_active_contacts=wp.zeros(shape=len(world_max_contacts), dtype=wp.int32),
+                wid=wp.full(value=-1, shape=(model_max_contacts,), dtype=wp.int32),
+                cid=wp.full(value=-1, shape=(model_max_contacts,), dtype=wp.int32),
+                gid_AB=wp.full(value=wp.vec2i(-1, -1), shape=(model_max_contacts,), dtype=wp.vec2i),
+                bid_AB=wp.full(value=wp.vec2i(-1, -1), shape=(model_max_contacts,), dtype=wp.vec2i),
+                position_A=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec3f),
+                position_B=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec3f),
+                gapfunc=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec4f),
+                frame=wp.zeros(shape=(model_max_contacts,), dtype=wp.quatf),
+                material=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec2f),
                 margins=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec2f),
                 key=wp.zeros(shape=(model_max_contacts,), dtype=wp.uint64),
                 reaction=wp.zeros(shape=(model_max_contacts,), dtype=wp.vec3f),

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -74,39 +74,39 @@ wp.set_module_options({"enable_backward": False})
 
 DEFAULT_MODEL_MAX_CONTACTS: int = 1000
 """
-The global default for maximum number of contacts per model.\n
-Used when allocating contact data without a specified capacity.\n
+The global default for maximum number of contacts per model.
+Used when allocating contact data without a specified capacity.
 Set to `1000`.
 """
 
 DEFAULT_WORLD_MAX_CONTACTS: int = 128
 """
-The global default for maximum number of contacts per world.\n
-Used when allocating contact data without a specified capacity.\n
+The global default for maximum number of contacts per world.
+Used when allocating contact data without a specified capacity.
 Set to `128`.
 """
 
 DEFAULT_GEOM_PAIR_MAX_CONTACTS: int = 12
 """
-The global default for maximum number of contacts per geom-pair.\n
-Used when allocating contact data without a specified capacity.\n
-Ignored for mesh-based collisions.\n
+The global default for maximum number of contacts per geom-pair.
+Used when allocating contact data without a specified capacity.
+Ignored for mesh-based collisions.
 Set to `12` (with box-box collisions being a prototypical case).
 """
 
 DEFAULT_TRIANGLE_MAX_PAIRS: int = 1_000_000
 """
-The global default for maximum number of triangle pairs to consider in the narrow-phase.\n
-Used only when the model contains triangle meshes or heightfields.\n
+The global default for maximum number of triangle pairs to consider in the narrow-phase.
+Used only when the model contains triangle meshes or heightfields.
 Defaults to `1_000_000`.
 """
 
 DEFAULT_GEOM_PAIR_CONTACT_GAP: float = 1e-5
 """
-The global default for the per-geometry detection gap [m].\n
+The global default for the per-geometry detection gap [m].
 Applied as a floor to each per-geometry gap value during pipeline
 initialization so that every geometry has at least this detection
-threshold.\n
+threshold.
 Set to `1e-5`.
 """
 
@@ -202,139 +202,139 @@ class ContactsKaminoData:
 
     model_max_contacts_host: int = 0
     """
-    Host-side cache of the maximum number of contacts allocated across all worlds.\n
+    Host-side cache of the maximum number of contacts allocated across all worlds.
     Intended for managing data allocations and setting thread sizes in kernels.
     """
 
     world_max_contacts_host: list[int] = field(default_factory=_default_num_world_max_contacts)
     """
-    Host-side cache of the maximum number of contacts allocated per world.\n
+    Host-side cache of the maximum number of contacts allocated per world.
     Intended for managing data allocations and setting thread sizes in kernels.
     """
 
     model_max_contacts: wp.array[wp.int32] | None = None
     """
-    The number of contacts pre-allocated across all worlds in the model.\n
+    The number of contacts pre-allocated across all worlds in the model.
     Shape of ``(1,)``.
     """
 
     model_active_contacts: wp.array[wp.int32] | None = None
     """
-    The number of active contacts detected across all worlds in the model.\n
+    The number of active contacts detected across all worlds in the model.
     Shape of ``(1,)``.
     """
 
     world_max_contacts: wp.array[wp.int32] | None = None
     """
-    The maximum number of contacts pre-allocated for each world.\n
+    The maximum number of contacts pre-allocated for each world.
     Shape of ``(num_worlds,)``.
     """
 
     world_active_contacts: wp.array[wp.int32] | None = None
     """
-    The number of active contacts detected in each world.\n
+    The number of active contacts detected in each world.
     Shape of ``(num_worlds,)``.
     """
 
     wid: wp.array[wp.int32] | None = None
     """
-    The world index of each active contact.\n
+    The world index of each active contact.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     cid: wp.array[wp.int32] | None = None
     """
-    The contact index of each active contact w.r.t its world.\n
+    The contact index of each active contact w.r.t its world.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     gid_AB: wp.array[wp.vec2i] | None = None
     """
-    The geometry indices of the geometry-pair AB associated with each active contact.\n
+    The geometry indices of the geometry-pair AB associated with each active contact.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     bid_AB: wp.array[wp.vec2i] | None = None
     """
-    The body indices of the body-pair AB associated with each active contact.\n
+    The body indices of the body-pair AB associated with each active contact.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     position_A: wp.array[wp.vec3f] | None = None
     """
-    The position of each active contact on the associated body-A in world coordinates.\n
+    The position of each active contact on the associated body-A in world coordinates.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     position_B: wp.array[wp.vec3f] | None = None
     """
-    The position of each active contact on the associated body-B in world coordinates.\n
+    The position of each active contact on the associated body-B in world coordinates.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     gapfunc: wp.array[wp.vec4f] | None = None
     """
-    Gap-function of each active contact, format ``(xyz: normal, w: signed_distance)``.\n
+    Gap-function of each active contact, format ``(xyz: normal, w: signed_distance)``.
     The ``w`` component stores the signed distance between margin-shifted surfaces:
     negative means penetration past the resting separation, positive means separation
-    within the detection gap.\n
+    within the detection gap.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     frame: wp.array[wp.quatf] | None = None
     """
-    The coordinate frame of each active contact as a rotation quaternion w.r.t the world.\n
+    The coordinate frame of each active contact as a rotation quaternion w.r.t the world.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     material: wp.array[wp.vec2f] | None = None
     """
-    The material properties of each active contact with format `(0: friction, 1: restitution)`.\n
+    The material properties of each active contact with format `(0: friction, 1: restitution)`.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     margins: wp.array[wp.vec2f] | None = None
     """
-    The shape-pair margins of each active contact.\n
+    The shape-pair margins of each active contact.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     key: wp.array[wp.uint64] | None = None
     """
-    Integer key uniquely identifying each active contact.\n
+    Integer key uniquely identifying each active contact.
     The per-contact key assignment is implementation-dependent, but is typically
     computed from the A/B geom-pair index as well as additional information such as:
     - the triangle index
     - shape-specific topological data
-    - contact index w.r.t the geom-pair\n
+    - contact index w.r.t the geom-pair
     Shape of ``(model_max_contacts_host,)``.
     """
 
     reaction: wp.array[wp.vec3f] | None = None
     """
-    The 3D contact reaction (force/impulse) expressed in the respective local contact frame.\n
-    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+    The 3D contact reaction (force/impulse) expressed in the respective local contact frame.
+    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     velocity: wp.array[wp.vec3f] | None = None
     """
-    The 3D contact velocity expressed in the respective local contact frame.\n
-    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+    The 3D contact velocity expressed in the respective local contact frame.
+    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     mode: wp.array[wp.int32] | None = None
     """
-    The discrete contact mode expressed as an integer value.\n
-    The possible values correspond to those of the :class:`ContactMode`.\n
-    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+    The discrete contact mode expressed as an integer value.
+    The possible values correspond to those of the :class:`ContactMode`.
+    This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
     Shape of ``(model_max_contacts_host,)``.
     """
 
     remap: wp.array[wp.int32] | None = None
     """
-    Per-contact mapping back to the source contact index when converted from Newton :class:`Contacts`.\n
+    Per-contact mapping back to the source contact index when converted from Newton :class:`Contacts`.
     Shape of ``(model_max_contacts_host,)``.
 
     Populated by :func:`convert_contacts_newton_to_kamino` so that each Kamino
@@ -427,19 +427,19 @@ class ContactsKamino:
 
         Args:
             model:
-                The model container holding the time-invariant data of the system being simulated.\n
+                The model container holding the time-invariant data of the system being simulated.
                 If provided, the contacts will be finalized using the contact allocation meta-data of the model.
-                Cannot be specified together with `capacity`.\n
+                Cannot be specified together with `capacity`.
                 If `None``, and `capacity` is also `None`, the contacts will be created empty without
                 allocating data, and can be finalized later by providing model/capacity to `finalize`.
             capacity:
-                The maximum number of contacts to allocate if no model is provided.\n
+                The maximum number of contacts to allocate if no model is provided.
                 If an integer is provided, it specifies the capacity for a single world.
                 If a list of integers is provided, it specifies the capacity for each world.
                 Cannot be specified together with `model`.
             default_max_contacts:
                 The default maximum number of contacts per world, if no model and no positive capacity
-                are provided.\n
+                are provided.
                 If `None`, uses the default value of 128.
             device:
                 The device on which to allocate the contacts data.
@@ -471,7 +471,7 @@ class ContactsKamino:
     @property
     def default_max_world_contacts(self) -> int:
         """
-        Returns the default maximum number of contacts per world.\n
+        Returns the default maximum number of contacts per world.
         This value is used when the capacity at allocation-time is unspecified or equals 0.
         """
         return self._default_max_world_contacts
@@ -506,7 +506,7 @@ class ContactsKamino:
     @property
     def model_max_contacts_host(self) -> int:
         """
-        Returns the host-side cache of the maximum number of contacts allocated across all worlds.\n
+        Returns the host-side cache of the maximum number of contacts allocated across all worlds.
         Intended for managing data allocations and setting thread sizes in kernels.
         """
         self._assert_has_data()
@@ -515,7 +515,7 @@ class ContactsKamino:
     @property
     def world_max_contacts_host(self) -> list[int]:
         """
-        Returns the host-side cache of the maximum number of contacts allocated per world.\n
+        Returns the host-side cache of the maximum number of contacts allocated per world.
         Intended for managing data allocations and setting thread sizes in kernels.
         """
         self._assert_has_data()
@@ -524,7 +524,7 @@ class ContactsKamino:
     @property
     def model_max_contacts(self) -> wp.array[wp.int32]:
         """
-        Returns the maximum number contacts pre-allocated across all worlds in the model.\n
+        Returns the maximum number contacts pre-allocated across all worlds in the model.
         Shape of ``(1,)``.
         """
         self._assert_has_data()
@@ -533,7 +533,7 @@ class ContactsKamino:
     @property
     def model_active_contacts(self) -> wp.array[wp.int32]:
         """
-        Returns the number of active contacts detected across all worlds in the model.\n
+        Returns the number of active contacts detected across all worlds in the model.
         Shape of ``(1,)``.
         """
         self._assert_has_data()
@@ -542,7 +542,7 @@ class ContactsKamino:
     @property
     def world_max_contacts(self) -> wp.array[wp.int32]:
         """
-        Returns the maximum number of contacts pre-allocated for each world.\n
+        Returns the maximum number of contacts pre-allocated for each world.
         Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
@@ -551,7 +551,7 @@ class ContactsKamino:
     @property
     def world_active_contacts(self) -> wp.array[wp.int32]:
         """
-        Returns the number of active contacts detected in each world.\n
+        Returns the number of active contacts detected in each world.
         Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
@@ -560,7 +560,7 @@ class ContactsKamino:
     @property
     def wid(self) -> wp.array[wp.int32]:
         """
-        Returns the world index of each active contact.\n
+        Returns the world index of each active contact.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -569,7 +569,7 @@ class ContactsKamino:
     @property
     def cid(self) -> wp.array[wp.int32]:
         """
-        Returns the contact index of each active contact w.r.t its world.\n
+        Returns the contact index of each active contact w.r.t its world.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -578,7 +578,7 @@ class ContactsKamino:
     @property
     def gid_AB(self) -> wp.array[wp.vec2i]:
         """
-        Returns the geometry indices of the geometry-pair AB associated with each active contact.\n
+        Returns the geometry indices of the geometry-pair AB associated with each active contact.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -587,7 +587,7 @@ class ContactsKamino:
     @property
     def bid_AB(self) -> wp.array[wp.vec2i]:
         """
-        Returns the body indices of the body-pair AB associated with each active contact.\n
+        Returns the body indices of the body-pair AB associated with each active contact.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -596,7 +596,7 @@ class ContactsKamino:
     @property
     def position_A(self) -> wp.array[wp.vec3f]:
         """
-        Returns the position of each active contact on the associated body-A in world coordinates.\n
+        Returns the position of each active contact on the associated body-A in world coordinates.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -605,7 +605,7 @@ class ContactsKamino:
     @property
     def position_B(self) -> wp.array[wp.vec3f]:
         """
-        Returns the position of each active contact on the associated body-B in world coordinates.\n
+        Returns the position of each active contact on the associated body-B in world coordinates.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -614,7 +614,7 @@ class ContactsKamino:
     @property
     def gapfunc(self) -> wp.array[wp.vec4f]:
         """
-        Returns the gap-function of each active contact, packed as``(xyz: normal, w: distance)``.\n
+        Returns the gap-function of each active contact, packed as``(xyz: normal, w: distance)``.
         Shape of ``(model_max_contacts_host,)``.
 
         The ``w`` component stores the signed ``distance`` between margin-shifted surfaces:
@@ -627,7 +627,7 @@ class ContactsKamino:
     @property
     def frame(self) -> wp.array[wp.quatf]:
         """
-        Returns the coordinate frame of each active contact as a rotation quaternion w.r.t the world.\n
+        Returns the coordinate frame of each active contact as a rotation quaternion w.r.t the world.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -636,7 +636,7 @@ class ContactsKamino:
     @property
     def material(self) -> wp.array[wp.vec2f]:
         """
-        Returns the material properties of each active contact with format `(0: friction, 1: restitution)`.\n
+        Returns the material properties of each active contact with format `(0: friction, 1: restitution)`.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -645,7 +645,7 @@ class ContactsKamino:
     @property
     def margins(self) -> wp.array[wp.vec2f]:
         """
-        Returns the effective shape-pair margins of each active contact.\n
+        Returns the effective shape-pair margins of each active contact.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -654,12 +654,12 @@ class ContactsKamino:
     @property
     def key(self) -> wp.array[wp.uint64]:
         """
-        Returns the integer key uniquely identifying each active contact.\n
+        Returns the integer key uniquely identifying each active contact.
         The per-contact key assignment is implementation-dependent, but is typically
         computed from the A/B geom-pair index as well as additional information such as:
         - the triangle index
         - shape-specific topological data
-        - contact index w.r.t the geom-pair\n
+        - contact index w.r.t the geom-pair
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -668,8 +668,8 @@ class ContactsKamino:
     @property
     def reaction(self) -> wp.array[wp.vec3f]:
         """
-        Returns the 3D contact reaction (force/impulse) expressed in the respective local contact frame.\n
-        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+        Returns the 3D contact reaction (force/impulse) expressed in the respective local contact frame.
+        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -678,8 +678,8 @@ class ContactsKamino:
     @property
     def velocity(self) -> wp.array[wp.vec3f]:
         """
-        Returns the 3D contact velocity expressed in the respective local contact frame.\n
-        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+        Returns the 3D contact velocity expressed in the respective local contact frame.
+        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -688,9 +688,9 @@ class ContactsKamino:
     @property
     def mode(self) -> wp.array[wp.int32]:
         """
-        Returns the discrete contact mode expressed as an integer value.\n
-        The possible values correspond to those of the :class:`ContactMode`.\n
-        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.\n
+        Returns the discrete contact mode expressed as an integer value.
+        The possible values correspond to those of the :class:`ContactMode`.
+        This is to be set by solvers at each step, and also facilitates contact visualization and warm-starting.
         Shape of ``(model_max_contacts_host,)``.
         """
         self._assert_has_data()
@@ -721,11 +721,11 @@ class ContactsKamino:
 
         Args:
             model:
-                The model container holding the time-invariant data of the system being simulated.\n
+                The model container holding the time-invariant data of the system being simulated.
                 If provided, the contacts will be finalized using the contact allocation meta-data of the model.
                 Cannot be specified together with `capacity`.
             capacity:
-                The maximum number of contacts to allocate if no model is provided.\n
+                The maximum number of contacts to allocate if no model is provided.
                 If an integer is provided, it specifies the capacity for a single world.
                 If a list of integers is provided, it specifies the capacity for each world.
                 Cannot be specified together with `model`.
@@ -1293,7 +1293,7 @@ def convert_contacts_newton_to_kamino(
         contacts_out:
             The output :class:`ContactsKamino` object to populate with the converted contact data.
         convert_forces:
-            If ``True``, also convert ``contacts_in.force`` into``contacts_out.reaction``.\n
+            If ``True``, also convert ``contacts_in.force`` into``contacts_out.reaction``.
             If ``False`` or ``contacts_in.force`` is missing, ``contacts_out.reaction`` is left untouched.
     """
     # Skip conversion if there are no contacts to convert or no capacity to store them.

--- a/newton/_src/solvers/kamino/_src/geometry/detector.py
+++ b/newton/_src/solvers/kamino/_src/geometry/detector.py
@@ -190,11 +190,11 @@ class CollisionDetector:
         Initialize the CollisionDetector.
 
         Args:
-            model: The model container holding the time-invariant data of the system being simulated.\n
-                If provided, the detector will be finalized using the provided model and config.\n
+            model: The model container holding the time-invariant data of the system being simulated.
+                If provided, the detector will be finalized using the provided model and config.
                 If `None`, the detector will be created empty without allocating data, and
-                can be finalized later by providing a model to the `finalize` method.\n
-            config: Config for the CollisionDetector.\n
+                can be finalized later by providing a model to the `finalize` method.
+            config: Config for the CollisionDetector.
                 If `None`, uses default config.
         """
         # Declare the device cache
@@ -269,11 +269,11 @@ class CollisionDetector:
         Allocates CollisionDetector data on the target device.
 
         Args:
-            model: The model container holding the time-invariant data of the system being simulated.\n
-                If provided, the detector will be finalized using the provided model and config.\n
+            model: The model container holding the time-invariant data of the system being simulated.
+                If provided, the detector will be finalized using the provided model and config.
                 If `None`, the detector will be created empty without allocating data, and
-                can be finalized later by providing a model to the `finalize` method.\n
-            config: Config for the CollisionDetector.\n
+                can be finalized later by providing a model to the `finalize` method.
+            config: Config for the CollisionDetector.
                 If `None`, uses default config.
         """
         # Override the model if specified explicitly

--- a/newton/_src/solvers/kamino/_src/geometry/detector.py
+++ b/newton/_src/solvers/kamino/_src/geometry/detector.py
@@ -190,12 +190,12 @@ class CollisionDetector:
         Initialize the CollisionDetector.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container holding the time-invariant data of the system being simulated.\n
+            model: The model container holding the time-invariant data of the system being simulated.\n
                 If provided, the detector will be finalized using the provided model and config.\n
                 If `None`, the detector will be created empty without allocating data, and
                 can be finalized later by providing a model to the `finalize` method.\n
-
+            config: Config for the CollisionDetector.\n
+                If `None`, uses default config.
         """
         # Declare the device cache
         self._device: wp.DeviceLike = None
@@ -269,13 +269,11 @@ class CollisionDetector:
         Allocates CollisionDetector data on the target device.
 
         Args:
-            model (ModelKamino, optional):
-                The model container holding the time-invariant data of the system being simulated.\n
+            model: The model container holding the time-invariant data of the system being simulated.\n
                 If provided, the detector will be finalized using the provided model and config.\n
                 If `None`, the detector will be created empty without allocating data, and
                 can be finalized later by providing a model to the `finalize` method.\n
-            config (CollisionDetector.Config, optional):
-                Config for the CollisionDetector.\n
+            config: Config for the CollisionDetector.\n
                 If `None`, uses default config.
         """
         # Override the model if specified explicitly
@@ -371,12 +369,9 @@ class CollisionDetector:
         the configuration set during the initialization of the CollisionDetector.
 
         Args:
-            data (DataKamino):
-                The solver data container holding solver-specific internal geome/shape data.
-            state (StateKamino):
-                The state container holding the time-varying state of simulation.
-            contacts (ContactsKamino, optional):
-                An optional ContactsKamino container to store the generated contacts.
+            data: The solver data container holding solver-specific internal geome/shape data.
+            state: The state container holding the time-varying state of simulation.
+            contacts: An optional ContactsKamino container to store the generated contacts.
                 If `None`, uses the internal ContactsKamino container managed by the CollisionDetector.
         """
         # If no contacts can be generated, skip collision detection

--- a/newton/_src/solvers/kamino/_src/geometry/keying.py
+++ b/newton/_src/solvers/kamino/_src/geometry/keying.py
@@ -338,7 +338,7 @@ class KeySorter:
         """Returns the sorted-to-unsorted index map array."""
         return self._sorted_to_unsorted_map
 
-    def sort(self, num_active_keys: wp.array[wp.int32], keys: wp.array[wp.int32]):
+    def sort(self, num_active_keys: wp.array[wp.int32], keys: wp.array[wp.uint64]):
         """
         Sorts the provided keys using radix sort.
 

--- a/newton/_src/solvers/kamino/_src/geometry/keying.py
+++ b/newton/_src/solvers/kamino/_src/geometry/keying.py
@@ -7,9 +7,9 @@ Provides functions for generating and searching for unique keys for pairs and tr
 TODO: Add more detailed description and documentation.
 """
 
-import warp as wp
+from __future__ import annotations
 
-from ..core.types import int32, int64, uint32, uint64, vec2i
+import warp as wp
 
 ###
 # Module interface
@@ -44,10 +44,10 @@ def make_bitmask(num_bits: int) -> int:
         num_bits=23 -> 0x00000000007FFFFF
 
     Args:
-        num_bits (int): Number of bits to set in the mask.
+        num_bits: Number of bits to set in the mask.
 
     Returns:
-        int: Bitmask with the specified number of lower bits set to `1`.
+        Bitmask with the specified number of lower bits set to `1`.
     """
     # Ensure the number of bits is valid
     if num_bits <= 0 or num_bits > 64:
@@ -63,16 +63,16 @@ def make_bitmask(num_bits: int) -> int:
 def build_pair_key2(index_A: wp.uint32, index_B: wp.uint32) -> wp.uint64:
     """
     Build a 63-bit key from two indices with the following layout:
-    - The highest bit is always `0`, reserved as a sign bit to support conversion to signed int64.
+    - The highest bit is always `0`, reserved as a sign bit to support conversion to signed wp.int64.
     - Upper 31 bits: lower 31 bits of index_A
     - Lower 32 bits: all 32 bits of index_B
 
     Args:
-        index_A (wp.uint32): First index.
-        index_B (wp.uint32): Second index.
+        index_A: First index.
+        index_B: Second index.
 
     Returns:
-        wp.uint64: Combined 64-bit key.
+        Combined 64-bit key.
     """
     key = wp.uint64(index_A & wp.uint32(wp.static(make_bitmask(31))))
     key = key << wp.uint64(32)
@@ -83,7 +83,7 @@ def build_pair_key2(index_A: wp.uint32, index_B: wp.uint32) -> wp.uint64:
 def make_build_pair_key3_func(main_key_bits: int, aux_key_bits: int | None = None):
     """
     Generates a function that builds a 63-bit key from three indices with the following layout:
-    - The highest bit is always `0`, reserved as a sign bit to support conversion to signed int64.
+    - The highest bit is always `0`, reserved as a sign bit to support conversion to signed wp.int64.
     - Upper `main_key_bits` bits: lower `main_key_bits` bits of index_A
     - Middle `main_key_bits` bits: lower `main_key_bits` bits of index_B
     - Lower `aux_key_bits` bits: lower `aux_key_bits` bits of index_C
@@ -92,12 +92,12 @@ def make_build_pair_key3_func(main_key_bits: int, aux_key_bits: int | None = Non
     - The total number of bits used is `2 * main_key_bits + aux_key_bits`, which must be less than or equal to 63.
 
     Args:
-        main_key_bits (int): Number of bits to allocate for index_A and index_B.
-        aux_key_bits (int, optional): Number of bits to allocate for index_C.
+        main_key_bits: Number of bits to allocate for index_A and index_B.
+        aux_key_bits: Number of bits to allocate for index_C.
             If `None`, it will be set to `63 - 2 * main_key_bits`.
 
     Returns:
-        function: A Warp function that takes three `wp.uint32` indices and returns a combined `wp.uint64` key.
+        A Warp function that takes three `wp.uint32` indices and returns a combined `wp.uint64` key.
     """
     # Ensure the number of bits is valid
     if main_key_bits <= 0 or main_key_bits > 32:
@@ -117,7 +117,7 @@ def make_build_pair_key3_func(main_key_bits: int, aux_key_bits: int | None = Non
 
     # Define the function
     @wp.func
-    def _build_pair_key3(index_A: uint32, index_B: uint32, index_C: uint32) -> uint64:
+    def _build_pair_key3(index_A: wp.uint32, index_B: wp.uint32, index_C: wp.uint32) -> wp.uint64:
         key = wp.uint64(index_A & wp.uint32(MAIN_BITMASK))
         key = key << wp.uint64(main_key_bits)
         key = key | wp.uint64(index_B & wp.uint32(MAIN_BITMASK))
@@ -131,10 +131,10 @@ def make_build_pair_key3_func(main_key_bits: int, aux_key_bits: int | None = Non
 
 @wp.func
 def binary_search_find_pair(
-    num_pairs: int32,
-    target: vec2i,
-    pairs: wp.array[vec2i],
-) -> int32:
+    num_pairs: wp.int32,
+    target: wp.vec2i,
+    pairs: wp.array[wp.vec2i],
+) -> wp.int32:
     """
     Performs binary-search over a sorted array of pairs to find the index of a target pair.
 
@@ -142,15 +142,15 @@ def binary_search_find_pair(
     order, i.e. first by the first element, then by the second.
 
     Args:
-        num_pairs (int32): Number of "active" pairs in the array.\n
+        num_pairs: Number of "active" pairs in the array.\n
             This is required because not all elements may be active.
-        target (vec2i): The target pair to search for.
-        pairs (wp.array[vec2i]): Sorted array of pairs to search within.
+        target: The target pair to search for.
+        pairs: Sorted array of pairs to search within.
 
     Returns:
         Index of the target pair if found, otherwise `-1`.
     """
-    lower = int32(0)
+    lower = wp.int32(0)
     upper = num_pairs
     while lower < upper:
         mid = (lower + upper) >> 1
@@ -169,11 +169,11 @@ def binary_search_find_pair(
 
 @wp.func
 def binary_search_find_range_start(
-    lower: int32,
-    upper: int32,
-    target: uint64,
-    keys: wp.array[uint64],
-) -> int32:
+    lower: wp.int32,
+    upper: wp.int32,
+    target: wp.uint64,
+    keys: wp.array[wp.uint64],
+) -> wp.int32:
     """
     Performs binary-search over a sorted array of integer keys
     to find the start index of the first occurrence of target.
@@ -181,10 +181,10 @@ def binary_search_find_range_start(
     Assumes that keys are sorted in ascending order.
 
     Args:
-        lower (wp.int32): Lower bound index for the search (inclusive).
-        upper (wp.int32): Upper bound index for the search (exclusive).
-        target (wp.uint64): The target key to search for.
-        keys (wp.array[wp.uint64]): Sorted array of keys to search within.
+        lower: Lower bound index for the search (inclusive).
+        upper: Upper bound index for the search (exclusive).
+        target: The target key to search for.
+        keys: Sorted array of keys to search within.
 
     Returns:
         Index of the first occurrence of target if found, otherwise `-1`.
@@ -227,10 +227,10 @@ def _prepare_key_sort(
     Prepares keys and sorting-maps for radix sort.
 
     Args:
-        num_active_keys (wp.array[wp.int32]): Number of active keys to copy
-        keys_source (wp.array[wp.uint64]): Source array of keys
-        keys (wp.array[wp.uint64]): Destination array of keys for sorting
-        sorted_to_unsorted_map (wp.array[wp.int32]): Map from sorted indices to original unsorted indices
+        num_active_keys: Number of active keys to copy.
+        keys_source: Source array of keys.
+        keys: Destination array of keys for sorting.
+        sorted_to_unsorted_map: Map from sorted indices to original unsorted indices.
     """
     # Retrieve the thread index
     tid = wp.tid()
@@ -241,7 +241,7 @@ def _prepare_key_sort(
         sorted_to_unsorted_map[tid] = tid
 
     # Otherwise fill unused slots with the sentinel value
-    # NOTE: This ensures that these entries sort to the end when treated as signed int64
+    # NOTE: This ensures that these entries sort to the end when treated as signed wp.int64
     else:
         # keys[tid] = wp.static(make_bitmask(63))
         keys[tid] = uint64_sentinel_value()
@@ -253,23 +253,19 @@ def _prepare_key_sort(
 
 
 def prepare_key_sort(
-    num_active: wp.array,
-    unsorted: wp.array,
-    sorted: wp.array,
-    sorted_to_unsorted_map: wp.array,
+    num_active: wp.array[wp.int32],
+    unsorted: wp.array[wp.uint64],
+    sorted: wp.array[wp.uint64],
+    sorted_to_unsorted_map: wp.array[wp.int32],
 ):
     """
     Prepares keys and sorting-maps for radix sort.
 
     Args:
-        num_active (wp.array):
-            An array containing the number of active keys to be sorted.
-        unsorted (wp.array):
-            The source array of keys to be sorted.
-        sorted (wp.array):
-            The destination array where sorted keys will be stored.
-        sorted_to_unsorted_map (wp.array):
-            An array of index-mappings from sorted to source key indices
+        num_active: An array containing the number of active keys to be sorted.
+        unsorted: The source array of keys to be sorted.
+        sorted: The destination array where sorted keys will be stored.
+        sorted_to_unsorted_map: An array of index-mappings from sorted to source key indices.
     """
     wp.launch(
         kernel=_prepare_key_sort,
@@ -294,8 +290,8 @@ class KeySorter:
         Creates a KeySorter instance to sort keys using radix sort.
 
         Args:
-            max_num_keys (int): Maximum number of keys to sort.
-            device (wp.DeviceLike, optional): Device to allocate buffers on (None for default).
+            max_num_keys: Maximum number of keys to sort.
+            device: Device to allocate buffers on (None for default).
         """
         # Declare and initialize the maximum number of keys
         # NOTE: This is used set dimensions of all kernel launches
@@ -309,16 +305,16 @@ class KeySorter:
         # NOTE: Allocations are multiplied by a factor of
         # 2 as required by the Warp radix sort algorithm
         with wp.ScopedDevice(device):
-            self._sorted_keys = wp.zeros(2 * self._max_num_keys, dtype=uint64)
-            self._sorted_to_unsorted_map = wp.zeros(2 * self._max_num_keys, dtype=int32)
+            self._sorted_keys = wp.zeros(2 * self._max_num_keys, dtype=wp.uint64)
+            self._sorted_to_unsorted_map = wp.zeros(2 * self._max_num_keys, dtype=wp.int32)
 
-        # Define a view of the sorted keys as int64
+        # Define a view of the sorted keys as wp.int64
         # NOTE: This required in order to use Warp's radix_sort_pairs, which only supports signed integers
         self._sorted_keys_int64 = wp.array(
             ptr=self._sorted_keys.ptr,
             shape=self._sorted_keys.shape,
             device=self._sorted_keys.device,
-            dtype=int64,
+            dtype=wp.int64,
             copy=False,
         )
 
@@ -328,27 +324,27 @@ class KeySorter:
         return self._device
 
     @property
-    def sorted_keys(self) -> wp.array:
+    def sorted_keys(self) -> wp.array[wp.uint64]:
         """Returns the sorted keys array."""
         return self._sorted_keys
 
     @property
-    def sorted_keys_int64(self) -> wp.array:
-        """Returns the sorted keys array as an int64 view."""
+    def sorted_keys_int64(self) -> wp.array[wp.int64]:
+        """Returns the sorted keys array as an wp.int64 view."""
         return self._sorted_keys_int64
 
     @property
-    def sorted_to_unsorted_map(self) -> wp.array:
+    def sorted_to_unsorted_map(self) -> wp.array[wp.int32]:
         """Returns the sorted-to-unsorted index map array."""
         return self._sorted_to_unsorted_map
 
-    def sort(self, num_active_keys: wp.array, keys: wp.array):
+    def sort(self, num_active_keys: wp.array[wp.int32], keys: wp.array[wp.int32]):
         """
         Sorts the provided keys using radix sort.
 
         Args:
-            num_active_keys (wp.array[int32]): Number of active keys to sort.
-            keys (wp.array[uint64]): The source keys to be sorted.
+            num_active_keys: Number of active keys to sort.
+            keys: The source keys to be sorted.
         """
         # Check compatibility of input sizes
         if num_active_keys.device != self._device:

--- a/newton/_src/solvers/kamino/_src/geometry/keying.py
+++ b/newton/_src/solvers/kamino/_src/geometry/keying.py
@@ -142,7 +142,7 @@ def binary_search_find_pair(
     order, i.e. first by the first element, then by the second.
 
     Args:
-        num_pairs: Number of "active" pairs in the array.\n
+        num_pairs: Number of "active" pairs in the array.
             This is required because not all elements may be active.
         target: The target pair to search for.
         pairs: Sorted array of pairs to search within.

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
@@ -13,9 +13,10 @@ from enum import IntEnum
 
 import warp as wp
 
+from ......core.types import override
 from ......geometry.types import GeoType
 from ...core.geometry import GeometriesData, GeometriesModel
-from ...core.types import float32, int32, override, transformf, vec2i, vec3f, vec6f, vec8f
+from ...core.types import vec6f, vec8f
 
 ###
 # Module interface
@@ -96,24 +97,22 @@ class BoundingVolumesData:
     and Bounding Spheres (BS), and allocations are conditioned on the broad-phase algorithm used.
 
     Attributes:
-        aabb (wp.array | None):
-            The vertices of the Axis-Aligned Bounding Box (AABB) of each collision geometry.\n
-            Shape of ``(sum_of_num_geoms,)`` and type :class:`mat83f`.
-        radius (wp.array | None):
-            The radius of the Bounding Sphere (BS) of each collision geometry.\n
-            Shape of ``(sum_of_num_geoms,)`` and type :class:`float32`.
+        aabb: The vertices of the Axis-Aligned Bounding Box (AABB) of each collision geometry.\n
+            Shape of ``(sum_of_num_geoms,)``.
+        radius: The radius of the Bounding Sphere (BS) of each collision geometry.\n
+            Shape of ``(sum_of_num_geoms,)``.
     """
 
-    aabb: wp.array | None = None
+    aabb: wp.array[vec6f] | None = None
     """
     The min/max extents of the Axis-Aligned Bounding Box (AABB) of each collision geometry.\n
-    Shape of ``(sum_of_num_geoms,)`` and type :class:`vec6f`.
+    Shape of ``(sum_of_num_geoms,)``.
     """
 
-    radius: wp.array | None = None
+    radius: wp.array[wp.float32] | None = None
     """
     The radius of the Bounding Sphere (BS) of each collision geometry.\n
-    Shape of ``(sum_of_num_geoms,)`` and type :class:`float32`.
+    Shape of ``(sum_of_num_geoms,)``.
     """
 
 
@@ -134,28 +133,28 @@ class CollisionCandidatesModel:
     num_world_geom_pairs: list[int] = field(default_factory=_default_world_geom_pairs)
     """(host-side) Number of collision pairs per world."""
 
-    model_num_pairs: wp.array | None = None
+    model_num_pairs: wp.array[wp.int32] | None = None
     """
     Total number of collisions pairs in the model.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
-    world_num_pairs: wp.array | None = None
+    world_num_pairs: wp.array[wp.int32] | None = None
     """
     The number of collisions pairs per world.
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     World index of each collision pair.\n
-    Shape of ``(sum_of_num_candidate_pairs,)`` and type :class:`int32`.
+    Shape of ``(sum_of_num_candidate_pairs,)``.
     """
 
-    geom_pair: wp.array | None = None
+    geom_pair: wp.array[wp.vec2i] | None = None
     """
     Geometry indices of each collision pair.\n
-    Shape of ``(sum_of_num_candidate_pairs,)`` and type :class:`vec2i`.
+    Shape of ``(sum_of_num_candidate_pairs,)``.
     """
 
 
@@ -170,28 +169,28 @@ class CollisionCandidatesData:
     num_model_geom_pairs: int = 0
     """(host-side) Total number of candidate collision pairs in the model across all worlds."""
 
-    model_num_collisions: wp.array | None = None
+    model_num_collisions: wp.array[wp.int32] | None = None
     """
     Number of collisions detected across all worlds in the model.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
-    world_num_collisions: wp.array | None = None
+    world_num_collisions: wp.array[wp.int32] | None = None
     """
     Number of collisions detected per world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     World index of each active collision pair.\n
-    Shape of ``(num_geom_pairs,)`` and type :class:`int32`.
+    Shape of ``(num_geom_pairs,)``.
     """
 
-    geom_pair: wp.array | None = None
+    geom_pair: wp.array[wp.vec2i] | None = None
     """
     Geometry indices of each active collision pair.\n
-    Shape of ``(num_geom_pairs,)`` and type :class:`vec2i`.
+    Shape of ``(num_geom_pairs,)``.
     """
 
     def clear(self):
@@ -216,55 +215,55 @@ class CollisionCandidatesData:
 
 
 @wp.func
-def bs_sphere(radius: float32) -> float32:
+def bs_sphere(radius: wp.float32) -> wp.float32:
     return radius
 
 
 @wp.func
-def bs_cylinder(radius: float32, half_height: float32) -> float32:
+def bs_cylinder(radius: wp.float32, half_height: wp.float32) -> wp.float32:
     return wp.sqrt(half_height * half_height + radius * radius)
 
 
 @wp.func
-def bs_cone(radius: float32, half_height: float32) -> float32:
+def bs_cone(radius: wp.float32, half_height: wp.float32) -> wp.float32:
     return wp.sqrt(half_height * half_height + radius * radius)
 
 
 @wp.func
-def bs_capsule(radius: float32, half_height: float32) -> float32:
+def bs_capsule(radius: wp.float32, half_height: wp.float32) -> wp.float32:
     return half_height + radius
 
 
 @wp.func
-def bs_ellipsoid(abc: vec3f) -> float32:
+def bs_ellipsoid(abc: wp.vec3f) -> wp.float32:
     return wp.max(abc[0], wp.max(abc[1], abc[2]))
 
 
 @wp.func
-def bs_box(half_extents: vec3f) -> float32:
+def bs_box(half_extents: wp.vec3f) -> wp.float32:
     hx, hy, hz = half_extents[0], half_extents[1], half_extents[2]
     return wp.sqrt(hx * hx + hy * hy + hz * hz)
 
 
 # TODO: Implement proper BS for planes
 @wp.func
-def bs_plane(normal: vec3f, distance: float32) -> float32:
-    return float32(0.0)
+def bs_plane(normal: wp.vec3f, distance: wp.float32) -> wp.float32:
+    return wp.float32(0.0)
 
 
 @wp.func
-def bs_geom(sid: int32, params: vec3f, margin: float32) -> float32:
+def bs_geom(sid: wp.int32, params: wp.vec3f, margin: wp.float32) -> wp.float32:
     """
     Compute the radius of the Bounding Sphere (BS) of a geometry element.
 
     Args:
-        sid (int32): Shape index of the geometry element.
-        params (vec3f): Shape parameters of the geometry element.
+        sid: Shape index of the geometry element.
+        params: Shape parameters of the geometry element.
 
     Returns:
-        float32: The radius of the BS of the geometry element.
+        The radius of the BS of the geometry element.
     """
-    r = float32(0.0)
+    r = wp.float32(0.0)
     if sid == GeoType.SPHERE:
         r = bs_sphere(params[0] + margin)
     elif sid == GeoType.CYLINDER:
@@ -274,22 +273,25 @@ def bs_geom(sid: int32, params: vec3f, margin: float32) -> float32:
     elif sid == GeoType.CAPSULE:
         r = bs_capsule(params[0] + margin, params[1] + margin)
     elif sid == GeoType.ELLIPSOID:
-        r = bs_ellipsoid(vec3f(params[0] + margin, params[1] + margin, params[2] + margin))
+        r = bs_ellipsoid(wp.vec3f(params[0] + margin, params[1] + margin, params[2] + margin))
     elif sid == GeoType.BOX:
-        r = bs_box(vec3f(params[0] + margin, params[1] + margin, params[2] + margin))
+        r = bs_box(wp.vec3f(params[0] + margin, params[1] + margin, params[2] + margin))
     return r
 
 
 @wp.func
-def has_bs_overlap(pose1: transformf, pose2: transformf, radius1: float32, radius2: float32) -> wp.bool:
+def has_bs_overlap(pose1: wp.transformf, pose2: wp.transformf, radius1: wp.float32, radius2: wp.float32) -> wp.bool:
     """
     Check for overlap between two bounding spheres.
 
     Args:
-        pose1 (transformf): Pose of the first bounding sphere in world coordinates.
-        pose2 (transformf): Pose of the second bounding sphere in world coordinates.
-        radius1 (float32): Radius of the first bounding sphere.
-        radius2 (float32): Radius of the second bounding sphere.
+        pose1: Pose of the first bounding sphere in world coordinates.
+        pose2: Pose of the second bounding sphere in world coordinates.
+        radius1: Radius of the first bounding sphere.
+        radius2: Radius of the second bounding sphere.
+
+    Returns:
+        Whether the bounding spheres overlap.
     """
     position1 = wp.transform_get_translation(pose1)
     position2 = wp.transform_get_translation(pose2)
@@ -303,20 +305,20 @@ def has_bs_overlap(pose1: transformf, pose2: transformf, radius1: float32, radiu
 
 
 @wp.func
-def compute_tight_aabb_from_local_extents(pose: transformf, extents: vec3f, margin: float32) -> vec6f:
+def compute_tight_aabb_from_local_extents(pose: wp.transformf, extents: wp.vec3f, margin: wp.float32) -> vec6f:
     R_g = wp.quat_to_matrix(wp.transform_get_rotation(pose))
     r_g = wp.transform_get_translation(pose)
     dx = extents[0] + margin
     dy = extents[1] + margin
     dz = extents[2] + margin
-    b_v_0 = vec3f(-dx, -dy, -dz)
-    b_v_1 = vec3f(-dx, -dy, dz)
-    b_v_2 = vec3f(-dx, dy, -dz)
-    b_v_3 = vec3f(-dx, dy, dz)
-    b_v_4 = vec3f(dx, -dy, -dz)
-    b_v_5 = vec3f(dx, -dy, dz)
-    b_v_6 = vec3f(dx, dy, -dz)
-    b_v_7 = vec3f(dx, dy, dz)
+    b_v_0 = wp.vec3f(-dx, -dy, -dz)
+    b_v_1 = wp.vec3f(-dx, -dy, dz)
+    b_v_2 = wp.vec3f(-dx, dy, -dz)
+    b_v_3 = wp.vec3f(-dx, dy, dz)
+    b_v_4 = wp.vec3f(dx, -dy, -dz)
+    b_v_5 = wp.vec3f(dx, -dy, dz)
+    b_v_6 = wp.vec3f(dx, dy, -dz)
+    b_v_7 = wp.vec3f(dx, dy, dz)
     w_v_0 = r_g + (R_g @ b_v_0)
     w_v_1 = r_g + (R_g @ b_v_1)
     w_v_2 = r_g + (R_g @ b_v_2)
@@ -336,9 +338,9 @@ def compute_tight_aabb_from_local_extents(pose: transformf, extents: vec3f, marg
 
 
 @wp.func
-def aabb_sphere(pose: transformf, radius: float32, margin: float32) -> vec6f:
+def aabb_sphere(pose: wp.transformf, radius: wp.float32, margin: wp.float32) -> vec6f:
     r_g = wp.transform_get_translation(pose)
-    extents = vec3f(radius + margin, radius + margin, radius + margin)
+    extents = wp.vec3f(radius + margin, radius + margin, radius + margin)
     min = r_g - extents
     max = r_g + extents
     aabb = vec6f(min.x, min.y, min.z, max.x, max.y, max.z)
@@ -346,52 +348,52 @@ def aabb_sphere(pose: transformf, radius: float32, margin: float32) -> vec6f:
 
 
 @wp.func
-def aabb_cylinder(pose: transformf, radius: float32, half_height: float32, margin: float32) -> vec6f:
-    extents = vec3f(radius, radius, half_height)
+def aabb_cylinder(pose: wp.transformf, radius: wp.float32, half_height: wp.float32, margin: wp.float32) -> vec6f:
+    extents = wp.vec3f(radius, radius, half_height)
     return compute_tight_aabb_from_local_extents(pose, extents, margin)
 
 
 @wp.func
-def aabb_cone(pose: transformf, radius: float32, half_height: float32, margin: float32) -> vec6f:
-    extents = vec3f(radius, radius, half_height)
+def aabb_cone(pose: wp.transformf, radius: wp.float32, half_height: wp.float32, margin: wp.float32) -> vec6f:
+    extents = wp.vec3f(radius, radius, half_height)
     return compute_tight_aabb_from_local_extents(pose, extents, margin)
 
 
 @wp.func
-def aabb_capsule(pose: transformf, radius: float32, half_height: float32, margin: float32) -> vec6f:
-    extents = vec3f(radius, radius, half_height + radius)
+def aabb_capsule(pose: wp.transformf, radius: wp.float32, half_height: wp.float32, margin: wp.float32) -> vec6f:
+    extents = wp.vec3f(radius, radius, half_height + radius)
     return compute_tight_aabb_from_local_extents(pose, extents, margin)
 
 
 @wp.func
-def aabb_ellipsoid(pose: transformf, abc: vec3f, margin: float32) -> vec6f:
-    extents = vec3f(abc[0], abc[1], abc[2])
+def aabb_ellipsoid(pose: wp.transformf, abc: wp.vec3f, margin: wp.float32) -> vec6f:
+    extents = wp.vec3f(abc[0], abc[1], abc[2])
     return compute_tight_aabb_from_local_extents(pose, extents, margin)
 
 
 @wp.func
-def aabb_box(pose: transformf, half_extents: vec3f, margin: float32) -> vec6f:
+def aabb_box(pose: wp.transformf, half_extents: wp.vec3f, margin: wp.float32) -> vec6f:
     return compute_tight_aabb_from_local_extents(pose, half_extents, margin)
 
 
 # TODO: Implement proper AABB for planes
 @wp.func
-def aabb_plane(pose: transformf, width: float32, length: float32, margin: float32) -> vec6f:
+def aabb_plane(pose: wp.transformf, width: wp.float32, length: wp.float32, margin: wp.float32) -> vec6f:
     return vec6f(0.0)
 
 
 @wp.func
-def aabb_geom(sid: int32, params: vec3f, margin: float32, pose: transformf) -> vec6f:
+def aabb_geom(sid: wp.int32, params: wp.vec3f, margin: wp.float32, pose: wp.transformf) -> vec6f:
     """
     Compute the Axis-Aligned Bounding Box (AABB) vertices of a geometry element.
 
     Args:
-        pose (transformf): Pose of the geometry element in world coordinates.
-        params (vec3f): Shape parameters of the geometry element.
-        sid (int32): Shape index of the geometry element.
+        pose: Pose of the geometry element in world coordinates.
+        params: Shape parameters of the geometry element.
+        sid: Shape index of the geometry element.
 
     Returns:
-        vec6f: The vertices of the AABB of the geometry element.
+        The vertices of the AABB of the geometry element.
     """
     aabb = vec6f(0.0)
     if sid == GeoType.SPHERE:
@@ -427,18 +429,18 @@ def has_aabb_overlap(aabb1: vec6f, aabb2: vec6f) -> wp.bool:
 @wp.func
 def add_active_pair(
     # Inputs:
-    wid_in: int32,
-    gid1_in: int32,
-    gid2_in: int32,
-    sid1_in: int32,
-    sid2_in: int32,
-    model_num_pairs_in: int32,
-    world_num_pairs_in: int32,
+    wid_in: wp.int32,
+    gid1_in: wp.int32,
+    gid2_in: wp.int32,
+    sid1_in: wp.int32,
+    sid2_in: wp.int32,
+    model_num_pairs_in: wp.int32,
+    world_num_pairs_in: wp.int32,
     # Outputs:
-    model_num_collisions_out: wp.array[int32],
-    world_num_collisions_out: wp.array[int32],
-    collision_wid_out: wp.array[int32],
-    collision_geom_pair_out: wp.array[vec2i],
+    model_num_collisions_out: wp.array[wp.int32],
+    world_num_collisions_out: wp.array[wp.int32],
+    collision_wid_out: wp.array[wp.int32],
+    collision_geom_pair_out: wp.array[wp.vec2i],
 ):
     # Increment the number of collisions detected for
     # the model and world and retrieve the pair indices
@@ -471,16 +473,16 @@ def add_active_pair(
 @wp.kernel
 def _update_geometries_state_and_aabb(
     # Inputs:
-    default_gap: float32,
-    geom_bid: wp.array[int32],
-    geom_sid: wp.array[int32],
-    geom_params: wp.array[vec3f],
-    geom_margin: wp.array[float32],
-    geom_gap: wp.array[float32],
-    geom_offset: wp.array[transformf],
-    body_pose: wp.array[transformf],
+    default_gap: wp.float32,
+    geom_bid: wp.array[wp.int32],
+    geom_sid: wp.array[wp.int32],
+    geom_params: wp.array[wp.vec3f],
+    geom_margin: wp.array[wp.float32],
+    geom_gap: wp.array[wp.float32],
+    geom_offset: wp.array[wp.transformf],
+    body_pose: wp.array[wp.transformf],
     # Outputs:
-    geom_pose: wp.array[transformf],
+    geom_pose: wp.array[wp.transformf],
     geom_aabb: wp.array[vec6f],
 ):
     """
@@ -498,7 +500,7 @@ def _update_geometries_state_and_aabb(
     margin = geom_margin[gid]
     gap = geom_gap[gid]
 
-    X_b = wp.transform_identity(dtype=float32)
+    X_b = wp.transform_identity(dtype=wp.float32)
     if bid > -1:
         X_b = body_pose[bid]
 
@@ -514,17 +516,17 @@ def _update_geometries_state_and_aabb(
 @wp.kernel
 def _update_geometries_state_and_bs(
     # Inputs:
-    default_gap: float32,
-    geom_bid: wp.array[int32],
-    geom_sid: wp.array[int32],
-    geom_params: wp.array[vec3f],
-    geom_margin: wp.array[float32],
-    geom_gap: wp.array[float32],
-    geom_offset: wp.array[transformf],
-    body_pose: wp.array[transformf],
+    default_gap: wp.float32,
+    geom_bid: wp.array[wp.int32],
+    geom_sid: wp.array[wp.int32],
+    geom_params: wp.array[wp.vec3f],
+    geom_margin: wp.array[wp.float32],
+    geom_gap: wp.array[wp.float32],
+    geom_offset: wp.array[wp.transformf],
+    body_pose: wp.array[wp.transformf],
     # Outputs:
-    geom_pose: wp.array[transformf],
-    geom_bs_radius: wp.array[float32],
+    geom_pose: wp.array[wp.transformf],
+    geom_bs_radius: wp.array[wp.float32],
 ):
     """
     Updates the state of each geometry and computes its bounding sphere (BS).
@@ -541,7 +543,7 @@ def _update_geometries_state_and_bs(
     margin = geom_margin[gid]
     gap = geom_gap[gid]
 
-    X_b = wp.transform_identity(dtype=float32)
+    X_b = wp.transform_identity(dtype=wp.float32)
     if bid > -1:
         X_b = body_pose[bid]
 
@@ -557,44 +559,33 @@ def _update_geometries_state_and_bs(
 @wp.kernel
 def _nxn_broadphase_aabb(
     # Inputs:
-    geom_sid: wp.array[int32],
+    geom_sid: wp.array[wp.int32],
     geom_aabb_minmax: wp.array[vec6f],
-    cmodel_model_num_pairs: wp.array[int32],
-    cmodel_world_num_pairs: wp.array[int32],
-    cmodel_wid: wp.array[int32],
-    cmodel_geom_pair: wp.array[vec2i],
+    cmodel_model_num_pairs: wp.array[wp.int32],
+    cmodel_world_num_pairs: wp.array[wp.int32],
+    cmodel_wid: wp.array[wp.int32],
+    cmodel_geom_pair: wp.array[wp.vec2i],
     # Outputs:
-    cdata_model_num_collisions: wp.array[int32],
-    cdata_world_num_collisions: wp.array[int32],
-    cdata_wid: wp.array[int32],
-    cdata_geom_pair: wp.array[vec2i],
+    cdata_model_num_collisions: wp.array[wp.int32],
+    cdata_world_num_collisions: wp.array[wp.int32],
+    cdata_wid: wp.array[wp.int32],
+    cdata_geom_pair: wp.array[wp.vec2i],
 ):
     """
     A kernel that performs broad-phase collision detection using Axis-Aligned Bounding Boxes (AABB).
 
     Inputs:
-        geom_sid (wp.array[int32]):
-            Shape index for each geometry.
-        geom_aabb_minmax (wp.array[vec6f]):
-            Minimum and maximum coordinates for each geometry's Axis-Aligned Bounding Box (AABB).
-        cmodel_model_num_pairs (wp.array[int32]):
-            Total number of collision pairs in the model.
-        cmodel_world_num_pairs (wp.array[int32]):
-            Number of collision pairs per world.
-        cmodel_wid (wp.array[int32]):
-            World index for each collision pair candidate.
-        cmodel_geom_pair (wp.array[vec2i]):
-            Geometry indices for each collision pair candidate.
-
+        geom_sid: Shape index for each geometry.
+        geom_aabb_minmax: Minimum and maximum coordinates for each geometry's Axis-Aligned Bounding Box (AABB).
+        cmodel_model_num_pairs: Total number of collision pairs in the model.
+        cmodel_world_num_pairs: Number of collision pairs per world.
+        cmodel_wid: World index for each collision pair candidate.
+        cmodel_geom_pair: Geometry indices for each collision pair candidate.
     Outputs:
-        cdata_model_num_collisions (wp.array[int32]):
-            Number of collisions detected across all worlds in the model.
-        cdata_world_num_collisions (wp.array[int32]):
-            Number of collisions detected per world.
-        cdata_wid (wp.array[int32]):
-            World index for each detected collision.
-        cdata_geom_pair (wp.array[vec2i]):
-            Geometry indices for each detected collision.
+        cdata_model_num_collisions: Number of collisions detected across all worlds in the model.
+        cdata_world_num_collisions: Number of collisions detected per world.
+        cdata_wid: World index for each detected collision.
+        cdata_geom_pair: Geometry indices for each detected collision.
     """
     # Retrieve the geom-pair index from the thread grid
     gpid = wp.tid()
@@ -637,47 +628,35 @@ def _nxn_broadphase_aabb(
 @wp.kernel
 def _nxn_broadphase_bs(
     # Inputs:
-    geom_sid: wp.array[int32],
-    geom_pose: wp.array[transformf],
-    geom_bs_radius: wp.array[float32],
-    cmodel_model_num_pairs: wp.array[int32],
-    cmodel_world_num_pairs: wp.array[int32],
-    cmodel_wid: wp.array[int32],
-    cmodel_geom_pair: wp.array[vec2i],
+    geom_sid: wp.array[wp.int32],
+    geom_pose: wp.array[wp.transformf],
+    geom_bs_radius: wp.array[wp.float32],
+    cmodel_model_num_pairs: wp.array[wp.int32],
+    cmodel_world_num_pairs: wp.array[wp.int32],
+    cmodel_wid: wp.array[wp.int32],
+    cmodel_geom_pair: wp.array[wp.vec2i],
     # Outputs:
-    cdata_model_num_collisions: wp.array[int32],
-    cdata_world_num_collisions: wp.array[int32],
-    cdata_wid: wp.array[int32],
-    cdata_geom_pair: wp.array[vec2i],
+    cdata_model_num_collisions: wp.array[wp.int32],
+    cdata_world_num_collisions: wp.array[wp.int32],
+    cdata_wid: wp.array[wp.int32],
+    cdata_geom_pair: wp.array[wp.vec2i],
 ):
     """
     A kernel that performs broad-phase collision detection using bounding spheres (BS).
 
     Inputs:
-        geom_sid (wp.array[int32]):
-            Shape index for each geometry.
-        geom_pose (wp.array[transformf]):
-            Pose of each geometry in world coordinates.
-        geom_bs_radius (wp.array[float32]):
-            Radius of the bounding sphere for each geometry.
-        cmodel_model_num_pairs (wp.array[int32]):
-            Total number of collision pairs in the model.
-        cmodel_world_num_pairs (wp.array[int32]):
-            Number of collision pairs per world.
-        cmodel_wid (wp.array[int32]):
-            World index for each collision pair candidate.
-        cmodel_geom_pair (wp.array[vec2i]):
-            Geometry indices for each collision pair candidate.
-
+        geom_sid: Shape index for each geometry.
+        geom_pose: Pose of each geometry in world coordinates.
+        geom_bs_radius: Radius of the bounding sphere for each geometry.
+        cmodel_model_num_pairs: Total number of collision pairs in the model.
+        cmodel_world_num_pairs: Number of collision pairs per world.
+        cmodel_wid: World index for each collision pair candidate.
+        cmodel_geom_pair: Geometry indices for each collision pair candidate.
     Outputs:
-        cdata_model_num_collisions (wp.array[int32]):
-            Number of collisions detected across all worlds in the model.
-        cdata_world_num_collisions (wp.array[int32]):
-            Number of collisions detected per world.
-        cdata_wid (wp.array[int32]):
-            World index of each active collision pair.
-        cdata_geom_pair (wp.array[vec2i]):
-            Geometry indices for each active collision pair.
+        cdata_model_num_collisions: Number of collisions detected across all worlds in the model.
+        cdata_world_num_collisions: Number of collisions detected per world.
+        cdata_wid: World index of each active collision pair.
+        cdata_geom_pair: Geometry indices for each active collision pair.
     """
     # Retrieve the geom-pair index from the thread grid
     gpid = wp.tid()
@@ -728,7 +707,7 @@ def _nxn_broadphase_bs(
 
 def update_geoms_aabb(
     # Inputs:
-    body_poses: wp.array,
+    body_poses: wp.array[wp.transformf],
     geoms_model: GeometriesModel,
     geoms_data: GeometriesData,
     # Outputs:
@@ -750,7 +729,7 @@ def update_geoms_aabb(
         _update_geometries_state_and_aabb,
         dim=geoms_model.num_geoms,
         inputs=[
-            float32(default_gap) if default_gap is not None else float32(0.0),
+            wp.float32(default_gap) if default_gap is not None else wp.float32(0.0),
             geoms_model.bid,
             geoms_model.type,
             geoms_model.params,
@@ -776,10 +755,10 @@ def nxn_broadphase_aabb(
     Launches a kernel to perform broad-phase collision detection using Axis-Aligned Bounding Boxes (AABB).
 
     Args:
-        geoms_model (CollisionGeometriesModel): Model data for collision geometries.
-        bv_data (BoundingVolumesData): Data for bounding volumes containing Axis-Aligned Bounding Boxes (AABB) vertices.
-        candidates_model (CollisionCandidatesModel): Model data for collision candidates.
-        candidates_data (CollisionCandidatesData): Data for collision candidates.
+        geoms_model: Model data for collision geometries.
+        bv_data: Data for bounding volumes containing Axis-Aligned Bounding Boxes (AABB) vertices.
+        candidates_model: Model data for collision candidates.
+        candidates_data: Data for collision candidates.
     """
     wp.launch(
         _nxn_broadphase_aabb,
@@ -804,7 +783,7 @@ def nxn_broadphase_aabb(
 
 def update_geoms_bs(
     # Inputs:
-    body_poses: wp.array,
+    body_poses: wp.array[wp.transformf],
     geoms_model: GeometriesModel,
     geoms_data: GeometriesData,
     # Outputs:
@@ -826,7 +805,7 @@ def update_geoms_bs(
         _update_geometries_state_and_bs,
         dim=geoms_model.num_geoms,
         inputs=[
-            float32(default_gap) if default_gap is not None else float32(0.0),
+            wp.float32(default_gap) if default_gap is not None else wp.float32(0.0),
             geoms_model.bid,
             geoms_model.type,
             geoms_model.params,
@@ -853,11 +832,11 @@ def nxn_broadphase_bs(
     Launches a kernel to perform broad-phase collision detection using bounding spheres (BS).
 
     Args:
-        geoms_model (CollisionGeometriesModel): Model data for collision geometries.
-        geoms_data (GeometriesData): Data for collision geometries.
-        bv_data (BoundingVolumesData): Data for bounding volumes containing bounding sphere radii.
-        candidates_model (CollisionCandidatesModel): Model data for collision candidates.
-        candidates_data (CollisionCandidatesData): Data for collision candidates.
+        geoms_model: Model data for collision geometries.
+        geoms_data: Data for collision geometries.
+        bv_data: Data for bounding volumes containing bounding sphere radii.
+        candidates_model: Model data for collision candidates.
+        candidates_data: Data for collision candidates.
     """
     wp.launch(
         _nxn_broadphase_bs,
@@ -883,7 +862,7 @@ def nxn_broadphase_bs(
 
 def primitive_broadphase_explicit(
     # Inputs:
-    body_poses: wp.array,
+    body_poses: wp.array[wp.transformf],
     geoms_model: GeometriesModel,
     geoms_data: GeometriesData,
     bv_data: BoundingVolumesData,

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
@@ -97,21 +97,21 @@ class BoundingVolumesData:
     and Bounding Spheres (BS), and allocations are conditioned on the broad-phase algorithm used.
 
     Attributes:
-        aabb: The vertices of the Axis-Aligned Bounding Box (AABB) of each collision geometry.\n
+        aabb: The vertices of the Axis-Aligned Bounding Box (AABB) of each collision geometry.
             Shape of ``(sum_of_num_geoms,)``.
-        radius: The radius of the Bounding Sphere (BS) of each collision geometry.\n
+        radius: The radius of the Bounding Sphere (BS) of each collision geometry.
             Shape of ``(sum_of_num_geoms,)``.
     """
 
     aabb: wp.array[vec6f] | None = None
     """
-    The min/max extents of the Axis-Aligned Bounding Box (AABB) of each collision geometry.\n
+    The min/max extents of the Axis-Aligned Bounding Box (AABB) of each collision geometry.
     Shape of ``(sum_of_num_geoms,)``.
     """
 
     radius: wp.array[wp.float32] | None = None
     """
-    The radius of the Bounding Sphere (BS) of each collision geometry.\n
+    The radius of the Bounding Sphere (BS) of each collision geometry.
     Shape of ``(sum_of_num_geoms,)``.
     """
 
@@ -135,7 +135,7 @@ class CollisionCandidatesModel:
 
     model_num_pairs: wp.array[wp.int32] | None = None
     """
-    Total number of collisions pairs in the model.\n
+    Total number of collisions pairs in the model.
     Shape of ``(1,)``.
     """
 
@@ -147,13 +147,13 @@ class CollisionCandidatesModel:
 
     wid: wp.array[wp.int32] | None = None
     """
-    World index of each collision pair.\n
+    World index of each collision pair.
     Shape of ``(sum_of_num_candidate_pairs,)``.
     """
 
     geom_pair: wp.array[wp.vec2i] | None = None
     """
-    Geometry indices of each collision pair.\n
+    Geometry indices of each collision pair.
     Shape of ``(sum_of_num_candidate_pairs,)``.
     """
 
@@ -171,25 +171,25 @@ class CollisionCandidatesData:
 
     model_num_collisions: wp.array[wp.int32] | None = None
     """
-    Number of collisions detected across all worlds in the model.\n
+    Number of collisions detected across all worlds in the model.
     Shape of ``(1,)``.
     """
 
     world_num_collisions: wp.array[wp.int32] | None = None
     """
-    Number of collisions detected per world.\n
+    Number of collisions detected per world.
     Shape of ``(num_worlds,)``.
     """
 
     wid: wp.array[wp.int32] | None = None
     """
-    World index of each active collision pair.\n
+    World index of each active collision pair.
     Shape of ``(num_geom_pairs,)``.
     """
 
     geom_pair: wp.array[wp.vec2i] | None = None
     """
-    Geometry indices of each active collision pair.\n
+    Geometry indices of each active collision pair.
     Shape of ``(num_geom_pairs,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/narrowphase.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/narrowphase.py
@@ -31,19 +31,6 @@ from ......geometry.types import GeoType
 from ...core.data import DataKamino
 from ...core.materials import make_get_material_pair_properties
 from ...core.model import ModelKamino
-from ...core.types import (
-    float32,
-    int32,
-    mat33f,
-    quatf,
-    transformf,
-    uint32,
-    uint64,
-    vec2f,
-    vec2i,
-    vec3f,
-    vec4f,
-)
 from ...geometry.contacts import ContactsKaminoData, make_contact_frame_znorm
 from ...geometry.keying import build_pair_key2
 from .broadphase import CollisionCandidatesData
@@ -95,78 +82,78 @@ List of primitive shape combinations supported by the primitive narrow-phase col
 
 @wp.struct
 class Box:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    size: vec3f
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    size: wp.vec3f
 
 
 @wp.struct
 class Sphere:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    radius: float32
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    radius: wp.float32
 
 
 @wp.struct
 class Capsule:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    axis: vec3f
-    radius: float32
-    half_length: float32
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    axis: wp.vec3f
+    radius: wp.float32
+    half_length: wp.float32
 
 
 @wp.struct
 class Cylinder:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    axis: vec3f
-    radius: float32
-    half_height: float32
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    axis: wp.vec3f
+    radius: wp.float32
+    half_height: wp.float32
 
 
 @wp.struct
 class Plane:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    normal: vec3f
-    distance: float32
-    width: float32
-    length: float32
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    normal: wp.vec3f
+    distance: wp.float32
+    width: wp.float32
+    length: wp.float32
 
 
 @wp.struct
 class Ellipsoid:
-    gid: int32
-    bid: int32
-    pos: vec3f
-    rot: mat33f
-    size: vec3f
+    gid: wp.int32
+    bid: wp.int32
+    pos: wp.vec3f
+    rot: wp.mat33f
+    size: wp.vec3f
 
 
 @wp.func
-def make_box(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Box:
+def make_box(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Box:
     box = Box()
     box.gid = gid
     box.bid = bid
     box.pos = wp.transform_get_translation(pose)
     box.rot = wp.quat_to_matrix(wp.transform_get_rotation(pose))
-    box.size = vec3f(params[0], params[1], params[2])
+    box.size = wp.vec3f(params[0], params[1], params[2])
     return box
 
 
 @wp.func
-def make_sphere(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Sphere:
+def make_sphere(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Sphere:
     sphere = Sphere()
     sphere.gid = gid
     sphere.bid = bid
@@ -177,7 +164,7 @@ def make_sphere(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Sphe
 
 
 @wp.func
-def make_capsule(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Capsule:
+def make_capsule(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Capsule:
     capsule = Capsule()
     capsule.gid = gid
     capsule.bid = bid
@@ -185,14 +172,14 @@ def make_capsule(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Cap
     rot_mat = wp.quat_to_matrix(wp.transform_get_rotation(pose))
     capsule.rot = rot_mat
     # Capsule axis is along the local Z-axis
-    capsule.axis = vec3f(rot_mat[0, 2], rot_mat[1, 2], rot_mat[2, 2])
+    capsule.axis = wp.vec3f(rot_mat[0, 2], rot_mat[1, 2], rot_mat[2, 2])
     capsule.radius = params[0]
     capsule.half_length = params[1]
     return capsule
 
 
 @wp.func
-def make_cylinder(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Cylinder:
+def make_cylinder(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Cylinder:
     cylinder = Cylinder()
     cylinder.gid = gid
     cylinder.bid = bid
@@ -200,21 +187,21 @@ def make_cylinder(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Cy
     rot_mat = wp.quat_to_matrix(wp.transform_get_rotation(pose))
     cylinder.rot = rot_mat
     # Cylinder axis is along the local Z-axis
-    cylinder.axis = vec3f(rot_mat[0, 2], rot_mat[1, 2], rot_mat[2, 2])
+    cylinder.axis = wp.vec3f(rot_mat[0, 2], rot_mat[1, 2], rot_mat[2, 2])
     cylinder.radius = params[0]
     cylinder.half_height = params[1]
     return cylinder
 
 
 @wp.func
-def make_plane(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Plane:
+def make_plane(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Plane:
     plane = Plane()
     plane.gid = gid
     plane.bid = bid
     plane.pos = wp.transform_get_translation(pose)
     plane.rot = wp.quat_to_matrix(wp.transform_get_rotation(pose))
     # Plane normal is extracted from the rotation matrix (assuming the plane's local Z-axis is the normal)
-    plane.normal = vec3f(plane.rot[0, 2], plane.rot[1, 2], plane.rot[2, 2])
+    plane.normal = wp.vec3f(plane.rot[0, 2], plane.rot[1, 2], plane.rot[2, 2])
     # Plane distance is extracted from the position along the normal direction
     plane.distance = -(plane.pos.x * plane.normal.x + plane.pos.y * plane.normal.y + plane.pos.z * plane.normal.z)
     # Plane dimensions (width and length) stored in params[0:2]
@@ -224,14 +211,14 @@ def make_plane(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Plane
 
 
 @wp.func
-def make_ellipsoid(pose: transformf, params: vec3f, gid: int32, bid: int32) -> Ellipsoid:
+def make_ellipsoid(pose: wp.transformf, params: wp.vec3f, gid: wp.int32, bid: wp.int32) -> Ellipsoid:
     ellipsoid = Ellipsoid()
     ellipsoid.gid = gid
     ellipsoid.bid = bid
     ellipsoid.pos = wp.transform_get_translation(pose)
     ellipsoid.rot = wp.quat_to_matrix(wp.transform_get_rotation(pose))
     # Ellipsoid size (radii) stored in params[0:3]
-    ellipsoid.size = vec3f(params[0], params[1], params[2])
+    ellipsoid.size = wp.vec3f(params[0], params[1], params[2])
     return ellipsoid
 
 
@@ -243,33 +230,33 @@ def make_ellipsoid(pose: transformf, params: vec3f, gid: int32, bid: int32) -> E
 @wp.func
 def add_single_contact(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
-    wid: int32,
-    gid_1: int32,
-    gid_2: int32,
-    bid_1: int32,
-    bid_2: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    distance: float32,
-    position: vec3f,
-    normal: vec3f,
-    friction: float32,
-    restitution: float32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
+    wid: wp.int32,
+    gid_1: wp.int32,
+    gid_2: wp.int32,
+    bid_1: wp.int32,
+    bid_2: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    distance: wp.float32,
+    position: wp.vec3f,
+    normal: wp.vec3f,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Skip if the contact distance exceeds the detection threshold
     if (distance - margin_plus_gap) > 0.0:
@@ -291,12 +278,12 @@ def add_single_contact(
     # and hence body B to be the "effected" body in the contact
     # so we have to ensure that bid_B is always non-negative
     if bid_2 < 0:
-        gid_AB = vec2i(gid_2, gid_1)
-        bid_AB = vec2i(bid_2, bid_1)
+        gid_AB = wp.vec2i(gid_2, gid_1)
+        bid_AB = wp.vec2i(bid_2, bid_1)
         normal = -normal
     else:
-        gid_AB = vec2i(gid_1, gid_2)
-        bid_AB = vec2i(bid_1, bid_2)
+        gid_AB = wp.vec2i(gid_1, gid_2)
+        bid_AB = wp.vec2i(bid_1, bid_2)
 
     # Compute absolute penetration distance
     distance_abs = wp.abs(distance)
@@ -310,10 +297,10 @@ def add_single_contact(
     # past the resting separation, zero means at rest, positive means within
     # the detection gap but not yet at rest.
     d = distance - margin
-    gapfunc = vec4f(normal.x, normal.y, normal.z, d)
+    gapfunc = wp.vec4f(normal.x, normal.y, normal.z, d)
     q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
-    material = vec2f(friction, restitution)
-    key = build_pair_key2(uint32(gid_AB[0]), uint32(gid_AB[1]))
+    material = wp.vec2f(friction, restitution)
+    key = build_pair_key2(wp.uint32(gid_AB[0]), wp.uint32(gid_AB[1]))
 
     # Store the active contact output data
     contact_wid[mcid] = wid
@@ -333,33 +320,33 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
     @wp.func
     def add_multiple_contacts(
         # Inputs:
-        model_max_contacts: int32,
-        world_max_contacts: int32,
-        wid: int32,
-        gid_1: int32,
-        gid_2: int32,
-        bid_1: int32,
-        bid_2: int32,
-        margin_plus_gap: float32,
-        margin: float32,
-        friction: float32,
-        restitution: float32,
+        model_max_contacts: wp.int32,
+        world_max_contacts: wp.int32,
+        wid: wp.int32,
+        gid_1: wp.int32,
+        gid_2: wp.int32,
+        bid_1: wp.int32,
+        bid_2: wp.int32,
+        margin_plus_gap: wp.float32,
+        margin: wp.float32,
+        friction: wp.float32,
+        restitution: wp.float32,
         distances: wp.types.vector(MAX_CONTACTS, wp.float32),
         positions: wp.types.matrix((MAX_CONTACTS, 3), wp.float32),
         normals: Any,
         # Outputs:
-        contact_model_num: wp.array[int32],
-        contact_world_num: wp.array[int32],
-        contact_wid: wp.array[int32],
-        contact_cid: wp.array[int32],
-        contact_gid_AB: wp.array[vec2i],
-        contact_bid_AB: wp.array[vec2i],
-        contact_position_A: wp.array[vec3f],
-        contact_position_B: wp.array[vec3f],
-        contact_gapfunc: wp.array[vec4f],
-        contact_frame: wp.array[quatf],
-        contact_material: wp.array[vec2f],
-        contact_key: wp.array[uint64],
+        contact_model_num: wp.array[wp.int32],
+        contact_world_num: wp.array[wp.int32],
+        contact_wid: wp.array[wp.int32],
+        contact_cid: wp.array[wp.int32],
+        contact_gid_AB: wp.array[wp.vec2i],
+        contact_bid_AB: wp.array[wp.vec2i],
+        contact_position_A: wp.array[wp.vec3f],
+        contact_position_B: wp.array[wp.vec3f],
+        contact_gapfunc: wp.array[wp.vec4f],
+        contact_frame: wp.array[wp.quatf],
+        contact_material: wp.array[wp.vec2f],
+        contact_key: wp.array[wp.uint64],
     ):
         # Count valid contacts (those within the detection threshold)
         num_contacts = wp.int32(0)
@@ -376,11 +363,11 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
         # and hence body B to be the "effected" body in the contact
         # so we have to ensure that bid_B is always non-negative
         if bid_2 < 0:
-            gid_AB = vec2i(gid_2, gid_1)
-            bid_AB = vec2i(bid_2, bid_1)
+            gid_AB = wp.vec2i(gid_2, gid_1)
+            bid_AB = wp.vec2i(bid_2, bid_1)
         else:
-            gid_AB = vec2i(gid_1, gid_2)
-            bid_AB = vec2i(bid_1, bid_2)
+            gid_AB = wp.vec2i(gid_1, gid_2)
+            bid_AB = wp.vec2i(bid_1, bid_2)
 
         # Safely increment the per-world active contact counter (see notes in _write_contact_unified_kamino in unified.py)
         wcio = wp.atomic_add(contact_world_num, wid, num_contacts)
@@ -408,8 +395,8 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
             wp.atomic_sub(contact_world_num, wid, max_num_contacts_prev - max_num_contacts)
 
         # Create the common material for this contact set
-        material = vec2f(friction, restitution)
-        key = build_pair_key2(uint32(gid_AB[0]), uint32(gid_AB[1]))
+        material = wp.vec2f(friction, restitution)
+        key = build_pair_key2(wp.uint32(gid_AB[0]), wp.uint32(gid_AB[1]))
 
         # Define a separate active contact index
         # NOTE: This is different from k since some contacts
@@ -429,11 +416,11 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
 
                 # Extract contact data based on whether we have shared or per-contact normals
                 distance = distances[k]
-                position = vec3f(positions[k, 0], positions[k, 1], positions[k, 2])
+                position = wp.vec3f(positions[k, 0], positions[k, 1], positions[k, 2])
                 if wp.static(SHARED_NORMAL):
                     normal = normals
                 else:
-                    normal = vec3f(normals[k, 0], normals[k, 1], normals[k, 2])
+                    normal = wp.vec3f(normals[k, 0], normals[k, 1], normals[k, 2])
                 distance_abs = wp.abs(distance)
 
                 # Adjust normal direction based on body assignment
@@ -447,7 +434,7 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
 
                 # Store margin-shifted distance in gapfunc.w
                 d = distance - margin
-                gapfunc = vec4f(normal.x, normal.y, normal.z, d)
+                gapfunc = wp.vec4f(normal.x, normal.y, normal.z, d)
                 q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
 
                 # Store contact data
@@ -477,28 +464,28 @@ def make_add_multiple_contacts(MAX_CONTACTS: int, SHARED_NORMAL: bool):
 @wp.func
 def sphere_sphere(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     sphere1: Sphere,
     sphere2: Sphere,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Run the respective collider function to detect sphere-sphere contacts
     distance, position, normal = collide_sphere_sphere(sphere1.pos, sphere1.radius, sphere2.pos, sphere2.radius)
@@ -537,28 +524,28 @@ def sphere_sphere(
 @wp.func
 def sphere_cylinder(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     sphere1: Sphere,
     cylinder2: Cylinder,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distance, position, normal = collide_sphere_cylinder(
@@ -609,28 +596,28 @@ def sphere_cone():
 @wp.func
 def sphere_capsule(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     sphere1: Sphere,
     capsule2: Capsule,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distance, position, normal = collide_sphere_capsule(
@@ -676,28 +663,28 @@ def sphere_capsule(
 @wp.func
 def sphere_box(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     sphere1: Sphere,
     box2: Box,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distance, position, normal = collide_sphere_box(sphere1.pos, sphere1.radius, box2.pos, box2.rot, box2.size)
@@ -786,28 +773,28 @@ def cone_ellipsoid():
 @wp.func
 def capsule_capsule(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     capsule1: Capsule,
     capsule2: Capsule,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distance, position, normal = collide_capsule_capsule(
@@ -857,28 +844,28 @@ def capsule_capsule(
 @wp.func
 def capsule_box(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     capsule1: Capsule,
     box2: Box,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distances, positions, normals = collide_capsule_box(
@@ -930,28 +917,28 @@ def capsule_ellipsoid():
 @wp.func
 def box_box(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     box1: Box,
     box2: Box,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distances, positions, normals = collide_box_box(
@@ -1002,28 +989,28 @@ def ellipsoid_ellipsoid():
 @wp.func
 def plane_sphere(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     plane1: Plane,
     sphere2: Sphere,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     # Note: collide_plane_sphere returns (distance, position) without normal
@@ -1066,28 +1053,28 @@ def plane_sphere(
 @wp.func
 def plane_box(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     plane1: Plane,
     box2: Box,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distances, positions, normal = collide_plane_box(
@@ -1128,28 +1115,28 @@ def plane_box(
 @wp.func
 def plane_ellipsoid(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     plane1: Plane,
     ellipsoid2: Ellipsoid,
-    wid: int32,
-    margin_plus_gap: float32,
-    margin: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    margin_plus_gap: wp.float32,
+    margin: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distance, position, normal = collide_plane_ellipsoid(
@@ -1190,28 +1177,28 @@ def plane_ellipsoid(
 @wp.func
 def plane_capsule(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     plane1: Plane,
     capsule2: Capsule,
-    wid: int32,
-    threshold: float32,
-    rest_offset: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    threshold: wp.float32,
+    rest_offset: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     # Note: collide_plane_capsule returns a contact frame, not individual normals
@@ -1221,7 +1208,7 @@ def plane_capsule(
 
     # Manually add contacts since plane_capsule returns a contact frame instead of normals
     # Count valid contacts
-    num_contacts = int32(0)
+    num_contacts = wp.int32(0)
     for k in range(2):
         if distances[k] != wp.inf and distances[k] <= threshold:
             num_contacts += 1
@@ -1231,19 +1218,19 @@ def plane_capsule(
         return
 
     # Extract normal from the contact frame (first column)
-    normal = vec3f(frame[0, 0], frame[1, 0], frame[2, 0])
+    normal = wp.vec3f(frame[0, 0], frame[1, 0], frame[2, 0])
 
     # Perform A/B geom and body assignment
     # NOTE: We want the normal to always point from A to B,
     # and hence body B to be the "effected" body in the contact
     # so we have to ensure that bid_B is always non-negative
     if capsule2.bid < 0:
-        gid_AB = vec2i(capsule2.gid, plane1.gid)
-        bid_AB = vec2i(capsule2.bid, plane1.bid)
+        gid_AB = wp.vec2i(capsule2.gid, plane1.gid)
+        bid_AB = wp.vec2i(capsule2.bid, plane1.bid)
         normal = -normal
     else:
-        gid_AB = vec2i(plane1.gid, capsule2.gid)
-        bid_AB = vec2i(plane1.bid, capsule2.bid)
+        gid_AB = wp.vec2i(plane1.gid, capsule2.gid)
+        bid_AB = wp.vec2i(plane1.bid, capsule2.bid)
 
     # Increment the active contact counter
     mcio = wp.atomic_add(contact_model_num, 0, num_contacts)
@@ -1254,11 +1241,11 @@ def plane_capsule(
 
     # Create the common properties shared by all contacts in the current set
     q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
-    material = vec2f(friction, restitution)
-    key = build_pair_key2(uint32(gid_AB[0]), uint32(gid_AB[1]))
+    material = wp.vec2f(friction, restitution)
+    key = build_pair_key2(wp.uint32(gid_AB[0]), wp.uint32(gid_AB[1]))
 
     # Add generated contacts data to the output arrays
-    active_contact_idx = int32(0)
+    active_contact_idx = wp.int32(0)
     for k in range(2):
         # Break if we've reached the maximum number of contacts
         if active_contact_idx >= max_num_contacts:
@@ -1271,7 +1258,7 @@ def plane_capsule(
 
             # Get contact data
             distance = distances[k]
-            position = vec3f(positions[k, 0], positions[k, 1], positions[k, 2])
+            position = wp.vec3f(positions[k, 0], positions[k, 1], positions[k, 2])
             distance_abs = wp.abs(distance)
 
             # Offset contact point by penetration depth
@@ -1279,7 +1266,7 @@ def plane_capsule(
             position_B = position - 0.5 * normal * distance_abs
 
             # Generate the gap-function and coordinate frame for this contact
-            gapfunc = vec4f(normal.x, normal.y, normal.z, distance - rest_offset)
+            gapfunc = wp.vec4f(normal.x, normal.y, normal.z, distance - rest_offset)
 
             # Store contact data
             contact_wid[mcid] = wid
@@ -1300,28 +1287,28 @@ def plane_capsule(
 @wp.func
 def plane_cylinder(
     # Inputs:
-    model_max_contacts: int32,
-    world_max_contacts: int32,
+    model_max_contacts: wp.int32,
+    world_max_contacts: wp.int32,
     plane1: Plane,
     cylinder2: Cylinder,
-    wid: int32,
-    threshold: float32,
-    rest_offset: float32,
-    friction: float32,
-    restitution: float32,
+    wid: wp.int32,
+    threshold: wp.float32,
+    rest_offset: wp.float32,
+    friction: wp.float32,
+    restitution: wp.float32,
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Use the tested collision calculation from collision_primitive.py
     distances, positions, normal = collide_plane_cylinder(
@@ -1367,38 +1354,38 @@ def plane_cylinder(
 @wp.kernel
 def _primitive_narrowphase(
     # Inputs
-    default_gap: float32,
-    geom_bid: wp.array[int32],
-    geom_sid: wp.array[int32],
-    geom_mid: wp.array[int32],
-    geom_params: wp.array[vec3f],
-    geom_gap: wp.array[float32],
-    geom_margin: wp.array[float32],
-    geom_pose: wp.array[transformf],
-    candidate_model_num_pairs: wp.array[int32],
-    candidate_wid: wp.array[int32],
-    candidate_geom_pair: wp.array[vec2i],
-    contact_model_max_num: wp.array[int32],
-    contact_world_max_num: wp.array[int32],
-    material_restitution: wp.array[float32],
-    material_static_friction: wp.array[float32],
-    material_dynamic_friction: wp.array[float32],
-    material_pair_restitution: wp.array[float32],
-    material_pair_static_friction: wp.array[float32],
-    material_pair_dynamic_friction: wp.array[float32],
+    default_gap: wp.float32,
+    geom_bid: wp.array[wp.int32],
+    geom_sid: wp.array[wp.int32],
+    geom_mid: wp.array[wp.int32],
+    geom_params: wp.array[wp.vec3f],
+    geom_gap: wp.array[wp.float32],
+    geom_margin: wp.array[wp.float32],
+    geom_pose: wp.array[wp.transformf],
+    candidate_model_num_pairs: wp.array[wp.int32],
+    candidate_wid: wp.array[wp.int32],
+    candidate_geom_pair: wp.array[wp.vec2i],
+    contact_model_max_num: wp.array[wp.int32],
+    contact_world_max_num: wp.array[wp.int32],
+    material_restitution: wp.array[wp.float32],
+    material_static_friction: wp.array[wp.float32],
+    material_dynamic_friction: wp.array[wp.float32],
+    material_pair_restitution: wp.array[wp.float32],
+    material_pair_static_friction: wp.array[wp.float32],
+    material_pair_dynamic_friction: wp.array[wp.float32],
     # Outputs:
-    contact_model_num: wp.array[int32],
-    contact_world_num: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gid_AB: wp.array[vec2i],
-    contact_bid_AB: wp.array[vec2i],
-    contact_position_A: wp.array[vec3f],
-    contact_position_B: wp.array[vec3f],
-    contact_gapfunc: wp.array[vec4f],
-    contact_frame: wp.array[quatf],
-    contact_material: wp.array[vec2f],
-    contact_key: wp.array[uint64],
+    contact_model_num: wp.array[wp.int32],
+    contact_world_num: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gid_AB: wp.array[wp.vec2i],
+    contact_bid_AB: wp.array[wp.vec2i],
+    contact_position_A: wp.array[wp.vec3f],
+    contact_position_B: wp.array[wp.vec3f],
+    contact_gapfunc: wp.array[wp.vec4f],
+    contact_frame: wp.array[wp.quatf],
+    contact_material: wp.array[wp.vec2f],
+    contact_key: wp.array[wp.uint64],
 ):
     # Retrieve the geom-pair index (gpid) from the thread grid
     gpid = wp.tid()
@@ -1832,7 +1819,7 @@ def primitive_narrowphase(
         _primitive_narrowphase,
         dim=candidates.num_model_geom_pairs,
         inputs=[
-            float32(default_gap),
+            wp.float32(default_gap),
             model.geoms.bid,
             model.geoms.type,
             model.geoms.material,

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
@@ -19,7 +19,7 @@ from ......geometry.types import GeoType
 from ...core.data import DataKamino
 from ...core.model import ModelKamino
 from ...core.state import StateKamino
-from ...core.types import float32, int32, to_warp_int32_array, vec6f
+from ...core.types import to_warp_int32_array, vec6f
 from ..contacts import DEFAULT_GEOM_PAIR_CONTACT_GAP, ContactsKamino
 from .broadphase import (
     PRIMITIVE_BROADPHASE_SUPPORTED_SHAPES,
@@ -54,15 +54,12 @@ class CollisionPipelinePrimitive:
         Initialize an instance of Kamino's optimized primitive collision detection pipeline.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container holding the time-invariant data of the system being simulated.\n
+            model: The model container holding the time-invariant data of the system being simulated.\n
                 If provided, the detector will be finalized using the provided model and settings.\n
                 If `None`, the detector will be created empty without allocating data, and
                 can be finalized later by providing a model to the `finalize` method.\n
-            bvtype (`Literal["aabb", "bs"]`, optional):
-                Type of bounding volume to use in broad-phase.
-            default_gap (`float`, optional):
-                Default detection gap [m] applied as a floor to per-geometry gaps.
+            bvtype: Type of bounding volume to use in broad-phase.
+            default_gap: Default detection gap [m] applied as a floor to per-geometry gaps.
         """
         # Cache the model reference, target device and settings
         self._model: ModelKamino | None = model
@@ -103,13 +100,11 @@ class CollisionPipelinePrimitive:
         Finalizes the collision detection pipeline by allocating all necessary data structures.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container holding the time-invariant data of the system being simulated.\n
+            model: The model container holding the time-invariant data of the system being simulated.\n
                 If provided, the detector will be finalized using the provided model and settings.\n
                 If `None`, the detector will be created empty without allocating data, and
                 can be finalized later by providing a model to the `finalize` method.\n
-            bvtype (`Literal["aabb", "bs"]`, optional):
-                Type of bounding volume to use in broad-phase.
+            bvtype: Type of bounding volume to use in broad-phase.
         """
         # Override the model if specified
         if model is not None:
@@ -142,7 +137,7 @@ class CollisionPipelinePrimitive:
                 case BoundingVolumeType.AABB:
                     self._bvdata.aabb = wp.zeros(shape=(num_geoms,), dtype=vec6f)
                 case BoundingVolumeType.BS:
-                    self._bvdata.radius = wp.zeros(shape=(num_geoms,), dtype=float32)
+                    self._bvdata.radius = wp.zeros(shape=(num_geoms,), dtype=wp.float32)
                 case _:
                     raise ValueError(f"Unsupported BoundingVolumeType: {self._bvtype}")
 
@@ -159,9 +154,9 @@ class CollisionPipelinePrimitive:
             # Allocate the time-varying collision candidates data
             self._cdata = CollisionCandidatesData(
                 num_model_geom_pairs=self._model.geoms.num_collidable_pairs,
-                model_num_collisions=wp.zeros(shape=(1,), dtype=int32),
-                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=int32),
-                wid=wp.zeros(shape=(self._model.geoms.num_collidable_pairs,), dtype=int32),
+                model_num_collisions=wp.zeros(shape=(1,), dtype=wp.int32),
+                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=wp.int32),
+                wid=wp.zeros(shape=(self._model.geoms.num_collidable_pairs,), dtype=wp.int32),
                 geom_pair=wp.zeros_like(self._model.geoms.collidable_pairs),
             )
 
@@ -170,12 +165,9 @@ class CollisionPipelinePrimitive:
         Runs the unified collision detection pipeline to generate discrete contacts.
 
         Args:
-            data (DataKamino):
-                The data container holding internal time-varying state of the solver.
-            state (StateKamino):
-                The state container holding the time-varying state of the simulation.
-            contacts (ContactsKamino):
-                Output contacts container (will be cleared and populated)
+            data: The data container holding internal time-varying state of the solver.
+            state: The state container holding the time-varying state of the simulation.
+            contacts: Output contacts container (will be cleared and populated)
         """
         # Ensure that the pipeline has been finalized
         # before proceeding with actual operations
@@ -224,8 +216,7 @@ class CollisionPipelinePrimitive:
         model are supported by the primitive narrow-phase collider.
 
         Args:
-            model (ModelKamino):
-                The model container holding the time-invariant parameters of the simulation.
+            model: The model container holding the time-invariant parameters of the simulation.
 
         Raises:
             ValueError: If any unsupported shape type is found.

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/pipeline.py
@@ -54,10 +54,10 @@ class CollisionPipelinePrimitive:
         Initialize an instance of Kamino's optimized primitive collision detection pipeline.
 
         Args:
-            model: The model container holding the time-invariant data of the system being simulated.\n
-                If provided, the detector will be finalized using the provided model and settings.\n
+            model: The model container holding the time-invariant data of the system being simulated.
+                If provided, the detector will be finalized using the provided model and settings.
                 If `None`, the detector will be created empty without allocating data, and
-                can be finalized later by providing a model to the `finalize` method.\n
+                can be finalized later by providing a model to the `finalize` method.
             bvtype: Type of bounding volume to use in broad-phase.
             default_gap: Default detection gap [m] applied as a floor to per-geometry gaps.
         """
@@ -100,10 +100,10 @@ class CollisionPipelinePrimitive:
         Finalizes the collision detection pipeline by allocating all necessary data structures.
 
         Args:
-            model: The model container holding the time-invariant data of the system being simulated.\n
-                If provided, the detector will be finalized using the provided model and settings.\n
+            model: The model container holding the time-invariant data of the system being simulated.
+                If provided, the detector will be finalized using the provided model and settings.
                 If `None`, the detector will be created empty without allocating data, and
-                can be finalized later by providing a model to the `finalize` method.\n
+                can be finalized later by providing a model to the `finalize` method.
             bvtype: Type of bounding volume to use in broad-phase.
         """
         # Override the model if specified

--- a/newton/_src/solvers/kamino/_src/geometry/unified.py
+++ b/newton/_src/solvers/kamino/_src/geometry/unified.py
@@ -31,17 +31,7 @@ from ..core.materials import DEFAULT_FRICTION, DEFAULT_RESTITUTION, make_get_mat
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
 from ..core.types import (
-    float32,
-    int32,
-    quatf,
     to_warp_int32_array,
-    transformf,
-    uint32,
-    uint64,
-    vec2f,
-    vec2i,
-    vec3f,
-    vec4f,
 )
 from ..geometry.contacts import (
     DEFAULT_GEOM_PAIR_CONTACT_GAP,
@@ -70,42 +60,42 @@ class ContactWriterDataKamino:
     """Contact writer data for writing contacts directly in Kamino format."""
 
     # Contact limits
-    model_max_contacts: int32
-    world_max_contacts: wp.array[int32]
+    model_max_contacts: wp.int32
+    world_max_contacts: wp.array[wp.int32]
 
     # Geometry information arrays
-    geom_wid: wp.array[int32]  # World ID for each geometry
-    geom_bid: wp.array[int32]  # Body ID for each geometry
-    geom_mid: wp.array[int32]  # Material ID for each geometry
-    geom_gap: wp.array[float32]  # Detection gap for each geometry [m]
-    geom_margin: wp.array[float32]  # Shape margin for each geometry [m]
+    geom_wid: wp.array[wp.int32]  # World ID for each geometry
+    geom_bid: wp.array[wp.int32]  # Body ID for each geometry
+    geom_mid: wp.array[wp.int32]  # Material ID for each geometry
+    geom_gap: wp.array[wp.float32]  # Detection gap for each geometry [m]
+    geom_margin: wp.array[wp.float32]  # Shape margin for each geometry [m]
 
     # Material properties (indexed by material pair)
-    material_restitution: wp.array[float32]
-    material_static_friction: wp.array[float32]
-    material_dynamic_friction: wp.array[float32]
-    material_pair_restitution: wp.array[float32]
-    material_pair_static_friction: wp.array[float32]
-    material_pair_dynamic_friction: wp.array[float32]
+    material_restitution: wp.array[wp.float32]
+    material_static_friction: wp.array[wp.float32]
+    material_dynamic_friction: wp.array[wp.float32]
+    material_pair_restitution: wp.array[wp.float32]
+    material_pair_static_friction: wp.array[wp.float32]
+    material_pair_dynamic_friction: wp.array[wp.float32]
 
     # Contact limit and active count (Newton interface)
-    contact_max: int32
-    contact_count: wp.array[int32]
+    contact_max: wp.int32
+    contact_count: wp.array[wp.int32]
 
     # Output arrays (Kamino Contacts format)
-    contacts_model_num_active: wp.array[int32]
-    contacts_world_num_active: wp.array[int32]
-    contact_wid: wp.array[int32]
-    contact_cid: wp.array[int32]
-    contact_gid_AB: wp.array[vec2i]
-    contact_bid_AB: wp.array[vec2i]
-    contact_position_A: wp.array[vec3f]
-    contact_position_B: wp.array[vec3f]
-    contact_gapfunc: wp.array[vec4f]
-    contact_frame: wp.array[quatf]
-    contact_material: wp.array[vec2f]
-    contact_margins: wp.array[vec2f]
-    contact_key: wp.array[uint64]
+    contacts_model_num_active: wp.array[wp.int32]
+    contacts_world_num_active: wp.array[wp.int32]
+    contact_wid: wp.array[wp.int32]
+    contact_cid: wp.array[wp.int32]
+    contact_gid_AB: wp.array[wp.vec2i]
+    contact_bid_AB: wp.array[wp.vec2i]
+    contact_position_A: wp.array[wp.vec3f]
+    contact_position_B: wp.array[wp.vec3f]
+    contact_gapfunc: wp.array[wp.vec4f]
+    contact_frame: wp.array[wp.quatf]
+    contact_material: wp.array[wp.vec2f]
+    contact_margins: wp.array[wp.vec2f]
+    contact_key: wp.array[wp.uint64]
 
 
 ###
@@ -193,19 +183,19 @@ def _write_contact_unified_kamino(
     # Ensure the static body is always body A so that the normal
     # always points from A to B and bid_B is non-negative
     if bid_b < 0:
-        gid_AB = vec2i(gid_b, gid_a)
-        bid_AB = vec2i(bid_b, bid_a)
+        gid_AB = wp.vec2i(gid_b, gid_a)
+        bid_AB = wp.vec2i(bid_b, bid_a)
         normal = -contact_normal_a_to_b
         pos_A = b_contact_world
         pos_B = a_contact_world
-        margins = vec2f(margin_b, margin_a)
+        margins = wp.vec2f(margin_b, margin_a)
     else:
-        gid_AB = vec2i(gid_a, gid_b)
-        bid_AB = vec2i(bid_a, bid_b)
+        gid_AB = wp.vec2i(gid_a, gid_b)
+        bid_AB = wp.vec2i(bid_a, bid_b)
         normal = contact_normal_a_to_b
         pos_A = a_contact_world
         pos_B = b_contact_world
-        margins = vec2f(margin_a, margin_b)
+        margins = wp.vec2f(margin_a, margin_b)
 
     # Retrieve the material properties for the geom pair
     restitution_ab, _, mu_ab = wp.static(make_get_material_pair_properties())(
@@ -218,13 +208,13 @@ def _write_contact_unified_kamino(
         writer_data.material_pair_static_friction,
         writer_data.material_pair_dynamic_friction,
     )
-    material = vec2f(mu_ab, restitution_ab)
+    material = wp.vec2f(mu_ab, restitution_ab)
 
     # Generate the gap-function (normal.x, normal.y, normal.z, distance),
     # contact frame (z-norm aligned with contact normal)
-    gapfunc = vec4f(normal[0], normal[1], normal[2], distance)
+    gapfunc = wp.vec4f(normal[0], normal[1], normal[2], distance)
     q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
-    key = build_pair_key2(uint32(gid_AB[0]), uint32(gid_AB[1]))
+    key = build_pair_key2(wp.uint32(gid_AB[0]), wp.uint32(gid_AB[1]))
 
     # Store contact data in Kamino format
     writer_data.contact_wid[mcid] = wid
@@ -246,13 +236,13 @@ def _write_contact_unified_kamino(
 
 
 @wp.func
-def _compute_collision_radius(geo_type: int32, scale: vec3f) -> float32:
+def _compute_collision_radius(geo_type: wp.int32, scale: wp.vec3f) -> wp.float32:
     """Compute the bounding-sphere radius for broadphase AABB fallback.
 
     Mirrors :func:`newton._src.geometry.utils.compute_shape_radius` for the
     primitive shape types that Kamino currently supports.
     """
-    radius = float32(10.0)
+    radius = wp.float32(10.0)
     if geo_type == GeoType.SPHERE:
         radius = scale[0]
     elif geo_type == GeoType.BOX:
@@ -265,24 +255,24 @@ def _compute_collision_radius(geo_type: int32, scale: vec3f) -> float32:
         if scale[0] > 0.0 and scale[1] > 0.0:
             radius = wp.length(scale) * 0.5
         else:
-            radius = float32(1.0e6)
+            radius = wp.float32(1.0e6)
     elif geo_type == GeoType.MESH or geo_type == GeoType.CONVEX_MESH or geo_type == GeoType.HFIELD:
         # Large bounding sphere; the AABB kernel computes a tighter bound from mesh data
-        radius = float32(1.0e6)
+        radius = wp.float32(1.0e6)
     return radius
 
 
 @wp.kernel
 def _convert_geom_data_kamino_to_newton(
     # Inputs:
-    default_gap: float32,
-    geom_type: wp.array[int32],
-    geom_params: wp.array[vec3f],
-    geom_margin: wp.array[float32],
+    default_gap: wp.float32,
+    geom_type: wp.array[wp.int32],
+    geom_params: wp.array[wp.vec3f],
+    geom_margin: wp.array[wp.float32],
     # Outputs:
-    geom_gap: wp.array[float32],
-    geom_data: wp.array[vec4f],
-    shape_collision_radius: wp.array[float32],
+    geom_gap: wp.array[wp.float32],
+    geom_data: wp.array[wp.vec4f],
+    shape_collision_radius: wp.array[wp.float32],
 ):
     """
     Converts Kamino geometry data to Newton-compatible format.
@@ -304,7 +294,7 @@ def _convert_geom_data_kamino_to_newton(
     # Store converted geometry data
     # NOTE: the per-geom margin is overridden because
     # the unified pipeline needs it during narrow-phase
-    geom_data[gid] = vec4f(scale[0], scale[1], scale[2], margin)
+    geom_data[gid] = wp.vec4f(scale[0], scale[1], scale[2], margin)
     geom_gap[gid] = wp.max(default_gap, gap)
     shape_collision_radius[gid] = _compute_collision_radius(type, scale)
 
@@ -312,19 +302,19 @@ def _convert_geom_data_kamino_to_newton(
 @wp.kernel
 def _update_geom_poses_and_compute_aabbs(
     # Inputs:
-    geom_type: wp.array[int32],
-    geom_bid: wp.array[int32],
+    geom_type: wp.array[wp.int32],
+    geom_bid: wp.array[wp.int32],
     geom_ptr: wp.array[wp.uint64],
-    geom_offset: wp.array[transformf],
-    geom_margin: wp.array[float32],
-    geom_gap: wp.array[float32],
-    geom_data: wp.array[vec4f],
-    geom_collision_radius: wp.array[float32],
-    body_pose: wp.array[transformf],
+    geom_offset: wp.array[wp.transformf],
+    geom_margin: wp.array[wp.float32],
+    geom_gap: wp.array[wp.float32],
+    geom_data: wp.array[wp.vec4f],
+    geom_collision_radius: wp.array[wp.float32],
+    body_pose: wp.array[wp.transformf],
     # Outputs:
-    geom_pose: wp.array[transformf],
-    shape_aabb_lower: wp.array[vec3f],
-    shape_aabb_upper: wp.array[vec3f],
+    geom_pose: wp.array[wp.transformf],
+    shape_aabb_lower: wp.array[wp.vec3f],
+    shape_aabb_upper: wp.array[wp.vec3f],
 ):
     """
     Updates the pose of each Kamino geometry in world coordinates and computes its AABB.
@@ -341,7 +331,7 @@ def _update_geom_poses_and_compute_aabbs(
     gap = geom_gap[gid]
     X_bg = geom_offset[gid]
 
-    X_b = wp.transform_identity(dtype=float32)
+    X_b = wp.transform_identity(dtype=wp.float32)
     if bid > -1:
         X_b = body_pose[bid]
 
@@ -350,8 +340,8 @@ def _update_geom_poses_and_compute_aabbs(
     r_g = wp.transform_get_translation(X_g)
     q_g = wp.transform_get_rotation(X_g)
 
-    # Format is (vec3f scale, float32 margin_offset)
-    scale = vec3f(geo_data[0], geo_data[1], geo_data[2])
+    # Format is (wp.vec3f scale, wp.float32 margin_offset)
+    scale = wp.vec3f(geo_data[0], geo_data[1], geo_data[2])
 
     # Enlarge AABB by margin + gap per shape (matching Newton core convention)
     expansion = margin + gap
@@ -475,7 +465,7 @@ class CollisionPipelineUnifiedKamino:
             self._max_contacts = max_contacts
 
         # Build shape pairs for EXPLICIT mode
-        self.shape_pairs_filtered: wp.array | None = None
+        self.shape_pairs_filtered: wp.array[wp.vec2i] | None = None
         if broadphase == "explicit":
             self.shape_pairs_filtered = self._model.geoms.collidable_pairs
             self._max_shape_pairs = self._model.geoms.num_collidable_pairs
@@ -488,14 +478,14 @@ class CollisionPipelineUnifiedKamino:
         # list of excluded pairs that encodes same-body, group/collides, and
         # neighbor-joint filtering.
         geom_collision_group_list = [1] * self._num_geoms
-        self._excluded_pairs: wp.array | None = None
+        self._excluded_pairs: wp.array[wp.vec2i] | None = None
         self._num_excluded_pairs: int = 0
         if broadphase in ("nxn", "sap"):
             self._excluded_pairs = self._model.geoms.excluded_pairs
             self._num_excluded_pairs = self._model.geoms.num_excluded_pairs
 
         # Capture a reference to per-geometry world indices already present in the model
-        self.geom_wid: wp.array = self._model.geoms.wid
+        self.geom_wid: wp.array[wp.int32] = self._model.geoms.wid
 
         # Define default shape flags for all geometries
         default_shape_flag: int = (
@@ -515,15 +505,15 @@ class CollisionPipelineUnifiedKamino:
         # Allocate internal data needed by the pipeline that
         # the Kamino model and data do not yet provide
         with wp.ScopedDevice(self._device):
-            self.geom_data = wp.zeros(self._num_geoms, dtype=vec4f)
+            self.geom_data = wp.zeros(self._num_geoms, dtype=wp.vec4f)
             self.geom_collision_group = to_warp_int32_array(geom_collision_group_list)
-            self.collision_radius = wp.zeros(self._num_geoms, dtype=float32)
-            self.shape_flags = wp.full(self._num_geoms, default_shape_flag, dtype=int32)
+            self.collision_radius = wp.zeros(self._num_geoms, dtype=wp.float32)
+            self.shape_flags = wp.full(self._num_geoms, default_shape_flag, dtype=wp.int32)
             self.shape_aabb_lower = wp.zeros(self._num_geoms, dtype=wp.vec3)
             self.shape_aabb_upper = wp.zeros(self._num_geoms, dtype=wp.vec3)
             self.broad_phase_pairs = wp.zeros(self._max_shape_pairs, dtype=wp.vec2i)
             self.broad_phase_pair_count = wp.zeros(1, dtype=wp.int32)
-            self.narrow_phase_contact_count = wp.zeros(1, dtype=int32)
+            self.narrow_phase_contact_count = wp.zeros(1, dtype=wp.int32)
             self.shape_sdf_data = wp.empty(shape=(0,), dtype=TextureSDFData)
             self.shape_sdf_index = wp.full_like(self._model.geoms.type, -1)
 
@@ -594,9 +584,9 @@ class CollisionPipelineUnifiedKamino:
         Runs the unified collision detection pipeline to generate discrete contacts.
 
         Args:
-            data (DataKamino): The data container holding the time-varying state of the simulation.
-            state (StateKamino): The state container holding the current simulation state.
-            contacts (ContactsKamino): Output contacts container (will be cleared and populated)
+            data: The data container holding the time-varying state of the simulation.
+            state: The state container holding the current simulation state.
+            contacts: Output contacts container (will be cleared and populated).
         """
         # Check if contacts is allocated on the same device
         if contacts.device != self._device:
@@ -641,10 +631,6 @@ class CollisionPipelineUnifiedKamino:
         Converts Kamino geometry data to the Newton format.
 
         This operation needs to be called only once during initialization.
-
-        Args:
-            model (ModelKamino):
-                The model container holding the time-invariant parameters of the simulation.
         """
         wp.launch(
             kernel=_convert_geom_data_kamino_to_newton,
@@ -673,10 +659,8 @@ class CollisionPipelineUnifiedKamino:
         Updates geometry poses from corresponding body states and computes respective AABBs.
 
         Args:
-            data (DataKamino):
-                The data container holding the time-varying state of the simulation.
-            state (StateKamino):
-                The state container holding the current simulation state.
+            data: The data container holding the time-varying state of the simulation.
+            state: The state container holding the current simulation state.
         """
         wp.launch(
             kernel=_update_geom_poses_and_compute_aabbs,
@@ -756,17 +740,15 @@ class CollisionPipelineUnifiedKamino:
         Runs narrow-phase collision detection to generate contacts.
 
         Args:
-            data (DataKamino):
-                The data container holding the time-varying state of the simulation.
-            contacts (ContactsKamino):
-                Output contacts container (will be populated by this function)
+            data: The data container holding the time-varying state of the simulation.
+            contacts: Output contacts container (will be populated by this function).
         """
         # Create a writer data struct to bundle all necessary input/output
         # arrays into a single object for the narrow phase custom writer
         # NOTE: Unfortunately, we need to do this on every call in python,
         # but graph-capture ensures this actually happens only once
         writer_data = ContactWriterDataKamino()
-        writer_data.model_max_contacts = int32(contacts.model_max_contacts_host)
+        writer_data.model_max_contacts = wp.int32(contacts.model_max_contacts_host)
         writer_data.world_max_contacts = contacts.world_max_contacts
         writer_data.geom_bid = self._model.geoms.bid
         writer_data.geom_wid = self._model.geoms.wid
@@ -779,7 +761,7 @@ class CollisionPipelineUnifiedKamino:
         writer_data.material_pair_restitution = self._model.material_pairs.restitution
         writer_data.material_pair_static_friction = self._model.material_pairs.static_friction
         writer_data.material_pair_dynamic_friction = self._model.material_pairs.dynamic_friction
-        writer_data.contact_max = int32(contacts.model_max_contacts_host)
+        writer_data.contact_max = wp.int32(contacts.model_max_contacts_host)
         writer_data.contact_count = self.narrow_phase_contact_count
         writer_data.contacts_model_num_active = contacts.model_active_contacts
         writer_data.contacts_world_num_active = contacts.world_active_contacts

--- a/newton/_src/solvers/kamino/_src/integrators/euler.py
+++ b/newton/_src/solvers/kamino/_src/integrators/euler.py
@@ -21,15 +21,6 @@ from ..core.math import (
 )
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
-from ..core.types import (
-    float32,
-    int32,
-    mat33f,
-    transformf,
-    vec3f,
-    vec4f,
-    vec6f,
-)
 from ..geometry.contacts import ContactsKamino
 from ..geometry.detector import CollisionDetector
 from ..kinematics.limits import LimitsKamino
@@ -58,16 +49,16 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def euler_semi_implicit_with_logmap(
-    alpha: float32,
-    dt: float32,
-    g: vec3f,
-    inv_m_i: float32,
-    I_i: mat33f,
-    inv_I_i: mat33f,
-    p_i: transformf,
-    u_i: vec6f,
-    w_i: vec6f,
-) -> tuple[transformf, vec6f]:
+    alpha: wp.float32,
+    dt: wp.float32,
+    g: wp.vec3f,
+    inv_m_i: wp.float32,
+    I_i: wp.mat33f,
+    inv_I_i: wp.mat33f,
+    p_i: wp.transformf,
+    u_i: wp.spatial_vectorf,
+    w_i: wp.spatial_vectorf,
+) -> tuple[wp.transformf, wp.spatial_vectorf]:
     # Integrate the body twist using the maximal coordinate forward dynamics equations
     v_i_n, omega_i_n = compute_body_twist_update_with_eom(
         dt=dt,
@@ -103,16 +94,16 @@ def euler_semi_implicit_with_logmap(
 def _integrate_semi_implicit_euler_inplace(
     # Inputs:
     alpha: float,
-    model_dt: wp.array[float32],
-    model_gravity: wp.array[vec4f],
-    model_bodies_wid: wp.array[int32],
-    model_bodies_inv_m: wp.array[float32],
-    model_bodies_I: wp.array[mat33f],
-    model_bodies_inv_I: wp.array[mat33f],
-    state_bodies_w: wp.array[vec6f],
+    model_dt: wp.array[wp.float32],
+    model_gravity: wp.array[wp.vec4f],
+    model_bodies_wid: wp.array[wp.int32],
+    model_bodies_inv_m: wp.array[wp.float32],
+    model_bodies_I: wp.array[wp.mat33f],
+    model_bodies_inv_I: wp.array[wp.mat33f],
+    state_bodies_w: wp.array[wp.spatial_vectorf],
     # Outputs:
-    state_bodies_q: wp.array[transformf],
-    state_bodies_u: wp.array[vec6f],
+    state_bodies_q: wp.array[wp.transformf],
+    state_bodies_u: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -123,7 +114,7 @@ def _integrate_semi_implicit_euler_inplace(
     # Retrieve the time step and gravity vector
     dt = model_dt[wid]
     gv = model_gravity[wid]
-    g = gv.w * vec3f(gv.x, gv.y, gv.z)
+    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]
@@ -212,10 +203,8 @@ class IntegratorEuler(IntegratorBase):
         Initializes the Semi-Implicit Euler integrator with the given :class:`ModelKamino` instance.
 
         Args:
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            alpha (`float`, optional):
-                The angular damping coefficient. Defaults to 0.0 if `None` is provided.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            alpha: The angular damping coefficient. Defaults to 0.0 if `None` is provided.
         """
         super().__init__(model)
 
@@ -247,26 +236,17 @@ class IntegratorEuler(IntegratorBase):
         to integrate the current state of the system over a single time-step.
 
         Args:
-            forward (`Callable`):
-                An operator that calls the underlying solver for the forward dynamics sub-problem.
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            data (`DataKamino`):
-                The data container holding the time-varying parameters of the system being simulated.
-            state_in (`StateKamino`):
-                The state of the system at the current time-step.
-            state_out (`StateKamino`):
-                The state of the system at the next time-step.
-            control (`ControlKamino`):
-                The control inputs applied to the system at the current time-step.
-            limits (`LimitsKamino`, optional):
-                The joint limits of the system at the current time-step.
+            forward: An operator that calls the underlying solver for the forward dynamics sub-problem.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            data: The data container holding the time-varying parameters of the system being simulated.
+            state_in: The state of the system at the current time-step.
+            state_out: The state of the system at the next time-step.
+            control: The control inputs applied to the system at the current time-step.
+            limits: The joint limits of the system at the current time-step.
                 If `None`, no joint limits are considered for the current time-step.
-            contacts (`ContactsKamino`, optional):
-                The set of active contacts of the system at the current time-step.
+            contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector (`CollisionDetector`, optional):
-                The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """

--- a/newton/_src/solvers/kamino/_src/integrators/euler.py
+++ b/newton/_src/solvers/kamino/_src/integrators/euler.py
@@ -210,7 +210,7 @@ class IntegratorEuler(IntegratorBase):
 
         self._alpha: float = alpha if alpha is not None else 0.0
         """
-        Damping coefficient for angular velocity used to improve numerical stability of the integrator.\n
+        Damping coefficient for angular velocity used to improve numerical stability of the integrator.
         Defaults to `0.0`, corresponding to no damping being applied.
         """
 
@@ -246,7 +246,7 @@ class IntegratorEuler(IntegratorBase):
                 If `None`, no joint limits are considered for the current time-step.
             contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """

--- a/newton/_src/solvers/kamino/_src/integrators/integrator.py
+++ b/newton/_src/solvers/kamino/_src/integrators/integrator.py
@@ -86,7 +86,7 @@ class IntegratorBase:
                 If `None`, no joint limits are considered for the current time-step.
             contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """

--- a/newton/_src/solvers/kamino/_src/integrators/integrator.py
+++ b/newton/_src/solvers/kamino/_src/integrators/integrator.py
@@ -52,8 +52,7 @@ class IntegratorBase:
         Initializes the time-integrator with the given :class:`ModelKamino` instance.
 
         Args:
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
+            model: The model container holding the time-invariant parameters of the system being simulated.
         """
         self._model = model
 
@@ -77,26 +76,17 @@ class IntegratorBase:
         Solves the time integration sub-problem to compute the next state of the system.
 
         Args:
-            forward (`Callable`):
-                An operator that calls the underlying solver for the forward dynamics sub-problem.
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            data (`DataKamino`):
-                The data container holding the time-varying parameters of the system being simulated.
-            state_in (`StateKamino`):
-                The state of the system at the current time-step.
-            state_out (`StateKamino`):
-                The state of the system at the next time-step.
-            control (`ControlKamino`):
-                The control inputs applied to the system at the current time-step.
-            limits (`LimitsKamino`, optional):
-                The joint limits of the system at the current time-step.
+            forward: An operator that calls the underlying solver for the forward dynamics sub-problem.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            data: The data container holding the time-varying parameters of the system being simulated.
+            state_in: The state of the system at the current time-step.
+            state_out: The state of the system at the next time-step.
+            control: The control inputs applied to the system at the current time-step.
+            limits: The joint limits of the system at the current time-step.
                 If `None`, no joint limits are considered for the current time-step.
-            contacts (`ContactsKamino`, optional):
-                The set of active contacts of the system at the current time-step.
+            contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector (`CollisionDetector`, optional):
-                The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """

--- a/newton/_src/solvers/kamino/_src/integrators/moreau.py
+++ b/newton/_src/solvers/kamino/_src/integrators/moreau.py
@@ -239,7 +239,7 @@ class IntegratorMoreauJean(IntegratorBase):
 
         self._alpha: float = alpha if alpha is not None else 0.0
         """
-        Damping coefficient for angular velocity used to improve numerical stability of the integrator.\n
+        Damping coefficient for angular velocity used to improve numerical stability of the integrator.
         Defaults to `0.0`, corresponding to no damping being applied.
         """
 
@@ -275,7 +275,7 @@ class IntegratorMoreauJean(IntegratorBase):
                 If `None`, no joint limits are considered for the current time-step.
             contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """

--- a/newton/_src/solvers/kamino/_src/integrators/moreau.py
+++ b/newton/_src/solvers/kamino/_src/integrators/moreau.py
@@ -24,15 +24,6 @@ from ..core.math import (
 )
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
-from ..core.types import (
-    float32,
-    int32,
-    mat33f,
-    transformf,
-    vec3f,
-    vec4f,
-    vec6f,
-)
 from ..geometry.contacts import ContactsKamino
 from ..geometry.detector import CollisionDetector
 from ..kinematics.limits import LimitsKamino
@@ -61,16 +52,16 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.func
 def moreau_jean_semi_implicit_with_logmap(
-    alpha: float32,
-    dt: float32,
-    g: vec3f,
-    inv_m_i: float32,
-    I_i: mat33f,
-    inv_I_i: mat33f,
-    p_i: transformf,
-    u_i: vec6f,
-    w_i: vec6f,
-) -> tuple[transformf, vec6f]:
+    alpha: wp.float32,
+    dt: wp.float32,
+    g: wp.vec3f,
+    inv_m_i: wp.float32,
+    I_i: wp.mat33f,
+    inv_I_i: wp.mat33f,
+    p_i: wp.transformf,
+    u_i: wp.spatial_vectorf,
+    w_i: wp.spatial_vectorf,
+) -> tuple[wp.transformf, wp.spatial_vectorf]:
     # Integrate the body twist using the maximal coordinate forward dynamics equations
     v_i_n, omega_i_n = compute_body_twist_update_with_eom(
         dt=dt,
@@ -105,11 +96,11 @@ def moreau_jean_semi_implicit_with_logmap(
 @wp.kernel
 def _integrate_moreau_jean_first_inplace(
     # Inputs:
-    model_dt: wp.array[float32],
-    model_bodies_wid: wp.array[int32],
-    bodies_u: wp.array[vec6f],
+    model_dt: wp.array[wp.float32],
+    model_bodies_wid: wp.array[wp.int32],
+    bodies_u: wp.array[wp.spatial_vectorf],
     # Outputs:
-    bodies_q: wp.array[transformf],
+    bodies_q: wp.array[wp.transformf],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -140,16 +131,16 @@ def _integrate_moreau_jean_first_inplace(
 def _integrate_moreau_jean_second_inplace(
     # Inputs:
     alpha: float,
-    model_dt: wp.array[float32],
-    model_gravity: wp.array[vec4f],
-    model_bodies_wid: wp.array[int32],
-    model_bodies_inv_m: wp.array[float32],
-    model_bodies_I: wp.array[mat33f],
-    model_bodies_inv_I: wp.array[mat33f],
-    state_bodies_w: wp.array[vec6f],
+    model_dt: wp.array[wp.float32],
+    model_gravity: wp.array[wp.vec4f],
+    model_bodies_wid: wp.array[wp.int32],
+    model_bodies_inv_m: wp.array[wp.float32],
+    model_bodies_I: wp.array[wp.mat33f],
+    model_bodies_inv_I: wp.array[wp.mat33f],
+    state_bodies_w: wp.array[wp.spatial_vectorf],
     # Outputs:
-    state_bodies_q: wp.array[transformf],
-    state_bodies_u: wp.array[vec6f],
+    state_bodies_q: wp.array[wp.transformf],
+    state_bodies_u: wp.array[wp.spatial_vectorf],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -161,7 +152,7 @@ def _integrate_moreau_jean_second_inplace(
     # gravity vector of the corresponding world
     dt = model_dt[wid]
     gv = model_gravity[wid]
-    g = gv.w * vec3f(gv.x, gv.y, gv.z)
+    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]
@@ -241,10 +232,8 @@ class IntegratorMoreauJean(IntegratorBase):
         Initializes the semi-implicit Moreau-Jean integrator with the given :class:`ModelKamino` instance.
 
         Args:
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            alpha (`float`, optional):
-                The angular damping coefficient. Defaults to 0.0 if `None` is provided.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            alpha: The angular damping coefficient. Defaults to 0.0 if `None` is provided.
         """
         super().__init__(model)
 
@@ -276,26 +265,17 @@ class IntegratorMoreauJean(IntegratorBase):
         scheme to integrate the current state of the system over a single time-step.
 
         Args:
-            forward (`Callable`):
-                An operator that calls the underlying solver for the forward dynamics sub-problem.
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            data (`DataKamino`):
-                The data container holding the time-varying parameters of the system being simulated.
-            state_in (`StateKamino`):
-                The state of the system at the current time-step.
-            state_out (`StateKamino`):
-                The state of the system at the next time-step.
-            control (`ControlKamino`):
-                The control inputs applied to the system at the current time-step.
-            limits (`LimitsKamino`, optional):
-                The joint limits of the system at the current time-step.
+            forward: An operator that calls the underlying solver for the forward dynamics sub-problem.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            data: The data container holding the time-varying parameters of the system being simulated.
+            state_in: The state of the system at the current time-step.
+            state_out: The state of the system at the next time-step.
+            control: The control inputs applied to the system at the current time-step.
+            limits: The joint limits of the system at the current time-step.
                 If `None`, no joint limits are considered for the current time-step.
-            contacts (`ContactsKamino`, optional):
-                The set of active contacts of the system at the current time-step.
+            contacts: The set of active contacts of the system at the current time-step.
                 If `None`, no contacts are considered for the current time-step.
-            detector (`CollisionDetector`, optional):
-                The collision detector to use for generating the set of active contacts at the current time-step.\n
+            detector: The collision detector to use for generating the set of active contacts at the current time-step.\n
                 If `None`, no collision detection is performed for the current time-step,
                 and active contacts must be provided via the `contacts` argument.
         """
@@ -333,10 +313,8 @@ class IntegratorMoreauJean(IntegratorBase):
         using the initial generalized velocities of the system.
 
         Args:
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            data (`DataKamino`):
-                The data container holding the time-varying parameters of the system being simulated.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            data: The data container holding the time-varying parameters of the system being simulated.
         """
         wp.launch(
             _integrate_moreau_jean_first_inplace,
@@ -360,10 +338,8 @@ class IntegratorMoreauJean(IntegratorBase):
         the constraint reactions computed from the forward dynamics.
 
         Args:
-            model (`ModelKamino`):
-                The model container holding the time-invariant parameters of the system being simulated.
-            data (`DataKamino`):
-                The data container holding the time-varying parameters of the system being simulated.
+            model: The model container holding the time-invariant parameters of the system being simulated.
+            data: The data container holding the time-varying parameters of the system being simulated.
         """
         wp.launch(
             _integrate_moreau_jean_second_inplace,

--- a/newton/_src/solvers/kamino/_src/kinematics/constraints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/constraints.py
@@ -5,11 +5,13 @@
 Provides mechanisms to define and manage constraints and their associated input/output data.
 """
 
+from __future__ import annotations
+
 import warp as wp
 
 from ..core.data import DataKamino
 from ..core.model import ModelKamino
-from ..core.types import float32, int32, to_warp_int32_array, vec3f
+from ..core.types import to_warp_int32_array
 from ..geometry.contacts import ContactMode, ContactsKamino
 from ..kinematics.limits import LimitsKamino
 
@@ -46,12 +48,12 @@ def get_max_constraints_per_world(
     Returns the maximum number of constraints for each world in the model.
 
     Args:
-        model (ModelKamino): The model for which to compute the maximum constraints.
-        limits (LimitsKamino, optional): The container holding the allocated joint-limit data.
-        contacts (ContactsKamino, optional): The container holding the allocated contacts data.
+        model: The model for which to compute the maximum constraints.
+        limits: The container holding the allocated joint-limit data.
+        contacts: The container holding the allocated contacts data.
 
     Returns:
-        List[int]: A list of the maximum constraints for each world in the model.
+        A list of the maximum constraints for each world in the model.
     """
     # Ensure the model container is valid
     if model is None:
@@ -89,10 +91,10 @@ def make_unilateral_constraints_info(
     Constructs constraints entries in the ModelKaminoInfo member of a model.
 
     Args:
-        model (ModelKamino): The model container holding time-invariant data.
-        data (DataKamino): The solver container holding time-varying data.
-        limits (LimitsKamino, optional): The limits container holding the joint-limit data.
-        contacts (ContactsKamino, optional): The contacts container holding the contact data.
+        model: The model container holding time-invariant data.
+        data: The solver container holding time-varying data.
+        limits: The limits container holding the joint-limit data.
+        contacts: The contacts container holding the contact data.
     """
 
     # Ensure the model is valid
@@ -133,8 +135,8 @@ def make_unilateral_constraints_info(
         model.size.sum_of_max_limits = 0
         model.size.max_of_max_limits = 0
         with wp.ScopedDevice(device):
-            model.info.max_limits = wp.zeros(shape=(num_worlds,), dtype=int32)
-            data.info.num_limits = wp.zeros(shape=(num_worlds,), dtype=int32)
+            model.info.max_limits = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
+            data.info.num_limits = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
 
     def _assign_model_contacts_info():
         nonlocal world_maxnc
@@ -150,8 +152,8 @@ def make_unilateral_constraints_info(
         model.size.sum_of_max_contacts = 0
         model.size.max_of_max_contacts = 0
         with wp.ScopedDevice(device):
-            model.info.max_contacts = wp.zeros(shape=(num_worlds,), dtype=int32)
-            data.info.num_contacts = wp.zeros(shape=(num_worlds,), dtype=int32)
+            model.info.max_contacts = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
+            data.info.num_contacts = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
 
     # If a limits container is provided, ensure it is valid
     # and then assign the entity counters to the model info.
@@ -256,8 +258,8 @@ def make_unilateral_constraints_info(
 
         # Allocate the per-world active constraints count arrays
         # data.info.num_total_cts = wp.clone(model.info.num_joint_cts)
-        data.info.num_limit_cts = wp.zeros(shape=(num_worlds,), dtype=int32)
-        data.info.num_contact_cts = wp.zeros(shape=(num_worlds,), dtype=int32)
+        data.info.num_limit_cts = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
+        data.info.num_contact_cts = wp.zeros(shape=(num_worlds,), dtype=wp.int32)
 
         # Allocate the per-world entity start arrays
         model.info.limits_offset = to_warp_int32_array(world_lio[:num_worlds])
@@ -286,15 +288,15 @@ def make_unilateral_constraints_info(
 @wp.kernel
 def _update_constraints_info(
     # Inputs:
-    model_info_num_joint_cts: wp.array[int32],
-    data_info_num_limits: wp.array[int32],
-    data_info_num_contacts: wp.array[int32],
+    model_info_num_joint_cts: wp.array[wp.int32],
+    data_info_num_limits: wp.array[wp.int32],
+    data_info_num_contacts: wp.array[wp.int32],
     # Outputs:
-    data_info_num_total_cts: wp.array[int32],
-    data_info_num_limit_cts: wp.array[int32],
-    data_info_num_contact_cts: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
+    data_info_num_total_cts: wp.array[wp.int32],
+    data_info_num_limit_cts: wp.array[wp.int32],
+    data_info_num_contact_cts: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
 ):
     # Retrieve the thread index as the world index
     wid = wp.tid()
@@ -327,17 +329,17 @@ def _update_constraints_info(
 @wp.kernel
 def _unpack_joint_constraint_solutions(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_joint_wid: wp.array[int32],
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_num_kinematic_cts: wp.array[int32],
-    model_joints_dynamic_cts_offset_joint_cts: wp.array[int32],
-    model_joints_kinematic_cts_offset_joint_cts: wp.array[int32],
-    model_joints_dynamic_cts_offset_total_cts: wp.array[int32],
-    model_joints_kinematic_cts_offset_total_cts: wp.array[int32],
-    lambdas: wp.array[float32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_num_kinematic_cts: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset_joint_cts: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset_joint_cts: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset_total_cts: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset_total_cts: wp.array[wp.int32],
+    lambdas: wp.array[wp.float32],
     # Outputs:
-    joint_lambda_j: wp.array[float32],
+    joint_lambda_j: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the joint index
     jid = wp.tid()
@@ -367,17 +369,17 @@ def _unpack_joint_constraint_solutions(
 @wp.kernel
 def _unpack_limit_constraint_solutions(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_info_total_cts_offset: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    limit_model_num_limits: wp.array[int32],
-    limit_wid: wp.array[int32],
-    limit_lid: wp.array[int32],
-    lambdas: wp.array[float32],
-    v_plus: wp.array[float32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    limit_model_num_limits: wp.array[wp.int32],
+    limit_wid: wp.array[wp.int32],
+    limit_lid: wp.array[wp.int32],
+    lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
     # Outputs:
-    limit_reaction: wp.array[float32],
-    limit_velocity: wp.array[float32],
+    limit_reaction: wp.array[wp.float32],
+    limit_velocity: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the contact index
     lid = wp.tid()
@@ -416,18 +418,18 @@ def _unpack_limit_constraint_solutions(
 @wp.kernel
 def _unpack_contact_constraint_solutions(
     # Inputs:
-    model_time_inv_dt: wp.array[float32],
-    model_info_total_cts_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    contact_model_num_contacts: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    lambdas: wp.array[float32],
-    v_plus: wp.array[float32],
+    model_time_inv_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    contact_model_num_contacts: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
     # Outputs:
-    contact_mode: wp.array[int32],
-    contact_reaction: wp.array[vec3f],
-    contact_velocity: wp.array[vec3f],
+    contact_mode: wp.array[wp.int32],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_velocity: wp.array[wp.vec3f],
 ):
     # Retrieve the thread index as the contact index
     cid = wp.tid()
@@ -453,8 +455,8 @@ def _unpack_contact_constraint_solutions(
     contact_cts_start = total_cts_offset + contact_cts_offset + 3 * cid_k
 
     # Load the contact reaction and velocity from the global constraint arrays
-    lambda_k = vec3f(0.0)
-    v_plus_k = vec3f(0.0)
+    lambda_k = wp.vec3f(0.0)
+    v_plus_k = wp.vec3f(0.0)
     for k in range(3):
         lambda_k[k] = lambdas[contact_cts_start + k]
         v_plus_k[k] = v_plus[contact_cts_start + k]
@@ -484,8 +486,8 @@ def update_constraints_info(
     Updates the active constraints info for the given model and current data.
 
     Args:
-        model (ModelKamino): The model container holding time-invariant data.
-        data (DataKamino): The solver container holding time-varying data.
+        model: The model container holding time-invariant data.
+        data: The solver container holding time-varying data.
     """
     wp.launch(
         _update_constraints_info,
@@ -507,8 +509,8 @@ def update_constraints_info(
 
 
 def unpack_constraint_solutions(
-    lambdas: wp.array,
-    v_plus: wp.array,
+    lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
     model: ModelKamino,
     data: DataKamino,
     limits: LimitsKamino | None = None,
@@ -518,12 +520,12 @@ def unpack_constraint_solutions(
     Unpacks the constraint reactions and velocities into respective data containers.
 
     Args:
-        lambdas (wp.array): The array of constraint reactions (i.e. lagrange multipliers).
-        v_plus (wp.array): The array of post-event constraint velocities.
-        data (DataKamino): The solver container holding time-varying data.
-        limits (LimitsKamino, optional): The limits container holding the joint-limit data.\n
+        lambdas: The array of constraint reactions (i.e. lagrange multipliers).
+        v_plus: The array of post-event constraint velocities.
+        data: The solver container holding time-varying data.
+        limits: The limits container holding the joint-limit data.\n
             If None, limits will be skipped.
-        contacts (ContactsKamino, optional): The contacts container holding the contact data.\n
+        contacts: The contacts container holding the contact data.\n
             If None, contacts will be skipped.
     """
     # Unpack joint constraint multipliers if the model has joints

--- a/newton/_src/solvers/kamino/_src/kinematics/constraints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/constraints.py
@@ -523,9 +523,9 @@ def unpack_constraint_solutions(
         lambdas: The array of constraint reactions (i.e. lagrange multipliers).
         v_plus: The array of post-event constraint velocities.
         data: The solver container holding time-varying data.
-        limits: The limits container holding the joint-limit data.\n
+        limits: The limits container holding the joint-limit data.
             If None, limits will be skipped.
-        contacts: The contacts container holding the contact data.\n
+        contacts: The contacts container holding the contact data.
             If None, contacts will be skipped.
     """
     # Unpack joint constraint multipliers if the model has joints

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -24,15 +24,8 @@ from ..core.math import (
 from ..core.model import ModelKamino
 from ..core.types import (
     assign_to_warp_int32_array,
-    float32,
-    int32,
-    mat33f,
     mat66f,
-    quatf,
     to_warp_int32_array,
-    transformf,
-    vec2i,
-    vec3f,
     vec6f,
 )
 from ..geometry.contacts import ContactsKamino
@@ -76,7 +69,7 @@ def make_store_joint_jacobian_dense_func(axes: Any):
         idx: int,
         axis: int,
         JT: mat66f,
-        J_data: wp.array[float32],
+        J_data: wp.array[wp.float32],
     ):
         for i in range(6):
             J_data[idx + i] = JT[i, axis]
@@ -90,20 +83,20 @@ def make_store_joint_jacobian_dense_func(axes: Any):
         bid_F: int,
         JT_B_j: mat66f,
         JT_F_j: mat66f,
-        J_data: wp.array[float32],
+        J_data: wp.array[wp.float32],
     ):
         """
         Stores the Jacobian blocks of a joint into the provided flat data array at the specified offset.
 
         Args:
-            J_row_offset (int): The offset at which the Jacobian matrix block of the corresponding world starts.
-            row_size (int): The number of columns in the world's Jacobian block.
-            bid_offset (int): The body index offset of the world's bodies w.r.t the model.
-            bid_B (int): The body index of the base body of the joint w.r.t the model.
-            bid_F (int): The body index of the follower body of the joint w.r.t the model.
-            JT_B_j (mat66f): The 6x6 Jacobian transpose block of the joint's base body.
-            JT_F_j (mat66f): The 6x6 Jacobian transpose block of the joint's follower body.
-            J_data (wp.array[float32]): The flat data array holding the Jacobian matrix blocks.
+            J_row_offset: The offset at which the Jacobian matrix block of the corresponding world starts.
+            row_size: The number of columns in the world's Jacobian block.
+            bid_offset: The body index offset of the world's bodies w.r.t the model.
+            bid_B: The body index of the base body of the joint w.r.t the model.
+            bid_F: The body index of the follower body of the joint w.r.t the model.
+            JT_B_j: The 6x6 Jacobian transpose block of the joint's base body.
+            JT_F_j: The 6x6 Jacobian transpose block of the joint's follower body.
+            J_data: The flat data array holding the Jacobian matrix blocks.
         """
         # Set the number of rows in the output Jacobian block
         # NOTE: This is evaluated statically at compile time
@@ -144,12 +137,13 @@ def make_store_joint_jacobian_sparse_func(axes: Any):
         """
         Function extracting rows corresponding to joint axes from the 6x6 joint jacobians,
         and storing them into the appropriate non-zero blocks.
+
         Args:
-            is_binary (bool): Whether the joint is binary
-            JT_B_j (mat66f): The 6x6 Jacobian transpose block of the joint's base body.
-            JT_F_j (mat66f): The 6x6 Jacobian transpose block of the joint's follower body.
-            J_nzb_offset (int): The index of the first nzb corresponding to this joint.
-            J_nzb_values (wp.array[vec6f]): Array storing the non-zero blocks of the Jacobians.
+            is_binary: Whether the joint is binary.
+            JT_B_j: The 6x6 Jacobian transpose block of the joint's base body.
+            JT_F_j: The 6x6 Jacobian transpose block of the joint's follower body.
+            J_nzb_offset: The index of the first nzb corresponding to this joint.
+            J_nzb_values: Array storing the non-zero blocks of the Jacobians.
         """
         # Set the number of rows in the output Jacobian block
         # NOTE: This is evaluated statically at compile time
@@ -180,7 +174,7 @@ def store_joint_cts_jacobian_dense(
     bid_F: int,
     JT_B: mat66f,
     JT_F: mat66f,
-    J_data: wp.array[float32],
+    J_data: wp.array[wp.float32],
 ):
     """
     Stores the constraints Jacobian block of a joint into the provided flat data array at the given offset.
@@ -237,7 +231,7 @@ def store_joint_dofs_jacobian_dense(
     bid_F: int,
     JT_B: mat66f,
     JT_F: mat66f,
-    J_data: wp.array[float32],
+    J_data: wp.array[wp.float32],
 ):
     """
     Stores the DoFs Jacobian block of a joint into the provided flat data array at the given offset.
@@ -393,7 +387,9 @@ def store_joint_dofs_jacobian_sparse(
 
 
 @wp.func
-def compute_joint_relative_quaternion(T_B_j: transformf, T_F_j: transformf, X_Bj: mat33f, X_Fj: mat33f) -> quatf:
+def compute_joint_relative_quaternion(
+    T_B_j: wp.transformf, T_F_j: wp.transformf, X_Bj: wp.mat33f, X_Fj: wp.mat33f
+) -> wp.quatf:
     """
     Computes the relative quaternion mapping base to follower joint frame, from the current base
     and follower pose, and the joint frames in local coordinates on either body.
@@ -409,17 +405,16 @@ def compute_joint_relative_quaternion(T_B_j: transformf, T_F_j: transformf, X_Bj
 
 @wp.func
 def compute_intermediate_body_frame_universal_joint(
-    j_q_j: quatf,
-) -> mat33f:
-    """ "
-    Computes the frame of the intermediate body of a universal joint (i.e. x axis on the base,
+    j_q_j: wp.quatf,
+) -> wp.mat33f:
+    """Computes the frame of the intermediate body of a universal joint (i.e. x axis on the base,
     y axis on the follower, and their cross product), from the relative quaternion mapping base to
     follower joint frame, as a rotation matrix expressed in the joint frame on the base body.
 
     The result is orthogonalized in case constraints are violated, and the x and y axes are not orthogonal.
     """
-    e_x = vec3f(1.0, 0.0, 0.0)
-    e_y = vec3f(0.0, 1.0, 0.0)
+    e_x = wp.vec3f(1.0, 0.0, 0.0)
+    e_y = wp.vec3f(0.0, 1.0, 0.0)
     a_x = e_x  # x axis on base
     a_y_raw = wp.quat_rotate(j_q_j, e_y)  #  y axis on follower (constrained to be orthogonal to a_x)
     a_y = a_y_raw - wp.dot(a_y_raw, a_x) * a_x  # orthogonalize (in case of constraint violations)
@@ -436,29 +431,29 @@ def compute_intermediate_body_frame_universal_joint(
 @wp.kernel
 def _build_joint_jacobians_dense(
     # Inputs
-    model_info_bodies_offset: wp.array[int32],
-    model_info_joint_dofs_offset: wp.array[int32],
-    model_info_joint_dynamic_cts_offset: wp.array[int32],
-    model_info_joint_kinematic_cts_offset: wp.array[int32],
-    model_info_joint_dynamic_cts_group_offset: wp.array[int32],
-    model_info_joint_kinematic_cts_group_offset: wp.array[int32],
-    model_joints_wid: wp.array[int32],
-    model_joints_dof_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_dynamic_cts_offset: wp.array[int32],
-    model_joints_kinematic_cts_offset: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    model_joints_bid_F: wp.array[int32],
-    model_joints_X_Bj: wp.array[mat33f],
-    model_joints_X_Fj: wp.array[mat33f],
-    state_joints_p: wp.array[transformf],
-    state_bodies_q: wp.array[transformf],
-    jac_cts_offsets: wp.array[int32],
-    jac_dofs_offsets: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_info_joint_dofs_offset: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_offset: wp.array[wp.int32],
+    model_info_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_info_joint_dynamic_cts_group_offset: wp.array[wp.int32],
+    model_info_joint_kinematic_cts_group_offset: wp.array[wp.int32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_dof_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_dynamic_cts_offset: wp.array[wp.int32],
+    model_joints_kinematic_cts_offset: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    model_joints_bid_F: wp.array[wp.int32],
+    model_joints_X_Bj: wp.array[wp.mat33f],
+    model_joints_X_Fj: wp.array[wp.mat33f],
+    state_joints_p: wp.array[wp.transformf],
+    state_bodies_q: wp.array[wp.transformf],
+    jac_cts_offsets: wp.array[wp.int32],
+    jac_dofs_offsets: wp.array[wp.int32],
     # Outputs
-    jac_cts_data: wp.array[float32],
-    jac_dofs_data: wp.array[float32],
+    jac_cts_data: wp.array[wp.float32],
+    jac_dofs_data: wp.array[wp.float32],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -542,11 +537,11 @@ def _build_joint_jacobians_dense(
 @wp.kernel
 def _configure_jacobians_sparse(
     # Input:
-    model_num_joint_cts: wp.array[int32],
-    num_limits: wp.array[int32],
-    num_contacts: wp.array[int32],
+    model_num_joint_cts: wp.array[wp.int32],
+    num_limits: wp.array[wp.int32],
+    num_contacts: wp.array[wp.int32],
     # Output:
-    jac_cts_rows: wp.array[int32],
+    jac_cts_rows: wp.array[wp.int32],
 ):
     world_id = wp.tid()
 
@@ -556,18 +551,18 @@ def _configure_jacobians_sparse(
 @wp.kernel
 def _build_joint_jacobians_sparse(
     # Inputs
-    model_joints_dof_type: wp.array[int32],
-    model_joints_num_dofs: wp.array[int32],
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    model_joints_bid_F: wp.array[int32],
-    model_joints_X_Bj: wp.array[mat33f],
-    model_joints_X_Fj: wp.array[mat33f],
-    model_joints_dynamic_cts_offset: wp.array[int32],
-    state_joints_p: wp.array[transformf],
-    state_bodies_q: wp.array[transformf],
-    jacobian_cts_nzb_offsets: wp.array[int32],
-    jacobian_dofs_nzb_offsets: wp.array[int32],
+    model_joints_dof_type: wp.array[wp.int32],
+    model_joints_num_dofs: wp.array[wp.int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    model_joints_bid_F: wp.array[wp.int32],
+    model_joints_X_Bj: wp.array[wp.mat33f],
+    model_joints_X_Fj: wp.array[wp.mat33f],
+    model_joints_dynamic_cts_offset: wp.array[wp.int32],
+    state_joints_p: wp.array[wp.transformf],
+    state_bodies_q: wp.array[wp.transformf],
+    jacobian_cts_nzb_offsets: wp.array[wp.int32],
+    jacobian_dofs_nzb_offsets: wp.array[wp.int32],
     # Outputs
     jacobian_cts_nzb_values: wp.array[vec6f],
     jacobian_dofs_nzb_values: wp.array[vec6f],
@@ -653,21 +648,21 @@ def _build_joint_jacobians_sparse(
 @wp.kernel
 def _build_limit_jacobians_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_info_joint_dofs_offset: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    limits_model_num: wp.array[int32],
-    limits_model_max: int32,
-    limits_wid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    limits_dof: wp.array[int32],
-    limits_side: wp.array[float32],
-    jacobian_dofs_offsets: wp.array[int32],
-    jacobian_dofs_data: wp.array[float32],
-    jacobian_cts_offsets: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_info_joint_dofs_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    limits_model_num: wp.array[wp.int32],
+    limits_model_max: wp.int32,
+    limits_wid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    limits_dof: wp.array[wp.int32],
+    limits_side: wp.array[wp.float32],
+    jacobian_dofs_offsets: wp.array[wp.int32],
+    jacobian_dofs_data: wp.array[wp.float32],
+    jacobian_cts_offsets: wp.array[wp.int32],
     # Outputs:
-    jacobian_cts_data: wp.array[float32],
+    jacobian_cts_data: wp.array[wp.float32],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -726,26 +721,26 @@ def _build_limit_jacobians_dense(
 @wp.kernel
 def _build_limit_jacobians_sparse(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_num_dofs: wp.array[int32],
-    state_info_limit_cts_group_offset: wp.array[int32],
-    limits_model_num: wp.array[int32],
-    limits_model_max: int32,
-    limits_wid: wp.array[int32],
-    limits_jid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    limits_dof: wp.array[int32],
-    limits_side: wp.array[float32],
-    jacobian_dofs_joint_nzb_offsets: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_num_dofs: wp.array[wp.int32],
+    state_info_limit_cts_group_offset: wp.array[wp.int32],
+    limits_model_num: wp.array[wp.int32],
+    limits_model_max: wp.int32,
+    limits_wid: wp.array[wp.int32],
+    limits_jid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    limits_dof: wp.array[wp.int32],
+    limits_side: wp.array[wp.float32],
+    jacobian_dofs_joint_nzb_offsets: wp.array[wp.int32],
     jacobian_dofs_nzb_values: wp.array[vec6f],
-    jacobian_cts_nzb_start: wp.array[int32],
+    jacobian_cts_nzb_start: wp.array[wp.int32],
     # Outputs:
-    jacobian_cts_num_nzb: wp.array[int32],
-    jacobian_cts_nzb_coords: wp.array2d[int32],
+    jacobian_cts_num_nzb: wp.array[wp.int32],
+    jacobian_cts_nzb_coords: wp.array2d[wp.int32],
     jacobian_cts_nzb_values: wp.array[vec6f],
-    jacobian_cts_limit_nzb_offsets: wp.array[int32],
+    jacobian_cts_limit_nzb_offsets: wp.array[wp.int32],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -800,20 +795,20 @@ def _build_limit_jacobians_sparse(
 @wp.kernel
 def _build_contact_jacobians_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    state_bodies_q: wp.array[transformf],
-    contacts_model_num: wp.array[int32],
-    contacts_model_max: int32,
-    contacts_wid: wp.array[int32],
-    contacts_cid: wp.array[int32],
-    contacts_bid_AB: wp.array[vec2i],
-    contacts_position_A: wp.array[vec3f],
-    contacts_position_B: wp.array[vec3f],
-    contacts_frame: wp.array[quatf],
-    jacobian_cts_offsets: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    state_bodies_q: wp.array[wp.transformf],
+    contacts_model_num: wp.array[wp.int32],
+    contacts_model_max: wp.int32,
+    contacts_wid: wp.array[wp.int32],
+    contacts_cid: wp.array[wp.int32],
+    contacts_bid_AB: wp.array[wp.vec2i],
+    contacts_position_A: wp.array[wp.vec3f],
+    contacts_position_B: wp.array[wp.vec3f],
+    contacts_frame: wp.array[wp.quatf],
+    jacobian_cts_offsets: wp.array[wp.int32],
     # Outputs:
-    jacobian_cts_data: wp.array[float32],
+    jacobian_cts_data: wp.array[wp.float32],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -881,23 +876,23 @@ def _build_contact_jacobians_dense(
 @wp.kernel
 def _build_contact_jacobians_sparse(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    state_info_contact_cts_group_offset: wp.array[int32],
-    state_bodies_q: wp.array[transformf],
-    contacts_model_num: wp.array[int32],
-    contacts_model_max: int32,
-    contacts_wid: wp.array[int32],
-    contacts_cid: wp.array[int32],
-    contacts_bid_AB: wp.array[vec2i],
-    contacts_position_A: wp.array[vec3f],
-    contacts_position_B: wp.array[vec3f],
-    contacts_frame: wp.array[quatf],
-    jacobian_cts_nzb_start: wp.array[int32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    state_info_contact_cts_group_offset: wp.array[wp.int32],
+    state_bodies_q: wp.array[wp.transformf],
+    contacts_model_num: wp.array[wp.int32],
+    contacts_model_max: wp.int32,
+    contacts_wid: wp.array[wp.int32],
+    contacts_cid: wp.array[wp.int32],
+    contacts_bid_AB: wp.array[wp.vec2i],
+    contacts_position_A: wp.array[wp.vec3f],
+    contacts_position_B: wp.array[wp.vec3f],
+    contacts_frame: wp.array[wp.quatf],
+    jacobian_cts_nzb_start: wp.array[wp.int32],
     # Outputs:
-    jacobian_cts_num_nzb: wp.array[int32],
-    jacobian_cts_nzb_coords: wp.array2d[int32],
+    jacobian_cts_num_nzb: wp.array[wp.int32],
+    jacobian_cts_nzb_coords: wp.array2d[wp.int32],
     jacobian_cts_nzb_values: wp.array[vec6f],
-    jacobian_cts_contact_nzb_offsets: wp.array[int32],
+    jacobian_cts_contact_nzb_offsets: wp.array[wp.int32],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -964,12 +959,12 @@ def _build_contact_jacobians_sparse(
 
 @wp.func
 def store_col_major_jacobian_block(
-    nzb_id: int32,
-    row_id: int32,
-    col_id: int32,
+    nzb_id: wp.int32,
+    row_id: wp.int32,
+    col_id: wp.int32,
     block: mat66f,
-    nzb_coords: wp.array2d[int32],
-    nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=float32)],
+    nzb_coords: wp.array2d[wp.int32],
+    nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=wp.float32)],
 ):
     for i in range(6):
         nzb_id_i = nzb_id + i
@@ -982,15 +977,15 @@ def store_col_major_jacobian_block(
 @wp.kernel
 def _update_col_major_joint_jacobians(
     # Inputs
-    model_joints_num_dynamic_cts: wp.array[int32],
-    model_joints_num_kinematic_cts: wp.array[int32],
-    model_joints_bid_B: wp.array[int32],
-    jac_cts_row_major_joint_nzb_offsets: wp.array[int32],
-    jac_cts_row_major_nzb_coords: wp.array2d[int32],
+    model_joints_num_dynamic_cts: wp.array[wp.int32],
+    model_joints_num_kinematic_cts: wp.array[wp.int32],
+    model_joints_bid_B: wp.array[wp.int32],
+    jac_cts_row_major_joint_nzb_offsets: wp.array[wp.int32],
+    jac_cts_row_major_nzb_coords: wp.array2d[wp.int32],
     jac_cts_row_major_nzb_values: wp.array[vec6f],
-    jac_cts_col_major_joint_nzb_offsets: wp.array[int32],
+    jac_cts_col_major_joint_nzb_offsets: wp.array[wp.int32],
     # Outputs
-    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=float32)],
+    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=wp.float32)],
 ):
     """
     A kernel to compute the Jacobians (constraints and actuated DoFs) for the joints in a model.
@@ -1059,18 +1054,18 @@ def _update_col_major_joint_jacobians(
 @wp.kernel
 def _update_col_major_limit_jacobians(
     # Inputs
-    limits_model_num: wp.array[int32],
-    limits_model_max: int32,
-    limits_wid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    jac_cts_row_major_limit_nzb_offsets: wp.array[int32],
-    jac_cts_row_major_nzb_coords: wp.array2d[int32],
+    limits_model_num: wp.array[wp.int32],
+    limits_model_max: wp.int32,
+    limits_wid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    jac_cts_row_major_limit_nzb_offsets: wp.array[wp.int32],
+    jac_cts_row_major_nzb_coords: wp.array2d[wp.int32],
     jac_cts_row_major_nzb_values: wp.array[vec6f],
-    jac_cts_col_major_nzb_start: wp.array[int32],
+    jac_cts_col_major_nzb_start: wp.array[wp.int32],
     # Outputs
-    jac_cts_col_major_num_nzb: wp.array[int32],
-    jac_cts_col_major_nzb_coords: wp.array2d[int32],
-    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=float32)],
+    jac_cts_col_major_num_nzb: wp.array[wp.int32],
+    jac_cts_col_major_nzb_coords: wp.array2d[wp.int32],
+    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=wp.float32)],
 ):
     """
     A kernel to assemble the limit constraint Jacobian in a model.
@@ -1141,18 +1136,18 @@ def _update_col_major_limit_jacobians(
 @wp.kernel
 def _update_col_major_contact_jacobians(
     # Inputs:
-    contacts_model_num: wp.array[int32],
-    contacts_model_max: int32,
-    contacts_wid: wp.array[int32],
-    contacts_bid_AB: wp.array[vec2i],
-    jac_cts_row_major_contact_nzb_offsets: wp.array[int32],
-    jac_cts_row_major_nzb_coords: wp.array2d[int32],
+    contacts_model_num: wp.array[wp.int32],
+    contacts_model_max: wp.int32,
+    contacts_wid: wp.array[wp.int32],
+    contacts_bid_AB: wp.array[wp.vec2i],
+    jac_cts_row_major_contact_nzb_offsets: wp.array[wp.int32],
+    jac_cts_row_major_nzb_coords: wp.array2d[wp.int32],
     jac_cts_row_major_nzb_values: wp.array[vec6f],
-    jac_cts_col_major_nzb_start: wp.array[int32],
+    jac_cts_col_major_nzb_start: wp.array[wp.int32],
     # Outputs
-    jac_cts_col_major_num_nzb: wp.array[int32],
-    jac_cts_col_major_nzb_coords: wp.array2d[int32],
-    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=float32)],
+    jac_cts_col_major_num_nzb: wp.array[wp.int32],
+    jac_cts_col_major_nzb_coords: wp.array2d[wp.int32],
+    jac_cts_col_major_nzb_values: wp.array[wp.types.matrix(shape=(6, 1), dtype=wp.float32)],
 ):
     """
     A kernel to assemble the contact constraint Jacobian in a model.
@@ -1234,32 +1229,32 @@ class DenseSystemJacobiansData:
         # Constraint Jacobian
         ###
 
-        self.J_cts_offsets: wp.array | None = None
+        self.J_cts_offsets: wp.array[wp.int32] | None = None
         """
         The index offset of the constraint Jacobian matrix block of each world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.\n
+        Shape of ``(num_worlds,)``.\n
         """
 
-        self.J_cts_data: wp.array | None = None
+        self.J_cts_data: wp.array[wp.float32] | None = None
         """
         A flat array containing the constraint Jacobian matrix data of all worlds.\n
-        Shape of ``(sum(ncts_w * nbd_w),)`` and type :class:`float32`.
+        Shape of ``(sum(ncts_w * nbd_w),)``.
         """
 
         ###
         # DoFs Jacobian
         ###
 
-        self.J_dofs_offsets: wp.array | None = None
+        self.J_dofs_offsets: wp.array[wp.int32] | None = None
         """
         The index offset of the DoF Jacobian matrix block of each world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.\n
+        Shape of ``(num_worlds,)``.\n
         """
 
-        self.J_dofs_data: wp.array | None = None
+        self.J_dofs_data: wp.array[wp.float32] | None = None
         """
         A flat array containing the joint DoF Jacobian matrix data of all worlds.\n
-        Shape of ``(sum(njad_w * nbd_w),)`` and type :class:`float32`.
+        Shape of ``(sum(njad_w * nbd_w),)``.
         """
 
 
@@ -1290,14 +1285,11 @@ class DenseSystemJacobians:
         constraint Jacobian matrix blocks of world ``w``.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container describing the system structure and properties, used
+            model: The model container describing the system structure and properties, used
                 to allocate the Jacobian data and compute the matrix block sizes and index offsets.
-            limits (`LimitsKamino`, optional):
-                The limits container describing the active limits in the system, used
+            limits: The limits container describing the active limits in the system, used
                 to compute the matrix block sizes and index offsets if provided.
-            contacts (`ContactsKamino`, optional):
-                The contacts container describing the active contacts in the system,
+            contacts: The contacts container describing the active contacts in the system,
                 used to compute the matrix block sizes and index offsets if provided.
         """
         # Declare and initialize the Jacobian data container
@@ -1368,8 +1360,8 @@ class DenseSystemJacobians:
         with wp.ScopedDevice(device):
             self._data.J_cts_offsets = to_warp_int32_array(J_cts_offsets)
             self._data.J_dofs_offsets = to_warp_int32_array(J_dofs_offsets)
-            self._data.J_cts_data = wp.zeros(shape=(total_J_cts_size,), dtype=float32)
-            self._data.J_dofs_data = wp.zeros(shape=(total_J_dofs_size,), dtype=float32)
+            self._data.J_cts_data = wp.zeros(shape=(total_J_cts_size,), dtype=wp.float32)
+            self._data.J_dofs_data = wp.zeros(shape=(total_J_dofs_size,), dtype=wp.float32)
 
     def build(
         self,
@@ -1384,20 +1376,15 @@ class DenseSystemJacobians:
         data of the provided model, data, limits and contacts containers.
 
         Args:
-            model (`ModelKamino`):
-                The model container describing the system structure
+            model: The model container describing the system structure
                 and properties, used to compute the Jacobians.
-            data (`DataKamino`):
-                The data container describing the time-varying state
+            data: The data container describing the time-varying state
                 of the system, used to compute the Jacobians.
-            limits (`LimitsKamino`, optional):
-                The limits container describing the active limits in the system,
+            limits: The limits container describing the active limits in the system,
                 used to compute the limit constraint Jacobians if provided.
-            contacts (`ContactsKamino`, optional):
-                The contacts container describing the active contacts in the system,
+            contacts: The contacts container describing the active contacts in the system,
                 used to compute the contact constraint Jacobians if provided.
-            reset_to_zero (`bool`, optional):
-                Whether to reset the Jacobian values to zero before building.\n
+            reset_to_zero: Whether to reset the Jacobian values to zero before building.\n
                 If false, the Jacobian values will be accumulated onto existing values.\n
                 Defaults to `True`.
         """
@@ -1510,14 +1497,11 @@ class SparseSystemJacobians:
         the non-zero block coordinates are stored as local offsets for each world, joint, limit, and contact.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container describing the system structure and properties, used
+            model: The model container describing the system structure and properties, used
                 to allocate the Jacobian data and compute the non-zero block coordinates.
-            limits (`LimitsKamino`, optional):
-                The limits container describing the active limits in the system, used to
+            limits: The limits container describing the active limits in the system, used to
                 compute the non-zero block coordinates of the limit constraint Jacobian.
-            contacts (`ContactsKamino`, optional):
-                The contacts container describing the active contacts in the system, used to
+            contacts: The contacts container describing the active contacts in the system, used to
                 compute the non-zero block coordinates of the contact constraint Jacobian.
         """
         # Declare and initialize the Jacobian data containers
@@ -1526,13 +1510,13 @@ class SparseSystemJacobians:
 
         # Local (in-world) offsets for the non-zero blocks of the constraint and dofs Jacobian for
         # each (global) joint, limit, and contact
-        self._J_cts_joint_nzb_offsets: wp.array | None = None
-        self._J_cts_limit_nzb_offsets: wp.array | None = None
-        self._J_cts_contact_nzb_offsets: wp.array | None = None
-        self._J_dofs_joint_nzb_offsets: wp.array | None = None
+        self._J_cts_joint_nzb_offsets: wp.array[wp.int32] | None = None
+        self._J_cts_limit_nzb_offsets: wp.array[wp.int32] | None = None
+        self._J_cts_contact_nzb_offsets: wp.array[wp.int32] | None = None
+        self._J_dofs_joint_nzb_offsets: wp.array[wp.int32] | None = None
 
         # Lists of number of non-zero blocks in each world connected to joint constraints
-        self._J_cts_num_joint_nzb: wp.array | None = None
+        self._J_cts_num_joint_nzb: wp.array[wp.int32] | None = None
 
         # If a model is provided, allocate the Jacobians data
         if model is not None:
@@ -1549,17 +1533,13 @@ class SparseSystemJacobians:
         for each world, joint, limit, and contact based on the provided model, limits, and contacts containers.
 
         Args:
-            model (`ModelKamino`):
-                The model container describing the system structure and properties, used
+            model: The model container describing the system structure and properties, used
                 to allocate the Jacobian data and compute the non-zero block coordinates.
-            limits (`LimitsKamino`, optional):
-                The limits container describing the active limits in the system, used to
+            limits: The limits container describing the active limits in the system, used to
                 compute the non-zero block coordinates of the limit constraint Jacobian.
-            contacts (`ContactsKamino`, optional):
-                The contacts container describing the active contacts in the system, used to
+            contacts: The contacts container describing the active contacts in the system, used to
                 compute the non-zero block coordinates of the contact constraint Jacobian.
-            device (`wp.DeviceLike`, optional):
-                The device on which to allocate the Jacobian data.\n
+            device: The device on which to allocate the Jacobian data.\n
                 If `None`, the Jacobian data will be allocated on same device as the model.
         """
 
@@ -1694,7 +1674,7 @@ class SparseSystemJacobians:
             # First allocate the geometric constraint Jacobian
             bsm_cts = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=float32, shape=(6,)),
+                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6,)),
                 device=device,
             )
             bsm_cts.finalize(max_dims=J_cts_dims_max, capacities=J_cts_nnzb_max)
@@ -1703,7 +1683,7 @@ class SparseSystemJacobians:
             # Then allocate the geometric DoFs Jacobian
             bsm_dofs = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=float32, shape=(6,)),
+                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6,)),
                 device=device,
             )
             bsm_dofs.finalize(max_dims=J_dofs_dims, capacities=J_dofs_nnzb)
@@ -1731,9 +1711,11 @@ class SparseSystemJacobians:
 
             # Create/move precomputed helper arrays to device
             self._J_cts_joint_nzb_offsets = to_warp_int32_array(J_cts_joint_nzb_offsets, device=device)
-            self._J_cts_limit_nzb_offsets = wp.zeros(shape=(model.size.sum_of_max_limits,), dtype=int32, device=device)
+            self._J_cts_limit_nzb_offsets = wp.zeros(
+                shape=(model.size.sum_of_max_limits,), dtype=wp.int32, device=device
+            )
             self._J_cts_contact_nzb_offsets = wp.zeros(
-                shape=(model.size.sum_of_max_contacts,), dtype=int32, device=device
+                shape=(model.size.sum_of_max_contacts,), dtype=wp.int32, device=device
             )
             self._J_dofs_joint_nzb_offsets = to_warp_int32_array(J_dofs_joint_nzb_offsets, device=device)
             self._J_cts_num_joint_nzb = to_warp_int32_array(J_cts_nnzb_min, device=device)
@@ -1751,18 +1733,13 @@ class SparseSystemJacobians:
         data of the provided model, data, limits and contacts containers.
 
         Args:
-            model (`ModelKamino`):
-                The model containing the system's kinematic structure.
-            data (`DataKamino`):
-                The data container holding the time-varying state of the system.
-            limits (`LimitsKamino`, optional):
-                LimitsKamino data container for joint-limit constraints. Needs to
+            model: The model containing the system's kinematic structure.
+            data: The data container holding the time-varying state of the system.
+            limits: LimitsKamino data container for joint-limit constraints. Needs to
                 be provided if the Jacobian also has limit constraints.
-            contacts (`ContactsKamino`, optional):
-                Contacts data container for contact constraints. Needs to
+            contacts: Contacts data container for contact constraints. Needs to
                 be provided if the Jacobian also has contact constraints.
-            reset_to_zero (`bool`, optional):
-                Whether to reset the Jacobian values to zero before building.\n
+            reset_to_zero: Whether to reset the Jacobian values to zero before building.\n
                 If false, the Jacobian values will be accumulated onto existing values.\n
                 Defaults to `True`.
 
@@ -1909,23 +1886,19 @@ class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
         Constructs a column-major sparse constraint Jacobian.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model containing the system's kinematic structure. If provided,
+            model: The model containing the system's kinematic structure. If provided,
                 the Jacobian will be immediately finalized with the given model.
-            limits (`LimitsKamino`, optional):
-                LimitsKamino data container for joint limit constraints. Needs to
+            limits: LimitsKamino data container for joint limit constraints. Needs to
                 be provided if the regular Jacobian also has limit constraints.
-            contacts (`ContactsKamino`, optional):
-                Contacts data container for contact constraints. Needs to be
+            contacts: Contacts data container for contact constraints. Needs to be
                 provided if the regular Jacobian also has contact constraints.
-            jacobians (`SparseSystemJacobians`, optional):
-                Row-major sparse Jacobians. If provided, the column-major Jacobian will be
+            jacobians: Row-major sparse Jacobians. If provided, the column-major Jacobian will be
                 immediately updated with values from the provided Jacobians after allocation.
         """
         super().__init__()
 
-        self._joint_nzb_offsets: wp.array | None = None
-        self._num_joint_nzb: wp.array | None = None
+        self._joint_nzb_offsets: wp.array[wp.int32] | None = None
+        self._num_joint_nzb: wp.array[wp.int32] | None = None
 
         if model is not None:
             self.finalize(model=model, limits=limits, contacts=contacts, jacobians=jacobians)
@@ -1941,16 +1914,12 @@ class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
         Initializes the data structure of the column-major constraint Jacobian.
 
         Args:
-            model (`ModelKamino`):
-                The model containing the system's kinematic structure.
-            limits (`LimitsKamino`, optional):
-                LimitsKamino data container for joint limit constraints. Needs to
+            model: The model containing the system's kinematic structure.
+            limits: LimitsKamino data container for joint limit constraints. Needs to
                 be provided if the regular Jacobian also has limit constraints.
-            contacts (`ContactsKamino`, optional):
-                Contacts data container for contact constraints. Needs to be
+            contacts: Contacts data container for contact constraints. Needs to be
                 provided if the regular Jacobian also has contact constraints.
-            jacobians (`SparseSystemJacobians`, optional):
-                Row-major sparse Jacobians. If provided, the column-major Jacobian will be
+            jacobians: Row-major sparse Jacobians. If provided, the column-major Jacobian will be
                 immediately updated with values from the provided Jacobians after allocation.
         """
         # Extract the constraint and DoF sizes of each world
@@ -2057,7 +2026,7 @@ class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
             # Allocate the column-major constraint Jacobian
             self.bsm = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=float32, shape=(6, 1)),
+                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6, 1)),
                 device=device,
             )
             self.bsm.finalize(max_dims=J_cts_cm_dims_max, capacities=J_cts_cm_nnzb_max)
@@ -2093,15 +2062,11 @@ class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
         values of an already assembled row-major Jacobian.
 
         Args:
-            jacobians (`SparseSystemJacobians`):
-                The row-major sparse system Jacobians containing the constraint Jacobians.
-            model (`ModelKamino`):
-                The model containing the system's kinematic structure.
-            limits (`LimitsKamino`, optional):
-                LimitsKamino data container for joint limit constraints. Needs to be
+            jacobians: The row-major sparse system Jacobians containing the constraint Jacobians.
+            model: The model containing the system's kinematic structure.
+            limits: LimitsKamino data container for joint limit constraints. Needs to be
                 provided if the regular Jacobian also has limit constraints.
-            contacts (`ContactsKamino`, optional):
-                Contacts data container for contact constraints. Needs to be
+            contacts: Contacts data container for contact constraints. Needs to be
                 provided if the regular Jacobian also has contact constraints.
 
         Note:

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -1231,13 +1231,13 @@ class DenseSystemJacobiansData:
 
         self.J_cts_offsets: wp.array[wp.int32] | None = None
         """
-        The index offset of the constraint Jacobian matrix block of each world.\n
-        Shape of ``(num_worlds,)``.\n
+        The index offset of the constraint Jacobian matrix block of each world.
+        Shape of ``(num_worlds,)``.
         """
 
         self.J_cts_data: wp.array[wp.float32] | None = None
         """
-        A flat array containing the constraint Jacobian matrix data of all worlds.\n
+        A flat array containing the constraint Jacobian matrix data of all worlds.
         Shape of ``(sum(ncts_w * nbd_w),)``.
         """
 
@@ -1247,13 +1247,13 @@ class DenseSystemJacobiansData:
 
         self.J_dofs_offsets: wp.array[wp.int32] | None = None
         """
-        The index offset of the DoF Jacobian matrix block of each world.\n
-        Shape of ``(num_worlds,)``.\n
+        The index offset of the DoF Jacobian matrix block of each world.
+        Shape of ``(num_worlds,)``.
         """
 
         self.J_dofs_data: wp.array[wp.float32] | None = None
         """
-        A flat array containing the joint DoF Jacobian matrix data of all worlds.\n
+        A flat array containing the joint DoF Jacobian matrix data of all worlds.
         Shape of ``(sum(njad_w * nbd_w),)``.
         """
 
@@ -1275,7 +1275,7 @@ class DenseSystemJacobians:
         contacts: ContactsKamino | None = None,
     ):
         """
-        Creates a :class:`DenseSystemJacobians` container and allocates the Jacobian data if a model is provided.\n
+        Creates a :class:`DenseSystemJacobians` container and allocates the Jacobian data if a model is provided.
 
         The Jacobians are stored in dense format as flat arrays, and the matrix blocks of each world are stored
         contiguously with the corresponding index offsets. The Jacobian matrix blocks of each world are stored
@@ -1384,8 +1384,8 @@ class DenseSystemJacobians:
                 used to compute the limit constraint Jacobians if provided.
             contacts: The contacts container describing the active contacts in the system,
                 used to compute the contact constraint Jacobians if provided.
-            reset_to_zero: Whether to reset the Jacobian values to zero before building.\n
-                If false, the Jacobian values will be accumulated onto existing values.\n
+            reset_to_zero: Whether to reset the Jacobian values to zero before building.
+                If false, the Jacobian values will be accumulated onto existing values.
                 Defaults to `True`.
         """
         # Optionally reset the Jacobian array data to zero
@@ -1491,7 +1491,7 @@ class SparseSystemJacobians:
         contacts: ContactsKamino | None = None,
     ):
         """
-        Creates a :class:`SparseSystemJacobians` container and allocates the Jacobian data if a model is provided.\n
+        Creates a :class:`SparseSystemJacobians` container and allocates the Jacobian data if a model is provided.
 
         The Jacobians are stored in block-sparse format using the :class:`BlockSparseLinearOperators` class, and
         the non-zero block coordinates are stored as local offsets for each world, joint, limit, and contact.
@@ -1539,7 +1539,7 @@ class SparseSystemJacobians:
                 compute the non-zero block coordinates of the limit constraint Jacobian.
             contacts: The contacts container describing the active contacts in the system, used to
                 compute the non-zero block coordinates of the contact constraint Jacobian.
-            device: The device on which to allocate the Jacobian data.\n
+            device: The device on which to allocate the Jacobian data.
                 If `None`, the Jacobian data will be allocated on same device as the model.
         """
 
@@ -1739,8 +1739,8 @@ class SparseSystemJacobians:
                 be provided if the Jacobian also has limit constraints.
             contacts: Contacts data container for contact constraints. Needs to
                 be provided if the Jacobian also has contact constraints.
-            reset_to_zero: Whether to reset the Jacobian values to zero before building.\n
-                If false, the Jacobian values will be accumulated onto existing values.\n
+            reset_to_zero: Whether to reset the Jacobian values to zero before building.
+                If false, the Jacobian values will be accumulated onto existing values.
                 Defaults to `True`.
 
         """

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -27,16 +27,7 @@ from ..core.math import (
 )
 from ..core.model import ModelKamino
 from ..core.types import (
-    float32,
-    int32,
-    mat33f,
-    quatf,
-    transformf,
     vec1f,
-    vec2f,
-    vec3f,
-    vec4f,
-    vec6f,
     vec7f,
 )
 
@@ -64,9 +55,9 @@ wp.set_module_options({"enable_backward": False})
 
 
 DEFAULT_LIMIT_V1F = vec1f(FLOAT32_MAX)
-DEFAULT_LIMIT_V2F = vec2f(FLOAT32_MAX)
-DEFAULT_LIMIT_V3F = vec3f(FLOAT32_MAX)
-DEFAULT_LIMIT_V4F = vec4f(FLOAT32_MAX)
+DEFAULT_LIMIT_V2F = wp.vec2f(FLOAT32_MAX)
+DEFAULT_LIMIT_V3F = wp.vec3f(FLOAT32_MAX)
+DEFAULT_LIMIT_V4F = wp.vec4f(FLOAT32_MAX)
 DEFAULT_LIMIT_V7F = vec7f(FLOAT32_MAX)
 
 
@@ -76,7 +67,9 @@ DEFAULT_LIMIT_V7F = vec7f(FLOAT32_MAX)
 
 
 @wp.func
-def correct_rotational_coord(q_j_in: float32, q_j_ref: float32 = 0.0, q_j_limit: float32 = FLOAT32_MAX) -> float32:
+def correct_rotational_coord(
+    q_j_in: wp.float32, q_j_ref: wp.float32 = 0.0, q_j_limit: wp.float32 = FLOAT32_MAX
+) -> wp.float32:
     """
     Corrects a rotational joint coordinate to be as close as possible to a reference coordinate.
     """
@@ -86,7 +79,7 @@ def correct_rotational_coord(q_j_in: float32, q_j_ref: float32 = 0.0, q_j_limit:
 
 
 @wp.func
-def correct_quat_vector_coord(q_j_in: vec4f, q_j_ref: vec4f) -> vec4f:
+def correct_quat_vector_coord(q_j_in: wp.vec4f, q_j_ref: wp.vec4f) -> wp.vec4f:
     """
     Corrects a quaternion joint coordinate to be as close as possible to a reference coordinate.
 
@@ -120,14 +113,18 @@ def correct_joint_coord_prismatic(q_j_in: vec1f, q_j_ref: vec1f, q_j_limit: vec1
 
 
 @wp.func
-def correct_joint_coord_cylindrical(q_j_in: vec2f, q_j_ref: vec2f, q_j_limit: vec2f = DEFAULT_LIMIT_V2F) -> vec2f:
+def correct_joint_coord_cylindrical(
+    q_j_in: wp.vec2f, q_j_ref: wp.vec2f, q_j_limit: wp.vec2f = DEFAULT_LIMIT_V2F
+) -> wp.vec2f:
     """Corrects only the rotational joint coordinate."""
     q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
     return q_j_in
 
 
 @wp.func
-def correct_joint_coord_universal(q_j_in: vec2f, q_j_ref: vec2f, q_j_limit: vec2f = DEFAULT_LIMIT_V2F) -> vec2f:
+def correct_joint_coord_universal(
+    q_j_in: wp.vec2f, q_j_ref: wp.vec2f, q_j_limit: wp.vec2f = DEFAULT_LIMIT_V2F
+) -> wp.vec2f:
     """Corrects each of the two rotational joint coordinates individually."""
     q_j_in[0] = correct_rotational_coord(q_j_in[0], q_j_ref[0], q_j_limit[0])
     q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
@@ -135,13 +132,17 @@ def correct_joint_coord_universal(q_j_in: vec2f, q_j_ref: vec2f, q_j_limit: vec2
 
 
 @wp.func
-def correct_joint_coord_spherical(q_j_in: vec4f, q_j_ref: vec4f, q_j_limit: vec4f = DEFAULT_LIMIT_V4F) -> vec4f:
+def correct_joint_coord_spherical(
+    q_j_in: wp.vec4f, q_j_ref: wp.vec4f, q_j_limit: wp.vec4f = DEFAULT_LIMIT_V4F
+) -> wp.vec4f:
     """Corrects a quaternion joint coordinate to be as close as possible to a reference."""
     return correct_quat_vector_coord(q_j_in, q_j_ref)
 
 
 @wp.func
-def correct_joint_coord_gimbal(q_j_in: vec3f, q_j_ref: vec3f, q_j_limit: vec3f = DEFAULT_LIMIT_V3F) -> vec3f:
+def correct_joint_coord_gimbal(
+    q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
+) -> wp.vec3f:
     """Corrects each of the XYZ Euler angles individually."""
     q_j_in[0] = correct_rotational_coord(q_j_in[0], q_j_ref[0], q_j_limit[0])
     q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
@@ -150,7 +151,9 @@ def correct_joint_coord_gimbal(q_j_in: vec3f, q_j_ref: vec3f, q_j_limit: vec3f =
 
 
 @wp.func
-def correct_joint_coord_cartesian(q_j_in: vec3f, q_j_ref: vec3f, q_j_limit: vec3f = DEFAULT_LIMIT_V3F) -> vec3f:
+def correct_joint_coord_cartesian(
+    q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
+) -> wp.vec3f:
     """No correction needed for Cartesian coordinates."""
     return q_j_in
 
@@ -188,39 +191,39 @@ def get_joint_coord_correction_function(dof_type: JointDoFType):
 
 
 @wp.func
-def map_to_joint_coords_free(j_r_j: vec3f, j_q_j: quatf) -> vec7f:
+def map_to_joint_coords_free(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> vec7f:
     """Returns the full 7D representation of joint pose (3D translation + 4D rotation)."""
     # TODO: Is there a more efficient way to construct a vec7f?
     return vec7f(j_r_j[0], j_r_j[1], j_r_j[2], j_q_j.x, j_q_j.y, j_q_j.z, j_q_j.w)
 
 
 @wp.func
-def map_to_joint_coords_revolute(j_r_j: vec3f, j_q_j: quatf) -> vec1f:
+def map_to_joint_coords_revolute(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> vec1f:
     """Returns the 1D rotation angle about the local X-axis."""
     # Measure rotation around the x-axis only
-    axis = vec3f(1.0, 0.0, 0.0)
+    axis = wp.vec3f(1.0, 0.0, 0.0)
     return vec1f(quat_twist_angle(j_q_j, axis))
 
 
 @wp.func
-def map_to_joint_coords_prismatic(j_r_j: vec3f, j_q_j: quatf) -> vec1f:
+def map_to_joint_coords_prismatic(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> vec1f:
     """Returns the 1D translation distance along the local X-axis."""
     return vec1f(j_r_j[0])
 
 
 @wp.func
-def map_to_joint_coords_cylindrical(j_r_j: vec3f, j_q_j: quatf) -> vec2f:
+def map_to_joint_coords_cylindrical(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec2f:
     """Returns the 2D vector of translation and rotation about the local X-axis."""
     j_p_j = quat_log(j_q_j)
-    return vec2f(j_r_j[0], j_p_j[0])
+    return wp.vec2f(j_r_j[0], j_p_j[0])
 
 
 @wp.func
-def map_to_joint_coords_universal(j_r_j: vec3f, j_q_j: quatf) -> vec2f:
+def map_to_joint_coords_universal(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec2f:
     """Returns the 2D vector of joint angles for the two revolute DoFs."""
     # X and Y axis in base frame
-    a_x_B = vec3f(1.0, 0.0, 0.0)
-    a_y_B = vec3f(0.0, 1.0, 0.0)
+    a_x_B = wp.vec3f(1.0, 0.0, 0.0)
+    a_y_B = wp.vec3f(0.0, 1.0, 0.0)
 
     # X and Y axis in follower frame
     a_x_F = wp.quat_rotate(j_q_j, a_x_B)
@@ -232,24 +235,24 @@ def map_to_joint_coords_universal(j_r_j: vec3f, j_q_j: quatf) -> vec2f:
     # Extract theta_y, as the angle of the rotation about a_y_F mapping a_x_B to a_x_F
     theta_y = wp.atan2(wp.dot(wp.cross(a_x_B, a_x_F), a_y_F), a_x_F[0])
 
-    return vec2f(theta_x, theta_y)
+    return wp.vec2f(theta_x, theta_y)
 
 
 @wp.func
-def map_to_joint_coords_spherical(j_r_j: vec3f, j_q_j: quatf) -> vec4f:
+def map_to_joint_coords_spherical(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec4f:
     """Returns the 4D unit-quaternion representing the joint rotation."""
     return quat_to_vec4(j_q_j)
 
 
 @wp.func
-def map_to_joint_coords_gimbal(j_r_j: vec3f, j_q_j: quatf) -> vec3f:
+def map_to_joint_coords_gimbal(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the 3D XYZ Euler angles (roll, pitch, yaw)."""
     # How can we make this safer?
     return quat_to_euler_xyz(j_q_j)
 
 
 @wp.func
-def map_to_joint_coords_cartesian(j_r_j: vec3f, j_q_j: quatf) -> vec3f:
+def map_to_joint_coords_cartesian(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the 3D translational."""
     return j_r_j
 
@@ -287,15 +290,15 @@ def get_joint_coords_mapping_function(dof_type: JointDoFType):
 
 
 @wp.func
-def joint_constraint_angular_residual_free(j_q_j: quatf) -> vec3f:
-    return vec3f(0.0, 0.0, 0.0)
+def joint_constraint_angular_residual_free(j_q_j: wp.quatf) -> wp.vec3f:
+    return wp.vec3f(0.0, 0.0, 0.0)
 
 
 @wp.func
-def joint_constraint_angular_residual_revolute(j_q_j: quatf) -> vec3f:
+def joint_constraint_angular_residual_revolute(j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the joint constraint residual for a revolute joint that rotates about the local X-axis."""
     # x-axis attached to the base body
-    j_x_B = vec3f(1.0, 0.0, 0.0)
+    j_x_B = wp.vec3f(1.0, 0.0, 0.0)
 
     # x-axis attached to the follower body, expressed in the joint frame on the base body.
     j_x_F = wp.quat_rotate(j_q_j, j_x_B)
@@ -306,16 +309,16 @@ def joint_constraint_angular_residual_revolute(j_q_j: quatf) -> vec3f:
 
 
 @wp.func
-def joint_constraint_angular_residual_universal(j_q_j: quatf) -> vec3f:
+def joint_constraint_angular_residual_universal(j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the joint constraint residual for a universal joint."""
-    e_y = vec3f(0.0, 1.0, 0.0)
+    e_y = wp.vec3f(0.0, 1.0, 0.0)
     a_x_dot_a_y = wp.quat_rotate(j_q_j, e_y)[0]
 
     return wp.vec3f(0.0, 0.0, -a_x_dot_a_y)
 
 
 @wp.func
-def joint_constraint_angular_residual_fixed(j_q_j: quatf) -> vec3f:
+def joint_constraint_angular_residual_fixed(j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the joint constraint residual for a fixed joint."""
     return quat_log(j_q_j)
 
@@ -349,14 +352,16 @@ def get_joint_constraint_angular_residual_function(dof_type: JointDoFType):
 
 
 @wp.func
-def convert_angular_vel_to_universal_joint_intermediary_frame(j_q_j: quatf, j_u_j: vec6f) -> vec6f:
+def convert_angular_vel_to_universal_joint_intermediary_frame(
+    j_q_j: wp.quatf, j_u_j: wp.spatial_vectorf
+) -> wp.spatial_vectorf:
     """
     Converts the angular part of a relative body velocity at a universal joint, from the
     joint frame on the base body to the intermediary frame.
     """
     # Compute intermediary body axes, in the joint frame on the base body
-    e_x = vec3f(1.0, 0.0, 0.0)
-    e_y = vec3f(0.0, 1.0, 0.0)
+    e_x = wp.vec3f(1.0, 0.0, 0.0)
+    e_y = wp.vec3f(0.0, 1.0, 0.0)
     a_x = e_x  # x axis on base
     a_y_raw = wp.quat_rotate(j_q_j, e_y)  #  y axis on follower (constrained to be orthogonal to a_x)
     a_y = a_y_raw - wp.dot(a_y_raw, a_x) * a_x  # orthogonalize (in case of constraint violations)
@@ -365,7 +370,7 @@ def convert_angular_vel_to_universal_joint_intermediary_frame(j_q_j: quatf, j_u_
 
     # Project angular velocity into intermediary body frame
     omega = screw_angular(j_u_j)
-    return screw(screw_linear(j_u_j), vec3f(wp.dot(omega, a_x), wp.dot(omega, a_y), wp.dot(omega, a_z)))
+    return screw(screw_linear(j_u_j), wp.vec3f(wp.dot(omega, a_x), wp.dot(omega, a_y), wp.dot(omega, a_z)))
 
 
 ###
@@ -398,18 +403,18 @@ def make_typed_write_joint_data(dof_type: JointDoFType, correction: JointCorrect
     @wp.func
     def _write_typed_joint_data(
         # Inputs:
-        cts_offset: int32,  # Index offset of the joint constraints
-        dofs_offset: int32,  # Index offset of the joint DoFs
-        coords_offset: int32,  # Index offset of the joint coordinates
-        j_r_j: vec3f,  # 3D vector of the joint-local relative pose
-        j_q_j: quatf,  # 4D unit-quaternion of the joint-local relative pose
-        j_u_j: vec6f,  # 6D vector of the joint-local relative twist
-        q_j_p: wp.array[float32],  # Reference joint coordinates for correction
+        cts_offset: wp.int32,  # Index offset of the joint constraints
+        dofs_offset: wp.int32,  # Index offset of the joint DoFs
+        coords_offset: wp.int32,  # Index offset of the joint coordinates
+        j_r_j: wp.vec3f,  # 3D vector of the joint-local relative pose
+        j_q_j: wp.quatf,  # 4D unit-quaternion of the joint-local relative pose
+        j_u_j: wp.spatial_vectorf,  # 6D vector of the joint-local relative twist
+        q_j_p: wp.array[wp.float32],  # Reference joint coordinates for correction
         # Outputs:
-        r_j_out: wp.array[float32],  # Flat array of joint constraint residuals
-        dr_j_out: wp.array[float32],  # Flat array of joint constraint velocities
-        q_j_out: wp.array[float32],  # Flat array of joint DoF coordinates
-        dq_j_out: wp.array[float32],  # Flat array of joint DoF velocities
+        r_j_out: wp.array[wp.float32],  # Flat array of joint constraint residuals
+        dr_j_out: wp.array[wp.float32],  # Flat array of joint constraint velocities
+        q_j_out: wp.array[wp.float32],  # Flat array of joint DoF coordinates
+        dq_j_out: wp.array[wp.float32],  # Flat array of joint DoF velocities
     ):
         # Convert angular velocity to intermediary body frame for universal joint
         if wp.static(dof_type == JointDoFType.UNIVERSAL):
@@ -459,35 +464,35 @@ def make_write_joint_data(correction: JointCorrectionMode = JointCorrectionMode.
     @wp.func
     def _write_joint_data(
         # Inputs:
-        dof_type: int32,
-        cts_offset: int32,
-        dofs_offset: int32,
-        coords_offset: int32,
-        j_r_j: vec3f,
-        j_q_j: quatf,
-        j_u_j: vec6f,
-        q_j_p: wp.array[float32],
+        dof_type: wp.int32,
+        cts_offset: wp.int32,
+        dofs_offset: wp.int32,
+        coords_offset: wp.int32,
+        j_r_j: wp.vec3f,
+        j_q_j: wp.quatf,
+        j_u_j: wp.spatial_vectorf,
+        q_j_p: wp.array[wp.float32],
         # Outputs:
-        data_r_j: wp.array[float32],
-        data_dr_j: wp.array[float32],
-        data_q_j: wp.array[float32],
-        data_dq_j: wp.array[float32],
+        data_r_j: wp.array[wp.float32],
+        data_dr_j: wp.array[wp.float32],
+        data_q_j: wp.array[wp.float32],
+        data_dq_j: wp.array[wp.float32],
     ):
         """
         Stores the joint constraint residuals and DoF motion based on the joint type.
 
         Args:
-            dof_type (int32): The type of joint DoF.
-            cts_offset (int32): Index offset of the joint constraints.
-            dofs_offset (int32): Index offset of the joint DoFs.
-            coords_offset (int32): Index offset of the joint coordinates.
-            j_r_j (vec3f): 3D vector of the joint-local relative translation.
-            j_q_j (quatf): 4D unit-quaternion of the joint-local relative rotation.
-            j_u_j (vec6f): 6D vector of the joint-local relative twist.
-            data_r_j (wp.array): Flat array of joint constraint residuals.
-            data_dr_j (wp.array): Flat array of joint constraint residuals.
-            data_q_j (wp.array): Flat array of joint DoF coordinates.
-            data_dq_j (wp.array): Flat array of joint DoF velocities.
+            dof_type: The type of joint DoF.
+            cts_offset: Index offset of the joint constraints.
+            dofs_offset: Index offset of the joint DoFs.
+            coords_offset: Index offset of the joint coordinates.
+            j_r_j: 3D vector of the joint-local relative translation.
+            j_q_j: 4D unit-quaternion of the joint-local relative rotation.
+            j_u_j: 6D vector of the joint-local relative twist.
+            data_r_j: Flat array of joint constraint residuals.
+            data_dr_j: Flat array of joint constraint residuals.
+            data_q_j: Flat array of joint DoF coordinates.
+            data_dq_j: Flat array of joint DoF velocities.
         """
         # TODO: Use wp.static to include conditionals at compile time based on the joint types present in the builder
 
@@ -637,30 +642,30 @@ def make_write_joint_data(correction: JointCorrectionMode = JointCorrectionMode.
 
 @wp.func
 def compute_joint_pose_and_relative_motion(
-    T_B_j: transformf,
-    T_F_j: transformf,
-    u_B_j: vec6f,
-    u_F_j: vec6f,
-    B_r_Bj: vec3f,
-    F_r_Fj: vec3f,
-    X_Bj: mat33f,
-    X_Fj: mat33f,
-) -> tuple[transformf, vec3f, quatf, vec6f]:
+    T_B_j: wp.transformf,
+    T_F_j: wp.transformf,
+    u_B_j: wp.spatial_vectorf,
+    u_F_j: wp.spatial_vectorf,
+    B_r_Bj: wp.vec3f,
+    F_r_Fj: wp.vec3f,
+    X_Bj: wp.mat33f,
+    X_Fj: wp.mat33f,
+) -> tuple[wp.transformf, wp.vec3f, wp.quatf, wp.spatial_vectorf]:
     """
     Computes the relative motion of a joint given the states of its Base and Follower bodies.
 
     Args:
-        T_B_j (transformf): The absolute pose of the Base body, in world coordinates.
-        T_F_j (transformf): The absolute pose of the Follower body, in world coordinates.
-        u_B_j (vec6f): The absolute twist of the Base body, in world coordinates.
-        u_F_j (vec6f): The absolute twist of the Follower body, in world coordinates.
-        B_r_Bj (vec3f): The position of the joint on the Base body, in local coordinates.
-        F_r_Fj (vec3f): The position of the joint on the Follower body, in local coordinates.
-        X_Bj (mat33f): The joint frame on the Base body, in local coordinates.
-        X_Fj (mat33f): The joint frame on the Follower body, in local coordinates.
+        T_B_j: The absolute pose of the Base body, in world coordinates.
+        T_F_j: The absolute pose of the Follower body, in world coordinates.
+        u_B_j: The absolute twist of the Base body, in world coordinates.
+        u_F_j: The absolute twist of the Follower body, in world coordinates.
+        B_r_Bj: The position of the joint on the Base body, in local coordinates.
+        F_r_Fj: The position of the joint on the Follower body, in local coordinates.
+        X_Bj: The joint frame on the Base body, in local coordinates.
+        X_Fj: The joint frame on the Follower body, in local coordinates.
 
     Returns:
-        tuple[transformf, vec6f, vec6f]: The absolute pose of the joint frame in world coordinates,
+        The absolute pose of the joint frame in world coordinates,
         and two 6D vectors encoding the relative motion of the bodies in the frame of the joint.
     """
 
@@ -689,7 +694,7 @@ def compute_joint_pose_and_relative_motion(
     # Compute the pose of the joint frame via the Base body
     r_j_B = r_B_j + r_Bj
     r_j_F = r_F_j + r_Fj
-    p_j = wp.transformation(r_j_B, q_Bj, dtype=float32)
+    p_j = wp.transformation(r_j_B, q_Bj, dtype=wp.float32)
     r_j = r_j_F - r_j_B
 
     # Compute the relative pose between the representations of joint frame w.r.t. the two bodies
@@ -710,26 +715,26 @@ def compute_joint_pose_and_relative_motion(
 @wp.func
 def compute_and_write_joint_implicit_dynamics(
     # Constants:
-    dt: float32,
-    coords_offset: int32,
-    dofs_offset: int32,
-    num_dynamic_cts: int32,
-    dynamic_cts_offset: int32,
+    dt: wp.float32,
+    coords_offset: wp.int32,
+    dofs_offset: wp.int32,
+    num_dynamic_cts: wp.int32,
+    dynamic_cts_offset: wp.int32,
     # Inputs:
-    model_joint_a_j: wp.array[float32],
-    model_joint_b_j: wp.array[float32],
-    model_joint_k_p_j: wp.array[float32],
-    model_joint_k_d_j: wp.array[float32],
-    data_joint_q_j: wp.array[float32],
-    data_joint_dq_j: wp.array[float32],
-    data_joint_tau_j: wp.array[float32],
-    data_joint_q_j_ref: wp.array[float32],
-    data_joint_dq_j_ref: wp.array[float32],
-    data_joint_tau_j_ref: wp.array[float32],  # Can be `None`
+    model_joint_a_j: wp.array[wp.float32],
+    model_joint_b_j: wp.array[wp.float32],
+    model_joint_k_p_j: wp.array[wp.float32],
+    model_joint_k_d_j: wp.array[wp.float32],
+    data_joint_q_j: wp.array[wp.float32],
+    data_joint_dq_j: wp.array[wp.float32],
+    data_joint_tau_j: wp.array[wp.float32],
+    data_joint_q_j_ref: wp.array[wp.float32],
+    data_joint_dq_j_ref: wp.array[wp.float32],
+    data_joint_tau_j_ref: wp.array[wp.float32],  # Can be `None`
     # Outputs:
-    data_joint_m_j: wp.array[float32],
-    data_joint_inv_m_j: wp.array[float32],
-    data_joint_dq_b_j: wp.array[float32],
+    data_joint_m_j: wp.array[wp.float32],
+    data_joint_inv_m_j: wp.array[wp.float32],
+    data_joint_dq_b_j: wp.array[wp.float32],
 ):
     # Iterate over the dynamic constraints of the joint and
     # compute and store the implicit dynamics intermediates
@@ -788,39 +793,39 @@ def make_compute_joints_data_kernel(correction: JointCorrectionMode = JointCorre
     @wp.kernel
     def _compute_joints_data(
         # Inputs:
-        model_time_dt: wp.array[float32],
-        model_joint_wid: wp.array[int32],
-        model_joint_dof_type: wp.array[int32],
-        model_joint_coords_offset: wp.array[int32],
-        model_joint_dofs_offset: wp.array[int32],
-        model_joint_dynamic_cts_offset: wp.array[int32],
-        model_joint_kinematic_cts_offset: wp.array[int32],
-        model_joint_bid_B: wp.array[int32],
-        model_joint_bid_F: wp.array[int32],
-        model_joint_B_r_Bj: wp.array[vec3f],
-        model_joint_F_r_Fj: wp.array[vec3f],
-        model_joint_X_Bj: wp.array[mat33f],
-        model_joint_X_Fj: wp.array[mat33f],
-        model_joint_a_j: wp.array[float32],
-        model_joint_b_j: wp.array[float32],
-        model_joint_k_p_j: wp.array[float32],
-        model_joint_k_d_j: wp.array[float32],
-        data_body_q_i: wp.array[transformf],
-        data_body_u_i: wp.array[vec6f],
-        data_joint_tau_j: wp.array[float32],
-        data_joint_q_j_ref: wp.array[float32],
-        data_joint_dq_j_ref: wp.array[float32],
-        data_joint_tau_j_ref: wp.array[float32],
-        q_j_p: wp.array[float32],
+        model_time_dt: wp.array[wp.float32],
+        model_joint_wid: wp.array[wp.int32],
+        model_joint_dof_type: wp.array[wp.int32],
+        model_joint_coords_offset: wp.array[wp.int32],
+        model_joint_dofs_offset: wp.array[wp.int32],
+        model_joint_dynamic_cts_offset: wp.array[wp.int32],
+        model_joint_kinematic_cts_offset: wp.array[wp.int32],
+        model_joint_bid_B: wp.array[wp.int32],
+        model_joint_bid_F: wp.array[wp.int32],
+        model_joint_B_r_Bj: wp.array[wp.vec3f],
+        model_joint_F_r_Fj: wp.array[wp.vec3f],
+        model_joint_X_Bj: wp.array[wp.mat33f],
+        model_joint_X_Fj: wp.array[wp.mat33f],
+        model_joint_a_j: wp.array[wp.float32],
+        model_joint_b_j: wp.array[wp.float32],
+        model_joint_k_p_j: wp.array[wp.float32],
+        model_joint_k_d_j: wp.array[wp.float32],
+        data_body_q_i: wp.array[wp.transformf],
+        data_body_u_i: wp.array[wp.spatial_vectorf],
+        data_joint_tau_j: wp.array[wp.float32],
+        data_joint_q_j_ref: wp.array[wp.float32],
+        data_joint_dq_j_ref: wp.array[wp.float32],
+        data_joint_tau_j_ref: wp.array[wp.float32],
+        q_j_p: wp.array[wp.float32],
         # Outputs:
-        data_joint_p_j: wp.array[transformf],
-        data_joint_r_j: wp.array[float32],
-        data_joint_dr_j: wp.array[float32],
-        data_joint_q_j: wp.array[float32],
-        data_joint_dq_j: wp.array[float32],
-        data_joint_m_j: wp.array[float32],
-        data_joint_inv_m_j: wp.array[float32],
-        data_joint_dq_b_j: wp.array[float32],
+        data_joint_p_j: wp.array[wp.transformf],
+        data_joint_r_j: wp.array[wp.float32],
+        data_joint_dr_j: wp.array[wp.float32],
+        data_joint_q_j: wp.array[wp.float32],
+        data_joint_dq_j: wp.array[wp.float32],
+        data_joint_m_j: wp.array[wp.float32],
+        data_joint_inv_m_j: wp.array[wp.float32],
+        data_joint_dq_b_j: wp.array[wp.float32],
     ):
         # Retrieve the thread index
         jid = wp.tid()
@@ -847,8 +852,8 @@ def make_compute_joints_data_kernel(correction: JointCorrectionMode = JointCorre
 
         # If the Base body is the world (bid=-1), use the identity transform (frame
         # of the world's origin), otherwise retrieve the Base body's pose and twist
-        T_B_j = wp.transform_identity(dtype=float32)
-        u_B_j = vec6f(0.0)
+        T_B_j = wp.transform_identity(dtype=wp.float32)
+        u_B_j = wp.spatial_vectorf(0.0)
         if bid_B > -1:
             T_B_j = data_body_q_i[bid_B]
             u_B_j = data_body_u_i[bid_B]
@@ -911,18 +916,18 @@ def make_compute_joints_data_kernel(correction: JointCorrectionMode = JointCorre
 @wp.kernel
 def _extract_actuators_state_from_joints(
     # Inputs:
-    world_mask: wp.array[bool],
-    model_joint_wid: wp.array[int32],
-    model_joint_act_type: wp.array[int32],
-    model_joint_coords_offset: wp.array[int32],
-    model_joint_dofs_offset: wp.array[int32],
-    model_joint_actuated_coords_offset: wp.array[int32],
-    model_joint_actuated_dofs_offset: wp.array[int32],
-    joint_q: wp.array[float32],
-    joint_u: wp.array[float32],
+    world_mask: wp.array[wp.bool],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_act_type: wp.array[wp.int32],
+    model_joint_coords_offset: wp.array[wp.int32],
+    model_joint_dofs_offset: wp.array[wp.int32],
+    model_joint_actuated_coords_offset: wp.array[wp.int32],
+    model_joint_actuated_dofs_offset: wp.array[wp.int32],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
     # Outputs:
-    actuator_q: wp.array[float32],
-    actuator_u: wp.array[float32],
+    actuator_q: wp.array[wp.float32],
+    actuator_u: wp.array[wp.float32],
 ):
     # Retrieve the joint index from the thread grid
     jid = wp.tid()
@@ -958,18 +963,18 @@ def _extract_actuators_state_from_joints(
 @wp.kernel
 def _extract_joints_state_from_actuators(
     # Inputs:
-    world_mask: wp.array[bool],
-    model_joint_wid: wp.array[int32],
-    model_joint_act_type: wp.array[int32],
-    model_joint_coords_offset: wp.array[int32],
-    model_joint_dofs_offset: wp.array[int32],
-    model_joint_actuated_coords_offset: wp.array[int32],
-    model_joint_actuated_dofs_offset: wp.array[int32],
-    actuator_q: wp.array[float32],
-    actuator_u: wp.array[float32],
+    world_mask: wp.array[wp.bool],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_act_type: wp.array[wp.int32],
+    model_joint_coords_offset: wp.array[wp.int32],
+    model_joint_dofs_offset: wp.array[wp.int32],
+    model_joint_actuated_coords_offset: wp.array[wp.int32],
+    model_joint_actuated_dofs_offset: wp.array[wp.int32],
+    actuator_q: wp.array[wp.float32],
+    actuator_u: wp.array[wp.float32],
     # Outputs:
-    joint_q: wp.array[float32],
-    joint_u: wp.array[float32],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
 ):
     # Retrieve the joint index from the thread grid
     jid = wp.tid()
@@ -1010,7 +1015,7 @@ def _extract_joints_state_from_actuators(
 def compute_joints_data(
     model: ModelKamino,
     data: DataKamino,
-    q_j_p: wp.array,
+    q_j_p: wp.array[wp.float32],
     correction: JointCorrectionMode = JointCorrectionMode.TWOPI,
 ) -> None:
     """
@@ -1021,14 +1026,11 @@ def compute_joints_data(
     residuals and velocities of the applied bilateral constraints.
 
     Args:
-        model (`ModelKamino`):
-            The model container holding the time-invariant data of the simulation.
-        q_j_p (`wp.array`):
-            An array of previous joint DoF coordinates used for coordinate correction.\n
+        model: The model container holding the time-invariant data of the simulation.
+        q_j_p: An array of previous joint DoF coordinates used for coordinate correction.\n
             Only used for revolute DoFs of the relevant joints to enforce angle continuity.\n
-            Shape of ``(sum_of_num_joint_coords,)`` and type :class:`float`.
-        data (`DataKamino`):
-            The solver data container holding the internal time-varying state of the simulation.
+            Shape of ``(sum_of_num_joint_coords,)``.
+        data: The solver data container holding the internal time-varying state of the simulation.
     """
 
     # Generate the kernel to compute the joint states
@@ -1081,11 +1083,11 @@ def compute_joints_data(
 
 def extract_actuators_state_from_joints(
     model: ModelKamino,
-    world_mask: wp.array,
-    joint_q: wp.array,
-    joint_u: wp.array,
-    actuator_q: wp.array,
-    actuator_u: wp.array,
+    world_mask: wp.array[wp.bool],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
+    actuator_q: wp.array[wp.float32],
+    actuator_u: wp.array[wp.float32],
 ):
     """
     Extracts the states of the actuated joints from the full joint state arrays.
@@ -1094,23 +1096,17 @@ def extract_actuators_state_from_joints(
     that are not masked will have their states extracted.
 
     Args:
-        model (`ModelKamino`):
-            The model container holding the time-invariant data of the simulation.
-        joint_q (`wp.array`):
-            The full array of joint coordinates.\n
-            Shape of ``(sum_of_num_joint_coords,)`` and type :class:`float`.
-        joint_u (`wp.array`):
-            The full array of joint velocities.\n
-            Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`.
-        actuator_q (`wp.array`):
-            The output array to store the actuated joint coordinates.\n
-            Shape of ``(sum_of_num_actuated_joint_coords,)`` and type :class:`float`.
-        actuator_u (`wp.array`):
-            The output array to store the actuated joint velocities.\n
-            Shape of ``(sum_of_actuated_joint_dofs,)`` and type :class:`float`.
-        world_mask (`wp.array`):
-            An array indicating which worlds are active (True) or skipped (False).\n
-            Shape of ``(num_worlds,)`` and type :class:`bool`.
+        model: The model container holding the time-invariant data of the simulation.
+        joint_q: The full array of joint coordinates.\n
+            Shape of ``(sum_of_num_joint_coords,)``.
+        joint_u: The full array of joint velocities.\n
+            Shape of ``(sum_of_num_joint_dofs,)``.
+        actuator_q: The output array to store the actuated joint coordinates.\n
+            Shape of ``(sum_of_num_actuated_joint_coords,)``.
+        actuator_u: The output array to store the actuated joint velocities.\n
+            Shape of ``(sum_of_actuated_joint_dofs,)``.
+        world_mask: An array indicating which worlds are active (True) or skipped (False).\n
+            Shape of ``(num_worlds,)``.
     """
     wp.launch(
         _extract_actuators_state_from_joints,
@@ -1136,11 +1132,11 @@ def extract_actuators_state_from_joints(
 
 def extract_joints_state_from_actuators(
     model: ModelKamino,
-    world_mask: wp.array,
-    actuator_q: wp.array,
-    actuator_u: wp.array,
-    joint_q: wp.array,
-    joint_u: wp.array,
+    world_mask: wp.array[wp.bool],
+    actuator_q: wp.array[wp.float32],
+    actuator_u: wp.array[wp.float32],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
 ):
     """
     Extracts the states of the actuated joints from the full joint state arrays.
@@ -1149,23 +1145,17 @@ def extract_joints_state_from_actuators(
     that are not masked will have their states extracted.
 
     Args:
-        model (`ModelKamino`):
-            The model container holding the time-invariant data of the simulation.
-        joint_q (`wp.array`):
-            The full array of joint coordinates.\n
-            Shape of ``(sum_of_num_joint_coords,)`` and type :class:`float`.
-        joint_u (`wp.array`):
-            The full array of joint velocities.\n
-            Shape of ``(sum_of_num_joint_dofs,)`` and type :class:`float`.
-        actuator_q (`wp.array`):
-            The output array to store the actuated joint coordinates.\n
-            Shape of ``(sum_of_num_actuated_joint_coords,)`` and type :class:`float`.
-        actuator_u (`wp.array`):
-            The output array to store the actuated joint velocities.\n
-            Shape of ``(sum_of_actuated_joint_dofs,)`` and type :class:`float`.
-        world_mask (`wp.array`):
-            An array indicating which worlds are active (True) or skipped (False).\n
-            Shape of ``(num_worlds,)`` and type :class:`bool`.
+        model: The model container holding the time-invariant data of the simulation.
+        joint_q: The full array of joint coordinates.\n
+            Shape of ``(sum_of_num_joint_coords,)``.
+        joint_u: The full array of joint velocities.\n
+            Shape of ``(sum_of_num_joint_dofs,)``.
+        actuator_q: The output array to store the actuated joint coordinates.\n
+            Shape of ``(sum_of_num_actuated_joint_coords,)``.
+        actuator_u: The output array to store the actuated joint velocities.\n
+            Shape of ``(sum_of_actuated_joint_dofs,)``.
+        world_mask: An array indicating which worlds are active (True) or skipped (False).\n
+            Shape of ``(num_worlds,)``.
     """
     wp.launch(
         _extract_joints_state_from_actuators,

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -1027,8 +1027,8 @@ def compute_joints_data(
 
     Args:
         model: The model container holding the time-invariant data of the simulation.
-        q_j_p: An array of previous joint DoF coordinates used for coordinate correction.\n
-            Only used for revolute DoFs of the relevant joints to enforce angle continuity.\n
+        q_j_p: An array of previous joint DoF coordinates used for coordinate correction.
+            Only used for revolute DoFs of the relevant joints to enforce angle continuity.
             Shape of ``(sum_of_num_joint_coords,)``.
         data: The solver data container holding the internal time-varying state of the simulation.
     """
@@ -1097,15 +1097,15 @@ def extract_actuators_state_from_joints(
 
     Args:
         model: The model container holding the time-invariant data of the simulation.
-        joint_q: The full array of joint coordinates.\n
+        joint_q: The full array of joint coordinates.
             Shape of ``(sum_of_num_joint_coords,)``.
-        joint_u: The full array of joint velocities.\n
+        joint_u: The full array of joint velocities.
             Shape of ``(sum_of_num_joint_dofs,)``.
-        actuator_q: The output array to store the actuated joint coordinates.\n
+        actuator_q: The output array to store the actuated joint coordinates.
             Shape of ``(sum_of_num_actuated_joint_coords,)``.
-        actuator_u: The output array to store the actuated joint velocities.\n
+        actuator_u: The output array to store the actuated joint velocities.
             Shape of ``(sum_of_actuated_joint_dofs,)``.
-        world_mask: An array indicating which worlds are active (True) or skipped (False).\n
+        world_mask: An array indicating which worlds are active (True) or skipped (False).
             Shape of ``(num_worlds,)``.
     """
     wp.launch(
@@ -1146,15 +1146,15 @@ def extract_joints_state_from_actuators(
 
     Args:
         model: The model container holding the time-invariant data of the simulation.
-        joint_q: The full array of joint coordinates.\n
+        joint_q: The full array of joint coordinates.
             Shape of ``(sum_of_num_joint_coords,)``.
-        joint_u: The full array of joint velocities.\n
+        joint_u: The full array of joint velocities.
             Shape of ``(sum_of_num_joint_dofs,)``.
-        actuator_q: The output array to store the actuated joint coordinates.\n
+        actuator_q: The output array to store the actuated joint coordinates.
             Shape of ``(sum_of_num_actuated_joint_coords,)``.
-        actuator_u: The output array to store the actuated joint velocities.\n
+        actuator_u: The output array to store the actuated joint velocities.
             Shape of ``(sum_of_actuated_joint_dofs,)``.
-        world_mask: An array indicating which worlds are active (True) or skipped (False).\n
+        world_mask: An array indicating which worlds are active (True) or skipped (False).
             Shape of ``(num_worlds,)``.
     """
     wp.launch(

--- a/newton/_src/solvers/kamino/_src/kinematics/limits.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/limits.py
@@ -54,117 +54,117 @@ class LimitsKaminoData:
 
     model_max_limits_host: int = 0
     """
-    Host-side cache of the maximum number of limits allocated across all worlds.\n
+    Host-side cache of the maximum number of limits allocated across all worlds.
     The number of allocated limits in the model is determined by the ModelBuilder when finalizing
-    a ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint.\n
-    The single entry is then less than or equal to the total ``num_joint_dofs`` of the entire model.\n
+    a ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint.
+    The single entry is then less than or equal to the total ``num_joint_dofs`` of the entire model.
     This is cached on the host-side for managing data allocations and setting thread sizes in kernels.
     """
 
     world_max_limits_host: list[int] = field(default_factory=list)
     """
-    Host-side cache of the maximum number of limits allocated per world.\n
+    Host-side cache of the maximum number of limits allocated per world.
     The number of allocated limits per world is determined by the ModelBuilder when finalizing a
-    ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint of each world.\n
-    Each entry is then less than or equal to the total ``num_joint_dofs`` of the corresponding world.\n
+    ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint of each world.
+    Each entry is then less than or equal to the total ``num_joint_dofs`` of the corresponding world.
     This is cached on the host-side for managing data allocations and setting thread sizes in kernels.
     """
 
     model_max_limits: wp.array[wp.int32] | None = None
     """
-    The maximum number of limits allocated for the model across all worlds.\n
+    The maximum number of limits allocated for the model across all worlds.
     The number of allocated limits in the model is determined by the ModelBuilder when finalizing
-    a ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint.\n
-    The single entry is then less than or equal to the total ``num_joint_dofs`` of the entire model.\n
+    a ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint.
+    The single entry is then less than or equal to the total ``num_joint_dofs`` of the entire model.
     Shape of ``(1,)``.
     """
 
     model_active_limits: wp.array[wp.int32] | None = None
     """
-    The total number of active limits currently active in the model across all worlds.\n
+    The total number of active limits currently active in the model across all worlds.
     Shape of ``(1,)``.
     """
 
     world_max_limits: wp.array[wp.int32] | None = None
     """
-    The maximum number of limits allocated per world.\n
+    The maximum number of limits allocated per world.
     The number of allocated limits per world is determined by the ModelBuilder when finalizing a
-    ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint of each world.\n
-    Each entry is then less than or equal to the total ``num_joint_dofs`` of the corresponding world.\n
+    ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint of each world.
+    Each entry is then less than or equal to the total ``num_joint_dofs`` of the corresponding world.
     Shape of ``(num_worlds,)``.
     """
 
     world_active_limits: wp.array[wp.int32] | None = None
     """
-    The total number of active limits currently active per world.\n
+    The total number of active limits currently active per world.
     Shape of ``(num_worlds,)``.
     """
 
     wid: wp.array[wp.int32] | None = None
     """
-    The world index of each limit.\n
+    The world index of each limit.
     Shape of ``(model_max_limits_host,)``.
     """
 
     lid: wp.array[wp.int32] | None = None
     """
-    The element index of each limit w.r.t its world.\n
+    The element index of each limit w.r.t its world.
     Shape of ``(model_max_limits_host,)``.
     """
 
     jid: wp.array[wp.int32] | None = None
     """
-    The element index of the corresponding joint w.r.t the model.\n
+    The element index of the corresponding joint w.r.t the model.
     Shape of ``(model_max_limits_host,)``.
     """
 
     bids: wp.array[wp.vec2i] | None = None
     """
-    The element indices of the interacting bodies w.r.t the model.\n
+    The element indices of the interacting bodies w.r.t the model.
     Shape of ``(model_max_limits_host,)``.
     """
 
     dof: wp.array[wp.int32] | None = None
     """
-    The DoF indices along which limits are active w.r.t the model.\n
+    The DoF indices along which limits are active w.r.t the model.
     Shape of ``(model_max_limits_host,)``.
     """
 
     side: wp.array[wp.float32] | None = None
     """
-    The direction (i.e. side) of the active limit.\n
-    `1.0` for active min limits, `-1.0` for active max limits.\n
+    The direction (i.e. side) of the active limit.
+    `1.0` for active min limits, `-1.0` for active max limits.
     Shape of ``(model_max_limits_host,)``.
     """
 
     r_q: wp.array[wp.float32] | None = None
     """
-    The amount of generalized coordinate violation per joint-limit.\n
+    The amount of generalized coordinate violation per joint-limit.
     Shape of ``(model_max_limits_host,)``.
     """
 
     key: wp.array[wp.uint64] | None = None
     """
-    Integer key uniquely identifying each limit.\n
+    Integer key uniquely identifying each limit.
     The per-limit key assignment is implementation-dependent, but is typically
     computed from the associated joint index as well as additional information such as:
-    - limit index w.r.t the associated B/F body-pair\n
+    - limit index w.r.t the associated B/F body-pair
     Shape of ``(model_max_limits_host,)``.
     """
 
     reaction: wp.array[wp.float32] | None = None
     """
-    The constraint reaction per joint-limit.\n
+    The constraint reaction per joint-limit.
     This is to be set by solvers at each step, and also
-    facilitates limit visualization and warm-starting.\n
+    facilitates limit visualization and warm-starting.
     Shape of ``(model_max_limits_host,)``.
     """
 
     velocity: wp.array[wp.float32] | None = None
     """
-    The constraint velocity per joint-limit.\n
+    The constraint velocity per joint-limit.
     This is to be set by solvers at each step, and also
-    facilitates limit visualization and warm-starting.\n
+    facilitates limit visualization and warm-starting.
     Shape of ``(model_max_limits_host,)``.
     """
 
@@ -623,7 +623,7 @@ class LimitsKamino:
     @property
     def model_max_limits(self) -> wp.array[wp.int32]:
         """
-        Returns the total number of maximum limits for the model.\n
+        Returns the total number of maximum limits for the model.
         Shape of ``(1,)``.
         """
         self._assert_has_data()
@@ -632,7 +632,7 @@ class LimitsKamino:
     @property
     def model_active_limits(self) -> wp.array[wp.int32]:
         """
-        Returns the total number of active limits for the model.\n
+        Returns the total number of active limits for the model.
         Shape of ``(1,)``.
         """
         self._assert_has_data()
@@ -641,7 +641,7 @@ class LimitsKamino:
     @property
     def world_max_limits(self) -> wp.array[wp.int32]:
         """
-        Returns the total number of maximum limits per world.\n
+        Returns the total number of maximum limits per world.
         Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
@@ -650,7 +650,7 @@ class LimitsKamino:
     @property
     def world_active_limits(self) -> wp.array[wp.int32]:
         """
-        Returns the total number of active limits per world.\n
+        Returns the total number of active limits per world.
         Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
@@ -659,7 +659,7 @@ class LimitsKamino:
     @property
     def wid(self) -> wp.array[wp.int32]:
         """
-        Returns the world index of each limit.\n
+        Returns the world index of each limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -668,7 +668,7 @@ class LimitsKamino:
     @property
     def lid(self) -> wp.array[wp.int32]:
         """
-        Returns the element index of each limit w.r.t its world.\n
+        Returns the element index of each limit w.r.t its world.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -677,7 +677,7 @@ class LimitsKamino:
     @property
     def jid(self) -> wp.array[wp.int32]:
         """
-        Returns the element index of the corresponding joint w.r.t the model.\n
+        Returns the element index of the corresponding joint w.r.t the model.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -686,7 +686,7 @@ class LimitsKamino:
     @property
     def bids(self) -> wp.array[wp.vec2i]:
         """
-        Returns the element indices of the interacting bodies w.r.t the model.\n
+        Returns the element indices of the interacting bodies w.r.t the model.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -695,7 +695,7 @@ class LimitsKamino:
     @property
     def dof(self) -> wp.array[wp.int32]:
         """
-        Returns the DoF indices along which limits are active w.r.t the model.\n
+        Returns the DoF indices along which limits are active w.r.t the model.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -704,8 +704,8 @@ class LimitsKamino:
     @property
     def side(self) -> wp.array[wp.float32]:
         """
-        Returns the direction (i.e. side) of the active limit.\n
-        `1.0` for active min limits, `-1.0` for active max limits.\n
+        Returns the direction (i.e. side) of the active limit.
+        `1.0` for active min limits, `-1.0` for active max limits.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -714,7 +714,7 @@ class LimitsKamino:
     @property
     def r_q(self) -> wp.array[wp.float32]:
         """
-        Returns the amount of generalized coordinate violation per joint-limit.\n
+        Returns the amount of generalized coordinate violation per joint-limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -723,7 +723,7 @@ class LimitsKamino:
     @property
     def key(self) -> wp.array[wp.uint64]:
         """
-        Returns the integer key uniquely identifying each limit.\n
+        Returns the integer key uniquely identifying each limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -732,7 +732,7 @@ class LimitsKamino:
     @property
     def reaction(self) -> wp.array[wp.float32]:
         """
-        Returns constraint velocity per joint-limit.\n
+        Returns constraint velocity per joint-limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
@@ -741,7 +741,7 @@ class LimitsKamino:
     @property
     def velocity(self) -> wp.array[wp.float32]:
         """
-        Returns constraint velocity per joint-limit.\n
+        Returns constraint velocity per joint-limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()

--- a/newton/_src/solvers/kamino/_src/kinematics/limits.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/limits.py
@@ -3,6 +3,8 @@
 
 """Provides data types, operations & interfaces for joint-limit detection."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 import warp as wp
@@ -15,16 +17,8 @@ from ..core.math import (
 )
 from ..core.model import ModelKamino
 from ..core.types import (
-    float32,
-    int32,
     to_warp_int32_array,
-    uint32,
-    uint64,
     vec1f,
-    vec2f,
-    vec2i,
-    vec3f,
-    vec4f,
     vec6f,
     vec7f,
 )
@@ -76,102 +70,102 @@ class LimitsKaminoData:
     This is cached on the host-side for managing data allocations and setting thread sizes in kernels.
     """
 
-    model_max_limits: wp.array | None = None
+    model_max_limits: wp.array[wp.int32] | None = None
     """
     The maximum number of limits allocated for the model across all worlds.\n
     The number of allocated limits in the model is determined by the ModelBuilder when finalizing
     a ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint.\n
     The single entry is then less than or equal to the total ``num_joint_dofs`` of the entire model.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
-    model_active_limits: wp.array | None = None
+    model_active_limits: wp.array[wp.int32] | None = None
     """
     The total number of active limits currently active in the model across all worlds.\n
-    Shape of ``(1,)`` and type :class:`int32`.
+    Shape of ``(1,)``.
     """
 
-    world_max_limits: wp.array | None = None
+    world_max_limits: wp.array[wp.int32] | None = None
     """
     The maximum number of limits allocated per world.\n
     The number of allocated limits per world is determined by the ModelBuilder when finalizing a
     ``ModelKamino``, and is equal to the sum over all finite-valued limits defined by each joint of each world.\n
     Each entry is then less than or equal to the total ``num_joint_dofs`` of the corresponding world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    world_active_limits: wp.array | None = None
+    world_active_limits: wp.array[wp.int32] | None = None
     """
     The total number of active limits currently active per world.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    wid: wp.array | None = None
+    wid: wp.array[wp.int32] | None = None
     """
     The world index of each limit.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    lid: wp.array | None = None
+    lid: wp.array[wp.int32] | None = None
     """
     The element index of each limit w.r.t its world.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    jid: wp.array | None = None
+    jid: wp.array[wp.int32] | None = None
     """
     The element index of the corresponding joint w.r.t the model.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    bids: wp.array | None = None
+    bids: wp.array[wp.vec2i] | None = None
     """
     The element indices of the interacting bodies w.r.t the model.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`vec2i`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    dof: wp.array | None = None
+    dof: wp.array[wp.int32] | None = None
     """
     The DoF indices along which limits are active w.r.t the model.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    side: wp.array | None = None
+    side: wp.array[wp.float32] | None = None
     """
     The direction (i.e. side) of the active limit.\n
     `1.0` for active min limits, `-1.0` for active max limits.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    r_q: wp.array | None = None
+    r_q: wp.array[wp.float32] | None = None
     """
     The amount of generalized coordinate violation per joint-limit.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    key: wp.array | None = None
+    key: wp.array[wp.uint64] | None = None
     """
     Integer key uniquely identifying each limit.\n
     The per-limit key assignment is implementation-dependent, but is typically
     computed from the associated joint index as well as additional information such as:
     - limit index w.r.t the associated B/F body-pair\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`uint64`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    reaction: wp.array | None = None
+    reaction: wp.array[wp.float32] | None = None
     """
     The constraint reaction per joint-limit.\n
     This is to be set by solvers at each step, and also
     facilitates limit visualization and warm-starting.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
-    velocity: wp.array | None = None
+    velocity: wp.array[wp.float32] | None = None
     """
     The constraint velocity per joint-limit.\n
     This is to be set by solvers at each step, and also
     facilitates limit visualization and warm-starting.\n
-    Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+    Shape of ``(model_max_limits_host,)``.
     """
 
     def clear(self):
@@ -189,7 +183,7 @@ class LimitsKaminoData:
         self.clear()
         self.wid.fill_(-1)
         self.jid.fill_(-1)
-        self.bids.fill_(vec2i(-1, -1))
+        self.bids.fill_(wp.vec2i(-1, -1))
         self.dof.fill_(-1)
         self.key.fill_(make_bitmask(63))
         self.reaction.zero_()
@@ -202,7 +196,7 @@ class LimitsKaminoData:
 
 
 @wp.func
-def map_joint_coords_to_dofs_free(q_j: vec7f) -> vec6f:
+def map_joint_coords_to_dofs_free(q_j: vec7f) -> wp.spatial_vectorf:
     """Maps free joint quaternion to a local axes-aligned rotation vector."""
     v_j = quat_log(quat_from_vec4(q_j[3:7]))
     return screw(q_j[0:3], v_j)
@@ -221,32 +215,32 @@ def map_joint_coords_to_dofs_prismatic(q_j: vec1f) -> vec1f:
 
 
 @wp.func
-def map_joint_coords_to_dofs_cylindrical(q_j: vec2f) -> vec2f:
+def map_joint_coords_to_dofs_cylindrical(q_j: wp.vec2f) -> wp.vec2f:
     """No mapping needed for cylindrical joints."""
     return q_j
 
 
 @wp.func
-def map_joint_coords_to_dofs_universal(q_j: vec2f) -> vec2f:
+def map_joint_coords_to_dofs_universal(q_j: wp.vec2f) -> wp.vec2f:
     """No mapping needed for universal joints."""
     return q_j
 
 
 @wp.func
-def map_joint_coords_to_dofs_spherical(q_j: vec4f) -> vec3f:
+def map_joint_coords_to_dofs_spherical(q_j: wp.vec4f) -> wp.vec3f:
     """Maps quaternion coordinates of a spherical
     joint to a local axes-aligned rotation vector."""
     return quat_log(quat_from_vec4(q_j))
 
 
 @wp.func
-def map_joint_coords_to_dofs_gimbal(q_j: vec3f) -> vec3f:
+def map_joint_coords_to_dofs_gimbal(q_j: wp.vec3f) -> wp.vec3f:
     """No mapping needed for gimbal joints."""
     return q_j
 
 
 @wp.func
-def map_joint_coords_to_dofs_cartesian(q_j: vec3f) -> vec3f:
+def map_joint_coords_to_dofs_cartesian(q_j: wp.vec3f) -> wp.vec3f:
     """No mapping needed for cartesian joints."""
     return q_j
 
@@ -295,12 +289,12 @@ def make_read_joint_coords_map_and_limits(dof_type: JointDoFType):
     @wp.func
     def _read_joint_coords_map_and_limits(
         # Inputs:
-        dofs_offset: int32,  # Index offset of the joint DoFs
-        coords_offset: int32,  # Index offset of the joint coordinates
-        model_joint_q_j_min: wp.array[float32],
-        model_joint_q_j_max: wp.array[float32],
-        state_joints_q_j: wp.array[float32],
-    ) -> tuple[int32, vec6f, vec6f, vec6f]:
+        dofs_offset: wp.int32,  # Index offset of the joint DoFs
+        coords_offset: wp.int32,  # Index offset of the joint coordinates
+        model_joint_q_j_min: wp.array[wp.float32],
+        model_joint_q_j_max: wp.array[wp.float32],
+        state_joints_q_j: wp.array[wp.float32],
+    ) -> tuple[wp.int32, vec6f, vec6f, vec6f]:
         # Statically define the joint DoF counts
         d_j = wp.static(num_dofs)
 
@@ -334,13 +328,13 @@ def make_read_joint_coords_map_and_limits(dof_type: JointDoFType):
 
 @wp.func
 def read_joint_coords_map_and_limits(
-    dof_type: int32,
-    dofs_offset: int32,
-    coords_offset: int32,
-    model_joint_q_j_min: wp.array[float32],
-    model_joint_q_j_max: wp.array[float32],
-    state_joints_q_j: wp.array[float32],
-) -> tuple[int32, vec6f, vec6f, vec6f]:
+    dof_type: wp.int32,
+    dofs_offset: wp.int32,
+    coords_offset: wp.int32,
+    model_joint_q_j_min: wp.array[wp.float32],
+    model_joint_q_j_max: wp.array[wp.float32],
+    state_joints_q_j: wp.array[wp.float32],
+) -> tuple[wp.int32, vec6f, vec6f, vec6f]:
     if dof_type == JointDoFType.REVOLUTE:
         d_j, q_j_min, q_j_max, q_j_map = wp.static(make_read_joint_coords_map_and_limits(JointDoFType.REVOLUTE))(
             dofs_offset,
@@ -413,7 +407,7 @@ def read_joint_coords_map_and_limits(
             state_joints_q_j,
         )
     else:
-        d_j = int32(0)
+        d_j = wp.int32(0)
         q_j_min = vec6f(0.0)
         q_j_max = vec6f(0.0)
         q_j_map = vec6f(0.0)
@@ -425,28 +419,28 @@ def read_joint_coords_map_and_limits(
 @wp.func
 def detect_active_dof_limit(
     # Inputs:
-    model_max_limits: int32,
-    world_max_limits: int32,
-    wid: int32,
-    jid: int32,
-    dof: int32,
-    dofid: int32,
-    bid_B: int32,
-    bid_F: int32,
-    q: float32,
-    qmin: float32,
-    qmax: float32,
+    model_max_limits: wp.int32,
+    world_max_limits: wp.int32,
+    wid: wp.int32,
+    jid: wp.int32,
+    dof: wp.int32,
+    dofid: wp.int32,
+    bid_B: wp.int32,
+    bid_F: wp.int32,
+    q: wp.float32,
+    qmin: wp.float32,
+    qmax: wp.float32,
     # Outputs:
-    limits_model_num: wp.array[int32],
-    limits_world_num: wp.array[int32],
-    limits_wid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_jid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    limits_dof: wp.array[int32],
-    limits_side: wp.array[float32],
-    limits_r_q: wp.array[float32],
-    limits_key: wp.array[uint64],
+    limits_model_num: wp.array[wp.int32],
+    limits_world_num: wp.array[wp.int32],
+    limits_wid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_jid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    limits_dof: wp.array[wp.int32],
+    limits_side: wp.array[wp.float32],
+    limits_r_q: wp.array[wp.float32],
+    limits_key: wp.array[wp.uint64],
 ):
     # Retrieve the state of the joint
     r_min = q - qmin
@@ -461,11 +455,11 @@ def detect_active_dof_limit(
             limits_wid[mlid] = wid
             limits_lid[mlid] = wlid
             limits_jid[mlid] = jid
-            limits_bids[mlid] = vec2i(bid_B, bid_F)
+            limits_bids[mlid] = wp.vec2i(bid_B, bid_F)
             limits_dof[mlid] = dofid
             limits_side[mlid] = 1.0 if exceeds_min else -1.0
             limits_r_q[mlid] = r_min if exceeds_min else r_max
-            limits_key[mlid] = build_pair_key2(uint32(jid), uint32(dof))
+            limits_key[mlid] = build_pair_key2(wp.uint32(jid), wp.uint32(dof))
 
 
 ###
@@ -475,28 +469,28 @@ def detect_active_dof_limit(
 
 @wp.kernel
 def _detect_active_joint_configuration_limits(
-    model_joint_wid: wp.array[int32],
-    model_joint_dof_type: wp.array[int32],
-    model_joint_dofs_offset: wp.array[int32],
-    model_joint_coords_offset: wp.array[int32],
-    model_joint_bid_B: wp.array[int32],
-    model_joint_bid_F: wp.array[int32],
-    model_joint_q_j_min: wp.array[float32],
-    model_joint_q_j_max: wp.array[float32],
-    state_joints_q_j: wp.array[float32],
-    limits_model_max: wp.array[int32],
-    limits_world_max: wp.array[int32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_dof_type: wp.array[wp.int32],
+    model_joint_dofs_offset: wp.array[wp.int32],
+    model_joint_coords_offset: wp.array[wp.int32],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_bid_F: wp.array[wp.int32],
+    model_joint_q_j_min: wp.array[wp.float32],
+    model_joint_q_j_max: wp.array[wp.float32],
+    state_joints_q_j: wp.array[wp.float32],
+    limits_model_max: wp.array[wp.int32],
+    limits_world_max: wp.array[wp.int32],
     # Outputs:
-    limits_model_num: wp.array[int32],
-    limits_world_num: wp.array[int32],
-    limits_wid: wp.array[int32],
-    limits_lid: wp.array[int32],
-    limits_jid: wp.array[int32],
-    limits_bids: wp.array[vec2i],
-    limits_dof: wp.array[int32],
-    limits_side: wp.array[float32],
-    limits_r_q: wp.array[float32],
-    limits_key: wp.array[uint64],
+    limits_model_num: wp.array[wp.int32],
+    limits_world_num: wp.array[wp.int32],
+    limits_wid: wp.array[wp.int32],
+    limits_lid: wp.array[wp.int32],
+    limits_jid: wp.array[wp.int32],
+    limits_bids: wp.array[wp.vec2i],
+    limits_dof: wp.array[wp.int32],
+    limits_side: wp.array[wp.float32],
+    limits_r_q: wp.array[wp.float32],
+    limits_key: wp.array[wp.uint64],
 ):
     # Retrieve the joint index for the current thread
     # This will be the index w.r.r the model
@@ -627,128 +621,128 @@ class LimitsKamino:
         return self._data.world_max_limits_host
 
     @property
-    def model_max_limits(self) -> wp.array:
+    def model_max_limits(self) -> wp.array[wp.int32]:
         """
         Returns the total number of maximum limits for the model.\n
-        Shape of ``(1,)`` and type :class:`int32`.
+        Shape of ``(1,)``.
         """
         self._assert_has_data()
         return self._data.model_max_limits
 
     @property
-    def model_active_limits(self) -> wp.array:
+    def model_active_limits(self) -> wp.array[wp.int32]:
         """
         Returns the total number of active limits for the model.\n
-        Shape of ``(1,)`` and type :class:`int32`.
+        Shape of ``(1,)``.
         """
         self._assert_has_data()
         return self._data.model_active_limits
 
     @property
-    def world_max_limits(self) -> wp.array:
+    def world_max_limits(self) -> wp.array[wp.int32]:
         """
         Returns the total number of maximum limits per world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.
+        Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
         return self._data.world_max_limits
 
     @property
-    def world_active_limits(self) -> wp.array:
+    def world_active_limits(self) -> wp.array[wp.int32]:
         """
         Returns the total number of active limits per world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.
+        Shape of ``(num_worlds,)``.
         """
         self._assert_has_data()
         return self._data.world_active_limits
 
     @property
-    def wid(self) -> wp.array:
+    def wid(self) -> wp.array[wp.int32]:
         """
         Returns the world index of each limit.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.wid
 
     @property
-    def lid(self) -> wp.array:
+    def lid(self) -> wp.array[wp.int32]:
         """
         Returns the element index of each limit w.r.t its world.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.lid
 
     @property
-    def jid(self) -> wp.array:
+    def jid(self) -> wp.array[wp.int32]:
         """
         Returns the element index of the corresponding joint w.r.t the model.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.jid
 
     @property
-    def bids(self) -> wp.array:
+    def bids(self) -> wp.array[wp.vec2i]:
         """
         Returns the element indices of the interacting bodies w.r.t the model.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`vec2i`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.bids
 
     @property
-    def dof(self) -> wp.array:
+    def dof(self) -> wp.array[wp.int32]:
         """
         Returns the DoF indices along which limits are active w.r.t the model.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`int32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.dof
 
     @property
-    def side(self) -> wp.array:
+    def side(self) -> wp.array[wp.float32]:
         """
         Returns the direction (i.e. side) of the active limit.\n
         `1.0` for active min limits, `-1.0` for active max limits.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.side
 
     @property
-    def r_q(self) -> wp.array:
+    def r_q(self) -> wp.array[wp.float32]:
         """
         Returns the amount of generalized coordinate violation per joint-limit.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.r_q
 
     @property
-    def key(self) -> wp.array:
+    def key(self) -> wp.array[wp.uint64]:
         """
         Returns the integer key uniquely identifying each limit.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`uint64`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.key
 
     @property
-    def reaction(self) -> wp.array:
+    def reaction(self) -> wp.array[wp.float32]:
         """
         Returns constraint velocity per joint-limit.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.reaction
 
     @property
-    def velocity(self) -> wp.array:
+    def velocity(self) -> wp.array[wp.float32]:
         """
         Returns constraint velocity per joint-limit.\n
-        Shape of ``(model_max_limits_host,)`` and type :class:`float32`.
+        Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()
         return self._data.velocity
@@ -796,19 +790,19 @@ class LimitsKamino:
                 model_max_limits_host=model_max_limits,
                 world_max_limits_host=world_max_limits,
                 model_max_limits=to_warp_int32_array([model_max_limits]),
-                model_active_limits=wp.zeros(shape=1, dtype=int32),
+                model_active_limits=wp.zeros(shape=1, dtype=wp.int32),
                 world_max_limits=to_warp_int32_array(world_max_limits),
-                world_active_limits=wp.zeros(shape=len(world_max_limits), dtype=int32),
-                wid=wp.zeros(shape=model_max_limits, dtype=int32),
-                lid=wp.zeros(shape=model_max_limits, dtype=int32),
-                jid=wp.zeros(shape=model_max_limits, dtype=int32),
-                bids=wp.zeros(shape=model_max_limits, dtype=vec2i),
-                dof=wp.zeros(shape=model_max_limits, dtype=int32),
-                side=wp.zeros(shape=model_max_limits, dtype=float32),
-                r_q=wp.zeros(shape=model_max_limits, dtype=float32),
-                key=wp.full(shape=model_max_limits, value=make_bitmask(63), dtype=uint64),
-                reaction=wp.zeros(shape=model_max_limits, dtype=float32),
-                velocity=wp.zeros(shape=model_max_limits, dtype=float32),
+                world_active_limits=wp.zeros(shape=len(world_max_limits), dtype=wp.int32),
+                wid=wp.zeros(shape=model_max_limits, dtype=wp.int32),
+                lid=wp.zeros(shape=model_max_limits, dtype=wp.int32),
+                jid=wp.zeros(shape=model_max_limits, dtype=wp.int32),
+                bids=wp.zeros(shape=model_max_limits, dtype=wp.vec2i),
+                dof=wp.zeros(shape=model_max_limits, dtype=wp.int32),
+                side=wp.zeros(shape=model_max_limits, dtype=wp.float32),
+                r_q=wp.zeros(shape=model_max_limits, dtype=wp.float32),
+                key=wp.full(shape=model_max_limits, value=make_bitmask(63), dtype=wp.uint64),
+                reaction=wp.zeros(shape=model_max_limits, dtype=wp.float32),
+                velocity=wp.zeros(shape=model_max_limits, dtype=wp.float32),
             )
 
     def clear(self):
@@ -825,7 +819,7 @@ class LimitsKamino:
         if self._data is not None and self._data.model_max_limits_host > 0:
             self._data.reset()
 
-    def detect(self, q_j: wp.array[float32]):
+    def detect(self, q_j: wp.array[wp.float32]):
         """
         Detects the active joint limits in the model and updates the limits data.
 
@@ -840,7 +834,7 @@ class LimitsKamino:
         if q_j is None:
             raise ValueError("LimitsKamino: data must be specified for detection (got None)")
         elif not isinstance(q_j, wp.array):
-            raise TypeError("LimitsKamino: q_j must be an instance of wp.array[float32]")
+            raise TypeError("LimitsKamino: q_j must be an instance of wp.array[wp.float32]")
         elif q_j.device != self._model.device:
             raise ValueError(f"LimitsKamino: q_j device {q_j.device} does not match limits device {self._model.device}")
 

--- a/newton/_src/solvers/kamino/_src/kinematics/limits.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/limits.py
@@ -732,7 +732,7 @@ class LimitsKamino:
     @property
     def reaction(self) -> wp.array[wp.float32]:
         """
-        Returns constraint velocity per joint-limit.
+        Returns constraint reaction per joint-limit.
         Shape of ``(model_max_limits_host,)``.
         """
         self._assert_has_data()

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import warp as wp
 
 from ..core.joints import JointDoFType
@@ -47,12 +49,11 @@ wp.set_module_options({"enable_backward": False})
 
 
 def make_correct_joint_coords(dof_type: JointDoFType):
-    CoordsType = dof_type.coords_storage_type
-
+    @wp.func
     def _correct_joint_coords(
-        coords,  # CoordsType,
-        coords_ref,  # wp.array[wp.float32],
-    ):  # -> CoordsType
+        coords: Any,  # dof_type.coords_storage_type,
+        coords_ref: wp.array[wp.float32],
+    ) -> Any:  # dof_type.coords_storage_type
         if wp.static(
             dof_type == JointDoFType.CARTESIAN or dof_type == JointDoFType.FIXED or dof_type == JointDoFType.PRISMATIC
         ):
@@ -86,14 +87,7 @@ def make_correct_joint_coords(dof_type: JointDoFType):
 
         return coords
 
-    # Set type annotations manually (else CoordsType fails to resolve)
-    _correct_joint_coords.__annotations__ = {
-        "coords": CoordsType,
-        "coords_ref": wp.array[wp.float32],
-        "return": CoordsType,
-    }
-
-    return wp.func(_correct_joint_coords)
+    return _correct_joint_coords
 
 
 def make_compute_and_write_joint_coords(dof_type: JointDoFType):

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -11,7 +11,6 @@ from ..core.joints import JointDoFType
 from ..core.math import quat_from_x_rot, quat_from_y_rot, quat_from_z_rot, screw, screw_angular, screw_linear
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
-from ..core.types import float32, int32, mat33f, quatf, transformf, vec3f, vec6f
 from ..kinematics.joints import (
     compute_joint_pose_and_relative_motion,
     convert_angular_vel_to_universal_joint_intermediary_frame,
@@ -52,7 +51,7 @@ def make_correct_joint_coords(dof_type: JointDoFType):
 
     def _correct_joint_coords(
         coords,  # CoordsType,
-        coords_ref,  # wp.array[float32],
+        coords_ref,  # wp.array[wp.float32],
     ):  # -> CoordsType
         if wp.static(
             dof_type == JointDoFType.CARTESIAN or dof_type == JointDoFType.FIXED or dof_type == JointDoFType.PRISMATIC
@@ -90,7 +89,7 @@ def make_correct_joint_coords(dof_type: JointDoFType):
     # Set type annotations manually (else CoordsType fails to resolve)
     _correct_joint_coords.__annotations__ = {
         "coords": CoordsType,
-        "coords_ref": wp.array[float32],
+        "coords_ref": wp.array[wp.float32],
         "return": CoordsType,
     }
 
@@ -107,11 +106,11 @@ def make_compute_and_write_joint_coords(dof_type: JointDoFType):
 
     @wp.func
     def _compute_and_write_joint_coords(
-        r_j: vec3f,
-        q_j: quatf,
-        coords_offset: int32,
-        joint_q_ref: wp.array[float32],
-        joint_q: wp.array[float32],
+        r_j: wp.vec3f,
+        q_j: wp.quatf,
+        coords_offset: wp.int32,
+        joint_q_ref: wp.array[wp.float32],
+        joint_q: wp.array[wp.float32],
     ):
         # Compute joint coordinates
         coords = wp.static(get_joint_coords_mapping_function(dof_type))(r_j, q_j)
@@ -138,10 +137,10 @@ def make_compute_and_write_joint_vel(dof_type: JointDoFType):
 
     @wp.func
     def _compute_and_write_joint_vel(
-        q_j: quatf,
-        u_j: vec6f,
-        dofs_offset: int32,
-        joint_u: wp.array[float32],
+        q_j: wp.quatf,
+        u_j: wp.spatial_vectorf,
+        dofs_offset: wp.int32,
+        joint_u: wp.array[wp.float32],
     ):
         # Convert angular velocity to intermediary body frame for universal joint
         if wp.static(dof_type == JointDoFType.UNIVERSAL):
@@ -156,15 +155,15 @@ def make_compute_and_write_joint_vel(dof_type: JointDoFType):
 
 @wp.func
 def _compute_and_write_joint_coords_and_vel(
-    dof_type: int32,
-    r_j: vec3f,
-    q_j: quatf,
-    u_j: vec6f,
-    coords_offset: int32,
-    dofs_offset: int32,
-    joint_q_ref: wp.array[float32],
-    joint_q: wp.array[float32],
-    joint_u: wp.array[float32],
+    dof_type: wp.int32,
+    r_j: wp.vec3f,
+    q_j: wp.quatf,
+    u_j: wp.spatial_vectorf,
+    coords_offset: wp.int32,
+    dofs_offset: wp.int32,
+    joint_q_ref: wp.array[wp.float32],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
 ):
     if dof_type == JointDoFType.CARTESIAN:
         wp.static(make_compute_and_write_joint_coords(JointDoFType.CARTESIAN))(
@@ -218,10 +217,10 @@ def _compute_and_write_joint_coords_and_vel(
 
 @wp.func
 def _get_joint_rel_transform_from_coords(
-    dof_type: int32,
-    coord_offset: int32,
-    joint_q: wp.array[float32],
-) -> transformf:
+    dof_type: wp.int32,
+    coord_offset: wp.int32,
+    joint_q: wp.array[wp.float32],
+) -> wp.transformf:
     """Compute the joint-frame relative body pose at a joint, from the joint coords."""
     # Initialize transform to identity
     t = wp.vec3f(0.0, 0.0, 0.0)
@@ -260,18 +259,20 @@ def _get_joint_rel_transform_from_coords(
     else:
         assert False, "Unexpected joint dof type"  # noqa: B011
 
-    return transformf(t, q)
+    return wp.transformf(t, q)
 
 
 @wp.func
-def convert_angular_vel_from_universal_joint_intermediary_frame(j_q_j: quatf, j_u_j: vec6f) -> vec6f:
+def convert_angular_vel_from_universal_joint_intermediary_frame(
+    j_q_j: wp.quatf, j_u_j: wp.spatial_vectorf
+) -> wp.spatial_vectorf:
     """
     Convert the angular part of a relative body velocity at a universal joint, from the
     intermediary frame to the joint frame on the base body.
     """
     # Compute intermediary body axes, in the joint frame on the base body
-    e_x = vec3f(1.0, 0.0, 0.0)
-    e_y = vec3f(0.0, 1.0, 0.0)
+    e_x = wp.vec3f(1.0, 0.0, 0.0)
+    e_y = wp.vec3f(0.0, 1.0, 0.0)
     a_x = e_x  # x axis on base
     a_y_raw = wp.quat_rotate(j_q_j, e_y)  #  y axis on follower (constrained to be orthogonal to a_x)
     a_y = a_y_raw - wp.dot(a_y_raw, a_x) * a_x  # orthogonalize (in case of constraint violations)
@@ -294,12 +295,12 @@ def make_typed_get_joint_rel_velocity_from_dofs(dof_type: JointDoFType):
 
     @wp.func
     def _get_joint_rel_velocity_from_dofs(
-        q_j: quatf,
-        dofs_offset: int32,
-        joint_u: wp.array[float32],
-    ) -> vec6f:
+        q_j: wp.quatf,
+        dofs_offset: wp.int32,
+        joint_u: wp.array[wp.float32],
+    ) -> wp.spatial_vectorf:
         # Expand dof-space velocity to 6D screw (with zero along constrained axes)
-        u_j = vec6f(0.0)
+        u_j = wp.spatial_vectorf(0.0)
         for i in range(num_dofs):
             u_j[dof_axes[i]] = joint_u[dofs_offset + i]
 
@@ -314,11 +315,11 @@ def make_typed_get_joint_rel_velocity_from_dofs(dof_type: JointDoFType):
 
 @wp.func
 def _get_joint_rel_velocity_from_dofs(
-    dof_type: int32,
-    q_j: quatf,
-    dofs_offset: int32,
-    joint_u: wp.array[float32],
-) -> vec6f:
+    dof_type: wp.int32,
+    q_j: wp.quatf,
+    dofs_offset: wp.int32,
+    joint_u: wp.array[wp.float32],
+) -> wp.spatial_vectorf:
     """
     Compute the joint-frame relative body velocity at a joint, from the dof-space velocity.
     For universal joints, also requires the joint_frame relative body orientation.
@@ -330,7 +331,7 @@ def _get_joint_rel_velocity_from_dofs(
             q_j, dofs_offset, joint_u
         )
     elif dof_type == JointDoFType.FIXED:
-        return vec6f(0.0)
+        return wp.spatial_vectorf(0.0)
     elif dof_type == JointDoFType.FREE:
         return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.FREE))(q_j, dofs_offset, joint_u)
     elif dof_type == JointDoFType.GIMBAL:
@@ -350,15 +351,15 @@ def _get_joint_rel_velocity_from_dofs(
 @wp.kernel
 def _get_base_q_from_joint_q_and_body_q(
     # Inputs:
-    model_base_joint_index: wp.array[int32],
-    model_base_body_index: wp.array[int32],
-    model_joint_dof_type: wp.array[int32],
-    model_joint_coords_offset: wp.array[int32],
-    state_joint_q: wp.array[float32],
-    state_body_q: wp.array[transformf],
-    world_mask: wp.array[bool],
+    model_base_joint_index: wp.array[wp.int32],
+    model_base_body_index: wp.array[wp.int32],
+    model_joint_dof_type: wp.array[wp.int32],
+    model_joint_coords_offset: wp.array[wp.int32],
+    state_joint_q: wp.array[wp.float32],
+    state_body_q: wp.array[wp.transformf],
+    world_mask: wp.array[wp.bool],
     # Outputs:
-    base_q: wp.array[transformf],
+    base_q: wp.array[wp.transformf],
 ):
     # Get thread id as world id
     wid = wp.tid()
@@ -384,15 +385,15 @@ def _get_base_q_from_joint_q_and_body_q(
 @wp.kernel
 def _get_base_u_from_joint_u_and_body_u(
     # Inputs:
-    model_base_joint_index: wp.array[int32],
-    model_base_body_index: wp.array[int32],
-    model_joint_dof_type: wp.array[int32],
-    model_joint_dofs_offset: wp.array[int32],
-    state_joint_u: wp.array[float32],
-    state_body_u: wp.array[vec6f],
-    world_mask: wp.array[bool],
+    model_base_joint_index: wp.array[wp.int32],
+    model_base_body_index: wp.array[wp.int32],
+    model_joint_dof_type: wp.array[wp.int32],
+    model_joint_dofs_offset: wp.array[wp.int32],
+    state_joint_u: wp.array[wp.float32],
+    state_body_u: wp.array[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
     # Outputs:
-    base_u: wp.array[vec6f],
+    base_u: wp.array[wp.spatial_vectorf],
 ):
     # Get thread id as world id
     wid = wp.tid()
@@ -409,7 +410,7 @@ def _get_base_u_from_joint_u_and_body_u(
         assert dof_type != JointDoFType.UNIVERSAL  # Universal base joints are not supported
         # Relative body orientation would be needed to interpret dof-space velocity,
         # complicating the code significantly for a corner case without clear usecase.
-        base_u[wid] = _get_joint_rel_velocity_from_dofs(dof_type, quatf(), dofs_offset, state_joint_u)
+        base_u[wid] = _get_joint_rel_velocity_from_dofs(dof_type, wp.quatf(), dofs_offset, state_joint_u)
 
     # Otherwise read base_u from body_u if a base body was set for this world
     else:
@@ -421,11 +422,11 @@ def _get_base_u_from_joint_u_and_body_u(
 @wp.kernel
 def _set_body_q(
     # Inputs:
-    body_world_id: wp.array[int32],
-    body_q_in: wp.array[transformf],
-    world_mask: wp.array[bool],
+    body_world_id: wp.array[wp.int32],
+    body_q_in: wp.array[wp.transformf],
+    world_mask: wp.array[wp.bool],
     # Outputs:
-    body_q_out: wp.array[transformf],
+    body_q_out: wp.array[wp.transformf],
 ):
     body_id = wp.tid()
     wid = body_world_id[body_id]
@@ -437,26 +438,26 @@ def _set_body_q(
 @wp.kernel
 def _reset_joints_state_from_bodies_state(
     # Inputs
-    joint_world_id: wp.array[int32],
-    joint_dof_type: wp.array[int32],
-    joint_coords_offset: wp.array[int32],
-    joint_dofs_offset: wp.array[int32],
-    joint_cts_offset: wp.array[int32],
-    joint_bid_B: wp.array[int32],
-    joint_bid_F: wp.array[int32],
-    joint_B_r_Bj: wp.array[vec3f],
-    joint_F_r_Fj: wp.array[vec3f],
-    joint_X_Bj: wp.array[mat33f],
-    joint_X_Fj: wp.array[mat33f],
-    joint_q_0: wp.array[float32],
-    body_q: wp.array[transformf],
-    body_u: wp.array[vec6f],
-    world_mask: wp.array[bool],
+    joint_world_id: wp.array[wp.int32],
+    joint_dof_type: wp.array[wp.int32],
+    joint_coords_offset: wp.array[wp.int32],
+    joint_dofs_offset: wp.array[wp.int32],
+    joint_cts_offset: wp.array[wp.int32],
+    joint_bid_B: wp.array[wp.int32],
+    joint_bid_F: wp.array[wp.int32],
+    joint_B_r_Bj: wp.array[wp.vec3f],
+    joint_F_r_Fj: wp.array[wp.vec3f],
+    joint_X_Bj: wp.array[wp.mat33f],
+    joint_X_Fj: wp.array[wp.mat33f],
+    joint_q_0: wp.array[wp.float32],
+    body_q: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
     # Outputs
-    joint_q: wp.array[float32],
-    joint_q_prev: wp.array[float32],
-    joint_u: wp.array[float32],
-    joint_lambda: wp.array[float32],
+    joint_q: wp.array[wp.float32],
+    joint_q_prev: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
+    joint_lambda: wp.array[wp.float32],
 ):
     # Get thread id as joint id
     jid = wp.tid()
@@ -481,8 +482,8 @@ def _reset_joints_state_from_bodies_state(
     X_F = joint_X_Fj[jid]
 
     # Get pose and velocity of base/follower bodies
-    T_B = wp.transform_identity(dtype=float32)
-    u_B = vec6f(0.0)
+    T_B = wp.transform_identity(dtype=wp.float32)
+    u_B = wp.spatial_vectorf(0.0)
     if bid_B > -1:
         T_B = body_q[bid_B]
         u_B = body_u[bid_B]
@@ -507,10 +508,10 @@ def _reset_joints_state_from_bodies_state(
 @wp.kernel
 def _reset_body_velocities(
     # Inputs
-    body_world_id: wp.array[int32],
-    world_mask: wp.array[bool],
+    body_world_id: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
     # Outputs
-    body_u: wp.array[vec6f],
+    body_u: wp.array[wp.spatial_vectorf],
 ):
     # Get thread id as body id
     body_id = wp.tid()
@@ -521,17 +522,17 @@ def _reset_body_velocities(
         return
 
     # Reset velocities to zero
-    body_u[body_id] = vec6f(0.0)
+    body_u[body_id] = wp.spatial_vectorf(0.0)
 
 
 @wp.kernel
 def _reset_body_wrenches(
     # Inputs
-    body_world_id: wp.array[int32],
-    world_mask: wp.array[bool],
+    body_world_id: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
     # Outputs
-    body_w: wp.array[vec6f],
-    body_w_e: wp.array[vec6f],
+    body_w: wp.array[wp.spatial_vectorf],
+    body_w_e: wp.array[wp.spatial_vectorf],
 ):
     # Get thread id as body id
     body_id = wp.tid()
@@ -542,17 +543,17 @@ def _reset_body_wrenches(
         return
 
     # Reset wrenches to zero
-    body_w[body_id] = vec6f(0.0)
-    body_w_e[body_id] = vec6f(0.0)
+    body_w[body_id] = wp.spatial_vectorf(0.0)
+    body_w_e[body_id] = wp.spatial_vectorf(0.0)
 
 
 @wp.kernel
 def _reset_time_of_select_worlds(
     # Inputs:
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
     # Outputs:
-    data_time: wp.array[float32],
-    data_steps: wp.array[int32],
+    data_time: wp.array[wp.float32],
+    data_steps: wp.array[wp.int32],
 ):
     # Retrieve the world index from the 1D thread index
     wid = wp.tid()
@@ -569,22 +570,22 @@ def _reset_time_of_select_worlds(
 @wp.kernel
 def _eval_floating_base_relative_transform(
     # Inputs:
-    model_base_joint_index: wp.array[int32],
-    model_base_body_index: wp.array[int32],
-    joint_B_r_Bj: wp.array[vec3f],
-    joint_F_r_Fj: wp.array[vec3f],
-    joint_X_Bj: wp.array[mat33f],
-    joint_X_Fj: wp.array[mat33f],
-    base_q: wp.array[transformf],  # None also supported
-    base_u: wp.array[vec6f],  # None also supported
-    body_q: wp.array[transformf],
-    body_u: wp.array[vec6f],
-    world_mask: wp.array[bool],
-    relative_base_u: bool,
+    model_base_joint_index: wp.array[wp.int32],
+    model_base_body_index: wp.array[wp.int32],
+    joint_B_r_Bj: wp.array[wp.vec3f],
+    joint_F_r_Fj: wp.array[wp.vec3f],
+    joint_X_Bj: wp.array[wp.mat33f],
+    joint_X_Fj: wp.array[wp.mat33f],
+    base_q: wp.array[wp.transformf],  # None also supported
+    base_u: wp.array[wp.spatial_vectorf],  # None also supported
+    body_q: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
+    relative_base_u: wp.bool,
     # Outputs:
-    rel_transform: wp.array[transformf],
-    rel_velocity: wp.array[vec6f],
-    new_base_pos: wp.array[vec3f],
+    rel_transform: wp.array[wp.transformf],
+    rel_velocity: wp.array[wp.spatial_vectorf],
+    new_base_pos: wp.array[wp.vec3f],
 ):
     # Get thread id as world id
     wid = wp.tid()
@@ -606,8 +607,8 @@ def _eval_floating_base_relative_transform(
         r_F = joint_F_r_Fj[base_joint_id]
         X_B = joint_X_Bj[base_joint_id]
         X_F = joint_X_Fj[base_joint_id]
-        T_B = transformf(r_B, wp.quat_from_matrix(X_B))
-        T_F = transformf(r_F, wp.quat_from_matrix(X_F))
+        T_B = wp.transformf(r_B, wp.quat_from_matrix(X_B))
+        T_F = wp.transformf(r_F, wp.quat_from_matrix(X_F))
         T_F_inv = wp.transform_inverse(T_F)
         base_body_pose = wp.transform_multiply(wp.transform_multiply(T_B, base_q[wid]), T_F_inv)
     else:  # Directly interpret base_q as the new base body pose if no base joint
@@ -616,7 +617,7 @@ def _eval_floating_base_relative_transform(
 
     # Determine relative transform to apply, from current to target base body pose
     if not base_q:
-        T_rel = wp.transform_identity(float32)
+        T_rel = wp.transform_identity(wp.float32)
         # Ensure we get a bit-accurate identity (although the formula below would yield the identity)
     else:
         T_rel = wp.transform_multiply(base_body_pose, wp.transform_inverse(base_body_curr_pose))
@@ -624,7 +625,7 @@ def _eval_floating_base_relative_transform(
 
     # Determine new velocity of the base body
     if not base_u:  # No prescribed base_u: use zero additional relative velocity to apply to the base
-        rel_velocity[wid] = vec6f(0.0)
+        rel_velocity[wid] = wp.spatial_vectorf(0.0)
         return
     base_u_ = base_u[wid]
     if base_joint_id >= 0:  # If there is a base joint, base_u is the velocity in joint frame
@@ -655,20 +656,20 @@ def _eval_floating_base_relative_transform(
     else:
         v_rel = v_F - wp.transform_vector(T_rel, v_curr)
         omega_rel = omega_F - wp.transform_vector(T_rel, omega_curr)
-    rel_velocity[wid] = vec6f(*v_rel, *omega_rel)
+    rel_velocity[wid] = wp.spatial_vectorf(*v_rel, *omega_rel)
 
 
 @wp.kernel
 def _apply_floating_base_transform(
     # Inputs:
-    body_world_id: wp.array[int32],
-    rel_transform: wp.array[transformf],
-    rel_velocity: wp.array[vec6f],
-    new_base_pos: wp.array[vec3f],
-    world_mask: wp.array[bool],
+    body_world_id: wp.array[wp.int32],
+    rel_transform: wp.array[wp.transformf],
+    rel_velocity: wp.array[wp.spatial_vectorf],
+    new_base_pos: wp.array[wp.vec3f],
+    world_mask: wp.array[wp.bool],
     # Outputs:
-    body_q: wp.array[transformf],
-    body_u: wp.array[vec6f],
+    body_q: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
 ):
     # Get thread id as body id
     body_id = wp.tid()
@@ -694,7 +695,7 @@ def _apply_floating_base_transform(
     body_pos_new = wp.transform_get_translation(body_q_new)
     body_v_new += u_rel[:3] + wp.cross(omega_rel, body_pos_new - new_base_pos[wid])
     body_omega_new += omega_rel
-    body_u[body_id] = vec6f(*body_v_new, *body_omega_new)
+    body_u[body_id] = wp.spatial_vectorf(*body_v_new, *body_omega_new)
 
 
 ###
@@ -704,9 +705,9 @@ def _apply_floating_base_transform(
 
 def reset_time(
     model: ModelKamino,
-    time: wp.array,
-    steps: wp.array,
-    world_mask: wp.array,
+    time: wp.array[wp.float32],
+    steps: wp.array[wp.int32],
+    world_mask: wp.array[wp.bool],
 ):
     wp.launch(
         _reset_time_of_select_worlds,
@@ -724,10 +725,10 @@ def reset_time(
 
 def get_base_q_from_joint_q_and_body_q(
     model: ModelKamino,
-    joint_q: wp.array[float32],
-    body_q: wp.array[transformf],
-    base_q: wp.array[transformf],
-    world_mask: wp.array[bool],
+    joint_q: wp.array[wp.float32],
+    body_q: wp.array[wp.transformf],
+    base_q: wp.array[wp.transformf],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Infer the floating base pose from joint coordinates, if a base joint was set, or from body poses,
@@ -759,10 +760,10 @@ def get_base_q_from_joint_q_and_body_q(
 
 def get_base_u_from_joint_u_and_body_u(
     model: ModelKamino,
-    joint_u: wp.array[float32],
-    body_u: wp.array[vec6f],
-    base_u: wp.array[vec6f],
-    world_mask: wp.array[bool],
+    joint_u: wp.array[wp.float32],
+    body_u: wp.array[wp.spatial_vectorf],
+    base_u: wp.array[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Infer the floating base velocity from joint velocities, if a base joint was set, or from body velocities,
@@ -794,9 +795,9 @@ def get_base_u_from_joint_u_and_body_u(
 
 def set_body_q(
     model: ModelKamino,
-    body_q_in: wp.array[transformf],
-    body_q_out: wp.array[transformf],
-    world_mask: wp.array[bool],
+    body_q_in: wp.array[wp.transformf],
+    body_q_out: wp.array[wp.transformf],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Set the body poses of select worlds to prescribed values.
@@ -817,11 +818,11 @@ def set_body_q(
 
 def set_floating_base(
     model: ModelKamino,
-    base_q: wp.array[transformf] | None,
-    base_u: wp.array[vec6f] | None,
-    body_q: wp.array[transformf],
-    body_u: wp.array[vec6f],
-    world_mask: wp.array[bool],
+    base_q: wp.array[wp.transformf] | None,
+    base_u: wp.array[wp.spatial_vectorf] | None,
+    body_q: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
+    world_mask: wp.array[wp.bool],
     relative_base_u: bool = False,
 ):
     """
@@ -846,9 +847,9 @@ def set_floating_base(
 
     # Compute relative transformation and velocity change applied to base body
     # Note: we also cache the new base body position to avoid a race condition as the base body is updated
-    rel_transform = wp.empty(shape=model.size.num_worlds, dtype=transformf, device=model.device)
-    rel_velocity = wp.empty(shape=model.size.num_worlds, dtype=vec6f, device=model.device)
-    new_base_pos = wp.empty(shape=model.size.num_worlds, dtype=vec3f, device=model.device)
+    rel_transform = wp.empty(shape=model.size.num_worlds, dtype=wp.transformf, device=model.device)
+    rel_velocity = wp.empty(shape=model.size.num_worlds, dtype=wp.spatial_vectorf, device=model.device)
+    new_base_pos = wp.empty(shape=model.size.num_worlds, dtype=wp.vec3f, device=model.device)
     wp.launch(
         _eval_floating_base_relative_transform,
         dim=model.size.num_worlds,
@@ -892,7 +893,7 @@ def set_floating_base(
 def reset_joints_state_from_bodies_state(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Reset joint-based components of the state given body poses and velocities, inferring consistent
@@ -934,7 +935,7 @@ def reset_joints_state_from_bodies_state(
 def reset_body_velocities(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Reset body velocities in the state to zero.
@@ -955,7 +956,7 @@ def reset_body_velocities(
 def reset_body_wrenches(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Reset body wrenches in the state to zero.

--- a/newton/_src/solvers/kamino/_src/linalg/blas.py
+++ b/newton/_src/solvers/kamino/_src/linalg/blas.py
@@ -3,12 +3,14 @@
 
 """BLAS-like operations for multi-linear systems"""
 
+from __future__ import annotations
+
 import functools
 from typing import Any
 
 import warp as wp
 
-from ..core.types import FloatType, float32, int32
+from ..core.types import FloatType
 from .sparse_matrix import BlockDType, BlockSparseMatrices
 
 ###
@@ -39,13 +41,13 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _mult_left_right_diag_matrix_with_matrix(
     # Inputs:
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    D: wp.array[float32],
-    X: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    D: wp.array[wp.float32],
+    X: wp.array[wp.float32],
     # Outputs:
-    Y: wp.array[float32],
+    Y: wp.array[wp.float32],
 ):
     # Retrieve the thread indices
     wid, tid = wp.tid()
@@ -84,12 +86,12 @@ def _mult_left_right_diag_matrix_with_matrix(
 @wp.kernel
 def _mult_left_diag_matrix_with_vector(
     # Inputs:
-    dim: wp.array[int32],
-    vio: wp.array[int32],
-    D: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    D: wp.array[wp.float32],
+    x: wp.array[wp.float32],
     # Outputs:
-    y: wp.array[float32],
+    y: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -124,9 +126,9 @@ def _make_masked_zero_kernel_1d(dtype: Any):
     @wp.kernel
     def masked_zero_kernel_1d(
         # Inputs:
-        segment_offset: wp.array[int32],
-        segment_size: wp.array[int32],
-        segment_mask: wp.array[bool],
+        segment_offset: wp.array[wp.int32],
+        segment_size: wp.array[wp.int32],
+        segment_mask: wp.array[wp.bool],
         # Outputs:
         x: wp.array[dtype],
     ):
@@ -147,7 +149,7 @@ def _make_masked_zero_kernel_2d(dtype: Any):
     @wp.kernel
     def masked_zero_kernel_2d(
         # Inputs:
-        row_mask: wp.array[bool],
+        row_mask: wp.array[wp.bool],
         # Outputs:
         x: wp.array2d[dtype],
     ):
@@ -174,18 +176,18 @@ def _make_block_sparse_matvec_kernel(block_type: BlockDType):
     @wp.kernel
     def block_sparse_matvec_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Vector:
         x: wp.array[block_type.dtype],
         y: wp.array[block_type.dtype],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -243,15 +245,15 @@ def _make_block_sparse_matvec_kernel_2d(block_type: BlockDType):
     @wp.kernel
     def block_sparse_matvec_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector:
         x: wp.array2d[block_type.dtype],
         y: wp.array2d[block_type.dtype],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -309,18 +311,18 @@ def _make_block_sparse_transpose_matvec_kernel(block_type: BlockDType):
     @wp.kernel
     def block_sparse_transpose_matvec_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Vector:
         y: wp.array[block_type.dtype],
         x: wp.array[block_type.dtype],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -376,15 +378,15 @@ def _make_block_sparse_transpose_matvec_kernel_2d(block_type: BlockDType):
     @wp.kernel
     def block_sparse_transpose_matvec_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector:
         y: wp.array2d[block_type.dtype],
         x: wp.array2d[block_type.dtype],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -431,10 +433,8 @@ def _make_scale_vector_kernel(space_dim: int):
     """Creates a kernel that scales a vector, taking into account a matrix mask and how the current
     size of a matrix affects the active entries of the vector.
 
-    Parameters
-    ----------
-    space_dim : int
-        Space of the vector in reference to the matrices (0: row space, 1: column space).
+    Args:
+        space_dim: Space of the vector in reference to the matrices (0: row space, 1: column space).
     """
 
     sp_dim = wp.constant(space_dim)
@@ -442,15 +442,15 @@ def _make_scale_vector_kernel(space_dim: int):
     @wp.kernel
     def scale_vector_kernel(
         # Matrix data:
-        matrix_dims: wp.array2d[int32],
+        matrix_dims: wp.array2d[wp.int32],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Inputs:
-        x: wp.array[Any],
-        beta: Any,
+        x: wp.array[wp.float32],
+        beta: wp.float32,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, entry_id = wp.tid()
 
@@ -473,10 +473,8 @@ def _make_scale_vector_kernel_2d(space_dim: int):
     """Creates a kernel that scales a vector, taking into account a matrix mask and how the current
     size of a matrix affects the active entries of the vector.
 
-    Parameters
-    ----------
-    space_dim : int
-        Space of the vector in reference to the matrices (0: row space, 1: column space).
+    Args:
+        space_dim: Space of the vector in reference to the matrices (0: row space, 1: column space).
     """
 
     sp_dim = wp.constant(space_dim)
@@ -484,12 +482,12 @@ def _make_scale_vector_kernel_2d(space_dim: int):
     @wp.kernel
     def scale_vector_kernel(
         # Matrix data:
-        matrix_dims: wp.array2d[int32],
+        matrix_dims: wp.array2d[wp.int32],
         # Inputs:
-        x: wp.array2d[Any],
-        beta: Any,
+        x: wp.array2d[wp.float32],
+        beta: wp.float32,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, entry_id = wp.tid()
 
@@ -516,20 +514,20 @@ def _make_block_sparse_gemv_kernel(block_type: BlockDType):
     @wp.kernel
     def block_sparse_gemv_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Vector:
         x: wp.array[block_type.dtype],
         y: wp.array[block_type.dtype],
         # Scaling:
         alpha: block_type.dtype,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -587,9 +585,9 @@ def _make_block_sparse_gemv_kernel_2d(block_type: BlockDType):
     @wp.kernel
     def block_sparse_gemv_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector:
         x: wp.array2d[block_type.dtype],
@@ -597,7 +595,7 @@ def _make_block_sparse_gemv_kernel_2d(block_type: BlockDType):
         # Scaling:
         alpha: block_type.dtype,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -655,20 +653,20 @@ def _make_block_sparse_transpose_gemv_kernel(block_type: BlockDType):
     @wp.kernel
     def block_sparse_transpose_gemv_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector block offsets:
-        row_start: wp.array[int32],
-        col_start: wp.array[int32],
+        row_start: wp.array[wp.int32],
+        col_start: wp.array[wp.int32],
         # Vector:
         y: wp.array[block_type.dtype],
         x: wp.array[block_type.dtype],
         # Scaling:
         alpha: block_type.dtype,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -724,9 +722,9 @@ def _make_block_sparse_transpose_gemv_kernel_2d(block_type: BlockDType):
     @wp.kernel
     def block_sparse_transpose_gemv_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Vector:
         y: wp.array2d[block_type.dtype],
@@ -734,7 +732,7 @@ def _make_block_sparse_transpose_gemv_kernel_2d(block_type: BlockDType):
         # Scaling:
         alpha: block_type.dtype,
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         mat_id, block_idx = wp.tid()
 
@@ -778,14 +776,14 @@ def _make_block_sparse_transpose_gemv_kernel_2d(block_type: BlockDType):
 
 @wp.kernel
 def _diag_gemv_kernel(
-    x: wp.array[Any],
-    y: wp.array[Any],
-    D: wp.array[Any],
-    active_dims: wp.array[Any],
-    world_active: wp.array[bool],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    D: wp.array[wp.float32],
+    active_dims: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
     vio: wp.array[wp.int32],
-    alpha: Any,
-    beta: Any,
+    alpha: wp.float32,
+    beta: wp.float32,
 ):
     """Computes y[w] = alpha * D[w] * x[w] + beta * y[w] for each world w."""
     world, row = wp.tid()
@@ -806,13 +804,13 @@ def _diag_gemv_kernel(
 
 @wp.kernel
 def _dense_gemv_kernel(
-    x: wp.array[Any],
-    y: wp.array[Any],
-    A: wp.array[Any],
-    active_dims: wp.array[Any],
-    world_active: wp.array[bool],
-    alpha: Any,
-    beta: Any,
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    A: wp.array[wp.float32],
+    active_dims: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    alpha: wp.float32,
+    beta: wp.float32,
     mio: wp.array[wp.int32],
     vio: wp.array[wp.int32],
     tile_size: int,
@@ -852,14 +850,14 @@ def _make_block_sparse_ATA_diagonal_kernel_2d(block_type: BlockDType):
     @wp.kernel
     def block_sparse_ATA_diagonal_kernel(
         # Matrix data:
-        num_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         nzb_values: wp.array[block_type.warp_type],
         # Output:
         diag: wp.array2d[block_type.dtype],
         # Mask:
-        matrix_mask: wp.array[bool],
+        matrix_mask: wp.array[wp.bool],
     ):
         """
         For a block sparse matrix (stack) A, computes the diagonal of A^T * A
@@ -904,15 +902,15 @@ class nzb_type_7(BlockDType(dtype=wp.float32, shape=(7,)).warp_type):
 @wp.kernel
 def block_sparse_ATA_diagonal_3_4_blocks_kernel_2d(
     # Matrix data:
-    num_nzb: wp.array[int32],
-    nzb_start: wp.array[int32],
-    nzb_coords: wp.array2d[int32],
+    num_nzb: wp.array[wp.int32],
+    nzb_start: wp.array[wp.int32],
+    nzb_coords: wp.array2d[wp.int32],
     nzb_values: wp.array[nzb_type_7],
     # Output:
     blocks_3: wp.array2d[wp.float32],
     blocks_4: wp.array2d[wp.float32],
     # Mask:
-    matrix_mask: wp.array[bool],
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     For a block sparse matrix (stack) A with 1x7 blocks, computes the blockwise-diagonal of A^T * A,
@@ -956,10 +954,10 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
     @wp.kernel
     def cwise_inverse_kernel(
         # Inputs
-        offset: float32,
+        offset: wp.float32,
         x: wp.array2d[dtype],
         dim: wp.array[wp.int32],
-        mask: wp.array[bool],
+        mask: wp.array[wp.bool],
     ):
         """Kernel computing x_i = 1 / (x_i + offset) for an array of scalars x_i"""
         mat_id, coeff_id = wp.tid()
@@ -975,10 +973,10 @@ def _make_cwise_inverse_kernel_2d(dtype: FloatType):
 @wp.kernel
 def blockwise_inverse_kernel_3_2d(
     # Inputs
-    diag_offset: float32,
+    diag_offset: wp.float32,
     blocks: wp.array2d[wp.mat33f],
     dim: wp.array[wp.int32],
-    mask: wp.array[bool],
+    mask: wp.array[wp.bool],
 ):
     """Kernel computing B_i = (B_i + diag_offset * I)^-1 for an array of 3x3 blocks B_i"""
     mat_id, block_id = wp.tid()
@@ -996,10 +994,10 @@ def blockwise_inverse_kernel_3_2d(
 @wp.kernel
 def blockwise_inverse_kernel_4_2d(
     # Inputs
-    diag_offset: float32,
+    diag_offset: wp.float32,
     blocks: wp.array2d[wp.mat44f],
     dim: wp.array[wp.int32],
-    mask: wp.array[bool],
+    mask: wp.array[wp.bool],
 ):
     """Kernel computing B_i = (B_i + diag_offset * I)^-1 for an array of 4x4 blocks B_i"""
     mat_id, block_id = wp.tid()
@@ -1022,7 +1020,7 @@ def _blockwise_diag_3_4_gemv_kernel_2d(
     blocks_3: wp.array2d[wp.mat33f],
     blocks_4: wp.array2d[wp.mat44f],
     active_dims: wp.array[wp.int32],
-    world_active: wp.array[bool],
+    world_active: wp.array[wp.bool],
     alpha: wp.float32,
     beta: wp.float32,
 ):
@@ -1062,12 +1060,12 @@ def _blockwise_diag_3_4_gemv_kernel_2d(
 
 
 def diag_gemv(
-    D: wp.array,
-    x: wp.array,
-    y: wp.array,
-    active_dims: wp.array,
-    world_active: wp.array[bool],
-    vio: wp.array,
+    D: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    active_dims: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
+    vio: wp.array[wp.int32],
     alpha: float,
     beta: float,
     max_dim: int,
@@ -1097,16 +1095,16 @@ def diag_gemv(
 
 
 def dense_gemv(
-    A: wp.array,
-    x: wp.array,
-    y: wp.array,
-    active_dims: wp.array,
-    world_active: wp.array[bool],
+    A: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    active_dims: wp.array[wp.int32],
+    world_active: wp.array[wp.bool],
     alpha: float,
     beta: float,
     max_dim: int,
-    mio: wp.array,
-    vio: wp.array,
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
     block_dim: int = 64,
 ):
     """
@@ -1140,21 +1138,21 @@ def dense_gemv(
 
 def block_sparse_matvec(
     A: BlockSparseMatrices,
-    x: wp.array,
-    y: wp.array,
-    matrix_mask: wp.array[bool],
+    x: wp.array[wp.float32] | wp.array2d[wp.float32],
+    y: wp.array[wp.float32] | wp.array2d[wp.float32],
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     Launch kernel for block-sparse matrix-vector product: y = A * x
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        x (wp.array): Stack of input vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_cols) for the 2D version.
-        y (wp.array): Stack of output vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_rows) for the 2D version.
-        matrix_mask (wp.array): Per-matrix boolean flag for whether to perform the operation. Blocks of `y`, that
-        correspond to matrices for which the mask is `False`, are left unchanged.
+        A: Sparse matrices.
+        x: Stack of input vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_cols) for the 2D version.
+        y: Stack of output vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_rows) for the 2D version.
+        matrix_mask: Per-matrix boolean flag for whether to perform the operation. Blocks of `y`, that
+            correspond to matrices for which the mask is `False`, are left unchanged.
     """
     if len(x.shape) == 1:
         wp.launch(
@@ -1204,21 +1202,21 @@ def block_sparse_matvec(
 
 def block_sparse_transpose_matvec(
     A: BlockSparseMatrices,
-    y: wp.array,
-    x: wp.array,
-    matrix_mask: wp.array[bool],
+    y: wp.array[wp.float32] | wp.array2d[wp.float32],
+    x: wp.array[wp.float32] | wp.array2d[wp.float32],
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     Launch kernel for block-sparse transpose matrix-vector product: x = A^T * y
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        y (wp.array): Stack of input vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_rows) for the 2D version.
-        x (wp.array): Stack of output vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_cols) for the 2D version.
-        matrix_mask (wp.array): Per-matrix boolean flag for whether to perform the operation. Blocks of `x`, that
-        correspond to matrices for which the mask is `False`, are left unchanged.
+        A: Sparse matrices.
+        y: Stack of input vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_rows) for the 2D version.
+        x: Stack of output vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_cols) for the 2D version.
+        matrix_mask: Per-matrix boolean flag for whether to perform the operation. Blocks of `x`, that
+            correspond to matrices for which the mask is `False`, are left unchanged.
     """
     if len(x.shape) == 1:
         wp.launch(
@@ -1268,24 +1266,24 @@ def block_sparse_transpose_matvec(
 
 def block_sparse_gemv(
     A: BlockSparseMatrices,
-    x: wp.array,
-    y: wp.array,
-    alpha: Any,
-    beta: Any,
-    matrix_mask: wp.array[bool],
+    x: wp.array[wp.float32] | wp.array2d[wp.float32],
+    y: wp.array[wp.float32] | wp.array2d[wp.float32],
+    alpha: wp.float32,
+    beta: wp.float32,
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     Launch kernel for generalized block-sparse matrix-vector product: y = alpha * (A * x) + beta * y
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        x (wp.array): Stack of input vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_cols) for the 2D version.
-        y (wp.array): Stack of input-output vectors, expects either shape (sum_of_max_rows,) for the 1D
-        flattened version; or shape (num_matrices, max_of_max_rows) for the 2D version.
-        alpha (Any): Input scaling for matrix-vector multiplication.
-        beta (Any): Input scaling for linear offset.
-        matrix_mask (wp.array): Boolean mask vector; matrices set to `False` are skipped.
+        A: Sparse matrices.
+        x: Stack of input vectors, expects either shape (sum_of_max_cols,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_cols) for the 2D version.
+        y: Stack of input-output vectors, expects either shape (sum_of_max_rows,) for the 1D
+            flattened version; or shape (num_matrices, max_of_max_rows) for the 2D version.
+        alpha: Input scaling for matrix-vector multiplication.
+        beta: Input scaling for linear offset.
+        matrix_mask: Boolean mask vector; matrices set to `False` are skipped.
     """
     if len(x.shape) == 1:
         # Compute y <= beta * y
@@ -1343,24 +1341,24 @@ def block_sparse_gemv(
 
 def block_sparse_transpose_gemv(
     A: BlockSparseMatrices,
-    y: wp.array,
-    x: wp.array,
-    alpha: Any,
-    beta: Any,
-    matrix_mask: wp.array[bool],
+    y: wp.array[wp.float32] | wp.array2d[wp.float32],
+    x: wp.array[wp.float32] | wp.array2d[wp.float32],
+    alpha: wp.float32,
+    beta: wp.float32,
+    matrix_mask: wp.array[wp.bool],
 ):
     """
     Launch kernel for generalized block-sparse transpose matrix-vector product: x = alpha * (A^T * y) + beta * x
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        y (wp.array): Stack of input vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
-        version; or shape (num_matrices, max_of_max_rows) for the 2D version.
-        x (wp.array): Stack of input-output vectors, expects either shape (sum_of_max_cols,) for the 1D
-        flattened version; or shape (num_matrices, max_of_max_cols) for the 2D version.
-        alpha (Any): Input scaling for matrix-vector multiplication.
-        beta (Any): Input scaling for linear offset.
-        matrix_mask (wp.array): Boolean mask vector; matrices set to `False` are skipped.
+        A: Sparse matrices.
+        y: Stack of input vectors, expects either shape (sum_of_max_rows,) for the 1D flattened
+            version; or shape (num_matrices, max_of_max_rows) for the 2D version.
+        x: Stack of input-output vectors, expects either shape (sum_of_max_cols,) for the 1D
+            flattened version; or shape (num_matrices, max_of_max_cols) for the 2D version.
+        alpha: Input scaling for matrix-vector multiplication.
+        beta: Input scaling for linear offset.
+        matrix_mask: Boolean mask vector; matrices set to `False` are skipped.
     """
     if len(x.shape) == 1:
         # Compute x <= beta * x
@@ -1417,16 +1415,19 @@ def block_sparse_transpose_gemv(
 
 
 def block_sparse_ATA_inv_diagonal_2d(
-    A: BlockSparseMatrices, inv_diag: wp.array, matrix_mask: wp.array[bool], diag_offset: float32 = 0.0
+    A: BlockSparseMatrices,
+    inv_diag: wp.array2d[wp.float32],
+    matrix_mask: wp.array[wp.bool],
+    diag_offset: wp.float32 = 0.0,
 ):
     """
     Function computing the inverse of the diagonal of A^T * A + diag_offset * I, given sparse matrix (stack) A.
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        inv_diag (wp.array): Stack of output vectors, expects shape (num_matrices, max_of_max_cols).
-        matrix_mask (wp.array): Boolean mask vector; matrices set to `False` are skipped.
-        diag_offset (float32, optional): Scalar diagonal offset added to A^T * A (defaults to zero).
+        A: Sparse matrices.
+        inv_diag: Stack of output vectors, expects shape (num_matrices, max_of_max_cols).
+        matrix_mask: Boolean mask vector; matrices set to `False` are skipped.
+        diag_offset: Scalar diagonal offset added to A^T * A (defaults to zero).
     """
     wp.launch(
         kernel=_make_masked_zero_kernel_2d(A.nzb_dtype.dtype),
@@ -1462,10 +1463,10 @@ def block_sparse_ATA_inv_diagonal_2d(
 
 def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
     A: BlockSparseMatrices,
-    inv_blocks_3: wp.array,
-    inv_blocks_4: wp.array,
-    matrix_mask: wp.array[bool],
-    diag_offset: float32 = 0.0,
+    inv_blocks_3: wp.array2d[wp.mat33f],
+    inv_blocks_4: wp.array2d[wp.mat44f],
+    matrix_mask: wp.array[wp.bool],
+    diag_offset: wp.float32 = 0.0,
 ):
     """
     Function computing the blockwise inverse of the diagonal of A^T * A + diag_offset * I given sparse matrix (stack) A,
@@ -1473,10 +1474,11 @@ def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
     A must have block size 1x7
 
     Args:
-        A (BlockSparseMatrices): Sparse matrices.
-        inv_blocks (wp.array): Stack of vectors of 3x3 blocks, expects shape (num_matrices, max_of_max_cols / 7).
-        matrix_mask (wp.array): Boolean mask vector; matrices set to `False` are skipped.
-        diag_offset (float32, optional): Scalar diagonal offset added to A^T * A (defaults to zero).
+        A: Sparse matrices.
+        inv_blocks_3: Stack of vectors of 3x3 blocks, expects shape (num_matrices, max_of_max_cols / 7).
+        inv_blocks_4: Stack of vectors of 4x4 blocks, expects shape (num_matrices, max_of_max_cols / 7).
+        matrix_mask: Boolean mask vector; matrices set to `False` are skipped.
+        diag_offset: Scalar diagonal offset added to A^T * A (defaults to zero).
     """
     wp.launch(
         _make_masked_zero_kernel_2d(wp.mat33f),
@@ -1550,7 +1552,7 @@ def get_blockwise_diag_3_4_gemv_2d(
     def gemv(
         x: wp.array2d[wp.float32],
         y: wp.array2d[wp.float32],
-        world_active: wp.array[bool],
+        world_active: wp.array[wp.bool],
         alpha: wp.float32,
         beta: wp.float32,
     ):

--- a/newton/_src/solvers/kamino/_src/linalg/conjugate.py
+++ b/newton/_src/solvers/kamino/_src/linalg/conjugate.py
@@ -45,12 +45,12 @@ class BatchedLinearOperator:
         gemv_fn: Callable,
         n_worlds: int,
         max_dim: int,
-        active_dims: wp.array,
+        active_dims: wp.array[wp.int32],
         device: wp.Device,
         dtype: type,
         matvec_fn: Callable | None = None,
-        mio: wp.array | None = None,
-        vio: wp.array | None = None,
+        mio: wp.array[wp.int32] | None = None,
+        vio: wp.array[wp.int32] | None = None,
         total_vec_size: int = 0,
     ):
         self._gemv_fn = gemv_fn
@@ -91,7 +91,9 @@ class BatchedLinearOperator:
         )
 
     @classmethod
-    def from_diagonal(cls, D: wp.array, active_dims: wp.array, vio: wp.array, max_dim: int) -> BatchedLinearOperator:
+    def from_diagonal(
+        cls, D: wp.array[Any], active_dims: wp.array[wp.int32], vio: wp.array[wp.int32], max_dim: int
+    ) -> BatchedLinearOperator:
         """Create operator from diagonal matrix (flat 1D storage)."""
         n_worlds = active_dims.shape[0]
 
@@ -101,7 +103,7 @@ class BatchedLinearOperator:
         return cls(gemv_fn, n_worlds, max_dim, active_dims, D.device, D.dtype, vio=vio, total_vec_size=D.shape[0])
 
     @classmethod
-    def from_block_sparse(cls, A: BlockSparseMatrices, active_dims: wp.array) -> BatchedLinearOperator:
+    def from_block_sparse(cls, A: BlockSparseMatrices, active_dims: wp.array[wp.int32]) -> BatchedLinearOperator:
         """Create operator from block-sparse matrix.
 
         The block-sparse matrix uses its own ``row_start``/``col_start`` offsets
@@ -166,11 +168,18 @@ class BatchedLinearOperator:
             total_vec_size=total_vec_size,
         )
 
-    def gemv(self, x: wp.array, y: wp.array, world_active: wp.array[bool], alpha: float, beta: float):
+    def gemv(
+        self,
+        x: wp.array[Any],
+        y: wp.array[Any],
+        world_active: wp.array[wp.bool],
+        alpha: float,
+        beta: float,
+    ):
         """Compute y = alpha * A @ x + beta * y."""
         self._gemv_fn(x, y, world_active, alpha, beta)
 
-    def matvec(self, x: wp.array, y: wp.array, world_active: wp.array[bool]):
+    def matvec(self, x: wp.array[Any], y: wp.array[Any], world_active: wp.array[wp.bool]):
         if self._matvec_fn is not None:
             return self._matvec_fn(x, y, world_active)
         return self._gemv_fn(x, y, world_active, 1.0, 0.0)
@@ -186,7 +195,7 @@ def check_termination(
     loop_granularity: int,
     r_norm_sq: wp.array[Any],
     atol_sq: wp.array[Any],
-    world_active: wp.array[bool],
+    world_active: wp.array[wp.bool],
     cur_iter: wp.array[int],
     world_condition: wp.array[wp.int32],
     batch_condition: wp.array[wp.int32],
@@ -309,12 +318,12 @@ def _cr_kernel_2(
 
 def _run_capturable_loop(
     do_iteration: Callable,
-    r_norm_sq: wp.array,
-    world_active: wp.array[bool],
+    r_norm_sq: wp.array[Any],
+    world_active: wp.array[wp.bool],
     cur_iter: wp.array[wp.int32],
     conditions: wp.array[wp.int32],
     maxiter: wp.array[int],
-    atol_sq: wp.array,
+    atol_sq: wp.array[Any],
     callback: Callable | None,
     use_cuda_graph: bool,
     use_graph_conditionals: bool = True,
@@ -399,7 +408,7 @@ def make_dot_kernel(tile_size: int, maxdim: int):
         b: wp.array2d[Any],
         vio: wp.array[wp.int32],
         world_size: wp.array[wp.int32],
-        world_active: wp.array[bool],
+        world_active: wp.array[wp.bool],
         result: wp.array2d[Any],
     ):
         """Compute the dot products between flat arrays using tiles and pairwise summation."""
@@ -440,7 +449,7 @@ def dot_sequential(
     b: wp.array2d[Any],
     vio: wp.array[wp.int32],
     world_size: wp.array[wp.int32],
-    world_active: wp.array[bool],
+    world_active: wp.array[wp.bool],
     partial_sum: wp.array3d[Any],
 ):
     col, world = wp.tid()
@@ -526,11 +535,11 @@ class ConjugateSolver:
     def __init__(
         self,
         A: BatchedLinearOperator,
-        active_dims: wp.array[Any] | None = None,
-        world_active: wp.array[bool] | None = None,
+        active_dims: wp.array[wp.int32] | None = None,
+        world_active: wp.array[wp.bool] | None = None,
         atol: float | wp.array[Any] | None = None,
         rtol: float | wp.array[Any] | None = None,
-        maxiter: wp.array = None,
+        maxiter: wp.array[wp.int32] = None,
         Mi: BatchedLinearOperator | None = None,
         callback: Callable | None = None,
         use_cuda_graph: bool = True,
@@ -582,7 +591,7 @@ class ConjugateSolver:
 
         if self.maxiter is None:
             maxiter = int(1.5 * self.maxdims)
-            self.maxiter = wp.full(self.n_worlds, maxiter, dtype=int, device=self.device)
+            self.maxiter = wp.full(self.n_worlds, maxiter, dtype=wp.int32, device=self.device)
             self.maxiter_host = maxiter
         else:
             self.maxiter_host = int(max(self.maxiter.numpy()))
@@ -670,10 +679,10 @@ class CGSolver(ConjugateSolver):
 
     def solve(
         self,
-        b: wp.array,
-        x: wp.array,
-        active_dims: wp.array[Any] | None = None,
-        world_active: wp.array[bool] | None = None,
+        b: wp.array[Any],
+        x: wp.array[Any],
+        active_dims: wp.array[wp.int32] | None = None,
+        world_active: wp.array[wp.bool] | None = None,
     ):
         if b.shape[0] != self.total_vec_size:
             raise ValueError(f"b has size {b.shape[0]} but solver expects total_vec_size={self.total_vec_size}")
@@ -788,10 +797,10 @@ class CRSolver(ConjugateSolver):
 
     def solve(
         self,
-        b: wp.array,
-        x: wp.array,
-        active_dims: wp.array[Any] | None = None,
-        world_active: wp.array[bool] | None = None,
+        b: wp.array[Any],
+        x: wp.array[Any],
+        active_dims: wp.array[wp.int32] | None = None,
+        world_active: wp.array[wp.bool] | None = None,
     ):
         if b.shape[0] != self.total_vec_size:
             raise ValueError(f"b has size {b.shape[0]} but solver expects total_vec_size={self.total_vec_size}")
@@ -901,7 +910,7 @@ class CRSolver(ConjugateSolver):
         )
 
 
-def _repeat_first(arr: wp.array):
+def _repeat_first(arr: wp.array[Any]):
     # returns a view of the first element repeated arr.shape[0] times
     view = wp.array(
         ptr=arr.ptr,

--- a/newton/_src/solvers/kamino/_src/linalg/core.py
+++ b/newton/_src/solvers/kamino/_src/linalg/core.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import numpy as np
 import warp as wp
 
-from ..core.types import FloatType, IntType, VecIntType, float32, int32
+from ..core.types import FloatType, IntType, VecIntType
 from ..utils import logger as msg
 
 ###
@@ -87,10 +87,10 @@ class DenseRectangularMultiLinearInfo:
     This is equal to `sum(maxdim[i][0] for i in range(num_blocks))`.
     """
 
-    dtype: FloatType = float32
+    dtype: FloatType = wp.float32
     """The data type of the underlying matrix and vector data arrays."""
 
-    itype: IntType = int32
+    itype: IntType = wp.int32
     """The integer type used for indexing the underlying data arrays."""
 
     device: wp.DeviceLike | None = None
@@ -148,8 +148,8 @@ class DenseRectangularMultiLinearInfo:
     def finalize(
         self,
         dimensions: list[tuple[int, int]],
-        dtype: FloatType = float32,
-        itype: IntType = int32,
+        dtype: FloatType = wp.float32,
+        itype: IntType = wp.int32,
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -209,7 +209,7 @@ class DenseRectangularMultiLinearInfo:
         mio: wp.array,
         rvio: wp.array,
         ivio: wp.array,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -344,10 +344,10 @@ class DenseSquareMultiLinearInfo:
     This is equal to `sum(maxdim[i][1] for i in range(num_blocks))`.
     """
 
-    dtype: FloatType = float32
+    dtype: FloatType = wp.float32
     """The data type of the underlying matrix and vector data arrays."""
 
-    itype: IntType = int32
+    itype: IntType = wp.int32
     """The integer type used for indexing the underlying data arrays."""
 
     device: wp.DeviceLike | None = None
@@ -391,7 +391,11 @@ class DenseSquareMultiLinearInfo:
         return dims
 
     def finalize(
-        self, dimensions: list[int], dtype: FloatType = float32, itype: IntType = int32, device: wp.DeviceLike = None
+        self,
+        dimensions: list[int],
+        dtype: FloatType = wp.float32,
+        itype: IntType = wp.int32,
+        device: wp.DeviceLike = None,
     ) -> None:
         """
         Constructs and allocates the data of the square multi-linear system info on the specified device.
@@ -438,7 +442,7 @@ class DenseSquareMultiLinearInfo:
         dim: wp.array,
         mio: wp.array,
         vio: wp.array,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -541,7 +545,7 @@ class DenseLinearOperatorData:
 ###
 
 
-def make_dtype_tolerance(tol: FloatType | float | None = None, dtype: FloatType = float32) -> FloatType:
+def make_dtype_tolerance(tol: FloatType | float | None = None, dtype: FloatType = wp.float32) -> FloatType:
     # First ensure the specified dtype is a valid warp type
     if not issubclass(dtype, FloatType):
         raise ValueError("data type 'dtype' must be a FloatType, e.g. a `wp.float32` or `wp.float64` value etc.")

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked.py
@@ -8,7 +8,6 @@ from functools import cache
 
 import warp as wp
 
-from ...core.types import float32, int32
 from ._tile_builtins import (
     HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE,
     HAS_NATIVE_TILE_MATMUL_TRANSPOSE_UPDATE,
@@ -63,16 +62,16 @@ def make_get_array_offset_ptr_func(dtype):
 
 
 get_int32_array_offset_ptr = make_get_array_offset_ptr_func(wp.int32)
-"""A Warp function to get the offset pointer of a int32 warp array."""
+"""A Warp function to get the offset pointer of a wp.int32 warp array."""
 
 get_float32_array_offset_ptr = make_get_array_offset_ptr_func(wp.float32)
-"""A Warp function to get the offset pointer of a float32 warp array."""
+"""A Warp function to get the offset pointer of a wp.float32 warp array."""
 
 
 # @wp.func
 # def tile_sum_func(a: wp.tile(dtype=float, shape=(TILE_M, TILE_N))):
 #     return wp.tile_sum(a) * 0.5
-# def make_tile_pad(block_size: int, dtype=float32):
+# def make_tile_pad(block_size: int, dtype=wp.float32):
 #     """Creates a function to pad a tile with identity values where the tile exceeds the matrix dimensions."""
 #     @wp.func
 #     def tile_pad(
@@ -111,11 +110,11 @@ def make_llt_blocked_factorize_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_factorize_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        A: wp.array[float32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        A: wp.array[wp.float32],
         # Outputs:
-        L: wp.array[float32],
+        L: wp.array[wp.float32],
     ):
         # Retrieve the thread index and thread-block configuration
         tid, tid_block = wp.tid()
@@ -155,7 +154,7 @@ def make_llt_blocked_factorize_kernel(block_size: int):
                     col = linear_index % block_size
                     value = A_kk_tile[row, col]
                     if k + row >= n_i or k + col >= n_i:
-                        value = wp.where(row == col, float32(1), float32(0))
+                        value = wp.where(row == col, wp.float32(1), wp.float32(0))
                     A_kk_tile[row, col] = value
 
             # Update the diagonal block with contributions from previously computed blocks.
@@ -196,7 +195,7 @@ def make_llt_blocked_factorize_kernel(block_size: int):
                         col = linear_index % block_size
                         value = A_ik_tile[row, col]
                         if i + row >= n_i or k + col >= n_i:
-                            value = wp.where(i + row == k + col, float32(1), float32(0))
+                            value = wp.where(i + row == k + col, wp.float32(1), wp.float32(0))
                         A_ik_tile[row, col] = value
 
                 # Update the block with contributions from previously computed blocks
@@ -231,14 +230,14 @@ def make_llt_blocked_solve_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_solve_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        vio: wp.array[int32],
-        L: wp.array[float32],
-        b: wp.array[float32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        L: wp.array[wp.float32],
+        b: wp.array[wp.float32],
         # Outputs:
-        y: wp.array[float32],
-        x: wp.array[float32],
+        y: wp.array[wp.float32],
+        x: wp.array[wp.float32],
     ):
         # Retrieve the thread index and thread-block configuration
         tid, tid_block = wp.tid()
@@ -297,7 +296,7 @@ def make_llt_blocked_solve_kernel(block_size: int):
                     col = linear_index % block_size
                     value = L_diag[row, col]
                     if i + row >= n_i:
-                        value = wp.where(i + row == i + col, float32(1), float32(0))
+                        value = wp.where(i + row == i + col, wp.float32(1), wp.float32(0))
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
@@ -326,13 +325,13 @@ def make_llt_blocked_solve_inplace_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_solve_inplace_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        vio: wp.array[int32],
-        L: wp.array[float32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        L: wp.array[wp.float32],
         # Outputs:
-        y: wp.array[float32],
-        x: wp.array[float32],
+        y: wp.array[wp.float32],
+        x: wp.array[wp.float32],
     ):
         # Retrieve the thread index and thread-block configuration
         tid, tid_block = wp.tid()
@@ -386,7 +385,7 @@ def make_llt_blocked_solve_inplace_kernel(block_size: int):
                     col = linear_index % block_size
                     value = L_diag[row, col]
                     if i + row >= n_i:
-                        value = wp.where(i + row == i + col, float32(1), float32(0))
+                        value = wp.where(i + row == i + col, wp.float32(1), wp.float32(0))
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
@@ -417,10 +416,10 @@ def make_llt_blocked_solve_inplace_kernel(block_size: int):
 
 def llt_blocked_factorize(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    A: wp.array[float32],
-    L: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    A: wp.array[wp.float32],
+    L: wp.array[wp.float32],
     num_blocks: int = 1,
     # Empirically, 128 threads (4 warps) gives the best factor throughput for large
     # matrices with this kernel layout; small matrices prefer 64. Callers may override.
@@ -432,25 +431,25 @@ def llt_blocked_factorize(
 
     Args:
         kernel: The kernel function to use for the blocked factorization.
-        num_blocks (int): The number of matrix blocks to process.
-        block_dim (int): The dimension of the thread block to use for the kernel launch.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the active dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the matrix index offset (mio) of each matrix block.
-        A (wp.array): The flat input array containing the input matrix blocks to be factorized.
-        L (wp.array): The flat output array containing the factorization of each matrix block.
+        dim: An array of shape `(num_blocks,)` containing the active dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the matrix index offset (mio) of each matrix block.
+        A: The flat input array containing the input matrix blocks to be factorized.
+        L: The flat output array containing the factorization of each matrix block.
+        num_blocks: The number of matrix blocks to process.
+        block_dim: The dimension of the thread block to use for the kernel launch.
     """
     wp.launch_tiled(kernel=kernel, dim=num_blocks, inputs=[dim, mio, A, L], block_dim=block_dim, device=A.device)
 
 
 def llt_blocked_solve(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    L: wp.array[float32],
-    b: wp.array[float32],
-    y: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    b: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    x: wp.array[wp.float32],
     num_blocks: int = 1,
     # Empirically, 128 threads per tile-block (4 warps) hides the gemm+trsm latency
     # better than 64 across the tested size range. Callers may override for batch
@@ -461,16 +460,16 @@ def llt_blocked_solve(
     Launches the blocked Cholesky solve kernel for a block partitioned matrix.
 
     Args:
-        num_blocks (int): The number of matrix blocks to process.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the matrix index offsets of each matrix block.
-        vio (wp.array): An array of shape `(num_blocks,)` containing the vector index offsets of each vector block.
-        L (wp.array2d): The flat input array containing the Cholesky factorization of each matrix block.
-        b (wp.array): The flat input array containing the stacked right-hand side vectors.
-        y (wp.array): The output array where the intermediate result will be stored.
-        x (wp.array): The output array where the solution to the linear system `A @ x = b` will be stored.
         kernel: The kernel function to use for the blocked solve.
-        block_dim (int): The dimension of the thread block to use for the kernel launch.
+        dim: An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the matrix index offsets of each matrix block.
+        vio: An array of shape `(num_blocks,)` containing the vector index offsets of each vector block.
+        L: The flat input array containing the Cholesky factorization of each matrix block.
+        b: The flat input array containing the stacked right-hand side vectors.
+        y: The output array where the intermediate result will be stored.
+        x: The output array where the solution to the linear system `A @ x = b` will be stored.
+        num_blocks: The number of matrix blocks to process.
+        block_dim: The dimension of the thread block to use for the kernel launch.
     """
     wp.launch_tiled(
         kernel=kernel, dim=num_blocks, inputs=[dim, mio, vio, L, b, y, x], block_dim=block_dim, device=L.device
@@ -479,12 +478,12 @@ def llt_blocked_solve(
 
 def llt_blocked_solve_inplace(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    L: wp.array[float32],
-    y: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    x: wp.array[wp.float32],
     num_blocks: int = 1,
     # See ``llt_blocked_solve`` for rationale; 128 threads/tile-block is the best
     # default across size ranges.
@@ -494,14 +493,15 @@ def llt_blocked_solve_inplace(
     Launches the blocked Cholesky in-place solve kernel for a block partitioned matrix.
 
     Args:
-        num_blocks (int): The number of matrix blocks to process.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the matrix index offsets of each matrix block.
-        vio (wp.array): An array of shape `(num_blocks,)` containing the vector index offsets of each vector block.
-        L (wp.array2d): The flat input array containing the Cholesky factorization of each matrix block.
-        x (wp.array): The input/output array where the solution to the linear system `A @ x = b` will be stored in-place.
         kernel: The kernel function to use for the blocked in-place solve.
-        block_dim (int): The dimension of the thread block to use for the kernel launch.
+        dim: An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the matrix index offsets of each matrix block.
+        vio: An array of shape `(num_blocks,)` containing the vector index offsets of each vector block.
+        L: The flat input array containing the Cholesky factorization of each matrix block.
+        y: The output array where the intermediate result will be stored.
+        x: The input/output array where the solution to the linear system `A @ x = b` will be stored in-place.
+        num_blocks: The number of matrix blocks to process.
+        block_dim: The dimension of the thread block to use for the kernel launch.
     """
     wp.launch_tiled(
         kernel=kernel, dim=num_blocks, inputs=[dim, mio, vio, L, y, x], block_dim=block_dim, device=L.device

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm.py
@@ -19,13 +19,13 @@ The caller-facing wrapper (:class:`llt_blocked_rcm_solver.LLTBlockedRCMSolver`)
 hides all of this behind the same public API as :class:`LLTBlockedSolver`.
 
 Layout conventions (same as llt_blocked):
-- ``dim`` (int32[num_blocks]):          active size ``n_i`` of each block
-- ``mio`` (int32[num_blocks]):          matrix-index offset into flat A/L (n_i*n_i per block)
-- ``vio`` (int32[num_blocks]):          vector-index offset into flat vectors (n_i per block)
-- ``tpo`` (int32[num_blocks]):          tile-pattern-index offset into flat tile_pattern
+- ``dim`` (wp.int32[num_blocks]):          active size ``n_i`` of each block
+- ``mio`` (wp.int32[num_blocks]):          matrix-index offset into flat A/L (n_i*n_i per block)
+- ``vio`` (wp.int32[num_blocks]):          vector-index offset into flat vectors (n_i per block)
+- ``tpo`` (wp.int32[num_blocks]):          tile-pattern-index offset into flat tile_pattern
                                         (``n_tiles_i * n_tiles_i`` entries per block,
                                         where ``n_tiles_i = ceil(n_i / block_size)``)
-- ``P``, ``inv_P`` (int32[total_vec_size]): concatenated per-block permutations
+- ``P``, ``inv_P`` (wp.int32[total_vec_size]): concatenated per-block permutations
                                             indexed by ``vio[i]`` with length ``dim[i]``
 """
 
@@ -34,7 +34,6 @@ from functools import cache
 
 import warp as wp
 
-from ...core.types import float32, int32
 from ._tile_builtins import (
     HAS_NATIVE_TILE_MATMUL_LEFT_TRANSPOSE_UPDATE,
     HAS_NATIVE_TILE_MATMUL_TRANSPOSE_UPDATE,
@@ -111,11 +110,11 @@ def make_llt_blocked_rcm_permute_vector_kernel(max_dim: int):
 
     @wp.kernel(enable_backward=False)
     def permute_vector_kernel(
-        dim: wp.array[int32],
-        vio: wp.array[int32],
-        P: wp.array[int32],
-        src: wp.array[float32],
-        dst: wp.array[float32],
+        dim: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        P: wp.array[wp.int32],
+        src: wp.array[wp.float32],
+        dst: wp.array[wp.float32],
     ):
         b, r = wp.tid()
         n_i = dim[b]
@@ -152,16 +151,16 @@ def make_llt_blocked_rcm_fused_permute_and_tp_kernel(block_size: int, max_dim: i
 
     @wp.kernel(enable_backward=False)
     def fused_permute_and_tp_kernel(
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        vio: wp.array[int32],
-        tpo: wp.array[int32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        tpo: wp.array[wp.int32],
         tol: float,
-        P: wp.array[int32],
-        A: wp.array[float32],
-        A_hat: wp.array[float32],
-        inv_P: wp.array[int32],
-        tile_pattern: wp.array[int32],
+        P: wp.array[wp.int32],
+        A: wp.array[wp.float32],
+        A_hat: wp.array[wp.float32],
+        inv_P: wp.array[wp.int32],
+        tile_pattern: wp.array[wp.int32],
     ):
         b, r, c = wp.tid()
         n_i = dim[b]
@@ -214,10 +213,10 @@ def make_llt_blocked_rcm_symbolic_fill_in_kernel(max_n_tiles: int):
 
     @wp.kernel(enable_backward=False)
     def symbolic_fill_in_kernel(
-        dim: wp.array[int32],
-        tpo: wp.array[int32],
+        dim: wp.array[wp.int32],
+        tpo: wp.array[wp.int32],
         block_size: int,
-        tile_pattern: wp.array[int32],
+        tile_pattern: wp.array[wp.int32],
     ):
         b = wp.tid()
         n_i = dim[b]
@@ -266,13 +265,13 @@ def make_llt_blocked_rcm_factorize_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_rcm_factorize_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        tpo: wp.array[int32],
-        A: wp.array[float32],
-        tile_pattern: wp.array[int32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        tpo: wp.array[wp.int32],
+        A: wp.array[wp.float32],
+        tile_pattern: wp.array[wp.int32],
         # Outputs:
-        L: wp.array[float32],
+        L: wp.array[wp.float32],
     ):
         tid, tid_block = wp.tid()
         num_threads_per_block = wp.block_dim()
@@ -309,7 +308,7 @@ def make_llt_blocked_rcm_factorize_kernel(block_size: int):
                     col = linear_index % block_size
                     value = A_kk_tile[row, col]
                     if k + row >= n_i or k + col >= n_i:
-                        value = wp.where(row == col, float32(1), float32(0))
+                        value = wp.where(row == col, wp.float32(1), wp.float32(0))
                     A_kk_tile[row, col] = value
 
             if k > 0:
@@ -351,7 +350,7 @@ def make_llt_blocked_rcm_factorize_kernel(block_size: int):
                         col = linear_index % block_size
                         value = A_ik_tile[row, col]
                         if i + row >= n_i or k + col >= n_i:
-                            value = wp.where(i + row == k + col, float32(1), float32(0))
+                            value = wp.where(i + row == k + col, wp.float32(1), wp.float32(0))
                         A_ik_tile[row, col] = value
 
                 if k > 0:
@@ -394,18 +393,18 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_rcm_solve_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        vio: wp.array[int32],
-        tpo: wp.array[int32],
-        P: wp.array[int32],
-        L: wp.array[float32],
-        tile_pattern: wp.array[int32],
-        b: wp.array[float32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        tpo: wp.array[wp.int32],
+        P: wp.array[wp.int32],
+        L: wp.array[wp.float32],
+        tile_pattern: wp.array[wp.int32],
+        b: wp.array[wp.float32],
         # Outputs:
-        y: wp.array[float32],
-        x_hat: wp.array[float32],
-        x: wp.array[float32],
+        y: wp.array[wp.float32],
+        x_hat: wp.array[wp.float32],
+        x: wp.array[wp.float32],
     ):
         tid, tid_block = wp.tid()
         num_threads_per_block = wp.block_dim()
@@ -467,7 +466,7 @@ def make_llt_blocked_rcm_solve_kernel(block_size: int):
                     col = linear_index % block_size
                     value = L_diag[row, col]
                     if i + row >= n_i:
-                        value = wp.where(i + row == i + col, float32(1), float32(0))
+                        value = wp.where(i + row == i + col, wp.float32(1), wp.float32(0))
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
@@ -511,15 +510,15 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
     @wp.kernel(enable_backward=False)
     def llt_blocked_rcm_solve_inplace_kernel(
         # Inputs:
-        dim: wp.array[int32],
-        mio: wp.array[int32],
-        vio: wp.array[int32],
-        tpo: wp.array[int32],
-        L: wp.array[float32],
-        tile_pattern: wp.array[int32],
+        dim: wp.array[wp.int32],
+        mio: wp.array[wp.int32],
+        vio: wp.array[wp.int32],
+        tpo: wp.array[wp.int32],
+        L: wp.array[wp.float32],
+        tile_pattern: wp.array[wp.int32],
         # Outputs:
-        y: wp.array[float32],
-        x: wp.array[float32],
+        y: wp.array[wp.float32],
+        x: wp.array[wp.float32],
     ):
         tid, tid_block = wp.tid()
         num_threads_per_block = wp.block_dim()
@@ -575,7 +574,7 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
                     col = linear_index % block_size
                     value = L_diag[row, col]
                     if i + row >= n_i:
-                        value = wp.where(i + row == i + col, float32(1), float32(0))
+                        value = wp.where(i + row == i + col, wp.float32(1), wp.float32(0))
                     L_diag[row, col] = value
 
             if i_end < n_i_padded:
@@ -608,11 +607,11 @@ def make_llt_blocked_rcm_solve_inplace_kernel(block_size: int):
 
 def llt_blocked_rcm_permute_vector(
     kernel,
-    dim: wp.array[int32],
-    vio: wp.array[int32],
-    P: wp.array[int32],
-    src: wp.array[float32],
-    dst: wp.array[float32],
+    dim: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    P: wp.array[wp.int32],
+    src: wp.array[wp.float32],
+    dst: wp.array[wp.float32],
     num_blocks: int,
     max_dim: int,
     device: wp.DeviceLike = None,
@@ -628,16 +627,16 @@ def llt_blocked_rcm_permute_vector(
 
 def llt_blocked_rcm_fused_permute_and_tp(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    tpo: wp.array[int32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    tpo: wp.array[wp.int32],
     tol: float,
-    P: wp.array[int32],
-    A: wp.array[float32],
-    A_hat: wp.array[float32],
-    inv_P: wp.array[int32],
-    tile_pattern: wp.array[int32],
+    P: wp.array[wp.int32],
+    A: wp.array[wp.float32],
+    A_hat: wp.array[wp.float32],
+    inv_P: wp.array[wp.int32],
+    tile_pattern: wp.array[wp.int32],
     num_blocks: int,
     max_dim: int,
     device: wp.DeviceLike = None,
@@ -657,10 +656,10 @@ def llt_blocked_rcm_fused_permute_and_tp(
 
 def llt_blocked_rcm_symbolic_fill_in(
     kernel,
-    dim: wp.array[int32],
-    tpo: wp.array[int32],
+    dim: wp.array[wp.int32],
+    tpo: wp.array[wp.int32],
     block_size: int,
-    tile_pattern: wp.array[int32],
+    tile_pattern: wp.array[wp.int32],
     num_blocks: int,
     device: wp.DeviceLike = None,
 ):
@@ -675,12 +674,12 @@ def llt_blocked_rcm_symbolic_fill_in(
 
 def llt_blocked_rcm_factorize(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    tpo: wp.array[int32],
-    A: wp.array[float32],
-    tile_pattern: wp.array[int32],
-    L: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    tpo: wp.array[wp.int32],
+    A: wp.array[wp.float32],
+    tile_pattern: wp.array[wp.int32],
+    L: wp.array[wp.float32],
     num_blocks: int = 1,
     block_dim: int = 128,
     device: wp.DeviceLike = None,
@@ -697,17 +696,17 @@ def llt_blocked_rcm_factorize(
 
 def llt_blocked_rcm_solve(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    tpo: wp.array[int32],
-    P: wp.array[int32],
-    L: wp.array[float32],
-    tile_pattern: wp.array[int32],
-    b: wp.array[float32],
-    y: wp.array[float32],
-    x_hat: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    tpo: wp.array[wp.int32],
+    P: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    tile_pattern: wp.array[wp.int32],
+    b: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    x_hat: wp.array[wp.float32],
+    x: wp.array[wp.float32],
     num_blocks: int = 1,
     block_dim: int = 128,
     device: wp.DeviceLike = None,
@@ -724,14 +723,14 @@ def llt_blocked_rcm_solve(
 
 def llt_blocked_rcm_solve_inplace(
     kernel,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    tpo: wp.array[int32],
-    L: wp.array[float32],
-    tile_pattern: wp.array[int32],
-    y: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    tpo: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    tile_pattern: wp.array[wp.int32],
+    y: wp.array[wp.float32],
+    x: wp.array[wp.float32],
     num_blocks: int = 1,
     block_dim: int = 128,
     device: wp.DeviceLike = None,

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
@@ -13,7 +13,7 @@ The caller-visible API is identical to :class:`LLTBlockedSolver`:
 
 .. code-block:: python
 
-    solver = LLTBlockedRCMSolver(operator=operator, block_size=32, dtype=float32)
+    solver = LLTBlockedRCMSolver(operator=operator, block_size=32, dtype=wp.float32)
     solver.compute(A)  # factorizes; reordering is internal
     solver.solve(b, x)  # or: solver.solve_inplace(x)
 
@@ -22,11 +22,14 @@ to the factorization buffer ``L``. They are exposed as read-only properties
 for debugging/introspection.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import warp as wp
 
-from ...core.types import FloatType, float32, int32, override, to_warp_int32_array
+from ......core.types import override
+from ...core.types import FloatType, to_warp_int32_array
 from ..core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
 from ..linear import DirectSolver
 from . import rcm_batch as _rcm_batch
@@ -104,7 +107,7 @@ class LLTBlockedRCMSolver(DirectSolver):
         reorder_tol: float = 0.0,
         # Cap on BFS steps per block. None => auto (``2*ceil(sqrt(n)) + 4``).
         rcm_max_bfs_iters: int | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -120,22 +123,22 @@ class LLTBlockedRCMSolver(DirectSolver):
             rcm_max_bfs_iters: BFS depth cap for the batched RCM pass.
         """
         # The underlying kernels (factorize / solve / permute / tile-pattern)
-        # are hard-coded to float32, so reject any other dtype up front
+        # are hard-coded to wp.float32, so reject any other dtype up front
         # instead of failing later at kernel launch with a shape/type error.
-        if dtype != float32:
-            raise NotImplementedError("LLTBlockedRCMSolver currently supports only float32.")
+        if dtype != wp.float32:
+            raise NotImplementedError("LLTBlockedRCMSolver currently supports only wp.float32.")
 
         # LLT-specific internal data
-        self._L: wp.array | None = None
-        self._y: wp.array | None = None
+        self._L: wp.array[dtype] | None = None
+        self._y: wp.array[dtype] | None = None
         # Reordering + semi-sparse state
-        self._A_hat: wp.array | None = None
-        self._b_hat: wp.array | None = None
-        self._x_hat: wp.array | None = None
-        self._P: wp.array | None = None
-        self._inv_P: wp.array | None = None
-        self._tile_pattern: wp.array | None = None
-        self._tpo: wp.array | None = None
+        self._A_hat: wp.array[dtype] | None = None
+        self._b_hat: wp.array[dtype] | None = None
+        self._x_hat: wp.array[dtype] | None = None
+        self._P: wp.array[wp.int32] | None = None
+        self._inv_P: wp.array[wp.int32] | None = None
+        self._tile_pattern: wp.array[wp.int32] | None = None
+        self._tpo: wp.array[wp.int32] | None = None
         # Batched-RCM scratch (owned here so the recorded launches in
         # ``_reorder_callback`` never reference buffers that outlive our
         # dict). Allocated in ``_allocate_impl`` alongside the other solver
@@ -146,7 +149,7 @@ class LLTBlockedRCMSolver(DirectSolver):
         # set over all blocks. Rebound whenever the caller-owned ``A`` buffer
         # pointer changes.
         self._reorder_callback = None
-        self._reorder_attached_to: wp.array | None = None
+        self._reorder_attached_to: wp.array[dtype] | None = None
 
         # Cache the fixed block/tile dimensions
         self._block_size: int = block_size
@@ -195,21 +198,21 @@ class LLTBlockedRCMSolver(DirectSolver):
 
     @property
     def P(self) -> wp.array:
-        """Concatenated per-block RCM permutation (int32[total_vec_size])."""
+        """Concatenated per-block RCM permutation (wp.int32[total_vec_size])."""
         if self._P is None:
             raise ValueError("Permutation array has not been allocated!")
         return self._P
 
     @property
     def inv_P(self) -> wp.array:
-        """Concatenated per-block inverse RCM permutation (int32[total_vec_size])."""
+        """Concatenated per-block inverse RCM permutation (wp.int32[total_vec_size])."""
         if self._inv_P is None:
             raise ValueError("Inverse permutation array has not been allocated!")
         return self._inv_P
 
     @property
     def tile_pattern(self) -> wp.array:
-        """Concatenated per-block tile-sparsity mask (int32, lower-tri inflated by fill-in)."""
+        """Concatenated per-block tile-sparsity mask (wp.int32, lower-tri inflated by fill-in)."""
         if self._tile_pattern is None:
             raise ValueError("Tile pattern array has not been allocated!")
         return self._tile_pattern
@@ -257,11 +260,11 @@ class LLTBlockedRCMSolver(DirectSolver):
             self._x_hat = wp.zeros(shape=(info.total_vec_size,), dtype=self._dtype)
 
             # Permutations (indexed by vio, length dim per block).
-            self._P = wp.zeros(shape=(info.total_vec_size,), dtype=int32)
-            self._inv_P = wp.zeros(shape=(info.total_vec_size,), dtype=int32)
+            self._P = wp.zeros(shape=(info.total_vec_size,), dtype=wp.int32)
+            self._inv_P = wp.zeros(shape=(info.total_vec_size,), dtype=wp.int32)
 
             # Tile-pattern flat storage + offsets.
-            self._tile_pattern = wp.zeros(shape=(total_tp_size,), dtype=int32)
+            self._tile_pattern = wp.zeros(shape=(total_tp_size,), dtype=wp.int32)
             self._tpo = to_warp_int32_array(tp_offsets[:-1])
 
             # Batched-RCM scratch. Owning these here matches how the other
@@ -292,7 +295,7 @@ class LLTBlockedRCMSolver(DirectSolver):
         self._tile_pattern.zero_()
         self._has_factors = False
 
-    def _ensure_reorder_launches_bound(self, A: wp.array) -> None:
+    def _ensure_reorder_launches_bound(self, A: wp.array[Any]) -> None:
         """(Re)build the batched-RCM launch callback bound to the current A buffer.
 
         The callback captures ``wp.array`` views of ``A`` that must stay
@@ -321,7 +324,7 @@ class LLTBlockedRCMSolver(DirectSolver):
         self._reorder_attached_to = A
 
     @override
-    def _factorize_impl(self, A: wp.array) -> None:
+    def _factorize_impl(self, A: wp.array[Any]) -> None:
         info = self._operator.info
         num_blocks = info.num_blocks
 
@@ -381,11 +384,11 @@ class LLTBlockedRCMSolver(DirectSolver):
         )
 
     @override
-    def _reconstruct_impl(self, A: wp.array) -> None:
+    def _reconstruct_impl(self, A: wp.array[Any]) -> None:
         raise NotImplementedError("LLT matrix reconstruction is not yet implemented.")
 
     @override
-    def _solve_impl(self, b: wp.array, x: wp.array) -> None:
+    def _solve_impl(self, b: wp.array[Any], x: wp.array[Any]) -> None:
         info = self._operator.info
         num_blocks = info.num_blocks
 
@@ -422,7 +425,7 @@ class LLTBlockedRCMSolver(DirectSolver):
         )
 
     @override
-    def _solve_inplace_impl(self, x: wp.array) -> None:
+    def _solve_inplace_impl(self, x: wp.array[Any]) -> None:
         info = self._operator.info
         num_blocks = info.num_blocks
 

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_semi_sparse.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_semi_sparse.py
@@ -3,6 +3,8 @@
 
 """KAMINO: Linear Algebra: Blocked Semi-Sparse LLT (i.e. Cholesky) factorization using Warp's Tile API."""
 
+from __future__ import annotations
+
 from functools import cache
 
 import numpy as np
@@ -63,10 +65,10 @@ def compute_inverse_ordering(ordering):
     Computes the inverse permutation of the given ordering.
 
     Args:
-        ordering (np.ndarray): The permutation array used for reordering (length n).
+        ordering: The permutation array used for reordering (length n).
 
     Returns:
-        inv_ordering (np.ndarray): The inverse permutation array.
+        The inverse permutation array.
     """
     inv_ordering = np.empty_like(ordering)
     inv_ordering[ordering] = np.arange(len(ordering))
@@ -80,7 +82,7 @@ def reorder_rows_kernel(
     ordering: wp.array2d[int],
     n_rows_arr: wp.array[int],
     n_cols_arr: wp.array[int],
-    batch_mask: wp.array[bool],
+    batch_mask: wp.array[wp.bool],
 ):
     batch_id, i, j = wp.tid()  # 2D launch: (n_rows, n_cols)
     n_rows = n_rows_arr[batch_id]
@@ -97,7 +99,7 @@ def reorder_rows_kernel_col_vector(
     dst: wp.array3d[float],
     ordering: wp.array2d[int],
     n_rows_arr: wp.array[int],
-    batch_mask: wp.array[bool],
+    batch_mask: wp.array[wp.bool],
 ):
     batch_id, i = wp.tid()
     n_rows = n_rows_arr[batch_id]
@@ -176,7 +178,7 @@ def create_blocked_cholesky_kernel(block_size: int):
         L_batched: wp.array3d[float],
         L_tile_pattern_batched: wp.array3d[int],
         active_matrix_size_arr: wp.array[int],
-        batch_mask: wp.array[bool],
+        batch_mask: wp.array[wp.bool],
     ):
         """
         Batched Cholesky factorization of symmetric positive definite matrices in blocks.
@@ -311,7 +313,7 @@ def create_blocked_cholesky_solve_kernel(block_size: int):
         x_batched: wp.array3d[float],
         y_batched: wp.array3d[float],
         active_matrix_size_arr: wp.array[int],
-        batch_mask: wp.array[bool],
+        batch_mask: wp.array[wp.bool],
     ):
         """
         Batched blocked Cholesky solver kernel. For each batch, solves A x = b using L L^T = A.
@@ -449,18 +451,15 @@ class SemiSparseBlockCholeskySolverBatched:
         Captures sparsity pattern and computes fill-reducing ordering for batched matrices.
 
         Args:
-        A (np.ndarray):
-            Input SPD matrices as float arrays or directly as binary 0/1 matrices indicating the sparsity
-            pattern (float arrays are converted to binary automatically).
-            Shape of (batch_size, n, n); or of (num_classes, n, n) if eq_classes is provided.
-        A_reorder_size (np.ndarray):
-            Size of the active top-left block per matrix, to reorder for sparsity.
-            Shape of (batch_size,); or of (num_classes,) if eq_classes is provided.
-        eq_classes (list[list[int]], optional):
-            List of list of matrix indices (along the batch dimension) that form equivalence classes with
-            the same sparsity pattern.
-            If provided, only one sparsity pattern per class should be provided in `A`.
-            The computed ordering will then be broadcast to all matrices in each class.
+            A: Input SPD matrices as float arrays or directly as binary 0/1 matrices indicating the sparsity
+                pattern (float arrays are converted to binary automatically).
+                Shape of (batch_size, n, n); or of (num_classes, n, n) if eq_classes is provided.
+            A_reorder_size: Size of the active top-left block per matrix, to reorder for sparsity.
+                Shape of (batch_size,); or of (num_classes,) if eq_classes is provided.
+            eq_classes: List of list of matrix indices (along the batch dimension) that form equivalence classes with
+                the same sparsity pattern.
+                If provided, only one sparsity pattern per class should be provided in `A`.
+                The computed ordering will then be broadcast to all matrices in each class.
 
         Computes Cuthill-McKee ordering on top-left block, analyzes symbolic Cholesky factorization,
         and stores tile-level sparsity patterns. Tiles beyond A_reorder_size are treated as dense.
@@ -523,7 +522,7 @@ class SemiSparseBlockCholeskySolverBatched:
         self,
         A: wp.array3d[float],
         num_active_equations: wp.array[int],
-        batch_mask: wp.array[bool],
+        batch_mask: wp.array[wp.bool],
     ):
         """
         Computes the Cholesky factorization of a symmetric positive definite matrix A in blocks.
@@ -566,7 +565,7 @@ class SemiSparseBlockCholeskySolverBatched:
         self,
         rhs: wp.array3d[float],
         result: wp.array3d[float],
-        batch_mask: wp.array[bool],
+        batch_mask: wp.array[wp.bool],
     ):
         """
         Solves A x = b given the Cholesky factor L (A = L L^T) using

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_sequential.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_sequential.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import warp as wp
 
 from ...core.math import FLOAT32_EPS
-from ...core.types import float32, int32
 
 ###
 # Module interface
@@ -36,11 +35,11 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel(enable_backward=False)
 def _llt_sequential_factorize(
     # Inputs:
-    dim_in: wp.array[int32],
-    mio_in: wp.array[int32],
-    A_in: wp.array[float32],
+    dim_in: wp.array[wp.int32],
+    mio_in: wp.array[wp.int32],
+    A_in: wp.array[wp.float32],
     # Outputs:
-    L_out: wp.array[float32],
+    L_out: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -60,7 +59,7 @@ def _llt_sequential_factorize(
             m_ij = m_i + j
             A_ij = A_in[m_ij]
             L_jj = L_out[m_jj]
-            sum = float32(0.0)
+            sum = wp.float32(0.0)
             for k in range(j):
                 m_ik = m_i + k
                 m_jk = m_j + k
@@ -74,14 +73,14 @@ def _llt_sequential_factorize(
 @wp.kernel(enable_backward=False)
 def _llt_sequential_solve(
     # Inputs:
-    dim_in: wp.array[int32],
-    mio_in: wp.array[int32],
-    vio_in: wp.array[int32],
-    L_in: wp.array[float32],
-    b_in: wp.array[float32],
+    dim_in: wp.array[wp.int32],
+    mio_in: wp.array[wp.int32],
+    vio_in: wp.array[wp.int32],
+    L_in: wp.array[wp.float32],
+    b_in: wp.array[wp.float32],
     # Outputs:
-    y_out: wp.array[float32],
-    x_out: wp.array[float32],
+    y_out: wp.array[wp.float32],
+    x_out: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -117,11 +116,11 @@ def _llt_sequential_solve(
 @wp.kernel(enable_backward=False)
 def _llt_sequential_solve_inplace(
     # Inputs:
-    dim_in: wp.array[int32],
-    mio_in: wp.array[int32],
-    vio_in: wp.array[int32],
-    L_in: wp.array[float32],
-    x_inout: wp.array[float32],
+    dim_in: wp.array[wp.int32],
+    mio_in: wp.array[wp.int32],
+    vio_in: wp.array[wp.int32],
+    L_in: wp.array[wp.float32],
+    x_inout: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     tid = wp.tid()
@@ -161,20 +160,20 @@ def _llt_sequential_solve_inplace(
 
 def llt_sequential_factorize(
     num_blocks: int,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    A: wp.array[float32],
-    L: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    A: wp.array[wp.float32],
+    L: wp.array[wp.float32],
 ):
     """
     Launches the sequential Cholesky factorization kernel for a block partitioned matrix.
 
     Args:
-        num_blocks (int): The number of matrix blocks to process.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the start indices of each matrix block.
-        A (wp.array): The flat input array containing the input matrix blocks to be factorized.
-        L (wp.array): The flat output array containing the Cholesky factorization of each matrix block.
+        num_blocks: The number of matrix blocks to process.
+        dim: An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the start indices of each matrix block.
+        A: The flat input array containing the input matrix blocks to be factorized.
+        L: The flat output array containing the Cholesky factorization of each matrix block.
     """
     wp.launch(
         kernel=_llt_sequential_factorize,
@@ -186,26 +185,26 @@ def llt_sequential_factorize(
 
 def llt_sequential_solve(
     num_blocks: int,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    L: wp.array[float32],
-    b: wp.array[float32],
-    y: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    b: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    x: wp.array[wp.float32],
 ):
     """
     Launches the sequential solve kernel using the Cholesky factorization of a block partitioned matrix.
 
     Args:
-        num_blocks (int): The number of matrix blocks to process.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the start indices of each matrix block.
-        vio (wp.array): An array of shape `(num_blocks,)` containing the start indices of each vector block.
-        L (wp.array): The flat input array containing the Cholesky factorization of each matrix block.
-        b (wp.array): The flat input array containing the stacked right-hand side vectors.
-        y (wp.array): The output array where the intermediate result will be stored.
-        x (wp.array): The output array where the solution to the linear system `A @ x = b` will be stored.
+        num_blocks: The number of matrix blocks to process.
+        dim: An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the start indices of each matrix block.
+        vio: An array of shape `(num_blocks,)` containing the start indices of each vector block.
+        L: The flat input array containing the Cholesky factorization of each matrix block.
+        b: The flat input array containing the stacked right-hand side vectors.
+        y: The output array where the intermediate result will be stored.
+        x: The output array where the solution to the linear system `A @ x = b` will be stored.
     """
     wp.launch(
         kernel=_llt_sequential_solve,
@@ -217,22 +216,22 @@ def llt_sequential_solve(
 
 def llt_sequential_solve_inplace(
     num_blocks: int,
-    dim: wp.array[int32],
-    mio: wp.array[int32],
-    vio: wp.array[int32],
-    L: wp.array[float32],
-    x: wp.array[float32],
+    dim: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
+    L: wp.array[wp.float32],
+    x: wp.array[wp.float32],
 ):
     """
     Launches the sequential in-place solve kernel using the Cholesky factorization of a block partitioned matrix.
 
     Args:
-        num_blocks (int): The number of matrix blocks to process.
-        dim (wp.array): An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
-        mio (wp.array): An array of shape `(num_blocks,)` containing the start indices of each matrix block.
-        vio (wp.array): An array of shape `(num_blocks,)` containing the start indices of each vector block.
-        L (wp.array): The flat input array containing the Cholesky factorization of each matrix block.
-        x (wp.array): The array where the solution to the linear system `A @ x = b` will be stored in-place.
+        num_blocks: The number of matrix blocks to process.
+        dim: An array of shape `(num_blocks,)` containing the dimensions of each matrix block.
+        mio: An array of shape `(num_blocks,)` containing the start indices of each matrix block.
+        vio: An array of shape `(num_blocks,)` containing the start indices of each vector block.
+        L: The flat input array containing the Cholesky factorization of each matrix block.
+        x: The array where the solution to the linear system `A @ x = b` will be stored in-place.
     """
     wp.launch(
         kernel=_llt_sequential_solve_inplace,

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
@@ -14,7 +14,7 @@ kernels **per block**. For a workload with ``B`` blocks this scales linearly
 in ``B * max_bfs_iters``. At small problem sizes (e.g. ``n = 256``, ``B = 8``)
 the resulting hundreds of launches dominate wall time over the actual compute.
 
-The CUDA/wp.float32 fast path runs each graph block inside one tiled Warp
+The CUDA/float32 fast path runs each graph block inside one tiled Warp
 kernel, using shared memory for the per-vertex RCM state and an in-kernel BFS
 loop. Larger or non-CUDA cases fall back to the staged batched path, which
 amortizes launch overhead by making each RCM stage a single launch that covers

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/rcm_batch.py
@@ -14,7 +14,7 @@ kernels **per block**. For a workload with ``B`` blocks this scales linearly
 in ``B * max_bfs_iters``. At small problem sizes (e.g. ``n = 256``, ``B = 8``)
 the resulting hundreds of launches dominate wall time over the actual compute.
 
-The CUDA/float32 fast path runs each graph block inside one tiled Warp
+The CUDA/wp.float32 fast path runs each graph block inside one tiled Warp
 kernel, using shared memory for the per-vertex RCM state and an in-kernel BFS
 loop. Larger or non-CUDA cases fall back to the staged batched path, which
 amortizes launch overhead by making each RCM stage a single launch that covers
@@ -26,9 +26,9 @@ Layout assumptions
 - ``A_flat``: a flat ``wp.array`` containing all block matrices concatenated
   in row-major order. Block ``b``'s matrix starts at offset ``mio[b]`` with
   size ``dims[b] * dims[b]``.
-- ``perm_flat``: flat int32 permutation output. Block ``b``'s output starts
+- ``perm_flat``: flat wp.int32 permutation output. Block ``b``'s output starts
   at offset ``vio[b]`` with size ``dims[b]``.
-- ``dims``, ``mio``, ``vio``: ``wp.array[int32]`` of length
+- ``dims``, ``mio``, ``vio``: ``wp.array[wp.int32]`` of length
   ``num_blocks``, precomputed on the device.
 
 API
@@ -53,6 +53,8 @@ API
     )
     launch()  # one zero-arg callable; CUDA-graph capturable
 """
+
+from __future__ import annotations
 
 import math
 from collections.abc import Callable
@@ -433,11 +435,11 @@ def _default_bfs_iters(max_dim: int) -> int:
 
 
 def create_rcm_batch_launch(
-    A_flat: wp.array,
-    perm_flat: wp.array,
-    dims: wp.array,
-    mio: wp.array,
-    vio: wp.array,
+    A_flat: wp.array[wp.float32],
+    perm_flat: wp.array[wp.int32],
+    dims: wp.array[wp.int32],
+    mio: wp.array[wp.int32],
+    vio: wp.array[wp.int32],
     scratch: dict,
     num_blocks: int,
     max_dim: int,
@@ -454,7 +456,7 @@ def create_rcm_batch_launch(
     A_flat, perm_flat:
         Flat buffers for the concatenated block matrices and output permutations.
     dims, mio, vio:
-        ``int32`` arrays describing the per-block sizes and flat offsets.
+        ``wp.int32`` arrays describing the per-block sizes and flat offsets.
     scratch:
         Caller-owned scratch buffers from :func:`allocate_rcm_batch_scratch`.
         The caller must keep this dict alive for the lifetime of the returned
@@ -468,7 +470,7 @@ def create_rcm_batch_launch(
         Same semantics as :func:`rcm.create_rcm_launch`.
     """
     if perm_flat.dtype != wp.int32:
-        raise TypeError(f"perm_flat must be int32; got {perm_flat.dtype}")
+        raise TypeError(f"perm_flat must be wp.int32; got {perm_flat.dtype}")
     dtype = A_flat.dtype
 
     if device is None:

--- a/newton/_src/solvers/kamino/_src/linalg/linear.py
+++ b/newton/_src/solvers/kamino/_src/linalg/linear.py
@@ -430,9 +430,9 @@ class IterativeSolver(LinearSolver):
 
 class LLTSequentialSolver(DirectSolver):
     """
-    A LLT (i.e. Cholesky) factorization class computing each matrix block sequentially.\n
-    This parallelizes the factorization and solve operations over each block\n
-    and supports heterogeneous matrix block sizes.\n
+    A LLT (i.e. Cholesky) factorization class computing each matrix block sequentially.
+    This parallelizes the factorization and solve operations over each block
+    and supports heterogeneous matrix block sizes.
     """
 
     def __init__(
@@ -547,7 +547,7 @@ class LLTSequentialSolver(DirectSolver):
 
 class LLTBlockedSolver(DirectSolver):
     """
-    A Blocked LLT (i.e. Cholesky) factorization class computing each matrix block with Tile-based parallelism.\n
+    A Blocked LLT (i.e. Cholesky) factorization class computing each matrix block with Tile-based parallelism.
     """
 
     def __init__(

--- a/newton/_src/solvers/kamino/_src/linalg/linear.py
+++ b/newton/_src/solvers/kamino/_src/linalg/linear.py
@@ -11,12 +11,15 @@ Depending on the particular solver implementation, both inter- and
 intra-system parallelism may be exploited.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any
 
 import warp as wp
 
-from ..core.types import FloatType, float32, override
+from .....core.types import override
+from ..core.types import FloatType
 from . import conjugate, factorize
 from .core import DenseLinearOperatorData, DenseSquareMultiLinearInfo, make_dtype_tolerance
 from .sparse_matrix import (
@@ -56,7 +59,7 @@ class LinearSolver(ABC):
         operator: DenseLinearOperatorData | None = None,
         atol: float | None = None,
         rtol: float | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -186,7 +189,7 @@ class DirectSolver(LinearSolver):
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -268,17 +271,17 @@ class IterativeSolver(LinearSolver):
         operator: conjugate.BatchedLinearOperator | DenseLinearOperatorData | BlockSparseLinearOperators | None = None,
         atol: float | wp.array | None = None,
         rtol: float | wp.array | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         maxiter: int | wp.array | None = None,
-        world_active: wp.array | None = None,
+        world_active: wp.array[wp.bool] | None = None,
         preconditioner: Any = None,
         loop_granularity: int = 1,
         **kwargs: dict[str, Any],
     ):
         self._maxiter: int | wp.array | None = maxiter
         self._preconditioner: Any = preconditioner
-        self._world_active: wp.array | None = world_active
+        self._world_active: wp.array[wp.bool] | None = world_active
         self.atol: float | wp.array | None = atol
         self.rtol: float | wp.array | None = rtol
 
@@ -324,7 +327,7 @@ class IterativeSolver(LinearSolver):
         self,
         operator: conjugate.BatchedLinearOperator | DenseLinearOperatorData | BlockSparseLinearOperators,
         maxiter: int | wp.array | None = None,
-        world_active: wp.array | None = None,
+        world_active: wp.array[wp.bool] | None = None,
         preconditioner: Any = None,
         **kwargs: dict[str, Any],
     ) -> None:
@@ -438,7 +441,7 @@ class LLTSequentialSolver(DirectSolver):
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -556,7 +559,7 @@ class LLTBlockedSolver(DirectSolver):
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = float32,
+        dtype: FloatType = wp.float32,
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
@@ -594,13 +594,14 @@ class BlockSparseMatrices:
 
 @functools.cache
 def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
+    @wp.kernel
     def masked_zero_kernel(
         # Inputs
-        nzb_start,  # wp.array[index_dtype],
-        max_nzb,  # wp.array[index_dtype],
-        matrix_mask,  # wp.array[wp.bool],
+        nzb_start: wp.array[Any],  # wp.array[index_dtype],
+        max_nzb: wp.array[Any],  # wp.array[index_dtype],
+        matrix_mask: wp.array[wp.bool],
         # Outputs
-        nzb_values,  # wp.array[block_type.warp_type],
+        nzb_values: wp.array[Any],  # wp.array[block_type.warp_type],
     ):
         mat_id, nzb_id_loc = wp.tid()
         if not matrix_mask[mat_id] or nzb_id_loc >= max_nzb[mat_id]:
@@ -608,15 +609,7 @@ def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
         nzb_id = nzb_start[mat_id] + nzb_id_loc
         nzb_values[nzb_id] = block_type.warp_type(0.0)
 
-    # Set type annotation manually (else generics fail to resolve)
-    masked_zero_kernel.__annotations__ = {
-        "nzb_start": wp.array[index_dtype],
-        "max_nzb": wp.array[index_dtype],
-        "matrix_mask": wp.array[wp.bool],
-        "nzb_values": wp.array[block_type.warp_type],
-    }
-
-    return wp.kernel(masked_zero_kernel)
+    return masked_zero_kernel
 
 
 ###

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
@@ -8,6 +8,8 @@ This module provides data structures and utilities for managing multiple
 independent linear systems, including rectangular and square systems.
 """
 
+from __future__ import annotations
+
 import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, get_args
@@ -16,7 +18,7 @@ import numpy as np
 import warp as wp
 from warp.types import type_size_in_bytes
 
-from ..core.types import FloatType, IntType, float32, int32
+from ..core.types import FloatType, IntType
 from .core import DenseSquareMultiLinearInfo
 
 if TYPE_CHECKING:
@@ -47,21 +49,17 @@ class BlockDType:
         Constructs a new BlockDType descriptor given scalar Warp data-type and the block shape.
 
         Args:
-            dtype (FloatType | IntType):
-                The underlying scalar Warp data-type of each sparse block.
-            shape (int | tuple[int] | tuple[int, int], optional):
-                The shape of each sparse block as an integer (for vectors) or a tuple of integers (for matrices).\n
+            dtype: The underlying scalar Warp data-type of each sparse block.
+            shape: The shape of each sparse block as an integer (for vectors) or a tuple of integers (for matrices).\n
                 If not provided, defaults to scalar blocks.
 
         Raises:
-            TypeError:
-                If the `dtype` field is not a valid FloatType or IntType.
-            ValueError:
-                If the `shape` field is not a positive integer or a tuple of one or two positive integers.
+            TypeError: If the `dtype` field is not a valid FloatType or IntType.
+            ValueError: If the `shape` field is not a positive integer or a tuple of one or two positive integers.
         """
         # Ensure the underlying scalar dtype is valid
         if (dtype not in get_args(FloatType)) and (dtype not in get_args(IntType)):
-            raise TypeError("The `dtype` field must be a valid FloatType or IntType such as float32 or int32.")
+            raise TypeError("The `dtype` field must be a valid FloatType or IntType such as wp.float32 or wp.int32.")
 
         # If no shape is provided, default to scalar blocks
         if shape is None:
@@ -156,7 +154,7 @@ class BlockSparseMatrices:
     nzb_dtype: BlockDType | None = None
     """Host-side cache of the fixed non-zero block data type contained in all sparse matrices."""
 
-    index_dtype: IntType = int32
+    index_dtype: IntType = wp.int32
     """Host-side cache of the integer type used for indexing the underlying data arrays."""
 
     num_matrices: int = 0
@@ -352,22 +350,17 @@ class BlockSparseMatrices:
         Finalizes the block-sparse matrix container by allocating on-device data arrays.
 
         Args:
-            max_dims (list[tuple[int, int]]):
-                A list of pairs of integers, specifying the maximum number of rows and columns for each matrix.
-            capacities (list[int]):
-                A list of integers specifying the maximum number of non-zero blocks for each sparse matrix.
-            block_type (BlockDType, optional):
-                An optional :class:`BlockDType` specifying the fixed type of each non-zero block.\n
+            max_dims: A list of pairs of integers, specifying the maximum number of rows and columns for each matrix.
+            capacities: A list of integers specifying the maximum number of non-zero blocks for each sparse matrix.
+            nzb_dtype: An optional :class:`BlockDType` specifying the fixed type of each non-zero block.\n
                 If not provided, it must be set prior to finalization.
-            device (wp.DeviceLike, optional):
-                An optional device on which to allocate the data arrays.\n
+            index_dtype: Integer type used for indexing the underlying data arrays.
+            device: An optional device on which to allocate the data arrays.\n
                 If not provided, the existing device of the container will be used.
 
         Raises:
-            RuntimeError:
-                If the `nzb_dtype` field has not been specified prior to finalization.
-            ValueError:
-                If the `capacities` field is not a non-empty list of non-negative integers.
+            RuntimeError: If the `nzb_dtype` field has not been specified prior to finalization.
+            ValueError: If the `capacities` field is not a non-empty list of non-negative integers.
         """
         # Override the device if provided
         if device is not None:
@@ -387,7 +380,7 @@ class BlockSparseMatrices:
         if self.index_dtype is None:
             raise RuntimeError("The `index_type` field must be specified before finalizing the data arrays.")
         elif self.index_dtype not in get_args(IntType):
-            raise TypeError("The `index_type` field must be a valid IntType such as int32 or int64.")
+            raise TypeError("The `index_type` field must be a valid IntType such as wp.int32 or wp.int64.")
 
         # Ensure that the max dimensions are valid
         if not isinstance(max_dims, list) or len(max_dims) == 0:
@@ -440,15 +433,15 @@ class BlockSparseMatrices:
         self.num_nzb.zero_()
         self.nzb_coords.zero_()
 
-    def zero(self, matrix_mask: wp.array | None = None):
+    def zero(self, matrix_mask: wp.array[wp.bool] | None = None):
         """
         Sets non-zero block data to zero, for all or a subset of the matrices.
 
         Args:
-            matrix_mask (optional): Per-matrix mask selecting which matrices to zero;
-                                    matrices with a `True` entry are zeroed, `False` entries are left unchanged.
-                                    If not provided, all matrices are set to zero.
-                                    Shape of ``(num_matrices,)``.
+            matrix_mask: Per-matrix mask selecting which matrices to zero;
+                matrices with a `True` entry are zeroed, `False` entries are left unchanged.
+                If not provided, all matrices are set to zero.
+                Shape of ``(num_matrices,)``.
         """
         self._assert_is_finalized()
         if matrix_mask is not None:
@@ -471,8 +464,7 @@ class BlockSparseMatrices:
         - the non-zero blocks are filled in row-major order according to the current values of `nzb_coords`.
 
         Args:
-            data (list[np.ndarray]):
-                A list of dense NumPy arrays to assign to each sparse matrix.
+            matrices: A list of dense NumPy arrays to assign to each sparse matrix.
         """
         # Ensure that the sparse matrices have been finalized
         self._assert_is_finalized()
@@ -602,14 +594,13 @@ class BlockSparseMatrices:
 
 @functools.cache
 def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
-    @wp.kernel
     def masked_zero_kernel(
         # Inputs
-        nzb_start: wp.array[index_dtype],
-        max_nzb: wp.array[index_dtype],
-        matrix_mask: wp.array[bool],
+        nzb_start,  # wp.array[index_dtype],
+        max_nzb,  # wp.array[index_dtype],
+        matrix_mask,  # wp.array[wp.bool],
         # Outputs
-        nzb_values: wp.array[block_type.warp_type],
+        nzb_values,  # wp.array[block_type.warp_type],
     ):
         mat_id, nzb_id_loc = wp.tid()
         if not matrix_mask[mat_id] or nzb_id_loc >= max_nzb[mat_id]:
@@ -617,7 +608,15 @@ def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
         nzb_id = nzb_start[mat_id] + nzb_id_loc
         nzb_values[nzb_id] = block_type.warp_type(0.0)
 
-    return masked_zero_kernel
+    # Set type annotation manually (else generics fail to resolve)
+    masked_zero_kernel.__annotations__ = {
+        "nzb_start": wp.array[index_dtype],
+        "max_nzb": wp.array[index_dtype],
+        "matrix_mask": wp.array[wp.bool],
+        "nzb_values": wp.array[block_type.warp_type],
+    }
+
+    return wp.kernel(masked_zero_kernel)
 
 
 ###
@@ -627,8 +626,8 @@ def _make_masked_zero_kernel(block_type: BlockDType, index_dtype: IntType):
 
 @wp.kernel
 def _copy_square_dims_kernel(
-    src_dim: wp.array[int32],
-    dst_dims: wp.array2d[int32],
+    src_dim: wp.array[wp.int32],
+    dst_dims: wp.array2d[wp.int32],
 ):
     """Copies square dimensions from 1D array to 2D (n, n) format."""
     wid = wp.tid()
@@ -647,15 +646,15 @@ def _make_dense_to_bsm_detect_kernel(block_size: int):
     @wp.kernel
     def kernel(
         # Dense matrix info
-        dense_dim: wp.array[int32],
-        dense_mio: wp.array[int32],
-        dense_mat: wp.array[float32],
+        dense_dim: wp.array[wp.int32],
+        dense_mio: wp.array[wp.int32],
+        dense_mat: wp.array[wp.float32],
         # BSM info
-        max_nzb: wp.array[int32],
-        nzb_start: wp.array[int32],
+        max_nzb: wp.array[wp.int32],
+        nzb_start: wp.array[wp.int32],
         # Outputs
-        num_nzb: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
     ):
         wid, bi, bj = wp.tid()
 
@@ -680,7 +679,7 @@ def _make_dense_to_bsm_detect_kernel(block_size: int):
                     col = col_start + j
                     if col < dim:
                         idx = m_offset + row * dim + col
-                        if dense_mat[idx] != float32(0.0):
+                        if dense_mat[idx] != wp.float32(0.0):
                             nonzero_count = nonzero_count + 1
 
         if nonzero_count > 0:
@@ -701,18 +700,18 @@ def _make_dense_to_bsm_copy_kernel(block_size: int):
     Note: Dense matrices use canonical compact storage where stride = active dim (not maxdim).
     """
 
-    mat_type = wp.types.matrix(shape=(block_size, block_size), dtype=float32)
+    mat_type = wp.types.matrix(shape=(block_size, block_size), dtype=wp.float32)
 
     @wp.kernel
     def kernel(
         # Dense matrix info
-        dense_dim: wp.array[int32],
-        dense_mio: wp.array[int32],
-        dense_mat: wp.array[float32],
+        dense_dim: wp.array[wp.int32],
+        dense_mio: wp.array[wp.int32],
+        dense_mat: wp.array[wp.float32],
         # BSM info
-        nzb_start: wp.array[int32],
-        num_nzb: wp.array[int32],
-        nzb_coords: wp.array2d[int32],
+        nzb_start: wp.array[wp.int32],
+        num_nzb: wp.array[wp.int32],
+        nzb_coords: wp.array2d[wp.int32],
         # Output
         nzb_values: wp.array[mat_type],
     ):
@@ -739,7 +738,7 @@ def _make_dense_to_bsm_copy_kernel(block_size: int):
                     idx = m_offset + row * dim + col
                     block[i, j] = dense_mat[idx]
                 else:
-                    block[i, j] = float32(0.0)
+                    block[i, j] = wp.float32(0.0)
 
         nzb_values[global_idx] = block
 
@@ -747,7 +746,7 @@ def _make_dense_to_bsm_copy_kernel(block_size: int):
 
 
 def allocate_block_sparse_from_dense(
-    dense_op: "DenseLinearOperatorData",
+    dense_op: DenseLinearOperatorData,
     block_size: int,
     sparsity_threshold: float = 1.0,
     device: wp.DeviceLike | None = None,
@@ -801,7 +800,7 @@ def allocate_block_sparse_from_dense(
 
 
 def dense_to_block_sparse_copy_values(
-    dense_op: "DenseLinearOperatorData",
+    dense_op: DenseLinearOperatorData,
     bsm: BlockSparseMatrices,
     block_size: int,
 ) -> None:

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
@@ -50,7 +50,7 @@ class BlockDType:
 
         Args:
             dtype: The underlying scalar Warp data-type of each sparse block.
-            shape: The shape of each sparse block as an integer (for vectors) or a tuple of integers (for matrices).\n
+            shape: The shape of each sparse block as an integer (for vectors) or a tuple of integers (for matrices).
                 If not provided, defaults to scalar blocks.
 
         Raises:
@@ -159,21 +159,21 @@ class BlockSparseMatrices:
 
     num_matrices: int = 0
     """
-    Host-side cache of the number of sparse matrices represented by this container.\n
-    When constructing the BSM via `finalize()`, this is inferred from the length of the provided capacities list.\n
+    Host-side cache of the number of sparse matrices represented by this container.
+    When constructing the BSM via `finalize()`, this is inferred from the length of the provided capacities list.
     Alternatively, it can be set directly if the BSM is constructed explicitly.
     """
 
     sum_of_num_nzb: int = 0
     """
-    Host-side cache of the sum of the number of non-zero blocks over all sparse matrices.\n
+    Host-side cache of the sum of the number of non-zero blocks over all sparse matrices.
     When constructing the BSM via `finalize()`, this is computed from the provided capacities list.
     Alternatively, it can be set directly if the BSM is constructed explicitly.
     """
 
     max_of_num_nzb: int = 0
     """
-    Host-side cache of the maximum number of non-zero blocks over all sparse matrices.\n
+    Host-side cache of the maximum number of non-zero blocks over all sparse matrices.
     When constructing the BSM via `finalize()`, this is computed from the provided capacities list.
     Alternatively, it can be set directly if the BSM is constructed explicitly.
     """
@@ -196,31 +196,31 @@ class BlockSparseMatrices:
 
     max_dims: wp.array | None = None
     """
-    The maximum dimensions of each sparse matrices.\n
+    The maximum dimensions of each sparse matrices.
     Shape of ``(num_matrices,)`` and type :class:`vec2i`.
     """
 
     max_nzb: wp.array | None = None
     """
-    The maximum number of non-zero blocks per sparse matrices.\n
+    The maximum number of non-zero blocks per sparse matrices.
     Shape of ``(num_matrices,)`` and type :class:`int`.
     """
 
     nzb_start: wp.array | None = None
     """
-    The index of the first non-zero block of each sparse matrices.\n
+    The index of the first non-zero block of each sparse matrices.
     Shape of ``(num_matrices,)`` and type :class:`int`.
     """
 
     row_start: wp.array | None = None
     """
-    The start index of each row vector block in a flattened data array of size sum_of_max_rows.\n
+    The start index of each row vector block in a flattened data array of size sum_of_max_rows.
     Shape of ``(num_matrices,)`` and type :class:`int`.
     """
 
     col_start: wp.array | None = None
     """
-    The start index of each column vector block in a flattened data array of size sum_of_max_cols.\n
+    The start index of each column vector block in a flattened data array of size sum_of_max_cols.
     Shape of ``(num_matrices,)`` and type :class:`int`.
     """
 
@@ -232,25 +232,25 @@ class BlockSparseMatrices:
 
     dims: wp.array | None = None
     """
-    The active dimensions of each sparse matrices.\n
+    The active dimensions of each sparse matrices.
     Shape of ``(num_matrices,)`` and type :class:`vec2i`.
     """
 
     num_nzb: wp.array | None = None
     """
-    The active number of non-zero blocks per sparse matrices.\n
+    The active number of non-zero blocks per sparse matrices.
     Shape of ``(num_matrices,)`` and type :class:`int`.
     """
 
     nzb_coords: wp.array | None = None
     """
-    The row-column coordinates of each non-zero block within its corresponding sparse matrix.\n
+    The row-column coordinates of each non-zero block within its corresponding sparse matrix.
     Shape of ``(sum_of_num_nzb,)`` and type :class:`vec2i`.
     """
 
     nzb_values: wp.array | None = None
     """
-    The flattened array containing all non-zero blocks over all sparse matrices.\n
+    The flattened array containing all non-zero blocks over all sparse matrices.
     Shape of ``(sum_of_num_nzb,)`` and type :class:`float | vector | matrix`.
     """
 
@@ -352,10 +352,10 @@ class BlockSparseMatrices:
         Args:
             max_dims: A list of pairs of integers, specifying the maximum number of rows and columns for each matrix.
             capacities: A list of integers specifying the maximum number of non-zero blocks for each sparse matrix.
-            nzb_dtype: An optional :class:`BlockDType` specifying the fixed type of each non-zero block.\n
+            nzb_dtype: An optional :class:`BlockDType` specifying the fixed type of each non-zero block.
                 If not provided, it must be set prior to finalization.
             index_dtype: Integer type used for indexing the underlying data arrays.
-            device: An optional device on which to allocate the data arrays.\n
+            device: An optional device on which to allocate the data arrays.
                 If not provided, the existing device of the container will be used.
 
         Raises:

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
@@ -69,25 +69,25 @@ class BlockSparseLinearOperators:
     Ax_op: Callable | None = None
     """
     The operator function for performing sparse matrix-vector products `y = A @ x`.\n
-    Example signature: ``Ax_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, matrix_mask: wp.array)``.
+    Example signature: ``Ax_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool])``.
     """
 
     ATy_op: Callable | None = None
     """
     The operator function for performing sparse matrix-transpose-vector products `x = A^T @ y`.\n
-    Example signature: ``ATy_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, matrix_mask: wp.array)``.
+    Example signature: ``ATy_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool])``.
     """
 
     gemv_op: Callable | None = None
     """
     The operator function for performing generalized sparse matrix-vector products `y = alpha * A @ x + beta * y`.\n
-    Example signature: ``gemv_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, alpha: float, beta: float, matrix_mask: wp.array)``.
+    Example signature: ``gemv_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
     """
 
     gemvt_op: Callable | None = None
     """
     The operator function for performing generalized sparse matrix-transpose-vector products `x = alpha * A^T @ y + beta * x`.\n
-    Example signature: ``gemvt_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, alpha: float, beta: float, matrix_mask: wp.array)``.
+    Example signature: ``gemvt_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
     """
 
     ###
@@ -142,25 +142,27 @@ class BlockSparseLinearOperators:
         self.gemv_op = block_sparse_gemv
         self.gemvt_op = block_sparse_transpose_gemv
 
-    def matvec(self, x: wp.array, y: wp.array, matrix_mask: wp.array):
+    def matvec(self, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool]):
         """Performs the sparse matrix-vector product `y = A @ x`."""
         if self.Ax_op is None:
             raise RuntimeError("No `A@x` operator has been assigned.")
         self.Ax_op(self.bsm, x, y, matrix_mask)
 
-    def matvec_transpose(self, y: wp.array, x: wp.array, matrix_mask: wp.array):
+    def matvec_transpose(self, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool]):
         """Performs the sparse matrix-transpose-vector product `x = A^T @ y`."""
         if self.ATy_op is None:
             raise RuntimeError("No `A^T@y` operator has been assigned.")
         self.ATy_op(self.bsm, y, x, matrix_mask)
 
-    def gemv(self, x: wp.array, y: wp.array, matrix_mask: wp.array, alpha: float = 1.0, beta: float = 0.0):
+    def gemv(self, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool], alpha: float = 1.0, beta: float = 0.0):
         """Performs a BLAS-like generalized sparse matrix-vector product `y = alpha * A @ x + beta * y`."""
         if self.gemv_op is None:
             raise RuntimeError("No BLAS-like `GEMV` operator has been assigned.")
         self.gemv_op(self.bsm, x, y, alpha, beta, matrix_mask)
 
-    def gemv_transpose(self, y: wp.array, x: wp.array, matrix_mask: wp.array, alpha: float = 1.0, beta: float = 0.0):
+    def gemv_transpose(
+        self, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool], alpha: float = 1.0, beta: float = 0.0
+    ):
         """Performs a BLAS-like generalized sparse matrix-transpose-vector product `x = alpha * A^T @ y + beta * x`."""
         if self.gemvt_op is None:
             raise RuntimeError("No BLAS-like transposed `GEMV` operator has been assigned.")

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
@@ -62,31 +62,31 @@ class BlockSparseLinearOperators:
 
     precompute_op: Callable | None = None
     """
-    The operator function for precomputing any necessary data for the operators.\n
+    The operator function for precomputing any necessary data for the operators.
     Signature: ``precompute_op(A: BlockSparseLinearOperators)``.
     """
 
     Ax_op: Callable | None = None
     """
-    The operator function for performing sparse matrix-vector products `y = A @ x`.\n
+    The operator function for performing sparse matrix-vector products `y = A @ x`.
     Example signature: ``Ax_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool])``.
     """
 
     ATy_op: Callable | None = None
     """
-    The operator function for performing sparse matrix-transpose-vector products `x = A^T @ y`.\n
+    The operator function for performing sparse matrix-transpose-vector products `x = A^T @ y`.
     Example signature: ``ATy_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool])``.
     """
 
     gemv_op: Callable | None = None
     """
-    The operator function for performing generalized sparse matrix-vector products `y = alpha * A @ x + beta * y`.\n
+    The operator function for performing generalized sparse matrix-vector products `y = alpha * A @ x + beta * y`.
     Example signature: ``gemv_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
     """
 
     gemvt_op: Callable | None = None
     """
-    The operator function for performing generalized sparse matrix-transpose-vector products `x = alpha * A^T @ y + beta * x`.\n
+    The operator function for performing generalized sparse matrix-transpose-vector products `x = alpha * A^T @ y + beta * x`.
     Example signature: ``gemvt_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
     """
 

--- a/newton/_src/solvers/kamino/_src/linalg/utils/matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/utils/matrix.py
@@ -32,7 +32,7 @@ DEFAULT_MATRIX_SYMMETRY_EPS = 1e-10
 """A global constant to configure the tolerance on matrix symmetry checks."""
 
 MAXLOG_FP64 = 709.782
-"""Maximum log value for float64 to avoid overflow in exp()."""
+"""Maximum log value for wp.float64 to avoid overflow in exp()."""
 
 ###
 # Types
@@ -157,8 +157,8 @@ class RectangularMatrixProperties:
         Compute the properties of the rectangular matrix.
 
         Args:
-            matrix (np.ndarray): The input matrix to analyze.
-            tol (float, optional): The tolerance for numerical stability.
+            matrix: The input matrix to analyze.
+            tol: The tolerance for numerical stability.
 
         Raises:
             TypeError: If the input matrix is not a numpy array.
@@ -302,8 +302,8 @@ class SquareSymmetricMatrixProperties:
         Compute the properties of the matrix.
 
         Args:
-            matrix (np.ndarray): The input matrix to analyze.
-            tol (float, optional): The tolerance for numerical stability.
+            matrix: The input matrix to analyze.
+            tol: The tolerance for numerical stability.
 
         Raises:
             TypeError: If the input matrix is not a numpy array.

--- a/newton/_src/solvers/kamino/_src/linalg/utils/matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/utils/matrix.py
@@ -32,7 +32,7 @@ DEFAULT_MATRIX_SYMMETRY_EPS = 1e-10
 """A global constant to configure the tolerance on matrix symmetry checks."""
 
 MAXLOG_FP64 = 709.782
-"""Maximum log value for wp.float64 to avoid overflow in exp()."""
+"""Maximum log value for float64 to avoid overflow in exp()."""
 
 ###
 # Types

--- a/newton/_src/solvers/kamino/_src/linalg/utils/rand.py
+++ b/newton/_src/solvers/kamino/_src/linalg/utils/rand.py
@@ -49,22 +49,23 @@ def eigenvalues_from_distribution(
         - The final counts are adjusted to sum to 'size'.
 
     Args:
-        size (int): The total size of the eigenvalue distribution.
-        num_pos (int | float): The number of positive eigenvalues (count or percentage).
-        num_pos_eps (int | float): The number of positive epsilon eigenvalues (count or percentage).
-        num_zero (int | float): The number of zero eigenvalues (count or percentage).
-        num_neg_eps (int | float): The number of negative epsilon eigenvalues (count or percentage).
-        num_neg (int | float): The number of negative eigenvalues (count or percentage).
-        max_pos (float): The maximum value for positive eigenvalues.
-        min_pos (float): The minimum value for positive eigenvalues.
-        eps_val (float): The value for epsilon eigenvalues.
-        max_neg (float): The maximum value for negative eigenvalues.
-        min_neg (float): The minimum value for negative eigenvalues.
-        dtype (np.dtype): The data type for the eigenvalues.
-        shuffle (bool): Whether to shuffle the eigenvalues.
+        size: The total size of the eigenvalue distribution.
+        num_pos: The number of positive eigenvalues (count or percentage).
+        num_pos_eps: The number of positive epsilon eigenvalues (count or percentage).
+        num_zero: The number of zero eigenvalues (count or percentage).
+        num_neg_eps: The number of negative epsilon eigenvalues (count or percentage).
+        num_neg: The number of negative eigenvalues (count or percentage).
+        max_pos: The maximum value for positive eigenvalues.
+        min_pos: The minimum value for positive eigenvalues.
+        eps_val: The value for epsilon eigenvalues.
+        max_neg: The maximum value for negative eigenvalues.
+        min_neg: The minimum value for negative eigenvalues.
+        dtype: The data type for the eigenvalues.
+        seed: Seed for the random number generator.
+        shuffle: Whether to shuffle the eigenvalues.
 
     Returns:
-        np.ndarray: The generated eigenvalue array.
+        The generated eigenvalue array.
     """
 
     # Helper to convert count/percentage to int
@@ -144,16 +145,17 @@ def random_symmetric_matrix(
     Generate a random symmetric matrix of size (dim, dim).
 
     Args:
-    - dim (int): The size of the matrix.
-    - dtype (data-type, optional): Data type of the matrix (default is float64).
-    - scale (float, optional): Scale factor for the matrix (default is 1.0).
-    - seed (int, optional): Seed for the random number generator.
-    - rank (int, optional): Rank of the matrix (must be <= dim).
-    - eigenvalues (array-like, optional): Eigenvalues for the matrix (must be of length dim).
-    - return_source (bool, optional): Whether to return the source matrix (default is False).
+        dim: The size of the matrix.
+        dtype: Data type of the matrix (default is np.float64).
+        scale: Scale factor for the matrix (default is 1.0).
+        seed: Seed for the random number generator.
+        rank: Rank of the matrix (must be <= dim).
+        eigenvalues: Eigenvalues for the matrix (must be of length dim).
+        return_source: Whether to return the source matrix (default is False).
 
     Returns:
-    - A (ndarray): A (dim, dim) symmetric matrix.
+        A (dim, dim) symmetric matrix, or a tuple of the matrix and source when
+        return_source is True.
     """
     # Set the random seed if specified and valid
     if seed is not None:
@@ -227,14 +229,16 @@ def random_spd_matrix(
     Generate a symmetric positive definite (SPD) matrix of shape (n, n).
 
     Args:
-    - n (int): The size of the matrix.
-    - dtype (data-type, optional): Data type of the matrix (default is float64).
-    - scale (float, optional): Scale factor for the matrix (default is 1.0).
-    - seed (int, optional): Seed for the random number generator.
-    - return_source (bool, optional): Whether to return the source matrix (default is False).
+        dim: The size of the matrix.
+        dtype: Data type of the matrix (default is np.float64).
+        scale: Scale factor for the matrix (default is 1.0).
+        eta: Diagonal regularizer added to ensure positive definiteness.
+        seed: Seed for the random number generator.
+        return_source: Whether to return the source matrix (default is False).
 
     Returns:
-    - A (ndarray): An n x n symmetric positive definite matrix.
+        An n x n symmetric positive definite matrix, or a tuple of the matrix and
+        source when return_source is True.
     """
     # Set the random seed if specified and valid
     if seed is not None:
@@ -285,12 +289,14 @@ def random_rhs_for_matrix(
     Generate a random RHS vector b that is in the range space of A.
 
     Args:
-        A (np.ndarray): The input matrix.
-        scale (float): Scale factor for the random vector (default is 1.0).
-        return_source (bool): Whether to return the source vector used to generate the RHS (default is False).
+        A: The input matrix.
+        scale: Scale factor for the random vector (default is 1.0).
+        seed: Seed for the random number generator.
+        return_source: Whether to return the source vector used to generate the RHS (default is False).
 
     Returns:
-        np.ndarray: A random RHS vector b in the range space of A.
+        A random RHS vector b in the range space of A, or a tuple of b and the
+        source vector when return_source is True.
     """
     # Set the random seed if specified and valid
     if seed is not None:

--- a/newton/_src/solvers/kamino/_src/models/builders/basics.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/basics.py
@@ -18,11 +18,11 @@ import math
 
 import warp as wp
 
+from ......core.types import Axis
 from ...core import ModelBuilderKamino, inertia
 from ...core.joints import JointActuationType, JointDoFType
-from ...core.math import FLOAT32_MAX, FLOAT32_MIN, I_3
+from ...core.math import FLOAT32_MAX, FLOAT32_MIN, I_3, axis_to_mat33
 from ...core.shapes import BoxShape, SphereShape
-from ...core.types import Axis, transformf, vec3f, vec6f
 
 ###
 # Module interface
@@ -55,26 +55,21 @@ def build_box_on_plane(
     Constructs a basic model of a free-floating 'box' body and a ground box geom.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -90,8 +85,8 @@ def build_box_on_plane(
     bid0 = _builder.add_rigid_body(
         m_i=1.0,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(1.0, 0.2, 0.2, 0.2),
-        q_i_0=transformf(0.0, 0.0, 0.1 + z_offset, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, 0.1 + z_offset, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -103,7 +98,7 @@ def build_box_on_plane(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -126,26 +121,21 @@ def build_box_pendulum(
     This version initializes the pendulum in a horizontal configuration.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -169,8 +159,8 @@ def build_box_pendulum(
         name="pendulum",
         m_i=m,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m, d, w, h),
-        q_i_0=transformf(0.5 * d, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.5 * d, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -181,9 +171,9 @@ def build_box_pendulum(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid0,
-        B_r_Bj=vec3f(0.0, 0.0, 0.5 * h + z_0),
-        F_r_Fj=vec3f(-0.5 * d, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, 0.5 * h + z_0),
+        F_r_Fj=wp.vec3f(-0.5 * d, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         a_j=1.0 if dynamic_joints else None,
         b_j=0.1 if dynamic_joints else None,
         k_p_j=100.0 if implicit_pd else None,
@@ -205,7 +195,7 @@ def build_box_pendulum(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -226,26 +216,21 @@ def build_box_pendulum_vertical(
     This version initializes the pendulum in a vertical configuration.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -269,8 +254,8 @@ def build_box_pendulum_vertical(
         name="pendulum",
         m_i=m,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m, d, w, h),
-        q_i_0=transformf(0.0, 0.0, -0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, -0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -281,9 +266,9 @@ def build_box_pendulum_vertical(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid0,
-        B_r_Bj=vec3f(0.0, 0.0, 0.0 + z_0),
-        F_r_Fj=vec3f(0.0, 0.0, 0.5 * h),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, 0.0 + z_0),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.5 * h),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
 
@@ -301,7 +286,7 @@ def build_box_pendulum_vertical(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -321,26 +306,21 @@ def build_cartpole(
     Constructs a basic model of a cartpole mounted onto a rail.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -367,8 +347,8 @@ def build_cartpole(
         name="cart",
         m_i=m_cart,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_cart, *dims_cart),
-        q_i_0=transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -379,8 +359,8 @@ def build_cartpole(
         name="pole",
         m_i=m_pole,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_pole, *dims_pole),
-        q_i_0=transformf(x_0_pole, 0.0, z_0_pole, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(x_0_pole, 0.0, z_0_pole, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -391,9 +371,9 @@ def build_cartpole(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid0,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         q_j_min=[-4.0] if limits else [float(FLOAT32_MIN)],
         q_j_max=[4.0] if limits else [float(FLOAT32_MAX)],
         tau_j_max=[1000.0],
@@ -407,9 +387,9 @@ def build_cartpole(
         act_type=JointActuationType.PASSIVE,
         bid_B=bid0,
         bid_F=bid1,
-        B_r_Bj=vec3f(0.5 * dims_cart[0], 0.0, 0.0),
-        F_r_Fj=vec3f(-0.5 * dims_pole[0], 0.0, -0.5 * dims_pole[2]),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.5 * dims_cart[0], 0.0, 0.0),
+        F_r_Fj=wp.vec3f(-0.5 * dims_pole[0], 0.0, -0.5 * dims_pole[2]),
+        X_Bj=axis_to_mat33(Axis.X),
         world_index=world_index,
     )
 
@@ -434,7 +414,7 @@ def build_cartpole(
         name="rail",
         body=-1,
         shape=BoxShape(*half_dims_rail),
-        offset=transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
+        offset=wp.transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
         group=1,
         collides=1,
         world_index=world_index,
@@ -446,7 +426,7 @@ def build_cartpole(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.0 + z_offset, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.0 + z_offset, 0.0, 0.0, 0.0, 1.0),
             group=1,
             collides=1,
             world_index=world_index,
@@ -469,26 +449,21 @@ def build_boxes_hinged(
     Constructs a basic model of a two floating boxes connected via revolute joint.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -513,8 +488,8 @@ def build_boxes_hinged(
         name="base",
         m_i=m_0,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_0, d, w, h),
-        q_i_0=transformf(0.25, -0.05, 0.05 + z0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.25, -0.05, 0.05 + z0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -523,8 +498,8 @@ def build_boxes_hinged(
         name="follower",
         m_i=m_1,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_1, d, w, h),
-        q_i_0=transformf(0.75, 0.05, 0.05 + z0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.75, 0.05, 0.05 + z0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -535,9 +510,9 @@ def build_boxes_hinged(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=bid0,
         bid_F=bid1,
-        B_r_Bj=vec3f(0.25, 0.05, 0.0),
-        F_r_Fj=vec3f(-0.25, -0.05, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, 0.05, 0.0),
+        F_r_Fj=wp.vec3f(-0.25, -0.05, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         a_j=1.0 if dynamic_joints else None,
         b_j=0.1 if dynamic_joints else None,
         k_p_j=100.0 if implicit_pd else None,
@@ -569,7 +544,7 @@ def build_boxes_hinged(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             group=1,
             collides=7,
             world_index=world_index,
@@ -593,26 +568,21 @@ def build_boxes_nunchaku(
     This version initializes the nunchaku in a horizontal configuration.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -642,8 +612,8 @@ def build_boxes_nunchaku(
         name="box_bottom",
         m_i=m_0,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_0, d, w, h),
-        q_i_0=transformf(0.5 * d, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.5 * d, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -652,8 +622,8 @@ def build_boxes_nunchaku(
         name="sphere_middle",
         m_i=m_1,
         i_I_i=inertia.solid_sphere_body_moment_of_inertia(m_1, r),
-        q_i_0=transformf(r + d, 0.0, r + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(r + d, 0.0, r + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -662,8 +632,8 @@ def build_boxes_nunchaku(
         name="box_top",
         m_i=m_2,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_2, d, w, h),
-        q_i_0=transformf(1.5 * d + 2.0 * r, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(1.5 * d + 2.0 * r, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -674,8 +644,8 @@ def build_boxes_nunchaku(
         act_type=JointActuationType.PASSIVE,
         bid_B=bid0,
         bid_F=bid1,
-        B_r_Bj=vec3f(0.5 * d, 0.0, 0.0),
-        F_r_Fj=vec3f(-r, 0.0, 0.0),
+        B_r_Bj=wp.vec3f(0.5 * d, 0.0, 0.0),
+        F_r_Fj=wp.vec3f(-r, 0.0, 0.0),
         X_Bj=I_3,
         world_index=world_index,
     )
@@ -687,8 +657,8 @@ def build_boxes_nunchaku(
         act_type=JointActuationType.PASSIVE,
         bid_B=bid1,
         bid_F=bid2,
-        B_r_Bj=vec3f(r, 0.0, 0.0),
-        F_r_Fj=vec3f(-0.5 * d, 0.0, 0.0),
+        B_r_Bj=wp.vec3f(r, 0.0, 0.0),
+        F_r_Fj=wp.vec3f(-0.5 * d, 0.0, 0.0),
         X_Bj=I_3,
         world_index=world_index,
     )
@@ -720,7 +690,7 @@ def build_boxes_nunchaku(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             group=1,
             collides=7,
             world_index=world_index,
@@ -744,26 +714,21 @@ def build_boxes_nunchaku_vertical(
     This version initializes the nunchaku in a vertical configuration.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -793,8 +758,8 @@ def build_boxes_nunchaku_vertical(
         name="box_bottom",
         m_i=m_0,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_0, d, w, h),
-        q_i_0=transformf(0.0, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, 0.5 * h + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -803,8 +768,8 @@ def build_boxes_nunchaku_vertical(
         name="sphere_middle",
         m_i=m_1,
         i_I_i=inertia.solid_sphere_body_moment_of_inertia(m_1, r),
-        q_i_0=transformf(0.0, 0.0, h + r + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, h + r + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -813,8 +778,8 @@ def build_boxes_nunchaku_vertical(
         name="box_top",
         m_i=m_2,
         i_I_i=inertia.solid_cuboid_body_moment_of_inertia(m_2, d, w, h),
-        q_i_0=transformf(0.0, 0.0, 1.5 * h + 2.0 * r + z_0, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, 1.5 * h + 2.0 * r + z_0, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
 
@@ -825,8 +790,8 @@ def build_boxes_nunchaku_vertical(
         act_type=JointActuationType.PASSIVE,
         bid_B=bid0,
         bid_F=bid1,
-        B_r_Bj=vec3f(0.0, 0.0, 0.5 * h),
-        F_r_Fj=vec3f(0.0, 0.0, -r),
+        B_r_Bj=wp.vec3f(0.0, 0.0, 0.5 * h),
+        F_r_Fj=wp.vec3f(0.0, 0.0, -r),
         X_Bj=I_3,
         world_index=world_index,
     )
@@ -838,8 +803,8 @@ def build_boxes_nunchaku_vertical(
         act_type=JointActuationType.PASSIVE,
         bid_B=bid1,
         bid_F=bid2,
-        B_r_Bj=vec3f(0.0, 0.0, r),
-        F_r_Fj=vec3f(0.0, 0.0, -0.5 * h),
+        B_r_Bj=wp.vec3f(0.0, 0.0, r),
+        F_r_Fj=wp.vec3f(0.0, 0.0, -0.5 * h),
         X_Bj=I_3,
         world_index=world_index,
     )
@@ -871,7 +836,7 @@ def build_boxes_nunchaku_vertical(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             group=1,
             collides=7,
             world_index=world_index,
@@ -899,26 +864,21 @@ def build_boxes_fourbar(
     Constructs a basic model of a four-bar linkage.
 
     Args:
-        builder (ModelBuilderKamino | None):
-            An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.\n
             If `None`, a new builder is created.
-        z_offset (float):
-            A vertical offset to apply to the initial position of the box.
-        ground (bool):
-            Whether to add a static ground plane to the model.
-        new_world (bool):
-            Whether to create a new world in the builder for this model.\n
+        z_offset: A vertical offset to apply to the initial position of the box.
+        ground: Whether to add a static ground plane to the model.
+        new_world: Whether to create a new world in the builder for this model.\n
             If `False`, the model is added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index (int):
-            The index of the world to which the model should be added if `new_world` is False.\n
+        world_index: The index of the world to which the model should be added if `new_world` is False.\n
             If `new_world` is True, this argument is ignored.\n
             If the value does not correspond to an existing world, an error will be raised.\n
             Defaults to `0`.
 
     Returns:
-        ModelBuilderKamino: A model builder containing the four-bar linkage.
+        A model builder containing the four-bar linkage.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -984,11 +944,11 @@ def build_boxes_fourbar(
         print(f"i_I_i_4:\n{i_I_i_4}")
 
     # Initial body positions
-    r_0 = vec3f(0.0, 0.0, z_0)
-    dr_b1 = vec3f(0.0, 0.0, 0.5 * d)
-    dr_b2 = vec3f(0.5 * h + dj, 0.0, 0.5 * h + dj)
-    dr_b3 = vec3f(0.0, 0.0, 0.5 * d + h + dj + mj)
-    dr_b4 = vec3f(-0.5 * h - dj, 0.0, 0.5 * h + dj)
+    r_0 = wp.vec3f(0.0, 0.0, z_0)
+    dr_b1 = wp.vec3f(0.0, 0.0, 0.5 * d)
+    dr_b2 = wp.vec3f(0.5 * h + dj, 0.0, 0.5 * h + dj)
+    dr_b3 = wp.vec3f(0.0, 0.0, 0.5 * d + h + dj + mj)
+    dr_b4 = wp.vec3f(-0.5 * h - dj, 0.0, 0.5 * h + dj)
 
     # Initial positions of the bodies
     r_b1 = r_0 + dr_b1
@@ -1002,16 +962,16 @@ def build_boxes_fourbar(
         print(f"r_b4: {r_b4}")
 
     # Initial body poses
-    q_i_1 = transformf(r_b1, wp.quat_identity())
-    q_i_2 = transformf(r_b2, wp.quat_identity())
-    q_i_3 = transformf(r_b3, wp.quat_identity())
-    q_i_4 = transformf(r_b4, wp.quat_identity())
+    q_i_1 = wp.transformf(r_b1, wp.quat_identity())
+    q_i_2 = wp.transformf(r_b2, wp.quat_identity())
+    q_i_3 = wp.transformf(r_b3, wp.quat_identity())
+    q_i_4 = wp.transformf(r_b4, wp.quat_identity())
 
     # Initial joint positions
-    r_j1 = vec3f(r_b2.x, 0.0, r_b1.z)
-    r_j2 = vec3f(r_b2.x, 0.0, r_b3.z)
-    r_j3 = vec3f(r_b4.x, 0.0, r_b3.z)
-    r_j4 = vec3f(r_b4.x, 0.0, r_b1.z)
+    r_j1 = wp.vec3f(r_b2.x, 0.0, r_b1.z)
+    r_j2 = wp.vec3f(r_b2.x, 0.0, r_b3.z)
+    r_j3 = wp.vec3f(r_b4.x, 0.0, r_b3.z)
+    r_j4 = wp.vec3f(r_b4.x, 0.0, r_b1.z)
     if verbose:
         print(f"r_j1: {r_j1}")
         print(f"r_j2: {r_j2}")
@@ -1019,7 +979,7 @@ def build_boxes_fourbar(
         print(f"r_j4: {r_j4}")
 
     # Joint axes matrix
-    X_j = Axis.Y.to_mat33()
+    X_j = axis_to_mat33(Axis.Y)
 
     ###
     # Bodies
@@ -1030,7 +990,7 @@ def build_boxes_fourbar(
         m_i=m_i,
         i_I_i=i_I_i_1,
         q_i_0=q_i_1,
-        u_i_0=vec6f(0.0),
+        u_i_0=wp.spatial_vectorf(0.0),
         world_index=world_index,
     )
 
@@ -1039,7 +999,7 @@ def build_boxes_fourbar(
         m_i=m_i,
         i_I_i=i_I_i_2,
         q_i_0=q_i_2,
-        u_i_0=vec6f(0.0),
+        u_i_0=wp.spatial_vectorf(0.0),
         world_index=world_index,
     )
 
@@ -1048,7 +1008,7 @@ def build_boxes_fourbar(
         m_i=m_i,
         i_I_i=i_I_i_3,
         q_i_0=q_i_3,
-        u_i_0=vec6f(0.0),
+        u_i_0=wp.spatial_vectorf(0.0),
         world_index=world_index,
     )
 
@@ -1057,7 +1017,7 @@ def build_boxes_fourbar(
         m_i=m_i,
         i_I_i=i_I_i_4,
         q_i_0=q_i_4,
-        u_i_0=vec6f(0.0),
+        u_i_0=wp.spatial_vectorf(0.0),
         world_index=world_index,
     )
 
@@ -1079,7 +1039,7 @@ def build_boxes_fourbar(
             act_type=JointActuationType.PASSIVE,
             bid_B=-1,
             bid_F=bid1,
-            B_r_Bj=vec3f(0.0),
+            B_r_Bj=wp.vec3f(0.0),
             F_r_Fj=-r_b1,
             X_Bj=I_3,
             world_index=world_index,
@@ -1092,7 +1052,7 @@ def build_boxes_fourbar(
             act_type=JointActuationType.FORCE if 0 in actuator_ids else JointActuationType.PASSIVE,
             bid_B=-1,
             bid_F=bid1,
-            B_r_Bj=vec3f(0.0),
+            B_r_Bj=wp.vec3f(0.0),
             F_r_Fj=-r_b1,
             X_Bj=I_3,
             world_index=world_index,
@@ -1184,7 +1144,7 @@ def build_boxes_fourbar(
             name="ground",
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -1203,7 +1163,7 @@ def make_basics_heterogeneous_builder(
     This function constructs a model builder containing all basic models.
 
     Returns:
-        ModelBuilderKamino: The constructed model builder.
+        The constructed model builder.
     """
     builder = ModelBuilderKamino(default_world=False)
     builder.add_builder(build_boxes_fourbar(ground=ground, dynamic_joints=dynamic_joints, implicit_pd=implicit_pd))

--- a/newton/_src/solvers/kamino/_src/models/builders/basics.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/basics.py
@@ -55,17 +55,17 @@ def build_box_on_plane(
     Constructs a basic model of a free-floating 'box' body and a ground box geom.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -121,17 +121,17 @@ def build_box_pendulum(
     This version initializes the pendulum in a horizontal configuration.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -216,17 +216,17 @@ def build_box_pendulum_vertical(
     This version initializes the pendulum in a vertical configuration.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -306,17 +306,17 @@ def build_cartpole(
     Constructs a basic model of a cartpole mounted onto a rail.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -449,17 +449,17 @@ def build_boxes_hinged(
     Constructs a basic model of a two floating boxes connected via revolute joint.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -568,17 +568,17 @@ def build_boxes_nunchaku(
     This version initializes the nunchaku in a horizontal configuration.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -714,17 +714,17 @@ def build_boxes_nunchaku_vertical(
     This version initializes the nunchaku in a vertical configuration.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:
@@ -864,17 +864,17 @@ def build_boxes_fourbar(
     Constructs a basic model of a four-bar linkage.
 
     Args:
-        builder: An optional existing model builder to populate.\n
+        builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
         z_offset: A vertical offset to apply to the initial position of the box.
         ground: Whether to add a static ground plane to the model.
-        new_world: Whether to create a new world in the builder for this model.\n
-            If `False`, the model is added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder for this model.
+            If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
-            argument is ignored, and the index of the newly created world will be used instead.\n
-        world_index: The index of the world to which the model should be added if `new_world` is False.\n
-            If `new_world` is True, this argument is ignored.\n
-            If the value does not correspond to an existing world, an error will be raised.\n
+            argument is ignored, and the index of the newly created world will be used instead.
+        world_index: The index of the world to which the model should be added if `new_world` is False.
+            If `new_world` is True, this argument is ignored.
+            If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
 
     Returns:

--- a/newton/_src/solvers/kamino/_src/models/builders/testing.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/testing.py
@@ -16,9 +16,10 @@ import os
 import numpy as np
 import warp as wp
 
+from ......core.types import Axis
 from ...core import ModelBuilderKamino
 from ...core.joints import JointActuationType, JointDoFType
-from ...core.math import I_3, quat_from_euler_xyz
+from ...core.math import I_3, axis_to_mat33, quat_from_euler_xyz
 from ...core.shapes import (
     BoxShape,
     CapsuleShape,
@@ -30,7 +31,6 @@ from ...core.shapes import (
     ShapeDescriptorType,
     SphereShape,
 )
-from ...core.types import Axis, mat33f, transformf, vec3f, vec6f
 from ...utils import logger as msg
 from ...utils.io.usd import USDImporter
 from . import utils
@@ -78,15 +78,15 @@ def build_free_joint_test(
     free joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -103,8 +103,8 @@ def build_free_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -113,8 +113,8 @@ def build_free_joint_test(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
         X_Bj=I_3,
         q_j_min=[-2.0, -2.0, -2.0, -0.6 * math.pi, -0.6 * math.pi, -0.6 * math.pi] if limits else None,
         q_j_max=[2.0, 2.0, 2.0, 0.6 * math.pi, 0.6 * math.pi, 0.6 * math.pi] if limits else None,
@@ -133,7 +133,7 @@ def build_free_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -158,17 +158,17 @@ def build_unary_revolute_joint_test(
     revolute joint, with optional limits applied to the joint degree of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degree of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to enable dynamic properties for the joint.
-        implicit_pd (bool): Whether to enable implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degree of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to enable dynamic properties for the joint.
+        implicit_pd: Whether to enable implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -185,8 +185,8 @@ def build_unary_revolute_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, -0.25, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, -0.25, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -195,9 +195,9 @@ def build_unary_revolute_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, -0.15, z_offset),
-        F_r_Fj=vec3f(-0.5, 0.1, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, -0.15, z_offset),
+        F_r_Fj=wp.vec3f(-0.5, 0.1, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         q_j_min=[-0.25 * math.pi] if limits else None,
         q_j_max=[0.25 * math.pi] if limits else None,
         a_j=0.1 if dynamic else None,
@@ -226,7 +226,7 @@ def build_unary_revolute_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -251,17 +251,17 @@ def build_binary_revolute_joint_test(
     joint, with optional limits applied to the joint degree of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degree of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to set the joint to be dynamic, with non-zero armature and damping.
-        implicit_pd (bool): Whether to use implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degree of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to set the joint to be dynamic, with non-zero armature and damping.
+        implicit_pd: Whether to use implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -278,16 +278,16 @@ def build_binary_revolute_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, -0.25, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, -0.25, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -296,9 +296,9 @@ def build_binary_revolute_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -307,9 +307,9 @@ def build_binary_revolute_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, -0.15, z_offset),
-        F_r_Fj=vec3f(-0.5, 0.1, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, -0.15, z_offset),
+        F_r_Fj=wp.vec3f(-0.5, 0.1, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         q_j_min=[-0.25 * math.pi] if limits else None,
         q_j_max=[0.25 * math.pi] if limits else None,
         a_j=0.1 if dynamic else None,
@@ -336,7 +336,7 @@ def build_binary_revolute_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -361,15 +361,15 @@ def build_unary_prismatic_joint_test(
     prismatic joint, with optional limits applied to the joint degree of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degree of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degree of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -386,8 +386,8 @@ def build_unary_prismatic_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -396,9 +396,9 @@ def build_unary_prismatic_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Z.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Z),
         q_j_min=[-0.5] if limits else None,
         q_j_max=[0.5] if limits else None,
         a_j=0.1 if dynamic else None,
@@ -427,7 +427,7 @@ def build_unary_prismatic_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -452,15 +452,15 @@ def build_binary_prismatic_joint_test(
     joint, with optional limits applied to the joint degree of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degree of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degree of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -477,16 +477,16 @@ def build_binary_prismatic_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -495,9 +495,9 @@ def build_binary_prismatic_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -506,9 +506,9 @@ def build_binary_prismatic_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Z.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Z),
         q_j_min=[-0.5] if limits else None,
         q_j_max=[0.5] if limits else None,
         a_j=0.1 if dynamic else None,
@@ -537,7 +537,7 @@ def build_binary_prismatic_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -562,17 +562,17 @@ def build_unary_cylindrical_joint_test(
     cylindrical joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to enable dynamic properties for the joint.
-        implicit_pd (bool): Whether to enable implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to enable dynamic properties for the joint.
+        implicit_pd: Whether to enable implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -589,8 +589,8 @@ def build_unary_cylindrical_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -599,9 +599,9 @@ def build_unary_cylindrical_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Z.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Z),
         q_j_min=[-0.5, -0.6 * math.pi] if limits else None,
         q_j_max=[0.5, 0.6 * math.pi] if limits else None,
         a_j=[0.1, 0.2] if dynamic else None,
@@ -630,7 +630,7 @@ def build_unary_cylindrical_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -655,17 +655,17 @@ def build_binary_cylindrical_joint_test(
     joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to enable dynamic properties for the joint.
-        implicit_pd (bool): Whether to enable implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to enable dynamic properties for the joint.
+        implicit_pd: Whether to enable implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -682,16 +682,16 @@ def build_binary_cylindrical_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -700,9 +700,9 @@ def build_binary_cylindrical_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -711,9 +711,9 @@ def build_binary_cylindrical_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Z.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Z),
         q_j_min=[-0.5, -0.6 * math.pi] if limits else None,
         q_j_max=[0.5, 0.6 * math.pi] if limits else None,
         a_j=[0.1, 0.2] if dynamic else None,
@@ -740,7 +740,7 @@ def build_binary_cylindrical_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -763,15 +763,15 @@ def build_unary_universal_joint_test(
     universal joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -788,8 +788,8 @@ def build_unary_universal_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -798,9 +798,9 @@ def build_unary_universal_joint_test(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-0.6 * math.pi, -0.6 * math.pi] if limits else None,
         q_j_max=[0.6 * math.pi, 0.6 * math.pi] if limits else None,
         world_index=world_index,
@@ -825,7 +825,7 @@ def build_unary_universal_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -848,15 +848,15 @@ def build_binary_universal_joint_test(
     joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -873,16 +873,16 @@ def build_binary_universal_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -891,9 +891,9 @@ def build_binary_universal_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -902,9 +902,9 @@ def build_binary_universal_joint_test(
         act_type=JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-0.6 * math.pi, -0.6 * math.pi] if limits else None,
         q_j_max=[0.6 * math.pi, 0.6 * math.pi] if limits else None,
         world_index=world_index,
@@ -927,7 +927,7 @@ def build_binary_universal_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -950,15 +950,15 @@ def build_unary_spherical_joint_test(
     spherical joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -975,8 +975,8 @@ def build_unary_spherical_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -985,9 +985,9 @@ def build_unary_spherical_joint_test(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-0.6 * math.pi, -0.6 * math.pi, -0.6 * math.pi] if limits else None,
         q_j_max=[0.6 * math.pi, 0.6 * math.pi, 0.6 * math.pi] if limits else None,
         world_index=world_index,
@@ -1012,7 +1012,7 @@ def build_unary_spherical_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -1035,15 +1035,15 @@ def build_binary_spherical_joint_test(
     joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        ground (bool): Whether to include a ground plane in the world.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        ground: Whether to include a ground plane in the world.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -1060,16 +1060,16 @@ def build_binary_spherical_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -1078,9 +1078,9 @@ def build_binary_spherical_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -1089,9 +1089,9 @@ def build_binary_spherical_joint_test(
         act_type=JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-0.6 * math.pi, -0.6 * math.pi, -0.6 * math.pi] if limits else None,
         q_j_max=[0.6 * math.pi, 0.6 * math.pi, 0.6 * math.pi] if limits else None,
         world_index=world_index,
@@ -1114,7 +1114,7 @@ def build_binary_spherical_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -1139,17 +1139,17 @@ def build_unary_cartesian_joint_test(
     cartesian joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to enable dynamic properties for the joint.
-        implicit_pd (bool): Whether to enable implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to enable dynamic properties for the joint.
+        implicit_pd: Whether to enable implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -1166,8 +1166,8 @@ def build_unary_cartesian_joint_test(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -1176,9 +1176,9 @@ def build_unary_cartesian_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-1.0, -1.0, -1.0] if limits else None,
         q_j_max=[1.0, 1.0, 1.0] if limits else None,
         a_j=[0.1, 0.2, 0.3] if dynamic else None,
@@ -1207,7 +1207,7 @@ def build_unary_cartesian_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -1232,17 +1232,17 @@ def build_binary_cartesian_joint_test(
     joint, with optional limits applied to the joint degrees of freedom.
 
     Args:
-        builder (ModelBuilderKamino | None): An optional existing ModelBuilderKamino to which the entities will be added.
-        z_offset (float): A vertical offset to apply to the rigid body position.
-        new_world (bool): Whether to create a new world in the builder, to which entities will be added.\n
+        builder: An optional existing ModelBuilderKamino to which the entities will be added.
+        z_offset: A vertical offset to apply to the rigid body position.
+        new_world: Whether to create a new world in the builder, to which entities will be added.\n
             If `False`, the contents are added to the existing world specified by `world_index`.\n
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
-        limits (bool): Whether to enable limits on the joint degrees of freedom.
-        ground (bool): Whether to include a ground plane in the world.
-        dynamic (bool): Whether to enable dynamic properties for the joint.
-        implicit_pd (bool): Whether to enable implicit PD control for the joint.
-        world_index (int): The index of the world in the builder where the test model should be added.
+        limits: Whether to enable limits on the joint degrees of freedom.
+        ground: Whether to include a ground plane in the world.
+        dynamic: Whether to enable dynamic properties for the joint.
+        implicit_pd: Whether to enable implicit PD control for the joint.
+        world_index: The index of the world in the builder where the test model should be added.
     """
     # Create a new builder if none is provided
     if builder is None:
@@ -1259,16 +1259,16 @@ def build_binary_cartesian_joint_test(
         name="base",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     bid_F = _builder.add_rigid_body(
         name="follower",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -1277,9 +1277,9 @@ def build_binary_cartesian_joint_test(
         act_type=JointActuationType.PASSIVE,
         bid_B=-1,
         bid_F=bid_B,
-        B_r_Bj=vec3f(0.0, 0.0, z_offset),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
-        X_Bj=Axis.Y.to_mat33(),
+        B_r_Bj=wp.vec3f(0.0, 0.0, z_offset),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
+        X_Bj=axis_to_mat33(Axis.Y),
         world_index=world_index,
     )
     _builder.add_joint(
@@ -1288,9 +1288,9 @@ def build_binary_cartesian_joint_test(
         act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
         bid_B=bid_B,
         bid_F=bid_F,
-        B_r_Bj=vec3f(0.25, -0.25, -0.25),
-        F_r_Fj=vec3f(-0.25, -0.25, -0.25),
-        X_Bj=Axis.X.to_mat33(),
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
         q_j_min=[-1.0, -1.0, -1.0] if limits else None,
         q_j_max=[1.0, 1.0, 1.0] if limits else None,
         a_j=[0.1, 0.2, 0.3] if dynamic else None,
@@ -1317,7 +1317,7 @@ def build_binary_cartesian_joint_test(
         _builder.add_geometry(
             body=-1,
             shape=BoxShape(10.0, 10.0, 0.5),
-            offset=transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 
@@ -1337,15 +1337,15 @@ def build_all_joints_test_model(
     Constructs a model builder containing a world for each joint type.
 
     Args:
-        unary_joints (bool): Whether to include unary joints.
-        binary_joints (bool): Whether to include binary joints.
-        actuated (bool): Whether to make the joints actuated (passive otherwise).
-        damped (bool): Whether to add slight damping to the joints to increase realism.
-        floating_base (bool): Whether to replace the fixed with a free base joint for binary examples.
-        exclude_universal (bool): Whether to skip universal joints.
+        unary_joints: Whether to include unary joints.
+        binary_joints: Whether to include binary joints.
+        actuated: Whether to make the joints actuated (passive otherwise).
+        damped: Whether to add slight damping to the joints to increase realism.
+        floating_base: Whether to replace the fixed with a free base joint for binary examples.
+        exclude_universal: Whether to skip universal joints.
 
     Returns:
-        ModelBuilderKamino: The populated model builder.
+        The populated model builder.
     """
 
     def alter_binary_joint(
@@ -1465,7 +1465,7 @@ shape_default_dims: dict[GeoType, tuple] = {
 """Mapping from GeoType enum to default scale/dimensions (Newton convention: half-extents)."""
 
 
-def make_shape_initial_position(name: str, dims: tuple, is_top: bool = True) -> vec3f:
+def make_shape_initial_position(name: str, dims: tuple, is_top: bool = True) -> wp.vec3f:
     """
     Computes the initial position along the z-axis for a given shape.
 
@@ -1473,17 +1473,13 @@ def make_shape_initial_position(name: str, dims: tuple, is_top: bool = True) -> 
     (or below) the origin along the z-axis, based on its type and dimensions.
 
     Args:
-        name (str):
-            The name of the shape (e.g., "sphere", "box", "capsule", etc.).
-        dims (tuple):
-            The dimensions of the shape. The expected format depends on the shape type.
-        is_top (bool):
-            If True, computes the position for a top shape (above the origin).
+        name: The name of the shape (e.g., "sphere", "box", "capsule", etc.).
+        dims: The dimensions of the shape. The expected format depends on the shape type.
+        is_top: If True, computes the position for a top shape (above the origin).
             If False, computes the position for a bottom shape (below the origin).
 
     Returns:
-        vec3f:
-            The computed position vector along the z-axis.
+        The computed position vector along the z-axis.
     """
     # Retrieve and check the shape type
     shape_type = shape_name_to_type.get(name)
@@ -1505,19 +1501,19 @@ def make_shape_initial_position(name: str, dims: tuple, is_top: bool = True) -> 
     # Compute the initial position along z-axis that places the shape just above.
     # Dimensions use Newton convention (half-extents, half-heights).
     if shape_type == GeoType.SPHERE:
-        r = vec3f(0.0, 0.0, dims[0])
+        r = wp.vec3f(0.0, 0.0, dims[0])
     elif shape_type == GeoType.BOX:
-        r = vec3f(0.0, 0.0, dims[2])
+        r = wp.vec3f(0.0, 0.0, dims[2])
     elif shape_type == GeoType.CAPSULE:
-        r = vec3f(0.0, 0.0, dims[1] + dims[0])
+        r = wp.vec3f(0.0, 0.0, dims[1] + dims[0])
     elif shape_type == GeoType.CYLINDER:
-        r = vec3f(0.0, 0.0, dims[1])
+        r = wp.vec3f(0.0, 0.0, dims[1])
     elif shape_type == GeoType.CONE:
-        r = vec3f(0.0, 0.0, dims[1])
+        r = wp.vec3f(0.0, 0.0, dims[1])
     elif shape_type == GeoType.ELLIPSOID:
-        r = vec3f(0.0, 0.0, dims[2])
+        r = wp.vec3f(0.0, 0.0, dims[2])
     elif shape_type == GeoType.PLANE:
-        r = vec3f(0.0, 0.0, 0.0)
+        r = wp.vec3f(0.0, 0.0, 0.0)
     else:
         raise ValueError(f"Unsupported shape type: {shape_type}")
 
@@ -1529,35 +1525,32 @@ def make_shape_initial_position(name: str, dims: tuple, is_top: bool = True) -> 
     return r
 
 
-def get_shape_bottom_position(center: vec3f, shape: ShapeDescriptorType) -> vec3f:
+def get_shape_bottom_position(center: wp.vec3f, shape: ShapeDescriptorType) -> wp.vec3f:
     """
     Computes the position of the bottom along the z-axis for a given shape.
 
     Args:
-        center (vec3f):
-            The center position of the shape.
-        shape (ShapeDescriptorType):
-            The shape descriptor instance.
+        center: The center position of the shape.
+        shape: The shape descriptor instance.
 
     Returns:
-        vec3f:
-            The computed bottom position of the shape along the z-axis.
+        The computed bottom position of the shape along the z-axis.
     """
     # Compute and return the bottom position along z-axis.
     # Shape params use Newton convention (half-extents, half-heights).
-    r_bottom = vec3f(0.0)
+    r_bottom = wp.vec3f(0.0)
     if shape.type == GeoType.SPHERE:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params)
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params)
     elif shape.type == GeoType.BOX:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params[2])
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params[2])
     elif shape.type == GeoType.CAPSULE:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params[1] + shape.params[0])
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params[1] + shape.params[0])
     elif shape.type == GeoType.CYLINDER:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params[1])
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params[1])
     elif shape.type == GeoType.CONE:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params[1])
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params[1])
     elif shape.type == GeoType.ELLIPSOID:
-        r_bottom = center - vec3f(0.0, 0.0, shape.params[2])
+        r_bottom = center - wp.vec3f(0.0, 0.0, shape.params[2])
     elif shape.type == GeoType.PLANE:
         r_bottom = center
     else:
@@ -1587,29 +1580,20 @@ def make_single_shape_pair_builder(
     the z-axis, effectively generating a "shape[0] atop shape[1]" configuration.
 
     Args:
-        shapes (tuple[str, str]):
-            A tuple specifying the names of the bottom and top shapes (e.g., ("box", "sphere")).
-        bottom_dims (tuple | None):
-            Dimensions for the bottom shape. If None, defaults are used.
-        bottom_xyz (tuple | None):
-            Position (x, y, z) for the bottom shape. If None, defaults to (0, 0, 0).
-        bottom_rpy (tuple | None):
-            Orientation (roll, pitch, yaw) for the bottom shape. If None, defaults to (0, 0, 0).
-        top_dims (tuple | None):
-            Dimensions for the top shape. If None, defaults are used.
-        top_xyz (tuple | None):
-            Position (x, y, z) for the top shape. If None, defaults to (0, 0, 0).
-        top_rpy (tuple | None):
-            Orientation (roll, pitch, yaw) for the top shape. If None, defaults to (0, 0, 0).
-        distance (float):
-            Mutual distance along the z-axis between the two shapes.\n
+        shapes: A tuple specifying the names of the bottom and top shapes (e.g., ("box", "sphere")).
+        bottom_dims: Dimensions for the bottom shape. If None, defaults are used.
+        bottom_xyz: Position (x, y, z) for the bottom shape. If None, defaults to (0, 0, 0).
+        bottom_rpy: Orientation (roll, pitch, yaw) for the bottom shape. If None, defaults to (0, 0, 0).
+        top_dims: Dimensions for the top shape. If None, defaults are used.
+        top_xyz: Position (x, y, z) for the top shape. If None, defaults to (0, 0, 0).
+        top_rpy: Orientation (roll, pitch, yaw) for the top shape. If None, defaults to (0, 0, 0).
+        distance: Mutual distance along the z-axis between the two shapes.\n
             If zero, the shapes are exactly touching.\n
             If positive, they are separated by that distance.\n
             If negative, they are penetrating by that distance.
 
     Returns:
-        ModelBuilderKamino:
-            The constructed ModelBuilderKamino with the specified shape combination.
+        The constructed ModelBuilderKamino with the specified shape combination.
     """
     # Check that the shape combination is tuple of strings
     if not (isinstance(shapes, tuple) and len(shapes) == 2 and all(isinstance(s, str) for s in shapes)):
@@ -1647,15 +1631,15 @@ def make_single_shape_pair_builder(
     top_descriptor = shape_type_to_descriptor[top_type]
 
     # Define the mutual separation along z-axis
-    r_dz = vec3f(0.0, 0.0, 0.5 * distance)
+    r_dz = wp.vec3f(0.0, 0.0, 0.5 * distance)
 
     # Compute bottom box position and orientation
-    r_b = vec3f(bottom_xyz) - r_dz
-    q_b = quat_from_euler_xyz(vec3f(*bottom_rpy))
+    r_b = wp.vec3f(bottom_xyz) - r_dz
+    q_b = quat_from_euler_xyz(wp.vec3f(*bottom_rpy))
 
     # Compute top sphere position and orientation
-    r_t = vec3f(top_xyz) + r_dz
-    q_t = quat_from_euler_xyz(vec3f(*top_rpy))
+    r_t = wp.vec3f(top_xyz) + r_dz
+    q_t = quat_from_euler_xyz(wp.vec3f(*top_rpy))
 
     # Create the shape descriptors for bottom and top shapes
     # with special handling for PlaneShape
@@ -1673,14 +1657,14 @@ def make_single_shape_pair_builder(
     bid0 = builder.add_rigid_body(
         name="bottom_" + bottom,
         m_i=1.0,
-        i_I_i=mat33f(np.eye(3, dtype=np.float32)),
-        q_i_0=transformf(r_b, q_b),
+        i_I_i=wp.mat33f(np.eye(3, dtype=np.float32)),
+        q_i_0=wp.transformf(r_b, q_b),
     )
     bid1 = builder.add_rigid_body(
         name="top_" + top,
         m_i=1.0,
-        i_I_i=mat33f(np.eye(3, dtype=np.float32)),
-        q_i_0=transformf(r_t, q_t),
+        i_I_i=wp.mat33f(np.eye(3, dtype=np.float32)),
+        q_i_0=wp.transformf(r_t, q_t),
     )
     builder.add_geometry(body=bid0, name="bottom_" + bottom, shape=bottom_shape)
     builder.add_geometry(body=bid1, name="top_" + top, shape=top_shape)
@@ -1720,14 +1704,11 @@ def make_shape_pairs_builder(
     Generates a builder containing a world for each specified shape combination.
 
     Args:
-        shape_pairs (list[tuple[str, str]]):
-            A list of tuples specifying the names of the bottom and top shapes
+        shape_pairs: A list of tuples specifying the names of the bottom and top shapes
             for each combination (e.g., [("box", "sphere"), ("cylinder", "cone")]).
-        **kwargs:
-            Additional keyword arguments to be passed to `make_single_shape_pair_builder`.
+        **kwargs: Additional keyword arguments to be passed to `make_single_shape_pair_builder`.
     Returns:
-        ModelBuilderKamino
-            A ModelBuilderKamino containing a world for each specified shape combination.
+        A ModelBuilderKamino containing a world for each specified shape combination.
     """
     # Create an empty ModelBuilderKamino to hold all shape pair worlds
     builder = ModelBuilderKamino(default_world=False)

--- a/newton/_src/solvers/kamino/_src/models/builders/testing.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/testing.py
@@ -81,8 +81,8 @@ def build_free_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -160,8 +160,8 @@ def build_unary_revolute_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degree of freedom.
@@ -253,8 +253,8 @@ def build_binary_revolute_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degree of freedom.
@@ -364,8 +364,8 @@ def build_unary_prismatic_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degree of freedom.
@@ -455,8 +455,8 @@ def build_binary_prismatic_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degree of freedom.
@@ -564,8 +564,8 @@ def build_unary_cylindrical_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -657,8 +657,8 @@ def build_binary_cylindrical_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -766,8 +766,8 @@ def build_unary_universal_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -851,8 +851,8 @@ def build_binary_universal_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -953,8 +953,8 @@ def build_unary_spherical_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -1038,8 +1038,8 @@ def build_binary_spherical_joint_test(
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
         ground: Whether to include a ground plane in the world.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -1141,8 +1141,8 @@ def build_unary_cartesian_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -1234,8 +1234,8 @@ def build_binary_cartesian_joint_test(
     Args:
         builder: An optional existing ModelBuilderKamino to which the entities will be added.
         z_offset: A vertical offset to apply to the rigid body position.
-        new_world: Whether to create a new world in the builder, to which entities will be added.\n
-            If `False`, the contents are added to the existing world specified by `world_index`.\n
+        new_world: Whether to create a new world in the builder, to which entities will be added.
+            If `False`, the contents are added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         limits: Whether to enable limits on the joint degrees of freedom.
@@ -1587,9 +1587,9 @@ def make_single_shape_pair_builder(
         top_dims: Dimensions for the top shape. If None, defaults are used.
         top_xyz: Position (x, y, z) for the top shape. If None, defaults to (0, 0, 0).
         top_rpy: Orientation (roll, pitch, yaw) for the top shape. If None, defaults to (0, 0, 0).
-        distance: Mutual distance along the z-axis between the two shapes.\n
-            If zero, the shapes are exactly touching.\n
-            If positive, they are separated by that distance.\n
+        distance: Mutual distance along the z-axis between the two shapes.
+            If zero, the shapes are exactly touching.
+            If positive, they are separated by that distance.
             If negative, they are penetrating by that distance.
 
     Returns:

--- a/newton/_src/solvers/kamino/_src/models/builders/utils.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/utils.py
@@ -20,7 +20,6 @@ import warp as wp
 
 from ...core.builder import ModelBuilderKamino
 from ...core.shapes import BoxShape, PlaneShape
-from ...core.types import transformf, vec3f, vec6f
 from ...utils.io.usd import USDImporter
 
 ###
@@ -53,27 +52,22 @@ def add_ground_plane(
     Adds a static plane geometry to a given builder to represent a flat ground with infinite dimensions.
 
     Args:
-        builder (ModelBuilderKamino):
-            The model builder to which the ground plane should be added.
-        group (int):
-            The collision group for the ground geometry.\n
+        builder: The model builder to which the ground plane should be added.
+        group: The collision group for the ground geometry.\n
             Defaults to `1`.
-        collides (int):
-            The collision mask for the ground geometry.\n
+        collides: The collision mask for the ground geometry.\n
             Defaults to `1`.
-        world_index (int):
-            The index of the world in the builder where the ground geometry should be added.\n
+        world_index: The index of the world in the builder where the ground geometry should be added.\n
             If the value does not correspond to an existing world an error will be raised.\n
             Defaults to `0`.
-        z_offset (float):
-            The vertical offset of the ground plane along the Z axis.\n
+        z_offset: The vertical offset of the ground plane along the Z axis.\n
             Defaults to `0.0`.
     Returns:
-        int: The ID of the added ground geometry.
+        The ID of the added ground geometry.
     """
     return builder.add_geometry(
-        shape=PlaneShape(vec3f(0.0, 0.0, 1.0), 0.0),
-        offset=transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
+        shape=PlaneShape(wp.vec3f(0.0, 0.0, 1.0), 0.0),
+        offset=wp.transformf(0.0, 0.0, z_offset, 0.0, 0.0, 0.0, 1.0),
         name="ground",
         group=group,
         collides=collides,
@@ -92,28 +86,23 @@ def add_ground_box(
     Adds a static box geometry to a given builder to represent a flat ground with finite dimensions.
 
     Args:
-        builder (ModelBuilderKamino):
-            The model builder to which the ground box should be added.
-        group (int):
-            The collision group for the ground geometry.\n
+        builder: The model builder to which the ground box should be added.
+        group: The collision group for the ground geometry.\n
             Defaults to `1`.
-        collides (int):
-            The collision mask for the ground geometry.\n
+        collides: The collision mask for the ground geometry.\n
             Defaults to `1`.
-        world_index (int):
-            The index of the world in the builder where the ground geometry should be added.\n
+        world_index: The index of the world in the builder where the ground geometry should be added.\n
             If the value does not correspond to an existing world an error will be raised.\n
             Defaults to `0`.
-        z_offset (float):
-            The vertical offset of the ground box along the Z axis.\n
+        z_offset: The vertical offset of the ground box along the Z axis.\n
             Defaults to `0.0`.
 
     Returns:
-        int: The ID of the added ground geometry.
+        The ID of the added ground geometry.
     """
     return builder.add_geometry(
         shape=BoxShape(10.0, 10.0, 0.5),
-        offset=transformf(0.0, 0.0, -0.5 + z_offset, 0.0, 0.0, 0.0, 1.0),
+        offset=wp.transformf(0.0, 0.0, -0.5 + z_offset, 0.0, 0.0, 0.0, 1.0),
         name="ground",
         group=group,
         collides=collides,
@@ -121,25 +110,25 @@ def add_ground_box(
     )
 
 
-def set_uniform_body_pose_offset(builder: ModelBuilderKamino, offset: transformf):
+def set_uniform_body_pose_offset(builder: ModelBuilderKamino, offset: wp.transformf):
     """
     Offsets the initial poses of all rigid bodies existing in the builder uniformly by the specified offset.
 
     Args:
-        builder (ModelBuilderKamino): The model builder containing the bodies to offset.
-        offset (transformf): The pose offset to apply to each body in the builder in the form of a :class:`transformf`.
+        builder: The model builder containing the bodies to offset.
+        offset: The pose offset to apply to each body in the builder in the form of a :class:`wp.transformf`.
     """
     for body in builder.all_bodies:
         body.q_i_0 = wp.mul(offset, body.q_i_0)
 
 
-def set_uniform_body_twist_offset(builder: ModelBuilderKamino, offset: vec6f):
+def set_uniform_body_twist_offset(builder: ModelBuilderKamino, offset: wp.spatial_vectorf):
     """
     Offsets the initial twists of all rigid bodies existing in the builder uniformly by the specified offset.
 
     Args:
-        builder (ModelBuilderKamino): The model builder containing the bodies to offset.
-        offset (vec6f): The twist offset to apply to each body in the builder in the form of a :class:`vec6f`.
+        builder: The model builder containing the bodies to offset.
+        offset: The twist offset to apply to each body in the builder in the form of a :class:`wp.spatial_vectorf`.
     """
     for body in builder.all_bodies:
         body.u_i_0 += offset
@@ -168,7 +157,7 @@ def build_usd(
         ground: Whether to add a ground plane
 
     Returns:
-        ModelBuilderKamino with imported USD model and optional ground plane
+        Model builder with imported USD model and optional ground plane.
     """
     # Import the USD model
     importer = USDImporter()
@@ -191,13 +180,13 @@ def make_homogeneous_builder(num_worlds: int, build_fn: Callable, show_progress=
     Utility factory function to create a multi-world builder with identical worlds replicated across the model.
 
     Args:
-        num_worlds (int): The number of worlds to create.
-        build_fn (callable): The model builder function to use.
-        show_progress (bool): Whether to display a progress bar as the worlds are being replicated.
+        num_worlds: The number of worlds to create.
+        build_fn: The model builder function to use.
+        show_progress: Whether to display a progress bar as the worlds are being replicated.
         **kwargs: Additional keyword arguments to pass to the builder function.
 
     Returns:
-        ModelBuilderKamino: The constructed model builder.
+        The constructed model builder.
     """
     # First build a single world
     # NOTE: We want to do this first to avoid re-constructing the same model multiple

--- a/newton/_src/solvers/kamino/_src/models/builders/utils.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/utils.py
@@ -53,14 +53,14 @@ def add_ground_plane(
 
     Args:
         builder: The model builder to which the ground plane should be added.
-        group: The collision group for the ground geometry.\n
+        group: The collision group for the ground geometry.
             Defaults to `1`.
-        collides: The collision mask for the ground geometry.\n
+        collides: The collision mask for the ground geometry.
             Defaults to `1`.
-        world_index: The index of the world in the builder where the ground geometry should be added.\n
-            If the value does not correspond to an existing world an error will be raised.\n
+        world_index: The index of the world in the builder where the ground geometry should be added.
+            If the value does not correspond to an existing world an error will be raised.
             Defaults to `0`.
-        z_offset: The vertical offset of the ground plane along the Z axis.\n
+        z_offset: The vertical offset of the ground plane along the Z axis.
             Defaults to `0.0`.
     Returns:
         The ID of the added ground geometry.
@@ -87,14 +87,14 @@ def add_ground_box(
 
     Args:
         builder: The model builder to which the ground box should be added.
-        group: The collision group for the ground geometry.\n
+        group: The collision group for the ground geometry.
             Defaults to `1`.
-        collides: The collision mask for the ground geometry.\n
+        collides: The collision mask for the ground geometry.
             Defaults to `1`.
-        world_index: The index of the world in the builder where the ground geometry should be added.\n
-            If the value does not correspond to an existing world an error will be raised.\n
+        world_index: The index of the world in the builder where the ground geometry should be added.
+            If the value does not correspond to an existing world an error will be raised.
             Defaults to `0`.
-        z_offset: The vertical offset of the ground box along the Z axis.\n
+        z_offset: The vertical offset of the ground box along the Z axis.
             Defaults to `0.0`.
 
     Returns:

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -9,6 +9,7 @@ simulating constrained multi-body systems for arbitrary mechanical assemblies.
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Any
 
 import warp as wp
 
@@ -26,7 +27,6 @@ from .core.joints import JointCorrectionMode
 from .core.model import ModelKamino
 from .core.state import StateKamino
 from .core.time import advance_time
-from .core.types import float32, transformf, vec6f
 from .dynamics.dual import DualProblem
 from .dynamics.wrenches import (
     compute_constraint_body_wrenches,
@@ -117,9 +117,9 @@ class SolverKaminoImpl(SolverBase):
         config is provided, a default config will be used.
 
         Args:
-            model (ModelKamino): The multi-body systems model to simulate.
-            contacts (ContactsKamino): The contact data container for the simulation.
-            config (SolverKaminoImpl.Config | None): Optional solver config.
+            model: The multi-body systems model to simulate.
+            contacts: The contact data container for the simulation.
+            config: Optional solver config.
         """
         # Ensure the input containers are valid
         if not isinstance(model, ModelKamino):
@@ -256,11 +256,11 @@ class SolverKaminoImpl(SolverBase):
         # Allocate additional internal data for reset operations
         with wp.ScopedDevice(self._model.device):
             self._all_worlds_mask = wp.ones(shape=(self._model.size.num_worlds,), dtype=wp.bool)
-            self._base_q = wp.zeros(shape=(self._model.size.num_worlds,), dtype=transformf)
-            self._base_u = wp.zeros(shape=(self._model.size.num_worlds,), dtype=vec6f)
-            self._bodies_u_zeros = wp.zeros(shape=(self._model.size.sum_of_num_bodies,), dtype=vec6f)
-            self._actuators_q = wp.zeros(shape=(self._model.size.sum_of_num_actuated_joint_coords,), dtype=float32)
-            self._actuators_u = wp.zeros(shape=(self._model.size.sum_of_num_actuated_joint_dofs,), dtype=float32)
+            self._base_q = wp.zeros(shape=(self._model.size.num_worlds,), dtype=wp.transformf)
+            self._base_u = wp.zeros(shape=(self._model.size.num_worlds,), dtype=wp.spatial_vectorf)
+            self._bodies_u_zeros = wp.zeros(shape=(self._model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf)
+            self._actuators_q = wp.zeros(shape=(self._model.size.sum_of_num_actuated_joint_coords,), dtype=wp.float32)
+            self._actuators_u = wp.zeros(shape=(self._model.size.sum_of_num_actuated_joint_dofs,), dtype=wp.float32)
 
         # Allocate the contacts warmstarter if enabled
         self._ws_limits: WarmstarterLimits | None = None
@@ -382,7 +382,7 @@ class SolverKaminoImpl(SolverBase):
     def reset(
         self,
         state: StateKamino,
-        world_mask: wp.array | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
         config: SolverKamino.ResetConfig | None = None,
     ):
         """
@@ -400,13 +400,13 @@ class SolverKaminoImpl(SolverBase):
             state: The simulation state to reset (modified in place).
             world_mask: Optional array of per-world masks indicating which
                 worlds should be reset.
-                Shape of ``(num_worlds,)`` and type :class:`wp.int8` | :class:`wp.bool`.
+                Shape of ``(num_worlds,)``.
             config: Optional reset configuration, controlling the reset behavior
                 for body poses/velocities as well as floating base pose/velocity.
                 If not provided, all components are reset to default (initial) values.
         """
 
-        def _check_length(data: wp.array, name: str, expected: int):
+        def _check_length(data: wp.array[Any], name: str, expected: int):
             if data is not None and data.shape[0] != expected:
                 raise ValueError(f"Invalid shape for {name}: Expected ({expected},), but got {data.shape}.")
 
@@ -641,19 +641,13 @@ class SolverKaminoImpl(SolverBase):
         `contacts`. The updated state is written to `state_out`.
 
         Args:
-            state_in (StateKamino):
-                The input current state of the simulation.
-            state_out (StateKamino):
-                The output next state after time integration.
-            control (ControlKamino):
-                The input controls applied to the system.
-            contacts (ContactsKamino, optional):
-                The set of active contacts.
-            detector (CollisionDetector, optional):
-                An optional collision detector to use for generating contacts at the current state.\n
+            state_in: The input current state of the simulation.
+            state_out: The output next state after time integration.
+            control: The input controls applied to the system.
+            contacts: The set of active contacts.
+            detector: An optional collision detector to use for generating contacts at the current state.\n
                 If `None`, the `contacts` data will be used as the current set of active contacts.
-            dt (float, optional):
-                A uniform time-step to apply uniformly to all worlds of the simulation.
+            dt: A uniform time-step to apply uniformly to all worlds of the simulation.
         """
         # If specified, configure the internal per-world solver time-step uniformly from the input argument
         if dt is not None:
@@ -839,7 +833,7 @@ class SolverKaminoImpl(SolverBase):
         # Reset the forward dynamics solver
         self._solver_fd.reset()
 
-    def _reset_solver_data(self, world_mask: wp.array | None = None):
+    def _reset_solver_data(self, world_mask: wp.array[wp.bool] | None = None):
         """
         Resets solver internal data and calls reset callbacks.
 
@@ -870,7 +864,7 @@ class SolverKaminoImpl(SolverBase):
     # Internals - Step Operations
     ###
 
-    def _update_joints_data(self, q_j_p: wp.array | None = None):
+    def _update_joints_data(self, q_j_p: wp.array[wp.float32] | None = None):
         """
         Updates the joint states based on the current body states.
         """
@@ -1034,21 +1028,15 @@ class SolverKaminoImpl(SolverBase):
         and total effective body wrenches applied to each body of the system.
 
         Args:
-            state_in (`StateKamino`):
-                State of the system at the current time-step.
-            state_out (`StateKamino`):
-                State of the system at the next time-step.
-            control (`ControlKamino`):
-                Input controls applied to the system.
-            limits (`LimitsKamino`, optional):
-                Optional container for joint limits.
+            state_in: State of the system at the current time-step.
+            state_out: State of the system at the next time-step.
+            control: Input controls applied to the system.
+            limits: Optional container for joint limits.
                 If `None`, joint limit handling is skipped.
-            contacts (`ContactsKamino`, optional):
-                Optional container of active contacts.
+            contacts: Optional container of active contacts.
                 If `None`, the solver will use the internal collision detector
                 if the model admits contacts, or skip contact handling if not.
-            detector (`CollisionDetector`, optional):
-                Optional collision detector.
+            detector: Optional collision detector.
                 If `None`, collision detection is skipped.
         """
         # Update intermediate quantities of the bodies and joints

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -645,7 +645,7 @@ class SolverKaminoImpl(SolverBase):
             state_out: The output next state after time integration.
             control: The input controls applied to the system.
             contacts: The set of active contacts.
-            detector: An optional collision detector to use for generating contacts at the current state.\n
+            detector: An optional collision detector to use for generating contacts at the current state.
                 If `None`, the `contacts` data will be used as the current set of active contacts.
             dt: A uniform time-step to apply uniformly to all worlds of the simulation.
         """

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -3,6 +3,8 @@
 
 """Defines the Warp kernels used by the Forward Kinematics solver."""
 
+from __future__ import annotations
+
 from functools import cache
 
 import warp as wp
@@ -20,7 +22,6 @@ from ...core.math import (
     unit_quat_conj_apply_jacobian,
     unit_quat_conj_to_rotation_matrix,
 )
-from ...core.types import vec6f
 from ...kinematics.joints import get_joint_coords_mapping_function
 from ...linalg.sparse_matrix import BlockDType
 from .types import FKJointDoFType
@@ -218,12 +219,9 @@ def _eval_fk_actuated_dofs_or_coords(
     main model actuated dofs/coords, and negative indices for base dofs/coords (base dof/coord i is stored as -i - 1)
 
     Inputs:
-        model_base_dofs:
-            Base dofs or coordinates of the main model (as a flat vector with 6 dofs or 7 coordinates per world)
-        model_actuated_dofs:
-            Actuated dofs/coords of the main model
-        actuated_dofs_map:
-            Map of fk to main model actuated/base dofs/coords
+        model_base_dofs: Base dofs or coordinates of the main model (as a flat vector with 6 dofs or 7 coordinates per world)
+        model_actuated_dofs: Actuated dofs/coords of the main model
+        actuated_dofs_map: Map of fk to main model actuated/base dofs/coords
     Outputs:
         fk_actuated_dofs: Actuated dofs or coordinates of the fk model
     """
@@ -1316,7 +1314,7 @@ def create_2d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
         More specifically, given an integer matrix of zeros and ones representing a sparsity pattern, multiply it by
         its transpose and clip values to [0, 1] to get the sparsity pattern of J^T * J
         Note: mostly redundant with _eval_jacobian_T_jacobian apart from the clipping, could possibly be removed
-        (was initially written to take int32, but float32 is actually faster)
+        (was initially written to take wp.int32, but wp.float32 is actually faster)
 
         Inputs:
             sparsity_pattern: Jacobian sparsity pattern per world
@@ -1490,7 +1488,7 @@ def create_1d_tile_based_kernels(TILE_SIZE_CTS: wp.int32, TILE_SIZE_VRS: wp.int3
 
     @wp.func
     def _isnan(x: wp.float32) -> wp.int32:
-        """Calls wp.isnan and converts the result to int32"""
+        """Calls wp.isnan and converts the result to wp.int32"""
         return wp.int32(wp.isnan(x))
 
     TILE_SIZE = TILE_SIZE_VRS if use_regularization else TILE_SIZE_CTS
@@ -1990,7 +1988,7 @@ def _eval_body_velocities(
     bodies_q_dot: wp.array2d[wp.float32],
     world_mask: wp.array[wp.bool],
     # Outputs
-    bodies_u: wp.array[vec6f],
+    bodies_u: wp.array[wp.spatial_vectorf],
 ):
     """
     A kernel computing the body velocities (twists) from the time derivative of body poses,

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -17,7 +17,7 @@ import warp as wp
 from ....config import ForwardKinematicsSolverConfig
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.model import ModelKamino
-from ...core.types import assign_to_warp_int32_array, to_warp_int32_array, vec6f
+from ...core.types import assign_to_warp_int32_array, to_warp_int32_array
 from ...linalg.blas import (
     block_sparse_ATA_blockwise_3_4_inv_diagonal_2d,
     block_sparse_ATA_inv_diagonal_2d,
@@ -104,13 +104,10 @@ class ForwardKinematicsSolver:
         """
         Initializes the solver to solve forward kinematics for a given model.
 
-        Parameters
-        ----------
-        model : ModelKamino, optional
-            ModelKamino for which to solve forward kinematics. If not provided, the finalize() method
-            must be called at a later time for deferred initialization (default: None).
-        config : ForwardKinematicsSolver.Config, optional
-            Solver config. If not provided, the default config will be used (default: None).
+        Args:
+            model: Model for which to solve forward kinematics. If not provided, the finalize() method
+                must be called at a later time for deferred initialization.
+            config: Solver config. If not provided, the default config will be used.
         """
 
         self.model: ModelKamino | None = None
@@ -140,14 +137,11 @@ class ForwardKinematicsSolver:
         This method only needs to be called manually if a model was not provided in the constructor,
         or to reset the solver for a new model.
 
-        Parameters
-        ----------
-        model : ModelKamino, optional
-            ModelKamino for which to solve forward kinematics. If not provided, the model given to the
-            constructor will be used. Must be provided if not given to the constructor (default: None).
-        config : ForwardKinematicsSolver.Config, optional
-            Solver config. If not provided, the config given to the constructor, or if not, the
-            default config will be used (default: None).
+        Args:
+            model: Model for which to solve forward kinematics. If not provided, the model given to the
+                constructor will be used. Must be provided if not given to the constructor.
+            config: Solver config. If not provided, the config given to the constructor, or if not, the
+                default config will be used.
         """
 
         # Initialize the model and config if provided
@@ -571,7 +565,7 @@ class ForwardKinematicsSolver:
 
             # Default base state
             self.base_q_default = wp.from_numpy(base_q_default, dtype=wp.transformf)
-            self.base_u_default = wp.zeros(shape=(self.num_worlds,), dtype=vec6f)
+            self.base_u_default = wp.zeros(shape=(self.num_worlds,), dtype=wp.spatial_vectorf)
 
             # Line search
             self.max_line_search_iterations = wp.array(dtype=wp.int32, shape=(1,))  # Max iterations
@@ -1695,10 +1689,10 @@ class ForwardKinematicsSolver:
     def _solve_for_body_velocities(
         self,
         target_rel_transforms: wp.array[wp.transformf],
-        base_u: wp.array[vec6f],
+        base_u: wp.array[wp.spatial_vectorf],
         actuators_u: wp.array[wp.float32],
         bodies_q: wp.array[wp.transformf],
-        bodies_u: wp.array[vec6f],
+        bodies_u: wp.array[wp.spatial_vectorf],
         world_mask: wp.array[wp.bool],
     ):
         """
@@ -1820,7 +1814,7 @@ class ForwardKinematicsSolver:
 
     def eval_kinematic_constraints(
         self, bodies_q: wp.array[wp.transformf], target_rel_transforms: wp.array[wp.transformf]
-    ):
+    ) -> wp.array2d[wp.float32]:
         """
         Evaluates and returns the kinematic constraints vector given the body poses and the position
         control transformations.
@@ -1842,7 +1836,7 @@ class ForwardKinematicsSolver:
 
     def eval_kinematic_constraints_jacobian(
         self, bodies_q: wp.array[wp.transformf], target_rel_transforms: wp.array[wp.transformf]
-    ):
+    ) -> wp.array3d[wp.float32]:
         """
         Evaluates and returns the kinematic constraints Jacobian (w.r.t. body poses) given the body poses
         and the position control transformations.
@@ -1874,8 +1868,8 @@ class ForwardKinematicsSolver:
         self,
         actuators_u: wp.array[wp.float32],
         bodies_q: wp.array[wp.transformf],
-        bodies_u: wp.array[vec6f],
-        base_u: wp.array[vec6f] | None = None,
+        bodies_u: wp.array[wp.spatial_vectorf],
+        base_u: wp.array[wp.spatial_vectorf] | None = None,
         target_rel_transforms: wp.array[wp.transformf] | None = None,
         world_mask: wp.array[wp.bool] | None = None,
     ):
@@ -1884,34 +1878,27 @@ class ForwardKinematicsSolver:
         More specifically, solves for body twists yielding zero constraint velocities, except at
         actuated dofs and at the base joint, where velocities must match prescribed velocities.
 
-        Parameters
-        ----------
-        actuators_u : wp.array
-            Array of actuated joint velocities.
-            Expects shape of ``(sum_of_num_actuated_joint_dofs,)`` and type :class:`float`.
-        bodies_q : wp.array
-            Array of rigid body poses. Must be the solution of FK given the position-control transforms.
-            Expects shape of ``(num_bodies,)`` and type :class:`transform`.
-        bodies_u : wp.array
-            Array of rigid body velocities (twists), written out by the solver.
-            Expects shape of ``(num_bodies,)`` and type :class:`vec6`.
-        base_u : wp.array, optional
-            Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
-            absolute otherwise.
-            If not provided, will default to zero. Ignored if no base body or joint was set for this model.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_worlds,)`` and type :class:`vec6`.
-        target_rel_transforms : wp.array, optional
-            Array of position-control transforms, encoding actuated coordinates and base pose.
-            Expects shape of ``(num_fk_joints,)`` and type :class:`transform`
-            If not provided, will be inferred from bodies_q, reading actuated coordinates and base pose
-            from body poses (assuming they are consistent).
-            If this function is captured in a graph, must be either always or never provided.
-        world_mask : wp.array, optional
-            Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
-            If not provided, all worlds are processed.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_worlds,)`` and type :class:`bool`.
+        Args:
+            actuators_u: Array of actuated joint velocities.
+                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+            bodies_q: Array of rigid body poses. Must be the solution of FK given the position-control transforms.
+                Expects shape of ``(num_bodies,)``.
+            bodies_u: Array of rigid body velocities (twists), written out by the solver.
+                Expects shape of ``(num_bodies,)``.
+            base_u: Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
+                absolute otherwise.
+                If not provided, will default to zero. Ignored if no base body or joint was set for this model.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_worlds,)``.
+            target_rel_transforms: Array of position-control transforms, encoding actuated coordinates and base pose.
+                Expects shape of ``(num_fk_joints,)``.
+                If not provided, will be inferred from bodies_q, reading actuated coordinates and base pose
+                from body poses (assuming they are consistent).
+                If this function is captured in a graph, must be either always or never provided.
+            world_mask: Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
+                If not provided, all worlds are processed.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_worlds,)``.
         """
         assert actuators_u.device == self.device
         assert bodies_q.device == self.device
@@ -1942,8 +1929,8 @@ class ForwardKinematicsSolver:
         bodies_q: wp.array[wp.transformf],
         base_q: wp.array[wp.transformf] | None = None,
         actuators_u: wp.array[wp.float32] | None = None,
-        base_u: wp.array[vec6f] | None = None,
-        bodies_u: wp.array[vec6f] | None = None,
+        base_u: wp.array[wp.spatial_vectorf] | None = None,
+        bodies_u: wp.array[wp.spatial_vectorf] | None = None,
         world_mask: wp.array[wp.bool] | None = None,
     ):
         """
@@ -1954,41 +1941,33 @@ class ForwardKinematicsSolver:
         base pose. Optionally also solves for rigid body velocities
         given actuator and base body velocities.
 
-        Parameters
-        ----------
-        actuators_q : wp.array
-            Array of actuated joint coordinates.
-            Expects shape of ``(sum_of_num_actuated_joint_coords,)`` and type :class:`float`.
-        bodies_q : wp.array
-            Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
-            solver setting is False.
-            Expects shape of ``(num_bodies,)`` and type :class:`transform`.
-        base_q : wp.array, optional
-            Pose of the base body for each world, in the frame of the base joint if it was set, or absolute otherwise.
-            If not provided, will default to zero coordinates of the base joint, or the initial pose of the base body.
-            If no base body or joint was set for this model, will be ignored.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_worlds,)`` and type :class:`transform`.
-        actuators_u : wp.array, optional
-            Array of actuated joint velocities.
-            Must be provided when solving for body velocities, i.e. if bodies_u is provided.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(sum_of_num_actuated_joint_dofs,)`` and type :class:`float`.
-        base_u : wp.array, optional
-            Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
-            absolute otherwise.
-            If not provided, will default to zero. Ignored if no base body or joint was set for this model.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_worlds,)`` and type :class:`vec6`.
-        bodies_u : wp.array, optional
-            Array of rigid body velocities (twists), written out by the solver if provided.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_bodies,)`` and type :class:`vec6`.
-        world_mask : wp.array, optional
-            Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
-            If not provided, all worlds are processed.
-            If this function is captured in a graph, must be either always or never provided.
-            Expects shape of ``(num_worlds,)`` and type :class:`bool`.
+        Args:
+            actuators_q: Array of actuated joint coordinates.
+                Expects shape of ``(sum_of_num_actuated_joint_coords,)``.
+            bodies_q: Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
+                solver setting is False.
+                Expects shape of ``(num_bodies,)``.
+            base_q: Pose of the base body for each world, in the frame of the base joint if it was set, or absolute otherwise.
+                If not provided, will default to zero coordinates of the base joint, or the initial pose of the base body.
+                If no base body or joint was set for this model, will be ignored.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_worlds,)``.
+            actuators_u: Array of actuated joint velocities.
+                Must be provided when solving for body velocities, i.e. if bodies_u is provided.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+            base_u: Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
+                absolute otherwise.
+                If not provided, will default to zero. Ignored if no base body or joint was set for this model.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_worlds,)``.
+            bodies_u: Array of rigid body velocities (twists), written out by the solver if provided.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_bodies,)``.
+            world_mask: Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
+                If not provided, all worlds are processed.
+                If this function is captured in a graph, must be either always or never provided.
+                Expects shape of ``(num_worlds,)``.
         """
         # Check that actuators_u are provided if we need to solve for bodies_u
         if bodies_u is not None and actuators_u is None:
@@ -2072,8 +2051,8 @@ class ForwardKinematicsSolver:
         bodies_q: wp.array[wp.transformf],
         base_q: wp.array[wp.transformf] | None = None,
         actuators_u: wp.array[wp.float32] | None = None,
-        base_u: wp.array[vec6f] | None = None,
-        bodies_u: wp.array[vec6f] | None = None,
+        base_u: wp.array[wp.spatial_vectorf] | None = None,
+        bodies_u: wp.array[wp.spatial_vectorf] | None = None,
         world_mask: wp.array[wp.bool] | None = None,
         verbose: bool = False,
         return_status: bool = False,
@@ -2086,48 +2065,36 @@ class ForwardKinematicsSolver:
         coordinates and base pose. Optionally also solves for rigid body velocities
         given actuator and base body velocities.
 
-        Parameters
-        ----------
-        actuators_q : wp.array
-            Array of actuated joint coordinates.
-            Expects shape of ``(sum_of_num_actuated_joint_coords,)`` and type :class:`float`.
-        bodies_q : wp.array
-            Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
-            solver setting is False.
-            Expects shape of ``(num_bodies,)`` and type :class:`transform`.
-        base_q : wp.array, optional
-            Pose of the base body for each world, in the frame of the base joint if it was set, or absolute otherwise.
-            If not provided, will default to zero coordinates of the base joint, or the initial pose of the base body.
-            If no base body or joint was set for this model, will be ignored.
-            Expects shape of ``(num_worlds,)`` and type :class:`transform`.
-        actuators_u : wp.array, optional
-            Array of actuated joint velocities.
-            Must be provided when solving for body velocities, i.e. if bodies_u is provided.
-            Expects shape of ``(sum_of_num_actuated_joint_dofs,)`` and type :class:`float`.
-        base_u : wp.array, optional
-            Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
-            absolute otherwise.
-            If not provided, will default to zero. Ignored if no base body or joint was set for this model.
-            Expects shape of ``(num_worlds,)`` and type :class:`vec6`.
-        bodies_u : wp.array, optional
-            Array of rigid body velocities (twists), written out by the solver if provided.
-            Expects shape of ``(num_bodies,)`` and type :class:`vec6`.
-        world_mask : wp.array, optional
-            Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
-            If not provided, all worlds are processed.
-            Expects shape of ``(num_worlds,)`` and type :class:`bool`.
-        verbose : bool, optional
-            whether to write a status message at the end (default: False)
-        return_status : bool, optional
-            whether to return the detailed solver status (default: False)
-        use_graph : bool, optional
-            whether to use graph capture internally to accelerate multiple calls to this function. Can be turned
-            off for profiling individual kernels (default: True)
+        Args:
+            actuators_q: Array of actuated joint coordinates.
+                Expects shape of ``(sum_of_num_actuated_joint_coords,)``.
+            bodies_q: Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
+                solver setting is False.
+                Expects shape of ``(num_bodies,)``.
+            base_q: Pose of the base body for each world, in the frame of the base joint if it was set, or absolute otherwise.
+                If not provided, will default to zero coordinates of the base joint, or the initial pose of the base body.
+                If no base body or joint was set for this model, will be ignored.
+                Expects shape of ``(num_worlds,)``.
+            actuators_u: Array of actuated joint velocities.
+                Must be provided when solving for body velocities, i.e. if bodies_u is provided.
+                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+            base_u: Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
+                absolute otherwise.
+                If not provided, will default to zero. Ignored if no base body or joint was set for this model.
+                Expects shape of ``(num_worlds,)``.
+            bodies_u: Array of rigid body velocities (twists), written out by the solver if provided.
+                Expects shape of ``(num_bodies,)``.
+            world_mask: Per-world boolean flags selecting which worlds to process (``False`` leaves a world unchanged).
+                If not provided, all worlds are processed.
+                Expects shape of ``(num_worlds,)``.
+            verbose: Whether to write a status message at the end (default: False)
+            return_status: Whether to return the detailed solver status (default: False)
+            use_graph: Whether to use graph capture internally to accelerate multiple calls to this function. Can be turned
+                off for profiling individual kernels (default: True)
 
-        Returns
-        -------
-        solver_status : ForwardKinematicsSolverStatus, optional
-            the detailed solver status with success flag, number of iterations and constraint residual per world
+        Returns:
+            If return_status is True, the detailed solver status with success flag, number of iterations
+            and constraint residual per world; otherwise nothing.
         """
         assert base_q is None or base_q.device == self.device
         assert actuators_q.device == self.device

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -85,7 +85,7 @@ class ForwardKinematicsStatus:
     success: np.ndarray(dtype=np.int32)
     """
     Solver success flag per world, as an integer array (0 = failure, 1 = success).\n
-    Shape `(num_worlds,)` and type :class:`np.int32`.
+    Shape of `(num_worlds,)`.
 
     Note that in some cases the solver may fail to converge within the maximum number
     of iterations, but still produce a solution with a reasonable residual.
@@ -97,7 +97,7 @@ class ForwardKinematicsStatus:
     iterations: np.ndarray(dtype=np.int32)
     """
     Number of Gauss-Newton iterations executed per world.\n
-    Shape `(num_worlds,)` and type :class:`np.int32`.
+    Shape of `(num_worlds,)`.
     """
 
     max_residual: np.ndarray(dtype=np.float32)
@@ -105,5 +105,5 @@ class ForwardKinematicsStatus:
     Maximal absolute residual at the final solution, per world. In the general case, the residual vector
     is the kinematic constraints vector; if regularization is enabled, it is the penalty gradient.
 
-    Shape `(num_worlds,)` and type :class:`np.float32`.
+    Shape of `(num_worlds,)`.
     """

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -84,7 +84,7 @@ class ForwardKinematicsStatus:
 
     success: np.ndarray(dtype=np.int32)
     """
-    Solver success flag per world, as an integer array (0 = failure, 1 = success).\n
+    Solver success flag per world, as an integer array (0 = failure, 1 = success).
     Shape of `(num_worlds,)`.
 
     Note that in some cases the solver may fail to converge within the maximum number
@@ -96,7 +96,7 @@ class ForwardKinematicsStatus:
 
     iterations: np.ndarray(dtype=np.int32)
     """
-    Number of Gauss-Newton iterations executed per world.\n
+    Number of Gauss-Newton iterations executed per world.
     Shape of `(num_worlds,)`.
     """
 

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -300,7 +300,7 @@ class SolutionMetricsData:
 
     r_ncp_primal_argmax: wp.array[wp.int32] | None = None
     """
-    The index of the constraint with the largest NCP primal residual.\n
+    The index of the constraint with the largest NCP primal residual.
     Shape of ``(num_worlds,)``.
     """
 
@@ -560,7 +560,7 @@ def compute_vector_difference_infnorm(
     y: wp.array[wp.float32],
 ) -> tuple[wp.float32, wp.int32]:
     """
-    Computes the infinity norm of the element-wise difference between vectors `x` and `y`.\n
+    Computes the infinity norm of the element-wise difference between vectors `x` and `y`.
     Both vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -72,6 +72,8 @@ A typical example for using this module is:
     )
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import warp as wp
@@ -80,7 +82,7 @@ from ..core.data import DataKamino
 from ..core.math import screw, screw_angular, screw_linear
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
-from ..core.types import float32, int32, int64, mat33f, uint32, vec2f, vec3f, vec4f, vec6f
+from ..core.types import vec6f
 from ..dynamics.dual import DualProblem
 from ..geometry.contacts import ContactsKamino
 from ..geometry.keying import build_pair_key2
@@ -126,28 +128,19 @@ class SolutionMetricsData:
     of the computed solution to the dual forward-dynamics Nonlinear Complementarity Problem (NCP).
 
     Attributes:
-        r_eom (wp.array):
-            The largest residual across all DoF dimensions of the Equations-of-Motion (EoM).
-        r_kinematics (wp.array):
-            The largest residual across all kinematic bilateral (i.e. equality) constraints.
-        r_cts_joints (wp.array):
-            The largest constraint violation residual across all bilateral kinematic joint constraints.
-        r_cts_limits (wp.array):
-            The largest constraint violation residual across all unilateral joint-limit constraints.
-        r_cts_contacts (wp.array):
-            The largest constraint violation residual across all contact constraints.
-        r_ncp_primal (wp.array):
-            The NCP primal residual representing the violation of set-valued constraint reactions.
-        r_ncp_dual (wp.array):
-            The NCP dual residual representing the violation of set-valued augmented constraint velocities.
-        r_ncp_compl (wp.array):
-            The NCP complementarity residual representing the violation of complementarity conditions.
-        r_vi_natmap (wp.array):
-            The Variational Inequality (VI) natural-map residual representing the proximity
+        r_eom: The largest residual across all DoF dimensions of the Equations-of-Motion (EoM).
+        r_kinematics: The largest residual across all kinematic bilateral (i.e. equality) constraints.
+        r_cts_joints: The largest constraint violation residual across all bilateral kinematic joint constraints.
+        r_cts_limits: The largest constraint violation residual across all unilateral joint-limit constraints.
+        r_cts_contacts: The largest constraint violation residual across all contact constraints.
+        r_ncp_primal: The NCP primal residual representing the violation of set-valued constraint reactions.
+        r_ncp_dual: The NCP dual residual representing the violation of set-valued augmented constraint velocities.
+        r_ncp_compl: The NCP complementarity residual representing the violation of complementarity conditions.
+        r_vi_natmap: The Variational Inequality (VI) natural-map residual representing the proximity
             of the constraint reactions to a true solution of the VI defined by the NCP.
     """
 
-    r_eom: wp.array | None = None
+    r_eom: wp.array[wp.float32] | None = None
     """
     The largest residual across all DoF dimensions of the Equations-of-Motion (EoM).
 
@@ -168,18 +161,18 @@ class SolutionMetricsData:
     - `J_dofs` is the actuation Jacobian matrix
     - `tau` is the vector of generalized actuation forces
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_eom_argmax: wp.array | None = None
+    r_eom_argmax: wp.array[wp.int64] | None = None
     """
     The index pair key computed from the body index and
     degree-of-freedom (DoF) with the largest EoM residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int64`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_kinematics: wp.array | None = None
+    r_kinematics: wp.array[wp.float32] | None = None
     """
     The largest residual across all kinematic bilateral (i.e. equality) constraints.
 
@@ -193,18 +186,18 @@ class SolutionMetricsData:
     - `J_cts_joints` is the constraint Jacobian matrix for bilateral joint constraints
     - `u^+` is the post-event generalized velocity
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_kinematics_argmax: wp.array | None = None
+    r_kinematics_argmax: wp.array[wp.int64] | None = None
     """
     The index pair key computed from the joint index and
     bilateral kinematic constraint with the largest residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int64`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_joints: wp.array | None = None
+    r_cts_joints: wp.array[wp.float32] | None = None
     """
     The largest constraint violation residual across all bilateral joint constraints.
 
@@ -213,18 +206,18 @@ class SolutionMetricsData:
     Equivalent to `r_cts_joints := || r_j ||_inf`, where `r_j` is the
     array of joint constraint residuals defined in :class:`JointsData`.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_joints_argmax: wp.array | None = None
+    r_cts_joints_argmax: wp.array[wp.int64] | None = None
     """
     The index pair key computed from the joint index and bilateral
     kinematic joint constraint with the largest residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int64`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_limits: wp.array | None = None
+    r_cts_limits: wp.array[wp.float32] | None = None
     """
     The largest constraint violation residual across all unilateral joint-limit constraints.
 
@@ -233,18 +226,18 @@ class SolutionMetricsData:
     Equivalent to `r_cts_limits := || r_l ||_inf`, where `r_l` would be an array of joint-limit
     constraint residuals constructed from the collection of `r_q` elements defined in :class:`LimitsKaminoData`.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_limits_argmax: wp.array | None = None
+    r_cts_limits_argmax: wp.array[wp.int64] | None = None
     """
     The index pair key computed from the joint index and degree-of-freedom
     (DoF) with the largest unilateral joint-limit constraint residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int64`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_contacts: wp.array | None = None
+    r_cts_contacts: wp.array[wp.float32] | None = None
     """
     The largest constraint violation residual across all contact constraints.
 
@@ -253,17 +246,17 @@ class SolutionMetricsData:
     Equivalent to `r_cts_contacts := || d_k ||_inf`, where `d_k` would be an array of
     contact penetrations extracted from the `gapfunc` elements of :class:`ContactsKaminoData`.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_cts_contacts_argmax: wp.array | None = None
+    r_cts_contacts_argmax: wp.array[wp.int32] | None = None
     """
-    The indexir of the contact  with the largest unilateral contact constraint residual.
+    The index of the contact  with the largest unilateral contact constraint residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_v_plus: wp.array | None = None
+    r_v_plus: wp.array[wp.float32] | None = None
     """
     The largest error in the estimation of the post-event constraint-space velocity.
 
@@ -278,17 +271,17 @@ class SolutionMetricsData:
       `v_plus_true = v_f + D @ lambdas`, where `v_f` is the unconstrained constraint-space velocity,
       `D` is the Delassus operator, and `lambdas` is the vector of all constraint reactions (i.e. Lagrange multipliers).
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_v_plus_argmax: wp.array | None = None
+    r_v_plus_argmax: wp.array[wp.int32] | None = None
     """
     The index of the constraint with the largest post-event constraint-space velocity estimation error.
 
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_primal: wp.array | None = None
+    r_ncp_primal: wp.array[wp.float32] | None = None
     """
     The NCP primal residual representing the violation of set-valued constraint reactions.
 
@@ -302,16 +295,16 @@ class SolutionMetricsData:
     Euclidean projection, i.e. proximal operator, onto K, and `lambda` is the
     vector of all constraint reactions (i.e. Lagrange multipliers).
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_primal_argmax: wp.array | None = None
+    r_ncp_primal_argmax: wp.array[wp.int32] | None = None
     """
     The index of the constraint with the largest NCP primal residual.\n
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_dual: wp.array | None = None
+    r_ncp_dual: wp.array[wp.float32] | None = None
     """
     The NCP dual residual representing the violation of set-valued augmented constraint velocities.
 
@@ -325,17 +318,17 @@ class SolutionMetricsData:
     `v_hat^+ = v^+ + Gamma(v^+)`, where `v^+ := v_f D @ lambda` is the post-event
     constraint-space velocity, and `Gamma(v^+)` is the De Saxce correction term.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_dual_argmax: wp.array | None = None
+    r_ncp_dual_argmax: wp.array[wp.int32] | None = None
     """
     The index of the constraint with the largest NCP dual residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_compl: wp.array | None = None
+    r_ncp_compl: wp.array[wp.float32] | None = None
     """
     The NCP complementarity residual representing the violation of complementarity conditions.
 
@@ -348,17 +341,17 @@ class SolutionMetricsData:
     where `lambda` is the vector of all constraint reactions (i.e. Lagrange multipliers),
     and `v_hat^+` is the augmented constraint-space velocity defined above.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_ncp_compl_argmax: wp.array | None = None
+    r_ncp_compl_argmax: wp.array[wp.int32] | None = None
     """
     The index of the constraint with the largest NCP complementarity residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_vi_natmap: wp.array | None = None
+    r_vi_natmap: wp.array[wp.float32] | None = None
     """
     The Variational Inequality (VI) natural-map residual representing the proximity
     of the constraint reactions to a true solution of the VI defined by the NCP.
@@ -374,17 +367,17 @@ class SolutionMetricsData:
     `lambda` is the vector of all constraint reactions (i.e. Lagrange multipliers),
     and `v_hat^+(lambda)` is the augmented constraint-space velocity defined above.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    r_vi_natmap_argmax: wp.array | None = None
+    r_vi_natmap_argmax: wp.array[wp.int32] | None = None
     """
     The index of the constraint with the largest VI natural-map residual.
 
-    Shape of ``(num_worlds,)`` and type :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    f_ncp: wp.array | None = None
+    f_ncp: wp.array[wp.float32] | None = None
     """
     Evaluation of the NCP energy dissipation objective function.
 
@@ -399,10 +392,10 @@ class SolutionMetricsData:
     `f_ncp(lambda) = f_ccp(lambda) + lambda.T @ s`,
     where `f_ccp` is the CCP energy dissipation objective.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    f_ccp: wp.array | None = None
+    f_ccp: wp.array[wp.float32] | None = None
     """
     Evaluation of the CCP energy dissipation objective function.
 
@@ -417,7 +410,7 @@ class SolutionMetricsData:
     `f_ccp(lambda) := 0.5 * lambda.T @ (v+ + v_f)`,
     where `v+ = v_f + D @ lambda` is the post-event constraint-space velocity.
 
-    Shape of ``(num_worlds,)`` and type :class:`float32`.
+    Shape of ``(num_worlds,)``.
     """
 
     def clear(self):
@@ -467,15 +460,15 @@ class SolutionMetricsData:
 
 @wp.func
 def compute_v_plus(
-    dim: int32,
-    vio: int32,
-    mio: int32,
-    sigma: float32,
-    P: wp.array[float32],
-    D_p: wp.array[float32],
-    v_f_p: wp.array[float32],
-    lambdas: wp.array[float32],
-    v_plus: wp.array[float32],
+    dim: wp.int32,
+    vio: wp.int32,
+    mio: wp.int32,
+    sigma: wp.float32,
+    P: wp.array[wp.float32],
+    D_p: wp.array[wp.float32],
+    v_f_p: wp.array[wp.float32],
+    lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
 ):
     """
     Computes the post-event constraint-space velocity as:
@@ -497,18 +490,14 @@ def compute_v_plus(
     with dimensions `dim`, starting from the vector index offset `vio`.
 
     Args:
-        maxdim (int32): The maximum dimension of the matrix `A`.
-        dim (int32): The active dimension of the matrix `A` and the vectors `x, b, c`.
-        vio (int32): The vector index offset (i.e. start index) for the vectors `x, b, c`.
-        mio (int32): The matrix index offset (i.e. start index) for the matrix `A`.
-        D_p (wp.array[float32]):
-            Input preconditioned Delassus matrix stored in row-major order.
-        v_f_p (wp.array[float32]):
-            Input preconditioned unconstrained constraint-space velocity vector.
-        lambdas (wp.array[float32]):
-            Input constraint reactions (i.e. Lagrange multipliers) vector.
-        v_plus (wp.array[float32]):
-            Output array to store the post-event constraint-space velocity vector.
+        maxdim: The maximum dimension of the matrix `A`.
+        dim: The active dimension of the matrix `A` and the vectors `x, b, c`.
+        vio: The vector index offset (i.e. start index) for the vectors `x, b, c`.
+        mio: The matrix index offset (i.e. start index) for the matrix `A`.
+        D_p: Input preconditioned Delassus matrix stored in row-major order.
+        v_f_p: Input preconditioned unconstrained constraint-space velocity vector.
+        lambdas: Input constraint reactions (i.e. Lagrange multipliers) vector.
+        v_plus: Output array to store the post-event constraint-space velocity vector.
     """
     v_f_p_i = float(0.0)
     lambdas_j = float(0.0)
@@ -529,12 +518,12 @@ def compute_v_plus(
 
 @wp.func
 def compute_v_plus_sparse(
-    dim: int32,
-    vio: int32,
-    P: wp.array[float32],
-    v_f_p: wp.array[float32],
-    D_p_lambdas: wp.array[float32],
-    v_plus: wp.array[float32],
+    dim: wp.int32,
+    vio: wp.int32,
+    P: wp.array[wp.float32],
+    v_f_p: wp.array[wp.float32],
+    D_p_lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
 ):
     """
     Computes the post-event constraint-space velocity as:
@@ -551,15 +540,12 @@ def compute_v_plus_sparse(
     the vector index offset `vio`.
 
     Args:
-        dim (int32): The active dimension of the matrix `A` and the vectors `x, b, c`.
-        vio (int32): The vector index offset (i.e. start index) for the vectors `x, b, c`.
-        v_f_p (wp.array[float32]):
-            Input preconditioned unconstrained constraint-space velocity vector.
-        D_p_lambdas (wp.array[float32]):
-            Product of the Delassus matrix with the input constraint reactions
+        dim: The active dimension of the matrix `A` and the vectors `x, b, c`.
+        vio: The vector index offset (i.e. start index) for the vectors `x, b, c`.
+        v_f_p: Input preconditioned unconstrained constraint-space velocity vector.
+        D_p_lambdas: Product of the Delassus matrix with the input constraint reactions
             (i.e. Lagrange multipliers) vector.
-        v_plus (wp.array[float32]):
-            Output array to store the post-event constraint-space velocity vector.
+        v_plus: Output array to store the post-event constraint-space velocity vector.
     """
     for i in range(dim):
         v_i = vio + i
@@ -568,27 +554,26 @@ def compute_v_plus_sparse(
 
 @wp.func
 def compute_vector_difference_infnorm(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-    y: wp.array[float32],
-) -> tuple[float32, int32]:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
     """
-    Computes the sum of two vectors `x` and `y` and stores the result in vector `z`.\n
-    All vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
+    Computes the infinity norm of the element-wise difference between vectors `x` and `y`.\n
+    Both vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        x (wp.array[float32]): The first vector.
-        y (wp.array[float32]): The second vector.
-        z (wp.array[float32]): The output vector where the sum is stored.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        x: The first vector.
+        y: The second vector.
 
     Returns:
-        None: The result is stored in the output vector `z`.
+        Maximum absolute difference and index of the largest component.
     """
     max = float(0.0)
-    argmax = int32(-1)
+    argmax = wp.int32(-1)
     for i in range(dim):
         v_i = vio + i
         err = wp.abs(x[v_i] - y[v_i])
@@ -606,17 +591,17 @@ def compute_vector_difference_infnorm(
 @wp.kernel
 def _compute_eom_residual(
     # Inputs
-    model_time_dt: wp.array[float32],
-    model_gravity: wp.array[vec4f],
-    model_bodies_wid: wp.array[int32],
-    model_bodies_m_i: wp.array[float32],
-    state_bodies_I_i: wp.array[mat33f],
-    state_bodies_w_i: wp.array[vec6f],
-    state_bodies_u_i: wp.array[vec6f],
-    state_bodies_u_i_p: wp.array[vec6f],
+    model_time_dt: wp.array[wp.float32],
+    model_gravity: wp.array[wp.vec4f],
+    model_bodies_wid: wp.array[wp.int32],
+    model_bodies_m_i: wp.array[wp.float32],
+    state_bodies_I_i: wp.array[wp.mat33f],
+    state_bodies_w_i: wp.array[wp.spatial_vectorf],
+    state_bodies_u_i: wp.array[wp.spatial_vectorf],
+    state_bodies_u_i_p: wp.array[wp.spatial_vectorf],
     # Outputs
-    metric_r_eom: wp.array[float32],
-    metric_r_eom_argmax: wp.array[int64],
+    metric_r_eom: wp.array[wp.float32],
+    metric_r_eom_argmax: wp.array[wp.int64],
 ):
     # Retrieve the thread index as the body index
     bid = wp.tid()
@@ -632,7 +617,7 @@ def _compute_eom_residual(
     # Retrieve the time step
     dt = model_time_dt[wid]
     gravity = model_gravity[wid]
-    g = gravity.w * vec3f(gravity.x, gravity.y, gravity.z)
+    g = gravity.w * wp.vec3f(gravity.x, gravity.y, gravity.z)
 
     # Decompose into linear and angular parts
     f_i = screw_linear(w_i)
@@ -650,32 +635,32 @@ def _compute_eom_residual(
 
     # Compute the per-body maximum residual and argmax index
     r_eom_i = wp.max(r_i)
-    r_eom_argmax_i = int32(wp.argmax(r_i))
+    r_eom_argmax_i = wp.int32(wp.argmax(r_i))
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_eom, wid, r_eom_i)
     if r_eom_i >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(bid), uint32(r_eom_argmax_i)))
-        wp.atomic_exch(metric_r_eom_argmax, int32(wid), argmax_key)
+        argmax_key = wp.int64(build_pair_key2(wp.uint32(bid), wp.uint32(r_eom_argmax_i)))
+        wp.atomic_exch(metric_r_eom_argmax, wp.int32(wid), argmax_key)
 
 
 @wp.kernel
 def _compute_joint_kinematics_residual_dense(
     # Inputs:
-    model_info_bodies_offset: wp.array[int32],
-    model_info_total_cts_offset: wp.array[int32],
-    model_info_joint_kinematic_cts_group_offset: wp.array[int32],
-    model_joint_wid: wp.array[int32],
-    model_joint_num_kinematic_cts: wp.array[int32],
-    model_joint_kinematic_cts_offset_total_cts: wp.array[int32],
-    model_joint_bid_B: wp.array[int32],
-    model_joint_bid_F: wp.array[int32],
-    data_bodies_u_i: wp.array[vec6f],
-    jacobian_cts_offset: wp.array[int32],
-    jacobian_cts_data: wp.array[float32],
+    model_info_bodies_offset: wp.array[wp.int32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    model_info_joint_kinematic_cts_group_offset: wp.array[wp.int32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_num_kinematic_cts: wp.array[wp.int32],
+    model_joint_kinematic_cts_offset_total_cts: wp.array[wp.int32],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_bid_F: wp.array[wp.int32],
+    data_bodies_u_i: wp.array[wp.spatial_vectorf],
+    jacobian_cts_offset: wp.array[wp.int32],
+    jacobian_cts_data: wp.array[wp.float32],
     # Outputs:
-    metric_r_kinematics: wp.array[float32],
-    metric_r_kinematics_argmax: wp.array[int64],
+    metric_r_kinematics: wp.array[wp.float32],
+    metric_r_kinematics_argmax: wp.array[wp.int64],
 ):
     # Retrieve the joint index from the thread index
     jid = wp.tid()
@@ -699,7 +684,7 @@ def _compute_joint_kinematics_residual_dense(
     mio = jacobian_cts_offset[wid]
 
     # Compute the per-joint constraint Jacobian matrix-vector product
-    j_v_j = vec6f(0.0)
+    j_v_j = wp.spatial_vectorf(0.0)
     u_i_F = data_bodies_u_i[bid_F_j]
     dio_F = 6 * (bid_F_j - bio)
     for j in range(num_cts_j):
@@ -722,26 +707,26 @@ def _compute_joint_kinematics_residual_dense(
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cts_offset_j - kgo) + kin_argmax_local))
+        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cts_offset_j - kgo) + kin_argmax_local))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 
 @wp.kernel
 def _compute_joint_kinematics_residual_sparse(
     # Inputs:
-    model_info_joint_kinematic_cts_offset: wp.array[int32],
-    model_joint_wid: wp.array[int32],
-    model_joint_num_dynamic_cts: wp.array[int32],
-    model_joint_num_kinematic_cts: wp.array[int32],
-    model_joint_kinematic_cts_offset: wp.array[int32],
-    model_joint_bid_B: wp.array[int32],
-    model_joint_bid_F: wp.array[int32],
-    data_bodies_u_i: wp.array[vec6f],
+    model_info_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_num_dynamic_cts: wp.array[wp.int32],
+    model_joint_num_kinematic_cts: wp.array[wp.int32],
+    model_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_bid_F: wp.array[wp.int32],
+    data_bodies_u_i: wp.array[wp.spatial_vectorf],
     jac_nzb_values: wp.array[vec6f],
-    jac_joint_nzb_offsets: wp.array[int32],
+    jac_joint_nzb_offsets: wp.array[wp.int32],
     # Outputs:
-    metric_r_kinematics: wp.array[float32],
-    metric_r_kinematics_argmax: wp.array[int64],
+    metric_r_kinematics: wp.array[wp.float32],
+    metric_r_kinematics_argmax: wp.array[wp.int64],
 ):
     # Retrieve the joint index from the thread index
     jid = wp.tid()
@@ -763,7 +748,7 @@ def _compute_joint_kinematics_residual_sparse(
     jac_j_nzb_start = jac_joint_nzb_offsets[jid] + (2 * num_dyn_cts_j if bid_B_j >= 0 else num_dyn_cts_j)
 
     # Compute the per-joint constraint Jacobian matrix-vector product
-    j_v_j = vec6f(0.0)
+    j_v_j = wp.spatial_vectorf(0.0)
     u_i_F = data_bodies_u_i[bid_F_j]
     for j in range(num_kin_cts_j):
         jac_block = jac_nzb_values[jac_j_nzb_start + j]
@@ -782,21 +767,21 @@ def _compute_joint_kinematics_residual_sparse(
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(kin_cts_offset_j) + kin_argmax_local))
+        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(kin_cts_offset_j) + kin_argmax_local))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 
 @wp.kernel
 def _compute_cts_joints_residual(
     # Inputs:
-    model_info_joint_kinematic_cts_offset: wp.array[int32],
-    model_joint_wid: wp.array[int32],
-    model_joint_num_kinematic_cts: wp.array[int32],
-    model_joint_kinematic_cts_offset: wp.array[int32],
-    data_joints_r_j: wp.array[float32],
+    model_info_joint_kinematic_cts_offset: wp.array[wp.int32],
+    model_joint_wid: wp.array[wp.int32],
+    model_joint_num_kinematic_cts: wp.array[wp.int32],
+    model_joint_kinematic_cts_offset: wp.array[wp.int32],
+    data_joints_r_j: wp.array[wp.float32],
     # Outputs:
-    metric_r_cts_joints: wp.array[float32],
-    metric_r_cts_joints_argmax: wp.array[int64],
+    metric_r_cts_joints: wp.array[wp.float32],
+    metric_r_cts_joints_argmax: wp.array[wp.int64],
 ):
     # Retrieve the joint index from the thread index
     jid = wp.tid()
@@ -807,35 +792,35 @@ def _compute_cts_joints_residual(
     cio_j = model_joint_kinematic_cts_offset[jid]
 
     # Compute the per-joint constraint residual (infinity-norm) and local argmax row
-    r_cts_joints_j = float32(0.0)
-    argmax_j = int32(0)
+    r_cts_joints_j = wp.float32(0.0)
+    argmax_j = wp.int32(0)
     if num_cts_j > 0:
         r_cts_joints_j = wp.abs(data_joints_r_j[cio_j])
         for j in range(1, num_cts_j):
             v = wp.abs(data_joints_r_j[cio_j + j])
             if v > r_cts_joints_j:
                 r_cts_joints_j = v
-                argmax_j = int32(j)
+                argmax_j = wp.int32(j)
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_cts_joints, wid, r_cts_joints_j)
     if r_cts_joints_j >= previous_max:
         cio_j_loc = cio_j - model_info_joint_kinematic_cts_offset[wid]
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cio_j_loc + argmax_j)))
+        argmax_key = wp.int64(build_pair_key2(wp.uint32(jid), wp.uint32(cio_j_loc + argmax_j)))
         wp.atomic_exch(metric_r_cts_joints_argmax, wid, argmax_key)
 
 
 @wp.kernel
 def _compute_cts_limits_residual(
     # Inputs:
-    limit_model_num_limits: wp.array[int32],
-    limit_wid: wp.array[int32],
-    limit_lid: wp.array[int32],
-    limit_dof: wp.array[int32],
-    limit_r_q: wp.array[float32],
+    limit_model_num_limits: wp.array[wp.int32],
+    limit_wid: wp.array[wp.int32],
+    limit_lid: wp.array[wp.int32],
+    limit_dof: wp.array[wp.int32],
+    limit_r_q: wp.array[wp.float32],
     # Outputs:
-    metric_r_cts_limits: wp.array[float32],
-    metric_r_cts_limits_argmax: wp.array[int64],
+    metric_r_cts_limits: wp.array[wp.float32],
+    metric_r_cts_limits_argmax: wp.array[wp.int64],
 ):
     # Retrieve the thread index as the limit index
     lid = wp.tid()
@@ -858,20 +843,20 @@ def _compute_cts_limits_residual(
     # Update the per-world maximum residual
     previous_max = wp.atomic_max(metric_r_cts_limits, wid, r_cts_limits_l)
     if r_cts_limits_l >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(wlid), uint32(dof)))
+        argmax_key = wp.int64(build_pair_key2(wp.uint32(wlid), wp.uint32(dof)))
         wp.atomic_exch(metric_r_cts_limits_argmax, wid, argmax_key)
 
 
 @wp.kernel
 def _compute_cts_contacts_residual(
     # Inputs:
-    contact_model_num_contacts: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_gapfunc: wp.array[vec4f],
+    contact_model_num_contacts: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_gapfunc: wp.array[wp.vec4f],
     # Outputs:
-    metric_r_cts_contacts: wp.array[float32],
-    metric_r_cts_contacts_argmax: wp.array[int32],
+    metric_r_cts_contacts: wp.array[wp.float32],
+    metric_r_cts_contacts_argmax: wp.array[wp.int32],
 ):
     # Retrieve the thread index as the contact index
     cid = wp.tid()
@@ -900,37 +885,37 @@ def _compute_cts_contacts_residual(
 @wp.kernel
 def _compute_dual_problem_metrics(
     # Inputs:
-    problem_nl: wp.array[int32],
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_lcgo: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mio: wp.array[int32],
-    problem_mu: wp.array[float32],
-    problem_v_f: wp.array[float32],
-    problem_D: wp.array[float32],
-    problem_P: wp.array[float32],
-    solution_sigma: wp.array[vec2f],
-    solution_lambdas: wp.array[float32],
-    solution_v_plus: wp.array[float32],
+    problem_nl: wp.array[wp.int32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_lcgo: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
+    problem_v_f: wp.array[wp.float32],
+    problem_D: wp.array[wp.float32],
+    problem_P: wp.array[wp.float32],
+    solution_sigma: wp.array[wp.vec2f],
+    solution_lambdas: wp.array[wp.float32],
+    solution_v_plus: wp.array[wp.float32],
     # Buffers:
-    buffer_s: wp.array[float32],
-    buffer_v: wp.array[float32],
+    buffer_s: wp.array[wp.float32],
+    buffer_v: wp.array[wp.float32],
     # Outputs:
-    metric_r_v_plus: wp.array[float32],
-    metric_r_v_plus_argmax: wp.array[int32],
-    metric_r_ncp_primal: wp.array[float32],
-    metric_r_ncp_primal_argmax: wp.array[int32],
-    metric_r_ncp_dual: wp.array[float32],
-    metric_r_ncp_dual_argmax: wp.array[int32],
-    metric_r_ncp_compl: wp.array[float32],
-    metric_r_ncp_compl_argmax: wp.array[int32],
-    metric_r_vi_natmap: wp.array[float32],
-    metric_r_vi_natmap_argmax: wp.array[int32],
-    metric_f_ncp: wp.array[float32],
-    metric_f_ccp: wp.array[float32],
+    metric_r_v_plus: wp.array[wp.float32],
+    metric_r_v_plus_argmax: wp.array[wp.int32],
+    metric_r_ncp_primal: wp.array[wp.float32],
+    metric_r_ncp_primal_argmax: wp.array[wp.int32],
+    metric_r_ncp_dual: wp.array[wp.float32],
+    metric_r_ncp_dual_argmax: wp.array[wp.int32],
+    metric_r_ncp_compl: wp.array[wp.float32],
+    metric_r_ncp_compl_argmax: wp.array[wp.int32],
+    metric_r_vi_natmap: wp.array[wp.float32],
+    metric_r_vi_natmap_argmax: wp.array[wp.int32],
+    metric_f_ncp: wp.array[wp.float32],
+    metric_f_ccp: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index
     wid = wp.tid()
@@ -1001,34 +986,34 @@ def _compute_dual_problem_metrics(
 @wp.kernel
 def _compute_dual_problem_metrics_sparse(
     # Inputs:
-    problem_nl: wp.array[int32],
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_lcgo: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mu: wp.array[float32],
-    problem_v_f: wp.array[float32],
-    problem_P: wp.array[float32],
-    solution_lambdas: wp.array[float32],
-    solution_v_plus: wp.array[float32],
+    problem_nl: wp.array[wp.int32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_lcgo: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
+    problem_v_f: wp.array[wp.float32],
+    problem_P: wp.array[wp.float32],
+    solution_lambdas: wp.array[wp.float32],
+    solution_v_plus: wp.array[wp.float32],
     # Buffers:
-    buffer_s: wp.array[float32],
-    buffer_v: wp.array[float32],
+    buffer_s: wp.array[wp.float32],
+    buffer_v: wp.array[wp.float32],
     # Outputs:
-    metric_r_v_plus: wp.array[float32],
-    metric_r_v_plus_argmax: wp.array[int32],
-    metric_r_ncp_primal: wp.array[float32],
-    metric_r_ncp_primal_argmax: wp.array[int32],
-    metric_r_ncp_dual: wp.array[float32],
-    metric_r_ncp_dual_argmax: wp.array[int32],
-    metric_r_ncp_compl: wp.array[float32],
-    metric_r_ncp_compl_argmax: wp.array[int32],
-    metric_r_vi_natmap: wp.array[float32],
-    metric_r_vi_natmap_argmax: wp.array[int32],
-    metric_f_ncp: wp.array[float32],
-    metric_f_ccp: wp.array[float32],
+    metric_r_v_plus: wp.array[wp.float32],
+    metric_r_v_plus_argmax: wp.array[wp.int32],
+    metric_r_ncp_primal: wp.array[wp.float32],
+    metric_r_ncp_primal_argmax: wp.array[wp.int32],
+    metric_r_ncp_dual: wp.array[wp.float32],
+    metric_r_ncp_dual_argmax: wp.array[wp.int32],
+    metric_r_ncp_compl: wp.array[wp.float32],
+    metric_r_ncp_compl_argmax: wp.array[wp.int32],
+    metric_r_vi_natmap: wp.array[wp.float32],
+    metric_r_vi_natmap_argmax: wp.array[wp.int32],
+    metric_f_ncp: wp.array[wp.float32],
+    metric_f_ccp: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the world index
     wid = wp.tid()
@@ -1118,8 +1103,7 @@ class SolutionMetrics:
         Initializes the solution metrics evaluator.
 
         Args:
-            model (ModelKamino):
-                The model containing the time-invariant data of the simulation.
+            model: The model containing the time-invariant data of the simulation.
         """
         # Declare the device cache
         self._device: wp.DeviceLike = None
@@ -1128,8 +1112,8 @@ class SolutionMetrics:
         self._data: SolutionMetricsData | None = None
 
         # Declare data buffers for metrics computations
-        self._buffer_s: wp.array | None = None
-        self._buffer_v: wp.array | None = None
+        self._buffer_s: wp.array[wp.float32] | None = None
+        self._buffer_v: wp.array[wp.float32] | None = None
 
         # If a model is provided, finalize the metrics data allocations
         if model is not None:
@@ -1140,8 +1124,7 @@ class SolutionMetrics:
         Finalizes the metrics data allocations on the specified device.
 
         Args:
-            model (ModelKamino):
-                The model containing the time-invariant data of the simulation.
+            model: The model containing the time-invariant data of the simulation.
         """
         # Ensure the model is valid
         if not isinstance(model, ModelKamino):
@@ -1153,33 +1136,33 @@ class SolutionMetrics:
         # Allocate metrics data on the target device
         with wp.ScopedDevice(self._device):
             # Allocate reusable buffers for metrics computations
-            self._buffer_v = wp.zeros(model.size.sum_of_max_total_cts, dtype=float32)
-            self._buffer_s = wp.zeros(model.size.sum_of_max_total_cts, dtype=float32)
+            self._buffer_v = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
+            self._buffer_s = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
 
             # Allocate the metrics container data arrays
             self._data = SolutionMetricsData(
-                r_eom=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_eom_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int64),
-                r_kinematics=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_kinematics_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int64),
-                r_cts_joints=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_cts_joints_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int64),
-                r_cts_limits=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_cts_limits_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int64),
-                r_cts_contacts=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_cts_contacts_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                r_v_plus=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_v_plus_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                r_ncp_primal=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_ncp_primal_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                r_ncp_dual=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_ncp_dual_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                r_ncp_compl=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_ncp_compl_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                r_vi_natmap=wp.zeros(model.size.num_worlds, dtype=float32),
-                r_vi_natmap_argmax=wp.full(model.size.num_worlds, value=-1, dtype=int32),
-                f_ncp=wp.zeros(model.size.num_worlds, dtype=float32),
-                f_ccp=wp.zeros(model.size.num_worlds, dtype=float32),
+                r_eom=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_eom_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int64),
+                r_kinematics=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_kinematics_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int64),
+                r_cts_joints=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_cts_joints_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int64),
+                r_cts_limits=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_cts_limits_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int64),
+                r_cts_contacts=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_cts_contacts_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                r_v_plus=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_v_plus_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                r_ncp_primal=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_ncp_primal_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                r_ncp_dual=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_ncp_dual_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                r_ncp_compl=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_ncp_compl_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                r_vi_natmap=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                r_vi_natmap_argmax=wp.full(model.size.num_worlds, value=-1, dtype=wp.int32),
+                f_ncp=wp.zeros(model.size.num_worlds, dtype=wp.float32),
+                f_ccp=wp.zeros(model.size.num_worlds, dtype=wp.float32),
             )
 
     ###
@@ -1213,9 +1196,9 @@ class SolutionMetrics:
 
     def evaluate(
         self,
-        sigma: wp.array,
-        lambdas: wp.array,
-        v_plus: wp.array,
+        sigma: wp.array[wp.vec2f],
+        lambdas: wp.array[wp.float32],
+        v_plus: wp.array[wp.float32],
         model: ModelKamino,
         data: DataKamino,
         state_p: StateKamino,
@@ -1228,26 +1211,16 @@ class SolutionMetrics:
         Evaluates all solution performance metrics.
 
         Args:
-            model (ModelKamino):
-                The model containing the time-invariant data of the simulation.
-            data (DataKamino):
-                The model data containing the time-variant data of the simulation.
-            state_p (StateKamino):
-                The previous state of the simulation.
-            limits (LimitsKamino):
-                The joint-limits data describing active limit constraints.
-            contacts (ContactsKamino):
-                The contact data describing active contact constraints.
-            problem (DualProblem):
-                The dual forward dynamics problem of the current time-step.
-            jacobians (DenseSystemJacobians | SparseSystemJacobians):
-                The system Jacobians of the current time-step.
-            sigma (wp.array):
-                The array diagonal regularization applied to the Delassus matrix of the current dual problem.
-            lambdas (wp.array):
-                The array of constraint reactions (i.e. Lagrange multipliers) of the current dual problem solution.
-            v_plus (wp.array):
-                The array of post-event constraint-space velocities of the current dual problem solution.
+            model: The model containing the time-invariant data of the simulation.
+            data: The model data containing the time-variant data of the simulation.
+            state_p: The previous state of the simulation.
+            limits: The joint-limits data describing active limit constraints.
+            contacts: The contact data describing active contact constraints.
+            problem: The dual forward dynamics problem of the current time-step.
+            jacobians: The system Jacobians of the current time-step.
+            sigma: The array diagonal regularization applied to the Delassus matrix of the current dual problem.
+            lambdas: The array of constraint reactions (i.e. Lagrange multipliers) of the current dual problem solution.
+            v_plus: The array of post-event constraint-space velocities of the current dual problem solution.
         """
         self._assert_has_data()
         self._evaluate_constraint_violations_perf(model, data, limits, contacts)
@@ -1279,14 +1252,10 @@ class SolutionMetrics:
         Evaluates the constraint-violation performance metrics.
 
         Args:
-            model (ModelKamino):
-                The model containing the time-invariant data of the simulation.
-            data (DataKamino):
-                The model data containing the time-variant data of the simulation.
-            limits (LimitsKamino):
-                The joint-limits data describing active limit constraints.
-            contacts (ContactsKamino):
-                The contact data describing active contact constraints.
+            model: The model containing the time-invariant data of the simulation.
+            data: The model data containing the time-variant data of the simulation.
+            limits: The joint-limits data describing active limit constraints.
+            contacts: The contact data describing active contact constraints.
         """
         # Ensure metrics data is available
         self._assert_has_data()
@@ -1358,14 +1327,10 @@ class SolutionMetrics:
         Evaluates the primal problem performance metrics.
 
         Args:
-            model (ModelKamino):
-                The model containing the time-invariant data of the simulation.
-            data (DataKamino):
-                The model data containing the time-variant data of the simulation.
-            state_p (StateKamino):
-                The previous state of the simulation.
-            jacobians (DenseSystemJacobians | SparseSystemJacobians):
-                The system Jacobians of the current time-step.
+            model: The model containing the time-invariant data of the simulation.
+            data: The model data containing the time-variant data of the simulation.
+            state_p: The previous state of the simulation.
+            jacobians: The system Jacobians of the current time-step.
         """
         # Ensure metrics data is available
         self._assert_has_data()
@@ -1443,23 +1408,19 @@ class SolutionMetrics:
 
     def _evaluate_dual_problem_perf(
         self,
-        sigma: wp.array,
-        lambdas: wp.array,
-        v_plus: wp.array,
+        sigma: wp.array[wp.vec2f],
+        lambdas: wp.array[wp.float32],
+        v_plus: wp.array[wp.float32],
         problem: DualProblem,
     ):
         """
         Evaluates the dual problem performance metrics.
 
         Args:
-            problem (DualProblem):
-                The dual problem containing the time-invariant and time-variant data of the simulation.
-            sigma (wp.array):
-                The array of sigma values for the dual problem.
-            lambdas (wp.array):
-                The array of lambda values for the dual problem.
-            v_plus (wp.array):
-                The array of v_plus values for the dual problem.
+            problem: The dual problem containing the time-invariant and time-variant data of the simulation.
+            sigma: The array of sigma values for the dual problem.
+            lambdas: The array of lambda values for the dual problem.
+            v_plus: The array of v_plus values for the dual problem.
         """
         # Ensure metrics data is available
         self._assert_has_data()

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -3,13 +3,14 @@
 
 """Defines the Warp kernels used by the Proximal-ADMM solver."""
 
+from __future__ import annotations
+
 import functools
 from typing import Any
 
 import warp as wp
 
 from ...core.math import FLOAT32_EPS, FLOAT32_MAX
-from ...core.types import float32, int32, vec2f, vec3f
 from .math import (
     compute_cwise_vec_div,
     compute_cwise_vec_mul,
@@ -76,11 +77,11 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _reset_solver_data(
     # Outputs:
-    world_mask: wp.array[bool],
-    problem_vio: wp.array[int32],
-    problem_maxdim: wp.array[int32],
-    lambdas: wp.array[float32],
-    v_plus: wp.array[float32],
+    world_mask: wp.array[wp.bool],
+    problem_vio: wp.array[wp.int32],
+    problem_maxdim: wp.array[wp.int32],
+    lambdas: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
 ):
     # Retrieve the world and constraint indices from the 2D thread grid
     wid, tid = wp.tid()
@@ -105,13 +106,13 @@ def _reset_solver_data(
 
 @wp.kernel
 def _warmstart_desaxce_correction(
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mu: wp.array[float32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
     # Outputs:
-    solver_z: wp.array[float32],
+    solver_z: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, cid = wp.tid()
@@ -153,20 +154,20 @@ def _warmstart_desaxce_correction(
 @wp.kernel
 def _warmstart_joint_constraints(
     # Inputs:
-    model_time_dt: wp.array[float32],
-    joint_wid: wp.array[int32],
-    joint_num_dynamic_cts: wp.array[int32],
-    joint_num_kinematic_cts: wp.array[int32],
-    joint_dynamic_cts_offset_joint_cts: wp.array[int32],
-    joint_kinematic_cts_offset_joint_cts: wp.array[int32],
-    joint_dynamic_cts_offset_total_cts: wp.array[int32],
-    joint_kinematic_cts_offset_total_cts: wp.array[int32],
-    joint_lambda_j: wp.array[float32],
-    problem_P: wp.array[float32],
+    model_time_dt: wp.array[wp.float32],
+    joint_wid: wp.array[wp.int32],
+    joint_num_dynamic_cts: wp.array[wp.int32],
+    joint_num_kinematic_cts: wp.array[wp.int32],
+    joint_dynamic_cts_offset_joint_cts: wp.array[wp.int32],
+    joint_kinematic_cts_offset_joint_cts: wp.array[wp.int32],
+    joint_dynamic_cts_offset_total_cts: wp.array[wp.int32],
+    joint_kinematic_cts_offset_total_cts: wp.array[wp.int32],
+    joint_lambda_j: wp.array[wp.float32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    x_0: wp.array[float32],
-    y_0: wp.array[float32],
-    z_0: wp.array[float32],
+    x_0: wp.array[wp.float32],
+    y_0: wp.array[wp.float32],
+    z_0: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the joint index
     jid = wp.tid()
@@ -204,19 +205,19 @@ def _warmstart_joint_constraints(
 @wp.kernel
 def _warmstart_limit_constraints(
     # Inputs:
-    model_time_dt: wp.array[float32],
-    model_info_total_cts_offset: wp.array[int32],
-    data_info_limit_cts_group_offset: wp.array[int32],
-    limit_model_num_active: wp.array[int32],
-    limit_wid: wp.array[int32],
-    limit_lid: wp.array[int32],
-    limit_reaction: wp.array[float32],
-    limit_velocity: wp.array[float32],
-    problem_P: wp.array[float32],
+    model_time_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_limit_cts_group_offset: wp.array[wp.int32],
+    limit_model_num_active: wp.array[wp.int32],
+    limit_wid: wp.array[wp.int32],
+    limit_lid: wp.array[wp.int32],
+    limit_reaction: wp.array[wp.float32],
+    limit_velocity: wp.array[wp.float32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    x_0: wp.array[float32],
-    y_0: wp.array[float32],
-    z_0: wp.array[float32],
+    x_0: wp.array[wp.float32],
+    y_0: wp.array[wp.float32],
+    z_0: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the limit index
     lid = wp.tid()
@@ -264,20 +265,20 @@ def _warmstart_limit_constraints(
 @wp.kernel
 def _warmstart_contact_constraints(
     # Inputs:
-    model_time_dt: wp.array[float32],
-    model_info_total_cts_offset: wp.array[int32],
-    data_info_contact_cts_group_offset: wp.array[int32],
-    contact_model_num_contacts: wp.array[int32],
-    contact_wid: wp.array[int32],
-    contact_cid: wp.array[int32],
-    contact_material: wp.array[vec2f],
-    contact_reaction: wp.array[vec3f],
-    contact_velocity: wp.array[vec3f],
-    problem_P: wp.array[float32],
+    model_time_dt: wp.array[wp.float32],
+    model_info_total_cts_offset: wp.array[wp.int32],
+    data_info_contact_cts_group_offset: wp.array[wp.int32],
+    contact_model_num_contacts: wp.array[wp.int32],
+    contact_wid: wp.array[wp.int32],
+    contact_cid: wp.array[wp.int32],
+    contact_material: wp.array[wp.vec2f],
+    contact_reaction: wp.array[wp.vec3f],
+    contact_velocity: wp.array[wp.vec3f],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    x_0: wp.array[float32],
-    y_0: wp.array[float32],
-    z_0: wp.array[float32],
+    x_0: wp.array[wp.float32],
+    y_0: wp.array[wp.float32],
+    z_0: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the contact index
     cid = wp.tid()
@@ -338,10 +339,10 @@ def make_initialize_solver_kernel(use_acceleration: bool = False):
     Specialized for whether acceleration is enabled to reduce unnecessary overhead and branching.
 
     Args:
-        use_acceleration (bool, optional): Flag indicating whether acceleration is enabled. Defaults to False.
+        use_acceleration: Flag indicating whether acceleration is enabled. Defaults to False.
 
     Returns:
-        wp.kernel: The kernel function to initialize the PADMM solver.
+        The kernel function to initialize the PADMM solver.
     """
 
     @wp.kernel
@@ -351,9 +352,9 @@ def make_initialize_solver_kernel(use_acceleration: bool = False):
         # Outputs:
         solver_status: wp.array[PADMMStatus],
         solver_penalty: wp.array[PADMMPenalty],
-        solver_state_sigma: wp.array[vec2f],
-        solver_state_a_p: wp.array[float32],
-        linear_solver_atol: wp.array[float32],
+        solver_state_sigma: wp.array[wp.vec2f],
+        solver_state_a_p: wp.array[wp.float32],
+        linear_solver_atol: wp.array[wp.float32],
     ):
         # Retrieve the world index as thread index
         wid = wp.tid()
@@ -365,32 +366,32 @@ def make_initialize_solver_kernel(use_acceleration: bool = False):
         sigma = solver_state_sigma[wid]
 
         # Initialize solver status
-        status.iterations = int32(0)
-        status.converged = int32(0)
-        status.r_p = float32(0.0)
-        status.r_d = float32(0.0)
-        status.r_c = float32(0.0)
+        status.iterations = wp.int32(0)
+        status.converged = wp.int32(0)
+        status.r_p = wp.float32(0.0)
+        status.r_d = wp.float32(0.0)
+        status.r_c = wp.float32(0.0)
         # NOTE: We initialize acceleration-related
         # entries only if acceleration is enabled
         if wp.static(use_acceleration):
-            status.r_dx = float32(0.0)
-            status.r_dy = float32(0.0)
-            status.r_dz = float32(0.0)
+            status.r_dx = wp.float32(0.0)
+            status.r_dy = wp.float32(0.0)
+            status.r_dz = wp.float32(0.0)
             status.r_a = FLOAT32_MAX
             status.r_a_p = FLOAT32_MAX
             status.r_a_pp = FLOAT32_MAX
-            status.restart = int32(0)
-            status.num_restarts = int32(0)
+            status.restart = wp.int32(0)
+            status.num_restarts = wp.int32(0)
 
         # Initialize ALM penalty parameter and relevant meta-data
         # NOTE: Currently only fixed penalty is used
         penalty.rho = config.rho_0
-        penalty.rho_p = float32(0.0)
-        penalty.num_updates = int32(0)
+        penalty.rho_p = wp.float32(0.0)
+        penalty.num_updates = wp.int32(0)
 
         # Initialize the total proximal regularization
         sigma[0] = config.eta + config.rho_0
-        sigma[1] = float32(0.0)
+        sigma[1] = wp.float32(0.0)
 
         # Store the initialized per-world solver data
         solver_status[wid] = status
@@ -420,7 +421,7 @@ def make_update_proximal_regularization_kernel(method: PADMMPenaltyUpdate):
         solver_penalty: wp.array[PADMMPenalty],
         solver_status: wp.array[PADMMStatus],
         # Outputs:
-        solver_state_sigma: wp.array[vec2f],
+        solver_state_sigma: wp.array[wp.vec2f],
     ):
         # Retrieve the world index from the thread index
         wid = wp.tid()
@@ -456,12 +457,12 @@ def make_update_proximal_regularization_kernel(method: PADMMPenaltyUpdate):
 @wp.kernel
 def _update_delassus_proximal_regularization(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_mio: wp.array[int32],
+    problem_dim: wp.array[wp.int32],
+    problem_mio: wp.array[wp.int32],
     solver_status: wp.array[PADMMStatus],
-    solver_state_sigma: wp.array[vec2f],
+    solver_state_sigma: wp.array[wp.vec2f],
     # Outputs:
-    D: wp.array[float32],
+    D: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -489,13 +490,13 @@ def _update_delassus_proximal_regularization(
 @wp.kernel
 def _update_delassus_proximal_regularization_sparse(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
     solver_config: wp.array[PADMMConfigStruct],
     solver_penalty: wp.array[PADMMPenalty],
     solver_status: wp.array[PADMMStatus],
     # Outputs:
-    delassus_eta: wp.array[float32],
+    delassus_eta: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -525,15 +526,15 @@ def _update_delassus_proximal_regularization_sparse(
 @wp.kernel
 def _compute_desaxce_correction(
     # Inputs:
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mu: wp.array[float32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
     solver_status: wp.array[PADMMStatus],
-    solver_z_p: wp.array[float32],
+    solver_z_p: wp.array[wp.float32],
     # Outputs:
-    solver_s: wp.array[float32],
+    solver_s: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the contact index
     wid, cid = wp.tid()
@@ -577,18 +578,18 @@ def _compute_desaxce_correction(
 @wp.kernel
 def _compute_velocity_bias(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_v_f: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_v_f: wp.array[wp.float32],
     solver_config: wp.array[PADMMConfigStruct],
     solver_penalty: wp.array[PADMMPenalty],
     solver_status: wp.array[PADMMStatus],
-    solver_s: wp.array[float32],
-    solver_x_p: wp.array[float32],
-    solver_y_p: wp.array[float32],
-    solver_z_p: wp.array[float32],
+    solver_s: wp.array[wp.float32],
+    solver_x_p: wp.array[wp.float32],
+    solver_y_p: wp.array[wp.float32],
+    solver_z_p: wp.array[wp.float32],
     # Outputs:
-    solver_v: wp.array[float32],
+    solver_v: wp.array[wp.float32],
 ):
     # Retrieve the thread indices as the world and constraint index
     wid, tid = wp.tid()
@@ -641,22 +642,22 @@ def make_desaxce_correction_and_velocity_bias_kernel(has_contacts: bool, collect
     @wp.kernel(module="unique", enable_backward=False)
     def _compute_desaxce_correction_and_velocity_bias(
         # Inputs:
-        problem_dim: wp.array[int32],
-        problem_nc: wp.array[int32],
-        problem_cio: wp.array[int32],
-        problem_ccgo: wp.array[int32],
-        problem_vio: wp.array[int32],
-        problem_mu: wp.array[float32],
-        problem_v_f: wp.array[float32],
+        problem_dim: wp.array[wp.int32],
+        problem_nc: wp.array[wp.int32],
+        problem_cio: wp.array[wp.int32],
+        problem_ccgo: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
+        problem_mu: wp.array[wp.float32],
+        problem_v_f: wp.array[wp.float32],
         solver_config: wp.array[PADMMConfigStruct],
         solver_penalty: wp.array[PADMMPenalty],
         solver_status: wp.array[PADMMStatus],
-        solver_x_p: wp.array[float32],
-        solver_y_p: wp.array[float32],
-        solver_z_p: wp.array[float32],
+        solver_x_p: wp.array[wp.float32],
+        solver_y_p: wp.array[wp.float32],
+        solver_z_p: wp.array[wp.float32],
         # Outputs:
-        solver_v: wp.array[float32],
-        solver_s: wp.array[float32],
+        solver_v: wp.array[wp.float32],
+        solver_s: wp.array[wp.float32],
     ):
         wid, tid = wp.tid()
 
@@ -677,7 +678,7 @@ def make_desaxce_correction_and_velocity_bias_kernel(has_contacts: bool, collect
         y_p = solver_y_p[thread_offset]
         z_p = solver_z_p[thread_offset]
 
-        s = float32(0.0)
+        s = wp.float32(0.0)
 
         if wp.static(has_contacts):
             nc = problem_nc[wid]
@@ -705,14 +706,14 @@ def make_desaxce_correction_and_velocity_bias_kernel(has_contacts: bool, collect
 @wp.kernel
 def _compute_projection_argument(
     # Inputs
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
     solver_penalty: wp.array[PADMMPenalty],
     solver_status: wp.array[PADMMStatus],
-    solver_z_hat: wp.array[float32],
-    solver_x: wp.array[float32],
+    solver_z_hat: wp.array[wp.float32],
+    solver_x: wp.array[wp.float32],
     # Outputs
-    solver_y: wp.array[float32],
+    solver_y: wp.array[wp.float32],
 ):
     # Retrieve the thread indices as the world and constraint index
     wid, tid = wp.tid()
@@ -747,16 +748,16 @@ def _compute_projection_argument(
 @wp.kernel
 def _project_to_feasible_cone(
     # Inputs:
-    problem_nl: wp.array[int32],
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_lcgo: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mu: wp.array[float32],
+    problem_nl: wp.array[wp.int32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_lcgo: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
     solver_status: wp.array[PADMMStatus],
     # Outputs:
-    solver_y: wp.array[float32],
+    solver_y: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the unilateral entity index
     wid, uid = wp.tid()
@@ -796,7 +797,7 @@ def _project_to_feasible_cone(
         # Compute the index offset of the contact constraint
         ccio_j = vio + ccgo + 3 * cid
         # Capture a 3D vector
-        x = vec3f(solver_y[ccio_j], solver_y[ccio_j + 1], solver_y[ccio_j + 2])
+        x = wp.vec3f(solver_y[ccio_j], solver_y[ccio_j + 1], solver_y[ccio_j + 2])
         # Project to the coulomb friction cone
         y_proj = project_to_coulomb_cone(x, problem_mu[cio + cid])
         # Copy vec3 projection into the slack variable array
@@ -812,33 +813,33 @@ def make_update_dual_variables_and_compute_primal_dual_residuals(use_acceleratio
     Specialized for whether acceleration is enabled to reduce unnecessary overhead and branching.
 
     Args:
-        use_acceleration (bool, optional): Flag indicating whether acceleration is enabled. Defaults to False.
+        use_acceleration: Flag indicating whether acceleration is enabled. Defaults to False.
 
     Returns:
-        wp.kernel: The kernel function to update dual variables and compute residuals.
+        The kernel function to update dual variables and compute residuals.
     """
 
     @wp.kernel
     def _update_dual_variables_and_compute_primal_dual_residuals(
         # Inputs:
-        problem_dim: wp.array[int32],
-        problem_vio: wp.array[int32],
-        problem_P: wp.array[float32],
+        problem_dim: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
+        problem_P: wp.array[wp.float32],
         solver_config: wp.array[PADMMConfigStruct],
         solver_penalty: wp.array[PADMMPenalty],
         solver_status: wp.array[PADMMStatus],
-        solver_x: wp.array[float32],
-        solver_y: wp.array[float32],
-        solver_x_p: wp.array[float32],
-        solver_y_p: wp.array[float32],
-        solver_z_p: wp.array[float32],
+        solver_x: wp.array[wp.float32],
+        solver_y: wp.array[wp.float32],
+        solver_x_p: wp.array[wp.float32],
+        solver_y_p: wp.array[wp.float32],
+        solver_z_p: wp.array[wp.float32],
         # Outputs:
-        solver_z: wp.array[float32],
-        solver_r_prim: wp.array[float32],
-        solver_r_dual: wp.array[float32],
-        solver_r_dx: wp.array[float32],
-        solver_r_dy: wp.array[float32],
-        solver_r_dz: wp.array[float32],
+        solver_z: wp.array[wp.float32],
+        solver_r_prim: wp.array[wp.float32],
+        solver_r_dual: wp.array[wp.float32],
+        solver_r_dx: wp.array[wp.float32],
+        solver_r_dy: wp.array[wp.float32],
+        solver_r_dz: wp.array[wp.float32],
     ):
         # Retrieve the thread indices as the world and constraint index
         wid, tid = wp.tid()
@@ -907,39 +908,39 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
     @wp.kernel(module="unique", enable_backward=False)
     def _project_dual_convergence_accel(
         # Inputs:
-        problem_dim: wp.array[int32],
-        problem_nl: wp.array[int32],
-        problem_nc: wp.array[int32],
-        problem_cio: wp.array[int32],
-        problem_lcgo: wp.array[int32],
-        problem_ccgo: wp.array[int32],
-        problem_vio: wp.array[int32],
-        problem_uio: wp.array[int32],
-        problem_mu: wp.array[float32],
-        problem_P: wp.array[float32],
+        problem_dim: wp.array[wp.int32],
+        problem_nl: wp.array[wp.int32],
+        problem_nc: wp.array[wp.int32],
+        problem_cio: wp.array[wp.int32],
+        problem_lcgo: wp.array[wp.int32],
+        problem_ccgo: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
+        problem_uio: wp.array[wp.int32],
+        problem_mu: wp.array[wp.float32],
+        problem_P: wp.array[wp.float32],
         solver_config: wp.array[PADMMConfigStruct],
         solver_penalty: wp.array[PADMMPenalty],
-        solver_state_a_p: wp.array[float32],
-        solver_state_x: wp.array[float32],
-        solver_state_x_p: wp.array[float32],
-        solver_state_y_hat_in: wp.array[float32],
-        solver_state_z_hat_in: wp.array[float32],
-        solver_state_y_p: wp.array[float32],
-        solver_state_z_p: wp.array[float32],
+        solver_state_a_p: wp.array[wp.float32],
+        solver_state_x: wp.array[wp.float32],
+        solver_state_x_p: wp.array[wp.float32],
+        solver_state_y_hat_in: wp.array[wp.float32],
+        solver_state_z_hat_in: wp.array[wp.float32],
+        solver_state_y_p: wp.array[wp.float32],
+        solver_state_z_p: wp.array[wp.float32],
         # Outputs:
-        solver_state_y: wp.array[float32],
-        solver_state_z: wp.array[float32],
-        solver_state_done: wp.array[int32],
-        solver_state_a: wp.array[float32],
-        solver_state_a_factor: wp.array[float32],
+        solver_state_y: wp.array[wp.float32],
+        solver_state_z: wp.array[wp.float32],
+        solver_state_done: wp.array[wp.int32],
+        solver_state_a: wp.array[wp.float32],
+        solver_state_a_factor: wp.array[wp.float32],
         solver_status: wp.array[PADMMStatus],
         solver_penalty_out: wp.array[PADMMPenalty],
-        solver_state_y_hat_out: wp.array[float32],
-        solver_state_z_hat_out: wp.array[float32],
-        solver_state_x_p_out: wp.array[float32],
-        solver_state_y_p_out: wp.array[float32],
-        solver_state_z_p_out: wp.array[float32],
-        solver_state_a_p_out: wp.array[float32],
+        solver_state_y_hat_out: wp.array[wp.float32],
+        solver_state_z_hat_out: wp.array[wp.float32],
+        solver_state_x_p_out: wp.array[wp.float32],
+        solver_state_y_p_out: wp.array[wp.float32],
+        solver_state_z_p_out: wp.array[wp.float32],
+        solver_state_a_p_out: wp.array[wp.float32],
     ):
         wid, tid = wp.tid()
         num_threads_per_block = wp.block_dim()
@@ -974,12 +975,12 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
         inv_rho = 1.0 / rho
         eta = config.eta
 
-        r_p_local = float32(0.0)
-        r_d_local = float32(0.0)
-        r_c_local = float32(0.0)
-        r_dx_local = float32(0.0)
-        r_dy_local = float32(0.0)
-        r_dz_local = float32(0.0)
+        r_p_local = wp.float32(0.0)
+        r_d_local = wp.float32(0.0)
+        r_c_local = wp.float32(0.0)
+        r_dx_local = wp.float32(0.0)
+        r_dy_local = wp.float32(0.0)
+        r_dz_local = wp.float32(0.0)
 
         # Each thread strides over rows. Contact rows are processed by the
         # first component thread because Coulomb projection is a 3D block op.
@@ -998,13 +999,13 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
                         y0 = solver_state_x[ccio_j] - inv_rho * solver_state_z_hat_in[ccio_j]
                         y1 = solver_state_x[ccio_j + 1] - inv_rho * solver_state_z_hat_in[ccio_j + 1]
                         y2 = solver_state_x[ccio_j + 2] - inv_rho * solver_state_z_hat_in[ccio_j + 2]
-                        y_proj = project_to_coulomb_cone(vec3f(y0, y1, y2), problem_mu[cio + cid])
-                        x_c = vec3f(
+                        y_proj = project_to_coulomb_cone(wp.vec3f(y0, y1, y2), problem_mu[cio + cid])
+                        x_c = wp.vec3f(
                             solver_state_x[ccio_j],
                             solver_state_x[ccio_j + 1],
                             solver_state_x[ccio_j + 2],
                         )
-                        z_c = vec3f(0.0, 0.0, 0.0)
+                        z_c = wp.vec3f(0.0, 0.0, 0.0)
 
                         for comp in range(3):
                             idx = ccio_j + comp
@@ -1065,12 +1066,12 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
                         r_c_local = wp.max(r_c_local, wp.abs(x * z))
 
         # Reduce per-thread residual contributions to world-level metrics.
-        r_p_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
-        r_d_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
-        r_c_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
-        r_dx_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
-        r_dy_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
-        r_dz_tile = wp.tile_zeros(shape=reduction_size, dtype=float32, storage="shared")
+        r_p_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
+        r_d_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
+        r_c_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
+        r_dx_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
+        r_dy_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
+        r_dz_tile = wp.tile_zeros(shape=reduction_size, dtype=wp.float32, storage="shared")
 
         active_thread = tid < num_threads_per_block
         wp.tile_scatter_masked(r_p_tile, tid, r_p_local, active_thread)
@@ -1120,7 +1121,7 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
                 status.num_restarts += 1
                 status.r_a = status.r_a_p / config.restart_tolerance
                 solver_state_a[wid] = float(config.a_0)
-                solver_state_a_factor[wid] = float32(0.0)
+                solver_state_a_factor[wid] = wp.float32(0.0)
             status.r_a_pp = status.r_a_p
             status.r_a_p = status.r_a
 
@@ -1128,13 +1129,13 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
             solver_penalty_out[wid] = _update_penalty(config, pen, status.iterations, r_p_max, r_d_max)
 
         # Broadcast convergence/restart control to all threads for writeback.
-        control_sync = wp.tile_zeros(shape=1, dtype=int32, storage="shared")
-        a_factor_sync = wp.tile_zeros(shape=1, dtype=float32, storage="shared")
+        control_sync = wp.tile_zeros(shape=1, dtype=wp.int32, storage="shared")
+        a_factor_sync = wp.tile_zeros(shape=1, dtype=wp.float32, storage="shared")
 
-        control_value = int32(0)
-        a_factor_value = float32(0.0)
+        control_value = wp.int32(0)
+        a_factor_value = wp.float32(0.0)
         if tid == 0:
-            control_value = status.restart + int32(2) * status.converged
+            control_value = status.restart + wp.int32(2) * status.converged
             a_factor_value = solver_state_a_factor[wid]
 
         wp.tile_scatter_masked(control_sync, 0, control_value, tid == 0)
@@ -1155,8 +1156,8 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
                 y_p = solver_state_y_p[vid]
                 z_p = solver_state_z_p[vid]
 
-                if control < int32(2):
-                    if control == int32(0):
+                if control < wp.int32(2):
+                    if control == wp.int32(0):
                         solver_state_y_hat_out[vid] = y + a_factor * (y - y_p)
                         solver_state_z_hat_out[vid] = z + a_factor * (z - z_p)
                     else:
@@ -1176,17 +1177,17 @@ def _make_project_dual_convergence_accel_kernel(reduction_size: int):
 @wp.kernel
 def _compute_complementarity_residuals(
     # Inputs:
-    problem_nl: wp.array[int32],
-    problem_nc: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_uio: wp.array[int32],
-    problem_lcgo: wp.array[int32],
-    problem_ccgo: wp.array[int32],
+    problem_nl: wp.array[wp.int32],
+    problem_nc: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_uio: wp.array[wp.int32],
+    problem_lcgo: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
     solver_status: wp.array[PADMMStatus],
-    solver_x: wp.array[float32],
-    solver_z: wp.array[float32],
+    solver_x: wp.array[wp.float32],
+    solver_z: wp.array[wp.float32],
     # Outputs:
-    solver_r_c: wp.array[float32],
+    solver_r_c: wp.array[wp.float32],
 ):
     # Retrieve the thread index as the unilateral entity index
     wid, uid = wp.tid()
@@ -1230,21 +1231,23 @@ def _compute_complementarity_residuals(
         # Compute the index offset of the contact constraint
         ccio_j = vio + ccgo + 3 * cid
         # Capture 3D vectors
-        x_c = vec3f(solver_x[ccio_j], solver_x[ccio_j + 1], solver_x[ccio_j + 2])
-        z_c = vec3f(solver_z[ccio_j], solver_z[ccio_j + 1], solver_z[ccio_j + 2])
+        x_c = wp.vec3f(solver_x[ccio_j], solver_x[ccio_j + 1], solver_x[ccio_j + 2])
+        z_c = wp.vec3f(solver_z[ccio_j], solver_z[ccio_j + 1], solver_z[ccio_j + 2])
         # Compute the inner product of the primal and dual variables
         solver_r_c[uio_u] = wp.dot(x_c, z_c)
 
 
 @wp.func
-def _update_penalty(config: PADMMConfigStruct, pen: PADMMPenalty, iterations: int32, r_p: float32, r_d: float32):
+def _update_penalty(
+    config: PADMMConfigStruct, pen: PADMMPenalty, iterations: wp.int32, r_p: wp.float32, r_d: wp.float32
+):
     """Adaptively updates the ADMM penalty parameter based on the configured strategy.
 
     For BALANCED mode, rho is scaled up when the primal residual dominates and
     scaled down (to ``config.rho_min``) when the dual residual dominates, every
     ``config.penalty_update_freq`` iterations.  For FIXED mode this is a no-op.
     """
-    if config.penalty_update_method == int32(PADMMPenaltyUpdate.BALANCED):
+    if config.penalty_update_method == wp.int32(PADMMPenaltyUpdate.BALANCED):
         freq = config.penalty_update_freq
         if freq > 0 and iterations > 0 and iterations % freq == 0:
             rho = pen.rho
@@ -1253,7 +1256,7 @@ def _update_penalty(config: PADMMConfigStruct, pen: PADMMPenalty, iterations: in
             elif r_d > config.alpha * r_p:
                 rho = wp.max(rho / config.tau, config.rho_min)
             pen.rho = rho
-            pen.num_updates += int32(1)
+            pen.num_updates += wp.int32(1)
     return pen
 
 
@@ -1276,20 +1279,20 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
     @wp.kernel(module="unique", enable_backward=False)
     def _compute_infnorm_residuals(
         # Inputs:
-        problem_nl: wp.array[int32],
-        problem_nc: wp.array[int32],
-        problem_uio: wp.array[int32],
-        problem_dim: wp.array[int32],
-        problem_vio: wp.array[int32],
+        problem_nl: wp.array[wp.int32],
+        problem_nc: wp.array[wp.int32],
+        problem_uio: wp.array[wp.int32],
+        problem_dim: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
         solver_config: wp.array[PADMMConfigStruct],
-        solver_r_p: wp.array[float32],
-        solver_r_d: wp.array[float32],
-        solver_r_c: wp.array[float32],
+        solver_r_p: wp.array[wp.float32],
+        solver_r_d: wp.array[wp.float32],
+        solver_r_c: wp.array[wp.float32],
         # Outputs:
-        solver_state_done: wp.array[int32],
+        solver_state_done: wp.array[wp.int32],
         solver_status: wp.array[PADMMStatus],
         solver_penalty: wp.array[PADMMPenalty],
-        linear_solver_atol: wp.array[float32],
+        linear_solver_atol: wp.array[wp.float32],
     ):
         # Retrieve the thread index as the world index + thread index within block
         wid, tid = wp.tid()
@@ -1325,11 +1328,11 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
         maxiters = config.max_iterations
 
         # Compute element-wise max over each residual vector to compute the infinity-norm
-        r_p_max = float32(0.0)
-        r_d_max = float32(0.0)
+        r_p_max = wp.float32(0.0)
+        r_d_max = wp.float32(0.0)
         if wp.static(num_tiles_cts > 1):
-            r_p_max_acc = wp.tile_zeros(num_tiles_cts, dtype=float32, storage="shared")
-            r_d_max_acc = wp.tile_zeros(num_tiles_cts, dtype=float32, storage="shared")
+            r_p_max_acc = wp.tile_zeros(num_tiles_cts, dtype=wp.float32, storage="shared")
+            r_d_max_acc = wp.tile_zeros(num_tiles_cts, dtype=wp.float32, storage="shared")
         for tile_id in range(num_tiles_cts):
             ct_id_tile = tile_id * tile_size
             if ct_id_tile >= ncts:
@@ -1339,7 +1342,7 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
             # Mask out extra entries in case of heterogenous worlds
             need_mask = ct_id_tile > ncts - tile_size
             if need_mask:
-                mask = wp.tile_map(less_than_op, wp.tile_arange(tile_size, dtype=int32), ncts - ct_id_tile)
+                mask = wp.tile_map(less_than_op, wp.tile_arange(tile_size, dtype=wp.int32), ncts - ct_id_tile)
 
             tile = wp.tile_load(solver_r_p, shape=tile_size, offset=rio_tile)
             tile = wp.tile_map(wp.abs, tile)
@@ -1364,9 +1367,9 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
 
         # Compute the infinity-norm of the complementarity residuals
         nu = nl + nc
-        r_c_max = float32(0.0)
+        r_c_max = wp.float32(0.0)
         if wp.static(num_tiles_u > 1):
-            r_c_max_acc = wp.tile_zeros(num_tiles_u, dtype=float32, storage="shared")
+            r_c_max_acc = wp.tile_zeros(num_tiles_u, dtype=wp.float32, storage="shared")
         for tile_id in range(num_tiles_u):
             u_id_tile = tile_id * tile_size
             if u_id_tile >= nu:
@@ -1376,7 +1379,7 @@ def _make_compute_infnorm_residuals_kernel(tile_size: int, n_cts_max: int, n_u_m
             # Mask out extra entries in case of heterogenous worlds
             need_mask = u_id_tile > nu - tile_size
             if need_mask:
-                mask = wp.tile_map(less_than_op, wp.tile_arange(tile_size, dtype=int32), nu - u_id_tile)
+                mask = wp.tile_map(less_than_op, wp.tile_arange(tile_size, dtype=wp.int32), nu - u_id_tile)
 
             tile = wp.tile_load(solver_r_c, shape=tile_size, offset=uio_tile)
             tile = wp.tile_map(wp.abs, tile)
@@ -1419,67 +1422,67 @@ def make_collect_solver_info_kernel(use_acceleration: bool):
     Specializes the kernel based on whether acceleration is enabled to reduce unnecessary overhead.
 
     Args:
-        use_acceleration (bool): Whether acceleration is enabled in the solver.
+        use_acceleration: Whether acceleration is enabled in the solver.
 
     Returns:
-        wp.kernel: The kernel function to collect solver convergence information.
+        The kernel function to collect solver convergence information.
     """
 
     @wp.kernel
     def _collect_solver_convergence_info(
         # Inputs:
-        problem_nl: wp.array[int32],
-        problem_nc: wp.array[int32],
-        problem_cio: wp.array[int32],
-        problem_lcgo: wp.array[int32],
-        problem_ccgo: wp.array[int32],
-        problem_dim: wp.array[int32],
-        problem_vio: wp.array[int32],
-        problem_mio: wp.array[int32],
-        problem_mu: wp.array[float32],
-        problem_v_f: wp.array[float32],
-        problem_D: wp.array[float32],
-        problem_P: wp.array[float32],
-        solver_state_sigma: wp.array[vec2f],
-        solver_state_s: wp.array[float32],
-        solver_state_x: wp.array[float32],
-        solver_state_x_p: wp.array[float32],
-        solver_state_y: wp.array[float32],
-        solver_state_y_p: wp.array[float32],
-        solver_state_z: wp.array[float32],
-        solver_state_z_p: wp.array[float32],
-        solver_state_a: wp.array[float32],
+        problem_nl: wp.array[wp.int32],
+        problem_nc: wp.array[wp.int32],
+        problem_cio: wp.array[wp.int32],
+        problem_lcgo: wp.array[wp.int32],
+        problem_ccgo: wp.array[wp.int32],
+        problem_dim: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
+        problem_mio: wp.array[wp.int32],
+        problem_mu: wp.array[wp.float32],
+        problem_v_f: wp.array[wp.float32],
+        problem_D: wp.array[wp.float32],
+        problem_P: wp.array[wp.float32],
+        solver_state_sigma: wp.array[wp.vec2f],
+        solver_state_s: wp.array[wp.float32],
+        solver_state_x: wp.array[wp.float32],
+        solver_state_x_p: wp.array[wp.float32],
+        solver_state_y: wp.array[wp.float32],
+        solver_state_y_p: wp.array[wp.float32],
+        solver_state_z: wp.array[wp.float32],
+        solver_state_z_p: wp.array[wp.float32],
+        solver_state_a: wp.array[wp.float32],
         solver_penalty: wp.array[PADMMPenalty],
         solver_status: wp.array[PADMMStatus],
         # Outputs:
-        solver_info_lambdas: wp.array[float32],
-        solver_info_v_plus: wp.array[float32],
-        solver_info_v_aug: wp.array[float32],
-        solver_info_s: wp.array[float32],
-        solver_info_offset: wp.array[int32],
-        solver_info_num_restarts: wp.array[int32],
-        solver_info_num_rho_updates: wp.array[int32],
-        solver_info_a: wp.array[float32],
-        solver_info_norm_s: wp.array[float32],
-        solver_info_norm_x: wp.array[float32],
-        solver_info_norm_y: wp.array[float32],
-        solver_info_norm_z: wp.array[float32],
-        solver_info_f_ccp: wp.array[float32],
-        solver_info_f_ncp: wp.array[float32],
-        solver_info_r_dx: wp.array[float32],
-        solver_info_r_dy: wp.array[float32],
-        solver_info_r_dz: wp.array[float32],
-        solver_info_r_primal: wp.array[float32],
-        solver_info_r_dual: wp.array[float32],
-        solver_info_r_compl: wp.array[float32],
-        solver_info_r_pd: wp.array[float32],
-        solver_info_r_dp: wp.array[float32],
-        solver_info_r_comb: wp.array[float32],
-        solver_info_r_comb_ratio: wp.array[float32],
-        solver_info_r_ncp_primal: wp.array[float32],
-        solver_info_r_ncp_dual: wp.array[float32],
-        solver_info_r_ncp_compl: wp.array[float32],
-        solver_info_r_ncp_natmap: wp.array[float32],
+        solver_info_lambdas: wp.array[wp.float32],
+        solver_info_v_plus: wp.array[wp.float32],
+        solver_info_v_aug: wp.array[wp.float32],
+        solver_info_s: wp.array[wp.float32],
+        solver_info_offset: wp.array[wp.int32],
+        solver_info_num_restarts: wp.array[wp.int32],
+        solver_info_num_rho_updates: wp.array[wp.int32],
+        solver_info_a: wp.array[wp.float32],
+        solver_info_norm_s: wp.array[wp.float32],
+        solver_info_norm_x: wp.array[wp.float32],
+        solver_info_norm_y: wp.array[wp.float32],
+        solver_info_norm_z: wp.array[wp.float32],
+        solver_info_f_ccp: wp.array[wp.float32],
+        solver_info_f_ncp: wp.array[wp.float32],
+        solver_info_r_dx: wp.array[wp.float32],
+        solver_info_r_dy: wp.array[wp.float32],
+        solver_info_r_dz: wp.array[wp.float32],
+        solver_info_r_primal: wp.array[wp.float32],
+        solver_info_r_dual: wp.array[wp.float32],
+        solver_info_r_compl: wp.array[wp.float32],
+        solver_info_r_pd: wp.array[wp.float32],
+        solver_info_r_dp: wp.array[wp.float32],
+        solver_info_r_comb: wp.array[wp.float32],
+        solver_info_r_comb_ratio: wp.array[wp.float32],
+        solver_info_r_ncp_primal: wp.array[wp.float32],
+        solver_info_r_ncp_dual: wp.array[wp.float32],
+        solver_info_r_ncp_compl: wp.array[wp.float32],
+        solver_info_r_ncp_natmap: wp.array[wp.float32],
     ):
         # Retrieve the thread index as the world index
         wid = wp.tid()
@@ -1605,64 +1608,64 @@ def make_collect_solver_info_kernel_sparse(use_acceleration: bool):
     Specializes the kernel based on whether acceleration is enabled to reduce unnecessary overhead.
 
     Args:
-        use_acceleration (bool): Whether acceleration is enabled in the solver.
+        use_acceleration: Whether acceleration is enabled in the solver.
 
     Returns:
-        wp.kernel: The kernel function to collect solver convergence information.
+        The kernel function to collect solver convergence information.
     """
 
     @wp.kernel
     def _collect_solver_convergence_info_sparse(
         # Inputs:
-        problem_nl: wp.array[int32],
-        problem_nc: wp.array[int32],
-        problem_cio: wp.array[int32],
-        problem_lcgo: wp.array[int32],
-        problem_ccgo: wp.array[int32],
-        problem_dim: wp.array[int32],
-        problem_vio: wp.array[int32],
-        problem_mu: wp.array[float32],
-        problem_v_f: wp.array[float32],
-        problem_P: wp.array[float32],
-        solver_state_s: wp.array[float32],
-        solver_state_x: wp.array[float32],
-        solver_state_x_p: wp.array[float32],
-        solver_state_y: wp.array[float32],
-        solver_state_y_p: wp.array[float32],
-        solver_state_z: wp.array[float32],
-        solver_state_z_p: wp.array[float32],
-        solver_state_a: wp.array[float32],
+        problem_nl: wp.array[wp.int32],
+        problem_nc: wp.array[wp.int32],
+        problem_cio: wp.array[wp.int32],
+        problem_lcgo: wp.array[wp.int32],
+        problem_ccgo: wp.array[wp.int32],
+        problem_dim: wp.array[wp.int32],
+        problem_vio: wp.array[wp.int32],
+        problem_mu: wp.array[wp.float32],
+        problem_v_f: wp.array[wp.float32],
+        problem_P: wp.array[wp.float32],
+        solver_state_s: wp.array[wp.float32],
+        solver_state_x: wp.array[wp.float32],
+        solver_state_x_p: wp.array[wp.float32],
+        solver_state_y: wp.array[wp.float32],
+        solver_state_y_p: wp.array[wp.float32],
+        solver_state_z: wp.array[wp.float32],
+        solver_state_z_p: wp.array[wp.float32],
+        solver_state_a: wp.array[wp.float32],
         solver_penalty: wp.array[PADMMPenalty],
         solver_status: wp.array[PADMMStatus],
         # Outputs:
-        solver_info_lambdas: wp.array[float32],
-        solver_info_v_plus: wp.array[float32],
-        solver_info_v_aug: wp.array[float32],
-        solver_info_s: wp.array[float32],
-        solver_info_offset: wp.array[int32],
-        solver_info_num_restarts: wp.array[int32],
-        solver_info_num_rho_updates: wp.array[int32],
-        solver_info_a: wp.array[float32],
-        solver_info_norm_s: wp.array[float32],
-        solver_info_norm_x: wp.array[float32],
-        solver_info_norm_y: wp.array[float32],
-        solver_info_norm_z: wp.array[float32],
-        solver_info_f_ccp: wp.array[float32],
-        solver_info_f_ncp: wp.array[float32],
-        solver_info_r_dx: wp.array[float32],
-        solver_info_r_dy: wp.array[float32],
-        solver_info_r_dz: wp.array[float32],
-        solver_info_r_primal: wp.array[float32],
-        solver_info_r_dual: wp.array[float32],
-        solver_info_r_compl: wp.array[float32],
-        solver_info_r_pd: wp.array[float32],
-        solver_info_r_dp: wp.array[float32],
-        solver_info_r_comb: wp.array[float32],
-        solver_info_r_comb_ratio: wp.array[float32],
-        solver_info_r_ncp_primal: wp.array[float32],
-        solver_info_r_ncp_dual: wp.array[float32],
-        solver_info_r_ncp_compl: wp.array[float32],
-        solver_info_r_ncp_natmap: wp.array[float32],
+        solver_info_lambdas: wp.array[wp.float32],
+        solver_info_v_plus: wp.array[wp.float32],
+        solver_info_v_aug: wp.array[wp.float32],
+        solver_info_s: wp.array[wp.float32],
+        solver_info_offset: wp.array[wp.int32],
+        solver_info_num_restarts: wp.array[wp.int32],
+        solver_info_num_rho_updates: wp.array[wp.int32],
+        solver_info_a: wp.array[wp.float32],
+        solver_info_norm_s: wp.array[wp.float32],
+        solver_info_norm_x: wp.array[wp.float32],
+        solver_info_norm_y: wp.array[wp.float32],
+        solver_info_norm_z: wp.array[wp.float32],
+        solver_info_f_ccp: wp.array[wp.float32],
+        solver_info_f_ncp: wp.array[wp.float32],
+        solver_info_r_dx: wp.array[wp.float32],
+        solver_info_r_dy: wp.array[wp.float32],
+        solver_info_r_dz: wp.array[wp.float32],
+        solver_info_r_primal: wp.array[wp.float32],
+        solver_info_r_dual: wp.array[wp.float32],
+        solver_info_r_compl: wp.array[wp.float32],
+        solver_info_r_pd: wp.array[wp.float32],
+        solver_info_r_dp: wp.array[wp.float32],
+        solver_info_r_comb: wp.array[wp.float32],
+        solver_info_r_comb_ratio: wp.array[wp.float32],
+        solver_info_r_ncp_primal: wp.array[wp.float32],
+        solver_info_r_ncp_dual: wp.array[wp.float32],
+        solver_info_r_ncp_compl: wp.array[wp.float32],
+        solver_info_r_ncp_natmap: wp.array[wp.float32],
     ):
         # Retrieve the thread index as the world index
         wid = wp.tid()
@@ -1782,13 +1785,13 @@ def make_collect_solver_info_kernel_sparse(use_acceleration: bool):
 @wp.kernel
 def _apply_dual_preconditioner_to_state(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_P: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    solver_x: wp.array[float32],
-    solver_y: wp.array[float32],
-    solver_z: wp.array[float32],
+    solver_x: wp.array[wp.float32],
+    solver_y: wp.array[wp.float32],
+    solver_z: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -1823,12 +1826,12 @@ def _apply_dual_preconditioner_to_state(
 @wp.kernel
 def _apply_dual_preconditioner_to_solution(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_P: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_P: wp.array[wp.float32],
     # Outputs:
-    solution_lambdas: wp.array[float32],
-    solution_v_plus: wp.array[float32],
+    solution_lambdas: wp.array[wp.float32],
+    solution_v_plus: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()
@@ -1860,14 +1863,14 @@ def _apply_dual_preconditioner_to_solution(
 
 @wp.kernel
 def _compute_final_desaxce_correction(
-    problem_nc: wp.array[int32],
-    problem_cio: wp.array[int32],
-    problem_ccgo: wp.array[int32],
-    problem_vio: wp.array[int32],
-    problem_mu: wp.array[float32],
-    solver_z: wp.array[float32],
+    problem_nc: wp.array[wp.int32],
+    problem_cio: wp.array[wp.int32],
+    problem_ccgo: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    problem_mu: wp.array[wp.float32],
+    solver_z: wp.array[wp.float32],
     # Outputs:
-    solver_s: wp.array[float32],
+    solver_s: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, cid = wp.tid()
@@ -1905,14 +1908,14 @@ def _compute_final_desaxce_correction(
 @wp.kernel
 def _compute_solution_vectors(
     # Inputs:
-    problem_dim: wp.array[int32],
-    problem_vio: wp.array[int32],
-    solver_s: wp.array[float32],
-    solver_y: wp.array[float32],
-    solver_z: wp.array[float32],
+    problem_dim: wp.array[wp.int32],
+    problem_vio: wp.array[wp.int32],
+    solver_s: wp.array[wp.float32],
+    solver_y: wp.array[wp.float32],
+    solver_z: wp.array[wp.float32],
     # Outputs:
-    solver_v_plus: wp.array[float32],
-    solver_lambdas: wp.array[float32],
+    solver_v_plus: wp.array[wp.float32],
+    solver_lambdas: wp.array[wp.float32],
 ):
     # Retrieve the thread index
     wid, tid = wp.tid()

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -3,9 +3,9 @@
 
 """Defines mathematical operations used by the Proximal-ADMM solver."""
 
-import warp as wp
+from __future__ import annotations
 
-from ...core.types import float32, int32, vec3f
+import warp as wp
 
 ###
 # Module interface
@@ -45,17 +45,17 @@ wp.set_module_options({"enable_backward": False})
 
 
 @wp.func
-def project_to_coulomb_cone(x: vec3f, mu: float32, epsilon: float32 = 0.0) -> vec3f:
+def project_to_coulomb_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0.0) -> wp.vec3f:
     """
     Projects a 3D vector `x` onto an isotropic Coulomb friction cone defined by the friction coefficient `mu`.
 
     Args:
-        x (vec3f): The input vector to be projected.
-        mu (float32): The friction coefficient defining the aperture of the cone.
-        epsilon (float32, optional): A numerical tolerance applied to the cone boundary. Defaults to 0.0.
+        x: The input vector to be projected.
+        mu: The friction coefficient defining the aperture of the cone.
+        epsilon: A numerical tolerance applied to the cone boundary. Defaults to 0.0.
 
     Returns:
-        vec3f: The vector projected onto the Coulomb cone.
+        The vector projected onto the Coulomb cone.
     """
     xn = x[2]
     xt_norm = wp.sqrt(x[0] * x[0] + x[1] * x[1])
@@ -73,18 +73,18 @@ def project_to_coulomb_cone(x: vec3f, mu: float32, epsilon: float32 = 0.0) -> ve
 
 
 @wp.func
-def project_to_coulomb_dual_cone(x: vec3f, mu: float32, epsilon: float32 = 0.0) -> vec3f:
+def project_to_coulomb_dual_cone(x: wp.vec3f, mu: wp.float32, epsilon: wp.float32 = 0.0) -> wp.vec3f:
     """
     Projects a 3D vector `x` onto the dual of an isotropic Coulomb
     friction cone defined by the friction coefficient `mu`.
 
     Args:
-        x (vec3f): The input vector to be projected.
-        mu (float32): The friction coefficient defining the aperture of the cone.
-        epsilon (float32, optional): A numerical tolerance applied to the cone boundary. Defaults to 0.0.
+        x: The input vector to be projected.
+        mu: The friction coefficient defining the aperture of the cone.
+        epsilon: A numerical tolerance applied to the cone boundary. Defaults to 0.0.
 
     Returns:
-        vec3f: The vector projected onto the dual Coulomb cone.
+        The vector projected onto the dual Coulomb cone.
     """
     xn = x[2]
     xt_norm = wp.sqrt(x[0] * x[0] + x[1] * x[1])
@@ -110,10 +110,10 @@ def project_to_coulomb_dual_cone(x: vec3f, mu: float32, epsilon: float32 = 0.0) 
 
 @wp.func
 def compute_inf_norm(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-) -> float32:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+) -> wp.float32:
     norm = float(0.0)
     for i in range(dim):
         norm = wp.max(norm, wp.abs(x[vio + i]))
@@ -122,10 +122,10 @@ def compute_inf_norm(
 
 @wp.func
 def compute_l1_norm(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-) -> float32:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+) -> wp.float32:
     sum = float(0.0)
     for i in range(dim):
         sum += wp.abs(x[vio + i])
@@ -134,10 +134,10 @@ def compute_l1_norm(
 
 @wp.func
 def compute_l2_norm(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-) -> float32:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+) -> wp.float32:
     sum = float(0.0)
     for i in range(dim):
         x_i = x[vio + i]
@@ -147,23 +147,23 @@ def compute_l2_norm(
 
 @wp.func
 def compute_dot_product(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-    y: wp.array[float32],
-) -> float32:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+) -> wp.float32:
     """
     Computes the dot (i.e. inner) product between two vectors `x` and `y` stored in flat arrays.\n
     Both vectors are of dimension `dim`, starting from the vector index offset `vio`.
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        x (wp.array[float32]): The first vector.
-        y (wp.array[float32]): The second vector.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        x: The first vector.
+        y: The second vector.
 
     Returns:
-        float32: The dot product of the two vectors.
+        The dot product of the two vectors.
     """
     product = float(0.0)
     for i in range(dim):
@@ -174,25 +174,25 @@ def compute_dot_product(
 
 @wp.func
 def compute_double_dot_product(
-    dim: int32,
-    vio: int32,
-    x: wp.array[float32],
-    y: wp.array[float32],
-    z: wp.array[float32],
-) -> float32:
+    dim: wp.int32,
+    vio: wp.int32,
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
+    z: wp.array[wp.float32],
+) -> wp.float32:
     """
     Computes the the inner product `x.T @ (y + z)` between a vector `x` and the sum of two vectors `y` and `z`.\n
     All vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        x (wp.array[float32]): The first vector.
-        y (wp.array[float32]): The second vector.
-        z (wp.array[float32]): The third vector.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        x: The first vector.
+        y: The second vector.
+        z: The third vector.
 
     Returns:
-        float32: The inner product of `x` with the sum of `y` and `z`.
+        The inner product of `x` with the sum of `y` and `z`.
     """
     product = float(0.0)
     for i in range(dim):
@@ -202,20 +202,22 @@ def compute_double_dot_product(
 
 
 @wp.func
-def compute_vector_sum(dim: int32, vio: int32, x: wp.array[float32], y: wp.array[float32], z: wp.array[float32]):
+def compute_vector_sum(
+    dim: wp.int32, vio: wp.int32, x: wp.array[wp.float32], y: wp.array[wp.float32], z: wp.array[wp.float32]
+):
     """
     Computes the sum of two vectors `x` and `y` and stores the result in vector `z`.\n
     All vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        x (wp.array[float32]): The first vector.
-        y (wp.array[float32]): The second vector.
-        z (wp.array[float32]): The output vector where the sum is stored.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        x: The first vector.
+        y: The second vector.
+        z: The output vector where the sum is stored.
 
     Returns:
-        None: The result is stored in the output vector `z`.
+        The result is stored in the output vector `z`.
     """
     for i in range(dim):
         v_i = vio + i
@@ -224,21 +226,21 @@ def compute_vector_sum(dim: int32, vio: int32, x: wp.array[float32], y: wp.array
 
 @wp.func
 def compute_cwise_vec_mul(
-    dim: int32,
-    vio: int32,
-    a: wp.array[float32],
-    x: wp.array[float32],
-    y: wp.array[float32],
+    dim: wp.int32,
+    vio: wp.int32,
+    a: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
 ):
     """
     Computes the coefficient-wise vector-vector product `y =  a * x`.\n
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        a (wp.array[float32]): Input array containing the first set of vectors.
-        x (wp.array[float32]): Input array containing the second set of vectors.
-        y (wp.array[float32]): Output array where the result is stored.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        a: Input array containing the first set of vectors.
+        x: Input array containing the second set of vectors.
+        y: Output array where the result is stored.
     """
     for i in range(dim):
         v_i = vio + i
@@ -247,21 +249,21 @@ def compute_cwise_vec_mul(
 
 @wp.func
 def compute_cwise_vec_div(
-    dim: int32,
-    vio: int32,
-    a: wp.array[float32],
-    x: wp.array[float32],
-    y: wp.array[float32],
+    dim: wp.int32,
+    vio: wp.int32,
+    a: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    y: wp.array[wp.float32],
 ):
     """
     Computes the coefficient-wise vector-vector division `y =  a / x`.\n
 
     Args:
-        dim (int32): The dimension (i.e. size) of the vectors.
-        vio (int32): The vector index offset (i.e. start index).
-        a (wp.array[float32]): Input array containing the first set of vectors.
-        x (wp.array[float32]): Input array containing the second set of vectors.
-        y (wp.array[float32]): Output array where the result is stored.
+        dim: The dimension (i.e. size) of the vectors.
+        vio: The vector index offset (i.e. start index).
+        a: Input array containing the first set of vectors.
+        x: Input array containing the second set of vectors.
+        y: Output array where the result is stored.
     """
     for i in range(dim):
         v_i = vio + i
@@ -270,15 +272,15 @@ def compute_cwise_vec_div(
 
 @wp.func
 def compute_gemv(
-    dim: int32,
-    vio: int32,
-    mio: int32,
-    sigma: float32,
-    P: wp.array[float32],
-    A: wp.array[float32],
-    x: wp.array[float32],
-    b: wp.array[float32],
-    c: wp.array[float32],
+    dim: wp.int32,
+    vio: wp.int32,
+    mio: wp.int32,
+    sigma: wp.float32,
+    P: wp.array[wp.float32],
+    A: wp.array[wp.float32],
+    x: wp.array[wp.float32],
+    b: wp.array[wp.float32],
+    c: wp.array[wp.float32],
 ):
     """
     Computes the generalized matrix-vector product `c =  b + (A - sigma * I_n)@ x`.\n
@@ -289,18 +291,14 @@ def compute_gemv(
     dimensions `dim`, starting from the vector index offset `vio`.
 
     Args:
-        maxdim (int32): The maximum dimension of the matrix `A`.
-        dim (int32): The active dimension of the matrix `A` and the vectors `x, b, c`.
-        vio (int32): The vector index offset (i.e. start index) for the vectors `x, b, c`.
-        mio (int32): The matrix index offset (i.e. start index) for the matrix `A`.
-        A (wp.array[float32]):
-            Input matrix `A` stored in row-major order.
-        x (wp.array[float32]):
-            Input array `x` to be multiplied with the matrix `A`.
-        b (wp.array[float32]):
-            Input array `b` to be added to the product `A @ x`.
-        c (wp.array[float32]):
-            Output array `c` where the result of the operation is stored.
+        maxdim: The maximum dimension of the matrix `A`.
+        dim: The active dimension of the matrix `A` and the vectors `x, b, c`.
+        vio: The vector index offset (i.e. start index) for the vectors `x, b, c`.
+        mio: The matrix index offset (i.e. start index) for the matrix `A`.
+        A: Input matrix `A` stored in row-major order.
+        x: Input array `x` to be multiplied with the matrix `A`.
+        b: Input array `b` to be added to the product `A @ x`.
+        c: Output array `c` where the result of the operation is stored.
     """
     b_i = float(0.0)
     x_j = float(0.0)
@@ -317,13 +315,13 @@ def compute_gemv(
 
 @wp.func
 def compute_desaxce_corrections(
-    nc: int32,
-    cio: int32,
-    vio: int32,
-    ccgo: int32,
-    mu: wp.array[float32],
-    v_plus: wp.array[float32],
-    s: wp.array[float32],
+    nc: wp.int32,
+    cio: wp.int32,
+    vio: wp.int32,
+    ccgo: wp.int32,
+    mu: wp.array[wp.float32],
+    v_plus: wp.array[wp.float32],
+    s: wp.array[wp.float32],
 ):
     """
     Computes the De Saxce correction for each active contact.
@@ -331,22 +329,19 @@ def compute_desaxce_corrections(
     `s = G(v) := [ 0, 0 , mu * || vt ||_2,]^T, where v := [vtx, vty, vn]^T, vt := [vtx, vty]^T`
 
     Args:
-        nc (int32): The number of active contact constraints.
-        cio (int32): The contact index offset (i.e. start index) for the contacts.
-        vio (int32): The vector index offset (i.e. start index)
-        ccgo (int32): The contact constraint group offset (i.e. start index)
-        mu (wp.array[float32]):
-            The array of friction coefficients for each contact constraint.
-        v_plus (wp.array[float32]):
-            The post-event constraint-space velocities array, which contains the tangential velocities `vtx`
+        nc: The number of active contact constraints.
+        cio: The contact index offset (i.e. start index) for the contacts.
+        vio: The vector index offset (i.e. start index)
+        ccgo: The contact constraint group offset (i.e. start index)
+        mu: The array of friction coefficients for each contact constraint.
+        v_plus: The post-event constraint-space velocities array, which contains the tangential velocities `vtx`
             and `vty` for each contact constraint.
-        s (wp.array[float32]):
-            The output array where the De Saxce corrections are stored.\n
+        s: The output array where the De Saxce corrections are stored.\n
             The size of this array should be at least `vio + ccgo + 3 * nc`, where `vio` is the vector index offset,
             `ccgo` is the contact constraint group offset, and `nc` is the number of active contact constraints.
 
     Returns:
-        None: The De Saxce corrections are stored in the output array `s`.
+        The De Saxce corrections are stored in the output array `s`.
     """
     # Iterate over each active contact
     for k in range(nc):
@@ -372,15 +367,15 @@ def compute_desaxce_corrections(
 
 @wp.func
 def compute_ncp_primal_residual(
-    nl: int32,
-    nc: int32,
-    vio: int32,
-    lcgo: int32,
-    ccgo: int32,
-    cio: int32,
-    mu: wp.array[float32],
-    lambdas: wp.array[float32],
-) -> tuple[float32, int32]:
+    nl: wp.int32,
+    nc: wp.int32,
+    vio: wp.int32,
+    lcgo: wp.int32,
+    ccgo: wp.int32,
+    cio: wp.int32,
+    mu: wp.array[wp.float32],
+    lambdas: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
     """
     Computes the NCP primal residual as: `r_p := || lambda - proj_K(lambda) ||_inf`, where:
     - `lambda` is the vector of constraint reactions (i.e. impulses)
@@ -394,24 +389,22 @@ def compute_ncp_primal_residual(
     - For contact constraints, the cone is defined as `K_c := { lambda | || lambda ||_2 <= mu * || vn ||_2 }`
 
     Args:
-        nl (int32): The number of active limit constraints.
-        nc (int32): The number of active contact constraints.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        lcgo (int32): The limit constraint group offset (i.e. start index).
-        ccgo (int32): The contact constraint group offset (i.e. start index).
-        cio (int32): The contact index offset (i.e. start index) for the contacts.
-        mu (wp.array[float32]):
-            The array of friction coefficients for each contact.
-        lambdas (wp.array[float32]):
-            The array of constraint reactions (i.e. impulses).
+        nl: The number of active limit constraints.
+        nc: The number of active contact constraints.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        lcgo: The limit constraint group offset (i.e. start index).
+        ccgo: The contact constraint group offset (i.e. start index).
+        cio: The contact index offset (i.e. start index) for the contacts.
+        mu: The array of friction coefficients for each contact.
+        lambdas: The array of constraint reactions (i.e. impulses).
 
     Returns:
-        float32: The maximum primal residual across all constraints, computed as the infinity norm.
-        int32: The index of the constraint with the maximum primal residual.
+        The maximum primal residual across all constraints, computed as the infinity norm,
+        and the index of the constraint with the maximum primal residual.
     """
     # Initialize the primal residual
     r_ncp_p = float(0.0)
-    r_ncp_p_argmax = int32(-1)
+    r_ncp_p_argmax = wp.int32(-1)
 
     # NOTE: We skip the joint constraint reactions are not bounded, the cone is all of R^njc
 
@@ -432,7 +425,7 @@ def compute_ncp_primal_residual(
         # Retrieve the friction coefficient for this contact
         mu_c = mu[cio + cid]
         # Compute the primal residual for the contact constraints
-        lambda_c = vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
+        lambda_c = wp.vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
         lambda_c -= project_to_coulomb_cone(lambda_c, mu_c)
         r_c = wp.max(wp.abs(lambda_c))
         r_ncp_p = wp.max(r_ncp_p, r_c)
@@ -445,16 +438,16 @@ def compute_ncp_primal_residual(
 
 @wp.func
 def compute_ncp_dual_residual(
-    njc: int32,
-    nl: int32,
-    nc: int32,
-    vio: int32,
-    lcgo: int32,
-    ccgo: int32,
-    cio: int32,
-    mu: wp.array[float32],
-    v_aug: wp.array[float32],
-) -> tuple[float32, int32]:
+    njc: wp.int32,
+    nl: wp.int32,
+    nc: wp.int32,
+    vio: wp.int32,
+    lcgo: wp.int32,
+    ccgo: wp.int32,
+    cio: wp.int32,
+    mu: wp.array[wp.float32],
+    v_aug: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
     """
     Computes the NCP dual residual as: `r_d := || v_aug - proj_K^*(v_aug) ||_inf`, where:
     - `v_aug` is the vector of augmented constraint velocities: v_aug := v_plus + s
@@ -470,25 +463,23 @@ def compute_ncp_dual_residual(
     - For contact constraints, the cone is defined as `K_c := { lambda | || lambda ||_2 <= mu * || vn ||_2 }`
 
     Args:
-        njc (int32): The number of joint constraints.
-        nl (int32): The number of active limit constraints.
-        nc (int32): The number of active contact constraints.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        lcgo (int32): The limit constraint group offset (i.e. start index).
-        ccgo (int32): The contact constraint group offset (i.e. start index).
-        cio (int32): The contact index offset (i.e. start index) for the contacts.
-        mu (wp.array[float32]):
-            The array of friction coefficients for each contact constraint.
-        v_aug (wp.array[float32]):
-            The array of augmented constraint velocities.
+        njc: The number of joint constraints.
+        nl: The number of active limit constraints.
+        nc: The number of active contact constraints.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        lcgo: The limit constraint group offset (i.e. start index).
+        ccgo: The contact constraint group offset (i.e. start index).
+        cio: The contact index offset (i.e. start index) for the contacts.
+        mu: The array of friction coefficients for each contact constraint.
+        v_aug: The array of augmented constraint velocities.
 
     Returns:
-        float32: The maximum dual residual across all constraints, computed as the infinity norm.
-        int32: The index of the constraint with the maximum dual residual.
+        The maximum dual residual across all constraints, computed as the infinity norm,
+        and the index of the constraint with the maximum dual residual.
     """
     # Initialize the dual residual
     r_ncp_d = float(0.0)
-    r_ncp_d_argmax = int32(-1)
+    r_ncp_d_argmax = wp.int32(-1)
 
     for jid in range(njc):
         # Compute the joint constraint index offset
@@ -521,7 +512,7 @@ def compute_ncp_dual_residual(
         mu_c = mu[cio + cid]
         # Compute the dual residual for the contact constraints
         # NOTE: Each constraint-space velocity should be lie in the dual of the Coulomb friction cone
-        v_c = vec3f(v_aug[ccio_c], v_aug[ccio_c + 1], v_aug[ccio_c + 2])
+        v_c = wp.vec3f(v_aug[ccio_c], v_aug[ccio_c + 1], v_aug[ccio_c + 2])
         v_c -= project_to_coulomb_dual_cone(v_c, mu_c)
         r_c = wp.max(wp.abs(v_c))
         r_ncp_d = wp.max(r_ncp_d, r_c)
@@ -534,14 +525,14 @@ def compute_ncp_dual_residual(
 
 @wp.func
 def compute_ncp_complementarity_residual(
-    nl: int32,
-    nc: int32,
-    vio: int32,
-    lcgo: int32,
-    ccgo: int32,
-    v_aug: wp.array[float32],
-    lambdas: wp.array[float32],
-) -> tuple[float32, int32]:
+    nl: wp.int32,
+    nc: wp.int32,
+    vio: wp.int32,
+    lcgo: wp.int32,
+    ccgo: wp.int32,
+    v_aug: wp.array[wp.float32],
+    lambdas: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
     """
     Computes the NCP complementarity residual as `r_c := || lambda.dot(v_plus + s) ||_inf`
 
@@ -551,23 +542,21 @@ def compute_ncp_complementarity_residual(
     constraint `k`, we compute `v_k.dot(lambda_k)`.
 
     Args:
-        nl (int32): The number of active limit constraints.
-        nc (int32): The number of active contact constraints.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        lcgo (int32): The limit constraint group offset (i.e. start index).
-        ccgo (int32): The contact constraint group offset (i.e. start index).
-        v_aug (wp.array[float32]):
-            The array of augmented constraint velocities.
-        lambdas (wp.array[float32]):
-            The array of constraint reactions (i.e. impulses).
+        nl: The number of active limit constraints.
+        nc: The number of active contact constraints.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        lcgo: The limit constraint group offset (i.e. start index).
+        ccgo: The contact constraint group offset (i.e. start index).
+        v_aug: The array of augmented constraint velocities.
+        lambdas: The array of constraint reactions (i.e. impulses).
 
     Returns:
-        float32: The maximum complementarity residual across all constraints, computed as the infinity norm.
-        int32: The index of the constraint with the maximum complementarity residual.
+        The maximum complementarity residual across all constraints, computed as the infinity norm,
+        and the index of the constraint with the maximum complementarity residual.
     """
     # Initialize the complementarity residual
     r_ncp_c = float(0.0)
-    r_ncp_c_argmax = int32(-1)
+    r_ncp_c_argmax = wp.int32(-1)
 
     for lid in range(nl):
         # Compute the limit constraint index offset
@@ -584,8 +573,8 @@ def compute_ncp_complementarity_residual(
         # Compute the contact constraint index offset
         ccio = vio + ccgo + 3 * cid
         # Compute the complementarity residual for the contact constraints
-        v_c = vec3f(v_aug[ccio], v_aug[ccio + 1], v_aug[ccio + 2])
-        lambda_c = vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
+        v_c = wp.vec3f(v_aug[ccio], v_aug[ccio + 1], v_aug[ccio + 2])
+        lambda_c = wp.vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
         r_c = wp.abs(wp.dot(v_c, lambda_c))
         r_ncp_c = wp.max(r_ncp_c, r_c)
         if r_ncp_c == r_c:
@@ -597,41 +586,38 @@ def compute_ncp_complementarity_residual(
 
 @wp.func
 def compute_ncp_natural_map_residual(
-    nl: int32,
-    nc: int32,
-    vio: int32,
-    lcgo: int32,
-    ccgo: int32,
-    cio: int32,
-    mu: wp.array[float32],
-    v_aug: wp.array[float32],
-    lambdas: wp.array[float32],
-) -> tuple[float32, int32]:
+    nl: wp.int32,
+    nc: wp.int32,
+    vio: wp.int32,
+    lcgo: wp.int32,
+    ccgo: wp.int32,
+    cio: wp.int32,
+    mu: wp.array[wp.float32],
+    v_aug: wp.array[wp.float32],
+    lambdas: wp.array[wp.float32],
+) -> tuple[wp.float32, wp.int32]:
     """
     Computes the natural-map residuals as: `r_natmap = || lambda - proj_K(lambda - (v + s)) ||_inf`
 
     Args:
-        nl (int32): The number of active limit constraints.
-        nc (int32): The number of active contact constraints.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        lcgo (int32): The limit constraint group offset (i.e. start index).
-        ccgo (int32): The contact constraint group offset (i.e. start index).
-        cio (int32): The contact index offset (i.e. start index) for the contacts.
-        mu (wp.array[float32]):
-            The array of friction coefficients for each contact.
-        v_aug (wp.array[float32]):
-            The array of augmented constraint velocities.
-        lambdas (wp.array[float32]):
-            The array of constraint reactions (i.e. impulses).
+        nl: The number of active limit constraints.
+        nc: The number of active contact constraints.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        lcgo: The limit constraint group offset (i.e. start index).
+        ccgo: The contact constraint group offset (i.e. start index).
+        cio: The contact index offset (i.e. start index) for the contacts.
+        mu: The array of friction coefficients for each contact.
+        v_aug: The array of augmented constraint velocities.
+        lambdas: The array of constraint reactions (i.e. impulses).
 
     Returns:
-        float32: The maximum natural-map residual across all constraints, computed as the infinity norm.
-        int32: The index of the constraint with the maximum natural-map residual.
+        The maximum natural-map residual across all constraints, computed as the infinity norm,
+        and the index of the constraint with the maximum natural-map residual.
     """
 
     # Initialize the natural-map residual
     r_ncp_natmap = float(0.0)
-    r_ncp_natmap_argmax = int32(-1)
+    r_ncp_natmap_argmax = wp.int32(-1)
 
     for lid in range(nl):
         # Compute the limit constraint index offset
@@ -651,8 +637,8 @@ def compute_ncp_natural_map_residual(
         # Retrieve the friction coefficient for this contact
         mu_c = mu[cio + cid]
         # Compute the natural-map residual for the contact constraints
-        v_c = vec3f(v_aug[ccio], v_aug[ccio + 1], v_aug[ccio + 2])
-        lambda_c = vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
+        v_c = wp.vec3f(v_aug[ccio], v_aug[ccio + 1], v_aug[ccio + 2])
+        lambda_c = wp.vec3f(lambdas[ccio], lambdas[ccio + 1], lambdas[ccio + 2])
         lambda_c -= project_to_coulomb_cone(lambda_c - v_c, mu_c)
         lambda_c = wp.abs(lambda_c)
         lambda_c_max = wp.max(lambda_c)
@@ -666,21 +652,19 @@ def compute_ncp_natural_map_residual(
 
 @wp.func
 def compute_preconditioned_iterate_residual(
-    ncts: int32, vio: int32, P: wp.array[float32], x: wp.array[float32], x_p: wp.array[float32]
-) -> float32:
+    ncts: wp.int32, vio: wp.int32, P: wp.array[wp.float32], x: wp.array[wp.float32], x_p: wp.array[wp.float32]
+) -> wp.float32:
     """
     Computes the iterate residual as: `r_dx := || P @ (x - x_p) ||_inf`
 
     Args:
-        ncts (int32): The number of active constraints in the world.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        x (wp.array[float32]):
-            The current solution vector.
-        x_p (wp.array[float32]):
-            The previous solution vector.
+        ncts: The number of active constraints in the world.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        x: The current solution vector.
+        x_p: The previous solution vector.
 
     Returns:
-        float32: The maximum iterate residual across all active constraints, computed as the infinity norm.
+        The maximum iterate residual across all active constraints, computed as the infinity norm.
     """
     # Initialize the iterate residual
     r_dx = float(0.0)
@@ -695,21 +679,19 @@ def compute_preconditioned_iterate_residual(
 
 @wp.func
 def compute_inverse_preconditioned_iterate_residual(
-    ncts: int32, vio: int32, P: wp.array[float32], x: wp.array[float32], x_p: wp.array[float32]
-) -> float32:
+    ncts: wp.int32, vio: wp.int32, P: wp.array[wp.float32], x: wp.array[wp.float32], x_p: wp.array[wp.float32]
+) -> wp.float32:
     """
     Computes the iterate residual as: `r_dx := || P^{-1} @ (x - x_p) ||_inf`
 
     Args:
-        ncts (int32): The number of active constraints in the world.
-        vio (int32): The vector index offset (i.e. start index) for the constraints.
-        x (wp.array[float32]):
-            The current solution vector.
-        x_p (wp.array[float32]):
-            The previous solution vector.
+        ncts: The number of active constraints in the world.
+        vio: The vector index offset (i.e. start index) for the constraints.
+        x: The current solution vector.
+        x_p: The previous solution vector.
 
     Returns:
-        float32: The maximum iterate residual across all active constraints, computed as the infinity norm.
+        The maximum iterate residual across all active constraints, computed as the infinity norm.
     """
     # Initialize the iterate residual
     r_dx = float(0.0)

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/math.py
@@ -153,7 +153,7 @@ def compute_dot_product(
     y: wp.array[wp.float32],
 ) -> wp.float32:
     """
-    Computes the dot (i.e. inner) product between two vectors `x` and `y` stored in flat arrays.\n
+    Computes the dot (i.e. inner) product between two vectors `x` and `y` stored in flat arrays.
     Both vectors are of dimension `dim`, starting from the vector index offset `vio`.
 
     Args:
@@ -181,7 +181,7 @@ def compute_double_dot_product(
     z: wp.array[wp.float32],
 ) -> wp.float32:
     """
-    Computes the the inner product `x.T @ (y + z)` between a vector `x` and the sum of two vectors `y` and `z`.\n
+    Computes the the inner product `x.T @ (y + z)` between a vector `x` and the sum of two vectors `y` and `z`.
     All vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:
@@ -206,7 +206,7 @@ def compute_vector_sum(
     dim: wp.int32, vio: wp.int32, x: wp.array[wp.float32], y: wp.array[wp.float32], z: wp.array[wp.float32]
 ):
     """
-    Computes the sum of two vectors `x` and `y` and stores the result in vector `z`.\n
+    Computes the sum of two vectors `x` and `y` and stores the result in vector `z`.
     All vectors are stored in flat arrays, with dimension `dim` and starting from the vector index offset `vio`.
 
     Args:
@@ -233,7 +233,7 @@ def compute_cwise_vec_mul(
     y: wp.array[wp.float32],
 ):
     """
-    Computes the coefficient-wise vector-vector product `y =  a * x`.\n
+    Computes the coefficient-wise vector-vector product `y =  a * x`.
 
     Args:
         dim: The dimension (i.e. size) of the vectors.
@@ -256,7 +256,7 @@ def compute_cwise_vec_div(
     y: wp.array[wp.float32],
 ):
     """
-    Computes the coefficient-wise vector-vector division `y =  a / x`.\n
+    Computes the coefficient-wise vector-vector division `y =  a / x`.
 
     Args:
         dim: The dimension (i.e. size) of the vectors.
@@ -283,7 +283,7 @@ def compute_gemv(
     c: wp.array[wp.float32],
 ):
     """
-    Computes the generalized matrix-vector product `c =  b + (A - sigma * I_n)@ x`.\n
+    Computes the generalized matrix-vector product `c =  b + (A - sigma * I_n)@ x`.
 
     The matrix `A` is stored using row-major order in flat array with allocation size `maxdim x maxdim`,
     starting from the matrix index offset `mio`. The active dimensions of the matrix are `dim x dim`,
@@ -336,7 +336,7 @@ def compute_desaxce_corrections(
         mu: The array of friction coefficients for each contact constraint.
         v_plus: The post-event constraint-space velocities array, which contains the tangential velocities `vtx`
             and `vty` for each contact constraint.
-        s: The output array where the De Saxce corrections are stored.\n
+        s: The output array where the De Saxce corrections are stored.
             The size of this array should be at least `vio + ccgo + 3 * nc`, where `vio` is the vector index offset,
             `ccgo` is the contact constraint group offset, and `nc` is the number of active contact constraints.
 

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -112,15 +112,15 @@ class PADMMSolver:
         target device, otherwise the user must call `finalize()` before using the solver.
 
         Args:
-            model (ModelKamino | None): The model for which to allocate the solver data.
-            limits (LimitsKamino | None): The limits container associated with the model.
-            contacts (ContactsKamino | None): The contacts container associated with the model.
-            config (list[PADMMSolver.Config] | PADMMSolver.Config | None): The solver config to use.
-            warmstart (PADMMWarmStartMode): The warm-start mode to use for the solver.\n
-            use_acceleration (bool): Set to `True` to enable Nesterov acceleration.
-            use_graph_conditionals (bool): Set to `False` to disable CUDA graph conditional nodes.\n
+            model: The model for which to allocate the solver data.
+            limits: The limits container associated with the model.
+            contacts: The contacts container associated with the model.
+            config: The solver config to use.
+            warmstart: The warm-start mode to use for the solver.\n
+            use_acceleration: Set to `True` to enable Nesterov acceleration.
+            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.\n
                 When disabled, replaces `wp.capture_while` with an unrolled for-loop over max iterations.
-            collect_info (bool): Set to `True` to enable collection of solver convergence info.\n
+            collect_info: Set to `True` to enable collection of solver convergence info.\n
                 This setting is intended only for analysis and debugging purposes, as it
                 will increase memory consumption and reduce wall-clock time.
         """
@@ -205,15 +205,15 @@ class PADMMSolver:
         Allocates the solver data structures on the specified device.
 
         Args:
-            model (ModelKamino | None): The model for which to allocate the solver data.
-            limits (LimitsKamino | None): The limits container associated with the model.
-            contacts (ContactsKamino | None): The contacts container associated with the model.
-            config (list[PADMMSolver.Config] | PADMMSolver.Config | None): The solver config to use.
-            warmstart (PADMMWarmStartMode): The warm-start mode to use for the solver.\n
-            use_acceleration (bool): Set to `True` to enable Nesterov acceleration.
-            use_graph_conditionals (bool): Set to `False` to disable CUDA graph conditional nodes.\n
+            model: The model for which to allocate the solver data.
+            limits: The limits container associated with the model.
+            contacts: The contacts container associated with the model.
+            config: The solver config to use.
+            warmstart: The warm-start mode to use for the solver.\n
+            use_acceleration: Set to `True` to enable Nesterov acceleration.
+            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.\n
                 When disabled, replaces `wp.capture_while` with an unrolled for-loop over max iterations.
-            collect_info (bool): Set to `True` to enable collection of solver convergence info.\n
+            collect_info: Set to `True` to enable collection of solver convergence info.\n
                 This setting is intended only for analysis and debugging purposes, as it
                 will increase memory consumption and reduce wall-clock time.
         """
@@ -280,7 +280,7 @@ class PADMMSolver:
         block_dim = get_block_dim(tile_size, ratio=2, min_size=1)
         self._project_dual_convergence_accel_kernel = _make_project_dual_convergence_accel_kernel(block_dim)
 
-    def reset(self, problem: DualProblem | None = None, world_mask: wp.array | None = None):
+    def reset(self, problem: DualProblem | None = None, world_mask: wp.array[wp.bool] | None = None):
         """
         Resets the all internal solver data to sentinel values.
         """
@@ -334,13 +334,13 @@ class PADMMSolver:
         - `PADMMWarmStartMode.CONTAINERS`: Warm-starts from the provided limits and contacts containers.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            model (ModelKamino): The model associated with the problem.
-            data (DataKamino): The model data associated with the problem.
-            limits (LimitsKamino | None): The limits container associated with the model.\n
+            model: The model associated with the problem.
+            data: The model data associated with the problem.
+            limits: The limits container associated with the model.\n
                 If `None`, no warm-starting from limits is performed.
-            contacts (ContactsKamino | None): The contacts container associated with the model.\n
+            contacts: The contacts container associated with the model.\n
                 If `None`, no warm-starting from contacts is performed.
         """
         # TODO: IS THIS EVEN NECESSARY AT ALL?
@@ -363,7 +363,7 @@ class PADMMSolver:
         Solves the given dual problem using PADMM.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Pass the PADMM-owned tolerance array to the iterative linear solver (if present).
         inner = getattr(problem._delassus._solver, "solver", None)
@@ -487,7 +487,7 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         if problem.sparse:
             self._update_sparse_regularization(problem)
@@ -516,7 +516,7 @@ class PADMMSolver:
         Performs a single PADMM solver iteration.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Compute De Saxce correction and velocity bias in one launch.
         self._update_desaxce_and_velocity_bias(problem, self._data.state.y_p, self._data.state.z_p)
@@ -557,7 +557,7 @@ class PADMMSolver:
           residual reduction, convergence, acceleration, and previous-state caching
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Compute De Saxce correction and velocity bias in one launch.
         self._update_desaxce_and_velocity_bias(problem, self._data.state.y_hat, self._data.state.z_hat)
@@ -582,14 +582,14 @@ class PADMMSolver:
     # Internals - Warm-starting
     ###
 
-    def _warmstart_desaxce_correction(self, problem: DualProblem, z: wp.array):
+    def _warmstart_desaxce_correction(self, problem: DualProblem, z: wp.array[wp.float32]):
         """
         Applies the De Saxce correction to the provided post-event constraint-space velocity warm-start.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            z (wp.array): The post-event constraint-space velocity warm-start variable.\n
+            z: The post-event constraint-space velocity warm-start variable.\n
                 This can either be `z_p` or `z_hat` depending on whether acceleration is used.
         """
         wp.launch(
@@ -613,21 +613,21 @@ class PADMMSolver:
         model: ModelKamino,
         data: DataKamino,
         problem: DualProblem,
-        x_0: wp.array,
-        y_0: wp.array,
-        z_0: wp.array,
+        x_0: wp.array[wp.float32],
+        y_0: wp.array[wp.float32],
+        z_0: wp.array[wp.float32],
     ):
         """
         Warm-starts the bilateral joint constraint variables from the model data container.
 
         Args:
-            model (ModelKamino): The model associated with the problem.
-            data (DataKamino): The model data associated with the problem.
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            model: The model associated with the problem.
+            data: The model data associated with the problem.
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            x_0 (wp.array): The output primal variables array to be warm-started.
-            y_0 (wp.array): The output slack variables array to be warm-started.
-            z_0 (wp.array): The output dual variables array to be warm-started.
+            x_0: The output primal variables array to be warm-started.
+            y_0: The output slack variables array to be warm-started.
+            z_0: The output dual variables array to be warm-started.
         """
         wp.launch(
             kernel=_warmstart_joint_constraints,
@@ -658,22 +658,22 @@ class PADMMSolver:
         data: DataKamino,
         limits: LimitsKamino,
         problem: DualProblem,
-        x_0: wp.array,
-        y_0: wp.array,
-        z_0: wp.array,
+        x_0: wp.array[wp.float32],
+        y_0: wp.array[wp.float32],
+        z_0: wp.array[wp.float32],
     ):
         """
         Warm-starts the unilateral limit constraint variables from the limits data container.
 
         Args:
-            model (ModelKamino): The model associated with the problem.
-            data (DataKamino): The model data associated with the problem.
-            limits (LimitsKamino): The limits container associated with the model.
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            model: The model associated with the problem.
+            data: The model data associated with the problem.
+            limits: The limits container associated with the model.
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            x_0 (wp.array): The output primal variables array to be warm-started.
-            y_0 (wp.array): The output slack variables array to be warm-started.
-            z_0 (wp.array): The output dual variables array to be warm-started.
+            x_0: The output primal variables array to be warm-started.
+            y_0: The output slack variables array to be warm-started.
+            z_0: The output dual variables array to be warm-started.
         """
         wp.launch(
             kernel=_warmstart_limit_constraints,
@@ -703,22 +703,22 @@ class PADMMSolver:
         data: DataKamino,
         contacts: ContactsKamino,
         problem: DualProblem,
-        x_0: wp.array,
-        y_0: wp.array,
-        z_0: wp.array,
+        x_0: wp.array[wp.float32],
+        y_0: wp.array[wp.float32],
+        z_0: wp.array[wp.float32],
     ):
         """
         Warm-starts the unilateral contact constraint variables from the contacts data container.
 
         Args:
-            model (ModelKamino): The model associated with the problem.
-            data (DataKamino): The model data associated with the problem.
-            contacts (ContactsKamino): The contacts container associated with the model.
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            model: The model associated with the problem.
+            data: The model data associated with the problem.
+            contacts: The contacts container associated with the model.
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            x_0 (wp.array): The output primal variables array to be warm-started.
-            y_0 (wp.array): The output slack variables array to be warm-started.
-            z_0 (wp.array): The output dual variables array to be warm-started.
+            x_0: The output primal variables array to be warm-started.
+            y_0: The output slack variables array to be warm-started.
+            z_0: The output dual variables array to be warm-started.
         """
         wp.launch(
             kernel=_warmstart_contact_constraints,
@@ -748,7 +748,7 @@ class PADMMSolver:
         Warm-starts the internal solver state from the stored solution variables.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
         """
         # Apply the dual-problem preconditioner to the stored solution
@@ -795,13 +795,13 @@ class PADMMSolver:
         Warm-starts the internal solver state from the provided model data and limits and contacts containers.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.\n
                 This is needed during warm-starts in order to access the problem preconditioning.
-            model (ModelKamino): The model associated with the problem.
-            data (DataKamino): The model data associated with the problem.
-            limits (LimitsKamino | None): The limits container associated with the model.\n
+            model: The model associated with the problem.
+            data: The model data associated with the problem.
+            limits: The limits container associated with the model.\n
                 If `None`, no warm-starting from limits is performed.
-            contacts (ContactsKamino | None): The contacts container associated with the model.\n
+            contacts: The contacts container associated with the model.\n
                 If `None`, no warm-starting from contacts is performed.
         """
         # Capture references to the warm-start variables
@@ -826,14 +826,14 @@ class PADMMSolver:
     # Internals - Per-Step Operations
     ###
 
-    def _update_desaxce_correction(self, problem: DualProblem, z: wp.array):
+    def _update_desaxce_correction(self, problem: DualProblem, z: wp.array[wp.float32]):
         """
         Launches a kernel to compute the De Saxce correction velocity using the previous dual variables.\n
         The kernel is parallelized over the number of worlds and the maximum number of contacts.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
-            z (wp.array): The dual variable array from the previous iteration.\n
+            problem: The dual forward dynamics problem to be solved.
+            z: The dual variable array from the previous iteration.\n
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z_p`.
         """
         wp.launch(
@@ -854,16 +854,16 @@ class PADMMSolver:
             device=self.device,
         )
 
-    def _update_velocity_bias(self, problem: DualProblem, y: wp.array, z: wp.array):
+    def _update_velocity_bias(self, problem: DualProblem, y: wp.array[wp.float32], z: wp.array[wp.float32]):
         """
         Launches a kernel to compute the total bias velocity vector using the previous state variables.\n
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
-            y (wp.array): The primal variable array from the previous iteration.\n
+            problem: The dual forward dynamics problem to be solved.
+            y: The primal variable array from the previous iteration.\n
                 This can either be the acceleration variable `y_hat` or the standard primal variable `y_p`.
-            z (wp.array): The dual variable array from the previous iteration.\n
+            z: The dual variable array from the previous iteration.\n
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z_p`.
         """
         wp.launch(
@@ -887,7 +887,7 @@ class PADMMSolver:
             device=self.device,
         )
 
-    def _update_desaxce_and_velocity_bias(self, problem: DualProblem, y: wp.array, z: wp.array):
+    def _update_desaxce_and_velocity_bias(self, problem: DualProblem, y: wp.array[wp.float32], z: wp.array[wp.float32]):
         """Fused De Saxce correction + velocity bias in a single kernel launch.
 
         Computes the De Saxce correction inline for contact constraints and the velocity
@@ -898,9 +898,9 @@ class PADMMSolver:
         read the original value.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
-            y (wp.array): The primal variable array from the previous iteration.
-            z (wp.array): The dual variable array from the previous iteration.
+            problem: The dual forward dynamics problem to be solved.
+            y: The primal variable array from the previous iteration.
+            z: The dual variable array from the previous iteration.
         """
         has_contacts = self._size.max_of_max_contacts > 0
         kernel = make_desaxce_correction_and_velocity_bias_kernel(has_contacts, self._collect_info)
@@ -934,14 +934,14 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # TODO: We should do this in-place
         # wp.copy(self._data.state.x, self._data.state.v)
         # problem._delassus.solve_inplace(x=self._data.state.x)
         problem._delassus.solve(v=self._data.state.v, x=self._data.state.x)
 
-    def _update_projection_argument(self, problem: DualProblem, z: wp.array):
+    def _update_projection_argument(self, problem: DualProblem, z: wp.array[wp.float32]):
         """
         Launches a kernel to compute the argument for the projection operator onto the
         feasible set using the accelerated state variables and the unconstrained solution.
@@ -949,8 +949,8 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
-            z (wp.array): The dual variable array from the previous iteration.\n
+            problem: The dual forward dynamics problem to be solved.
+            z: The dual variable array from the previous iteration.\n
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z
         """
         # Apply over-relaxation and compute the argument to the projection operator
@@ -980,7 +980,7 @@ class PADMMSolver:
         number of unilateral constraints, i.e. 1D limits and 3D contacts.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Project to the feasible set defined by the cone K := R^{njd} x R_+^{nld} x K_{mu}^{nc}
         wp.launch(
@@ -1008,7 +1008,7 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds and the maximum number of unilateral constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Compute complementarity residual from the current state
         wp.launch(
@@ -1039,7 +1039,7 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Update the dual variables and compute primal-dual residuals from the current state
         # NOTE: These are combined into a single kernel to reduce kernel launch overhead
@@ -1128,7 +1128,7 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Compute infinity-norm of all residuals and check for convergence
         tile_size = get_tile_size(self._size.max_of_max_total_cts)
@@ -1168,7 +1168,7 @@ class PADMMSolver:
         The kernel is parallelized over the number of worlds.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # First reset the internal buffer arrays to zero
         # to ensure we do not accumulate values across iterations
@@ -1328,7 +1328,7 @@ class PADMMSolver:
         the final solution from the internal PADMM state data.
 
         Args:
-            problem (DualProblem): The dual forward dynamics problem to be solved.
+            problem: The dual forward dynamics problem to be solved.
         """
         # Apply the dual preconditioner to recover the final PADMM state
         wp.launch(

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -116,11 +116,11 @@ class PADMMSolver:
             limits: The limits container associated with the model.
             contacts: The contacts container associated with the model.
             config: The solver config to use.
-            warmstart: The warm-start mode to use for the solver.\n
+            warmstart: The warm-start mode to use for the solver.
             use_acceleration: Set to `True` to enable Nesterov acceleration.
-            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.\n
+            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.
                 When disabled, replaces `wp.capture_while` with an unrolled for-loop over max iterations.
-            collect_info: Set to `True` to enable collection of solver convergence info.\n
+            collect_info: Set to `True` to enable collection of solver convergence info.
                 This setting is intended only for analysis and debugging purposes, as it
                 will increase memory consumption and reduce wall-clock time.
         """
@@ -160,7 +160,7 @@ class PADMMSolver:
     @property
     def config(self) -> list[PADMMSolver.Config]:
         """
-        Returns the host-side cache of the solver config.\n
+        Returns the host-side cache of the solver config.
         They are used to construct the warp array of type :class:`PADMMSolver.Config` on the target device.
         """
         return self._config
@@ -209,11 +209,11 @@ class PADMMSolver:
             limits: The limits container associated with the model.
             contacts: The contacts container associated with the model.
             config: The solver config to use.
-            warmstart: The warm-start mode to use for the solver.\n
+            warmstart: The warm-start mode to use for the solver.
             use_acceleration: Set to `True` to enable Nesterov acceleration.
-            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.\n
+            use_graph_conditionals: Set to `False` to disable CUDA graph conditional nodes.
                 When disabled, replaces `wp.capture_while` with an unrolled for-loop over max iterations.
-            collect_info: Set to `True` to enable collection of solver convergence info.\n
+            collect_info: Set to `True` to enable collection of solver convergence info.
                 This setting is intended only for analysis and debugging purposes, as it
                 will increase memory consumption and reduce wall-clock time.
         """
@@ -311,7 +311,7 @@ class PADMMSolver:
 
     def coldstart(self):
         """
-        Initializes the internal solver state to perform a cold-start solve.\n
+        Initializes the internal solver state to perform a cold-start solve.
         This method sets all solver state variables to zeros.
         """
         # Initialize state arrays to zero
@@ -334,13 +334,13 @@ class PADMMSolver:
         - `PADMMWarmStartMode.CONTAINERS`: Warm-starts from the provided limits and contacts containers.
 
         Args:
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
             model: The model associated with the problem.
             data: The model data associated with the problem.
-            limits: The limits container associated with the model.\n
+            limits: The limits container associated with the model.
                 If `None`, no warm-starting from limits is performed.
-            contacts: The contacts container associated with the model.\n
+            contacts: The contacts container associated with the model.
                 If `None`, no warm-starting from contacts is performed.
         """
         # TODO: IS THIS EVEN NECESSARY AT ALL?
@@ -439,7 +439,7 @@ class PADMMSolver:
 
     def _initialize(self):
         """
-        Launches a kernel to initialize the internal solver state before starting a new solve.\n
+        Launches a kernel to initialize the internal solver state before starting a new solve.
         The kernel is parallelized over the number of worlds.
         """
         # Initialize solver status, penalty parameters, and iterative solver tolerance
@@ -482,8 +482,8 @@ class PADMMSolver:
 
     def _update_regularization(self, problem: DualProblem):
         """
-        Updates the diagonal regularization of the lhs matrix with the proximal regularization terms.\n
-        For `DualProblem` solves, the lhs matrix corresponds to the Delassus matrix.\n
+        Updates the diagonal regularization of the lhs matrix with the proximal regularization terms.
+        For `DualProblem` solves, the lhs matrix corresponds to the Delassus matrix.
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
@@ -587,9 +587,9 @@ class PADMMSolver:
         Applies the De Saxce correction to the provided post-event constraint-space velocity warm-start.
 
         Args:
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
-            z: The post-event constraint-space velocity warm-start variable.\n
+            z: The post-event constraint-space velocity warm-start variable.
                 This can either be `z_p` or `z_hat` depending on whether acceleration is used.
         """
         wp.launch(
@@ -623,7 +623,7 @@ class PADMMSolver:
         Args:
             model: The model associated with the problem.
             data: The model data associated with the problem.
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
             x_0: The output primal variables array to be warm-started.
             y_0: The output slack variables array to be warm-started.
@@ -669,7 +669,7 @@ class PADMMSolver:
             model: The model associated with the problem.
             data: The model data associated with the problem.
             limits: The limits container associated with the model.
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
             x_0: The output primal variables array to be warm-started.
             y_0: The output slack variables array to be warm-started.
@@ -714,7 +714,7 @@ class PADMMSolver:
             model: The model associated with the problem.
             data: The model data associated with the problem.
             contacts: The contacts container associated with the model.
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
             x_0: The output primal variables array to be warm-started.
             y_0: The output slack variables array to be warm-started.
@@ -748,7 +748,7 @@ class PADMMSolver:
         Warm-starts the internal solver state from the stored solution variables.
 
         Args:
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
         """
         # Apply the dual-problem preconditioner to the stored solution
@@ -795,13 +795,13 @@ class PADMMSolver:
         Warm-starts the internal solver state from the provided model data and limits and contacts containers.
 
         Args:
-            problem: The dual forward dynamics problem to be solved.\n
+            problem: The dual forward dynamics problem to be solved.
                 This is needed during warm-starts in order to access the problem preconditioning.
             model: The model associated with the problem.
             data: The model data associated with the problem.
-            limits: The limits container associated with the model.\n
+            limits: The limits container associated with the model.
                 If `None`, no warm-starting from limits is performed.
-            contacts: The contacts container associated with the model.\n
+            contacts: The contacts container associated with the model.
                 If `None`, no warm-starting from contacts is performed.
         """
         # Capture references to the warm-start variables
@@ -828,12 +828,12 @@ class PADMMSolver:
 
     def _update_desaxce_correction(self, problem: DualProblem, z: wp.array[wp.float32]):
         """
-        Launches a kernel to compute the De Saxce correction velocity using the previous dual variables.\n
+        Launches a kernel to compute the De Saxce correction velocity using the previous dual variables.
         The kernel is parallelized over the number of worlds and the maximum number of contacts.
 
         Args:
             problem: The dual forward dynamics problem to be solved.
-            z: The dual variable array from the previous iteration.\n
+            z: The dual variable array from the previous iteration.
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z_p`.
         """
         wp.launch(
@@ -856,14 +856,14 @@ class PADMMSolver:
 
     def _update_velocity_bias(self, problem: DualProblem, y: wp.array[wp.float32], z: wp.array[wp.float32]):
         """
-        Launches a kernel to compute the total bias velocity vector using the previous state variables.\n
+        Launches a kernel to compute the total bias velocity vector using the previous state variables.
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
             problem: The dual forward dynamics problem to be solved.
-            y: The primal variable array from the previous iteration.\n
+            y: The primal variable array from the previous iteration.
                 This can either be the acceleration variable `y_hat` or the standard primal variable `y_p`.
-            z: The dual variable array from the previous iteration.\n
+            z: The dual variable array from the previous iteration.
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z_p`.
         """
         wp.launch(
@@ -929,8 +929,8 @@ class PADMMSolver:
 
     def _update_unconstrained_solution(self, problem: DualProblem):
         """
-        Launches a kernel to solve the unconstrained sub-problem for the primal variables.\n
-        For `DualProblem` solves, this corresponds to solving a linear system with the Delassus matrix.\n
+        Launches a kernel to solve the unconstrained sub-problem for the primal variables.
+        For `DualProblem` solves, this corresponds to solving a linear system with the Delassus matrix.
         The kernel is parallelized over the number of worlds and the maximum number of total constraints.
 
         Args:
@@ -950,7 +950,7 @@ class PADMMSolver:
 
         Args:
             problem: The dual forward dynamics problem to be solved.
-            z: The dual variable array from the previous iteration.\n
+            z: The dual variable array from the previous iteration.
                 This can either be the acceleration variable `z_hat` or the standard dual variable `z
         """
         # Apply over-relaxation and compute the argument to the projection operator

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -39,9 +39,10 @@ from typing import Any
 import numpy as np
 import warp as wp
 
+from ......core.types import override
 from ....config import PADMMSolverConfig
 from ...core.size import SizeKamino
-from ...core.types import float32, int32, override, to_warp_int32_array, vec2f
+from ...core.types import to_warp_int32_array
 
 ###
 # Module interface
@@ -189,121 +190,121 @@ class PADMMConfigStruct:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        primal_tolerance (float32): The target tolerance on the total primal residual `r_primal`.\n
+        primal_tolerance: The target tolerance on the total primal residual `r_primal`.\n
             Must be greater than zero. Defaults to `1e-6`.
-        dual_tolerance (float32): The target tolerance on the total dual residual `r_dual`.\n
+        dual_tolerance: The target tolerance on the total dual residual `r_dual`.\n
             Must be greater than zero. Defaults to `1e-6`.
-        compl_tolerance (float32): The target tolerance on the total complementarity residual `r_compl`.\n
+        compl_tolerance: The target tolerance on the total complementarity residual `r_compl`.\n
             Must be greater than zero. Defaults to `1e-6`.
-        restart_tolerance (float32): The tolerance on the total combined primal-dual
+        restart_tolerance: The tolerance on the total combined primal-dual
             residual `r_comb`, for determining when gradient acceleration should be restarted.\n
             Must be greater than zero. Defaults to `0.999`.
-        eta (float32): The proximal regularization parameter.\n
+        eta: The proximal regularization parameter.\n
             Must be greater than zero. Defaults to `1e-5`.
-        rho_0 (float32): The initial value of the penalty parameter.\n
+        rho_0: The initial value of the penalty parameter.\n
             Must be greater than zero. Defaults to `1.0`.
-        a_0 (float32): The initial value of the acceleration parameter.\n
+        a_0: The initial value of the acceleration parameter.\n
             Must be greater than zero. Defaults to `1.0`.
-        alpha (float32): The threshold on primal-dual residual ratios,
+        alpha: The threshold on primal-dual residual ratios,
             used to determine when penalty updates should occur.\n
             Must be greater than `1.0`. Defaults to `10.0`.
-        tau (float32): The factor by which the penalty is increased/decreased
+        tau: The factor by which the penalty is increased/decreased
             when the primal-dual residual ratios exceed the threshold `alpha`.\n
             Must be greater than `1.0`. Defaults to `1.5`.
-        max_iterations (int32): The maximum number of solver iterations.\n
+        max_iterations: The maximum number of solver iterations.\n
             Must be greater than zero. Defaults to `200`.
-        penalty_update_freq (int32): The permitted frequency of penalty updates.\n
+        penalty_update_freq: The permitted frequency of penalty updates.\n
             If zero, no updates are performed. Otherwise, updates are performed every
             `penalty_update_freq` iterations. Defaults to `10`.
-        penalty_update_method (int32): The penalty update method used to adapt the penalty parameter.\n
+        penalty_update_method: The penalty update method used to adapt the penalty parameter.\n
             Defaults to `PADMMPenaltyUpdate.FIXED`.\n
             See :class:`PADMMPenaltyUpdate` for details.
     """
 
-    primal_tolerance: float32
+    primal_tolerance: wp.float32
     """
     The target tolerance on the total primal residual `r_primal`.\n
     Must be greater than zero. Defaults to `1e-6`.
     """
 
-    dual_tolerance: float32
+    dual_tolerance: wp.float32
     """
     The target tolerance on the total dual residual `r_dual`.\n
     Must be greater than zero. Defaults to `1e-6`.
     """
 
-    compl_tolerance: float32
+    compl_tolerance: wp.float32
     """
     The target tolerance on the total complementarity residual `r_compl`.\n
     Must be greater than zero. Defaults to `1e-6`.
     """
 
-    restart_tolerance: float32
+    restart_tolerance: wp.float32
     """
     The tolerance applied on the total combined primal-dual residual `r_comb`,
     for determining when gradient acceleration should be restarted.\n
     Must be greater than zero. Defaults to `0.999`.
     """
 
-    eta: float32
+    eta: wp.float32
     """
     The proximal regularization parameter.\n
     Must be greater than zero. Defaults to `1e-5`.
     """
 
-    rho_0: float32
+    rho_0: wp.float32
     """
     The initial value of the ALM penalty parameter.\n
     Must be greater than zero. Defaults to `1.0`.
     """
 
-    rho_min: float32
+    rho_min: wp.float32
     """
     The lower-bound applied to the ALM penalty parameter.\n
     Must be greater than zero. Defaults to `1e-5`.
     """
 
-    a_0: float32
+    a_0: wp.float32
     """
     The initial value of the acceleration parameter.\n
     Must be greater than zero. Defaults to `1.0`.
     """
 
-    alpha: float32
+    alpha: wp.float32
     """
     The threshold on primal-dual residual ratios,
     used to determine when penalty updates should occur.\n
     Must be greater than `1.0`. Defaults to `10.0`.
     """
 
-    tau: float32
+    tau: wp.float32
     """
     The factor by which the penalty is increased/decreased
     when the primal-dual residual ratios exceed the threshold `alpha`.\n
     Must be greater than `1.0`. Defaults to `1.5`.
     """
 
-    max_iterations: int32
+    max_iterations: wp.int32
     """
     The maximum number of solver iterations.\n
     Must be greater than zero. Defaults to `200`.
     """
 
-    penalty_update_freq: int32
+    penalty_update_freq: wp.int32
     """
     The permitted frequency of penalty updates.\n
     If zero, no updates are performed. Otherwise, updates are performed every
     `penalty_update_freq` iterations. Defaults to `10`.
     """
 
-    penalty_update_method: int32
+    penalty_update_method: wp.int32
     """
     The penalty update method used to adapt the penalty parameter.\n
     Defaults to `PADMMPenaltyUpdate.FIXED`.\n
     See :class:`PADMMPenaltyUpdate` for details.
     """
 
-    linear_solver_tolerance: float32
+    linear_solver_tolerance: wp.float32
     """
     The default absolute tolerance for the iterative linear solver.\n
     When positive, the iterative solver's atol is initialized to this value
@@ -312,7 +313,7 @@ class PADMMConfigStruct:
     Must be non-negative. Defaults to `0.0`.
     """
 
-    linear_solver_tolerance_ratio: float32
+    linear_solver_tolerance_ratio: wp.float32
     """
     The ratio used to adapt the iterative linear solver tolerance from the ADMM primal residual.\n
     When positive, the linear solver absolute tolerance is set to
@@ -330,36 +331,36 @@ class PADMMStatus:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        converged (int32): A flag indicating whether the solver has converged (`1`) or not (`0`).\n
+        converged: A flag indicating whether the solver has converged (`1`) or not (`0`).\n
             Used internally to keep track of per-world convergence status,
             with `1` being set only when all total residuals have satisfied their
             respective tolerances. If by the end of the solve the flag is still `0`,
             it indicates that the solve reached the maximum number of iterations.
-        iterations (int32): The number of iterations performed by the solver.\n
+        iterations: The number of iterations performed by the solver.\n
             Used internally to keep track of per-world iteration counts.
-        r_p (float32): The total primal residual.\n
+        r_p: The total primal residual.\n
             Computed using the L-inf norm as `r_primal := || x - y ||_inf`.\n
-        r_d (float32): The total dual residual.\n
+        r_d: The total dual residual.\n
             Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.\n
-        r_c (float32): The total complementarity residual.
+        r_c: The total complementarity residual.
             Computed using the L-inf norm as `r_compl := || [x_k.T @ z_k] ||_inf`,
             with `k` indexing each unilateral constraint set, i.e. 1D limits and 3D contacts.
-        r_dx (float32): The total primal iterate residual.\n
+        r_dx: The total primal iterate residual.\n
             Computed as the L2-norm `r_dx := || x - x_p ||_2`.
-        r_dy (float32): The total slack iterate residual.\n
+        r_dy: The total slack iterate residual.\n
             Computed as the L2-norm `r_dy := || y - y_p ||_2`.
-        r_dz (float32): The total dual iterate residual.\n
+        r_dz: The total dual iterate residual.\n
             Computed as the L2-norm `r_dz := || z - z_p ||_2`.
-        r_a (float32): The total combined primal-dual residual used for acceleration restart checks.
+        r_a: The total combined primal-dual residual used for acceleration restart checks.
             Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
-        r_a_p (float32): The previous total combined primal-dual residual.
-        r_a_pp (float32): An auxiliary cache of the previous total combined primal-dual residual.
-        restart (int32): A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).\n
+        r_a_p: The previous total combined primal-dual residual.
+        r_a_pp: An auxiliary cache of the previous total combined primal-dual residual.
+        restart: A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).\n
             Used internally to keep track of per-world acceleration restarts.
-        num_restarts (int32): The number of acceleration restarts performed during the solve.
+        num_restarts: The number of acceleration restarts performed during the solve.
     """
 
-    converged: int32
+    converged: wp.int32
     """
     A flag indicating whether the solver has converged (`1`) or not (`0`).\n
     Used internally to keep track of per-world convergence status,
@@ -368,68 +369,68 @@ class PADMMStatus:
     it indicates that the solve reached the maximum number of iterations.
     """
 
-    iterations: int32
+    iterations: wp.int32
     """
     The number of iterations performed by the solver.\n
     Used internally to keep track of per-world iteration counts.
     """
 
-    r_p: float32
+    r_p: wp.float32
     """
     The total primal residual.\n
     Computed using the L-inf norm as `r_primal := || x - y ||_inf`.\n
     """
 
-    r_d: float32
+    r_d: wp.float32
     """
     The total dual residual.\n
     Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.\n
     """
 
-    r_c: float32
+    r_c: wp.float32
     """
     The total complementarity residual.
     Computed using the L-inf norm as `r_compl := || [x_k.T @ z_k] ||_inf`,
     with `k` indexing each unilateral constraint set, i.e. 1D limits and 3D contacts.
     """
 
-    r_dx: float32
+    r_dx: wp.float32
     """
     The total primal iterate residual.\n
     Computed as the L2-norm `r_dx := || x - x_p ||_2`.
     """
 
-    r_dy: float32
+    r_dy: wp.float32
     """
     The total slack iterate residual.\n
     Computed as the L2-norm `r_dy := || y - y_p ||_2`.
     """
 
-    r_dz: float32
+    r_dz: wp.float32
     """
     The total dual iterate residual.\n
     Computed as the L2-norm `r_dz := || z - z_p ||_2`.
     """
 
-    r_a: float32
+    r_a: wp.float32
     """
     The total combined primal-dual residual used for acceleration restart checks.\n
     Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
     """
 
-    r_a_p: float32
+    r_a_p: wp.float32
     """The previous total combined primal-dual residual."""
 
-    r_a_pp: float32
+    r_a_pp: wp.float32
     """An auxiliary cache of the previous total combined primal-dual residual."""
 
-    restart: int32
+    restart: wp.int32
     """
     A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).\n
     Used internally to keep track of per-world acceleration restarts.
     """
 
-    num_restarts: int32
+    num_restarts: wp.int32
     """The number of acceleration restarts performed during the solve."""
 
 
@@ -441,28 +442,28 @@ class PADMMPenalty:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        num_updates (int32): The number of penalty updates performed during a solve.\n
+        num_updates: The number of penalty updates performed during a solve.\n
             If a direct linear-system solver is used, this also
             equals the number of matrix factorizations performed.
-        rho (float32): The current value of the ALM penalty parameter.\n
+        rho: The current value of the ALM penalty parameter.\n
             If adaptive penalty scheme is used, this value may change during
             solve operations, while being lower-bounded by `config.rho_min`
             to ensure numerical stability.
-        rho_p (float32): The previous value of the ALM penalty parameter.\n
+        rho_p: The previous value of the ALM penalty parameter.\n
             As diagonal regularization of the lhs matrix (e.g. Delassus
             operator) is performed in-place, we must keep track of the
             previous penalty value  to remove the previous regularization
             before applying the current penalty value.
     """
 
-    num_updates: int32
+    num_updates: wp.int32
     """
     The number of penalty updates performed during a solve.\n
     If a direct linear-system solver is used, this also
     equals the number of matrix factorizations performed.
     """
 
-    rho: float32
+    rho: wp.float32
     """
     The current value of the ALM penalty parameter.\n
     If adaptive penalty scheme is used, this value may change during
@@ -470,7 +471,7 @@ class PADMMPenalty:
     to ensure numerical stability.
     """
 
-    rho_p: float32
+    rho_p: wp.float32
     """
     The previous value of the ALM penalty parameter.\n
     As diagonal regularization of the lhs matrix (e.g. Delassus
@@ -490,37 +491,37 @@ class PADMMState:
     A data container to bundle the internal PADMM state arrays.
 
     Attributes:
-        done (wp.array): A single-element array containing the global
+        done: A single-element array containing the global
             flag that indicates whether the solver should terminate.\n
             Its value is initialized to ``num_worlds`` at the beginning of each
             solve, and decremented by one for each world that has converged.\n
-            Shape of ``(1,)`` and type :class:`int`.
-        s (wp.array): The De Saxce correction velocities `s = Gamma(v_plus)`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        v (wp.array): The total bias velocity vector serving as the right-hand-side of the PADMM linear system.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        x (wp.array): The current PADMM primal variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        x_p (wp.array): The previous PADMM primal variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        y (wp.array): The current PADMM slack variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        y_p (wp.array): The previous PADMM slack variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        z (wp.array): The current PADMM dual variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        z_p (wp.array): The previous PADMM dual variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        y_hat (wp.array): The auxiliary PADMM slack variables used with gradient acceleration.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        z_hat (wp.array): The auxiliary PADMM dual variables used with gradient acceleration.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        a (wp.array): The per-world current Nesterov acceleration variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        a_p (wp.array): The per-world previous Nesterov acceleration variables.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        a_factor (wp.array): The per-world Nesterov factor computed from the previous and current acceleration
-            variables. Shape of ``(num_worlds,)`` and type :class:`float32`.
+            Shape of ``(1,)``.
+        s: The De Saxce correction velocities `s = Gamma(v_plus)`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        v: The total bias velocity vector serving as the right-hand-side of the PADMM linear system.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        x: The current PADMM primal variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        x_p: The previous PADMM primal variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        y: The current PADMM slack variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        y_p: The previous PADMM slack variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        z: The current PADMM dual variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        z_p: The previous PADMM dual variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        y_hat: The auxiliary PADMM slack variables used with gradient acceleration.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        z_hat: The auxiliary PADMM dual variables used with gradient acceleration.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        a: The per-world current Nesterov acceleration variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        a_p: The per-world previous Nesterov acceleration variables.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        a_factor: The per-world Nesterov factor computed from the previous and current acceleration
+            variables. Shape of ``(num_worlds,)``.
     """
 
     def __init__(self, size: SizeKamino | None = None, use_acceleration: bool = False):
@@ -530,18 +531,18 @@ class PADMMState:
         If a model size is provided, allocates the state arrays accordingly.
 
         Args:
-            size (SizeKamino | None): The model-size utility container holding the dimensionality of the model.
+            size: The model-size utility container holding the dimensionality of the model.
         """
 
-        self.done: wp.array | None = None
+        self.done: wp.array[wp.int32] | None = None
         """
         A single-element array containing the global flag that indicates whether the solver should terminate.\n
         Its value is initialized to ``num_worlds`` at the beginning of each
         solve, and decremented by one for each world that has converged.\n
-        Shape of ``(1,)`` and type :class:`int32`.
+        Shape of ``(1,)``.
         """
 
-        self.sigma: wp.array | None = None
+        self.sigma: wp.array[wp.vec2f] | None = None
         """
         The scalar diagonal regularization applied uniformly across constraint dimensions.
 
@@ -552,91 +553,91 @@ class PADMMState:
         `sigma` is the current and `sigma_p` is the previous value, used to undo
         the prior regularization when the ALM penalty parameter `rho` is updated.
 
-        Shape of ``(num_worlds,)`` and type :class:`vec2f`.
+        Shape of ``(num_worlds,)``.
         """
 
-        self.s: wp.array | None = None
+        self.s: wp.array[wp.float32] | None = None
         """
         The De Saxce correction velocities `s = Gamma(v_plus)`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.v: wp.array | None = None
+        self.v: wp.array[wp.float32] | None = None
         """
         The total bias velocity vector serving as the right-hand-side of the PADMM linear system.\n
         It is computed from the PADMM state and proximal parameters `eta` and `rho`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.x: wp.array | None = None
+        self.x: wp.array[wp.float32] | None = None
         """
         The current PADMM primal variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.x_p: wp.array | None = None
+        self.x_p: wp.array[wp.float32] | None = None
         """
         The previous PADMM primal variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.y: wp.array | None = None
+        self.y: wp.array[wp.float32] | None = None
         """
         The current PADMM slack variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.y_p: wp.array | None = None
+        self.y_p: wp.array[wp.float32] | None = None
         """
         The previous PADMM slack variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.z: wp.array | None = None
+        self.z: wp.array[wp.float32] | None = None
         """
         The current PADMM dual variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.z_p: wp.array | None = None
+        self.z_p: wp.array[wp.float32] | None = None
         """
         The previous PADMM dual variables.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.y_hat: wp.array | None = None
+        self.y_hat: wp.array[wp.float32] | None = None
         """
         The auxiliary PADMM slack variables used with gradient acceleration.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.z_hat: wp.array | None = None
+        self.z_hat: wp.array[wp.float32] | None = None
         """
         The auxiliary PADMM dual variables used with gradient acceleration.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.a: wp.array | None = None
+        self.a: wp.array[wp.float32] | None = None
         """
         The per-world current Nesterov acceleration variables.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(num_worlds,)`` and type :class:`float32`.
+        Shape of ``(num_worlds,)``.
         """
 
-        self.a_p: wp.array | None = None
+        self.a_p: wp.array[wp.float32] | None = None
         """
         The per-world previous Nesterov acceleration variables.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(num_worlds,)`` and type :class:`float32`.
+        Shape of ``(num_worlds,)``.
         """
 
-        self.a_factor: wp.array | None = None
+        self.a_factor: wp.array[wp.float32] | None = None
         """
         The per-world current Nesterov acceleration factor.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(num_worlds,)`` and type :class:`float32`.
+        Shape of ``(num_worlds,)``.
         """
 
         # Perform memory allocations if model size is specified
@@ -648,29 +649,29 @@ class PADMMState:
         Allocates the PADMM solver state arrays based on the model size.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
+            size: The model-size utility container holding the dimensionality of the model.
         """
         # Allocate per-world solver done flags
-        self.done = wp.zeros(1, dtype=int32)
+        self.done = wp.zeros(1, dtype=wp.int32)
 
         # Allocate primary state variables
-        self.sigma = wp.zeros(size.num_worlds, dtype=vec2f)
-        self.s = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.v = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.x = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.x_p = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.y = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.y_p = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.z = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.z_p = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
+        self.sigma = wp.zeros(size.num_worlds, dtype=wp.vec2f)
+        self.s = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.v = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.x = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.x_p = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.y = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.y_p = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.z = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.z_p = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
 
         # Allocate auxiliary state variables used with acceleration
         if use_acceleration:
-            self.y_hat = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-            self.z_hat = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-            self.a = wp.zeros(size.num_worlds, dtype=float32)
-            self.a_p = wp.zeros(size.num_worlds, dtype=float32)
-            self.a_factor = wp.zeros(size.num_worlds, dtype=float32)
+            self.y_hat = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+            self.z_hat = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+            self.a = wp.zeros(size.num_worlds, dtype=wp.float32)
+            self.a_p = wp.zeros(size.num_worlds, dtype=wp.float32)
+            self.a_factor = wp.zeros(size.num_worlds, dtype=wp.float32)
 
     def reset(self, use_acceleration: bool = False):
         """
@@ -681,8 +682,7 @@ class PADMMState:
         - If acceleration is enabled, the momentum arrays `a_p` and `a` are set to ones.
 
         Args:
-            use_acceleration (bool):
-                Whether to reset the acceleration state variables.\n
+            use_acceleration: Whether to reset the acceleration state variables.\n
                 If `True`, auxiliary state variables and acceleration scales are reset as well.\n
                 Defaults to `False`.
         """
@@ -714,19 +714,19 @@ class PADMMResiduals:
     A data container to bundle the internal PADMM residual arrays.
 
     Attributes:
-        r_primal (wp.array): The PADMM primal residual vector, computed as `r_primal := x - y`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        r_dual (wp.array): The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        r_compl (wp.array): The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,\n
+        r_primal: The PADMM primal residual vector, computed as `r_primal := x - y`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        r_dual: The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        r_compl: The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,\n
             where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).\n
-            Shape of ``(sum_of_num_unilateral_cts,)`` and type :class:`float32`.
-        r_dx (wp.array): The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        r_dy (wp.array): The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        r_dz (wp.array): The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+            Shape of ``(sum_of_num_unilateral_cts,)``.
+        r_dx: The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        r_dy: The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        r_dz: The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.\n
+            Shape of ``(sum_of_max_total_cts,)``.
     """
 
     def __init__(self, size: SizeKamino | None = None, use_acceleration: bool = False):
@@ -736,47 +736,47 @@ class PADMMResiduals:
         If a model size is provided, allocates the residuals arrays accordingly.
 
         Args:
-            size (SizeKamino | None): The model-size utility container holding the dimensionality of the model.
+            size: The model-size utility container holding the dimensionality of the model.
         """
 
-        self.r_primal: wp.array | None = None
+        self.r_primal: wp.array[wp.float32] | None = None
         """
         The PADMM primal residual vector, computed as `r_primal := x - y`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.r_dual: wp.array | None = None
+        self.r_dual: wp.array[wp.float32] | None = None
         """
         The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.r_compl: wp.array | None = None
+        self.r_compl: wp.array[wp.float32] | None = None
         """
         The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,\n
         where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).\n
-        Shape of ``(sum_of_num_unilateral_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_num_unilateral_cts,)``.
         """
 
-        self.r_dx: wp.array | None = None
+        self.r_dx: wp.array[wp.float32] | None = None
         """
         The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.r_dy: wp.array | None = None
+        self.r_dy: wp.array[wp.float32] | None = None
         """
         The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.r_dz: wp.array | None = None
+        self.r_dz: wp.array[wp.float32] | None = None
         """
         The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.\n
         Only allocated if acceleration is enabled.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
         # Perform memory allocations if model size is specified
@@ -788,19 +788,19 @@ class PADMMResiduals:
         Allocates the residuals arrays based on the model size.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
-            use_acceleration (bool): Flag indicating whether to allocate arrays used with acceleration.
+            size: The model-size utility container holding the dimensionality of the model.
+            use_acceleration: Flag indicating whether to allocate arrays used with acceleration.
         """
         # Allocate the main residuals arrays
-        self.r_primal = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.r_dual = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.r_compl = wp.zeros(size.sum_of_max_unilaterals, dtype=float32)
+        self.r_primal = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.r_dual = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.r_compl = wp.zeros(size.sum_of_max_unilaterals, dtype=wp.float32)
 
         # Optionally allocate iterate residuals used when acceleration is enabled
         if use_acceleration:
-            self.r_dx = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-            self.r_dy = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-            self.r_dz = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
+            self.r_dx = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+            self.r_dy = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+            self.r_dz = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
 
     def zero(self, use_acceleration: bool = False):
         """
@@ -820,10 +820,10 @@ class PADMMSolution:
     An interface container to the PADMM solver solution arrays.
 
     Attributes:
-        lambdas (wp.array): The constraint reactions (i.e. impulses) solution array.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        v_plus (wp.array): The post-event constraint-space velocities solution array.
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        lambdas: The constraint reactions (i.e. impulses) solution array.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        v_plus: The post-event constraint-space velocities solution array.
+            Shape of ``(sum_of_max_total_cts,)``.
     """
 
     def __init__(self, size: SizeKamino | None = None):
@@ -833,19 +833,19 @@ class PADMMSolution:
         If a model size is provided, allocates the solution arrays accordingly.
 
         Args:
-            size (SizeKamino | None): The model-size utility container holding the dimensionality of the model.
+            size: The model-size utility container holding the dimensionality of the model.
         """
 
-        self.lambdas: wp.array | None = None
+        self.lambdas: wp.array[wp.float32] | None = None
         """
         The constraint reactions (i.e. impulses) solution array.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.v_plus: wp.array | None = None
+        self.v_plus: wp.array[wp.float32] | None = None
         """
         The post-event constraint-space velocities solution array.
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
         # Perform memory allocations if model size is specified
@@ -857,10 +857,10 @@ class PADMMSolution:
         Allocates the PADMM solution arrays based on the model size.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
+            size: The model-size utility container holding the dimensionality of the model.
         """
-        self.lambdas = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.v_plus = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
+        self.lambdas = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.v_plus = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
 
     def zero(self):
         """
@@ -875,61 +875,61 @@ class PADMMInfo:
     An interface container to hold the PADMM solver convergence info arrays.
 
     Attributes:
-        lambdas (wp.array): The constraint reactions (i.e. impulses) of each world.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        v_plus (wp.array): The post-event constraint-space velocities of each world.\n
+        lambdas: The constraint reactions (i.e. impulses) of each world.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        v_plus: The post-event constraint-space velocities of each world.\n
             This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        v_aug (wp.array): The post-event augmented constraint-space velocities of each world.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        v_aug: The post-event augmented constraint-space velocities of each world.\n
             This is computed using the current solution as: `v_aug := v_plus + s`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        s (wp.array): The De Saxce correction velocities of each world.\n
+            Shape of ``(sum_of_max_total_cts,)``.
+        s: The De Saxce correction velocities of each world.\n
             This is computed using the current solution as: `s := Gamma(v_plus)`.\n
-            Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        offsets (wp.array): The residuals index offset of each world.\n
-            Shape of ``(num_worlds,)`` and type :class:`int32`.
-        num_restarts (wp.array): History of the number of acceleration restarts performed for each world.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`int32`.
-        num_rho_updates (wp.array): History of the number of penalty updates performed for each world.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`int32`.
-        a (wp.array): History of PADMM acceleration variables.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        norm_s (wp.array): History of the L2 norm of De Saxce correction velocities.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        norm_x (wp.array): History of the L2 norm of primal variables.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        norm_y (wp.array): History of the L2 norm of slack variables.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        norm_z (wp.array): History of the L2 norm of dual variables.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        f_ccp (wp.array): History of CCP optimization objectives.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        f_ncp (wp.array): History of the NCP optimization objectives.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_dx (wp.array): History of the total primal iterate residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_dy (wp.array): History of the total slack iterate residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_dz (wp.array): History of the total dual iterate residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_primal (wp.array): History of the total primal residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_dual (wp.array): History of the total dual residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_compl (wp.array): History of the total complementarity residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_comb (wp.array): History of the total combined primal-dual residual.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_comb_ratio (wp.array): History of the combined primal-dual residual ratio.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_ncp_primal (wp.array): History of NCP primal residuals.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_ncp_dual (wp.array): History of NCP dual residuals.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_ncp_compl (wp.array): History of NCP complementarity residuals.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
-        r_ncp_natmap (wp.array): History of NCP natural-map residuals.\n
-            Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+            Shape of ``(sum_of_max_total_cts,)``.
+        offsets: The residuals index offset of each world.\n
+            Shape of ``(num_worlds,)``.
+        num_restarts: History of the number of acceleration restarts performed for each world.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        num_rho_updates: History of the number of penalty updates performed for each world.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        a: History of PADMM acceleration variables.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        norm_s: History of the L2 norm of De Saxce correction velocities.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        norm_x: History of the L2 norm of primal variables.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        norm_y: History of the L2 norm of slack variables.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        norm_z: History of the L2 norm of dual variables.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        f_ccp: History of CCP optimization objectives.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        f_ncp: History of the NCP optimization objectives.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_dx: History of the total primal iterate residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_dy: History of the total slack iterate residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_dz: History of the total dual iterate residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_primal: History of the total primal residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_dual: History of the total dual residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_compl: History of the total complementarity residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_comb: History of the total combined primal-dual residual.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_comb_ratio: History of the combined primal-dual residual ratio.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_ncp_primal: History of NCP primal residuals.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_ncp_dual: History of NCP dual residuals.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_ncp_compl: History of NCP complementarity residuals.\n
+            Shape of ``(num_worlds * max_iters,)``.
+        r_ncp_natmap: History of NCP natural-map residuals.\n
+            Shape of ``(num_worlds * max_iters,)``.
 
     Notes:
     - The length of the arrays is determined by the maximum number of iterations
@@ -951,179 +951,179 @@ class PADMMInfo:
         If a model size is provided, allocates the solution arrays accordingly.
 
         Args:
-            size (SizeKamino | None): The model-size utility container holding the dimensionality of the model.
-            max_iters (int | None): The maximum number of iterations for which to allocate convergence data.
+            size: The model-size utility container holding the dimensionality of the model.
+            max_iters: The maximum number of iterations for which to allocate convergence data.
         """
 
-        self.lambdas: wp.array | None = None
+        self.lambdas: wp.array[wp.float32] | None = None
         """
         The constraint reactions (i.e. impulses) of each world.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.v_plus: wp.array | None = None
+        self.v_plus: wp.array[wp.float32] | None = None
         """
         The post-event constraint-space velocities of each world.\n
         This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.v_aug: wp.array | None = None
+        self.v_aug: wp.array[wp.float32] | None = None
         """
         The post-event augmented constraint-space velocities of each world.\n
         This is computed using the current solution as: `v_aug := v_plus + s`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.s: wp.array | None = None
+        self.s: wp.array[wp.float32] | None = None
         """
         The De Saxce correction velocities of each world.\n
         This is computed using the current solution as: `s := Gamma(v_plus)`.\n
-        Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        Shape of ``(sum_of_max_total_cts,)``.
         """
 
-        self.offsets: wp.array | None = None
+        self.offsets: wp.array[wp.int32] | None = None
         """
         The residuals index offset of each world.\n
-        Shape of ``(num_worlds,)`` and type :class:`int32`.
+        Shape of ``(num_worlds,)``.
         """
 
-        self.num_restarts: wp.array | None = None
+        self.num_restarts: wp.array[wp.int32] | None = None
         """
         History of the number of acceleration restarts performed for each world.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`int32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.num_rho_updates: wp.array | None = None
+        self.num_rho_updates: wp.array[wp.int32] | None = None
         """
         History of the number of penalty updates performed for each world.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`int32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.a: wp.array | None = None
+        self.a: wp.array[wp.float32] | None = None
         """
         History of PADMM acceleration variables.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.norm_s: wp.array | None = None
+        self.norm_s: wp.array[wp.float32] | None = None
         """
         History of the L2 norm of De Saxce correction velocities.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.norm_x: wp.array | None = None
+        self.norm_x: wp.array[wp.float32] | None = None
         """
         History of the L2 norm of primal variables.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.norm_y: wp.array | None = None
+        self.norm_y: wp.array[wp.float32] | None = None
         """
         History of the L2 norm of slack variables.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.norm_z: wp.array | None = None
+        self.norm_z: wp.array[wp.float32] | None = None
         """
         History of the L2 norm of dual variables.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.f_ccp: wp.array | None = None
+        self.f_ccp: wp.array[wp.float32] | None = None
         """
         History of CCP optimization objectives.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.f_ncp: wp.array | None = None
+        self.f_ncp: wp.array[wp.float32] | None = None
         """
         History of the NCP optimization objectives.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_dx: wp.array | None = None
+        self.r_dx: wp.array[wp.float32] | None = None
         """
         History of the total primal iterate residual.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_dy: wp.array | None = None
+        self.r_dy: wp.array[wp.float32] | None = None
         """
         History of the total slack iterate residual.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_dz: wp.array | None = None
+        self.r_dz: wp.array[wp.float32] | None = None
         """
         History of the total dual iterate residual.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_primal: wp.array | None = None
+        self.r_primal: wp.array[wp.float32] | None = None
         """
         History of PADMM primal residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_dual: wp.array | None = None
+        self.r_dual: wp.array[wp.float32] | None = None
         """
         History of PADMM dual residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_compl: wp.array | None = None
+        self.r_compl: wp.array[wp.float32] | None = None
         """
         History of PADMM complementarity residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_pd: wp.array | None = None
+        self.r_pd: wp.array[wp.float32] | None = None
         """
         History of PADMM primal-dual residual ratio.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_dp: wp.array | None = None
+        self.r_dp: wp.array[wp.float32] | None = None
         """
         History of PADMM dual-primal residual ratio.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_comb: wp.array | None = None
+        self.r_comb: wp.array[wp.float32] | None = None
         """
         History of PADMM combined residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_comb_ratio: wp.array | None = None
+        self.r_comb_ratio: wp.array[wp.float32] | None = None
         """
         History of PADMM combined residuals ratio.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_ncp_primal: wp.array | None = None
+        self.r_ncp_primal: wp.array[wp.float32] | None = None
         """
         History of NCP primal residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_ncp_dual: wp.array | None = None
+        self.r_ncp_dual: wp.array[wp.float32] | None = None
         """
         History of NCP dual residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_ncp_compl: wp.array | None = None
+        self.r_ncp_compl: wp.array[wp.float32] | None = None
         """
         History of NCP complementarity residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
-        self.r_ncp_natmap: wp.array | None = None
+        self.r_ncp_natmap: wp.array[wp.float32] | None = None
         """
         History of NCP natural-map residuals.\n
-        Shape of ``(num_worlds * max_iters,)`` and type :class:`float32`.
+        Shape of ``(num_worlds * max_iters,)``.
         """
 
         # Perform memory allocations if model size is specified
@@ -1135,8 +1135,8 @@ class PADMMInfo:
         Allocates the PADMM solver info arrays based on the model size and maximum number of iterations.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
-            max_iters (int): The maximum number of iterations for which to allocate convergence data.
+            size: The model-size utility container holding the dimensionality of the model.
+            max_iters: The maximum number of iterations for which to allocate convergence data.
 
         Raises:
             ValueError: If either ``size.num_worlds`` or ``max_iters`` are not positive integers.
@@ -1151,10 +1151,10 @@ class PADMMInfo:
             raise ValueError("max_iters must be a positive integer specifying the maximum number of iterations.")
 
         # Allocate intermediate arrays
-        self.lambdas = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.v_plus = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.v_aug = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
-        self.s = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
+        self.lambdas = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.v_plus = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.v_aug = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
+        self.s = wp.zeros(size.sum_of_max_total_cts, dtype=wp.float32)
 
         # Compute the index offsets for the info of each world
         maxsize = max_iters * size.num_worlds
@@ -1162,30 +1162,30 @@ class PADMMInfo:
 
         # Allocate the on-device solver info data arrays
         self.offsets = to_warp_int32_array(offsets)
-        self.num_rho_updates = wp.zeros(maxsize, dtype=int32)
-        self.norm_s = wp.zeros(maxsize, dtype=float32)
-        self.norm_x = wp.zeros(maxsize, dtype=float32)
-        self.norm_y = wp.zeros(maxsize, dtype=float32)
-        self.norm_z = wp.zeros(maxsize, dtype=float32)
-        self.r_dx = wp.zeros(maxsize, dtype=float32)
-        self.r_dy = wp.zeros(maxsize, dtype=float32)
-        self.r_dz = wp.zeros(maxsize, dtype=float32)
-        self.f_ccp = wp.zeros(maxsize, dtype=float32)
-        self.f_ncp = wp.zeros(maxsize, dtype=float32)
-        self.r_primal = wp.zeros(maxsize, dtype=float32)
-        self.r_dual = wp.zeros(maxsize, dtype=float32)
-        self.r_compl = wp.zeros(maxsize, dtype=float32)
-        self.r_pd = wp.zeros(maxsize, dtype=float32)
-        self.r_dp = wp.zeros(maxsize, dtype=float32)
-        self.r_ncp_primal = wp.zeros(maxsize, dtype=float32)
-        self.r_ncp_dual = wp.zeros(maxsize, dtype=float32)
-        self.r_ncp_compl = wp.zeros(maxsize, dtype=float32)
-        self.r_ncp_natmap = wp.zeros(maxsize, dtype=float32)
+        self.num_rho_updates = wp.zeros(maxsize, dtype=wp.int32)
+        self.norm_s = wp.zeros(maxsize, dtype=wp.float32)
+        self.norm_x = wp.zeros(maxsize, dtype=wp.float32)
+        self.norm_y = wp.zeros(maxsize, dtype=wp.float32)
+        self.norm_z = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_dx = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_dy = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_dz = wp.zeros(maxsize, dtype=wp.float32)
+        self.f_ccp = wp.zeros(maxsize, dtype=wp.float32)
+        self.f_ncp = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_primal = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_dual = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_compl = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_pd = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_dp = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_ncp_primal = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_ncp_dual = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_ncp_compl = wp.zeros(maxsize, dtype=wp.float32)
+        self.r_ncp_natmap = wp.zeros(maxsize, dtype=wp.float32)
         if use_acceleration:
-            self.num_restarts = wp.zeros(maxsize, dtype=int32)
-            self.a = wp.zeros(maxsize, dtype=float32)
-            self.r_comb = wp.zeros(maxsize, dtype=float32)
-            self.r_comb_ratio = wp.zeros(maxsize, dtype=float32)
+            self.num_restarts = wp.zeros(maxsize, dtype=wp.int32)
+            self.a = wp.zeros(maxsize, dtype=wp.float32)
+            self.r_comb = wp.zeros(maxsize, dtype=wp.float32)
+            self.r_comb_ratio = wp.zeros(maxsize, dtype=wp.float32)
 
     def zero(self, use_acceleration: bool = False):
         """
@@ -1226,21 +1226,21 @@ class PADMMData:
     A high-level container to manage all internal PADMM solver data.
 
     Attributes:
-        config (wp.array): Array of per-world solver configurations,
+        config: Array of per-world solver configurations,
             of type :class:`PADMMConfigStruct` and shape ``(num_worlds,)``.\n
             Each element is the on-device version of :class:`PADMMConfig`.
-        status (wp.array): Array of per-world solver status,
+        status: Array of per-world solver status,
             of type :class:`PADMMStatus` and shape ``(num_worlds,)``.\n
             Each element holds the status of the solver on
             solving the dynamics of the corresponding world.
-        penalty (wp.array): Array of per-world ALM penalty states,
+        penalty: Array of per-world ALM penalty states,
             of type :class:`PADMMPenalty` and shape ``(num_worlds,)``.\n
             Each element holds the current and previous ALM penalty `rho`,
             as well as additional meta-data regarding it's adaptation.
-        state (PADMMState): A container holding the PADMM state variable arrays.
-        residuals (PADMMResiduals): A container holding the PADMM residuals arrays.
-        solution (PADMMSolution): A container holding the PADMM solution arrays.
-        info (PADMMInfo): A container holding the PADMM solver convergence info arrays.
+        state: A container holding the PADMM state variable arrays.
+        residuals: A container holding the PADMM residuals arrays.
+        solution: A container holding the PADMM solution arrays.
+        info: A container holding the PADMM solver convergence info arrays.
     """
 
     def __init__(
@@ -1255,31 +1255,31 @@ class PADMMData:
         Initializes a PADMM solver data container.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
-            max_iters (int): The maximum number of iterations for which to allocate convergence data.
-            collect_info (bool): Set to `True` to allocate data for reporting solver convergence info.
-            device (wp.DeviceLike): The target Warp device on which all data will be allocated.
+            size: The model-size utility container holding the dimensionality of the model.
+            max_iters: The maximum number of iterations for which to allocate convergence data.
+            collect_info: Set to `True` to allocate data for reporting solver convergence info.
+            device: The target Warp device on which all data will be allocated.
 
         Raises:
             ValueError: If either ``size.num_worlds`` or ``max_iters`` are not positive integers.
         """
 
-        self.config: wp.array | None = None
+        self.config: wp.array[PADMMConfigStruct] | None = None
         """
         Array of on-device PADMM solver configs.\n
-        Shape is (num_worlds,) and type :class:`PADMMConfigStruct`.
+        Shape is (num_worlds,).
         """
 
-        self.status: wp.array | None = None
+        self.status: wp.array[PADMMStatus] | None = None
         """
         Array of PADMM solver status.\n
-        Shape is (num_worlds,) and type :class:`PADMMStatus`.
+        Shape is (num_worlds,).
         """
 
-        self.penalty: wp.array | None = None
+        self.penalty: wp.array[PADMMPenalty] | None = None
         """
         Array of PADMM solver penalty parameters.\n
-        Shape is (num_worlds,) and type :class:`PADMMPenalty`.
+        Shape is (num_worlds,).
         """
 
         self.state: PADMMState | None = None
@@ -1294,10 +1294,10 @@ class PADMMData:
         self.info: PADMMInfo | None = None
         """The (optional) PADMM solver info container."""
 
-        self.linear_solver_atol: wp.array | None = None
+        self.linear_solver_atol: wp.array[wp.float32] | None = None
         """
         Per-world absolute tolerance array for the iterative linear solver.\n
-        Shape is (num_worlds,) and type :class:`float32`.
+        Shape is (num_worlds,).
         """
 
         # Perform memory allocations if model size is specified
@@ -1322,10 +1322,10 @@ class PADMMData:
         Allocates the PADMM solver data based on the model size and maximum number of iterations.
 
         Args:
-            size (SizeKamino): The model-size utility container holding the dimensionality of the model.
-            max_iters (int): The maximum number of iterations for which to allocate convergence data.
-            collect_info (bool): Set to `True` to allocate data for reporting solver convergence info.
-            device (wp.DeviceLike): The target Warp device on which all data will be allocated.
+            size: The model-size utility container holding the dimensionality of the model.
+            max_iters: The maximum number of iterations for which to allocate convergence data.
+            collect_info: Set to `True` to allocate data for reporting solver convergence info.
+            device: The target Warp device on which all data will be allocated.
 
         Raises:
             ValueError: If either ``size.num_worlds`` or ``max_iters`` are not positive integers.
@@ -1337,7 +1337,9 @@ class PADMMData:
             self.state = PADMMState(size, use_acceleration)
             self.residuals = PADMMResiduals(size, use_acceleration)
             self.solution = PADMMSolution(size)
-            self.linear_solver_atol = wp.full(shape=(size.num_worlds,), value=np.finfo(np.float32).eps, dtype=float32)
+            self.linear_solver_atol = wp.full(
+                shape=(size.num_worlds,), value=np.finfo(np.float32).eps, dtype=wp.float32
+            )
             if collect_info and max_iters > 0:
                 self.info = PADMMInfo(size, max_iters, use_acceleration)
 
@@ -1352,7 +1354,7 @@ def convert_config_to_struct(config: PADMMSolverConfig) -> PADMMConfigStruct:
     Converts the host-side config to the corresponding device-side object.
 
     Returns:
-        PADMMConfigStruct: The solver config as a warp struct.
+        The solver config as a warp struct.
     """
     config_struct = PADMMConfigStruct()
     config_struct.primal_tolerance = config.primal_tolerance

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -8,7 +8,7 @@ High-level Settings:
 - :class:`PADMMPenaltyUpdate`:
     Defines the ALM penalty update methods supported by the PADMM solver.
 - :class:`PADMMWarmStartMode`:
-    Defines the warmstart modes supported by the PADMM solver.\n
+    Defines the warmstart modes supported by the PADMM solver.
 
 Warp Structs:
 - :class:`PADMMConfigStruct`:
@@ -190,135 +190,135 @@ class PADMMConfigStruct:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        primal_tolerance: The target tolerance on the total primal residual `r_primal`.\n
+        primal_tolerance: The target tolerance on the total primal residual `r_primal`.
             Must be greater than zero. Defaults to `1e-6`.
-        dual_tolerance: The target tolerance on the total dual residual `r_dual`.\n
+        dual_tolerance: The target tolerance on the total dual residual `r_dual`.
             Must be greater than zero. Defaults to `1e-6`.
-        compl_tolerance: The target tolerance on the total complementarity residual `r_compl`.\n
+        compl_tolerance: The target tolerance on the total complementarity residual `r_compl`.
             Must be greater than zero. Defaults to `1e-6`.
         restart_tolerance: The tolerance on the total combined primal-dual
-            residual `r_comb`, for determining when gradient acceleration should be restarted.\n
+            residual `r_comb`, for determining when gradient acceleration should be restarted.
             Must be greater than zero. Defaults to `0.999`.
-        eta: The proximal regularization parameter.\n
+        eta: The proximal regularization parameter.
             Must be greater than zero. Defaults to `1e-5`.
-        rho_0: The initial value of the penalty parameter.\n
+        rho_0: The initial value of the penalty parameter.
             Must be greater than zero. Defaults to `1.0`.
-        a_0: The initial value of the acceleration parameter.\n
+        a_0: The initial value of the acceleration parameter.
             Must be greater than zero. Defaults to `1.0`.
         alpha: The threshold on primal-dual residual ratios,
-            used to determine when penalty updates should occur.\n
+            used to determine when penalty updates should occur.
             Must be greater than `1.0`. Defaults to `10.0`.
         tau: The factor by which the penalty is increased/decreased
-            when the primal-dual residual ratios exceed the threshold `alpha`.\n
+            when the primal-dual residual ratios exceed the threshold `alpha`.
             Must be greater than `1.0`. Defaults to `1.5`.
-        max_iterations: The maximum number of solver iterations.\n
+        max_iterations: The maximum number of solver iterations.
             Must be greater than zero. Defaults to `200`.
-        penalty_update_freq: The permitted frequency of penalty updates.\n
+        penalty_update_freq: The permitted frequency of penalty updates.
             If zero, no updates are performed. Otherwise, updates are performed every
             `penalty_update_freq` iterations. Defaults to `10`.
-        penalty_update_method: The penalty update method used to adapt the penalty parameter.\n
-            Defaults to `PADMMPenaltyUpdate.FIXED`.\n
+        penalty_update_method: The penalty update method used to adapt the penalty parameter.
+            Defaults to `PADMMPenaltyUpdate.FIXED`.
             See :class:`PADMMPenaltyUpdate` for details.
     """
 
     primal_tolerance: wp.float32
     """
-    The target tolerance on the total primal residual `r_primal`.\n
+    The target tolerance on the total primal residual `r_primal`.
     Must be greater than zero. Defaults to `1e-6`.
     """
 
     dual_tolerance: wp.float32
     """
-    The target tolerance on the total dual residual `r_dual`.\n
+    The target tolerance on the total dual residual `r_dual`.
     Must be greater than zero. Defaults to `1e-6`.
     """
 
     compl_tolerance: wp.float32
     """
-    The target tolerance on the total complementarity residual `r_compl`.\n
+    The target tolerance on the total complementarity residual `r_compl`.
     Must be greater than zero. Defaults to `1e-6`.
     """
 
     restart_tolerance: wp.float32
     """
     The tolerance applied on the total combined primal-dual residual `r_comb`,
-    for determining when gradient acceleration should be restarted.\n
+    for determining when gradient acceleration should be restarted.
     Must be greater than zero. Defaults to `0.999`.
     """
 
     eta: wp.float32
     """
-    The proximal regularization parameter.\n
+    The proximal regularization parameter.
     Must be greater than zero. Defaults to `1e-5`.
     """
 
     rho_0: wp.float32
     """
-    The initial value of the ALM penalty parameter.\n
+    The initial value of the ALM penalty parameter.
     Must be greater than zero. Defaults to `1.0`.
     """
 
     rho_min: wp.float32
     """
-    The lower-bound applied to the ALM penalty parameter.\n
+    The lower-bound applied to the ALM penalty parameter.
     Must be greater than zero. Defaults to `1e-5`.
     """
 
     a_0: wp.float32
     """
-    The initial value of the acceleration parameter.\n
+    The initial value of the acceleration parameter.
     Must be greater than zero. Defaults to `1.0`.
     """
 
     alpha: wp.float32
     """
     The threshold on primal-dual residual ratios,
-    used to determine when penalty updates should occur.\n
+    used to determine when penalty updates should occur.
     Must be greater than `1.0`. Defaults to `10.0`.
     """
 
     tau: wp.float32
     """
     The factor by which the penalty is increased/decreased
-    when the primal-dual residual ratios exceed the threshold `alpha`.\n
+    when the primal-dual residual ratios exceed the threshold `alpha`.
     Must be greater than `1.0`. Defaults to `1.5`.
     """
 
     max_iterations: wp.int32
     """
-    The maximum number of solver iterations.\n
+    The maximum number of solver iterations.
     Must be greater than zero. Defaults to `200`.
     """
 
     penalty_update_freq: wp.int32
     """
-    The permitted frequency of penalty updates.\n
+    The permitted frequency of penalty updates.
     If zero, no updates are performed. Otherwise, updates are performed every
     `penalty_update_freq` iterations. Defaults to `10`.
     """
 
     penalty_update_method: wp.int32
     """
-    The penalty update method used to adapt the penalty parameter.\n
-    Defaults to `PADMMPenaltyUpdate.FIXED`.\n
+    The penalty update method used to adapt the penalty parameter.
+    Defaults to `PADMMPenaltyUpdate.FIXED`.
     See :class:`PADMMPenaltyUpdate` for details.
     """
 
     linear_solver_tolerance: wp.float32
     """
-    The default absolute tolerance for the iterative linear solver.\n
+    The default absolute tolerance for the iterative linear solver.
     When positive, the iterative solver's atol is initialized to this value
-    at the start of each ADMM solve.\n
-    When zero, the iterative solver's own tolerance is left unchanged.\n
+    at the start of each ADMM solve.
+    When zero, the iterative solver's own tolerance is left unchanged.
     Must be non-negative. Defaults to `0.0`.
     """
 
     linear_solver_tolerance_ratio: wp.float32
     """
-    The ratio used to adapt the iterative linear solver tolerance from the ADMM primal residual.\n
+    The ratio used to adapt the iterative linear solver tolerance from the ADMM primal residual.
     When positive, the linear solver absolute tolerance is set to
-    `ratio * ||r_primal||_2` at each ADMM iteration.\n
-    When zero, the linear solver tolerance is not adapted (fixed tolerance).\n
+    `ratio * ||r_primal||_2` at each ADMM iteration.
+    When zero, the linear solver tolerance is not adapted (fixed tolerance).
     Must be non-negative. Defaults to `0.0`.
     """
 
@@ -331,38 +331,38 @@ class PADMMStatus:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        converged: A flag indicating whether the solver has converged (`1`) or not (`0`).\n
+        converged: A flag indicating whether the solver has converged (`1`) or not (`0`).
             Used internally to keep track of per-world convergence status,
             with `1` being set only when all total residuals have satisfied their
             respective tolerances. If by the end of the solve the flag is still `0`,
             it indicates that the solve reached the maximum number of iterations.
-        iterations: The number of iterations performed by the solver.\n
+        iterations: The number of iterations performed by the solver.
             Used internally to keep track of per-world iteration counts.
-        r_p: The total primal residual.\n
-            Computed using the L-inf norm as `r_primal := || x - y ||_inf`.\n
-        r_d: The total dual residual.\n
-            Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.\n
+        r_p: The total primal residual.
+            Computed using the L-inf norm as `r_primal := || x - y ||_inf`.
+        r_d: The total dual residual.
+            Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.
         r_c: The total complementarity residual.
             Computed using the L-inf norm as `r_compl := || [x_k.T @ z_k] ||_inf`,
             with `k` indexing each unilateral constraint set, i.e. 1D limits and 3D contacts.
-        r_dx: The total primal iterate residual.\n
+        r_dx: The total primal iterate residual.
             Computed as the L2-norm `r_dx := || x - x_p ||_2`.
-        r_dy: The total slack iterate residual.\n
+        r_dy: The total slack iterate residual.
             Computed as the L2-norm `r_dy := || y - y_p ||_2`.
-        r_dz: The total dual iterate residual.\n
+        r_dz: The total dual iterate residual.
             Computed as the L2-norm `r_dz := || z - z_p ||_2`.
         r_a: The total combined primal-dual residual used for acceleration restart checks.
             Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
         r_a_p: The previous total combined primal-dual residual.
         r_a_pp: An auxiliary cache of the previous total combined primal-dual residual.
-        restart: A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).\n
+        restart: A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).
             Used internally to keep track of per-world acceleration restarts.
         num_restarts: The number of acceleration restarts performed during the solve.
     """
 
     converged: wp.int32
     """
-    A flag indicating whether the solver has converged (`1`) or not (`0`).\n
+    A flag indicating whether the solver has converged (`1`) or not (`0`).
     Used internally to keep track of per-world convergence status,
     with `1` being set only when all total residuals have satisfied their
     respective tolerances. If by the end of the solve the flag is still `0`,
@@ -371,20 +371,20 @@ class PADMMStatus:
 
     iterations: wp.int32
     """
-    The number of iterations performed by the solver.\n
+    The number of iterations performed by the solver.
     Used internally to keep track of per-world iteration counts.
     """
 
     r_p: wp.float32
     """
-    The total primal residual.\n
-    Computed using the L-inf norm as `r_primal := || x - y ||_inf`.\n
+    The total primal residual.
+    Computed using the L-inf norm as `r_primal := || x - y ||_inf`.
     """
 
     r_d: wp.float32
     """
-    The total dual residual.\n
-    Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.\n
+    The total dual residual.
+    Computed using the L-inf norm as `r_dual := || eta * (x - x_p) + rho * (y - y_p) ||_inf`.
     """
 
     r_c: wp.float32
@@ -396,25 +396,25 @@ class PADMMStatus:
 
     r_dx: wp.float32
     """
-    The total primal iterate residual.\n
+    The total primal iterate residual.
     Computed as the L2-norm `r_dx := || x - x_p ||_2`.
     """
 
     r_dy: wp.float32
     """
-    The total slack iterate residual.\n
+    The total slack iterate residual.
     Computed as the L2-norm `r_dy := || y - y_p ||_2`.
     """
 
     r_dz: wp.float32
     """
-    The total dual iterate residual.\n
+    The total dual iterate residual.
     Computed as the L2-norm `r_dz := || z - z_p ||_2`.
     """
 
     r_a: wp.float32
     """
-    The total combined primal-dual residual used for acceleration restart checks.\n
+    The total combined primal-dual residual used for acceleration restart checks.
     Computed as `r_a := rho * r_dy + (1.0 / rho) * r_dz`.
     """
 
@@ -426,7 +426,7 @@ class PADMMStatus:
 
     restart: wp.int32
     """
-    A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).\n
+    A flag indicating whether gradient acceleration requires a restart (`1`) or not (`0`).
     Used internally to keep track of per-world acceleration restarts.
     """
 
@@ -442,14 +442,14 @@ class PADMMPenalty:
     Intended to be used as ``dtype`` for warp arrays.
 
     Attributes:
-        num_updates: The number of penalty updates performed during a solve.\n
+        num_updates: The number of penalty updates performed during a solve.
             If a direct linear-system solver is used, this also
             equals the number of matrix factorizations performed.
-        rho: The current value of the ALM penalty parameter.\n
+        rho: The current value of the ALM penalty parameter.
             If adaptive penalty scheme is used, this value may change during
             solve operations, while being lower-bounded by `config.rho_min`
             to ensure numerical stability.
-        rho_p: The previous value of the ALM penalty parameter.\n
+        rho_p: The previous value of the ALM penalty parameter.
             As diagonal regularization of the lhs matrix (e.g. Delassus
             operator) is performed in-place, we must keep track of the
             previous penalty value  to remove the previous regularization
@@ -458,14 +458,14 @@ class PADMMPenalty:
 
     num_updates: wp.int32
     """
-    The number of penalty updates performed during a solve.\n
+    The number of penalty updates performed during a solve.
     If a direct linear-system solver is used, this also
     equals the number of matrix factorizations performed.
     """
 
     rho: wp.float32
     """
-    The current value of the ALM penalty parameter.\n
+    The current value of the ALM penalty parameter.
     If adaptive penalty scheme is used, this value may change during
     solve operations, while being lower-bounded by `config.rho_min`
     to ensure numerical stability.
@@ -473,7 +473,7 @@ class PADMMPenalty:
 
     rho_p: wp.float32
     """
-    The previous value of the ALM penalty parameter.\n
+    The previous value of the ALM penalty parameter.
     As diagonal regularization of the lhs matrix (e.g. Delassus
     operator) is performed in-place, we must keep track of the
     previous penalty value  to remove the previous regularization
@@ -492,33 +492,33 @@ class PADMMState:
 
     Attributes:
         done: A single-element array containing the global
-            flag that indicates whether the solver should terminate.\n
+            flag that indicates whether the solver should terminate.
             Its value is initialized to ``num_worlds`` at the beginning of each
-            solve, and decremented by one for each world that has converged.\n
+            solve, and decremented by one for each world that has converged.
             Shape of ``(1,)``.
-        s: The De Saxce correction velocities `s = Gamma(v_plus)`.\n
+        s: The De Saxce correction velocities `s = Gamma(v_plus)`.
             Shape of ``(sum_of_max_total_cts,)``.
-        v: The total bias velocity vector serving as the right-hand-side of the PADMM linear system.\n
+        v: The total bias velocity vector serving as the right-hand-side of the PADMM linear system.
             Shape of ``(sum_of_max_total_cts,)``.
-        x: The current PADMM primal variables.\n
+        x: The current PADMM primal variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        x_p: The previous PADMM primal variables.\n
+        x_p: The previous PADMM primal variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        y: The current PADMM slack variables.\n
+        y: The current PADMM slack variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        y_p: The previous PADMM slack variables.\n
+        y_p: The previous PADMM slack variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        z: The current PADMM dual variables.\n
+        z: The current PADMM dual variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        z_p: The previous PADMM dual variables.\n
+        z_p: The previous PADMM dual variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        y_hat: The auxiliary PADMM slack variables used with gradient acceleration.\n
+        y_hat: The auxiliary PADMM slack variables used with gradient acceleration.
             Shape of ``(sum_of_max_total_cts,)``.
-        z_hat: The auxiliary PADMM dual variables used with gradient acceleration.\n
+        z_hat: The auxiliary PADMM dual variables used with gradient acceleration.
             Shape of ``(sum_of_max_total_cts,)``.
-        a: The per-world current Nesterov acceleration variables.\n
+        a: The per-world current Nesterov acceleration variables.
             Shape of ``(sum_of_max_total_cts,)``.
-        a_p: The per-world previous Nesterov acceleration variables.\n
+        a_p: The per-world previous Nesterov acceleration variables.
             Shape of ``(sum_of_max_total_cts,)``.
         a_factor: The per-world Nesterov factor computed from the previous and current acceleration
             variables. Shape of ``(num_worlds,)``.
@@ -536,9 +536,9 @@ class PADMMState:
 
         self.done: wp.array[wp.int32] | None = None
         """
-        A single-element array containing the global flag that indicates whether the solver should terminate.\n
+        A single-element array containing the global flag that indicates whether the solver should terminate.
         Its value is initialized to ``num_worlds`` at the beginning of each
-        solve, and decremented by one for each world that has converged.\n
+        solve, and decremented by one for each world that has converged.
         Shape of ``(1,)``.
         """
 
@@ -558,14 +558,14 @@ class PADMMState:
 
         self.s: wp.array[wp.float32] | None = None
         """
-        The De Saxce correction velocities `s = Gamma(v_plus)`.\n
+        The De Saxce correction velocities `s = Gamma(v_plus)`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.v: wp.array[wp.float32] | None = None
         """
-        The total bias velocity vector serving as the right-hand-side of the PADMM linear system.\n
-        It is computed from the PADMM state and proximal parameters `eta` and `rho`.\n
+        The total bias velocity vector serving as the right-hand-side of the PADMM linear system.
+        It is computed from the PADMM state and proximal parameters `eta` and `rho`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
@@ -607,36 +607,36 @@ class PADMMState:
 
         self.y_hat: wp.array[wp.float32] | None = None
         """
-        The auxiliary PADMM slack variables used with gradient acceleration.\n
-        Only allocated if acceleration is enabled.\n
+        The auxiliary PADMM slack variables used with gradient acceleration.
+        Only allocated if acceleration is enabled.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.z_hat: wp.array[wp.float32] | None = None
         """
-        The auxiliary PADMM dual variables used with gradient acceleration.\n
-        Only allocated if acceleration is enabled.\n
+        The auxiliary PADMM dual variables used with gradient acceleration.
+        Only allocated if acceleration is enabled.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.a: wp.array[wp.float32] | None = None
         """
-        The per-world current Nesterov acceleration variables.\n
-        Only allocated if acceleration is enabled.\n
+        The per-world current Nesterov acceleration variables.
+        Only allocated if acceleration is enabled.
         Shape of ``(num_worlds,)``.
         """
 
         self.a_p: wp.array[wp.float32] | None = None
         """
-        The per-world previous Nesterov acceleration variables.\n
-        Only allocated if acceleration is enabled.\n
+        The per-world previous Nesterov acceleration variables.
+        Only allocated if acceleration is enabled.
         Shape of ``(num_worlds,)``.
         """
 
         self.a_factor: wp.array[wp.float32] | None = None
         """
-        The per-world current Nesterov acceleration factor.\n
-        Only allocated if acceleration is enabled.\n
+        The per-world current Nesterov acceleration factor.
+        Only allocated if acceleration is enabled.
         Shape of ``(num_worlds,)``.
         """
 
@@ -682,8 +682,8 @@ class PADMMState:
         - If acceleration is enabled, the momentum arrays `a_p` and `a` are set to ones.
 
         Args:
-            use_acceleration: Whether to reset the acceleration state variables.\n
-                If `True`, auxiliary state variables and acceleration scales are reset as well.\n
+            use_acceleration: Whether to reset the acceleration state variables.
+                If `True`, auxiliary state variables and acceleration scales are reset as well.
                 Defaults to `False`.
         """
         # Reset primary state variables
@@ -714,18 +714,18 @@ class PADMMResiduals:
     A data container to bundle the internal PADMM residual arrays.
 
     Attributes:
-        r_primal: The PADMM primal residual vector, computed as `r_primal := x - y`.\n
+        r_primal: The PADMM primal residual vector, computed as `r_primal := x - y`.
             Shape of ``(sum_of_max_total_cts,)``.
-        r_dual: The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.\n
+        r_dual: The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.
             Shape of ``(sum_of_max_total_cts,)``.
-        r_compl: The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,\n
-            where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).\n
+        r_compl: The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,
+            where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).
             Shape of ``(sum_of_num_unilateral_cts,)``.
-        r_dx: The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.\n
+        r_dx: The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.
             Shape of ``(sum_of_max_total_cts,)``.
-        r_dy: The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.\n
+        r_dy: The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.
             Shape of ``(sum_of_max_total_cts,)``.
-        r_dz: The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.\n
+        r_dz: The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.
             Shape of ``(sum_of_max_total_cts,)``.
     """
 
@@ -741,41 +741,41 @@ class PADMMResiduals:
 
         self.r_primal: wp.array[wp.float32] | None = None
         """
-        The PADMM primal residual vector, computed as `r_primal := x - y`.\n
+        The PADMM primal residual vector, computed as `r_primal := x - y`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.r_dual: wp.array[wp.float32] | None = None
         """
-        The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.\n
+        The PADMM dual residual vector, computed as `r_dual := eta * (x - x_p) + rho * (y - y_p)`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.r_compl: wp.array[wp.float32] | None = None
         """
-        The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,\n
-        where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).\n
+        The PADMM complementarity residual vector, computed as `r_compl := [x_j.dot(z_j)]`,
+        where `j` indexes each unilateral constraint set (i.e. 1D limits and 3D contacts).
         Shape of ``(sum_of_num_unilateral_cts,)``.
         """
 
         self.r_dx: wp.array[wp.float32] | None = None
         """
-        The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.\n
-        Only allocated if acceleration is enabled.\n
+        The PADMM primal iterate residual vector, computed as `r_dx := x - x_p`.
+        Only allocated if acceleration is enabled.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.r_dy: wp.array[wp.float32] | None = None
         """
-        The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.\n
-        Only allocated if acceleration is enabled.\n
+        The PADMM slack iterate residual vector, computed as `r_dy := y - y_p`.
+        Only allocated if acceleration is enabled.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.r_dz: wp.array[wp.float32] | None = None
         """
-        The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.\n
-        Only allocated if acceleration is enabled.\n
+        The PADMM dual iterate residual vector, computed as `r_dz := z - z_p`.
+        Only allocated if acceleration is enabled.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
@@ -820,7 +820,7 @@ class PADMMSolution:
     An interface container to the PADMM solver solution arrays.
 
     Attributes:
-        lambdas: The constraint reactions (i.e. impulses) solution array.\n
+        lambdas: The constraint reactions (i.e. impulses) solution array.
             Shape of ``(sum_of_max_total_cts,)``.
         v_plus: The post-event constraint-space velocities solution array.
             Shape of ``(sum_of_max_total_cts,)``.
@@ -838,7 +838,7 @@ class PADMMSolution:
 
         self.lambdas: wp.array[wp.float32] | None = None
         """
-        The constraint reactions (i.e. impulses) solution array.\n
+        The constraint reactions (i.e. impulses) solution array.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
@@ -875,60 +875,60 @@ class PADMMInfo:
     An interface container to hold the PADMM solver convergence info arrays.
 
     Attributes:
-        lambdas: The constraint reactions (i.e. impulses) of each world.\n
+        lambdas: The constraint reactions (i.e. impulses) of each world.
             Shape of ``(sum_of_max_total_cts,)``.
-        v_plus: The post-event constraint-space velocities of each world.\n
-            This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.\n
+        v_plus: The post-event constraint-space velocities of each world.
+            This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.
             Shape of ``(sum_of_max_total_cts,)``.
-        v_aug: The post-event augmented constraint-space velocities of each world.\n
-            This is computed using the current solution as: `v_aug := v_plus + s`.\n
+        v_aug: The post-event augmented constraint-space velocities of each world.
+            This is computed using the current solution as: `v_aug := v_plus + s`.
             Shape of ``(sum_of_max_total_cts,)``.
-        s: The De Saxce correction velocities of each world.\n
-            This is computed using the current solution as: `s := Gamma(v_plus)`.\n
+        s: The De Saxce correction velocities of each world.
+            This is computed using the current solution as: `s := Gamma(v_plus)`.
             Shape of ``(sum_of_max_total_cts,)``.
-        offsets: The residuals index offset of each world.\n
+        offsets: The residuals index offset of each world.
             Shape of ``(num_worlds,)``.
-        num_restarts: History of the number of acceleration restarts performed for each world.\n
+        num_restarts: History of the number of acceleration restarts performed for each world.
             Shape of ``(num_worlds * max_iters,)``.
-        num_rho_updates: History of the number of penalty updates performed for each world.\n
+        num_rho_updates: History of the number of penalty updates performed for each world.
             Shape of ``(num_worlds * max_iters,)``.
-        a: History of PADMM acceleration variables.\n
+        a: History of PADMM acceleration variables.
             Shape of ``(num_worlds * max_iters,)``.
-        norm_s: History of the L2 norm of De Saxce correction velocities.\n
+        norm_s: History of the L2 norm of De Saxce correction velocities.
             Shape of ``(num_worlds * max_iters,)``.
-        norm_x: History of the L2 norm of primal variables.\n
+        norm_x: History of the L2 norm of primal variables.
             Shape of ``(num_worlds * max_iters,)``.
-        norm_y: History of the L2 norm of slack variables.\n
+        norm_y: History of the L2 norm of slack variables.
             Shape of ``(num_worlds * max_iters,)``.
-        norm_z: History of the L2 norm of dual variables.\n
+        norm_z: History of the L2 norm of dual variables.
             Shape of ``(num_worlds * max_iters,)``.
-        f_ccp: History of CCP optimization objectives.\n
+        f_ccp: History of CCP optimization objectives.
             Shape of ``(num_worlds * max_iters,)``.
-        f_ncp: History of the NCP optimization objectives.\n
+        f_ncp: History of the NCP optimization objectives.
             Shape of ``(num_worlds * max_iters,)``.
-        r_dx: History of the total primal iterate residual.\n
+        r_dx: History of the total primal iterate residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_dy: History of the total slack iterate residual.\n
+        r_dy: History of the total slack iterate residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_dz: History of the total dual iterate residual.\n
+        r_dz: History of the total dual iterate residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_primal: History of the total primal residual.\n
+        r_primal: History of the total primal residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_dual: History of the total dual residual.\n
+        r_dual: History of the total dual residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_compl: History of the total complementarity residual.\n
+        r_compl: History of the total complementarity residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_comb: History of the total combined primal-dual residual.\n
+        r_comb: History of the total combined primal-dual residual.
             Shape of ``(num_worlds * max_iters,)``.
-        r_comb_ratio: History of the combined primal-dual residual ratio.\n
+        r_comb_ratio: History of the combined primal-dual residual ratio.
             Shape of ``(num_worlds * max_iters,)``.
-        r_ncp_primal: History of NCP primal residuals.\n
+        r_ncp_primal: History of NCP primal residuals.
             Shape of ``(num_worlds * max_iters,)``.
-        r_ncp_dual: History of NCP dual residuals.\n
+        r_ncp_dual: History of NCP dual residuals.
             Shape of ``(num_worlds * max_iters,)``.
-        r_ncp_compl: History of NCP complementarity residuals.\n
+        r_ncp_compl: History of NCP complementarity residuals.
             Shape of ``(num_worlds * max_iters,)``.
-        r_ncp_natmap: History of NCP natural-map residuals.\n
+        r_ncp_natmap: History of NCP natural-map residuals.
             Shape of ``(num_worlds * max_iters,)``.
 
     Notes:
@@ -957,172 +957,172 @@ class PADMMInfo:
 
         self.lambdas: wp.array[wp.float32] | None = None
         """
-        The constraint reactions (i.e. impulses) of each world.\n
+        The constraint reactions (i.e. impulses) of each world.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.v_plus: wp.array[wp.float32] | None = None
         """
-        The post-event constraint-space velocities of each world.\n
-        This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.\n
+        The post-event constraint-space velocities of each world.
+        This is computed using the current solution as: `v_plus := v_f + D @ lambdas`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.v_aug: wp.array[wp.float32] | None = None
         """
-        The post-event augmented constraint-space velocities of each world.\n
-        This is computed using the current solution as: `v_aug := v_plus + s`.\n
+        The post-event augmented constraint-space velocities of each world.
+        This is computed using the current solution as: `v_aug := v_plus + s`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.s: wp.array[wp.float32] | None = None
         """
-        The De Saxce correction velocities of each world.\n
-        This is computed using the current solution as: `s := Gamma(v_plus)`.\n
+        The De Saxce correction velocities of each world.
+        This is computed using the current solution as: `s := Gamma(v_plus)`.
         Shape of ``(sum_of_max_total_cts,)``.
         """
 
         self.offsets: wp.array[wp.int32] | None = None
         """
-        The residuals index offset of each world.\n
+        The residuals index offset of each world.
         Shape of ``(num_worlds,)``.
         """
 
         self.num_restarts: wp.array[wp.int32] | None = None
         """
-        History of the number of acceleration restarts performed for each world.\n
+        History of the number of acceleration restarts performed for each world.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.num_rho_updates: wp.array[wp.int32] | None = None
         """
-        History of the number of penalty updates performed for each world.\n
+        History of the number of penalty updates performed for each world.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.a: wp.array[wp.float32] | None = None
         """
-        History of PADMM acceleration variables.\n
+        History of PADMM acceleration variables.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.norm_s: wp.array[wp.float32] | None = None
         """
-        History of the L2 norm of De Saxce correction velocities.\n
+        History of the L2 norm of De Saxce correction velocities.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.norm_x: wp.array[wp.float32] | None = None
         """
-        History of the L2 norm of primal variables.\n
+        History of the L2 norm of primal variables.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.norm_y: wp.array[wp.float32] | None = None
         """
-        History of the L2 norm of slack variables.\n
+        History of the L2 norm of slack variables.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.norm_z: wp.array[wp.float32] | None = None
         """
-        History of the L2 norm of dual variables.\n
+        History of the L2 norm of dual variables.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.f_ccp: wp.array[wp.float32] | None = None
         """
-        History of CCP optimization objectives.\n
+        History of CCP optimization objectives.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.f_ncp: wp.array[wp.float32] | None = None
         """
-        History of the NCP optimization objectives.\n
+        History of the NCP optimization objectives.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_dx: wp.array[wp.float32] | None = None
         """
-        History of the total primal iterate residual.\n
+        History of the total primal iterate residual.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_dy: wp.array[wp.float32] | None = None
         """
-        History of the total slack iterate residual.\n
+        History of the total slack iterate residual.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_dz: wp.array[wp.float32] | None = None
         """
-        History of the total dual iterate residual.\n
+        History of the total dual iterate residual.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_primal: wp.array[wp.float32] | None = None
         """
-        History of PADMM primal residuals.\n
+        History of PADMM primal residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_dual: wp.array[wp.float32] | None = None
         """
-        History of PADMM dual residuals.\n
+        History of PADMM dual residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_compl: wp.array[wp.float32] | None = None
         """
-        History of PADMM complementarity residuals.\n
+        History of PADMM complementarity residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_pd: wp.array[wp.float32] | None = None
         """
-        History of PADMM primal-dual residual ratio.\n
+        History of PADMM primal-dual residual ratio.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_dp: wp.array[wp.float32] | None = None
         """
-        History of PADMM dual-primal residual ratio.\n
+        History of PADMM dual-primal residual ratio.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_comb: wp.array[wp.float32] | None = None
         """
-        History of PADMM combined residuals.\n
+        History of PADMM combined residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_comb_ratio: wp.array[wp.float32] | None = None
         """
-        History of PADMM combined residuals ratio.\n
+        History of PADMM combined residuals ratio.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_ncp_primal: wp.array[wp.float32] | None = None
         """
-        History of NCP primal residuals.\n
+        History of NCP primal residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_ncp_dual: wp.array[wp.float32] | None = None
         """
-        History of NCP dual residuals.\n
+        History of NCP dual residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_ncp_compl: wp.array[wp.float32] | None = None
         """
-        History of NCP complementarity residuals.\n
+        History of NCP complementarity residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
         self.r_ncp_natmap: wp.array[wp.float32] | None = None
         """
-        History of NCP natural-map residuals.\n
+        History of NCP natural-map residuals.
         Shape of ``(num_worlds * max_iters,)``.
         """
 
@@ -1227,14 +1227,14 @@ class PADMMData:
 
     Attributes:
         config: Array of per-world solver configurations,
-            of type :class:`PADMMConfigStruct` and shape ``(num_worlds,)``.\n
+            of type :class:`PADMMConfigStruct` and shape ``(num_worlds,)``.
             Each element is the on-device version of :class:`PADMMConfig`.
         status: Array of per-world solver status,
-            of type :class:`PADMMStatus` and shape ``(num_worlds,)``.\n
+            of type :class:`PADMMStatus` and shape ``(num_worlds,)``.
             Each element holds the status of the solver on
             solving the dynamics of the corresponding world.
         penalty: Array of per-world ALM penalty states,
-            of type :class:`PADMMPenalty` and shape ``(num_worlds,)``.\n
+            of type :class:`PADMMPenalty` and shape ``(num_worlds,)``.
             Each element holds the current and previous ALM penalty `rho`,
             as well as additional meta-data regarding it's adaptation.
         state: A container holding the PADMM state variable arrays.
@@ -1266,19 +1266,19 @@ class PADMMData:
 
         self.config: wp.array[PADMMConfigStruct] | None = None
         """
-        Array of on-device PADMM solver configs.\n
+        Array of on-device PADMM solver configs.
         Shape is (num_worlds,).
         """
 
         self.status: wp.array[PADMMStatus] | None = None
         """
-        Array of PADMM solver status.\n
+        Array of PADMM solver status.
         Shape is (num_worlds,).
         """
 
         self.penalty: wp.array[PADMMPenalty] | None = None
         """
-        Array of PADMM solver penalty parameters.\n
+        Array of PADMM solver penalty parameters.
         Shape is (num_worlds,).
         """
 
@@ -1296,7 +1296,7 @@ class PADMMData:
 
         self.linear_solver_atol: wp.array[wp.float32] | None = None
         """
-        Per-world absolute tolerance array for the iterative linear solver.\n
+        Per-world absolute tolerance array for the iterative linear solver.
         Shape is (num_worlds,).
         """
 

--- a/newton/_src/solvers/kamino/_src/solvers/warmstart.py
+++ b/newton/_src/solvers/kamino/_src/solvers/warmstart.py
@@ -25,10 +25,10 @@ from enum import IntEnum
 
 import warp as wp
 
+from .....core.types import override
 from ..core.data import DataKamino
 from ..core.math import contact_wrench_matrix_from_points
 from ..core.model import ModelKamino
-from ..core.types import float32, int32, override, quatf, transformf, uint64, vec2f, vec2i, vec3f, vec6f
 from ..geometry.contacts import ContactsKamino, ContactsKaminoData
 from ..geometry.keying import KeySorter, binary_search_find_range_start, make_bitmask
 from ..kinematics.limits import LimitsKamino, LimitsKaminoData
@@ -60,17 +60,17 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _warmstart_limits_by_matched_jid_dof_key(
     # Inputs - Previous:
-    sorted_limit_keys_old: wp.array[uint64],
-    sorted_to_unsorted_map_old: wp.array[int32],
-    num_active_limits_old: wp.array[int32],
-    limit_velocity_old: wp.array[float32],
-    limit_reaction_old: wp.array[float32],
+    sorted_limit_keys_old: wp.array[wp.uint64],
+    sorted_to_unsorted_map_old: wp.array[wp.int32],
+    num_active_limits_old: wp.array[wp.int32],
+    limit_velocity_old: wp.array[wp.float32],
+    limit_reaction_old: wp.array[wp.float32],
     # Inputs - Next:
-    num_active_limits_new: wp.array[int32],
-    limit_key_new: wp.array[uint64],
+    num_active_limits_new: wp.array[wp.int32],
+    limit_key_new: wp.array[wp.uint64],
     # Outputs:
-    limit_reaction_new: wp.array[float32],
-    limit_velocity_new: wp.array[float32],
+    limit_reaction_new: wp.array[wp.float32],
+    limit_velocity_new: wp.array[wp.float32],
 ):
     """
     Match current limits to previous timestep limits using joint-DoF index pair keys.
@@ -113,28 +113,28 @@ def _warmstart_limits_by_matched_jid_dof_key(
 @wp.kernel
 def _warmstart_contacts_by_matched_geom_pair_key_and_position(
     # Inputs - Common:
-    tolerance: float32,
-    time_dt: wp.array[float32],
-    body_q_i: wp.array[transformf],
-    body_u_i: wp.array[vec6f],
+    tolerance: wp.float32,
+    time_dt: wp.array[wp.float32],
+    body_q_i: wp.array[wp.transformf],
+    body_u_i: wp.array[wp.spatial_vectorf],
     # Inputs - Previous:
-    sorted_contact_keys_old: wp.array[uint64],
-    sorted_to_unsorted_map_old: wp.array[int32],
-    num_active_contacts_old: wp.array[int32],
-    contact_position_B_old: wp.array[vec3f],
-    contact_frame_old: wp.array[quatf],
-    contact_reaction_old: wp.array[vec3f],
-    contact_velocity_old: wp.array[vec3f],
+    sorted_contact_keys_old: wp.array[wp.uint64],
+    sorted_to_unsorted_map_old: wp.array[wp.int32],
+    num_active_contacts_old: wp.array[wp.int32],
+    contact_position_B_old: wp.array[wp.vec3f],
+    contact_frame_old: wp.array[wp.quatf],
+    contact_reaction_old: wp.array[wp.vec3f],
+    contact_velocity_old: wp.array[wp.vec3f],
     # Inputs - Next:
-    num_active_contacts_new: wp.array[int32],
-    contact_key_new: wp.array[uint64],
-    contact_wid_new: wp.array[int32],
-    contact_bid_AB_new: wp.array[vec2i],
-    contact_position_B_new: wp.array[vec3f],
-    contact_frame_new: wp.array[quatf],
+    num_active_contacts_new: wp.array[wp.int32],
+    contact_key_new: wp.array[wp.uint64],
+    contact_wid_new: wp.array[wp.int32],
+    contact_bid_AB_new: wp.array[wp.vec2i],
+    contact_position_B_new: wp.array[wp.vec3f],
+    contact_frame_new: wp.array[wp.quatf],
     # Outputs:
-    contact_reaction_new: wp.array[vec3f],
-    contact_velocity_new: wp.array[vec3f],
+    contact_reaction_new: wp.array[wp.vec3f],
+    contact_velocity_new: wp.array[wp.vec3f],
 ):
     """
     Match current contacts to previous timestep contacts using geom-pair keys and relative distance.
@@ -156,8 +156,8 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position(
 
     # Initialize the target reaction and velocity to zero
     # to account for the case where no matching contact is found
-    target_reaction = vec3f(0.0)
-    target_velocity = vec3f(0.0)
+    target_reaction = wp.vec3f(0.0)
+    target_velocity = wp.vec3f(0.0)
 
     # Perform binary search to find the start index of the target key - i.e. assuming a geom-pair key
     start = binary_search_find_range_start(0, num_active_old, target_key, sorted_contact_keys_old)
@@ -187,7 +187,7 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position(
     # Iterate through all old contacts with the same key and check if contacts match
     # based on distance of contact points after accounting for associated body motion
     # NOTE: For the comparison, new_idx -> cid, old_idx -> sorted_to_unsorted_map_old[start + k]
-    k = int32(0)
+    k = wp.int32(0)
     old_key = sorted_contact_keys_old[start]
     while target_key == old_key:
         # Retrieve the old contact index from the sorted->unsorted map
@@ -223,26 +223,26 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position(
 @wp.kernel
 def _warmstart_contacts_from_geom_pair_net_force(
     # Inputs - Common:
-    scaling: float32,
-    body_q_i: wp.array[transformf],
-    body_u_i: wp.array[vec6f],
+    scaling: wp.float32,
+    body_q_i: wp.array[wp.transformf],
+    body_u_i: wp.array[wp.spatial_vectorf],
     # Inputs - Previous:
-    sorted_contact_keys_old: wp.array[uint64],
-    sorted_to_unsorted_map_old: wp.array[int32],
-    num_active_contacts_old: wp.array[int32],
-    contact_frame_old: wp.array[quatf],
-    contact_reaction_old: wp.array[vec3f],
+    sorted_contact_keys_old: wp.array[wp.uint64],
+    sorted_to_unsorted_map_old: wp.array[wp.int32],
+    num_active_contacts_old: wp.array[wp.int32],
+    contact_frame_old: wp.array[wp.quatf],
+    contact_reaction_old: wp.array[wp.vec3f],
     # Inputs - Next:
-    num_active_contacts_new: wp.array[int32],
-    contact_key_new: wp.array[uint64],
-    contact_bid_AB_new: wp.array[vec2i],
-    contact_position_A_new: wp.array[vec3f],
-    contact_position_B_new: wp.array[vec3f],
-    contact_frame_new: wp.array[quatf],
-    contact_material_new: wp.array[vec2f],
+    num_active_contacts_new: wp.array[wp.int32],
+    contact_key_new: wp.array[wp.uint64],
+    contact_bid_AB_new: wp.array[wp.vec2i],
+    contact_position_A_new: wp.array[wp.vec3f],
+    contact_position_B_new: wp.array[wp.vec3f],
+    contact_frame_new: wp.array[wp.quatf],
+    contact_material_new: wp.array[wp.vec2f],
     # Outputs:
-    contact_reaction_new: wp.array[vec3f],
-    contact_velocity_new: wp.array[vec3f],
+    contact_reaction_new: wp.array[wp.vec3f],
+    contact_velocity_new: wp.array[wp.vec3f],
 ):
     """
     Match current contacts to previous timestep contacts using geom-pair keys and relative distance.
@@ -264,8 +264,8 @@ def _warmstart_contacts_from_geom_pair_net_force(
 
     # Initialize the target reaction and velocity to zero
     # to account for the case where no matching contact is found
-    target_reaction = vec3f(0.0)
-    target_velocity = vec3f(0.0)
+    target_reaction = wp.vec3f(0.0)
+    target_velocity = wp.vec3f(0.0)
 
     # Perform binary search to find the start index of the target key - i.e. assuming a geom-pair key
     start = binary_search_find_range_start(0, num_active_old, target_key, sorted_contact_keys_old)
@@ -289,7 +289,7 @@ def _warmstart_contacts_from_geom_pair_net_force(
     # Retrieve the body indices and states for the contact's associated bodies
     # NOTE: If body A is static, then its velocity contribution is zero by definition
     bid_AB = contact_bid_AB_new[cid]
-    v_Ak = vec3f(0.0)
+    v_Ak = wp.vec3f(0.0)
     if bid_AB[0] >= 0:
         u_A = body_u_i[bid_AB[0]]
         r_A = wp.transform_get_translation(body_q_i[bid_AB[0]])
@@ -311,8 +311,8 @@ def _warmstart_contacts_from_geom_pair_net_force(
 
     # Iterate through all old contacts with the same key and accumulate net body-com wrench
     # NOTE: We only need body B since it is the body on which the contact reaction acts positively
-    geom_pair_force_body_B = vec3f(0.0)
-    k = int32(0)
+    geom_pair_force_body_B = wp.vec3f(0.0)
+    k = wp.int32(0)
     old_key = sorted_contact_keys_old[start]
     while target_key == old_key:
         # Retrieve the old contact index from the sorted->unsorted map
@@ -331,13 +331,13 @@ def _warmstart_contacts_from_geom_pair_net_force(
 
     # TODO: We need to cache this value per geom-pair
     # TODO: Replace this with a new cache instead of recomputing every time --- IGNORE ---
-    num_contacts_gid_AB_new = int32(0)
+    num_contacts_gid_AB_new = wp.int32(0)
     for i in range(num_active_contacts_new[0]):
         if contact_key_new[i] == target_key:
             num_contacts_gid_AB_new += 1
 
     # Average the net body-com force over the number of contacts for this geom-pair
-    contact_force_uniform_new = (1.0 / float32(num_contacts_gid_AB_new)) * geom_pair_force_body_B
+    contact_force_uniform_new = (1.0 / wp.float32(num_contacts_gid_AB_new)) * geom_pair_force_body_B
 
     # Project to the new contact frame and local
     # friction cone to obtain the contact reaction
@@ -353,31 +353,31 @@ def _warmstart_contacts_from_geom_pair_net_force(
 @wp.kernel
 def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_backup(
     # Inputs - Common:
-    tolerance: float32,
-    scaling: float32,
-    time_dt: wp.array[float32],
-    body_q_i: wp.array[transformf],
-    body_u_i: wp.array[vec6f],
+    tolerance: wp.float32,
+    scaling: wp.float32,
+    time_dt: wp.array[wp.float32],
+    body_q_i: wp.array[wp.transformf],
+    body_u_i: wp.array[wp.spatial_vectorf],
     # Inputs - Previous:
-    sorted_contact_keys_old: wp.array[uint64],
-    sorted_to_unsorted_map_old: wp.array[int32],
-    num_active_contacts_old: wp.array[int32],
-    contact_position_B_old: wp.array[vec3f],
-    contact_frame_old: wp.array[quatf],
-    contact_reaction_old: wp.array[vec3f],
-    contact_velocity_old: wp.array[vec3f],
+    sorted_contact_keys_old: wp.array[wp.uint64],
+    sorted_to_unsorted_map_old: wp.array[wp.int32],
+    num_active_contacts_old: wp.array[wp.int32],
+    contact_position_B_old: wp.array[wp.vec3f],
+    contact_frame_old: wp.array[wp.quatf],
+    contact_reaction_old: wp.array[wp.vec3f],
+    contact_velocity_old: wp.array[wp.vec3f],
     # Inputs - Next:
-    num_active_contacts_new: wp.array[int32],
-    contact_key_new: wp.array[uint64],
-    contact_wid_new: wp.array[int32],
-    contact_bid_AB_new: wp.array[vec2i],
-    contact_position_A_new: wp.array[vec3f],
-    contact_position_B_new: wp.array[vec3f],
-    contact_frame_new: wp.array[quatf],
-    contact_material_new: wp.array[vec2f],
+    num_active_contacts_new: wp.array[wp.int32],
+    contact_key_new: wp.array[wp.uint64],
+    contact_wid_new: wp.array[wp.int32],
+    contact_bid_AB_new: wp.array[wp.vec2i],
+    contact_position_A_new: wp.array[wp.vec3f],
+    contact_position_B_new: wp.array[wp.vec3f],
+    contact_frame_new: wp.array[wp.quatf],
+    contact_material_new: wp.array[wp.vec2f],
     # Outputs:
-    contact_reaction_new: wp.array[vec3f],
-    contact_velocity_new: wp.array[vec3f],
+    contact_reaction_new: wp.array[wp.vec3f],
+    contact_velocity_new: wp.array[wp.vec3f],
 ):
     """
     Match current contacts to previous timestep contacts using geom-pair keys and relative distance.
@@ -399,8 +399,8 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
 
     # Initialize the target reaction and velocity to zero
     # to account for the case where no matching contact is found
-    target_reaction = vec3f(0.0)
-    target_velocity = vec3f(0.0)
+    target_reaction = wp.vec3f(0.0)
+    target_velocity = wp.vec3f(0.0)
 
     # Perform binary search to find the start index of the target key - i.e. assuming a geom-pair key
     start = binary_search_find_range_start(0, num_active_old, target_key, sorted_contact_keys_old)
@@ -430,8 +430,8 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
     # Iterate through all old contacts with the same key and check if contacts match
     # based on distance of contact points after accounting for associated body motion
     # NOTE: For the comparison, new_idx -> cid, old_idx -> sorted_to_unsorted_map_old[start + k]
-    k = int32(0)
-    found_match = int32(0)
+    k = wp.int32(0)
+    found_match = wp.int32(0)
     old_key = sorted_contact_keys_old[start]
     while target_key == old_key:
         # Retrieve the old contact index from the sorted->unsorted map
@@ -452,7 +452,7 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
             R_k_old_to_new = wp.transpose(R_k_target) @ R_k_old
             target_reaction = R_k_old_to_new @ lambda_k_old
             target_velocity = R_k_old_to_new @ v_k_old
-            found_match = int32(1)
+            found_match = wp.int32(1)
             break
 
         # Update the current old-key to check in the next iteration
@@ -467,7 +467,7 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
 
         # Retrieve the body indices and states for the contact's associated bodies
         # NOTE: If body A is static, then its velocity contribution is zero by definition
-        v_Ak = vec3f(0.0)
+        v_Ak = wp.vec3f(0.0)
         if bid_AB[0] >= 0:
             u_A = body_u_i[bid_AB[0]]
             r_A = wp.transform_get_translation(body_q_i[bid_AB[0]])
@@ -490,8 +490,8 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
 
         # Iterate through all old contacts with the same key and accumulate net body-com wrench
         # NOTE: We only need body B since it is the body on which the contact reaction acts positively
-        geom_pair_force_body_B = vec3f(0.0)
-        k = int32(0)
+        geom_pair_force_body_B = wp.vec3f(0.0)
+        k = wp.int32(0)
         old_key = sorted_contact_keys_old[start]
         while target_key == old_key:
             # Retrieve the old contact index from the sorted->unsorted map
@@ -510,13 +510,13 @@ def _warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_bac
 
         # TODO: We need to cache this value per geom-pair
         # TODO: Replace this with a new cache instead of recomputing every time --- IGNORE ---
-        num_contacts_gid_AB_new = int32(0)
+        num_contacts_gid_AB_new = wp.int32(0)
         for i in range(num_active_contacts_new[0]):
             if contact_key_new[i] == target_key:
                 num_contacts_gid_AB_new += 1
 
         # Average the net body-com force over the number of contacts for this geom-pair
-        contact_force_uniform_new = (1.0 / float32(num_contacts_gid_AB_new)) * geom_pair_force_body_B
+        contact_force_uniform_new = (1.0 / wp.float32(num_contacts_gid_AB_new)) * geom_pair_force_body_B
 
         # Project to the new contact frame and local
         # friction cone to obtain the contact reaction
@@ -543,9 +543,9 @@ def warmstart_limits_by_matched_jid_dof_key(
     Warm-starts limits by matching joint-DoF index-pair keys.
 
     Args:
-        sorter (KeySorter): The key sorter used to sort cached limit keys.
-        cache (LimitsKaminoData): The cached limits data from the previous simulation step.
-        limits (LimitsKaminoData): The current limits data to be warm-started.
+        sorter: The key sorter used to sort cached limit keys.
+        cache: The cached limits data from the previous simulation step.
+        limits: The current limits data to be warm-started.
     """
     # First sort the keys of cached limits to facilitate binary search
     sorter.sort(num_active_keys=cache.model_active_limits, keys=cache.key)
@@ -578,21 +578,21 @@ def warmstart_contacts_by_matched_geom_pair_key_and_position(
     sorter: KeySorter,
     cache: ContactsKaminoData,
     contacts: ContactsKaminoData,
-    tolerance: float32 | None = None,
+    tolerance: wp.float32 | None = None,
 ):
     """
     Warm-starts contacts by matching geom-pair keys and contact point positions.
 
     Args:
-        model (ModelKamino): The model containing simulation parameters.
-        data (DataKamino): The model data containing body states.
-        sorter (KeySorter): The key sorter used to sort cached contact keys.
-        cache (ContactsKaminoData): The cached contacts data from the previous simulation step.
-        contacts (ContactsKaminoData): The current contacts data to be warm-started.
+        model: The model containing simulation parameters.
+        data: The model data containing body states.
+        sorter: The key sorter used to sort cached contact keys.
+        cache: The cached contacts data from the previous simulation step.
+        contacts: The current contacts data to be warm-started.
     """
     # Define tolerance for matching contact points based on distance after accounting for body motion
     if tolerance is None:
-        tolerance = float32(1e-5)
+        tolerance = wp.float32(1e-5)
 
     # First sort the keys of cached contacts to facilitate binary search
     sorter.sort(num_active_keys=cache.model_active_contacts, keys=cache.key)
@@ -635,21 +635,21 @@ def warmstart_contacts_from_geom_pair_net_force(
     sorter: KeySorter,
     cache: ContactsKaminoData,
     contacts: ContactsKaminoData,
-    scaling: float32 | None = None,
+    scaling: wp.float32 | None = None,
 ):
     """
     Warm-starts contacts by matching geom-pair keys and contact point positions.
 
     Args:
-        model (ModelKamino): The model containing simulation parameters.
-        data (DataKamino): The model data containing body states.
-        sorter (KeySorter): The key sorter used to sort cached contact keys.
-        cache (ContactsKaminoData): The cached contacts data from the previous simulation step.
-        contacts (ContactsKaminoData): The current contacts data to be warm-started.
+        model: The model containing simulation parameters.
+        data: The model data containing body states.
+        sorter: The key sorter used to sort cached contact keys.
+        cache: The cached contacts data from the previous simulation step.
+        contacts: The current contacts data to be warm-started.
     """
     # Define scaling for warm-started reactions and velocities
     if scaling is None:
-        scaling = float32(1.0)
+        scaling = wp.float32(1.0)
 
     # First sort the keys of cached contacts to facilitate binary search
     sorter.sort(num_active_keys=cache.model_active_contacts, keys=cache.key)
@@ -691,25 +691,25 @@ def warmstart_contacts_by_matched_geom_pair_key_and_position_with_net_force_back
     sorter: KeySorter,
     cache: ContactsKaminoData,
     contacts: ContactsKaminoData,
-    tolerance: float32 | None = None,
-    scaling: float32 | None = None,
+    tolerance: wp.float32 | None = None,
+    scaling: wp.float32 | None = None,
 ):
     """
     Warm-starts contacts by matching geom-pair keys and contact point positions.
 
     Args:
-        model (ModelKamino): The model containing simulation parameters.
-        data (DataKamino): The model data containing body states.
-        sorter (KeySorter): The key sorter used to sort cached contact keys.
-        cache (ContactsKaminoData): The cached contacts data from the previous simulation step.
-        contacts (ContactsKaminoData): The current contacts data to be warm-started.
+        model: The model containing simulation parameters.
+        data: The model data containing body states.
+        sorter: The key sorter used to sort cached contact keys.
+        cache: The cached contacts data from the previous simulation step.
+        contacts: The current contacts data to be warm-started.
     """
     # Define tolerance for matching contact points based on distance after accounting for body motion
     if tolerance is None:
-        tolerance = float32(1e-5)
+        tolerance = wp.float32(1e-5)
     # Define scaling for warm-started reactions and velocities
     if scaling is None:
-        scaling = float32(1.0)
+        scaling = wp.float32(1.0)
 
     # First sort the keys of cached contacts to facilitate binary search
     sorter.sort(num_active_keys=cache.model_active_contacts, keys=cache.key)
@@ -765,7 +765,7 @@ class WarmstarterLimits:
         Initializes the limits warmstarter using the allocations of the provided limits container.
 
         Args:
-            limits (LimitsKamino): The limits container whose allocations are used to initialize the warmstarter.
+            limits: The limits container whose allocations are used to initialize the warmstarter.
         """
         # Store the device of the provided contacts container
         self._device: wp.DeviceLike = limits.device if limits is not None else None
@@ -812,9 +812,9 @@ class WarmstarterLimits:
         The current implementation matches contacts based on geom-pair keys and contact point positions.
 
         Args:
-            model (ModelKamino): The model containing simulation parameters.
-            data (DataKamino): The model data containing body states.
-            limits (LimitsKamino): The limits container to warm-start.
+            model: The model containing simulation parameters.
+            data: The model data containing body states.
+            limits: The limits container to warm-start.
         """
         # Early exit if no cache is allocated
         if self._cache is None:
@@ -832,7 +832,7 @@ class WarmstarterLimits:
         Updates the warmstarter's internal cache with the provided limits data.
 
         Args:
-            limits (LimitsKamino): The limits container from which to update the cache.
+            limits: The limits container from which to update the cache.
         """
         # Early exit if no cache is allocated or no limits data is provided
         if self._cache is None or limits is None:
@@ -935,19 +935,19 @@ class WarmstarterContacts:
         Initializes the contacts warmstarter using the allocations of the provided contacts container.
 
         Args:
-            contacts (ContactsKamino): The contacts container whose allocations are used to initialize the warmstarter.
-            method (WarmstarterContacts.Method): The warm-starting method to use.
-            tolerance (float): The tolerance used for matching contact point positions.\n
+            contacts: The contacts container whose allocations are used to initialize the warmstarter.
+            method: The warm-starting method to use.
+            tolerance: The tolerance used for matching contact point positions.\n
                 Must be a floating-point value specified in meters, and within the range `[0, +inf)`.\n
                 Setting this to `0.0` requires exact position matches, effectively disabling position-based matching.
-            scaling (float): The scaling factor applied to warm-started reactions and velocities.\n
+            scaling: The scaling factor applied to warm-started reactions and velocities.\n
                 Must be a floating-point value specified in the range `[0, 1.0)`.\n
                 Setting this to `0.0` effectively disables warm-starting.
         """
         # Store the specified warm-starting configurations
         self._method: WarmstarterContacts.Method = method
-        self._tolerance: float32 = float32(tolerance)
-        self._scaling: float32 = float32(scaling)
+        self._tolerance: wp.float32 = wp.float32(tolerance)
+        self._scaling: wp.float32 = wp.float32(scaling)
 
         # Set the device to use as that of the provided contacts container
         self._device: wp.DeviceLike = contacts.device if contacts is not None else None
@@ -965,7 +965,7 @@ class WarmstarterContacts:
                 model_max_contacts_host=contacts.model_max_contacts_host,
                 world_max_contacts_host=contacts.world_max_contacts_host,
                 model_active_contacts=wp.zeros_like(contacts.model_active_contacts),
-                bid_AB=wp.full_like(contacts.bid_AB, value=vec2i(-1, -1)),
+                bid_AB=wp.full_like(contacts.bid_AB, value=wp.vec2i(-1, -1)),
                 position_A=wp.zeros_like(contacts.position_A),
                 position_B=wp.zeros_like(contacts.position_B),
                 frame=wp.zeros_like(contacts.frame),
@@ -998,9 +998,9 @@ class WarmstarterContacts:
         The current implementation matches contacts based on geom-pair keys and contact point positions.
 
         Args:
-            model (ModelKamino): The model containing simulation parameters.
-            data (DataKamino): The model data containing body states.
-            contacts (ContactsKamino): The contacts container to warm-start.
+            model: The model containing simulation parameters.
+            data: The model data containing body states.
+            contacts: The contacts container to warm-start.
         """
         # Early exit if no cache is allocated
         if self._cache is None:
@@ -1062,7 +1062,7 @@ class WarmstarterContacts:
         Updates the warmstarter's internal cache with the provided contacts data.
 
         Args:
-            contacts (ContactsKamino): The contacts container from which to update the cache.
+            contacts: The contacts container from which to update the cache.
         """
         # Early exit if no cache is allocated or no contacts data is provided
         if self._cache is None or contacts is None:
@@ -1085,7 +1085,7 @@ class WarmstarterContacts:
         if self._cache is None or self._cache.model_active_contacts is None:
             return
         self._cache.model_active_contacts.zero_()
-        self._cache.bid_AB.fill_(vec2i(-1, -1))
+        self._cache.bid_AB.fill_(wp.vec2i(-1, -1))
         self._cache.position_A.zero_()
         self._cache.position_B.zero_()
         self._cache.frame.zero_()

--- a/newton/_src/solvers/kamino/_src/solvers/warmstart.py
+++ b/newton/_src/solvers/kamino/_src/solvers/warmstart.py
@@ -937,11 +937,11 @@ class WarmstarterContacts:
         Args:
             contacts: The contacts container whose allocations are used to initialize the warmstarter.
             method: The warm-starting method to use.
-            tolerance: The tolerance used for matching contact point positions.\n
-                Must be a floating-point value specified in meters, and within the range `[0, +inf)`.\n
+            tolerance: The tolerance used for matching contact point positions.
+                Must be a floating-point value specified in meters, and within the range `[0, +inf)`.
                 Setting this to `0.0` requires exact position matches, effectively disabling position-based matching.
-            scaling: The scaling factor applied to warm-started reactions and velocities.\n
-                Must be a floating-point value specified in the range `[0, 1.0)`.\n
+            scaling: The scaling factor applied to warm-started reactions and velocities.
+                Must be a floating-point value specified in the range `[0, 1.0)`.
                 Setting this to `0.0` effectively disables warm-starting.
         """
         # Store the specified warm-starting configurations

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/__main__.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/__main__.py
@@ -37,18 +37,18 @@ Each mode includes the metrics of the previous modes, with increasing levels of 
 The supported modes are as follows:
 
 - "total":
-    Only collects total runtime and final memory usage of each solver configuration and problem.\n
+    Only collects total runtime and final memory usage of each solver configuration and problem.
     This mode is intended to be used for a high-level comparison of the overall throughput of
     different solver configurations across problems, without detailed step-by-step metrics.
 
 - "stepstats":
-    Collects detailed timings of each simulation step to compute throughput statistics.\n
+    Collects detailed timings of each simulation step to compute throughput statistics.
     This mode lightly impacts overall throughput as it requires synchronizing the device at
     each  step to measure accurate timings. It is intended to be used for analyzing the step
     time distribution and variability across different solver configurations.
 
 - "convergence":
-    Collects solver performance metrics such as PADMM iterations and residuals.\n
+    Collects solver performance metrics such as PADMM iterations and residuals.
     This mode moderately impacts overall throughput as it requires additional computation to
     collect and store solver metrics at each step. It is intended to be used for analyzing
     solver convergence behavior and its relationship to step time.
@@ -60,7 +60,7 @@ The supported modes are as follows:
     analysis and to evaluate the trade-off between fast convergence and physical correctness.
 
 - "import":
-    Generates plots for the collected metrics given an HDF5 file containing benchmark results.\n
+    Generates plots for the collected metrics given an HDF5 file containing benchmark results.
     NOTE: This mode does not execute any benchmarks and only produces plots from existing data.
 """
 

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/metrics.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/metrics.py
@@ -1061,7 +1061,7 @@ class BenchmarkMetrics:
         optionally saves the plots to a file at the specified path.
 
         Args:
-            path: Target file path of the generated plot image.\n
+            path: Target file path of the generated plot image.
 
         Raises:
             ValueError: If the PADMM solver metrics are not available.
@@ -1154,7 +1154,7 @@ class BenchmarkMetrics:
         saves the plots to a file at the specified path.
 
         Args:
-            path: Target file path of the generated plot image.\n
+            path: Target file path of the generated plot image.
 
         Raises:
             ValueError: If the physics metrics are not available.

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/metrics.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/metrics.py
@@ -44,8 +44,7 @@ class CodeInfo:
         Initialize a CodeInfo object.
 
         Args:
-            path (str | None):
-                The path to the git repository. If None, the current working directory is used.
+            path: The path to the git repository. If None, the current working directory is used.
 
         Raises:
             RuntimeError: If there is an error retrieving git repository info from the specified path.
@@ -129,8 +128,8 @@ class StatsFloat:
         Initialize a StatsFloat object.
 
         Args:
-            data (np.ndarray): A floating-point data array.
-            name (str | None): An optional name for the statistics object.
+            data: A floating-point data array.
+            name: An optional name for the statistics object.
 
         Raises:
             ValueError: If the data array is not of a floating-point type.
@@ -174,9 +173,9 @@ class StatsInteger:
         Initialize a StatsInteger object.
 
         Args:
-            data (np.ndarray): An integer data array.
-            num_bins (int): Number of bins for histogram (default: 20).
-            name (str | None): An optional name for the statistics object.
+            data: An integer data array.
+            num_bins: Number of bins for histogram (default: 20).
+            name: An optional name for the statistics object.
 
         Raises:
             ValueError: If the data array is not of an integer type.
@@ -220,8 +219,8 @@ class StatsBinary:
         Initialize a StatsBinary object.
 
         Args:
-            data (np.ndarray): A binary (boolean) data array.
-            name (str | None): An optional name for the statistics object.
+            data: A binary (boolean) data array.
+            name: An optional name for the statistics object.
 
         Raises:
             ValueError: If the data array is not of a binary (boolean) type.
@@ -633,8 +632,7 @@ class BenchmarkMetrics:
         table to a text file at the specified path.
 
         Args:
-            path (`str`):
-                File path to save the table as a text file.
+            path: File path to save the table as a text file.
 
         Raises:
             ValueError: If the total metrics (memory used, total time, total FPS) are not available.
@@ -662,8 +660,7 @@ class BenchmarkMetrics:
         the table to a text file at the specified path.
 
         Args:
-            path (`str`):
-                File path to save the table as a text file.
+            path: File path to save the table as a text file.
 
         Raises:
             ValueError: If the step time metrics are not available.
@@ -724,8 +721,7 @@ class BenchmarkMetrics:
         file at the specified path.
 
         Args:
-            path (`str`):
-                File path to save the table as a text file.
+            path: File path to save the table as a text file.
 
         Raises:
             ValueError: If the PADMM solver metrics are not available.
@@ -842,8 +838,7 @@ class BenchmarkMetrics:
         saves the table to a text file at the specified path.
 
         Args:
-            path (`str`):
-                File path to save the table as a text file.
+            path: File path to save the table as a text file.
 
         Raises:
             ValueError: If the physics metrics are not available.
@@ -1066,8 +1061,7 @@ class BenchmarkMetrics:
         optionally saves the plots to a file at the specified path.
 
         Args:
-            path (`str`):
-                Target file path of the generated plot image.\n
+            path: Target file path of the generated plot image.\n
 
         Raises:
             ValueError: If the PADMM solver metrics are not available.
@@ -1160,8 +1154,7 @@ class BenchmarkMetrics:
         saves the plots to a file at the specified path.
 
         Args:
-            path (`str`):
-                Target file path of the generated plot image.\n
+            path: Target file path of the generated plot image.\n
 
         Raises:
             ValueError: If the physics metrics are not available.

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/render.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/render.py
@@ -328,26 +328,20 @@ def render_solver_configs_table(
     Renders a rich table summarizing the solver configurations.
 
     Args:
-        configs (dict[str, SolverKaminoImpl.Config]):
-            A dictionary mapping configuration names to SolverKaminoImpl.Config objects.
-        path (str, optional):
-            The file path to save the rendered table as a text file. If None, the table is not saved to a file.
-        groups (list[str], optional):
-            A list of groups to include in the table. If None, "sparse", "linear" and "padmm" are used.\n
+        configs: A dictionary mapping configuration names to SolverKaminoImpl.Config objects.
+        path: The file path to save the rendered table as a text file. If None, the table is not saved to a file.
+        groups: A list of groups to include in the table. If None, "sparse", "linear" and "padmm" are used.\n
             Supported groups include:
             - "cts": Constraint parameters (alpha, beta, gamma, delta, preconditioning)
             - "sparse": Sparse representation settings (sparse, sparse_jacobian)
             - "linear": Linear solver settings (type, kwargs)
             - "padmm": PADMM settings (max_iterations, primal_tol, dual_tol, etc)
             - "warmstart": Warmstarting settings (mode, contact_method)
-        to_console (bool, optional):
-            If True, also prints the table to the console.
+        to_console: If True, also prints the table to the console.
 
     Raises:
-        ValueError:
-            If the configs dictionary is empty or if any of the configuration objects are missing required attributes.
-        IOError:
-            If there is an error writing the table to the specified file path.
+        ValueError: If the configs dictionary is empty or if any of the configuration objects are missing required attributes.
+        IOError: If there is an error writing the table to the specified file path.
     """
     # Attempt to import rich first, and warn user
     # if the necessary package is not installed
@@ -464,18 +458,13 @@ def render_problem_dimensions_table(
     Renders a rich table summarizing the problem dimensions.
 
     Args:
-        configs (dict[str, SolverKaminoImpl.Config]):
-            A dictionary mapping configuration names to problem dimensions.
-        path (str, optional):
-            The file path to save the rendered table as a text file. If None, the table is not saved to a file.
-        to_console (bool, optional):
-            If True, also prints the table to the console.
+        problem_dims: A dictionary mapping configuration names to problem dimensions.
+        path: The file path to save the rendered table as a text file. If None, the table is not saved to a file.
+        to_console: If True, also prints the table to the console.
 
     Raises:
-        ValueError:
-            If the configs dictionary is empty or if any of the configuration objects are missing required attributes.
-        IOError:
-            If there is an error writing the table to the specified file path.
+        ValueError: If the configs dictionary is empty or if any of the configuration objects are missing required attributes.
+        IOError: If there is an error writing the table to the specified file path.
     """
     # Attempt to import rich first, and warn user
     # if the necessary package is not installed

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/render.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/render.py
@@ -330,7 +330,7 @@ def render_solver_configs_table(
     Args:
         configs: A dictionary mapping configuration names to SolverKaminoImpl.Config objects.
         path: The file path to save the rendered table as a text file. If None, the table is not saved to a file.
-        groups: A list of groups to include in the table. If None, "sparse", "linear" and "padmm" are used.\n
+        groups: A list of groups to include in the table. If None, "sparse", "linear" and "padmm" are used.
             Supported groups include:
             - "cts": Constraint parameters (alpha, beta, gamma, delta, preconditioning)
             - "sparse": Sparse representation settings (sparse, sparse_jacobian)

--- a/newton/_src/solvers/kamino/_src/utils/control/animation.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/animation.py
@@ -14,8 +14,6 @@ from ...core.model import ModelKamino
 from ...core.time import TimeData
 from ...core.types import (
     assign_to_warp_int32_array,
-    float32,
-    int32,
     to_warp_int32_array,
 )
 
@@ -66,80 +64,71 @@ class AnimationJointReferenceData:
     reaching the end, or stop at the last frame.
 
     Attributes:
-        num_actuated_joint_dofs: wp.array
-            The number of actuated joint DoFs per world.
-        actuated_joint_dofs_offset: wp.array
-            The offset indices for the actuated joint DoFs per world.
-        q_j_ref: wp.array
-            The reference actuator joint positions.
-        dq_j_ref: wp.array
-            The reference actuator joint velocities.
-        loop: wp.array
-            Flag indicating whether the animation should loop.
-        rate: wp.array
-            The rate at which to progress the animation sequence.
-        decimation: wp.array
-            The decimation factor for extracting references from the animation sequence.
-        length: wp.array
-            The length of the animation sequence.
-        frame: wp.array
-            The current frame index in the animation sequence that is active.
+        num_actuated_joint_dofs: The number of actuated joint DoFs per world.
+        actuated_joint_dofs_offset: The offset indices for the actuated joint DoFs per world.
+        q_j_ref: The reference actuator joint positions.
+        dq_j_ref: The reference actuator joint velocities.
+        loop: Flag indicating whether the animation should loop.
+        rate: The rate at which to progress the animation sequence.
+        decimation: The decimation factor for extracting references from the animation sequence.
+        length: The length of the animation sequence.
+        frame: The current frame index in the animation sequence that is active.
     """
 
-    num_actuated_joint_dofs: wp.array | None = None
+    num_actuated_joint_dofs: wp.array[wp.int32] | None = None
     """
     Number of actuated joint DoFs per world.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    actuated_joint_dofs_offset: wp.array | None = None
+    actuated_joint_dofs_offset: wp.array[wp.int32] | None = None
     """
     Offset indices for the actuated joint DoFs per world.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    q_j_ref: wp.array | None = None
+    q_j_ref: wp.array2d[wp.float32] | None = None
     """
     Sequence of reference joint actuator positions.\n
-    Shape is ``(max_of_num_actuated_joint_coords, sequence_length)`` and dtype is :class:`float32`.
+    Shape of ``(max_of_num_actuated_joint_coords, sequence_length)``.
     """
 
-    dq_j_ref: wp.array | None = None
+    dq_j_ref: wp.array2d[wp.float32] | None = None
     """
     Sequence of reference joint actuator velocities.\n
-    Shape is ``(max_of_num_actuated_joint_dofs, sequence_length)`` and dtype is :class:`float32`.
+    Shape of ``(max_of_num_actuated_joint_dofs, sequence_length)``.
     """
 
-    length: wp.array | None = None
+    length: wp.array[wp.int32] | None = None
     """
     Integer length of the animation sequence.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    decimation: wp.array | None = None
+    decimation: wp.array[wp.int32] | None = None
     """
     Integer decimation factor by which references are extracted from the animation sequence.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    rate: wp.array | None = None
+    rate: wp.array[wp.int32] | None = None
     """
     Integer rate by which to progress the active frame of the animation sequence at each step.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
-    loop: wp.array | None = None
+    loop: wp.array[wp.int32] | None = None
     """
     Integer flag to indicate if the animation should loop.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.\n
+    Shape of ``(num_worlds,)``.\n
     If `1`, the animation will restart from the beginning after reaching the end.\n
     If `0`, the animation will stop at the last frame.
     """
 
-    frame: wp.array | None = None
+    frame: wp.array[wp.int32] | None = None
     """
     Integer index indicating the active frame of the animation sequence.\n
-    Shape is ``(num_worlds,)`` and dtype is :class:`int32`.
+    Shape of ``(num_worlds,)``.
     """
 
 
@@ -151,13 +140,13 @@ class AnimationJointReferenceData:
 @wp.kernel
 def _advance_animation_frame(
     # Inputs
-    time_steps: wp.array[int32],
-    animation_length: wp.array[int32],
-    animation_decimation: wp.array[int32],
-    animation_rate: wp.array[int32],
-    animation_loop: wp.array[int32],
+    time_steps: wp.array[wp.int32],
+    animation_length: wp.array[wp.int32],
+    animation_decimation: wp.array[wp.int32],
+    animation_rate: wp.array[wp.int32],
+    animation_loop: wp.array[wp.int32],
     # Outputs
-    animation_frame: wp.array[int32],
+    animation_frame: wp.array[wp.int32],
 ):
     """
     A kernel to advance the animation frame index for each world
@@ -201,14 +190,14 @@ def _advance_animation_frame(
 @wp.kernel
 def _extract_animation_references(
     # Inputs
-    num_actuated_joint_dofs: wp.array[int32],
-    actuated_joint_dofs_offset: wp.array[int32],
-    animation_frame: wp.array[int32],
-    animation_q_j_ref: wp.array2d[float32],
-    animation_dq_j_ref: wp.array2d[float32],
+    num_actuated_joint_dofs: wp.array[wp.int32],
+    actuated_joint_dofs_offset: wp.array[wp.int32],
+    animation_frame: wp.array[wp.int32],
+    animation_q_j_ref: wp.array2d[wp.float32],
+    animation_dq_j_ref: wp.array2d[wp.float32],
     # Outputs
-    q_j_ref_active: wp.array[float32],
-    dq_j_ref_active: wp.array[float32],
+    q_j_ref_active: wp.array[wp.float32],
+    dq_j_ref_active: wp.array[wp.float32],
 ):
     """
     A kernel to extract the active joint-space references from the animation data.
@@ -260,20 +249,20 @@ class AnimationJointReference:
         Initialize the animation joint reference interface.
 
         Args:
-            model (ModelKamino | None): The model container used to determine the required allocation sizes.
+            model: The model container used to determine the required allocation sizes.
                 If None, calling ``finalize()`` later can be used for deferred allocation.
-            data (np.ndarray | None): The input animation reference data as a 2D numpy array.
+            data: The input animation reference data as a 2D numpy array.
                 If None, calling ``finalize()`` later can be used for deferred allocation.
-            data_dt (float | None): The time-step between frames in the input data.
-            target_dt (float | None): The desired time-step between frames in the animation reference.
+            data_dt: The time-step between frames in the input data.
+            target_dt: The desired time-step between frames in the animation reference.
                 If None, defaults to ``data_dt``.
-            decimation (int | list[int]): Decimation factor(s) defining the rate at which the animation
+            decimation: Decimation factor(s) defining the rate at which the animation
                 frame index is updated w.r.t the simulation step. If a list of integers, then frame
                 progression can proceed independently in each world. Defaults to 1 for all worlds.
-            rate (int | list[int]): Rate(s) by which to progress the animation frame index each time
+            rate: Rate(s) by which to progress the animation frame index each time
                 the simulation step matches the set decimation. Defaults to 1 for all worlds.
-            loop (bool | list[bool]): Flag(s) indicating whether the animation should loop.
-            use_fd (bool): Whether to compute finite-difference velocities from the input coordinates.
+            loop: Flag(s) indicating whether the animation should loop.
+            use_fd: Whether to compute finite-difference velocities from the input coordinates.
         """
 
         # Declare the device cache
@@ -343,16 +332,16 @@ class AnimationJointReference:
         Upsample the given reference joint coordinates from the input time-step to the output time-step.
 
         Args:
-            q_ref (np.ndarray): Reference joint positions of shape (sequence_length, num_actuated_dofs).
-            dt_in (float): Input time step between frames.
-            dt_out (float): Output time step between frames.
-            t0 (float): Initial time corresponding to the first frame.
-            t_start (float | None): Start time for the up-sampled reference. If None, uses t0.
-            t_end (float | None): End time for the up-sampled reference. If None, uses the last input frame time.
-            extrapolate (bool): Whether to allow extrapolation beyond the input time range.
+            q_ref: Reference joint positions of shape (sequence_length, num_actuated_dofs).
+            dt_in: Input time step between frames.
+            dt_out: Output time step between frames.
+            t0: Initial time corresponding to the first frame.
+            t_start: Start time for the up-sampled reference. If None, uses t0.
+            t_end: End time for the up-sampled reference. If None, uses the last input frame time.
+            extrapolate: Whether to allow extrapolation beyond the input time range.
 
         Returns:
-            np.ndarray: Up-sampled reference joint positions of shape (new_sequence_length, num_actuated_dofs).
+            Up-sampled reference joint positions of shape (new_sequence_length, num_actuated_dofs).
         """
         # Attempt to import the required interpolation function from scipy,
         # and raise an informative error if scipy is not installed
@@ -395,11 +384,11 @@ class AnimationJointReference:
         Compute finite-difference velocities for the given reference positions.
 
         Args:
-            q_ref (np.ndarray): Reference joint positions of shape (sequence_length, num_actuated_dofs).
-            dt (float): Time step between frames.
+            q_ref: Reference joint positions of shape (sequence_length, num_actuated_dofs).
+            dt: Time step between frames.
 
         Returns:
-            np.ndarray: Reference joint velocities of shape (sequence_length, num_actuated_dofs).
+            Reference joint velocities of shape (sequence_length, num_actuated_dofs).
         """
         # TODO: Try this instead (it might be more robust):
         # _compute_finite_difference_velocities = staticmethod(lambda q_ref_np, dt: np.gradient(q_ref_np, dt, axis=0))
@@ -446,18 +435,18 @@ class AnimationJointReference:
         Allocate the animation joint reference data.
 
         Args:
-            model (ModelKamino): The model container used to determine the required allocation sizes.
-            data (np.ndarray): The input animation reference data as a 2D numpy array.
-            data_dt (float): The time-step between frames in the input data.
-            target_dt (float | None): The desired time-step between frames in the animation reference.
+            model: The model container used to determine the required allocation sizes.
+            data: The input animation reference data as a 2D numpy array.
+            data_dt: The time-step between frames in the input data.
+            target_dt: The desired time-step between frames in the animation reference.
                 If None, defaults to ``data_dt``.
-            decimation (int | list[int]): Decimation factor(s) defining the rate at which the animation
+            decimation: Decimation factor(s) defining the rate at which the animation
                 frame index is updated w.r.t the simulation step. If a list of integers, then frame
                 progression can proceed independently in each world. Defaults to 1 for all worlds.
-            rate (int | list[int]): Rate(s) by which to progress the animation frame index each time
+            rate: Rate(s) by which to progress the animation frame index each time
                 the simulation step matches the set decimation. Defaults to 1 for all worlds.
-            loop (bool | list[bool]): Flag(s) indicating whether the animation should loop.
-            use_fd (bool): Whether to compute finite-difference velocities from the input coordinates.
+            loop: Flag(s) indicating whether the animation should loop.
+            use_fd: Whether to compute finite-difference velocities from the input coordinates.
 
         Raises:
             ValueError: If the model is not valid or actuated DoFs are not properly configured.
@@ -564,13 +553,13 @@ class AnimationJointReference:
             self._data = AnimationJointReferenceData(
                 num_actuated_joint_dofs=model.info.num_actuated_joint_dofs,
                 actuated_joint_dofs_offset=model.info.joint_actuated_dofs_offset,
-                q_j_ref=wp.array(q_j_ref_np, dtype=float32),
-                dq_j_ref=wp.array(dq_j_ref_np, dtype=float32),
+                q_j_ref=wp.array(q_j_ref_np, dtype=wp.float32),
+                dq_j_ref=wp.array(dq_j_ref_np, dtype=wp.float32),
                 length=to_warp_int32_array(length_np),
                 decimation=to_warp_int32_array(decimation_np),
                 rate=to_warp_int32_array(rate_np),
                 loop=to_warp_int32_array(loop_np),
-                frame=wp.zeros(self._num_worlds, dtype=int32),
+                frame=wp.zeros(self._num_worlds, dtype=wp.int32),
             )
 
     def plot(self, path: str | None = None, show: bool = False) -> None:
@@ -612,7 +601,7 @@ class AnimationJointReference:
         Enable or disable looping of the animation sequence.
 
         Args:
-            enabled (bool | list[bool]): If True, enable looping. If False, disable looping.
+            enabled: If True, enable looping. If False, disable looping.
         """
         # Ensure the animation data container is allocated
         if self._data is None:
@@ -635,7 +624,7 @@ class AnimationJointReference:
         decimation and rate, in accordance with the current simulation time-step.
 
         Args:
-            time (TimeData): The time data container holding the current simulation time.
+            time: The time data container holding the current simulation time.
         """
         self._assert_has_data()
         wp.launch(
@@ -654,13 +643,13 @@ class AnimationJointReference:
             device=self._device,
         )
 
-    def extract(self, q_j_ref_out: wp.array, dq_j_ref_out: wp.array) -> None:
+    def extract(self, q_j_ref_out: wp.array[wp.float32], dq_j_ref_out: wp.array[wp.float32]) -> None:
         """
         Extract the reference arrays from the animation sequence at the current frame index.
 
         Args:
-            q_j_ref_out (wp.array): Output array for the reference joint positions.
-            dq_j_ref_out (wp.array): Output array for the reference joint velocities.
+            q_j_ref_out: Output array for the reference joint positions.
+            dq_j_ref_out: Output array for the reference joint velocities.
         """
         self._assert_has_data()
         wp.launch(
@@ -680,20 +669,20 @@ class AnimationJointReference:
             device=self._device,
         )
 
-    def reset(self, q_j_ref_out: wp.array, dq_j_ref_out: wp.array) -> None:
+    def reset(self, q_j_ref_out: wp.array[wp.float32], dq_j_ref_out: wp.array[wp.float32]) -> None:
         """
         Reset the active frame index of the animation sequence to zero
         and extracts the initial references into the output arrays.
 
         Args:
-            q_j_ref_out (wp.array): Output array for the reference joint positions.
-            dq_j_ref_out (wp.array): Output array for the reference joint velocities.
+            q_j_ref_out: Output array for the reference joint positions.
+            dq_j_ref_out: Output array for the reference joint velocities.
         """
         self._assert_has_data()
         self._data.frame.fill_(0)
         self.extract(q_j_ref_out, dq_j_ref_out)
 
-    def step(self, time: TimeData, q_j_ref_out: wp.array, dq_j_ref_out: wp.array) -> None:
+    def step(self, time: TimeData, q_j_ref_out: wp.array[wp.float32], dq_j_ref_out: wp.array[wp.float32]) -> None:
         """
         Advances the animation sequence by the configured decimation and
         rate, and extracts the reference arrays at the active frame index.
@@ -702,9 +691,9 @@ class AnimationJointReference:
         ``advance()`` and ``extract()`` into a single operation.
 
         Args:
-            time (TimeData): The time data container holding the current simulation time.
-            q_j_ref_out (wp.array): Output array for the reference joint positions.
-            dq_j_ref_out (wp.array): Output array for the reference joint velocities.
+            time: The time data container holding the current simulation time.
+            q_j_ref_out: Output array for the reference joint positions.
+            dq_j_ref_out: Output array for the reference joint velocities.
         """
         self.advance(time)
         self.extract(q_j_ref_out, dq_j_ref_out)

--- a/newton/_src/solvers/kamino/_src/utils/control/animation.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/animation.py
@@ -77,57 +77,57 @@ class AnimationJointReferenceData:
 
     num_actuated_joint_dofs: wp.array[wp.int32] | None = None
     """
-    Number of actuated joint DoFs per world.\n
+    Number of actuated joint DoFs per world.
     Shape of ``(num_worlds,)``.
     """
 
     actuated_joint_dofs_offset: wp.array[wp.int32] | None = None
     """
-    Offset indices for the actuated joint DoFs per world.\n
+    Offset indices for the actuated joint DoFs per world.
     Shape of ``(num_worlds,)``.
     """
 
     q_j_ref: wp.array2d[wp.float32] | None = None
     """
-    Sequence of reference joint actuator positions.\n
+    Sequence of reference joint actuator positions.
     Shape of ``(max_of_num_actuated_joint_coords, sequence_length)``.
     """
 
     dq_j_ref: wp.array2d[wp.float32] | None = None
     """
-    Sequence of reference joint actuator velocities.\n
+    Sequence of reference joint actuator velocities.
     Shape of ``(max_of_num_actuated_joint_dofs, sequence_length)``.
     """
 
     length: wp.array[wp.int32] | None = None
     """
-    Integer length of the animation sequence.\n
+    Integer length of the animation sequence.
     Shape of ``(num_worlds,)``.
     """
 
     decimation: wp.array[wp.int32] | None = None
     """
-    Integer decimation factor by which references are extracted from the animation sequence.\n
+    Integer decimation factor by which references are extracted from the animation sequence.
     Shape of ``(num_worlds,)``.
     """
 
     rate: wp.array[wp.int32] | None = None
     """
-    Integer rate by which to progress the active frame of the animation sequence at each step.\n
+    Integer rate by which to progress the active frame of the animation sequence at each step.
     Shape of ``(num_worlds,)``.
     """
 
     loop: wp.array[wp.int32] | None = None
     """
-    Integer flag to indicate if the animation should loop.\n
-    Shape of ``(num_worlds,)``.\n
-    If `1`, the animation will restart from the beginning after reaching the end.\n
+    Integer flag to indicate if the animation should loop.
+    Shape of ``(num_worlds,)``.
+    If `1`, the animation will restart from the beginning after reaching the end.
     If `0`, the animation will stop at the last frame.
     """
 
     frame: wp.array[wp.int32] | None = None
     """
-    Integer index indicating the active frame of the animation sequence.\n
+    Integer index indicating the active frame of the animation sequence.
     Shape of ``(num_worlds,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/utils/control/pid.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/pid.py
@@ -15,7 +15,7 @@ from ...core.joints import JointActuationType
 from ...core.model import ModelKamino
 from ...core.state import StateKamino
 from ...core.time import TimeData
-from ...core.types import FloatArrayLike, IntArrayLike, float32, int32, to_warp_int32_array
+from ...core.types import FloatArrayLike, IntArrayLike, to_warp_int32_array
 
 ###
 # Module interface
@@ -46,21 +46,21 @@ wp.set_module_options({"enable_backward": False})
 class PIDControllerData:
     """A data container for joint-space PID controller parameters and state."""
 
-    q_j_ref: wp.array | None = None
+    q_j_ref: wp.array[wp.float32] | None = None
     """The reference actuator joint positions."""
-    dq_j_ref: wp.array | None = None
+    dq_j_ref: wp.array[wp.float32] | None = None
     """The reference actuator joint velocities."""
-    tau_j_ref: wp.array | None = None
+    tau_j_ref: wp.array[wp.float32] | None = None
     """The feedforward actuator joint torques."""
-    K_p: wp.array | None = None
+    K_p: wp.array[wp.float32] | None = None
     """The proportional gains."""
-    K_i: wp.array | None = None
+    K_i: wp.array[wp.float32] | None = None
     """The integral gains."""
-    K_d: wp.array | None = None
+    K_d: wp.array[wp.float32] | None = None
     """The derivative gains."""
-    integrator: wp.array | None = None
+    integrator: wp.array[wp.float32] | None = None
     """Integrator of joint-space position tracking error."""
-    decimation: wp.array | None = None
+    decimation: wp.array[wp.int32] | None = None
     """The control decimation for each world expressed as a multiple of simulation steps."""
 
     @property
@@ -79,15 +79,15 @@ class PIDControllerData:
 @wp.kernel
 def _reset_jointspace_pid_references(
     # Inputs
-    model_joints_wid: wp.array[int32],
-    model_joints_act_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_actuated_dofs_offset: wp.array[int32],
-    state_joints_q_j: wp.array[float32],
-    state_joints_dq_j: wp.array[float32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_act_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_actuated_dofs_offset: wp.array[wp.int32],
+    state_joints_q_j: wp.array[wp.float32],
+    state_joints_dq_j: wp.array[wp.float32],
     # Outputs
-    controller_q_j_ref: wp.array[float32],
-    controller_dq_j_ref: wp.array[float32],
+    controller_q_j_ref: wp.array[wp.float32],
+    controller_dq_j_ref: wp.array[wp.float32],
 ):
     """
     A kernel to reset motion references of the joint-space controller.
@@ -128,25 +128,25 @@ def _reset_jointspace_pid_references(
 @wp.kernel
 def _compute_jointspace_pid_control(
     # Inputs
-    model_joints_wid: wp.array[int32],
-    model_joints_act_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_actuated_dofs_offset: wp.array[int32],
-    model_joints_tau_j_max: wp.array[float32],
-    model_time_dt: wp.array[float32],
-    state_time_steps: wp.array[int32],
-    state_joints_q_j: wp.array[float32],
-    state_joints_dq_j: wp.array[float32],
-    controller_q_j_ref: wp.array[float32],
-    controller_dq_j_ref: wp.array[float32],
-    controller_tau_j_ref: wp.array[float32],
-    controller_K_p: wp.array[float32],
-    controller_K_i: wp.array[float32],
-    controller_K_d: wp.array[float32],
-    controller_integrator: wp.array[float32],
-    controller_decimation: wp.array[int32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_act_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_actuated_dofs_offset: wp.array[wp.int32],
+    model_joints_tau_j_max: wp.array[wp.float32],
+    model_time_dt: wp.array[wp.float32],
+    state_time_steps: wp.array[wp.int32],
+    state_joints_q_j: wp.array[wp.float32],
+    state_joints_dq_j: wp.array[wp.float32],
+    controller_q_j_ref: wp.array[wp.float32],
+    controller_dq_j_ref: wp.array[wp.float32],
+    controller_tau_j_ref: wp.array[wp.float32],
+    controller_K_p: wp.array[wp.float32],
+    controller_K_i: wp.array[wp.float32],
+    controller_K_d: wp.array[wp.float32],
+    controller_integrator: wp.array[wp.float32],
+    controller_decimation: wp.array[wp.int32],
     # Outputs
-    control_tau_j: wp.array[float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     A kernel to compute joint-space PID control outputs for force-actuated joints.
@@ -176,7 +176,7 @@ def _compute_jointspace_pid_control(
 
     # Decimate the simulation time-step by the control
     # decimation to get the effective control time-step
-    dt *= float32(decimation)
+    dt *= wp.float32(decimation)
 
     # Retrieve the number of DoFs and offsets of the joint
     dofs_offset = model_joints_dofs_offset[jid]
@@ -331,12 +331,12 @@ class JointSpacePIDController:
         A simple PID controller in joint space.
 
         Args:
-            model (ModelKamino | None): The model container describing the system to be simulated.
+            model: The model container describing the system to be simulated.
                 If None, call ``finalize()`` later.
-            K_p (FloatArrayLike | None): Proportional gains per actuated joint DoF.
-            K_i (FloatArrayLike | None): Integral gains per actuated joint DoF.
-            K_d (FloatArrayLike | None): Derivative gains per actuated joint DoF.
-            decimation (IntArrayLike | None): Control decimation for each world
+            K_p: Proportional gains per actuated joint DoF.
+            K_i: Integral gains per actuated joint DoF.
+            K_d: Derivative gains per actuated joint DoF.
+            decimation: Control decimation for each world
                 expressed as a multiple of simulation steps.
         """
 
@@ -382,11 +382,11 @@ class JointSpacePIDController:
         Allocates all internal data arrays of the controller.
 
         Args:
-            model (ModelKamino): The model container describing the system to be simulated.
-            K_p (FloatArrayLike): Proportional gains per actuated joint DoF.
-            K_i (FloatArrayLike): Integral gains per actuated joint DoF.
-            K_d (FloatArrayLike): Derivative gains per actuated joint DoF.
-            decimation (IntArrayLike | None): Control decimation for each world expressed
+            model: The model container describing the system to be simulated.
+            K_p: Proportional gains per actuated joint DoF.
+            K_i: Integral gains per actuated joint DoF.
+            K_d: Derivative gains per actuated joint DoF.
+            decimation: Control decimation for each world expressed
                 as a multiple of simulation steps. Defaults to 1 for all worlds if None.
 
         Raises:
@@ -431,13 +431,13 @@ class JointSpacePIDController:
         # Allocate the controller data
         with wp.ScopedDevice(self._device):
             self._data = PIDControllerData(
-                q_j_ref=wp.zeros(num_actuated_dofs, dtype=float32),
-                dq_j_ref=wp.zeros(num_actuated_dofs, dtype=float32),
-                tau_j_ref=wp.zeros(num_actuated_dofs, dtype=float32),
-                K_p=wp.array(K_p if K_p is not None else np.zeros(num_actuated_dofs), dtype=float32),
-                K_i=wp.array(K_i if K_i is not None else np.zeros(num_actuated_dofs), dtype=float32),
-                K_d=wp.array(K_d if K_d is not None else np.zeros(num_actuated_dofs), dtype=float32),
-                integrator=wp.zeros(num_actuated_dofs, dtype=float32),
+                q_j_ref=wp.zeros(num_actuated_dofs, dtype=wp.float32),
+                dq_j_ref=wp.zeros(num_actuated_dofs, dtype=wp.float32),
+                tau_j_ref=wp.zeros(num_actuated_dofs, dtype=wp.float32),
+                K_p=wp.array(K_p if K_p is not None else np.zeros(num_actuated_dofs), dtype=wp.float32),
+                K_i=wp.array(K_i if K_i is not None else np.zeros(num_actuated_dofs), dtype=wp.float32),
+                K_d=wp.array(K_d if K_d is not None else np.zeros(num_actuated_dofs), dtype=wp.float32),
+                integrator=wp.zeros(num_actuated_dofs, dtype=wp.float32),
                 decimation=to_warp_int32_array(decimation),
             )
 
@@ -450,8 +450,8 @@ class JointSpacePIDController:
         forces `tau_j` and the integrator are set to zeros.
 
         Args:
-            model (ModelKamino): The model container holding the time-invariant parameters of the simulation.
-            state (StateKamino): The current state of the system to which the references will be reset.
+            model: The model container holding the time-invariant parameters of the simulation.
+            state: The current state of the system to which the references will be reset.
         """
 
         # First reset the references to the current state
@@ -472,9 +472,9 @@ class JointSpacePIDController:
         Set the controller reference trajectories.
 
         Args:
-            q_j_ref (FloatArrayLike): The reference generalized actuator positions.
-            dq_j_ref (FloatArrayLike | None): The reference generalized actuator velocities.
-            tau_j_ref (FloatArrayLike | None): The feedforward generalized actuator forces.
+            q_j_ref: The reference generalized actuator positions.
+            dq_j_ref: The reference generalized actuator velocities.
+            tau_j_ref: The feedforward generalized actuator forces.
         """
         if len(q_j_ref) != len(self._data.q_j_ref):
             raise ValueError(f"q_j_ref must have length {len(self._data.q_j_ref)}, but has length {len(q_j_ref)}")
@@ -505,10 +505,10 @@ class JointSpacePIDController:
         Compute the control torques.
 
         Args:
-            model (ModelKamino): The input model container holding the time-invariant parameters of the simulation.
-            state (StateKamino): The input state container holding the current state of the simulation.
-            time (TimeData): The input time data container holding the current simulation time and steps.
-            control (ControlKamino): The output control container where the computed control torques will be stored.
+            model: The input model container holding the time-invariant parameters of the simulation.
+            state: The input state container holding the current state of the simulation.
+            time: The input time data container holding the current simulation time and steps.
+            control: The output control container where the computed control torques will be stored.
         """
         compute_jointspace_pid_control(
             model=model,

--- a/newton/_src/solvers/kamino/_src/utils/control/rand.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/rand.py
@@ -22,7 +22,7 @@ from ...core.joints import JointActuationType
 from ...core.math import FLOAT32_MAX
 from ...core.model import ModelKamino
 from ...core.time import TimeData
-from ...core.types import FloatArrayLike, IntArrayLike, float32, int32, to_warp_int32_array
+from ...core.types import FloatArrayLike, IntArrayLike, to_warp_int32_array
 
 ###
 # Module interface
@@ -53,21 +53,21 @@ class RandomJointControllerData:
     seed: int = 0
     """Seed for random number generation."""
 
-    scale: wp.array | None = None
+    scale: wp.array[wp.float32] | None = None
     """
     Scaling applied to randomly generated control inputs.
 
-    Shape of `(sum_of_num_actuated_joint_dofs,)` and dtype of :class:`float32`.
+    Shape of `(sum_of_num_actuated_joint_dofs,)`.
     """
 
-    decimation: wp.array | None = None
+    decimation: wp.array[wp.int32] | None = None
     """
     Control decimation of each world expressed as a multiple of simulation steps.
 
     Values greater than `1` result in a zero-order hold of the control
     inputs, meaning that they will change only every `decimation` steps.
 
-    Shape of `(num_worlds,)` and dtype of :class:`int32`.
+    Shape of `(num_worlds,)`.
     """
 
 
@@ -80,17 +80,17 @@ class RandomJointControllerData:
 def _generate_random_control_inputs(
     # Inputs
     controller_seed: int,
-    controller_decimation: wp.array[int32],
-    controller_scale: wp.array[float32],
-    model_joints_wid: wp.array[int32],
-    model_joints_act_type: wp.array[int32],
-    model_joints_dofs_offset: wp.array[int32],
-    model_joints_tau_j_max: wp.array[float32],
-    state_time_steps: wp.array[int32],
+    controller_decimation: wp.array[wp.int32],
+    controller_scale: wp.array[wp.float32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_act_type: wp.array[wp.int32],
+    model_joints_dofs_offset: wp.array[wp.int32],
+    model_joints_tau_j_max: wp.array[wp.float32],
+    state_time_steps: wp.array[wp.int32],
     # Outputs
     # TODO: Add support for other control types
     # (e.g. position and velocity targets)
-    control_tau_j: wp.array[float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     A kernel to generate random control inputs for testing and benchmarking purposes.
@@ -172,19 +172,15 @@ class RandomJointController:
         on-device data arrays if a model instance is provided.
 
         Args:
-            model (`ModelKamino`, optional):
-                The model container describing the system to be simulated.\n
+            model: The model container describing the system to be simulated.\n
                 If `None`, a call to ``finalize()`` must be made later.
-            decimation (`int` or `IntArrayLike`, optional):
-                Control decimation for each world expressed as a multiple of simulation steps.\n
+            decimation: Control decimation for each world expressed as a multiple of simulation steps.\n
                 Defaults to `1` for all worlds if `None`.
-            scale (`float` or `FloatArrayLike`, optional):
-                Scaling applied to randomly generated control inputs.\n
+            scale: Scaling applied to randomly generated control inputs.\n
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
-                and dtype of `float32`, or as a single float value applied uniformly across all DoFs.\n
+                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.\n
                 Defaults to `1.0` if `None`.
-            seed (`int`, optional):
-                Seed for random number generation. If `None`, it will default to `0`.
+            seed: Seed for random number generation. If `None`, it will default to `0`.
         """
         # Declare a local reference to the model
         # for which this controller is created
@@ -260,18 +256,14 @@ class RandomJointController:
         on-device data arrays based on the provided model.
 
         Args:
-            model (`ModelKamino`):
-                The model container describing the system to be simulated.
-            decimation (`int` or `IntArrayLike`, optional):
-                Control decimation for each world expressed as a multiple of simulation steps.\n
+            model: The model container describing the system to be simulated.
+            decimation: Control decimation for each world expressed as a multiple of simulation steps.\n
                 Defaults to `1` for all worlds if `None`.
-            scale (`float` or `FloatArrayLike`, optional):
-                Scaling applied to randomly generated control inputs.\n
+            scale: Scaling applied to randomly generated control inputs.\n
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
-                and dtype of `float32`, or as a single float value applied uniformly across all DoFs.\n
+                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.\n
                 Defaults to `1.0` if `None`.
-            seed (`int`, optional):
-                Seed for random number generation. If `None`, it will default to `0`.
+            seed: Seed for random number generation. If `None`, it will default to `0`.
 
         Raises:
             ValueError: If the model has no actuated DoFs.
@@ -308,7 +300,7 @@ class RandomJointController:
             self._data = RandomJointControllerData(
                 seed=self._seed,
                 decimation=to_warp_int32_array(self._decimation),
-                scale=wp.array(self._scale, dtype=float32),
+                scale=wp.array(self._scale, dtype=wp.float32),
             )
 
     def compute(self, time: TimeData, control: ControlKamino):
@@ -319,12 +311,8 @@ class RandomJointController:
         joint index, and local DoF index to ensure reproducibility across runs.
 
         Args:
-            model (ModelKamino):
-                The input model container holding the time-invariant parameters of the simulation.
-            time (TimeData):
-                The input time data container holding the current simulation time and steps.
-            control (ControlKamino):
-                The output control container where the computed control torques will be stored.
+            time: The input time data container holding the current simulation time and steps.
+            control: The output control container where the computed control torques will be stored.
         """
         # Ensure a model has been assigned and finalized
         if self._model is None or self._data is None:

--- a/newton/_src/solvers/kamino/_src/utils/control/rand.py
+++ b/newton/_src/solvers/kamino/_src/utils/control/rand.py
@@ -172,13 +172,13 @@ class RandomJointController:
         on-device data arrays if a model instance is provided.
 
         Args:
-            model: The model container describing the system to be simulated.\n
+            model: The model container describing the system to be simulated.
                 If `None`, a call to ``finalize()`` must be made later.
-            decimation: Control decimation for each world expressed as a multiple of simulation steps.\n
+            decimation: Control decimation for each world expressed as a multiple of simulation steps.
                 Defaults to `1` for all worlds if `None`.
-            scale: Scaling applied to randomly generated control inputs.\n
+            scale: Scaling applied to randomly generated control inputs.
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
-                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.\n
+                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.
                 Defaults to `1.0` if `None`.
             seed: Seed for random number generation. If `None`, it will default to `0`.
         """
@@ -257,11 +257,11 @@ class RandomJointController:
 
         Args:
             model: The model container describing the system to be simulated.
-            decimation: Control decimation for each world expressed as a multiple of simulation steps.\n
+            decimation: Control decimation for each world expressed as a multiple of simulation steps.
                 Defaults to `1` for all worlds if `None`.
-            scale: Scaling applied to randomly generated control inputs.\n
+            scale: Scaling applied to randomly generated control inputs.
                 Can be specified per-DoF as an array of shape `(sum_of_num_actuated_joint_dofs,)`
-                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.\n
+                and dtype of `wp.float32`, or as a single float value applied uniformly across all DoFs.
                 Defaults to `1.0` if `None`.
             seed: Seed for random number generation. If `None`, it will default to `0`.
 

--- a/newton/_src/solvers/kamino/_src/utils/device.py
+++ b/newton/_src/solvers/kamino/_src/utils/device.py
@@ -27,11 +27,9 @@ def _fmt_bytes(bytes: int) -> str:
     Helper function to format a byte value into a human-readable string with appropriate units.
 
     Args:
-        bytes (int):
-            The number of bytes to format.
+        bytes: The number of bytes to format.
     Returns:
-        str:
-            A formatted string representing the byte value in appropriate units (bytes, KB, MB, GB, etc.).
+        A formatted string representing the byte value in appropriate units (bytes, KB, MB, GB, etc.).
     """
     if bytes < 1024:
         return f"{bytes} bytes"
@@ -50,12 +48,10 @@ def get_device_spec_info(device: wp.DeviceLike) -> str:
     Retrieves detailed specifications of a given Warp device as a formatted string.
 
     Args:
-        device (wp.DeviceLike):
-            The device for which to retrieve specifications.
+        device: The device for which to retrieve specifications.
 
     Returns:
-        str:
-            A formatted string containing detailed specifications for the specified device.
+        A formatted string containing detailed specifications for the specified device.
     """
     spec_info: str = f"[device: `{device}`]:\n"
     spec_info += f"                name: {device.name}\n"
@@ -91,12 +87,10 @@ def get_device_malloc_info(
     Retrieves memory allocation information for the specified device as a formatted string.
 
     Args:
-        device (wp.DeviceLike):
-            The device for which to retrieve memory allocation information.
+        device: The device for which to retrieve memory allocation information.
 
     Returns:
-        str:
-            A formatted string containing memory allocation information for the specified device.
+        A formatted string containing memory allocation information for the specified device.
     """
     # Initialize the info string
     malloc_info: str = f"[device: `{device}`][{usage}]: "

--- a/newton/_src/solvers/kamino/_src/utils/io/usd.py
+++ b/newton/_src/solvers/kamino/_src/utils/io/usd.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import warp as wp
 
+from ......core.types import Axis, AxisType, Transform
 from ......geometry.flags import ShapeFlags
 from ......usd import utils as usd_utils
 from ......utils.topology import topological_sort_undirected
@@ -33,7 +34,7 @@ from ...core.materials import (
     MaterialDescriptor,
     MaterialPairProperties,
 )
-from ...core.math import I_3, screw
+from ...core.math import I_3, axis_to_mat33, screw
 from ...core.shapes import (
     BoxShape,
     CapsuleShape,
@@ -44,7 +45,6 @@ from ...core.shapes import (
     PlaneShape,
     SphereShape,
 )
-from ...core.types import Axis, AxisType, Transform, quatf, transformf, vec3f
 from ...utils import logger as msg
 
 ###
@@ -54,15 +54,15 @@ from ...utils import logger as msg
 __axis_rotations = {}
 
 
-def quat_between_axes(*axes: AxisType) -> quatf:
+def quat_between_axes(*axes: AxisType) -> wp.quatf:
     """
     Returns a quaternion that represents the rotations between the given sequence of axes.
 
     Args:
-        axes (AxisType): The axes between to rotate.
+        axes: The axes between to rotate.
 
     Returns:
-        wp.quat: The rotation quaternion.
+        The rotation quaternion.
     """
     q = wp.quat_identity()
     for i in range(len(axes) - 1):
@@ -590,8 +590,8 @@ class USDImporter:
         # Retrieve the linear and angular velocities
         # NOTE: They are transformed to world coordinates since the
         # RigidBodyAPI specifies them in local body coordinates
-        v_i = wp.transform_vector(body_xform, distance_unit * vec3f(rigid_body_spec.linearVelocity))
-        omega_i = wp.transform_vector(body_xform, rotation_unit * vec3f(rigid_body_spec.angularVelocity))
+        v_i = wp.transform_vector(body_xform, distance_unit * wp.vec3f(rigid_body_spec.linearVelocity))
+        omega_i = wp.transform_vector(body_xform, rotation_unit * wp.vec3f(rigid_body_spec.angularVelocity))
         msg.debug(f"body_xform: {body_xform}")
         msg.debug(f"omega_i: {omega_i}")
         msg.debug(f"v_i: {v_i}")
@@ -655,11 +655,11 @@ class USDImporter:
         msg.debug(f"i_I_i:\n{i_I_i}")
 
         # Compute the center of mass in world coordinates
-        r_com_i = wp.transform_point(body_xform, vec3f(i_r_com_i))
+        r_com_i = wp.transform_point(body_xform, wp.vec3f(i_r_com_i))
         msg.debug(f"r_com_i: {r_com_i}")
 
         # Construct the initial pose and twist of the body in world coordinates
-        q_i_0 = transformf(r_com_i, body_xform.q)
+        q_i_0 = wp.transformf(r_com_i, body_xform.q)
         u_i_0 = screw(v_i, omega_i)
         msg.debug(f"q_i_0: {q_i_0}")
         msg.debug(f"u_i_0: {u_i_0}")
@@ -740,7 +740,7 @@ class USDImporter:
     ):
         dof_type = JointDoFType.REVOLUTE
         act_type = JointActuationType.PASSIVE
-        X_j = self.usd_axis_to_axis[joint_spec.axis].to_mat33()
+        X_j = axis_to_mat33(self.usd_axis_to_axis[joint_spec.axis])
         q_j_min, q_j_max, tau_j_max = self._make_joint_default_limits(dof_type)
         a_j, b_j, k_p_j, k_d_j = self._make_joint_default_dynamics(dof_type)
         if joint_spec.limit.enabled:
@@ -770,7 +770,7 @@ class USDImporter:
     def _parse_joint_prismatic(self, joint_spec, distance_unit: float = 1.0, load_drive_dynamics: bool = False):
         dof_type = JointDoFType.PRISMATIC
         act_type = JointActuationType.PASSIVE
-        X_j = self.usd_axis_to_axis[joint_spec.axis].to_mat33()
+        X_j = axis_to_mat33(self.usd_axis_to_axis[joint_spec.axis])
         q_j_min, q_j_max, tau_j_max = self._make_joint_default_limits(dof_type)
         a_j, b_j, k_p_j, k_d_j = self._make_joint_default_dynamics(dof_type)
         if joint_spec.limit.enabled:
@@ -798,7 +798,7 @@ class USDImporter:
 
     def _parse_joint_revolute_from_d6(self, name, joint_prim, joint_spec, joint_dof, rotation_unit: float = 1.0):
         dof_type = JointDoFType.REVOLUTE
-        X_j = self.usd_dofs_to_axis[joint_dof].to_mat33()
+        X_j = axis_to_mat33(self.usd_dofs_to_axis[joint_dof])
         q_j_min, q_j_max, tau_j_max = self._make_joint_default_limits(dof_type)
         for limit in joint_spec.jointLimits:
             dof = limit.first
@@ -822,7 +822,7 @@ class USDImporter:
 
     def _parse_joint_prismatic_from_d6(self, name, joint_prim, joint_spec, joint_dof, distance_unit: float = 1.0):
         dof_type = JointDoFType.PRISMATIC
-        X_j = self.usd_dofs_to_axis[joint_dof].to_mat33()
+        X_j = axis_to_mat33(self.usd_dofs_to_axis[joint_dof])
         q_j_min, q_j_max, tau_j_max = self._make_joint_default_limits(dof_type)
         for limit in joint_spec.jointLimits:
             dof = limit.first
@@ -1080,8 +1080,8 @@ class USDImporter:
             )
 
         # Extract the relative poses of the joint
-        B_r_Bj = distance_unit * vec3f(joint_spec.localPose0Position)
-        F_r_Fj = distance_unit * vec3f(joint_spec.localPose1Position)
+        B_r_Bj = distance_unit * wp.vec3f(joint_spec.localPose0Position)
+        F_r_Fj = distance_unit * wp.vec3f(joint_spec.localPose1Position)
         B_q_Bj = self._from_gfquat(joint_spec.localPose0Orientation)
         F_q_Fj = self._from_gfquat(joint_spec.localPose1Orientation)
         msg.debug(f"B_r_Bj (before COM correction): {B_r_Bj}")
@@ -1095,7 +1095,7 @@ class USDImporter:
             i_r_com_B = distance_unit * self._parse_vec(
                 body_B_prim, "physics:centerOfMass", default=np.zeros(3, dtype=np.float32)
             )
-            B_r_Bj = B_r_Bj - vec3f(i_r_com_B)
+            B_r_Bj = B_r_Bj - wp.vec3f(i_r_com_B)
             msg.debug(f"i_r_com_B: {i_r_com_B}")
             msg.debug(f"B_r_Bj (after COM correction): {B_r_Bj}")
 
@@ -1104,7 +1104,7 @@ class USDImporter:
             i_r_com_F = distance_unit * self._parse_vec(
                 body_F_prim, "physics:centerOfMass", default=np.zeros(3, dtype=np.float32)
             )
-            F_r_Fj = F_r_Fj - vec3f(i_r_com_F)
+            F_r_Fj = F_r_Fj - wp.vec3f(i_r_com_F)
             msg.debug(f"i_r_com_F: {i_r_com_F}")
             msg.debug(f"F_r_Fj (after COM correction): {F_r_Fj}")
 
@@ -1166,7 +1166,7 @@ class USDImporter:
         elif joint_type == self.UsdPhysics.ObjectType.SphericalJoint:
             dof_type = JointDoFType.SPHERICAL
             act_type = JointActuationType.PASSIVE
-            X_j = self.usd_axis_to_axis[joint_spec.axis].to_mat33()
+            X_j = axis_to_mat33(self.usd_axis_to_axis[joint_spec.axis])
 
         elif joint_type == self.UsdPhysics.ObjectType.DistanceJoint:
             raise NotImplementedError("Distance joints are not yet supported.")
@@ -1361,12 +1361,12 @@ class USDImporter:
             i_r_com = distance_unit * self._parse_vec(
                 body_prim, "physics:centerOfMass", default=np.zeros(3, dtype=np.float32)
             )
-            i_r_ig = i_r_ig - vec3f(i_r_com)
+            i_r_ig = i_r_ig - wp.vec3f(i_r_com)
             msg.debug(f"[{name}]: i_r_com: {i_r_com}")
             msg.debug(f"[{name}]: i_r_ig (after COM correction): {i_r_ig}")
 
         # Construct the transform descriptor
-        i_T_ig = transformf(i_r_ig, i_q_ig)
+        i_T_ig = wp.transformf(i_r_ig, i_q_ig)
         msg.debug(f"[{name}]: i_T_ig: {i_T_ig}")
 
         ###
@@ -1385,7 +1385,7 @@ class USDImporter:
             radius = distance_unit * capsule.GetRadiusAttr().Get()
             axis = Axis.from_string(capsule.GetAxisAttr().Get())
             i_q_ig = self._align_geom_to_axis(axis, i_q_ig)
-            i_T_ig = transformf(i_r_ig, i_q_ig)
+            i_T_ig = wp.transformf(i_r_ig, i_q_ig)
             shape = CapsuleShape(radius=radius, half_height=0.5 * height)
 
         elif geom_type == self.UsdGeom.Capsule_1:
@@ -1397,7 +1397,7 @@ class USDImporter:
             radius = distance_unit * cone.GetRadiusAttr().Get()
             axis = Axis.from_string(cone.GetAxisAttr().Get())
             i_q_ig = self._align_geom_to_axis(axis, i_q_ig)
-            i_T_ig = transformf(i_r_ig, i_q_ig)
+            i_T_ig = wp.transformf(i_r_ig, i_q_ig)
             shape = ConeShape(radius=radius, half_height=0.5 * height)
 
         elif geom_type == self.UsdGeom.Cube:
@@ -1410,7 +1410,7 @@ class USDImporter:
             radius = distance_unit * cylinder.GetRadiusAttr().Get()
             axis = Axis.from_string(cylinder.GetAxisAttr().Get())
             i_q_ig = self._align_geom_to_axis(axis, i_q_ig)
-            i_T_ig = transformf(i_r_ig, i_q_ig)
+            i_T_ig = wp.transformf(i_r_ig, i_q_ig)
             shape = CylinderShape(radius=radius, half_height=0.5 * height)
 
         elif geom_type == self.UsdGeom.Cylinder_1:
@@ -1533,7 +1533,7 @@ class USDImporter:
         ###
 
         # Extract the relative poses of the geom w.r.t the rigid body frame
-        i_r_ig = distance_unit * vec3f(geom_spec.localPos)
+        i_r_ig = distance_unit * wp.vec3f(geom_spec.localPos)
         i_q_ig = self._from_gfquat(geom_spec.localRot)
         msg.debug(f"[{name}]: i_r_ig (before COM correction): {i_r_ig}")
         msg.debug(f"[{name}]: i_q_ig: {i_q_ig}")
@@ -1544,12 +1544,12 @@ class USDImporter:
             i_r_com = distance_unit * self._parse_vec(
                 body_prim, "physics:centerOfMass", default=np.zeros(3, dtype=np.float32)
             )
-            i_r_ig = i_r_ig - vec3f(i_r_com)
+            i_r_ig = i_r_ig - wp.vec3f(i_r_com)
             msg.debug(f"[{name}]: i_r_com: {i_r_com}")
             msg.debug(f"[{name}]: i_r_ig (after COM correction): {i_r_ig}")
 
         # Construct the transform descriptor
-        i_T_ig = transformf(i_r_ig, i_q_ig)
+        i_T_ig = wp.transformf(i_r_ig, i_q_ig)
 
         ###
         # PhysicsGeom Shape Properties
@@ -1581,7 +1581,7 @@ class USDImporter:
             )
 
         elif geom_type == self.UsdPhysics.ObjectType.CubeShape:
-            he = distance_unit * vec3f(geom_spec.halfExtents)
+            he = distance_unit * wp.vec3f(geom_spec.halfExtents)
             shape = BoxShape(hx=he[0], hy=he[1], hz=he[2])
 
         elif geom_type == self.UsdPhysics.ObjectType.CylinderShape:
@@ -1814,7 +1814,7 @@ class USDImporter:
 
             # Extract the world gravity from the physics scene
             gravity.acceleration = distance_unit * scene_desc.gravityMagnitude
-            gravity.direction = vec3f(scene_desc.gravityDirection)
+            gravity.direction = wp.vec3f(scene_desc.gravityDirection)
             builder.set_gravity(gravity)
             msg.debug(f"World gravity: {gravity}")
 
@@ -1830,7 +1830,7 @@ class USDImporter:
             axis_xform = wp.transform_identity()
             msg.debug(f"Using stage up axis {up_axis} as builder up axis")
         else:
-            axis_xform = wp.transform(vec3f(0.0), quat_between_axes(up_axis, builder.up_axes[0]))
+            axis_xform = wp.transform(wp.vec3f(0.0), quat_between_axes(up_axis, builder.up_axes[0]))
             msg.debug(f"Rotating stage to align its up axis {up_axis} with builder up axis {builder.up_axes[0]}")
 
         # Set the world offset transform based on the provided xform
@@ -2086,8 +2086,8 @@ class USDImporter:
                     bid_B=-1,
                     bid_F=root_body_index,
                     B_r_Bj=wp.transform_get_translation(builder.bodies[0][root_body_index].q_i_0),
-                    F_r_Fj=vec3f(0.0),
-                    X_Bj=Axis.X.to_mat33(),
+                    F_r_Fj=wp.vec3f(0.0),
+                    X_Bj=axis_to_mat33(Axis.X),
                 )
                 msg.debug(
                     f"Adding FREE joint '{joint_desc.name}' to attach articulation "

--- a/newton/_src/solvers/kamino/_src/utils/profiles.py
+++ b/newton/_src/solvers/kamino/_src/utils/profiles.py
@@ -76,32 +76,32 @@ class PerformanceProfile:
     and cached for later use.
 
     Args:
-        data (np.ndarray): Array of shape (num_solvers, num_problems) with measurements for num_solvers
+        data: Array of shape (num_solvers, num_problems) with measurements for num_solvers
             solvers across num_problems problems. Each entry typically represents a cost such as time,
             iterations, or error.
-        success (np.ndarray | None): Optional boolean or integer array of shape
+        success: Optional boolean or integer array of shape
             (num_solvers, num_problems) indicating successful runs (nonzero/True means success). Failed
             runs are excluded from the profile. If None, all runs are treated as
             successful.
-        taumax (float): Maximum performance ratio τ for which the profile is
+        taumax: Maximum performance ratio τ for which the profile is
             generated. If set to float('inf'), τ_max is chosen as 2x (max observed ratio).
-        ppfixmax (float): Upper threshold used by the Dingle-Higham refinement when
+        ppfixmax: Upper threshold used by the Dingle-Higham refinement when
             ppfix is True (useful when the data represent relative errors).
-        ppfixmin (float): Lower floor used by the Dingle-Higham refinement when
+        ppfixmin: Lower floor used by the Dingle-Higham refinement when
             ppfix is True to prevent zero or near-zero values.
-        ppfix (bool): If True, apply Dingle-Higham style refinement to the input
+        ppfix: If True, apply Dingle-Higham style refinement to the input
             data before computing ratios.
 
     Attributes:
-        _t_p_min (np.ndarray | None): Per-problem best (minimal) measurement across
+        _t_p_min: Per-problem best (minimal) measurement across
             solvers, used to form performance ratios.
-        _r_ps (np.ndarray | None): Array of performance ratios r_{p,s}.
-        _rho_s (list[np.ndarray]): Empirical distribution functions rho_s(τ) for each
+        _r_ps: Array of performance ratios r_{p,s}.
+        _rho_s: Empirical distribution functions rho_s(τ) for each
             solver over the profile domain.
-        _r_min (float): Minimum observed performance ratio.
-        _r_max (float): Maximum observed performance ratio.
-        _tau_max (float): Effective maximum τ used for the profile domain.
-        _valid (bool): True if the profile was successfully computed given the input
+        _r_min: Minimum observed performance ratio.
+        _r_max: Maximum observed performance ratio.
+        _tau_max: Effective maximum τ used for the profile domain.
+        _valid: True if the profile was successfully computed given the input
             data and success mask; False otherwise.
 
     Notes:
@@ -326,9 +326,8 @@ class PerformanceProfile:
         Compute solver rankings at tau=1.0 and at rho=1.0.
 
         Returns:
-            tuple[np.ndarray, np.ndarray]: A pair of 1D integer arrays with length equal to the number of solvers.
-                - First array: rankings based on rho at tau=1.0 (higher is better).
-                - Second array: rankings based on the smallest tau at which rho=1.0 (lower is better).
+            Mapping from metric name to ranking arrays and validity flags at
+            ``tau=1.0`` and ``rho=1.0``.
 
         Notes:
             Rankings are dense: solvers with the same value share the same rank, and
@@ -395,16 +394,16 @@ class PerformanceProfile:
         Generates a 2D plot to visualize the performance profile using Matplotlib.
 
         Args:
-            names (str, optional): A vector of solver names used to generate plot labels.
-            title (str, optional): The title of the plot.
-            xtitle (str, optional): The label for the x-axis.
-            ytitle (str, optional): The label for the y-axis.
-            xlim (tuple, optional): The limits for the x-axis as (xmin, xmax). If None, defaults to (1.0, tau_max).
-            ylim (tuple, optional): The limits for the y-axis as (ymin, ymax). If None, defaults to (0.0, 1.1).
-            xscale (str, optional): The scale for the x-axis. Options are 'linear', 'log2', or 'log10'.
-            yscale (str, optional): The scale for the y-axis. Options are 'linear', 'log2', or 'log10'.
-            legend_loc (str, optional): The location of the legend on the plot.
-            style (str, optional): An optional Matplotlib style to apply to the plot.
+            names: A vector of solver names used to generate plot labels.
+            title: The title of the plot.
+            xtitle: The label for the x-axis.
+            ytitle: The label for the y-axis.
+            xlim: The limits for the x-axis as (xmin, xmax). If None, defaults to (1.0, tau_max).
+            ylim: The limits for the y-axis as (ymin, ymax). If None, defaults to (0.0, 1.1).
+            xscale: The scale for the x-axis. Options are 'linear', 'log2', or 'log10'.
+            yscale: The scale for the y-axis. Options are 'linear', 'log2', or 'log10'.
+            legend_loc: The location of the legend on the plot.
+            style: An optional Matplotlib style to apply to the plot.
         """
         # Ensure a valid profile has been computed before plotting
         if not self._valid:

--- a/newton/_src/solvers/kamino/_src/utils/profiles.py
+++ b/newton/_src/solvers/kamino/_src/utils/profiles.py
@@ -123,46 +123,46 @@ class PerformanceProfile:
     ) -> None:
         self._t_p_min: np.ndarray | None = None
         """
-        The per-problem best performance amongst all solvers\n
-        For every p in P : t_p_min = min{s in S : t_ps}\n
+        The per-problem best performance amongst all solvers
+        For every p in P : t_p_min = min{s in S : t_ps}
         Dimensions are: |P|
         """
 
         self._r_ps: np.ndarray | None = None
         """
-        The per-sample performance ratios\n
-        For every s in S and p in P : r_ps = t_ps / min{s in S : t_ps}\n
+        The per-sample performance ratios
+        For every s in S and p in P : r_ps = t_ps / min{s in S : t_ps}
         Dimensions are: |P| x |S|
         """
 
         self._rho_s: list[np.ndarray] = []
         """
-        The per-solver cumulative distributions\n
-        For every s in S : rho_s(tau) = (1/np) * size{p in P : r_ps <= tau}\n
+        The per-solver cumulative distributions
+        For every s in S : rho_s(tau) = (1/np) * size{p in P : r_ps <= tau}
         Dimensions are: |S| x |Rho|
         """
 
         self._r_min: float = np.inf
         """
-        The smallest performance ratio present in the data\n
+        The smallest performance ratio present in the data
         r in [r_min, r_max]
         """
 
         self._r_max: float = np.inf
         """
-        The largest performance ratio present in the data\n
+        The largest performance ratio present in the data
         r in [r_min, r_max]
         """
 
         self._tau_max: float = np.inf
         """
-        The largest performance ratio considered for generating the performance profile\n
+        The largest performance ratio considered for generating the performance profile
         tau in [1, tau_max]
         """
 
         self._valid: bool = False
         """
-        Flag to indicate if last call to 'compute' was valid\n
+        Flag to indicate if last call to 'compute' was valid
         This is also useful to check construction-time generation was successful.
         """
 

--- a/newton/_src/solvers/kamino/_src/utils/sim/simulator.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/simulator.py
@@ -111,7 +111,7 @@ class Simulator:
 
         dt: float | FloatArrayLike = 0.001
         """
-        The time-step to be used for the simulation.\n
+        The time-step to be used for the simulation.
         Defaults to `0.001` seconds.
         """
 
@@ -123,7 +123,7 @@ class Simulator:
 
         solver: SolverKaminoImpl.Config = field(default_factory=SolverKaminoImpl.Config)
         """
-        The config for the dynamics solver.\n
+        The config for the dynamics solver.
         See :class:`SolverKaminoImpl.Config` for more details.
         """
 

--- a/newton/_src/solvers/kamino/_src/utils/sim/simulator.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/simulator.py
@@ -46,13 +46,10 @@ class SimulatorData:
     Holds the time-varying data for the simulation.
 
     Attributes:
-        state_p (StateKamino):
-            The previous state data of the simulation
-        state_n (StateKamino):
-            The current state data of the simulation, computed from the previous step as:
+        state_p: The previous state data of the simulation.
+        state_n: The current state data of the simulation, computed from the previous step as:
             ``state_n = f(state_p, control)``, where ``f()`` is the system dynamics function.
-        control (ControlKamino):
-            The control data, computed at each step as:
+        control: The control data, computed at each step as:
             ``control = g(state_n, state_p, control)``, where ``g()`` is the control function.
     """
 
@@ -177,9 +174,9 @@ class Simulator:
         Initializes the simulator with the given model builder, time-step, and device.
 
         Args:
-            builder (ModelBuilderKamino): The model builder defining the model to be simulated.
-            config (Simulator.Config, optional): The simulator config to use. If None, the default config are used.
-            device (wp.DeviceLike, optional): The device to run the simulation on. If None, the default device is used.
+            builder: The model builder defining the model to be simulated.
+            config: The simulator config to use. If None, the default config are used.
+            device: The device to run the simulation on. If None, the default device is used.
         """
         # Cache simulator config: If no config is provided, use default configs
         if config is None:
@@ -343,7 +340,7 @@ class Simulator:
 
     def reset(
         self,
-        world_mask: wp.array | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
         config: SolverKamino.ResetConfig | None = None,
     ):
         """
@@ -358,7 +355,7 @@ class Simulator:
         Args:
             world_mask: Optional array of per-world masks indicating which
                 worlds should be reset.
-                Shape of ``(num_worlds,)`` and type :class:`wp.int8` | :class:`wp.bool`.
+                Shape of ``(num_worlds,)``.
             config: Optional reset configuration, controlling the reset behavior
                 for body poses/velocities as well as floating base pose/velocity.
                 If not provided, all components are reset to default (initial) values.

--- a/newton/_src/solvers/kamino/_src/utils/sim/viewer.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/viewer.py
@@ -17,7 +17,6 @@ from ......geometry.types import GeoType
 from ......viewer import ViewerGL
 from ...core.builder import ModelBuilderKamino
 from ...core.geometry import GeometryDescriptor
-from ...core.types import vec3f
 from ...core.world import WorldDescriptor
 from ...geometry.contacts import ContactMode
 from ...utils import logger as msg
@@ -187,7 +186,7 @@ class ViewerKamino(ViewerGL):
     ]
 
     # Define a static world spacing offset for multiple worlds
-    world_spacing: ClassVar[vec3f] = vec3f(-2.0, 0.0, 0.0)
+    world_spacing: ClassVar[wp.vec3f] = wp.vec3f(-2.0, 0.0, 0.0)
 
     def __init__(
         self,
@@ -245,7 +244,7 @@ class ViewerKamino(ViewerGL):
         if self._record_video:
             os.makedirs(self._video_folder, exist_ok=True)
 
-    def render_geometry(self, body_poses: wp.array, geom: GeometryDescriptor, scope: str):
+    def render_geometry(self, body_poses: wp.array[wp.transformf], geom: GeometryDescriptor, scope: str):
         # TODO: Fix this
         bid = geom.body + self._worlds[geom.wid].bodies_idx_offset if geom.body >= 0 else -1
 
@@ -580,7 +579,7 @@ class ViewerKamino(ViewerGL):
 
         # Only capture and save if we've reached the skip threshold
         if self._img_idx >= self._skip_img_idx:
-            # Get frame from viewer as GPU array (height, width, 3) uint8
+            # Get frame from viewer as GPU array with shape (height, width, 3) and dtype wp.uint8
             frame = self.get_frame(target_image=self._frame_buffer)
 
             # Cache buffer for reuse to minimize allocations

--- a/newton/_src/solvers/kamino/_src/utils/sparse.py
+++ b/newton/_src/solvers/kamino/_src/utils/sparse.py
@@ -22,6 +22,19 @@ def sparseplot(
     grid: bool = False,
     path: str | None = None,
 ):
+    """Visualize the sparsity pattern of a matrix.
+
+    Zero entries are shown in red. Non-zero entries are shown in grayscale
+    (black to white).
+
+    Args:
+        matrix: 2D array to visualize.
+        title: Title for the plot.
+        tick_fontsize: Font size for axis tick labels.
+        max_ticks: Maximum number of ticks per axis.
+        grid: Whether to overlay a major grid on the plot.
+        path: If provided, save the image to this path; otherwise display it.
+    """
     # Attempt to import matplotlib
     try:
         import matplotlib.pyplot as plt
@@ -30,17 +43,6 @@ def sparseplot(
     except Exception as exc:  # pragma: no cover - optional dependency
         msg.error(f"`matplotlib` is required to plot profiles: {exc}")
         return
-
-    """
-    Visualize the sparsity pattern of a matrix.
-    Zero entries are shown in red.
-    Non-zero entries are shown in grayscale (black to white).
-
-    Parameters:
-    - matrix: 2D numpy array
-    - title: Title for the plot (used for display or saved image)
-    - save_path: If provided, saves the image to this file path; otherwise, displays it.
-    """
 
     # Check if the input is a 2D NumPy array
     if not isinstance(matrix, np.ndarray):

--- a/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
+++ b/newton/_src/solvers/kamino/_src/utils/world_equivalence.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 import warp as wp
 
-from ..core.types import assign_to_warp_int32_array, int32, to_warp_int32_array, uint64
+from ..core.types import assign_to_warp_int32_array, to_warp_int32_array
 
 ###
 # Module interface
@@ -47,25 +47,24 @@ class DiscreteSignature:
     num_worlds: int
     """Number of worlds"""
 
-    data: wp.array
-    """Flat data array, with type int32, concatenating a signature block for each world"""
+    data: wp.array[wp.int32]
+    """Flat data array, concatenating a signature block for each world"""
 
-    world_offset: wp.array | None = None
+    world_offset: wp.array[wp.int32] | None = None
     """
-    Per-world offset of the signature block into `data`, with shape (num_worlds) and type int32.
+    Per-world offset of the signature block into `data`, with shape (num_worlds).
     Optional if data has exactly one entry per world.
     """
 
-    world_size: wp.array | None = None
+    world_size: wp.array[wp.int32] | None = None
     """
-    Per-world size of the signature block into `data`, with shape (num_worlds) and type int32.
+    Per-world size of the signature block into `data`, with shape (num_worlds).
     Optional if data has exactly one entry per world.
     """
 
-    world_delta: wp.array | None = None
+    world_delta: wp.array[wp.int32] | None = None
     """
-    Optional per-world delta to subtract from signature values before comparison, with shape (num_worlds)
-    and type int32.
+    Optional per-world delta to subtract from signature values before comparison, with shape (num_worlds).
     If provided, two signature coefficients are considered equivalent if coeff1 - delta1 = coeff2 - delta2.
     """
 
@@ -110,7 +109,7 @@ class DiscreteSignature:
 
 
 @wp.func
-def comparison_value(value: int32, delta: int32, ignore_negative: wp.bool):
+def comparison_value(value: wp.int32, delta: wp.int32, ignore_negative: wp.bool):
     if ignore_negative and value < 0:
         return -1
     return value - delta
@@ -118,12 +117,12 @@ def comparison_value(value: int32, delta: int32, ignore_negative: wp.bool):
 
 @wp.kernel
 def equivalence_mask_kernel(
-    data: wp.array[int32],
-    world_offset: wp.array[int32],
-    world_size: wp.array[int32],
-    world_delta: wp.array[int32],
+    data: wp.array[wp.int32],
+    world_offset: wp.array[wp.int32],
+    world_size: wp.array[wp.int32],
+    world_delta: wp.array[wp.int32],
     ignore_negative: wp.bool,
-    world_ref_index: wp.array[int32],
+    world_ref_index: wp.array[wp.int32],
     world_equivalence_mask: wp.array[wp.bool],
 ):
     """Updates a mask indicating whether the signature of each world matches the one of the reference world"""
@@ -157,13 +156,13 @@ def equivalence_mask_kernel(
 
 @wp.kernel
 def hash_kernel(
-    data: wp.array[int32],
-    world_offset: wp.array[int32],
-    world_size: wp.array[int32],
-    world_delta: wp.array[int32],
+    data: wp.array[wp.int32],
+    world_offset: wp.array[wp.int32],
+    world_size: wp.array[wp.int32],
+    world_delta: wp.array[wp.int32],
     ignore_negative: wp.bool,
-    world_class_index: wp.array[int32],
-    world_hash: wp.array[uint64],
+    world_class_index: wp.array[wp.int32],
+    world_hash: wp.array[wp.uint64],
 ):
     """Updates a per-world hash based on the signature, for worlds that don't have a class yet"""
     wid = wp.tid()  # Retrieve world index

--- a/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
@@ -11,7 +11,6 @@ from scipy.spatial.transform import Rotation  # noqa: TID253
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32, int32, transformf, vec6f
 from newton._src.solvers.kamino._src.models.builders.utils import (
     make_homogeneous_builder,
     set_uniform_body_pose_offset,
@@ -32,9 +31,9 @@ from newton._src.solvers.kamino.solver_kamino import SolverKamino
 def _test_control_callback(
     sim_has_started_resets: wp.array[wp.bool],
     sim_reset_index: wp.array[wp.int32],
-    actuated_joint_idx: wp.array[int32],
-    state_t: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    actuated_joint_idx: wp.array[wp.int32],
+    state_t: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -49,8 +48,8 @@ def _test_control_callback(
         joint_reset_index = actuated_joint_idx.shape[0] - 1
 
     # Define the time window for the active external force profile
-    t_start = float32(0.0)
-    t_end = float32(0.5)
+    t_start = wp.float32(0.0)
+    t_end = wp.float32(0.5)
 
     # Get the current time
     t = state_t[0]
@@ -126,7 +125,7 @@ class Example:
 
         # Offset the model to place it above the ground
         # NOTE: The USD model is centered at the origin
-        q_base = wp.transformf((0.0, 0.0, 0.265), wp.quat_identity(dtype=float32))
+        q_base = wp.transformf((0.0, 0.0, 0.265), wp.quat_identity(dtype=wp.float32))
         set_uniform_body_pose_offset(builder=self.builder, offset=q_base)
 
         # Set gravity
@@ -167,13 +166,13 @@ class Example:
 
         # Allocate utility arrays for resetting
         with wp.ScopedDevice(self.device):
-            self.base_q = wp.zeros(shape=(self.sim.model.size.num_worlds,), dtype=transformf)
-            self.base_u = wp.zeros(shape=(self.sim.model.size.num_worlds,), dtype=vec6f)
-            self.joint_q = wp.zeros(shape=(self.sim.model.size.sum_of_num_joint_coords,), dtype=float32)
-            self.joint_u = wp.zeros(shape=(self.sim.model.size.sum_of_num_joint_dofs,), dtype=float32)
-            self.actuator_q = wp.zeros(shape=(self.sim.model.size.sum_of_num_actuated_joint_coords,), dtype=float32)
-            self.actuator_u = wp.zeros(shape=(self.sim.model.size.sum_of_num_actuated_joint_dofs,), dtype=float32)
-            self.actuated_joint_idx = wp.array(self.actuated_joint_idx_np, dtype=int32)
+            self.base_q = wp.zeros(shape=(self.sim.model.size.num_worlds,), dtype=wp.transformf)
+            self.base_u = wp.zeros(shape=(self.sim.model.size.num_worlds,), dtype=wp.spatial_vectorf)
+            self.joint_q = wp.zeros(shape=(self.sim.model.size.sum_of_num_joint_coords,), dtype=wp.float32)
+            self.joint_u = wp.zeros(shape=(self.sim.model.size.sum_of_num_joint_dofs,), dtype=wp.float32)
+            self.actuator_q = wp.zeros(shape=(self.sim.model.size.sum_of_num_actuated_joint_coords,), dtype=wp.float32)
+            self.actuator_u = wp.zeros(shape=(self.sim.model.size.sum_of_num_actuated_joint_dofs,), dtype=wp.float32)
+            self.actuated_joint_idx = wp.array(self.actuated_joint_idx_np, dtype=wp.int32)
             self.sim_has_started_resets = wp.full(shape=(1,), dtype=wp.bool, value=False)
             self.sim_reset_index = wp.full(shape=(1,), dtype=wp.int32, value=-1)
 
@@ -314,7 +313,7 @@ class Example:
             R_b = Rotation.from_rotvec(np.pi / 4 * np.array([0, 0, 1]))
             q_b = R_b.as_quat()  # x, y, z, w
             q_base = wp.transformf((0.1, 0.1, 0.3), q_b)
-            u_base = vec6f(0.0, 0.0, 0.05, 0.0, 0.0, 0.3)
+            u_base = wp.spatial_vectorf(0.0, 0.0, 0.05, 0.0, 0.0, 0.3)
             self.base_q.assign([q_base] * self.sim.model.size.num_worlds)
             self.base_u.assign([u_base] * self.sim.model.size.num_worlds)
             reset_config = SolverKamino.ResetConfig(
@@ -333,7 +332,7 @@ class Example:
             R_b = Rotation.from_rotvec(np.pi / 4 * np.array([0, 0, 1]))
             q_b = R_b.as_quat()  # x, y, z, w
             q_base = wp.transformf((0.1, 0.1, 0.3), q_b)
-            u_base = vec6f(0.0, 0.0, -0.05, 0.0, 0.0, 0.3)
+            u_base = wp.spatial_vectorf(0.0, 0.0, -0.05, 0.0, 0.0, 0.3)
             self.base_q.assign([q_base] * self.sim.model.size.num_worlds)
             self.base_u.assign([u_base] * self.sim.model.size.num_worlds)
             actuated_joint_config = np.array(
@@ -374,7 +373,7 @@ class Example:
             R_b = Rotation.from_rotvec(np.pi / 4 * np.array([0, 0, 1]))
             q_b = R_b.as_quat()  # x, y, z, w
             q_base = wp.transformf((0.1, 0.1, 0.3), q_b)
-            u_base = vec6f(0.0, 0.0, -0.05, 0.0, 0.0, -0.3)
+            u_base = wp.spatial_vectorf(0.0, 0.0, -0.05, 0.0, 0.0, -0.3)
             self.base_q.assign([q_base] * self.sim.model.size.num_worlds)
             self.base_u.assign([u_base] * self.sim.model.size.num_worlds)
             actuated_joint_config = np.array(

--- a/newton/_src/solvers/kamino/examples/rl/simulation.py
+++ b/newton/_src/solvers/kamino/examples/rl/simulation.py
@@ -27,7 +27,6 @@ from newton._src.solvers.kamino._src.core.bodies import convert_body_com_to_orig
 from newton._src.solvers.kamino._src.core.control import ControlKamino
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.state import StateKamino
-from newton._src.solvers.kamino._src.core.types import float32, transformf, vec6f
 from newton._src.solvers.kamino._src.geometry import CollisionDetector
 from newton._src.solvers.kamino._src.geometry.aggregation import ContactAggregation
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino, convert_contacts_newton_to_kamino
@@ -459,10 +458,10 @@ class RigidBodySim:
         self._world_mask = wp.to_torch(self._world_mask_wp)
 
         # Reset buffers
-        self._reset_base_q_wp = wp.zeros(nw, dtype=transformf, device=self._device)
-        self._reset_base_u_wp = wp.zeros(nw, dtype=vec6f, device=self._device)
-        self._reset_q_j_wp = wp.zeros(nw * njc, dtype=float32, device=self._device)
-        self._reset_dq_j_wp = wp.zeros(nw * njd, dtype=float32, device=self._device)
+        self._reset_base_q_wp = wp.zeros(nw, dtype=wp.transformf, device=self._device)
+        self._reset_base_u_wp = wp.zeros(nw, dtype=wp.spatial_vectorf, device=self._device)
+        self._reset_q_j_wp = wp.zeros(nw * njc, dtype=wp.float32, device=self._device)
+        self._reset_dq_j_wp = wp.zeros(nw * njd, dtype=wp.float32, device=self._device)
         self._reset_base_q = wp.to_torch(self._reset_base_q_wp).reshape(nw, 7)
         self._reset_base_u = wp.to_torch(self._reset_base_u_wp).reshape(nw, 6)
         self._reset_q_j = wp.to_torch(self._reset_q_j_wp).reshape(nw, njc)

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
@@ -10,7 +10,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.models.builders import basics
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino._src.utils.sim import SimulationLogger, Simulator, ViewerKamino
@@ -30,8 +29,8 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _test_control_callback(
-    state_t: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    state_t: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -40,8 +39,8 @@ def _test_control_callback(
     wid = int(0)
 
     # Define the time window for the active external force profile
-    t_start = float32(1.0)
-    t_end = float32(3.0)
+    t_start = wp.float32(1.0)
+    t_end = wp.float32(3.0)
 
     # Get the current time
     t = state_t[wid]

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
@@ -10,7 +10,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32, int32, vec6f
 from newton._src.solvers.kamino._src.models.builders.basics import build_box_on_plane
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -33,10 +32,10 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _control_callback(
-    model_body_wid: wp.array[int32],
-    contact_world_num_active: wp.array[int32],
-    data_t: wp.array[float32],
-    state_w_i_e: wp.array[vec6f],
+    model_body_wid: wp.array[wp.int32],
+    contact_world_num_active: wp.array[wp.int32],
+    data_t: wp.array[wp.float32],
+    state_w_i_e: wp.array[wp.spatial_vectorf],
 ):
     """
     An example control callback kernel.
@@ -51,21 +50,21 @@ def _control_callback(
     wnc = contact_world_num_active[wid]
 
     # Define the time window for the active external force profile
-    t_start = float32(0.0)
-    t_end = float32(6.0)
+    t_start = wp.float32(0.0)
+    t_end = wp.float32(6.0)
 
     # Get the current time
     t = data_t[wid]
 
     # Apply a time-dependent external force
     if t > t_start and t < t_end and wnc > 0:
-        m = float32(1.0)  # Mass of the box
-        g = float32(9.8067)  # Gravitational acceleration
-        mu = float32(0.9)  # Friction coefficient
+        m = wp.float32(1.0)  # Mass of the box
+        g = wp.float32(9.8067)  # Gravitational acceleration
+        mu = wp.float32(0.9)  # Friction coefficient
         f_ext = 1.1 * m * g * mu  # Magnitude of the external force
-        state_w_i_e[bid] = vec6f(f_ext, 0.0, 0.0, 0.0, 0.0, 0.0)
+        state_w_i_e[bid] = wp.spatial_vectorf(f_ext, 0.0, 0.0, 0.0, 0.0, 0.0)
     else:
-        state_w_i_e[bid] = vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        state_w_i_e[bid] = wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
 
 ###

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
@@ -10,7 +10,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_fourbar
 from newton._src.solvers.kamino._src.models.builders.utils import (
     make_homogeneous_builder,
@@ -36,10 +35,10 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _pd_control_callback(
-    state_t: wp.array[float32],
-    control_q_j_ref: wp.array[float32],
-    control_dq_j_ref: wp.array[float32],
-    control_tau_j_ref: wp.array[float32],
+    state_t: wp.array[wp.float32],
+    control_q_j_ref: wp.array[wp.float32],
+    control_dq_j_ref: wp.array[wp.float32],
+    control_tau_j_ref: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -49,8 +48,8 @@ def _pd_control_callback(
     jid = int(0)
 
     # Define the time window for the active external force profile
-    t_start = float32(3.0)
-    t_window = float32(3.0)
+    t_start = wp.float32(3.0)
+    t_window = wp.float32(3.0)
     t_0 = t_start + t_window
     t_1 = t_0 + t_window
     t_2 = t_1 + t_window
@@ -94,8 +93,8 @@ def _pd_control_callback(
 
 @wp.kernel
 def _torque_control_callback(
-    state_t: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    state_t: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -105,8 +104,8 @@ def _torque_control_callback(
     jid = int(0)
 
     # Define the time window for the active external force profile
-    t_start = float32(2.0)
-    t_end = float32(2.5)
+    t_start = wp.float32(2.0)
+    t_end = wp.float32(2.5)
 
     # Get the current time
     t = state_t[wid]

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
@@ -10,7 +10,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_hinged
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -33,8 +32,8 @@ wp.set_module_options({"enable_backward": False})
 
 @wp.kernel
 def _control_callback(
-    state_t: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    state_t: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -44,8 +43,8 @@ def _control_callback(
     jid = int(0)
 
     # Define the time window for the active external force profile
-    t_start = float32(2.0)
-    t_end = float32(2.5)
+    t_start = wp.float32(2.0)
+    t_end = wp.float32(2.5)
 
     # Get the current time
     t = state_t[wid]

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import argparse
 import os
 from dataclasses import dataclass
@@ -12,7 +14,6 @@ import warp as wp
 import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32, uint32
 from newton._src.solvers.kamino._src.models import get_basics_usd_assets_path
 from newton._src.solvers.kamino._src.models.builders.basics import build_cartpole
 from newton._src.solvers.kamino._src.models.builders.utils import add_ground_box, make_homogeneous_builder
@@ -44,8 +45,8 @@ class CartpoleActions:
 
 @wp.kernel
 def _test_control_callback(
-    state_t: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    state_t: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -54,15 +55,15 @@ def _test_control_callback(
     wid = wp.tid()
 
     # Define the time window for the active external force profile
-    t_start = float32(1.0)
-    t_end = float32(3.1)
+    t_start = wp.float32(1.0)
+    t_end = wp.float32(3.1)
 
     # Get the current time
     t = state_t[wid]
 
     # Apply a time-dependent external force
     if t >= 0.0 and t < t_start:
-        control_tau_j[wid * 2 + 0] = 1.0 * wp.randf(uint32(wid) + uint32(t), -1.0, 1.0)
+        control_tau_j[wid * 2 + 0] = 1.0 * wp.randf(wp.uint32(wid) + wp.uint32(t), -1.0, 1.0)
         control_tau_j[wid * 2 + 1] = 0.0
     elif t > t_start and t < t_end:
         control_tau_j[wid * 2 + 0] = 10.0
@@ -203,18 +204,18 @@ class Example:
         # Declare a PyTorch data interface for the current state and controls data
         self.states: CartpoleStates | None = None
         self.actions: CartpoleActions | None = None
-        self.world_mask_wp: wp.array | None = None
+        self.world_mask_wp: wp.array[wp.float32] | None = None
         self.world_mask_pt: torch.Tensor | None = None
 
         # Set default default reset joint coordinates
         _q_j_ref = [0.0, 0.0]
         q_j_ref = np.tile(_q_j_ref, reps=self.sim.model.size.num_worlds)
-        self.q_j_ref: wp.array = wp.array(q_j_ref, dtype=float32, device=self.device)
+        self.q_j_ref: wp.array[wp.float32] = wp.array(q_j_ref, dtype=wp.float32, device=self.device)
 
         # Set default default reset joint velocities
         _dq_j_ref = [0.0, 0.0]
         dq_j_ref = np.tile(_dq_j_ref, reps=self.sim.model.size.num_worlds)
-        self.dq_j_ref: wp.array = wp.array(dq_j_ref, dtype=float32, device=self.device)
+        self.dq_j_ref: wp.array[wp.float32] = wp.array(dq_j_ref, dtype=wp.float32, device=self.device)
 
         # Initialize RL interfaces
         self.make_rl_interface()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -11,7 +11,6 @@ import newton
 import newton.examples
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.joints import JointActuationType
-from newton._src.solvers.kamino._src.core.types import float32, int32
 from newton._src.solvers.kamino._src.linalg.linear import LinearSolverTypeToName as LinearSolverShorthand
 from newton._src.solvers.kamino._src.models.builders.utils import (
     add_ground_box,
@@ -39,23 +38,23 @@ wp.set_module_options({"enable_backward": False})
 @wp.kernel
 def _pd_control_callback(
     # Inputs:
-    decimation: int32,
-    model_info_joint_actuated_coords_offset: wp.array[int32],
-    model_info_joint_actuated_dofs_offset: wp.array[int32],
-    model_joints_wid: wp.array[int32],
-    model_joints_act_type: wp.array[int32],
-    model_joint_coords_offset: wp.array[int32],
-    model_joint_dofs_offset: wp.array[int32],
-    model_joint_actuated_coords_offset: wp.array[int32],
-    model_joint_actuated_dofs_offset: wp.array[int32],
-    data_time_steps: wp.array[int32],
-    animation_frame: wp.array[int32],
-    animation_q_j_ref: wp.array2d[float32],
-    animation_dq_j_ref: wp.array2d[float32],
+    decimation: wp.int32,
+    model_info_joint_actuated_coords_offset: wp.array[wp.int32],
+    model_info_joint_actuated_dofs_offset: wp.array[wp.int32],
+    model_joints_wid: wp.array[wp.int32],
+    model_joints_act_type: wp.array[wp.int32],
+    model_joint_coords_offset: wp.array[wp.int32],
+    model_joint_dofs_offset: wp.array[wp.int32],
+    model_joint_actuated_coords_offset: wp.array[wp.int32],
+    model_joint_actuated_dofs_offset: wp.array[wp.int32],
+    data_time_steps: wp.array[wp.int32],
+    animation_frame: wp.array[wp.int32],
+    animation_q_j_ref: wp.array2d[wp.float32],
+    animation_dq_j_ref: wp.array2d[wp.float32],
     # Outputs:
-    control_q_j_ref: wp.array[float32],
-    control_dq_j_ref: wp.array[float32],
-    control_tau_j_ref: wp.array[float32],
+    control_q_j_ref: wp.array[wp.float32],
+    control_dq_j_ref: wp.array[wp.float32],
+    control_tau_j_ref: wp.array[wp.float32],
 ):
     """
     A kernel to compute joint-space PID control outputs for force-actuated joints.
@@ -112,7 +111,7 @@ def pd_control_callback(sim: Simulator, animation: AnimationJointReference, deci
         dim=sim.model.size.sum_of_num_joints,
         inputs=[
             # Inputs
-            int32(decimation),
+            wp.int32(decimation),
             sim.model.info.joint_actuated_coords_offset,
             sim.model.info.joint_actuated_dofs_offset,
             sim.model.joints.wid,

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -654,7 +654,7 @@ class SolverKamino(SolverBase):
     def reset(
         self,
         state: State,
-        world_mask: wp.array | None = None,
+        world_mask: wp.array[wp.bool] | None = None,
         flags: StateFlags | int | None = None,
         *,
         config: SolverKamino.ResetConfig | None = None,
@@ -674,7 +674,7 @@ class SolverKamino(SolverBase):
             state: The simulation state to reset (modified in place).
             world_mask: Optional array of per-world masks indicating which
                 worlds should be reset.
-                Shape of ``(num_worlds,)`` and type :class:`wp.int8` | :class:`wp.bool`.
+                Shape of ``(num_worlds,)``.
             flags: Optional :class:`~newton.StateFlags` or ``int`` bitmask controlling
                 which state attributes need to be reset.  If ``None``, all
                 state attributes are reset.
@@ -730,7 +730,7 @@ class SolverKamino(SolverBase):
         # Cache fields excluded from the reset op, to restore them afterwards
         restore_after_reset: list[tuple[wp.array, wp.array]] = []
 
-        def _preserve_if_unset(array: wp.array | None, flag: int) -> None:
+        def _preserve_if_unset(array: wp.array[Any] | None, flag: int) -> None:
             if array is not None and not (state_flags & flag):
                 restore_after_reset.append((array, wp.clone(array, device=array.device)))
 

--- a/newton/_src/solvers/kamino/tests/test_core_builder.py
+++ b/newton/_src/solvers/kamino/tests/test_core_builder.py
@@ -10,6 +10,7 @@ import unittest
 import numpy as np
 import warp as wp
 
+from newton._src.core.types import Axis
 from newton._src.solvers.kamino._src.core.bodies import RigidBodyDescriptor
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.geometry import GeometryDescriptor
@@ -22,7 +23,6 @@ from newton._src.solvers.kamino._src.core.joints import JointActuationType, Join
 from newton._src.solvers.kamino._src.core.materials import MaterialDescriptor
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.shapes import SphereShape
-from newton._src.solvers.kamino._src.core.types import Axis, mat33f, transformf, vec6f
 from newton._src.solvers.kamino._src.models.builders import basics
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -208,9 +208,9 @@ class TestModelBuilder(unittest.TestCase):
         bid = builder.add_rigid_body(
             name="test_rigid_body",
             m_i=1.0,
-            i_I_i=mat33f(np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
             world_index=wid,
         )
 
@@ -221,7 +221,7 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(builder.bodies[wid][bid].wid, wid)
         self.assertEqual(builder.bodies[wid][bid].m_i, 1.0)
         np.testing.assert_array_equal(builder.bodies[wid][bid].i_I_i, np.eye(3, dtype=np.float32).flatten())
-        np.testing.assert_array_equal(builder.bodies[wid][bid].q_i_0, np.array(transformf(), dtype=np.float32))
+        np.testing.assert_array_equal(builder.bodies[wid][bid].q_i_0, np.array(wp.transformf(), dtype=np.float32))
         np.testing.assert_array_equal(builder.bodies[wid][bid].u_i_0, np.zeros(6, dtype=np.float32))
 
     def test_04_add_rigid_body_descriptor(self):
@@ -231,9 +231,9 @@ class TestModelBuilder(unittest.TestCase):
         body = RigidBodyDescriptor(
             name="test_rigid_body",
             m_i=2.0,
-            i_I_i=mat33f(2.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(2.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         bid = builder.add_rigid_body_descriptor(body, world_index=wid)
 
@@ -244,7 +244,7 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(builder.bodies[wid][bid].wid, wid)
         self.assertEqual(builder.bodies[wid][bid].m_i, 2.0)
         np.testing.assert_array_equal(builder.bodies[wid][bid].i_I_i, 2.0 * np.eye(3, dtype=np.float32).flatten())
-        np.testing.assert_array_equal(builder.bodies[wid][bid].q_i_0, np.array(transformf(), dtype=np.float32))
+        np.testing.assert_array_equal(builder.bodies[wid][bid].q_i_0, np.array(wp.transformf(), dtype=np.float32))
         np.testing.assert_array_equal(builder.bodies[wid][bid].u_i_0, np.zeros(6, dtype=np.float32))
 
     def test_05_add_duplicate_rigid_body(self):
@@ -254,9 +254,9 @@ class TestModelBuilder(unittest.TestCase):
         body_0 = RigidBodyDescriptor(
             name="test_rigid_body",
             m_i=2.0,
-            i_I_i=mat33f(2.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(2.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         builder.add_rigid_body_descriptor(body_0, world_index=wid)
 
@@ -271,16 +271,16 @@ class TestModelBuilder(unittest.TestCase):
         body_0 = RigidBodyDescriptor(
             name="test_rigid_body_0",
             m_i=2.0,
-            i_I_i=mat33f(2.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(2.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         body_1 = RigidBodyDescriptor(
             name="test_rigid_body_1",
             m_i=1.0,
-            i_I_i=mat33f(1.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(1.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         bid_0 = builder.add_rigid_body_descriptor(body_0, world_index=wid)
         bid_1 = builder.add_rigid_body_descriptor(body_1, world_index=wid)
@@ -321,16 +321,16 @@ class TestModelBuilder(unittest.TestCase):
         body_0 = RigidBodyDescriptor(
             name="test_rigid_body_0",
             m_i=2.0,
-            i_I_i=mat33f(2.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(2.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         body_1 = RigidBodyDescriptor(
             name="test_rigid_body_1",
             m_i=1.0,
-            i_I_i=mat33f(1.0 * np.eye(3, dtype=np.float32)),
-            q_i_0=transformf(),
-            u_i_0=vec6f(),
+            i_I_i=wp.mat33f(1.0 * np.eye(3, dtype=np.float32)),
+            q_i_0=wp.transformf(),
+            u_i_0=wp.spatial_vectorf(),
         )
         bid_0 = builder.add_rigid_body_descriptor(body_0, world_index=wid)
         bid_1 = builder.add_rigid_body_descriptor(body_1, world_index=wid)

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -1109,7 +1109,7 @@ class TestModelConversions(unittest.TestCase):
         state_newton_converted: State = StateKamino.to_newton(model_newton, state_kamino_converted)
         self.assertIsInstance(state_newton_converted.body_q, wp.array)
         self.assertEqual(state_newton_converted.body_q.size, model_newton.body_count)
-        # NOTE: Check ptr due to conversion from vec6f
+        # NOTE: Check ptr due to conversion from wp.spatial_vectorf
         self.assertIs(state_newton_converted.body_qd.ptr, state_kamino_converted.u_i.ptr)
         self.assertIs(state_newton_converted.body_f.ptr, state_kamino_converted.w_i_e.ptr)
         self.assertIs(state_newton_converted.body_f_total.ptr, state_kamino_converted.w_i.ptr)

--- a/newton/_src/solvers/kamino/tests/test_core_types.py
+++ b/newton/_src/solvers/kamino/tests/test_core_types.py
@@ -8,7 +8,7 @@ Tests for the ``to_warp_int32_array`` and ``assign_to_warp_int32_array``
 helpers in :mod:`newton._src.solvers.kamino._src.core.types`.
 
 These helpers exist to catch silent overflow when converting Python or NumPy
-integer data to a Warp ``int32`` array. Direct ``wp.array(np_int64_arr,
+integer data to a Warp ``wp.int32`` array. Direct ``wp.array(np_int64_arr,
 dtype=wp.int32)`` and ``wp_int32_array.assign(np_int64_arr)`` silently
 truncate; the helpers raise :class:`OverflowError` instead.
 """

--- a/newton/_src/solvers/kamino/tests/test_geometry_contacts.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_contacts.py
@@ -16,7 +16,6 @@ import warp as wp
 import newton
 from newton._src.sim import Model, ModelBuilder, State
 from newton._src.sim.contacts import Contacts
-from newton._src.solvers.kamino._src.core.types import int32, mat33f, vec3f
 from newton._src.solvers.kamino._src.geometry.contacts import (
     ContactMode,
     ContactsKamino,
@@ -196,9 +195,9 @@ def build_dynamic_static_sphere_scene(
 @wp.kernel
 def _compute_contact_frame_znorm(
     # Inputs:
-    normal: wp.array[vec3f],
+    normal: wp.array[wp.vec3f],
     # Outputs:
-    frame: wp.array[mat33f],
+    frame: wp.array[wp.mat33f],
 ):
     tid = wp.tid()
     frame[tid] = make_contact_frame_znorm(normal[tid])
@@ -207,9 +206,9 @@ def _compute_contact_frame_znorm(
 @wp.kernel
 def _compute_contact_frame_xnorm(
     # Inputs:
-    normal: wp.array[vec3f],
+    normal: wp.array[wp.vec3f],
     # Outputs:
-    frame: wp.array[mat33f],
+    frame: wp.array[wp.mat33f],
 ):
     tid = wp.tid()
     frame[tid] = make_contact_frame_xnorm(normal[tid])
@@ -218,9 +217,9 @@ def _compute_contact_frame_xnorm(
 @wp.kernel
 def _compute_contact_mode(
     # Inputs:
-    velocity: wp.array[vec3f],
+    velocity: wp.array[wp.vec3f],
     # Outputs:
-    mode: wp.array[int32],
+    mode: wp.array[wp.int32],
 ):
     tid = wp.tid()
     mode[tid] = wp.static(ContactMode.make_compute_mode_func())(velocity[tid])
@@ -231,7 +230,7 @@ def _compute_contact_mode(
 ###
 
 
-def compute_contact_frame_znorm(normal: wp.array, frame: wp.array, num_threads: int = 1):
+def compute_contact_frame_znorm(normal: wp.array[wp.vec3f], frame: wp.array[wp.mat33f], num_threads: int = 1):
     wp.launch(
         _compute_contact_frame_znorm,
         dim=num_threads,
@@ -241,7 +240,7 @@ def compute_contact_frame_znorm(normal: wp.array, frame: wp.array, num_threads: 
     )
 
 
-def compute_contact_frame_xnorm(normal: wp.array, frame: wp.array, num_threads: int = 1):
+def compute_contact_frame_xnorm(normal: wp.array[wp.vec3f], frame: wp.array[wp.mat33f], num_threads: int = 1):
     wp.launch(
         _compute_contact_frame_xnorm,
         dim=num_threads,
@@ -251,7 +250,7 @@ def compute_contact_frame_xnorm(normal: wp.array, frame: wp.array, num_threads: 
     )
 
 
-def compute_contact_mode(velocity: wp.array, mode: wp.array, num_threads: int = 1):
+def compute_contact_mode(velocity: wp.array[wp.vec3f], mode: wp.array[wp.int32], num_threads: int = 1):
     wp.launch(
         _compute_contact_mode,
         dim=num_threads,
@@ -326,19 +325,19 @@ class TestGeometryContactFrames(unittest.TestCase):
 
     def test_01_make_contact_frame_znorm(self):
         # Create a normal vectors
-        test_normals: list[vec3f] = []
+        test_normals: list[wp.vec3f] = []
 
         # Add normals for which to test contact frame creation
-        test_normals.append(vec3f(1.0, 0.0, 0.0))
-        test_normals.append(vec3f(0.0, 1.0, 0.0))
-        test_normals.append(vec3f(0.0, 0.0, 1.0))
-        test_normals.append(vec3f(-1.0, 0.0, 0.0))
-        test_normals.append(vec3f(0.0, -1.0, 0.0))
-        test_normals.append(vec3f(0.0, 0.0, -1.0))
+        test_normals.append(wp.vec3f(1.0, 0.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 1.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 0.0, 1.0))
+        test_normals.append(wp.vec3f(-1.0, 0.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, -1.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 0.0, -1.0))
 
         # Create the input output arrays
-        normals = wp.array(test_normals, dtype=vec3f, device=self.default_device)
-        frames = wp.zeros(shape=(len(test_normals),), dtype=mat33f, device=self.default_device)
+        normals = wp.array(test_normals, dtype=wp.vec3f, device=self.default_device)
+        frames = wp.zeros(shape=(len(test_normals),), dtype=wp.mat33f, device=self.default_device)
 
         # Compute the contact frames
         compute_contact_frame_znorm(normal=normals, frame=frames, num_threads=len(test_normals))
@@ -376,19 +375,19 @@ class TestGeometryContactFrames(unittest.TestCase):
 
     def test_02_make_contact_frame_xnorm(self):
         # Create a normal vectors
-        test_normals: list[vec3f] = []
+        test_normals: list[wp.vec3f] = []
 
         # Add normals for which to test contact frame creation
-        test_normals.append(vec3f(1.0, 0.0, 0.0))
-        test_normals.append(vec3f(0.0, 1.0, 0.0))
-        test_normals.append(vec3f(0.0, 0.0, 1.0))
-        test_normals.append(vec3f(-1.0, 0.0, 0.0))
-        test_normals.append(vec3f(0.0, -1.0, 0.0))
-        test_normals.append(vec3f(0.0, 0.0, -1.0))
+        test_normals.append(wp.vec3f(1.0, 0.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 1.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 0.0, 1.0))
+        test_normals.append(wp.vec3f(-1.0, 0.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, -1.0, 0.0))
+        test_normals.append(wp.vec3f(0.0, 0.0, -1.0))
 
         # Create the input output arrays
-        normals = wp.array(test_normals, dtype=vec3f, device=self.default_device)
-        frames = wp.zeros(shape=(len(test_normals),), dtype=mat33f, device=self.default_device)
+        normals = wp.array(test_normals, dtype=wp.vec3f, device=self.default_device)
+        frames = wp.zeros(shape=(len(test_normals),), dtype=wp.mat33f, device=self.default_device)
 
         # Compute the contact frames
         compute_contact_frame_xnorm(normal=normals, frame=frames, num_threads=len(test_normals))
@@ -425,8 +424,8 @@ class TestGeometryContactMode(unittest.TestCase):
             msg.reset_log_level()
 
     def test_01_contact_mode_opening(self):
-        v_input = wp.array([vec3f(0.0, 0.0, 0.01)], dtype=vec3f, device=self.default_device)
-        mode_output = wp.zeros(shape=(1,), dtype=int32, device=self.default_device)
+        v_input = wp.array([wp.vec3f(0.0, 0.0, 0.01)], dtype=wp.vec3f, device=self.default_device)
+        mode_output = wp.zeros(shape=(1,), dtype=wp.int32, device=self.default_device)
         compute_contact_mode(velocity=v_input, mode=mode_output, num_threads=1)
         mode_int32 = mode_output.numpy()[0]
         mode = ContactMode(int(mode_int32))
@@ -434,8 +433,8 @@ class TestGeometryContactMode(unittest.TestCase):
         self.assertEqual(mode, ContactMode.OPENING)
 
     def test_02_contact_mode_sticking(self):
-        v_input = wp.array([vec3f(0.0, 0.0, 1e-7)], dtype=vec3f, device=self.default_device)
-        mode_output = wp.zeros(shape=(1,), dtype=int32, device=self.default_device)
+        v_input = wp.array([wp.vec3f(0.0, 0.0, 1e-7)], dtype=wp.vec3f, device=self.default_device)
+        mode_output = wp.zeros(shape=(1,), dtype=wp.int32, device=self.default_device)
         compute_contact_mode(velocity=v_input, mode=mode_output, num_threads=1)
         mode_int32 = mode_output.numpy()[0]
         mode = ContactMode(int(mode_int32))
@@ -443,8 +442,8 @@ class TestGeometryContactMode(unittest.TestCase):
         self.assertEqual(mode, ContactMode.STICKING)
 
     def test_03_contact_mode_slipping(self):
-        v_input = wp.array([vec3f(0.1, 0.0, 0.0)], dtype=vec3f, device=self.default_device)
-        mode_output = wp.zeros(shape=(1,), dtype=int32, device=self.default_device)
+        v_input = wp.array([wp.vec3f(0.1, 0.0, 0.0)], dtype=wp.vec3f, device=self.default_device)
+        mode_output = wp.zeros(shape=(1,), dtype=wp.int32, device=self.default_device)
         compute_contact_mode(velocity=v_input, mode=mode_output, num_threads=1)
         mode_int32 = mode_output.numpy()[0]
         mode = ContactMode(int(mode_int32))

--- a/newton/_src/solvers/kamino/tests/test_geometry_keying.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_keying.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import int32, uint32, uint64
 from newton._src.solvers.kamino._src.geometry.keying import (
     KeySorter,
     binary_search_find_pair,
@@ -93,7 +92,9 @@ class TestPairKeyOps(unittest.TestCase):
 
         # Define a Warp kernel to test build_pair_key2
         @wp.kernel
-        def _test_kernel_build_pair_key2(index_A: wp.array[uint32], index_B: wp.array[uint32], key: wp.array[uint64]):
+        def _test_kernel_build_pair_key2(
+            index_A: wp.array[wp.uint32], index_B: wp.array[wp.uint32], key: wp.array[wp.uint64]
+        ):
             tid = wp.tid()
             key[tid] = build_pair_key2(index_A[tid], index_B[tid])
 
@@ -112,9 +113,9 @@ class TestPairKeyOps(unittest.TestCase):
 
         # Create Warp arrays for inputs and outputs
         with wp.ScopedDevice(device=self.default_device):
-            index_A = wp.array([index_A for index_A, _ in test_cases], dtype=uint32)
-            index_B = wp.array([index_B for _, index_B in test_cases], dtype=uint32)
-            keys = wp.zeros(num_test_cases, dtype=uint64)
+            index_A = wp.array([index_A for index_A, _ in test_cases], dtype=wp.uint32)
+            index_B = wp.array([index_B for _, index_B in test_cases], dtype=wp.uint32)
+            keys = wp.zeros(num_test_cases, dtype=wp.uint64)
         msg.info("Inputs: index_A: %s", index_A)
         msg.info("Inputs: index_B: %s", index_B)
         msg.info("Inputs: keys: %s", keys)
@@ -149,10 +150,10 @@ class TestPairKeyOps(unittest.TestCase):
             # Generate the test kernel for the specified build_pair_key3 function
             @wp.kernel
             def _test_kernel_build_pair_key3(
-                index_A: wp.array[uint32],
-                index_B: wp.array[uint32],
-                index_C: wp.array[uint32],
-                key: wp.array[uint64],
+                index_A: wp.array[wp.uint32],
+                index_B: wp.array[wp.uint32],
+                index_C: wp.array[wp.uint32],
+                key: wp.array[wp.uint64],
             ):
                 tid = wp.tid()
                 key[tid] = build_pair_key3(index_A[tid], index_B[tid], index_C[tid])
@@ -174,10 +175,10 @@ class TestPairKeyOps(unittest.TestCase):
 
         # Create Warp arrays for inputs and outputs
         with wp.ScopedDevice(device=self.default_device):
-            index_A = wp.array([index_A for index_A, _, _ in test_cases], dtype=uint32)
-            index_B = wp.array([index_B for _, index_B, _ in test_cases], dtype=uint32)
-            index_C = wp.array([index_C for *_, index_C in test_cases], dtype=uint32)
-            keys = wp.zeros(num_test_cases, dtype=uint64)
+            index_A = wp.array([index_A for index_A, _, _ in test_cases], dtype=wp.uint32)
+            index_B = wp.array([index_B for _, index_B, _ in test_cases], dtype=wp.uint32)
+            index_C = wp.array([index_C for *_, index_C in test_cases], dtype=wp.uint32)
+            keys = wp.zeros(num_test_cases, dtype=wp.uint64)
         msg.info("Inputs: index_A: %s", index_A)
         msg.info("Inputs: index_B: %s", index_B)
         msg.info("Inputs: index_C: %s", index_C)
@@ -252,7 +253,7 @@ class TestBinarySearchOps(unittest.TestCase):
         @wp.kernel
         def _test_kernel_binary_search_find_pair(
             # Inputs:
-            num_active_pairs: wp.array[int32],
+            num_active_pairs: wp.array[wp.int32],
             all_pairs: wp.array[wp.vec2i],
             target_pair: wp.array[wp.vec2i],
             # Output:
@@ -303,21 +304,23 @@ class TestBinarySearchOps(unittest.TestCase):
         @wp.kernel
         def _test_kernel_binary_search_find_range_start(
             # Inputs:
-            num_active_keys: wp.array[int32],
-            all_keys: wp.array[uint64],
-            target_key: wp.array[uint64],
+            num_active_keys: wp.array[wp.int32],
+            all_keys: wp.array[wp.uint64],
+            target_key: wp.array[wp.uint64],
             # Output:
-            target_start: wp.array[int32],
+            target_start: wp.array[wp.int32],
         ):
             tid = wp.tid()
-            target_start[tid] = binary_search_find_range_start(int32(0), num_active_keys[0], target_key[tid], all_keys)
+            target_start[tid] = binary_search_find_range_start(
+                wp.int32(0), num_active_keys[0], target_key[tid], all_keys
+            )
 
         # Define sorted array of unique integer keys with some inactive dummy keys at the end
         keys_list = [0, 1, 1, 3, 5, 5, 9, 11, 11, 0, 0, 0, 0]
         num_all_keys = len(keys_list)
         with wp.ScopedDevice(device=self.default_device):
-            keys = wp.array(keys_list, dtype=uint64)
-            num_active_keys = wp.array([9], dtype=int32)  # Only first 9 keys are active
+            keys = wp.array(keys_list, dtype=wp.uint64)
+            num_active_keys = wp.array([9], dtype=wp.int32)  # Only first 9 keys are active
         msg.info("keys:\n%s", keys)
         msg.info("num_active_keys: %s", num_active_keys)
         msg.info("num_all_keys: %s", num_all_keys)
@@ -327,8 +330,8 @@ class TestBinarySearchOps(unittest.TestCase):
         expected_range_start_idxs = [1, 4, 7, -1, 6, -1]  # Expected start indices or -1 if not found
         num_target_elements = len(target_keys_list)
         with wp.ScopedDevice(device=self.default_device):
-            target_keys = wp.array(target_keys_list, dtype=uint64)
-            target_start_idxs = wp.zeros(num_target_elements, dtype=int32)
+            target_keys = wp.array(target_keys_list, dtype=wp.uint64)
+            target_start_idxs = wp.zeros(num_target_elements, dtype=wp.int32)
         msg.info("target_keys:\n%s", target_keys)
         msg.info("expected_range_start_idxs: %s", expected_range_start_idxs)
 
@@ -395,9 +398,9 @@ class TestKeySorter(unittest.TestCase):
         # Generate random keys
         sentinel = make_bitmask(64)
         num_active_keys_const = 8
-        num_active_keys = wp.array([num_active_keys_const], dtype=int32, device=self.default_device)
+        num_active_keys = wp.array([num_active_keys_const], dtype=wp.int32, device=self.default_device)
         keys_list = [5, 3, 9, 1, 7, 3, 5, 11, sentinel, sentinel]
-        keys = wp.array(keys_list, dtype=uint64, device=self.default_device)
+        keys = wp.array(keys_list, dtype=wp.uint64, device=self.default_device)
         msg.info("num_active_keys: %s", num_active_keys)
         msg.info("keys: %s", keys)
 
@@ -440,10 +443,10 @@ class TestKeySorter(unittest.TestCase):
 
         # Generate random keys
         num_active_keys_const = 8
-        num_active_keys = wp.array([num_active_keys_const], dtype=int32, device=self.default_device)
+        num_active_keys = wp.array([num_active_keys_const], dtype=wp.int32, device=self.default_device)
         random_keys_np = rng.integers(low=0, high=100, size=max_num_keys, dtype=np.uint64)
         random_keys_np[-2:] = make_bitmask(63)  # Set last two keys to sentinel value
-        random_keys = wp.array(random_keys_np, dtype=uint64, device=self.default_device)
+        random_keys = wp.array(random_keys_np, dtype=wp.uint64, device=self.default_device)
         msg.info("num_active_keys: %s", num_active_keys)
         msg.info("random_keys: %s", random_keys)
 

--- a/newton/_src/solvers/kamino/tests/test_geometry_margin_gap.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_margin_gap.py
@@ -19,7 +19,6 @@ from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.joints import JointActuationType, JointDoFType
 from newton._src.solvers.kamino._src.core.math import I_3
 from newton._src.solvers.kamino._src.core.shapes import BoxShape, SphereShape
-from newton._src.solvers.kamino._src.core.types import mat33f, transformf, vec3f, vec6f
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
 from newton._src.solvers.kamino._src.geometry.detector import CollisionDetector
 from newton._src.solvers.kamino._src.geometry.primitive import CollisionPipelinePrimitive
@@ -45,14 +44,14 @@ def _make_sphere_pair_builder(
     bid0 = builder.add_rigid_body(
         name="bottom_sphere",
         m_i=1.0,
-        i_I_i=mat33f(np.eye(3, dtype=np.float32)),
-        q_i_0=transformf(vec3f(0.0, 0.0, -radius - 0.5 * distance), wp.quat_identity()),
+        i_I_i=wp.mat33f(np.eye(3, dtype=np.float32)),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, -radius - 0.5 * distance), wp.quat_identity()),
     )
     bid1 = builder.add_rigid_body(
         name="top_sphere",
         m_i=1.0,
-        i_I_i=mat33f(np.eye(3, dtype=np.float32)),
-        q_i_0=transformf(vec3f(0.0, 0.0, radius + 0.5 * distance), wp.quat_identity()),
+        i_I_i=wp.mat33f(np.eye(3, dtype=np.float32)),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, radius + 0.5 * distance), wp.quat_identity()),
     )
     builder.add_geometry(body=bid0, name="bottom", shape=SphereShape(radius), margin=margin_bottom, gap=gap_bottom)
     builder.add_geometry(body=bid1, name="top", shape=SphereShape(radius), margin=margin_top, gap=gap_top)
@@ -294,8 +293,8 @@ def _build_sphere_on_ground(
         name="sphere",
         m_i=1.0,
         i_I_i=I_3,
-        q_i_0=transformf(vec3f(0.0, 0.0, sphere_z), wp.quat_identity()),
-        u_i_0=vec6f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        q_i_0=wp.transformf(wp.vec3f(0.0, 0.0, sphere_z), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
     )
     builder.add_joint(
         name="world_to_sphere",
@@ -303,8 +302,8 @@ def _build_sphere_on_ground(
         act_type=JointActuationType.FORCE,
         bid_B=-1,
         bid_F=bid,
-        B_r_Bj=vec3f(0.0, 0.0, sphere_z),
-        F_r_Fj=vec3f(0.0, 0.0, 0.0),
+        B_r_Bj=wp.vec3f(0.0, 0.0, sphere_z),
+        F_r_Fj=wp.vec3f(0.0, 0.0, 0.0),
         X_Bj=I_3,
     )
     builder.add_geometry(
@@ -318,7 +317,7 @@ def _build_sphere_on_ground(
         body=-1,
         name="ground",
         shape=BoxShape(2.0, 2.0, GROUND_HALF_H),
-        offset=transformf(vec3f(0.0, 0.0, 0.0), wp.quat_identity()),
+        offset=wp.transformf(wp.vec3f(0.0, 0.0, 0.0), wp.quat_identity()),
         margin=margin,
         gap=gap,
     )

--- a/newton/_src/solvers/kamino/tests/test_geometry_primitive.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_primitive.py
@@ -12,7 +12,7 @@ from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.state import StateKamino
-from newton._src.solvers.kamino._src.core.types import float32, int32, vec6f
+from newton._src.solvers.kamino._src.core.types import vec6f
 from newton._src.solvers.kamino._src.geometry.contacts import DEFAULT_GEOM_PAIR_CONTACT_GAP, ContactsKamino
 from newton._src.solvers.kamino._src.geometry.primitive import (
     BoundingVolumeType,
@@ -93,22 +93,22 @@ class PrimitiveBroadPhaseTestBS:
         # Allocate the collision model data
         with wp.ScopedDevice(model.device):
             # Allocate the bounding volumes data
-            self.bvdata = BoundingVolumesData(radius=wp.zeros(shape=(num_geoms,), dtype=float32))
+            self.bvdata = BoundingVolumesData(radius=wp.zeros(shape=(num_geoms,), dtype=wp.float32))
             # Allocate the time-invariant collision candidates model
             self._cmodel = CollisionCandidatesModel(
                 num_model_geom_pairs=model.geoms.num_collidable_pairs,
                 num_world_geom_pairs=world_num_geom_pairs,
-                model_num_pairs=wp.array([model.geoms.num_collidable_pairs], dtype=int32),
-                world_num_pairs=wp.array(world_num_geom_pairs, dtype=int32),
-                wid=wp.array(model_wid, dtype=int32),
+                model_num_pairs=wp.array([model.geoms.num_collidable_pairs], dtype=wp.int32),
+                world_num_pairs=wp.array(world_num_geom_pairs, dtype=wp.int32),
+                wid=wp.array(model_wid, dtype=wp.int32),
                 geom_pair=model.geoms.collidable_pairs,
             )
             # Allocate the time-varying collision candidates data
             self._cdata = CollisionCandidatesData(
                 num_model_geom_pairs=model.geoms.num_collidable_pairs,
-                model_num_collisions=wp.zeros(shape=(1,), dtype=int32),
-                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=int32),
-                wid=wp.zeros(shape=(model.geoms.num_collidable_pairs,), dtype=int32),
+                model_num_collisions=wp.zeros(shape=(1,), dtype=wp.int32),
+                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=wp.int32),
+                wid=wp.zeros(shape=(model.geoms.num_collidable_pairs,), dtype=wp.int32),
                 geom_pair=wp.zeros_like(model.geoms.collidable_pairs),
             )
 
@@ -133,17 +133,17 @@ class PrimitiveBroadPhaseTestAABB:
             self._cmodel = CollisionCandidatesModel(
                 num_model_geom_pairs=model.geoms.num_collidable_pairs,
                 num_world_geom_pairs=world_num_geom_pairs,
-                model_num_pairs=wp.array([model.geoms.num_collidable_pairs], dtype=int32),
-                world_num_pairs=wp.array(world_num_geom_pairs, dtype=int32),
-                wid=wp.array(model_wid, dtype=int32),
+                model_num_pairs=wp.array([model.geoms.num_collidable_pairs], dtype=wp.int32),
+                world_num_pairs=wp.array(world_num_geom_pairs, dtype=wp.int32),
+                wid=wp.array(model_wid, dtype=wp.int32),
                 geom_pair=model.geoms.collidable_pairs,
             )
             # Allocate the time-varying collision candidates data
             self._cdata = CollisionCandidatesData(
                 num_model_geom_pairs=model.geoms.num_collidable_pairs,
-                model_num_collisions=wp.zeros(shape=(1,), dtype=int32),
-                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=int32),
-                wid=wp.zeros(shape=(model.geoms.num_collidable_pairs,), dtype=int32),
+                model_num_collisions=wp.zeros(shape=(1,), dtype=wp.int32),
+                world_num_collisions=wp.zeros(shape=(num_worlds,), dtype=wp.int32),
+                wid=wp.zeros(shape=(model.geoms.num_collidable_pairs,), dtype=wp.int32),
                 geom_pair=wp.zeros_like(model.geoms.collidable_pairs),
             )
 

--- a/newton/_src/solvers/kamino/tests/test_geometry_unified.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_unified.py
@@ -18,7 +18,6 @@ from newton._src.solvers.kamino._src.core.math import I_3
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.shapes import SphereShape
 from newton._src.solvers.kamino._src.core.state import StateKamino
-from newton._src.solvers.kamino._src.core.types import transformf, vec6f
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
 from newton._src.solvers.kamino._src.geometry.unified import CollisionPipelineUnifiedKamino
 from newton._src.solvers.kamino._src.models.builders import basics, testing
@@ -651,8 +650,8 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
         bid_a = builder.add_rigid_body(
             m_i=1.0,
             i_I_i=I_3,
-            q_i_0=transformf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),
-            u_i_0=vec6f(0.0),
+            q_i_0=wp.transformf(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0),
+            u_i_0=wp.spatial_vectorf(0.0),
         )
         if same_body:
             bid_b = bid_a
@@ -660,8 +659,8 @@ class TestUnifiedPipelineNxnBroadphase(unittest.TestCase):
             bid_b = builder.add_rigid_body(
                 m_i=1.0,
                 i_I_i=I_3,
-                q_i_0=transformf(0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
-                u_i_0=vec6f(0.0),
+                q_i_0=wp.transformf(0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+                u_i_0=wp.spatial_vectorf(0.0),
             )
         builder.add_geometry(body=bid_a, shape=SphereShape(radius=0.5), group=group_a, collides=collides_a)
         builder.add_geometry(body=bid_b, shape=SphereShape(radius=0.5), group=group_b, collides=collides_b)

--- a/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
@@ -12,7 +12,6 @@ import warp as wp
 from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.math import quat_exp, screw, screw_angular, screw_linear
 from newton._src.solvers.kamino._src.core.model import ModelKamino
-from newton._src.solvers.kamino._src.core.types import float32, int32, mat33f, transformf, vec3f, vec6f
 from newton._src.solvers.kamino._src.kinematics.joints import compute_joints_data
 from newton._src.solvers.kamino._src.models.builders.testing import build_unary_revolute_joint_test
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
@@ -32,9 +31,9 @@ wp.set_module_options({"enable_backward": False})
 Q_X_J = 0.5 * math.pi
 THETA_Y_J = 0.1
 THETA_Z_J = -0.2
-J_DR_J = vec3f(0.01, 0.02, 0.03)
-J_DV_J = vec3f(0.1, -0.2, 0.3)
-J_DOMEGA_J = vec3f(-1.0, 0.04, -0.05)
+J_DR_J = wp.vec3f(0.01, 0.02, 0.03)
+J_DV_J = wp.vec3f(0.1, -0.2, 0.3)
+J_DOMEGA_J = wp.vec3f(-1.0, 0.04, -0.05)
 
 # Compute revolute joint rotational residual: sin(angle) * axis
 ROT_RES_VEC = np.array([0.0, THETA_Y_J, THETA_Z_J])
@@ -48,13 +47,13 @@ ROT_RES = (np.sin(ROT_RES_ANGLE) / ROT_RES_ANGLE) * ROT_RES_VEC
 
 @wp.kernel
 def _set_joint_follower_body_state(
-    model_joint_bid_F: wp.array[int32],
-    model_joint_B_r_Bj: wp.array[vec3f],
-    model_joint_F_r_Fj: wp.array[vec3f],
-    model_joint_X_Bj: wp.array[mat33f],
-    model_joint_X_Fj: wp.array[mat33f],
-    state_body_q_i: wp.array[transformf],
-    state_body_u_i: wp.array[vec6f],
+    model_joint_bid_F: wp.array[wp.int32],
+    model_joint_B_r_Bj: wp.array[wp.vec3f],
+    model_joint_F_r_Fj: wp.array[wp.vec3f],
+    model_joint_X_Bj: wp.array[wp.mat33f],
+    model_joint_X_Fj: wp.array[wp.mat33f],
+    state_body_q_i: wp.array[wp.transformf],
+    state_body_u_i: wp.array[wp.spatial_vectorf],
 ):
     """
     Set the state of the bodies to a certain values in order to check computations of joint states.
@@ -70,8 +69,8 @@ def _set_joint_follower_body_state(
     X_Fj = model_joint_X_Fj[jid]
 
     # The base body is assumed to be at the origin with no rotation or twist
-    p_B = transformf(vec3f(0.0), wp.quat_identity())
-    u_B = vec6f(0.0)
+    p_B = wp.transformf(wp.vec3f(0.0), wp.quat_identity())
+    u_B = wp.spatial_vectorf(0.0)
     r_B = wp.transform_get_translation(p_B)
     q_B = wp.transform_get_rotation(p_B)
     R_B = wp.quat_to_matrix(q_B)
@@ -79,8 +78,8 @@ def _set_joint_follower_body_state(
     omega_B = screw_angular(u_B)
 
     # Define the joint rotation offset
-    j_dR_yz_j = vec3f(0.0, THETA_Y_J, THETA_Z_J)  # Joint residual as rotation vector
-    j_dR_x_j = vec3f(Q_X_J, 0.0, 0.0)  # Joint dof rotation as rotation vector
+    j_dR_yz_j = wp.vec3f(0.0, THETA_Y_J, THETA_Z_J)  # Joint residual as rotation vector
+    j_dR_x_j = wp.vec3f(Q_X_J, 0.0, 0.0)  # Joint dof rotation as rotation vector
     q_jq = quat_exp(j_dR_yz_j) * quat_exp(j_dR_x_j)  # Total joint offset
     R_jq = wp.quat_to_matrix(q_jq)  # Joint offset as rotation matrix
 
@@ -107,7 +106,7 @@ def _set_joint_follower_body_state(
     v_F_new = R_B_X_j @ j_dv_j + v_B + wp.cross(omega_B, r_Bj) - wp.cross(omega_F_new, r_Fj)
 
     # Offset the bose of the body by a fixed amount
-    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=float32)
+    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=wp.float32)
     state_body_u_i[bid_F] = screw(v_F_new, omega_F_new)
 
 

--- a/newton/_src/solvers/kamino/tests/test_kinematics_limits.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_limits.py
@@ -13,7 +13,6 @@ import warp as wp
 from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.math import quat_exp, screw, screw_angular, screw_linear
 from newton._src.solvers.kamino._src.core.model import ModelKamino
-from newton._src.solvers.kamino._src.core.types import float32, int32, mat33f, transformf, vec3f, vec6f
 from newton._src.solvers.kamino._src.kinematics.joints import compute_joints_data
 from newton._src.solvers.kamino._src.kinematics.limits import LimitsKamino
 from newton._src.solvers.kamino._src.models.builders import basics, testing
@@ -43,14 +42,14 @@ Q_X_J_MAX = 0.25 * math.pi
 
 @wp.kernel
 def _set_joint_follower_body_state(
-    model_joint_bid_B: wp.array[int32],
-    model_joint_bid_F: wp.array[int32],
-    model_joint_B_r_Bj: wp.array[vec3f],
-    model_joint_F_r_Fj: wp.array[vec3f],
-    model_joint_X_Bj: wp.array[mat33f],
-    model_joint_X_Fj: wp.array[mat33f],
-    state_body_q_i: wp.array[transformf],
-    state_body_u_i: wp.array[vec6f],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_bid_F: wp.array[wp.int32],
+    model_joint_B_r_Bj: wp.array[wp.vec3f],
+    model_joint_F_r_Fj: wp.array[wp.vec3f],
+    model_joint_X_Bj: wp.array[wp.mat33f],
+    model_joint_X_Fj: wp.array[wp.mat33f],
+    state_body_q_i: wp.array[wp.transformf],
+    state_body_u_i: wp.array[wp.spatial_vectorf],
 ):
     """
     Set the state of the bodies to a certain values in order to check computations of joint states.
@@ -83,16 +82,16 @@ def _set_joint_follower_body_state(
     q_x_j = Q_X_J
     theta_y_j = 0.0
     theta_z_j = 0.0
-    j_dR_j = vec3f(q_x_j, theta_y_j, theta_z_j)  # Joint offset as rotation vector
+    j_dR_j = wp.vec3f(q_x_j, theta_y_j, theta_z_j)  # Joint offset as rotation vector
     q_jq = quat_exp(j_dR_j)  # Joint offset as rotation quaternion
     R_jq = wp.quat_to_matrix(q_jq)  # Joint offset as rotation matrix
 
     # Define the joint translation offset
-    j_dr_j = vec3f(0.0)
+    j_dr_j = wp.vec3f(0.0)
 
     # Define the joint twist offset
-    j_dv_j = vec3f(0.0)
-    j_domega_j = vec3f(0.0)
+    j_dv_j = wp.vec3f(0.0)
+    j_domega_j = wp.vec3f(0.0)
 
     # Follower body rotation via the Base and joint frames
     R_B_X_j = R_B @ X_Bj
@@ -110,7 +109,7 @@ def _set_joint_follower_body_state(
     v_F_new = R_B_X_j @ j_dv_j + v_B + wp.cross(omega_B, r_Bj) - wp.cross(omega_F_new, r_Fj)
 
     # Offset the bose of the body by a fixed amount
-    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=float32)
+    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=wp.float32)
     state_body_u_i[bid_F] = screw(v_F_new, omega_F_new)
 
 

--- a/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
@@ -12,7 +12,6 @@ import numpy as np
 import warp as wp
 
 from newton._src.solvers.kamino._src.core.model import DataKamino, ModelKamino
-from newton._src.solvers.kamino._src.core.types import float32, transformf, vec6f
 from newton._src.solvers.kamino._src.kinematics.joints import JointCorrectionMode, compute_joints_data
 from newton._src.solvers.kamino._src.kinematics.resets import reset_joints_state_from_bodies_state, set_floating_base
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_fourbar
@@ -38,10 +37,10 @@ atol = 1e-5
 
 def assert_binary_joint_states_equal(
     model: ModelKamino,
-    joint_q: wp.array[float32],
-    joint_q_ref: wp.array[float32],
-    joint_u: wp.array[float32],
-    joint_u_ref: wp.array[float32],
+    joint_q: wp.array[wp.float32],
+    joint_q_ref: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
+    joint_u_ref: wp.array[wp.float32],
 ):
     """Check that joint coords/velocities match provided references, except possibly for unary joints."""
     # Build boolean mask for joint coords/dofs, excluding unary joints
@@ -62,10 +61,10 @@ def assert_binary_joint_states_equal(
 
 def assert_body_states_equal_masked(
     model: ModelKamino,
-    body_q: wp.array[transformf],
-    body_q_ref: wp.array[transformf],
-    body_u: wp.array[vec6f],
-    body_u_ref: wp.array[vec6f],
+    body_q: wp.array[wp.transformf],
+    body_q_ref: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
+    body_u_ref: wp.array[wp.spatial_vectorf],
     world_mask: wp.array[wp.bool],
 ):
     """Check that body poses/velocities match provided references for worlds where the mask is False."""
@@ -109,10 +108,10 @@ def assert_rigid_poses_close(
 
 def validate_base_pose_reset(
     model: ModelKamino,
-    base_q: wp.array[transformf] | None,
+    base_q: wp.array[wp.transformf] | None,
     data_prev: DataKamino,
     data_new: DataKamino,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Check that the result of set_floating_base() has the expected base pose
@@ -157,10 +156,10 @@ def validate_base_pose_reset(
 
 def validate_base_velocity_reset(
     model: ModelKamino,
-    base_u: wp.array[vec6f] | None,
+    base_u: wp.array[wp.spatial_vectorf] | None,
     data_prev: DataKamino,
     data_new: DataKamino,
-    world_mask: wp.array[bool],
+    world_mask: wp.array[wp.bool],
 ):
     """
     Check that the result of set_floating_base() has the expected base velocity (relative_base_u = False case)
@@ -220,9 +219,9 @@ def validate_base_velocity_reset(
 
 def run_set_floating_base_check(
     model: ModelKamino,
-    base_q: wp.array[transformf] | None,
-    base_u: wp.array[vec6f] | None,
-    world_mask: wp.array[bool],
+    base_q: wp.array[wp.transformf] | None,
+    base_u: wp.array[wp.spatial_vectorf] | None,
+    world_mask: wp.array[wp.bool],
     data_prev: DataKamino,
 ):
     """
@@ -304,16 +303,16 @@ def setup_test_fourbar_model(
 
 def sample_base_state_wp(model: ModelKamino, rng: np.random.Generator):
     base_q_np, base_u_np = sample_base_state(model.size.num_worlds, rng)
-    base_q = wp.from_numpy(base_q_np[0], dtype=transformf, device=model.device)
-    base_u = wp.from_numpy(base_u_np[0], dtype=vec6f, device=model.device)
+    base_q = wp.from_numpy(base_q_np[0], dtype=wp.transformf, device=model.device)
+    base_u = wp.from_numpy(base_u_np[0], dtype=wp.spatial_vectorf, device=model.device)
     return base_q, base_u
 
 
 def sample_actuator_state_wp(model: ModelKamino, rng: np.random.Generator):
     actuator_q_np = sample_actuator_coords(model, rng)[0]
     actuator_u_np = sample_actuator_velocities(model, rng)[0]
-    actuator_q = wp.from_numpy(actuator_q_np, dtype=float32, device=model.device)
-    actuator_u = wp.from_numpy(actuator_u_np, dtype=float32, device=model.device)
+    actuator_q = wp.from_numpy(actuator_q_np, dtype=wp.float32, device=model.device)
+    actuator_u = wp.from_numpy(actuator_u_np, dtype=wp.float32, device=model.device)
     return actuator_q, actuator_u
 
 
@@ -393,7 +392,7 @@ class TestSetFloatingBase(unittest.TestCase):
         data = set_model_to_random_pose(self, model, rng)
 
         # Sample non-trivial world mask and base state
-        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=bool, device=self.default_device)
+        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=wp.bool, device=self.default_device)
         base_q, base_u = sample_base_state_wp(model, rng)
 
         # Check validity of set_floating_base for all options combinations
@@ -418,7 +417,7 @@ class TestSetFloatingBase(unittest.TestCase):
         data = set_model_to_random_pose(self, model, rng)
 
         # Sample non-trivial world mask and base state
-        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=bool, device=self.default_device)
+        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=wp.bool, device=self.default_device)
         base_q, base_u = sample_base_state_wp(model, rng)
 
         # Check validity of set_floating_base for all options combinations
@@ -442,7 +441,7 @@ class TestSetFloatingBase(unittest.TestCase):
         data = set_model_to_random_pose(self, model, rng)
 
         # Sample non-trivial world mask and base state
-        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=bool, device=self.default_device)
+        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=wp.bool, device=self.default_device)
         base_q, base_u = sample_base_state_wp(model, rng)
 
         # Check that a call to set_floating_base() with relative_base_u enabled is equivalent
@@ -496,7 +495,7 @@ class TestSetFloatingBase(unittest.TestCase):
         data = set_model_to_random_pose(self, model, rng)
 
         # Sample non-trivial world mask and base state
-        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=bool, device=self.default_device)
+        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=wp.bool, device=self.default_device)
         base_q, base_u = sample_base_state_wp(model, rng)
 
         # Check that a call to set_floating_base() with relative_base_u enabled is equivalent
@@ -578,7 +577,7 @@ class TestJointBodyStateConversions(unittest.TestCase):
         state = model.state()
         wp.copy(state.q_i, data.bodies.q_i)
         wp.copy(state.u_i, data.bodies.u_i)
-        all_worlds_mask = wp.ones(shape=model.size.num_worlds, dtype=bool, device=model.device)
+        all_worlds_mask = wp.ones(shape=model.size.num_worlds, dtype=wp.bool, device=model.device)
         reset_joints_state_from_bodies_state(model, state, world_mask=all_worlds_mask)
 
         # Compare against joint state in joint data

--- a/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_blocked.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_blocked.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.linalg.core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
 from newton._src.solvers.kamino._src.linalg.factorize import (
     llt_blocked_factorize,
@@ -71,7 +70,7 @@ class TestLinAlgLLTBlocked(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -228,7 +227,7 @@ class TestLinAlgLLTBlocked(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -383,7 +382,7 @@ class TestLinAlgLLTBlocked(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)
@@ -552,7 +551,7 @@ class TestLinAlgLLTBlocked(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)

--- a/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_sequential.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_factorize_llt_sequential.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.linalg.core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
 from newton._src.solvers.kamino._src.linalg.factorize import (
     llt_sequential_factorize,
@@ -60,7 +59,7 @@ class TestLinAlgLLTSequential(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -213,7 +212,7 @@ class TestLinAlgLLTSequential(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -364,7 +363,7 @@ class TestLinAlgLLTSequential(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)
@@ -529,7 +528,7 @@ class TestLinAlgLLTSequential(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)

--- a/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.linalg.conjugate import (
     BatchedLinearOperator,
     CGSolver,
@@ -45,7 +44,7 @@ class TestLinalgConjugate(unittest.TestCase):
             **problem_params,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=device,
         )
 
@@ -53,14 +52,14 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Create operator with per-world maxdims
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=problem.maxdims, dtype=float32, device=device)
+        info.finalize(dimensions=problem.maxdims, dtype=wp.float32, device=device)
         info.dim = problem.dim_wp  # Override with actual active dimensions
         operator = DenseLinearOperatorData(info=info, mat=problem.A_wp)
         A = BatchedLinearOperator.from_dense(operator)
 
         # b and x are flat 1D arrays
         b_wp = problem.b_wp
-        x_wp = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+        x_wp = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
 
         world_active = wp.full(n_worlds, True, dtype=wp.bool, device=device)
 
@@ -184,7 +183,7 @@ class TestLinalgConjugate(unittest.TestCase):
         bsm.finalize(
             max_dims=[(pd, pd) for pd in padded_dims],
             capacities=capacities,
-            nzb_dtype=BlockDType(float32, (block_size, block_size)),
+            nzb_dtype=BlockDType(wp.float32, (block_size, block_size)),
             device=device,
         )
         bsm.dims.assign(np.array([[pd, pd] for pd in padded_dims], dtype=np.int32))
@@ -194,11 +193,11 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Build dense operator for comparison (flat 1D matrix storage)
         A_flat = np.concatenate([A.flatten() for A in A_padded_list]).astype(np.float32)
-        A_wp = wp.array(A_flat, dtype=float32, device=device)
+        A_wp = wp.array(A_flat, dtype=wp.float32, device=device)
         active_dims = wp.array(dims, dtype=wp.int32, device=device)
 
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=padded_dims, dtype=float32, device=device)
+        info.finalize(dimensions=padded_dims, dtype=wp.float32, device=device)
         info.dim = active_dims
         dense_op = BatchedLinearOperator.from_dense(DenseLinearOperatorData(info=info, mat=A_wp))
         sparse_op = BatchedLinearOperator.from_block_sparse(bsm, active_dims)
@@ -208,14 +207,14 @@ class TestLinalgConjugate(unittest.TestCase):
         b_flat = np.zeros(total_vec_size, dtype=np.float32)
         for m in range(n_worlds):
             b_flat[vio_np[m] : vio_np[m] + dims[m]] = b_list[m]
-        b_wp = wp.array(b_flat, dtype=float32, device=device)
+        b_wp = wp.array(b_flat, dtype=wp.float32, device=device)
 
         world_active = wp.full(n_worlds, True, dtype=wp.bool, device=device)
-        atol = wp.full(n_worlds, 1.0e-6, dtype=float32, device=device)
-        rtol = wp.full(n_worlds, 1.0e-6, dtype=float32, device=device)
+        atol = wp.full(n_worlds, 1.0e-6, dtype=wp.float32, device=device)
+        rtol = wp.full(n_worlds, 1.0e-6, dtype=wp.float32, device=device)
 
         # Solve with dense operator
-        x_dense = wp.zeros(total_vec_size, dtype=float32, device=device)
+        x_dense = wp.zeros(total_vec_size, dtype=wp.float32, device=device)
         solver_dense = solver_cls(
             A=dense_op,
             world_active=world_active,
@@ -229,7 +228,7 @@ class TestLinalgConjugate(unittest.TestCase):
         solver_dense.solve(b_wp, x_dense)
 
         # Solve with sparse operator
-        x_sparse = wp.zeros(total_vec_size, dtype=float32, device=device)
+        x_sparse = wp.zeros(total_vec_size, dtype=wp.float32, device=device)
         solver_sparse = solver_cls(
             A=sparse_op,
             world_active=world_active,
@@ -299,7 +298,7 @@ class TestLinalgConjugate(unittest.TestCase):
         bsm.finalize(
             max_dims=[(dim, dim)],
             capacities=[total_blocks],
-            nzb_dtype=BlockDType(float32, (block_size, block_size)),
+            nzb_dtype=BlockDType(wp.float32, (block_size, block_size)),
             device=device,
         )
         bsm.dims.assign(np.array([[dim, dim]], dtype=np.int32))
@@ -323,11 +322,11 @@ class TestLinalgConjugate(unittest.TestCase):
 
         sparse_op = self._build_sparse_operator(A, block_size, device)
 
-        b_wp = wp.array(b, dtype=float32, device=device)
-        x_wp = wp.zeros(dim, dtype=float32, device=device)
+        b_wp = wp.array(b, dtype=wp.float32, device=device)
+        x_wp = wp.zeros(dim, dtype=wp.float32, device=device)
         world_active = wp.full(1, True, dtype=wp.bool, device=device)
-        atol = wp.full(1, 1e-6, dtype=float32, device=device)
-        rtol = wp.full(1, 1e-6, dtype=float32, device=device)
+        atol = wp.full(1, 1e-6, dtype=wp.float32, device=device)
+        rtol = wp.full(1, 1e-6, dtype=wp.float32, device=device)
 
         solver = CGSolver(
             A=sparse_op,
@@ -391,10 +390,10 @@ class TestLinalgConjugate(unittest.TestCase):
             offset = w * max_dim * max_dim
             # Store compactly with dim as stride (canonical format)
             A_flat[offset : offset + dim * dim] = matrix.flatten()
-        A_wp = wp.array(A_flat, dtype=float32, device=device)
+        A_wp = wp.array(A_flat, dtype=wp.float32, device=device)
 
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=[max_dim] * n_worlds, dtype=float32, device=device)
+        info.finalize(dimensions=[max_dim] * n_worlds, dtype=wp.float32, device=device)
         info.dim = wp.array(dims, dtype=wp.int32, device=device)
         dense_op = DenseLinearOperatorData(info=info, mat=A_wp)
 
@@ -447,7 +446,7 @@ class TestLinalgConjugate(unittest.TestCase):
             **problem_params,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=device,
         )
 
@@ -455,20 +454,20 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Create operator with heterogeneous maxdims
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=problem.maxdims, dtype=float32, device=device)
+        info.finalize(dimensions=problem.maxdims, dtype=wp.float32, device=device)
         info.dim = problem.dim_wp  # Override with actual active dimensions
         operator = DenseLinearOperatorData(info=info, mat=problem.A_wp)
         A = BatchedLinearOperator.from_dense(operator)
 
         # b and x are flat 1D arrays
         b = problem.b_wp
-        x_wp = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+        x_wp = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
 
         world_active = wp.full(n_worlds, True, dtype=wp.bool, device=device)
 
         maxdim = max(problem.maxdims)
-        atol = wp.full(n_worlds, 1.0e-4, dtype=float32, device=device)
-        rtol = wp.full(n_worlds, 1.0e-5, dtype=float32, device=device)
+        atol = wp.full(n_worlds, 1.0e-4, dtype=wp.float32, device=device)
+        rtol = wp.full(n_worlds, 1.0e-5, dtype=wp.float32, device=device)
         maxiter = wp.full(n_worlds, max(3 * maxdim, 50), dtype=int, device=device)
         solver = solver_cls(
             A=A,
@@ -529,7 +528,7 @@ class TestLinalgConjugate(unittest.TestCase):
             **problem_params,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=device,
         )
 
@@ -537,14 +536,14 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Create operator with heterogeneous maxdims
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=problem.maxdims, dtype=float32, device=device)
+        info.finalize(dimensions=problem.maxdims, dtype=wp.float32, device=device)
         info.dim = problem.dim_wp
         operator = DenseLinearOperatorData(info=info, mat=problem.A_wp)
         A = BatchedLinearOperator.from_dense(operator)
 
         # Build Jacobi preconditioner
         maxdim = max(problem.maxdims)
-        jacobi_diag = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+        jacobi_diag = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
         wp.launch(
             make_jacobi_preconditioner,
             dim=(n_worlds, maxdim),
@@ -556,12 +555,12 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # b and x are flat 1D arrays
         b = problem.b_wp
-        x_wp = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+        x_wp = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
 
         world_active = wp.full(n_worlds, True, dtype=wp.bool, device=device)
 
-        atol = wp.full(n_worlds, 1.0e-4, dtype=float32, device=device)
-        rtol = wp.full(n_worlds, 1.0e-5, dtype=float32, device=device)
+        atol = wp.full(n_worlds, 1.0e-4, dtype=wp.float32, device=device)
+        rtol = wp.full(n_worlds, 1.0e-5, dtype=wp.float32, device=device)
         maxiter = wp.full(n_worlds, max(3 * maxdim, 50), dtype=int, device=device)
         solver = solver_cls(
             A=A,
@@ -618,7 +617,7 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Create DenseSquareMultiLinearInfo with heterogeneous dimensions
         info = DenseSquareMultiLinearInfo()
-        info.finalize(dimensions=dims_list, dtype=float32, device=device)
+        info.finalize(dimensions=dims_list, dtype=wp.float32, device=device)
         mio_np = info.mio.numpy()
         vio_np = info.vio.numpy()
 
@@ -627,7 +626,7 @@ class TestLinalgConjugate(unittest.TestCase):
         for w, (A, dim) in enumerate(zip(A_list, dims_list, strict=True)):
             offset = mio_np[w]
             A_flat[offset : offset + dim * dim] = A.flatten()
-        A_wp = wp.array(A_flat, dtype=float32, device=device)
+        A_wp = wp.array(A_flat, dtype=wp.float32, device=device)
 
         dense_op = DenseLinearOperatorData(info=info, mat=A_wp)
 
@@ -635,8 +634,8 @@ class TestLinalgConjugate(unittest.TestCase):
         b_flat = np.zeros(info.total_vec_size, dtype=np.float32)
         for w, (b, dim) in enumerate(zip(b_list, dims_list, strict=True)):
             b_flat[vio_np[w] : vio_np[w] + dim] = b
-        b_wp = wp.array(b_flat, dtype=float32, device=device)
-        x_wp = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+        b_wp = wp.array(b_flat, dtype=wp.float32, device=device)
+        x_wp = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
 
         # Solve
         kwargs = {}
@@ -661,7 +660,7 @@ class TestLinalgConjugate(unittest.TestCase):
 
         if discover_sparse:
             # Also solve with discover_sparse=False and compare
-            x_dense_wp = wp.zeros(info.total_vec_size, dtype=float32, device=device)
+            x_dense_wp = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
             solver_dense = solver_cls(discover_sparse=False, device=device)
             solver_dense.finalize(dense_op)
             solver_dense.compute(A_wp)

--- a/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_blocked.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_blocked.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.linalg.core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
 from newton._src.solvers.kamino._src.linalg.linear import LLTBlockedSolver
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -49,7 +48,7 @@ class TestLinAlgLLTBlockedSolver(unittest.TestCase):
         """
         llt = LLTBlockedSolver(device=self.default_device)
         self.assertIsNone(llt._operator)
-        self.assertEqual(llt.dtype, float32)
+        self.assertEqual(llt.dtype, wp.float32)
         self.assertEqual(llt.device, self.default_device)
 
     def test_01_single_problem_dims_all_active(self):
@@ -65,7 +64,7 @@ class TestLinAlgLLTBlockedSolver(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -203,7 +202,7 @@ class TestLinAlgLLTBlockedSolver(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -339,7 +338,7 @@ class TestLinAlgLLTBlockedSolver(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)
@@ -488,7 +487,7 @@ class TestLinAlgLLTBlockedSolver(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)

--- a/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_sequential.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solver_llt_sequential.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.linalg.core import DenseLinearOperatorData, DenseSquareMultiLinearInfo
 from newton._src.solvers.kamino._src.linalg.linear import LLTSequentialSolver
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -49,7 +48,7 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
         """
         llt = LLTSequentialSolver(device=self.default_device)
         self.assertIsNone(llt._operator)
-        self.assertEqual(llt.dtype, float32)
+        self.assertEqual(llt.dtype, wp.float32)
         self.assertEqual(llt.device, self.default_device)
 
     def test_01_single_problem_dims_all_active(self):
@@ -65,7 +64,7 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -203,7 +202,7 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
 
@@ -339,7 +338,7 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
             dims=N,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)
@@ -488,7 +487,7 @@ class TestLinAlgLLTSequentialSolver(unittest.TestCase):
             maxdims=N_max,
             seed=self.seed,
             np_dtype=np.float32,
-            wp_dtype=float32,
+            wp_dtype=wp.float32,
             device=self.default_device,
         )
         msg.debug("Problem:\n%s\n", problem)

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -15,7 +15,6 @@ from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.joints import JointActuationType
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.state import StateKamino
-from newton._src.solvers.kamino._src.core.types import float32, transformf, vec6f
 from newton._src.solvers.kamino._src.dynamics import DualProblem
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
 from newton._src.solvers.kamino._src.kinematics.jacobians import DenseSystemJacobians, SparseSystemJacobians
@@ -37,9 +36,9 @@ from newton._src.solvers.kamino.tests import setup_tests, test_context
 
 @wp.kernel
 def _test_control_callback(
-    model_dt: wp.array[float32],
-    data_time: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    model_dt: wp.array[wp.float32],
+    data_time: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -52,7 +51,7 @@ def _test_control_callback(
     t = data_time[wid]
 
     # Define the time window for the active external force profile
-    t_start = float32(0.0)
+    t_start = wp.float32(0.0)
     t_end = 10.0 * dt
 
     # Compute the first actuated joint index for the current world
@@ -245,10 +244,10 @@ def assert_states_close_masked(
 
 def check_body_and_joint_state_consistency(
     model: ModelKamino,
-    body_q: wp.array[transformf],
-    body_u: wp.array[vec6f],
-    joint_q: wp.array[float32],
-    joint_u: wp.array[float32],
+    body_q: wp.array[wp.transformf],
+    body_u: wp.array[wp.spatial_vectorf],
+    joint_q: wp.array[wp.float32],
+    joint_u: wp.array[wp.float32],
 ):
     """Check that provided joint/body positions and velocities are consistent for a given model."""
     # Check dimensions
@@ -595,13 +594,15 @@ class TestSolverKaminoImpl(unittest.TestCase):
         base_q_0_np = [0.1, 0.0, 0.5, 0.0, 0.0, 0.0, 1.0]
         base_q_0_np = np.tile(base_q_0_np, reps=model.size.num_worlds).astype(np.float32)
         base_q_0_np = base_q_0_np.reshape(model.size.num_worlds, 7)
-        base_q_0: wp.array = wp.array(base_q_0_np, dtype=transformf, device=self.default_device)
+        base_q_0: wp.array[wp.transformf] = wp.array(base_q_0_np, dtype=wp.transformf, device=self.default_device)
 
         # Define the reset base twist
         base_u_0_np = [0.0, 1.5, 0.0, 0.0, 0.0, 0.0]
         base_u_0_np = np.tile(base_u_0_np, reps=model.size.num_worlds).astype(np.float32)
         base_u_0_np = base_u_0_np.reshape(model.size.num_worlds, 6)
-        base_u_0: wp.array = wp.array(base_u_0_np, dtype=vec6f, device=self.default_device)
+        base_u_0: wp.array[wp.spatial_vectorf] = wp.array(
+            base_u_0_np, dtype=wp.spatial_vectorf, device=self.default_device
+        )
 
         # Step the solver a few times to change the state
         step_solver(
@@ -720,12 +721,12 @@ class TestSolverKaminoImpl(unittest.TestCase):
         # Set default reset joint coordinates
         joint_q_0_np = [0.1, 0.1, 0.1, 0.1]
         joint_q_0_np = np.tile(joint_q_0_np, reps=model.size.num_worlds).astype(np.float32)
-        joint_q_0: wp.array = wp.array(joint_q_0_np, dtype=float32, device=self.default_device)
+        joint_q_0: wp.array[wp.float32] = wp.array(joint_q_0_np, dtype=wp.float32, device=self.default_device)
 
         # Set default reset joint velocities
         joint_u_0_np = [0.1, 0.1, 0.1, 0.1]
         joint_u_0_np = np.tile(joint_u_0_np, reps=model.size.num_worlds).astype(np.float32)
-        joint_u_0: wp.array = wp.array(joint_u_0_np, dtype=float32, device=self.default_device)
+        joint_u_0: wp.array[wp.float32] = wp.array(joint_u_0_np, dtype=wp.float32, device=self.default_device)
 
         # Step the solver a few times to change the state
         step_solver(
@@ -854,12 +855,12 @@ class TestSolverKaminoImpl(unittest.TestCase):
         # Set default reset joint coordinates
         actuator_q_0_np = [0.25, 0.25]
         actuator_q_0_np = np.tile(actuator_q_0_np, reps=model.size.num_worlds)
-        actuator_q_0: wp.array = wp.array(actuator_q_0_np, dtype=float32, device=self.default_device)
+        actuator_q_0: wp.array[wp.float32] = wp.array(actuator_q_0_np, dtype=wp.float32, device=self.default_device)
 
         # Set default reset joint velocities
         actuator_u_0_np = [-1.0, -1.0]
         actuator_u_0_np = np.tile(actuator_u_0_np, reps=model.size.num_worlds)
-        actuator_u_0: wp.array = wp.array(actuator_u_0_np, dtype=float32, device=self.default_device)
+        actuator_u_0: wp.array[wp.float32] = wp.array(actuator_u_0_np, dtype=wp.float32, device=self.default_device)
 
         # Step the solver a few times to change the state
         step_solver(

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -17,7 +17,6 @@ import newton
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.joints import JointActuationType, JointCorrectionMode, JointDoFType
 from newton._src.solvers.kamino._src.core.model import ModelKamino
-from newton._src.solvers.kamino._src.core.types import vec6f
 from newton._src.solvers.kamino._src.kinematics.joints import compute_joints_data
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_fourbar
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
@@ -310,8 +309,8 @@ def simulate_random_poses(
         bodies_q = wp.array(shape=(model.size.sum_of_num_bodies), dtype=wp.transformf)
         base_q = wp.array(shape=(model.size.num_worlds), dtype=wp.transformf)
         actuators_q = wp.array(shape=(actuators_q_np.shape[1]), dtype=wp.float32)
-        bodies_u = wp.array(shape=(model.size.sum_of_num_bodies), dtype=vec6f)
-        base_u = wp.array(shape=(model.size.num_worlds), dtype=vec6f)
+        bodies_u = wp.array(shape=(model.size.sum_of_num_bodies), dtype=wp.spatial_vectorf)
+        base_u = wp.array(shape=(model.size.num_worlds), dtype=wp.spatial_vectorf)
         actuators_u = wp.array(shape=(actuators_u_np.shape[1]), dtype=wp.float32)
     data = model.data(device=model.device)
     epsilon = 1e-3 if config.use_regularization else 1e-4

--- a/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
@@ -31,7 +31,7 @@ from newton._src.solvers.kamino.tests.utils.extract import (
 
 
 def compute_metrics_numpy(problem: DualProblem, solver_data: PADMMData) -> dict[np.ndarray]:
-    """Compute the solver metrics with numpy, using wp.float64."""
+    """Compute the solver metrics with numpy, using float64."""
     output = {}
     output["r_v_plus"] = []
     output["s"] = []
@@ -580,7 +580,7 @@ class TestSolverMetrics(unittest.TestCase):
     def test_05_validate_metrics_boxes_hinged(self):
         """
         Compares metrics from `SolutionMetrics` with metrics computed by a
-        reference routine using wp.float64 numpy arrays, on a perturbed PADMM solution.
+        reference routine using float64 numpy arrays, on a perturbed PADMM solution.
         """
         # Create the test problem
         test = TestSetup(

--- a/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
@@ -31,7 +31,7 @@ from newton._src.solvers.kamino.tests.utils.extract import (
 
 
 def compute_metrics_numpy(problem: DualProblem, solver_data: PADMMData) -> dict[np.ndarray]:
-    """Compute the solver metrics with numpy, using float64."""
+    """Compute the solver metrics with numpy, using wp.float64."""
     output = {}
     output["r_v_plus"] = []
     output["s"] = []
@@ -580,7 +580,7 @@ class TestSolverMetrics(unittest.TestCase):
     def test_05_validate_metrics_boxes_hinged(self):
         """
         Compares metrics from `SolutionMetrics` with metrics computed by a
-        reference routine using float64 numpy arrays, on a perturbed PADMM solution.
+        reference routine using wp.float64 numpy arrays, on a perturbed PADMM solution.
         """
         # Create the test problem
         test = TestSetup(
@@ -608,7 +608,7 @@ class TestSolverMetrics(unittest.TestCase):
         # Perturb solution to have non-trivial metrics
         rng = np.random.default_rng(seed=self.seed)
 
-        def perturb_array(arr: wp.array):
+        def perturb_array(arr: wp.array[wp.float32]):
             arr_np = arr.numpy()
             arr_np += 0.1 * rng.standard_normal(arr_np.shape, dtype=np.float32)
             arr.assign(arr_np)
@@ -719,7 +719,7 @@ class TestSolverMetrics(unittest.TestCase):
         # Perturb problem to have non-trivial metrics
         rng = np.random.default_rng(seed=self.seed)
 
-        def perturb_array(arr: wp.array):
+        def perturb_array(arr: wp.array[wp.float32]):
             arr_np = arr.numpy()
             arr_np += rng.standard_normal(arr_np.shape, dtype=np.float32)
             arr.assign(arr_np)

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -9,7 +9,7 @@ import numpy as np
 import warp as wp
 
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.math import screw, vec3f
+from newton._src.solvers.kamino._src.core.math import screw
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.dynamics.dual import DualProblem
 from newton._src.solvers.kamino._src.kinematics.constraints import unpack_constraint_solutions
@@ -52,7 +52,7 @@ class TestSetup:
         # Set ad-hoc configurations
         self.builder.gravity[0].enabled = gravity
         if perturb:
-            u_0 = screw(vec3f(+10.0, 0.0, 0.0), vec3f(0.0, 0.0, 0.0))
+            u_0 = screw(wp.vec3f(+10.0, 0.0, 0.0), wp.vec3f(0.0, 0.0, 0.0))
             for body in self.builder.all_bodies:
                 body.u_i_0 = u_0
 

--- a/newton/_src/solvers/kamino/tests/test_utils_control_animation.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_control_animation.py
@@ -10,7 +10,6 @@ import warp as wp
 
 import newton
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino._src.utils.control import AnimationJointReference
 from newton._src.solvers.kamino._src.utils.io.usd import USDImporter
@@ -110,8 +109,8 @@ class TestAnimationJointReference(unittest.TestCase):
         np.testing.assert_array_almost_equal(animation.data.dq_j_ref.numpy(), np.zeros_like(animation_np), decimal=6)
 
         # Allocate output arrays for joint references
-        q_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
-        dq_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
+        q_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
+        dq_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
 
         # Retrieve the reference at the initial step (0)
         animation.reset(q_j_ref_out=q_j_ref_out, dq_j_ref_out=dq_j_ref_out)
@@ -217,8 +216,8 @@ class TestAnimationJointReference(unittest.TestCase):
         np.testing.assert_array_almost_equal(animation.data.dq_j_ref.numpy(), np.zeros_like(animation_np), decimal=6)
 
         # Allocate output arrays for joint references
-        q_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
-        dq_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
+        q_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
+        dq_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
 
         # Retrieve the reference at the initial step (0)
         animation.reset(q_j_ref_out=q_j_ref_out, dq_j_ref_out=dq_j_ref_out)
@@ -358,8 +357,8 @@ class TestAnimationJointReference(unittest.TestCase):
         np.testing.assert_array_almost_equal(animation.data.dq_j_ref.numpy(), np.zeros_like(animation_np), decimal=6)
 
         # Allocate output arrays for joint references
-        q_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
-        dq_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
+        q_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
+        dq_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
 
         # Retrieve the reference at the initial step (0)
         animation.reset(q_j_ref_out=q_j_ref_out, dq_j_ref_out=dq_j_ref_out)
@@ -499,8 +498,8 @@ class TestAnimationJointReference(unittest.TestCase):
         np.testing.assert_array_almost_equal(animation.data.dq_j_ref.numpy(), np.zeros_like(animation_np), decimal=6)
 
         # Allocate output arrays for joint references
-        q_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
-        dq_j_ref_out = wp.zeros(njad, dtype=float32, device=self.default_device)
+        q_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
+        dq_j_ref_out = wp.zeros(njad, dtype=wp.float32, device=self.default_device)
 
         # Reset the reference at the initial step (0)
         animation.reset(q_j_ref_out=q_j_ref_out, dq_j_ref_out=dq_j_ref_out)

--- a/newton/_src/solvers/kamino/tests/test_utils_sim_simulator.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_sim_simulator.py
@@ -9,7 +9,6 @@ import unittest
 import numpy as np
 import warp as wp
 
-from newton._src.solvers.kamino._src.core.types import float32
 from newton._src.solvers.kamino._src.models.builders.basics import build_cartpole
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -24,9 +23,9 @@ from newton._src.solvers.kamino.tests import setup_tests, test_context
 
 @wp.kernel
 def _test_control_callback(
-    model_dt: wp.array[float32],
-    data_time: wp.array[float32],
-    control_tau_j: wp.array[float32],
+    model_dt: wp.array[wp.float32],
+    data_time: wp.array[wp.float32],
+    control_tau_j: wp.array[wp.float32],
 ):
     """
     An example control callback kernel.
@@ -39,7 +38,7 @@ def _test_control_callback(
     t = data_time[wid]
 
     # Define the time window for the active external force profile
-    t_start = float32(0.0)
+    t_start = wp.float32(0.0)
     t_end = 10.0 * dt
 
     # Compute the first actuated joint index for the current world

--- a/newton/_src/solvers/kamino/tests/utils/extract.py
+++ b/newton/_src/solvers/kamino/tests/utils/extract.py
@@ -47,7 +47,9 @@ def extract_active_constraint_dims(data: DataKamino) -> list[int]:
     return [int(active_dim_np[i]) for i in range(len(active_dim_np))]
 
 
-def extract_active_constraint_vectors(model: ModelKamino, data: DataKamino, x: wp.array) -> list[np.ndarray]:
+def extract_active_constraint_vectors(
+    model: ModelKamino, data: DataKamino, x: wp.array[wp.float32]
+) -> list[np.ndarray]:
     cts_start_np = model.info.total_cts_offset.numpy()
     num_active_cts_np = extract_active_constraint_dims(data)
     x_np = x.numpy()

--- a/newton/_src/solvers/kamino/tests/utils/make.py
+++ b/newton/_src/solvers/kamino/tests/utils/make.py
@@ -17,7 +17,6 @@ from ..._src.core.data import DataKamino
 from ..._src.core.math import quat_exp, screw, screw_angular, screw_linear
 from ..._src.core.model import ModelKamino
 from ..._src.core.state import StateKamino
-from ..._src.core.types import float32, int32, mat33f, transformf, vec3f, vec6f
 from ..._src.geometry.contacts import ContactsKamino
 from ..._src.geometry.detector import CollisionDetector
 from ..._src.kinematics.constraints import make_unilateral_constraints_info, update_constraints_info
@@ -284,7 +283,7 @@ def make_test_problem(
 
 def make_constraint_multiplier_arrays(model: ModelKamino) -> tuple[wp.array, wp.array]:
     with wp.ScopedDevice(model.device):
-        lambdas = wp.zeros(model.size.sum_of_max_total_cts, dtype=float32)
+        lambdas = wp.zeros(model.size.sum_of_max_total_cts, dtype=wp.float32)
     return model.info.total_cts_offset, lambdas
 
 
@@ -298,21 +297,21 @@ def make_constraint_multiplier_arrays(model: ModelKamino) -> tuple[wp.array, wp.
 Q_X_J = 0.3 * math.pi
 THETA_Y_J = 0.0
 THETA_Z_J = 0.0
-J_DR_J = vec3f(0.0)
-J_DV_J = vec3f(0.0)
-J_DOMEGA_J = vec3f(0.0)
+J_DR_J = wp.vec3f(0.0)
+J_DV_J = wp.vec3f(0.0)
+J_DOMEGA_J = wp.vec3f(0.0)
 
 
 @wp.kernel
 def _set_fourbar_body_states(
-    model_joint_bid_B: wp.array[int32],
-    model_joint_bid_F: wp.array[int32],
-    model_joint_B_r_Bj: wp.array[vec3f],
-    model_joint_F_r_Fj: wp.array[vec3f],
-    model_joint_X_Bj: wp.array[mat33f],
-    model_joint_X_Fj: wp.array[mat33f],
-    state_body_q_i: wp.array[transformf],
-    state_body_u_i: wp.array[vec6f],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_bid_F: wp.array[wp.int32],
+    model_joint_B_r_Bj: wp.array[wp.vec3f],
+    model_joint_F_r_Fj: wp.array[wp.vec3f],
+    model_joint_X_Bj: wp.array[wp.mat33f],
+    model_joint_X_Fj: wp.array[wp.mat33f],
+    state_body_q_i: wp.array[wp.transformf],
+    state_body_u_i: wp.array[wp.spatial_vectorf],
 ):
     """
     Set the state of the bodies to a certain values in order to check computations of joint states.
@@ -345,7 +344,7 @@ def _set_fourbar_body_states(
     q_x_j = Q_X_J * wp.pow(-1.0, float(jid))  # Alternate sign for each joint
     theta_y_j = THETA_Y_J
     theta_z_j = THETA_Z_J
-    j_dR_j = vec3f(q_x_j, theta_y_j, theta_z_j)  # Joint offset as rotation vector
+    j_dR_j = wp.vec3f(q_x_j, theta_y_j, theta_z_j)  # Joint offset as rotation vector
     q_jq = quat_exp(j_dR_j)  # Joint offset as rotation quaternion
     R_jq = wp.quat_to_matrix(q_jq)  # Joint offset as rotation matrix
 
@@ -372,7 +371,7 @@ def _set_fourbar_body_states(
     v_F_new = R_B_X_j @ j_dv_j + v_B + wp.cross(omega_B, r_Bj) - wp.cross(omega_F_new, r_Fj)
 
     # Offset the pose of the body by a fixed amount
-    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=float32)
+    state_body_q_i[bid_F] = wp.transformation(r_F_new, q_F_new, dtype=wp.float32)
     state_body_u_i[bid_F] = screw(v_F_new, omega_F_new)
 
 

--- a/newton/_src/solvers/kamino/tests/utils/rand.py
+++ b/newton/_src/solvers/kamino/tests/utils/rand.py
@@ -3,10 +3,12 @@
 
 """Unit-test utilities for generating random linear system and factorization problems."""
 
+from __future__ import annotations
+
 import numpy as np
 import warp as wp
 
-from ..._src.core.types import FloatArrayLike, float32, int32
+from ..._src.core.types import FloatArrayLike
 from ..._src.linalg.utils.rand import (
     random_rhs_for_matrix,
     random_spd_matrix,
@@ -27,7 +29,7 @@ class RandomProblemLLT:
         A: list[np.ndarray] | None = None,
         b: list[np.ndarray] | None = None,
         np_dtype=np.float32,
-        wp_dtype=float32,
+        wp_dtype=wp.float32,
         device: wp.DeviceLike = None,
         upper: bool = False,
     ):
@@ -82,12 +84,12 @@ class RandomProblemLLT:
         self.x_np: list[np.ndarray] = []
 
         # Declare the warp arrays of concatenated problem data
-        self.maxdim_wp: wp.array | None = None
-        self.dim_wp: wp.array | None = None
-        self.mio_wp: wp.array | None = None
-        self.vio_wp: wp.array | None = None
-        self.A_wp: wp.array | None = None
-        self.b_wp: wp.array | None = None
+        self.maxdim_wp: wp.array[wp.int32] | None = None
+        self.dim_wp: wp.array[wp.int32] | None = None
+        self.mio_wp: wp.array[wp.int32] | None = None
+        self.vio_wp: wp.array[wp.int32] | None = None
+        self.A_wp: wp.array[wp.float32] | None = None
+        self.b_wp: wp.array[wp.float32] | None = None
 
         # Initialize the flattened problem data
         A_sizes = [n * n for n in self.maxdims]
@@ -140,12 +142,12 @@ class RandomProblemLLT:
 
         # Construct the warp arrays
         with wp.ScopedDevice(self.device):
-            self.maxdim_wp = wp.array(self.maxdims, dtype=int32)
-            self.dim_wp = wp.array(self.dims, dtype=int32)
-            self.mio_wp = wp.array(A_offsets[: self.num_blocks], dtype=int32)
-            self.vio_wp = wp.array(b_offsets[: self.num_blocks], dtype=int32)
-            self.A_wp = wp.array(A_flat, dtype=float32)
-            self.b_wp = wp.array(b_flat, dtype=float32)
+            self.maxdim_wp = wp.array(self.maxdims, dtype=wp.int32)
+            self.dim_wp = wp.array(self.dims, dtype=wp.int32)
+            self.mio_wp = wp.array(A_offsets[: self.num_blocks], dtype=wp.int32)
+            self.vio_wp = wp.array(b_offsets[: self.num_blocks], dtype=wp.int32)
+            self.A_wp = wp.array(A_flat, dtype=wp.float32)
+            self.b_wp = wp.array(b_flat, dtype=wp.float32)
 
     def __str__(self) -> str:
         return (
@@ -183,7 +185,7 @@ class RandomProblemLDLT:
         A: list[np.ndarray] | None = None,
         b: list[np.ndarray] | None = None,
         np_dtype=np.float32,
-        wp_dtype=float32,
+        wp_dtype=wp.float32,
         device: wp.DeviceLike = None,
         lower: bool = True,
     ):
@@ -267,12 +269,12 @@ class RandomProblemLDLT:
         self.x_np: list[np.ndarray] = []
 
         # Declare the warp arrays of concatenated problem data
-        self.maxdim_wp: wp.array | None = None
-        self.dim_wp: wp.array | None = None
-        self.mio_wp: wp.array | None = None
-        self.vio_wp: wp.array | None = None
-        self.A_wp: wp.array | None = None
-        self.b_wp: wp.array | None = None
+        self.maxdim_wp: wp.array[wp.int32] | None = None
+        self.dim_wp: wp.array[wp.int32] | None = None
+        self.mio_wp: wp.array[wp.int32] | None = None
+        self.vio_wp: wp.array[wp.int32] | None = None
+        self.A_wp: wp.array[wp.float32] | None = None
+        self.b_wp: wp.array[wp.float32] | None = None
 
         # Initialize the flattened problem data
         A_sizes = [n * n for n in self.maxdims]
@@ -330,12 +332,12 @@ class RandomProblemLDLT:
 
         # Construct the warp arrays
         with wp.ScopedDevice(self.device):
-            self.maxdim_wp = wp.array(self.maxdims, dtype=int32)
-            self.dim_wp = wp.array(self.dims, dtype=int32)
-            self.mio_wp = wp.array(A_offsets[: self.num_blocks], dtype=int32)
-            self.vio_wp = wp.array(b_offsets[: self.num_blocks], dtype=int32)
-            self.A_wp = wp.array(A_flat, dtype=float32)
-            self.b_wp = wp.array(b_flat, dtype=float32)
+            self.maxdim_wp = wp.array(self.maxdims, dtype=wp.int32)
+            self.dim_wp = wp.array(self.dims, dtype=wp.int32)
+            self.mio_wp = wp.array(A_offsets[: self.num_blocks], dtype=wp.int32)
+            self.vio_wp = wp.array(b_offsets[: self.num_blocks], dtype=wp.int32)
+            self.A_wp = wp.array(A_flat, dtype=wp.float32)
+            self.b_wp = wp.array(b_flat, dtype=wp.float32)
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
## Description

This removes the Kamino type aliases that are redundant with warp or newton types, and updates all type annotations.
This also does a docstring sanitization pass, so that we use the Google-style docstrings everywhere in Kamino (and in particular, do not repeat the argument types in function docstrings that already have annotated arguments). Extraneous \n in docstrings were also removed, and some docstrings with wrong arguments listed were fixed. All warp arrays as class members, function arguments or return types are also properly documented with the bracket notation [] when possible, to increase readability of the code.

I didn't take a full pass through linalg code yet, because there is a lot of generics there (matrix/solver classes with their own scalar type), so I added some Any in some places but also just left plain wp.array annotations in most places.

When it comes to matrix/vector types that don't have a warp built-in (e.g. vec6f), I kept the type aliases in types.py for those that we use in the code. I replaced vec6f with wp.spatial_vector whenever it corresponded to a twist or wrench, but not for Jacobian NZBs or AABB coordinates for instance.

Resolves vastsoun#7
Resolves vastsoun#183

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Unfortunately type checking won't catch that the right type in brackets is used for warp arrays, so we can't check this automatically, but I manually checked all changed files (which is basically all Kamino files) and verified that Kamino-internal unit tests run as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Warp-native scalar, vector, matrix, transform, and spatial-quantity types across the KAMINO simulation stack.
  * Updated public API type hints to require explicitly typed Warp arrays and correct mask element types, including conversions, model/control/state containers, kernels/launchers, collision/kinematics, integrators, and linear algebra.
  * Adjusted builders and physics utilities to use consistent Warp-friendly identity/zero/default values.
* **Documentation**
  * Re-formatted and clarified many public docstrings and parameter sections to match the updated, more explicit typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->