### PR TITLE
Skip immovable bodies in VBD contact lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fix swapped kinetic and potential energy labels in the `basic_plotting` example, and report per-world values directly so the live plot overlays match the side-panel readouts
 - Fix `SolverMuJoCo` reporting incorrect `State.body_qd` angular velocity for `JointType.D6` joints with two or three angular DOFs at non-identity configurations.
 - Fix VBD collision damping to use relative normal gap rate so uniform contact-stencil motion and tangential sliding do not create artificial normal damping.
+- Fix `SolverVBD` building unused per-body rigid and particle contact lists for static and kinematic bodies, which caused unnecessary work and misleading contact-buffer overflow warnings.
 - Fix multi-world soft contact filtering to avoid cross-world rigid-soft particle-shape pairs and VBD soft-soft triangle/edge candidates.
 - Fix `ModelBuilder.add_usd` so a stray authored joint outside any articulation root no longer suppresses base-joint (articulation) creation for unrelated floating rigid bodies in the same call. (#3002)
 - Fix `SolverSemiImplicit` ball joints to apply `joint_damping` on all three angular DOFs.

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -1906,6 +1906,7 @@ def build_body_body_contact_lists(
     rigid_contact_shape0: wp.array[int],
     rigid_contact_shape1: wp.array[int],
     shape_body: wp.array[wp.int32],
+    body_inv_mass_effective: wp.array[float],
     body_contact_buffer_pre_alloc: int,
     body_contact_counts: wp.array[wp.int32],
     body_contact_indices: wp.array[wp.int32],
@@ -1913,7 +1914,10 @@ def build_body_body_contact_lists(
 ):
     """
     Build per-body contact lists for body-centric per-color contact evaluation.
-    Tracks overflow into body_contact_overflow_max for diagnostics.
+
+    Each contact is listed only under its dynamic bodies (effective inverse
+    mass > 0); static/kinematic bodies are skipped since VBD never moves them.
+    Overflow is tracked in body_contact_overflow_max for diagnostics.
     """
     t_id = wp.tid()
     if t_id >= rigid_contact_count[0]:
@@ -1924,14 +1928,14 @@ def build_body_body_contact_lists(
     b0 = shape_body[s0] if s0 >= 0 else -1
     b1 = shape_body[s1] if s1 >= 0 else -1
 
-    if b0 >= 0:
+    if b0 >= 0 and body_inv_mass_effective[b0] > 0.0:
         idx = wp.atomic_add(body_contact_counts, b0, 1)
         if idx < body_contact_buffer_pre_alloc:
             body_contact_indices[b0 * body_contact_buffer_pre_alloc + idx] = t_id
         else:
             wp.atomic_max(body_contact_overflow_max, 0, idx + 1)
 
-    if b1 >= 0:
+    if b1 >= 0 and body_inv_mass_effective[b1] > 0.0:
         idx = wp.atomic_add(body_contact_counts, b1, 1)
         if idx < body_contact_buffer_pre_alloc:
             body_contact_indices[b1 * body_contact_buffer_pre_alloc + idx] = t_id
@@ -1944,6 +1948,7 @@ def build_body_particle_contact_lists(
     body_particle_contact_count: wp.array[int],
     body_particle_contact_shape: wp.array[int],
     shape_body: wp.array[wp.int32],
+    body_inv_mass_effective: wp.array[float],
     body_particle_contact_buffer_pre_alloc: int,
     body_particle_contact_counts: wp.array[wp.int32],
     body_particle_contact_indices: wp.array[wp.int32],
@@ -1951,7 +1956,10 @@ def build_body_particle_contact_lists(
 ):
     """
     Build per-body contact lists for body-particle contacts.
-    Tracks overflow into body_particle_contact_overflow_max for diagnostics.
+
+    Each contact is listed only if its body is dynamic (effective inverse
+    mass > 0); static/kinematic bodies are skipped since VBD never moves them.
+    Overflow is tracked in body_particle_contact_overflow_max for diagnostics.
     """
     tid = wp.tid()
     if tid >= body_particle_contact_count[0]:
@@ -1960,7 +1968,7 @@ def build_body_particle_contact_lists(
     shape = body_particle_contact_shape[tid]
     body = shape_body[shape] if shape >= 0 else -1
 
-    if body < 0:
+    if body < 0 or body_inv_mass_effective[body] <= 0.0:
         return
 
     idx = wp.atomic_add(body_particle_contact_counts, body, 1)

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -1465,7 +1465,9 @@ class SolverVBD(SolverBase):
         used by the previous refresh; do not run collision into the contacts
         buffer between refreshes. Passing newly collided contacts while update is
         disabled can mismatch stale per-body contact lists with current contact
-        rows.
+        rows. For the same reason, do not change a body's solvability (mass or
+        kinematic flag) while update is disabled: the per-body lists depend on
+        effective inverse mass and are not rebuilt until the next refresh.
 
         Joint AVBD maintenance (C0 snapshot, lambda decay)
         runs every step regardless of this flag via step_joint_C0_lambda().
@@ -1819,6 +1821,7 @@ class SolverVBD(SolverBase):
                             contacts.rigid_contact_shape0,
                             contacts.rigid_contact_shape1,
                             model.shape_body,
+                            self.body_inv_mass_effective,
                             self.body_body_contact_buffer_pre_alloc,
                         ],
                         outputs=[
@@ -2090,6 +2093,7 @@ class SolverVBD(SolverBase):
                         contacts.soft_contact_count,
                         contacts.soft_contact_shape,
                         model.shape_body,
+                        self.body_inv_mass_effective,
                         self.body_particle_contact_buffer_pre_alloc,
                     ],
                     outputs=[

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -23,6 +23,8 @@ from newton._src.solvers.vbd.particle_vbd_kernels import (
 )
 from newton._src.solvers.vbd.rigid_vbd_kernels import (
     RigidContactHistory,
+    build_body_body_contact_lists,
+    build_body_particle_contact_lists,
     compute_rigid_contact_forces,
     evaluate_angular_constraint_force_hessian,
     evaluate_body_particle_contact,
@@ -2017,10 +2019,90 @@ def _collect_rigid_contact_forces_reports_surface_points(test, device):
     np.testing.assert_allclose(reported1_np[:count], expected1, atol=1.0e-5)
 
 
+def _body_body_contact_lists_skip_static_kinematic(test, device):
+    """An immovable body must not cause a spurious per-body list overflow."""
+    buffer_pre_alloc = 1
+    # Effective inverse mass folds together zero-mass and kinematic bodies.
+    # Bodies 0 and 2 are dynamic; body 1 is immovable.
+    body_inv_mass_effective = wp.array([1.0, 0.0, 1.0], dtype=float, device=device)
+    shape_body = wp.array([0, 1, 2], dtype=wp.int32, device=device)
+    # Both contacts touch body 1, but each dynamic body has only one contact.
+    rigid_contact_count = wp.array([2], dtype=int, device=device)
+    rigid_contact_shape0 = wp.array([0, 1], dtype=int, device=device)
+    rigid_contact_shape1 = wp.array([1, 2], dtype=int, device=device)
+
+    body_contact_counts = wp.zeros(3, dtype=wp.int32, device=device)
+    body_contact_indices = wp.full(3 * buffer_pre_alloc, -1, dtype=wp.int32, device=device)
+    body_contact_overflow_max = wp.zeros(1, dtype=wp.int32, device=device)
+
+    wp.launch(
+        build_body_body_contact_lists,
+        dim=2,
+        inputs=[
+            rigid_contact_count,
+            rigid_contact_shape0,
+            rigid_contact_shape1,
+            shape_body,
+            body_inv_mass_effective,
+            buffer_pre_alloc,
+        ],
+        outputs=[body_contact_counts, body_contact_indices, body_contact_overflow_max],
+        device=device,
+    )
+
+    np.testing.assert_array_equal(body_contact_counts.numpy(), np.array([1, 0, 1], dtype=np.int32))
+    np.testing.assert_array_equal(body_contact_indices.numpy(), np.array([0, -1, 1], dtype=np.int32))
+    test.assertEqual(int(body_contact_overflow_max.numpy()[0]), 0)
+
+
+def _body_particle_contact_lists_skip_static_kinematic(test, device):
+    """Immovable body-particle contacts must not cause a list overflow."""
+    buffer_pre_alloc = 1
+    # Body 0 is dynamic; body 1 represents a static or kinematic body.
+    body_inv_mass_effective = wp.array([1.0, 0.0], dtype=float, device=device)
+    shape_body = wp.array([0, 1], dtype=wp.int32, device=device)
+    body_particle_contact_count = wp.array([3], dtype=int, device=device)
+    body_particle_contact_shape = wp.array([0, 1, 1], dtype=int, device=device)
+
+    counts = wp.zeros(2, dtype=wp.int32, device=device)
+    indices = wp.full(2 * buffer_pre_alloc, -1, dtype=wp.int32, device=device)
+    overflow_max = wp.zeros(1, dtype=wp.int32, device=device)
+
+    wp.launch(
+        build_body_particle_contact_lists,
+        dim=3,
+        inputs=[
+            body_particle_contact_count,
+            body_particle_contact_shape,
+            shape_body,
+            body_inv_mass_effective,
+            buffer_pre_alloc,
+        ],
+        outputs=[counts, indices, overflow_max],
+        device=device,
+    )
+
+    np.testing.assert_array_equal(counts.numpy(), np.array([1, 0], dtype=np.int32))
+    np.testing.assert_array_equal(indices.numpy(), np.array([0, -1], dtype=np.int32))
+    test.assertEqual(int(overflow_max.numpy()[0]), 0)
+
+
 class TestSolverVBD(unittest.TestCase):
     pass
 
 
+add_function_test(
+    TestSolverVBD,
+    "test_body_body_contact_lists_skip_static_kinematic",
+    _body_body_contact_lists_skip_static_kinematic,
+    devices=devices,
+)
+add_function_test(
+    TestSolverVBD,
+    "test_body_particle_contact_lists_skip_static_kinematic",
+    _body_particle_contact_lists_skip_static_kinematic,
+    devices=devices,
+)
 add_function_test(
     TestSolverVBD, "test_self_contact_barrier_c2_at_tau", test_self_contact_barrier_c2_at_tau, devices=devices
 )


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->


This PR prevents SolverVBD from adding static and kinematic body sides to its per-body rigid and body-particle contact lists.
Bodies with zero effective inverse mass are already skipped by the body solve, so these entries were unused. In contact-heavy scenes, they could nevertheless overflow an immovable body’s fixed-capacity list, produce misleading warnings, and perform unnecessary atomic operations.

Global contacts are unchanged:
Dynamic–static and dynamic–kinematic contacts remain listed for the dynamic body.
Body-particle contacts remain available to the particle-side solve.
Dynamic–dynamic contacts remain listed for both bodies.
Legitimate dynamic-body buffer overflows are still reported.


## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VBD contact-list building to skip non-dynamic (static/kinematic) bodies, avoiding unnecessary per-body contact processing.
  * Reduced misleading contact-buffer overflow warnings by only recording applicable contacts.
  * Clarified rigid history update guidance: contact lists aren’t refreshed until the next update, so changing effective mass/kinematic solvability while updates are disabled is not supported.
* **Tests**
  * Added coverage to confirm per-body contact-list builders skip static/kinematic bodies without overflowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->