### PR TITLE
Deduplicate tail call in SolverMuJoCo.step

### DIFF
--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3506,11 +3506,9 @@ class SolverMuJoCo(SolverBase):
                 self._update_mjc_data(self.mjw_data, self.model, state_in)
             self.mjw_model.opt.timestep.fill_(dt)
             with wp.ScopedDevice(self.model.device):
-                if self.mjw_model.opt.run_collision_detection:
-                    self._mujoco_warp_step()
-                else:
+                if not self.mjw_model.opt.run_collision_detection:
                     self._convert_contacts_to_mjwarp(self.model, state_in, contacts)
-                    self._mujoco_warp_step()
+                self._mujoco_warp_step()
 
             self._update_newton_state(self.model, state_out, self.mjw_data, state_prev=state_in)
         self._step += 1


### PR DESCRIPTION
## Description

No-op refactor in `SolverMuJoCo.step()`: both arms of the `run_collision_detection` branch ended by calling `_mujoco_warp_step()`, differing only in whether `_convert_contacts_to_mjwarp()` runs first. Invert the condition so the contact conversion is a guarded prologue and the step call appears once.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

No behavior change; existing MuJoCo solver tests exercise both paths:

```
uv run --extra dev -m newton.tests -k test_mujoco_solver
```

Also manually stepped a sphere-on-ground scene with both `use_mujoco_contacts=True` and `False`; identical resting state on both paths.
