### PR TITLE
Honor USD joint collision settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Fixed
 
+- Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Fix `SolverMuJoCo` dropping the authored `actuator_ctrlrange`/`actuator_ctrllimited`/`actuator_forcerange`/`actuator_forcelimited` when rebuilding USD/MJCF position/velocity actuators imported as `JOINT_TARGET`, so the compiled `mj_model` now clamps control targets and actuator forces like native MuJoCo.
 - Fix `SolverVBD` rigid contact injecting kinetic energy for yawed finite-radius contacts (e.g. small-radius cables blowing up). The normal response now acts at the geometric skeleton point rather than the rotating surface anchor, which was non-conservative under reorientation; friction still uses the surface anchor to preserve finite-radius slip. (#3125)

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -504,9 +504,9 @@ UsdPhysics ``physics:filteredPairs`` relationships).
 Filter pairs are automatically populated in several cases:
 
 - **Adjacent bodies**: Parent-child body pairs connected by joints (when
-  ``collision_filter_parent=True``). USD joint ``physics:collisionEnabled`` maps to the inverse of
-  this flag for joints with two explicit bodies. Articulation-wide self-collision filtering remains
-  additive. Also applies to max-coordinate jointed bodies.
+  ``collision_filter_parent=True``). For USD joints with two explicit bodies,
+  ``physics:collisionEnabled`` controls this filter with inverse polarity; joints to world do not
+  create a body-pair filter. Also applies to max-coordinate jointed bodies.
 - **Same-body shapes**: Shapes attached to the same rigid body
 - **Disabled self-collision**: All shape pairs within an articulation when ``enable_self_collisions=False``
 - **USD filtered pairs**: Pairs defined by ``physics:filteredPairs`` relationships in USD files

--- a/docs/concepts/collisions.rst
+++ b/docs/concepts/collisions.rst
@@ -503,7 +503,10 @@ UsdPhysics ``physics:filteredPairs`` relationships).
 
 Filter pairs are automatically populated in several cases:
 
-- **Adjacent bodies**: Parent-child body pairs connected by joints (when ``collision_filter_parent=True``). Also applies to max-coordinate jointed bodies.
+- **Adjacent bodies**: Parent-child body pairs connected by joints (when
+  ``collision_filter_parent=True``). USD joint ``physics:collisionEnabled`` maps to the inverse of
+  this flag for joints with two explicit bodies. Articulation-wide self-collision filtering remains
+  additive. Also applies to max-coordinate jointed bodies.
 - **Same-body shapes**: Shapes attached to the same rigid body
 - **Disabled self-collision**: All shape pairs within an articulation when ``enable_self_collisions=False``
 - **USD filtered pairs**: Pairs defined by ``physics:filteredPairs`` relationships in USD files

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1147,6 +1147,7 @@ def parse_usd(
             "parent_xform": parent_tf,
             "child_xform": child_tf,
             "label": joint_path,
+            "collision_filter_parent": parent_id != -1 and not joint_desc.collisionEnabled,
             "enabled": joint_desc.jointEnabled,
             "custom_attributes": joint_custom_attrs,
         }
