### PR TITLE
Accept labels for distance joints

### DIFF
--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4660,6 +4660,7 @@ class ModelBuilder:
         child_xform: Transform | None = None,
         min_distance: float = -1.0,
         max_distance: float = 1.0,
+        label: str | None = None,
         collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
@@ -4674,6 +4675,7 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             min_distance: The minimum distance between the bodies (no limit if negative).
             max_distance: The maximum distance between the bodies (no limit if negative).
+            label: The label of the joint.
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
@@ -4696,6 +4698,7 @@ class ModelBuilder:
             child,
             parent_xform=parent_xform,
             child_xform=child_xform,
+            label=label,
             linear_axes=[
                 ax,
                 ModelBuilder.JointDofConfig.create_unlimited(Axis.Y),

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -4660,10 +4660,10 @@ class ModelBuilder:
         child_xform: Transform | None = None,
         min_distance: float = -1.0,
         max_distance: float = 1.0,
-        label: str | None = None,
         collision_filter_parent: bool | None = None,
         enabled: bool = True,
         custom_attributes: dict[str, Any] | None = None,
+        label: str | None = None,
     ) -> int:
         """Adds a distance joint to the model. The distance joint constraints the distance between the joint anchor points on the two bodies (see :ref:`FK-IK`) it connects to the interval [`min_distance`, `max_distance`].
         It has 7 positional degrees of freedom (first 3 linear and then 4 angular dimensions for the orientation quaternion in `xyzw` notation) and 6 velocity degrees of freedom (first 3 linear and then 3 angular velocity dimensions).
@@ -4675,10 +4675,10 @@ class ModelBuilder:
             child_xform: The transform of the joint in the child body's local frame.
             min_distance: The minimum distance between the bodies (no limit if negative).
             max_distance: The maximum distance between the bodies (no limit if negative).
-            label: The label of the joint.
             collision_filter_parent: Whether to filter collisions between shapes of the parent and child bodies. Defaults to ``False`` for joints to world, ``True`` otherwise.
             enabled: Whether the joint is enabled.
             custom_attributes: Dictionary of custom attribute values for JOINT, JOINT_DOF, or JOINT_COORD frequency attributes.
+            label: The label of the joint.
 
         Returns:
             The index of the added joint.

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -787,6 +787,28 @@ def Xform "World"
 
 class TestImportUsdJoints(unittest.TestCase):
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_distance_joint_label(self):
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        articulation = UsdGeom.Xform.Define(stage, "/World")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+        body0 = UsdGeom.Xform.Define(stage, "/World/Body0")
+        UsdPhysics.RigidBodyAPI.Apply(body0.GetPrim())
+        body1 = UsdGeom.Xform.Define(stage, "/World/Body1")
+        UsdPhysics.RigidBodyAPI.Apply(body1.GetPrim())
+
+        joint = UsdPhysics.DistanceJoint.Define(stage, "/World/DistanceJoint")
+        joint.CreateBody0Rel().SetTargets([body0.GetPath()])
+        joint.CreateBody1Rel().SetTargets([body1.GetPath()])
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        self.assertIn("/World/DistanceJoint", builder.joint_label)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_ordering(self):
         builder_dfs = newton.ModelBuilder()
         builder_dfs.add_usd(


### PR DESCRIPTION
`ModelBuilder.add_usd` forwards a shared joint label to each joint convenience method. `add_joint_distance` was the only constructor that did not accept that argument, causing every USD distance-joint import to fail with `TypeError` before construction.

This adds the optional label parameter and forwards it to the generic joint builder, consistent with the other joint constructors. The regression test imports a minimal USD distance joint and verifies that its prim path is retained as the joint label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distance joints can now be added with an optional label, improving tracking of joint names.
* **Bug Fixes**
  * Importing USD distance joints better preserves labeled joint information, retaining the joint’s original USD path.
* **Tests**
  * Added a unit test that imports an in-memory USD stage with a labeled distance joint and verifies the stored joint label/path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->