@@ -1540,6 +1541,7 @@ def parse_usd(
         angular_initial_pos: list[float | None] = []
         angular_initial_vel: list[float | None] = []
         enabled_count = 0
+        collision_filter_parent = False
 
         # Find the first enabled joint to use as representative for transforms and metadata
         first_desc = None
@@ -1602,6 +1604,7 @@ def parse_usd(
             jd = joint_descriptions[jp]
             if not jd.jointEnabled and only_load_enabled_joints:
                 continue
+            collision_filter_parent = collision_filter_parent or not jd.collisionEnabled
             jp_prim = stage.GetPrimAtPath(jd.primPath)
             if collect_schema_attrs:
                 R.collect_prim_attrs(jp_prim)
@@ -1796,6 +1799,7 @@ def parse_usd(
             parent_xform=parent_tf,
             child_xform=child_tf,
             label=label,
+            collision_filter_parent=parent_id != -1 and collision_filter_parent,
             enabled=first_desc.jointEnabled,
             custom_attributes=joint_custom_attrs,
         )

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -787,6 +787,88 @@ def Xform "World"
 
 class TestImportUsdJoints(unittest.TestCase):
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_joint_collision_enabled(self):
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        def build(joints, *, enable_self_collisions=True):
+            stage = Usd.Stage.CreateInMemory()
+            articulation = UsdGeom.Xform.Define(stage, "/World")
+            UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+            bodies = []
+            for name in ("Body0", "Body1"):
+                body = UsdGeom.Cube.Define(stage, f"/World/{name}")
+                UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+                UsdPhysics.CollisionAPI.Apply(body.GetPrim())
+                bodies.append(body)
+
+            for joint_type, name, collision_enabled in joints:
+                joint = joint_type.Define(stage, f"/World/{name}")
+                joint.CreateBody0Rel().SetTargets([bodies[0].GetPath()])
+                joint.CreateBody1Rel().SetTargets([bodies[1].GetPath()])
+                joint.CreateCollisionEnabledAttr().Set(collision_enabled)
+
+            builder = newton.ModelBuilder()
+            builder.add_usd(stage, enable_self_collisions=enable_self_collisions)
+            shape_pair = tuple(sorted(builder.shape_label.index(str(body.GetPath())) for body in bodies))
+            return builder, shape_pair
+
+        for collision_enabled in (False, True):
+            with self.subTest(collision_enabled=collision_enabled):
+                builder, shape_pair = build([(UsdPhysics.RevoluteJoint, "Joint", collision_enabled)])
+                self.assertEqual(
+                    shape_pair in builder.shape_collision_filter_pairs,
+                    not collision_enabled,
+                )
+
+        for collision_values in ((True, True), (True, False), (False, True)):
+            with self.subTest(merged_collision_enabled=collision_values):
+                builder, shape_pair = build(
+                    [
+                        (UsdPhysics.RevoluteJoint, "Angular", collision_values[0]),
+                        (UsdPhysics.PrismaticJoint, "Linear", collision_values[1]),
+                    ]
+                )
+                self.assertEqual(
+                    shape_pair in builder.shape_collision_filter_pairs,
+                    not all(collision_values),
+                )
+
+        builder, shape_pair = build(
+            [(UsdPhysics.RevoluteJoint, "Joint", True)],
+            enable_self_collisions=False,
+        )
+        self.assertIn(shape_pair, builder.shape_collision_filter_pairs)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_world_joint_does_not_filter_collisions(self):
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        for joint_type in (UsdPhysics.FixedJoint, UsdPhysics.RevoluteJoint):
+            for collision_enabled in (False, True):
+                with self.subTest(joint_type=joint_type, collision_enabled=collision_enabled):
+                    stage = Usd.Stage.CreateInMemory()
+                    articulation = UsdGeom.Xform.Define(stage, "/World")
+                    UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+                    ground = UsdGeom.Cube.Define(stage, "/Ground")
+                    UsdPhysics.CollisionAPI.Apply(ground.GetPrim())
+                    body = UsdGeom.Cube.Define(stage, "/World/Body")
+                    UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+                    UsdPhysics.CollisionAPI.Apply(body.GetPrim())
+
+                    joint = joint_type.Define(stage, "/World/Joint")
+                    joint.CreateBody1Rel().SetTargets([body.GetPath()])
+                    joint.CreateCollisionEnabledAttr().Set(collision_enabled)
+
+                    builder = newton.ModelBuilder()
+                    builder.add_usd(stage)
+                    shape_pair = tuple(
+                        sorted(builder.shape_label.index(str(prim.GetPath())) for prim in (ground, body))
+                    )
+                    self.assertNotIn(shape_pair, builder.shape_collision_filter_pairs)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_joint_ordering(self):
         builder_dfs = newton.ModelBuilder()
         builder_dfs.add_usd(


### PR DESCRIPTION
USD joint `physics:collisionEnabled` was parsed but not forwarded to `ModelBuilder`, so joints between two bodies always used Newton's default parent-child collision filter. In particular, authored `collisionEnabled=true` could not enable contacts between the connected bodies.

This maps the USD value to the inverse `collision_filter_parent` setting for joints with two explicit bodies. Multiple source joints merged into one D6 filter the shared pair if any source joint disables collision. Articulation-wide self-collision filtering remains additive, and joints to world do not suppress body/world collisions as required by the USD joint contract.

The regression covers enabled and disabled collision, mixed merged joints, articulation-wide filtering precedence, and fixed and revolute joints to world.
