### PR TITLE
Add generic type annotations in linalg

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/types.py
+++ b/newton/_src/solvers/kamino/_src/core/types.py
@@ -75,6 +75,10 @@ class vec8f(wp.types.vector(length=8, dtype=wp.float32)):
     pass
 
 
+class mat61f(wp.types.matrix(shape=(6, 1), dtype=wp.float32)):
+    pass
+
+
 class mat63f(wp.types.matrix(shape=(6, 3), dtype=wp.float32)):
     pass
 

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -642,8 +642,8 @@ def _scale_row_vector_kernel(
     # Vector block offsets:
     row_start: wp.array[wp.int32],
     # Inputs:
-    x: wp.array[Any],
-    beta: Any,
+    x: wp.array[wp.float32],
+    beta: float,
     # Mask:
     matrix_mask: wp.array[wp.bool],
 ):
@@ -779,7 +779,7 @@ class DelassusOperator:
         self._size: SizeKamino | None = None
 
         # Initialize the Delassus data container
-        self._operator: DenseLinearOperatorData | None = None
+        self._operator: DenseLinearOperatorData[wp.float32, wp.int32] | None = None
 
         # Declare the optional Cholesky factorization
         self._solver: LinearSolverType | None = None
@@ -820,7 +820,7 @@ class DelassusOperator:
         return self._model_maxsize
 
     @property
-    def operator(self) -> DenseLinearOperatorData:
+    def operator(self) -> DenseLinearOperatorData[wp.float32, wp.int32]:
         """
         Returns a reference to the flat Delassus matrix array.
         """
@@ -835,7 +835,7 @@ class DelassusOperator:
         return self._solver
 
     @property
-    def info(self) -> DenseSquareMultiLinearInfo:
+    def info(self) -> DenseSquareMultiLinearInfo[wp.float32, wp.int32]:
         """
         Returns a reference to the flat Delassus matrix array.
         """
@@ -913,8 +913,8 @@ class DelassusOperator:
         self._device = model.device
 
         # Construct the Delassus operator data structure
-        self._operator = DenseLinearOperatorData()
-        self._operator.info = DenseSquareMultiLinearInfo()
+        self._operator = DenseLinearOperatorData[wp.float32, wp.int32]()
+        self._operator.info = DenseSquareMultiLinearInfo[wp.float32, wp.int32]()
         self._operator.mat = wp.zeros(shape=(self._model_maxsize,), dtype=wp.float32, device=self._device)
         if (model.info is not None) and (data.info is not None):
             mat_offsets = [0] + [sum(self._world_maxsize[:i]) for i in range(1, self._num_worlds + 1)]
@@ -1141,7 +1141,7 @@ class DelassusOperator:
         return self._solver.solve_inplace(x=x)
 
 
-class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
+class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators[wp.float32, wp.int32]):
     """
     A matrix-free Delassus operator for representing and operating on multiple independent sparse
     linear systems.
@@ -1240,7 +1240,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
 
         # Problem info object
         # TODO: Create more general info object independent of dense matrix representation
-        self._info: DenseSquareMultiLinearInfo | None = None
+        self._info: DenseSquareMultiLinearInfo[wp.float32, wp.int32] | None = None
 
         # Declare the device cache
         self._device: wp.DeviceLike = None
@@ -1255,7 +1255,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         self._vec_temp_body_space: wp.array[wp.float32] | None = None
 
         self._col_major_jacobian: ColMajorSparseConstraintJacobians | None = None
-        self._transpose_op_matrix: BlockSparseMatrices | None = None
+        self._transpose_op_matrix: BlockSparseMatrices[wp.float32, wp.int32, Any] | None = None
 
         # Combined regularization vector for implicit joint dynamics
         self._combined_regularization: wp.array[wp.float32] | None = None
@@ -1327,7 +1327,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         # Use the model's device
         self._device = model.device
 
-        self._info = DenseSquareMultiLinearInfo()
+        self._info = DenseSquareMultiLinearInfo[wp.float32, wp.int32]()
         if model.info is not None and data.info is not None:
             self._info.assign(
                 maxdim=model.info.max_total_cts,
@@ -1715,7 +1715,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
     ###
 
     @property
-    def info(self) -> DenseSquareMultiLinearInfo | None:
+    def info(self) -> DenseSquareMultiLinearInfo[wp.float32, wp.int32] | None:
         """
         Returns the info object for the Delassus problem dimensions and sizes.
         """
@@ -1752,7 +1752,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         return self._model.device
 
     @property
-    def constraint_jacobian(self) -> BlockSparseMatrices:
+    def constraint_jacobian(self) -> BlockSparseMatrices[wp.float32, wp.int32, vec6f]:
         return self._jacobians._J_cts.bsm
 
     ###

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -24,6 +24,7 @@ from ..core.math import (
 from ..core.model import ModelKamino
 from ..core.types import (
     assign_to_warp_int32_array,
+    mat61f,
     mat66f,
     to_warp_int32_array,
     vec6f,
@@ -1505,8 +1506,8 @@ class SparseSystemJacobians:
                 compute the non-zero block coordinates of the contact constraint Jacobian.
         """
         # Declare and initialize the Jacobian data containers
-        self._J_cts: BlockSparseLinearOperators | None = None
-        self._J_dofs: BlockSparseLinearOperators | None = None
+        self._J_cts: BlockSparseLinearOperators[wp.float32, wp.int32] | None = None
+        self._J_dofs: BlockSparseLinearOperators[wp.float32, wp.int32] | None = None
 
         # Local (in-world) offsets for the non-zero blocks of the constraint and dofs Jacobian for
         # each (global) joint, limit, and contact
@@ -1672,22 +1673,22 @@ class SparseSystemJacobians:
         # Allocate the block-sparse linear-operator data to represent each system Jacobian
         with wp.ScopedDevice(device):
             # First allocate the geometric constraint Jacobian
-            bsm_cts = BlockSparseMatrices(
+            bsm_cts: BlockSparseMatrices[wp.float32, wp.int32, vec6f] = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6,)),
+                nzb_dtype=BlockDType[wp.float32](dtype=wp.float32, shape=(6,)),
                 device=device,
             )
             bsm_cts.finalize(max_dims=J_cts_dims_max, capacities=J_cts_nnzb_max)
-            self._J_cts = BlockSparseLinearOperators(bsm=bsm_cts)
+            self._J_cts = BlockSparseLinearOperators[wp.float32, wp.int32](bsm=bsm_cts)
 
             # Then allocate the geometric DoFs Jacobian
-            bsm_dofs = BlockSparseMatrices(
+            bsm_dofs: BlockSparseMatrices[wp.float32, wp.int32, vec6f] = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6,)),
+                nzb_dtype=BlockDType[wp.float32](dtype=wp.float32, shape=(6,)),
                 device=device,
             )
             bsm_dofs.finalize(max_dims=J_dofs_dims, capacities=J_dofs_nnzb)
-            self._J_dofs = BlockSparseLinearOperators(bsm=bsm_dofs)
+            self._J_dofs = BlockSparseLinearOperators[wp.float32, wp.int32](bsm=bsm_dofs)
 
             # Set all constant values into BSMs (corresponding to joint dofs/cts)
             if bsm_cts.max_of_max_dims[0] * bsm_cts.max_of_max_dims[1] > 0:
@@ -1861,7 +1862,7 @@ class SparseSystemJacobians:
             )
 
 
-class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
+class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators[wp.float32, wp.int32]):
     """
     Container to hold a column-major version of the constraint Jacobian
     that uses 6x1 blocks instead of the regular 1x6 blocks.
@@ -2023,10 +2024,10 @@ class ColMajorSparseConstraintJacobians(BlockSparseLinearOperators):
 
         # Allocate the block-sparse linear-operator data to represent each system Jacobian
         with wp.ScopedDevice(device):
-            # Allocate the column-major constraint Jacobian
-            self.bsm = BlockSparseMatrices(
+            # Allocate the column-major constraint Jacobian.
+            self.bsm: BlockSparseMatrices[wp.float32, wp.int32, mat61f] = BlockSparseMatrices(
                 num_matrices=num_worlds,
-                nzb_dtype=BlockDType(dtype=wp.float32, shape=(6, 1)),
+                nzb_dtype=BlockDType[wp.float32](dtype=wp.float32, shape=(6, 1)),
                 device=device,
             )
             self.bsm.finalize(max_dims=J_cts_cm_dims_max, capacities=J_cts_cm_nnzb_max)

--- a/newton/_src/solvers/kamino/_src/linalg/blas.py
+++ b/newton/_src/solvers/kamino/_src/linalg/blas.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import warp as wp
 
-from ..core.types import FloatType
+from ..core.types import FloatType, vec7f
 from .sparse_matrix import BlockDType, BlockSparseMatrices
 
 ###
@@ -1137,7 +1137,7 @@ def dense_gemv(
 
 
 def block_sparse_matvec(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, Any],
     x: wp.array[wp.float32] | wp.array2d[wp.float32],
     y: wp.array[wp.float32] | wp.array2d[wp.float32],
     matrix_mask: wp.array[wp.bool],
@@ -1201,7 +1201,7 @@ def block_sparse_matvec(
 
 
 def block_sparse_transpose_matvec(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, Any],
     y: wp.array[wp.float32] | wp.array2d[wp.float32],
     x: wp.array[wp.float32] | wp.array2d[wp.float32],
     matrix_mask: wp.array[wp.bool],
@@ -1265,7 +1265,7 @@ def block_sparse_transpose_matvec(
 
 
 def block_sparse_gemv(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, Any],
     x: wp.array[wp.float32] | wp.array2d[wp.float32],
     y: wp.array[wp.float32] | wp.array2d[wp.float32],
     alpha: wp.float32,
@@ -1340,7 +1340,7 @@ def block_sparse_gemv(
 
 
 def block_sparse_transpose_gemv(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, Any],
     y: wp.array[wp.float32] | wp.array2d[wp.float32],
     x: wp.array[wp.float32] | wp.array2d[wp.float32],
     alpha: wp.float32,
@@ -1415,7 +1415,7 @@ def block_sparse_transpose_gemv(
 
 
 def block_sparse_ATA_inv_diagonal_2d(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, Any],
     inv_diag: wp.array2d[wp.float32],
     matrix_mask: wp.array[wp.bool],
     diag_offset: wp.float32 = 0.0,
@@ -1462,7 +1462,7 @@ def block_sparse_ATA_inv_diagonal_2d(
 
 
 def block_sparse_ATA_blockwise_3_4_inv_diagonal_2d(
-    A: BlockSparseMatrices,
+    A: BlockSparseMatrices[wp.float32, wp.int32, vec7f],
     inv_blocks_3: wp.array2d[wp.mat33f],
     inv_blocks_4: wp.array2d[wp.mat44f],
     matrix_mask: wp.array[wp.bool],

--- a/newton/_src/solvers/kamino/_src/linalg/conjugate.py
+++ b/newton/_src/solvers/kamino/_src/linalg/conjugate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import functools
 import math
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Generic
 
 import warp as wp
 
@@ -18,6 +18,7 @@ from . import blas
 from .core import DenseLinearOperatorData
 from .sparse_matrix import BlockSparseMatrices
 from .sparse_operator import BlockSparseLinearOperators
+from .types import IndexType, ScalarType
 
 # No need to auto-generate adjoint code for linear solvers
 wp.set_module_options({"enable_backward": False})
@@ -33,7 +34,7 @@ __all__ = [
 ]
 
 
-class BatchedLinearOperator:
+class BatchedLinearOperator(Generic[ScalarType, IndexType]):
     """Linear operator for batched matrix-vector products.
 
     Supports dense, diagonal, and block-sparse matrices.
@@ -45,12 +46,12 @@ class BatchedLinearOperator:
         gemv_fn: Callable,
         n_worlds: int,
         max_dim: int,
-        active_dims: wp.array[wp.int32],
+        active_dims: wp.array[IndexType],
         device: wp.Device,
-        dtype: type,
+        dtype: type[ScalarType],
         matvec_fn: Callable | None = None,
-        mio: wp.array[wp.int32] | None = None,
-        vio: wp.array[wp.int32] | None = None,
+        mio: wp.array[IndexType] | None = None,
+        vio: wp.array[IndexType] | None = None,
         total_vec_size: int = 0,
     ):
         self._gemv_fn = gemv_fn
@@ -65,7 +66,9 @@ class BatchedLinearOperator:
         self.total_vec_size = total_vec_size
 
     @classmethod
-    def from_dense(cls, operator: DenseLinearOperatorData) -> BatchedLinearOperator:
+    def from_dense(
+        cls, operator: DenseLinearOperatorData[ScalarType, IndexType]
+    ) -> BatchedLinearOperator[ScalarType, IndexType]:
         """Create operator from dense matrix data."""
         info = operator.info
         n_worlds = info.num_blocks
@@ -92,8 +95,12 @@ class BatchedLinearOperator:
 
     @classmethod
     def from_diagonal(
-        cls, D: wp.array[Any], active_dims: wp.array[wp.int32], vio: wp.array[wp.int32], max_dim: int
-    ) -> BatchedLinearOperator:
+        cls,
+        D: wp.array[ScalarType],
+        active_dims: wp.array[IndexType],
+        vio: wp.array[IndexType],
+        max_dim: int,
+    ) -> BatchedLinearOperator[ScalarType, IndexType]:
         """Create operator from diagonal matrix (flat 1D storage)."""
         n_worlds = active_dims.shape[0]
 
@@ -103,7 +110,11 @@ class BatchedLinearOperator:
         return cls(gemv_fn, n_worlds, max_dim, active_dims, D.device, D.dtype, vio=vio, total_vec_size=D.shape[0])
 
     @classmethod
-    def from_block_sparse(cls, A: BlockSparseMatrices, active_dims: wp.array[wp.int32]) -> BatchedLinearOperator:
+    def from_block_sparse(
+        cls,
+        A: BlockSparseMatrices[ScalarType, IndexType, Any],
+        active_dims: wp.array[IndexType],
+    ) -> BatchedLinearOperator[ScalarType, IndexType]:
         """Create operator from block-sparse matrix.
 
         The block-sparse matrix uses its own ``row_start``/``col_start`` offsets
@@ -139,7 +150,9 @@ class BatchedLinearOperator:
         )
 
     @classmethod
-    def from_block_sparse_operator(cls, A: BlockSparseLinearOperators) -> BatchedLinearOperator:
+    def from_block_sparse_operator(
+        cls, A: BlockSparseLinearOperators[ScalarType, IndexType]
+    ) -> BatchedLinearOperator[ScalarType, IndexType]:
         """Create operator from block-sparse operator.
 
         Args:
@@ -170,8 +183,8 @@ class BatchedLinearOperator:
 
     def gemv(
         self,
-        x: wp.array[Any],
-        y: wp.array[Any],
+        x: wp.array[ScalarType],
+        y: wp.array[ScalarType],
         world_active: wp.array[wp.bool],
         alpha: float,
         beta: float,
@@ -179,7 +192,7 @@ class BatchedLinearOperator:
         """Compute y = alpha * A @ x + beta * y."""
         self._gemv_fn(x, y, world_active, alpha, beta)
 
-    def matvec(self, x: wp.array[Any], y: wp.array[Any], world_active: wp.array[wp.bool]):
+    def matvec(self, x: wp.array[ScalarType], y: wp.array[ScalarType], world_active: wp.array[wp.bool]):
         if self._matvec_fn is not None:
             return self._matvec_fn(x, y, world_active)
         return self._gemv_fn(x, y, world_active, 1.0, 0.0)
@@ -509,7 +522,7 @@ def make_jacobi_preconditioner(
     diag[v_idx] = el_inv
 
 
-class ConjugateSolver:
+class ConjugateSolver(Generic[ScalarType, IndexType]):
     """Base class for conjugate iterative solvers (CG, CR).
 
     Solves batched linear systems Ax = b for multiple independent worlds in parallel.
@@ -534,13 +547,13 @@ class ConjugateSolver:
 
     def __init__(
         self,
-        A: BatchedLinearOperator,
-        active_dims: wp.array[wp.int32] | None = None,
+        A: BatchedLinearOperator[ScalarType, IndexType],
+        active_dims: wp.array[IndexType] | None = None,
         world_active: wp.array[wp.bool] | None = None,
-        atol: float | wp.array[Any] | None = None,
-        rtol: float | wp.array[Any] | None = None,
-        maxiter: wp.array[wp.int32] = None,
-        Mi: BatchedLinearOperator | None = None,
+        atol: float | wp.array[ScalarType] | None = None,
+        rtol: float | wp.array[ScalarType] | None = None,
+        maxiter: wp.array[wp.int32] | None = None,
+        Mi: BatchedLinearOperator[ScalarType, IndexType] | None = None,
         callback: Callable | None = None,
         use_cuda_graph: bool = True,
         use_graph_conditionals: bool = True,
@@ -587,7 +600,7 @@ class ConjugateSolver:
         self._allocate()
 
     def _allocate(self):
-        self.residual = wp.empty((self.n_worlds), dtype=self.scalar_type, device=self.device)
+        self.residual: wp.array[ScalarType] = wp.empty((self.n_worlds), dtype=self.scalar_type, device=self.device)
 
         if self.maxiter is None:
             maxiter = int(1.5 * self.maxdims)
@@ -598,9 +611,13 @@ class ConjugateSolver:
 
         # TODO: non-tiled variant for CPU
         if self.tiled_dot_product:
-            self.dot_product = wp.zeros((2, self.n_worlds), dtype=self.scalar_type, device=self.device)
+            self.dot_product: wp.array2d[ScalarType] = wp.zeros(
+                (2, self.n_worlds), dtype=self.scalar_type, device=self.device
+            )
         else:
-            self.dot_partial_sums = wp.zeros((2, self.n_worlds, (self.maxdims + 1) // 2), device=self.device)
+            self.dot_partial_sums: wp.array3d[ScalarType] = wp.zeros(
+                (2, self.n_worlds, (self.maxdims + 1) // 2), dtype=self.scalar_type, device=self.device
+            )
             self.dot_product = self.dot_partial_sums[:, :, 0]
 
         atol_val = self.atol if isinstance(self.atol, float) else 1e-8
@@ -612,9 +629,9 @@ class ConjugateSolver:
         if self.rtol is None or isinstance(self.rtol, float):
             self.rtol = wp.full(self.n_worlds, rtol_val, dtype=self.scalar_type, device=self.device)
 
-        self.atol_sq = wp.empty(self.n_worlds, dtype=self.scalar_type, device=self.device)
-        self.cur_iter = wp.empty(self.n_worlds, dtype=wp.int32, device=self.device)
-        self.conditions = wp.empty(self.n_worlds + 1, dtype=wp.int32, device=self.device)
+        self.atol_sq: wp.array[ScalarType] = wp.empty(self.n_worlds, dtype=self.scalar_type, device=self.device)
+        self.cur_iter: wp.array[wp.int32] = wp.empty(self.n_worlds, dtype=wp.int32, device=self.device)
+        self.conditions: wp.array[wp.int32] = wp.empty(self.n_worlds + 1, dtype=wp.int32, device=self.device)
 
     @property
     def tiled_dot_product(self):
@@ -646,7 +663,7 @@ class ConjugateSolver:
             )
 
 
-class CGSolver(ConjugateSolver):
+class CGSolver(ConjugateSolver[ScalarType, IndexType]):
     """Conjugate Gradient solver for symmetric positive definite systems.
 
     The solver terminates when ||r||^2 < max(rtol^2 * ||b||^2, atol^2) or
@@ -657,15 +674,17 @@ class CGSolver(ConjugateSolver):
         super()._allocate()
 
         # Temp storage: (2, total_vec_size) paired arrays
-        self.r_and_z = wp.zeros((2, self.total_vec_size), dtype=self.scalar_type, device=self.device)
-        self.p_and_Ap = wp.zeros_like(self.r_and_z)
+        self.r_and_z: wp.array2d[ScalarType] = wp.zeros(
+            (2, self.total_vec_size), dtype=self.scalar_type, device=self.device
+        )
+        self.p_and_Ap: wp.array2d[ScalarType] = wp.zeros_like(self.r_and_z)
 
         # (r, r) -- so we can compute r.z and r.r at once
-        self.r_repeated = _repeat_first(self.r_and_z)
+        self.r_repeated: wp.array2d[ScalarType] = _repeat_first(self.r_and_z)
         if self.Mi is None:
             # without preconditioner r == z
             self.r_and_z = self.r_repeated
-            self.rz_new = self.dot_product[0]
+            self.rz_new: wp.array[ScalarType] = self.dot_product[0]
         else:
             self.rz_new = self.dot_product[1]
 
@@ -679,9 +698,9 @@ class CGSolver(ConjugateSolver):
 
     def solve(
         self,
-        b: wp.array[Any],
-        x: wp.array[Any],
-        active_dims: wp.array[wp.int32] | None = None,
+        b: wp.array[ScalarType],
+        x: wp.array[ScalarType],
+        active_dims: wp.array[IndexType] | None = None,
         world_active: wp.array[wp.bool] | None = None,
     ):
         if b.shape[0] != self.total_vec_size:
@@ -698,7 +717,7 @@ class CGSolver(ConjugateSolver):
             world_active = self.world_active
 
         r, z = self.r_and_z[0], self.r_and_z[1]
-        r_norm_sq = self.dot_product[0]
+        r_norm_sq: wp.array[ScalarType] = self.dot_product[0]
         p, Ap = self.p_and_Ap[0], self.p_and_Ap[1]
 
         self.compute_dot(b, b, active_dims, world_active)
@@ -768,7 +787,7 @@ class CGSolver(ConjugateSolver):
         )
 
 
-class CRSolver(ConjugateSolver):
+class CRSolver(ConjugateSolver[ScalarType, IndexType]):
     """Conjugate Residual solver for symmetric (possibly indefinite) systems.
 
     The solver terminates when ||r||^2 < max(rtol^2 * ||b||^2, atol^2) or
@@ -779,10 +798,12 @@ class CRSolver(ConjugateSolver):
         super()._allocate()
 
         # Temp storage: (2, total_vec_size) paired arrays
-        self.r_and_z = wp.zeros((2, self.total_vec_size), dtype=self.scalar_type, device=self.device)
-        self.r_and_Az = wp.zeros_like(self.r_and_z)
-        self.y_and_Ap = wp.zeros_like(self.r_and_z)
-        self.p = wp.zeros((self.total_vec_size,), dtype=self.scalar_type, device=self.device)
+        self.r_and_z: wp.array2d[ScalarType] = wp.zeros(
+            (2, self.total_vec_size), dtype=self.scalar_type, device=self.device
+        )
+        self.r_and_Az: wp.array2d[ScalarType] = wp.zeros_like(self.r_and_z)
+        self.y_and_Ap: wp.array2d[ScalarType] = wp.zeros_like(self.r_and_z)
+        self.p: wp.array[ScalarType] = wp.zeros((self.total_vec_size,), dtype=self.scalar_type, device=self.device)
         # (r, r) -- so we can compute r.z and r.r at once
 
         if self.Mi is None:
@@ -797,9 +818,9 @@ class CRSolver(ConjugateSolver):
 
     def solve(
         self,
-        b: wp.array[Any],
-        x: wp.array[Any],
-        active_dims: wp.array[wp.int32] | None = None,
+        b: wp.array[ScalarType],
+        x: wp.array[ScalarType],
+        active_dims: wp.array[IndexType] | None = None,
         world_active: wp.array[wp.bool] | None = None,
     ):
         if b.shape[0] != self.total_vec_size:

--- a/newton/_src/solvers/kamino/_src/linalg/core.py
+++ b/newton/_src/solvers/kamino/_src/linalg/core.py
@@ -8,13 +8,17 @@ This module provides data structures and utilities for managing multiple
 independent linear systems, including rectangular and square systems.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Any, Generic
 
 import numpy as np
 import warp as wp
 
 from ..core.types import FloatType, IntType, VecIntType
 from ..utils import logger as msg
+from .types import IndexType, ScalarType
 
 ###
 # Module interface
@@ -34,7 +38,7 @@ __all__ = [
 
 
 @dataclass
-class DenseRectangularMultiLinearInfo:
+class DenseRectangularMultiLinearInfo(Generic[ScalarType, IndexType]):
     """
     A data structure for managing multiple rectangular linear systems of inhomogeneous and mutable shapes, i.e.:
 
@@ -87,45 +91,45 @@ class DenseRectangularMultiLinearInfo:
     This is equal to `sum(maxdim[i][0] for i in range(num_blocks))`.
     """
 
-    dtype: FloatType = wp.float32
+    dtype: type[ScalarType] = wp.float32  # type: ignore[assignment]
     """The data type of the underlying matrix and vector data arrays."""
 
-    itype: IntType = wp.int32
+    itype: type[IndexType] = wp.int32  # type: ignore[assignment]
     """The integer type used for indexing the underlying data arrays."""
 
     device: wp.DeviceLike | None = None
     """The device on which the data arrays are allocated."""
 
-    maxdim: wp.array | None = None
+    maxdim: wp.array[Any] | None = None  # wp.array[vec2<itype>]
     """
     The maximum dimensions of each rectangular matrix block.
     Shape of ``(num_blocks,)`` and type :class:`vec2i`.
     Each entry corresponds to the shape `(max_rows, max_cols)`.
     """
 
-    dim: wp.array | None = None
+    dim: wp.array[Any] | None = None  # wp.array[vec2<itype>]
     """
     The active dimensions of each rectangular matrix block.
     Shape of ``(num_blocks,)`` and type :class:`vec2i`.
     Each entry corresponds to the shape `(rows, cols)`.
     """
 
-    mio: wp.array | None = None
+    mio: wp.array[IndexType] | None = None
     """
     The matrix index offset (mio) of each block in the flat data array.
-    Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
+    Shape of ``(num_blocks,)``.
     """
 
-    rvio: wp.array | None = None
+    rvio: wp.array[IndexType] | None = None
     """
     The rhs vector index offset (vio) of each block in the flat data array.
-    Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
+    Shape of ``(num_blocks,)``.
     """
 
-    ivio: wp.array | None = None
+    ivio: wp.array[IndexType] | None = None
     """
     The input vector index offset (vio) of each block in the flat data array.
-    Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
+    Shape of ``(num_blocks,)``.
     """
 
     @staticmethod
@@ -148,8 +152,8 @@ class DenseRectangularMultiLinearInfo:
     def finalize(
         self,
         dimensions: list[tuple[int, int]],
-        dtype: FloatType = wp.float32,
-        itype: IntType = wp.int32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
+        itype: type[IndexType] = wp.int32,  # type: ignore[assignment]
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -204,12 +208,12 @@ class DenseRectangularMultiLinearInfo:
 
     def assign(
         self,
-        maxdim: wp.array,
-        dim: wp.array,
-        mio: wp.array,
-        rvio: wp.array,
-        ivio: wp.array,
-        dtype: FloatType = wp.float32,
+        maxdim: wp.array[Any],  # wp.array[vec2<IndexType>]
+        dim: wp.array[Any],  # wp.array[vec2<IndexType>]
+        mio: wp.array[IndexType],
+        rvio: wp.array[IndexType],
+        ivio: wp.array[IndexType],
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -268,15 +272,15 @@ class DenseRectangularMultiLinearInfo:
         self.rvio = rvio
         self.ivio = ivio
 
-    def is_matrix_compatible(self, A: wp.array) -> bool:
+    def is_matrix_compatible(self, A: wp.array[ScalarType]) -> bool:
         """Checks if the provided matrix data array is compatible with the specified info structure."""
         return A.dtype == self.dtype and A.size >= self.total_mat_size
 
-    def is_rhs_compatible(self, b: wp.array) -> bool:
+    def is_rhs_compatible(self, b: wp.array[ScalarType]) -> bool:
         """Checks if the provided rhs vector data array is compatible with the specified info structure."""
         return b.dtype == self.dtype and b.size >= self.total_rhs_size
 
-    def is_input_compatible(self, x: wp.array) -> bool:
+    def is_input_compatible(self, x: wp.array[ScalarType]) -> bool:
         """Checks if the provided input vector data array is compatible with the specified info structure."""
         return x.dtype == self.dtype and x.size >= self.total_inp_size
 
@@ -297,7 +301,7 @@ class DenseRectangularMultiLinearInfo:
 
 
 @dataclass
-class DenseSquareMultiLinearInfo:
+class DenseSquareMultiLinearInfo(Generic[ScalarType, IndexType]):
     """
     A data structure for managing multiple square linear systems of inhomogeneous and mutable shapes, i.e.:
 
@@ -344,34 +348,34 @@ class DenseSquareMultiLinearInfo:
     This is equal to `sum(maxdim[i][1] for i in range(num_blocks))`.
     """
 
-    dtype: FloatType = wp.float32
+    dtype: type[ScalarType] = wp.float32  # type: ignore[assignment]
     """The data type of the underlying matrix and vector data arrays."""
 
-    itype: IntType = wp.int32
+    itype: type[IndexType] = wp.int32  # type: ignore[assignment]
     """The integer type used for indexing the underlying data arrays."""
 
     device: wp.DeviceLike | None = None
     """The device on which the data arrays are allocated."""
 
-    maxdim: wp.array | None = None
+    maxdim: wp.array[IndexType] | None = None
     """
     The maximum dimensions of each square matrix block.
     Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
     """
 
-    dim: wp.array | None = None
+    dim: wp.array[IndexType] | None = None
     """
     The active dimensions of each square matrix block.
     Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
     """
 
-    mio: wp.array | None = None
+    mio: wp.array[IndexType] | None = None
     """
     The matrix index offset (mio) of each matrix block in the flat data array.
     Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
     """
 
-    vio: wp.array | None = None
+    vio: wp.array[IndexType] | None = None
     """
     The vector index offset (vio) of each vector block in the flat data array.
     Shape of ``(num_blocks,)`` and type :class:`int | int32 | int64`.
@@ -393,8 +397,8 @@ class DenseSquareMultiLinearInfo:
     def finalize(
         self,
         dimensions: list[int],
-        dtype: FloatType = wp.float32,
-        itype: IntType = wp.int32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
+        itype: type[IndexType] = wp.int32,  # type: ignore[assignment]
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -438,11 +442,11 @@ class DenseSquareMultiLinearInfo:
 
     def assign(
         self,
-        maxdim: wp.array,
-        dim: wp.array,
-        mio: wp.array,
-        vio: wp.array,
-        dtype: FloatType = wp.float32,
+        maxdim: wp.array[IndexType],
+        dim: wp.array[IndexType],
+        mio: wp.array[IndexType],
+        vio: wp.array[IndexType],
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike = None,
     ) -> None:
         """
@@ -489,15 +493,15 @@ class DenseSquareMultiLinearInfo:
         self.mio = mio
         self.vio = vio
 
-    def is_matrix_compatible(self, A: wp.array) -> bool:
+    def is_matrix_compatible(self, A: wp.array[ScalarType]) -> bool:
         """Checks if the provided matrix data array is compatible with the specified info structure."""
         return A.dtype == self.dtype and A.size >= self.total_mat_size
 
-    def is_rhs_compatible(self, b: wp.array) -> bool:
+    def is_rhs_compatible(self, b: wp.array[ScalarType]) -> bool:
         """Checks if the provided rhs vector data array is compatible with the specified info structure."""
         return b.dtype == self.dtype and b.size >= self.total_vec_size
 
-    def is_input_compatible(self, x: wp.array) -> bool:
+    def is_input_compatible(self, x: wp.array[ScalarType]) -> bool:
         """Checks if the provided input vector data array is compatible with the specified info structure."""
         return x.dtype == self.dtype and x.size >= self.total_vec_size
 
@@ -517,7 +521,7 @@ class DenseSquareMultiLinearInfo:
 
 
 @dataclass
-class DenseLinearOperatorData:
+class DenseLinearOperatorData(Generic[ScalarType, IndexType]):
     """
     A data structure for encapsulating a multi-linear matrix operator.
 
@@ -530,10 +534,14 @@ class DenseLinearOperatorData:
     from an external source to avoid unnecessary memory reallocations.
     """
 
-    info: DenseRectangularMultiLinearInfo | DenseSquareMultiLinearInfo | None = None
+    info: (
+        DenseRectangularMultiLinearInfo[ScalarType, IndexType]
+        | DenseSquareMultiLinearInfo[ScalarType, IndexType]
+        | None
+    ) = None
     """The multi-linear data structure describing the operator."""
 
-    mat: wp.array | None = None
+    mat: wp.array[ScalarType] | None = None
     """The flat data array containing the matrix blocks."""
 
     def zero(self) -> None:

--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked_rcm_solver.py
@@ -62,7 +62,7 @@ __all__ = ["LLTBlockedRCMSolver"]
 wp.set_module_options({"enable_backward": False})
 
 
-class LLTBlockedRCMSolver(DirectSolver):
+class LLTBlockedRCMSolver(DirectSolver[wp.float32, wp.int32]):
     """RCM-reordered, semi-sparse Blocked LLT (Cholesky) solver.
 
     Same public API as :class:`LLTBlockedSolver`.
@@ -94,7 +94,7 @@ class LLTBlockedRCMSolver(DirectSolver):
 
     def __init__(
         self,
-        operator: DenseLinearOperatorData | None = None,
+        operator: DenseLinearOperatorData[wp.float32, wp.int32] | None = None,
         block_size: int = 32,
         solve_block_dim: int = 256,
         factorize_block_dim: int = 128,
@@ -222,7 +222,7 @@ class LLTBlockedRCMSolver(DirectSolver):
     ###
 
     @override
-    def _allocate_impl(self, A: DenseLinearOperatorData, **kwargs: dict[str, Any]) -> None:
+    def _allocate_impl(self, A: DenseLinearOperatorData[wp.float32, wp.int32], **kwargs: dict[str, Any]) -> None:
         if A.info is None:
             raise ValueError("The provided operator does not have any associated info!")
         if not isinstance(A.info, DenseSquareMultiLinearInfo):

--- a/newton/_src/solvers/kamino/_src/linalg/linear.py
+++ b/newton/_src/solvers/kamino/_src/linalg/linear.py
@@ -14,12 +14,11 @@ intra-system parallelism may be exploited.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Generic
 
 import warp as wp
 
 from .....core.types import override
-from ..core.types import FloatType
 from . import conjugate, factorize
 from .core import DenseLinearOperatorData, DenseSquareMultiLinearInfo, make_dtype_tolerance
 from .sparse_matrix import (
@@ -28,6 +27,7 @@ from .sparse_matrix import (
     dense_to_block_sparse_copy_values,
 )
 from .sparse_operator import BlockSparseLinearOperators
+from .types import IndexType, ScalarType
 
 ###
 # Module interface
@@ -49,29 +49,29 @@ __all__ = [
 ###
 
 
-class LinearSolver(ABC):
+class LinearSolver(ABC, Generic[ScalarType, IndexType]):
     """
     An abstract base class for linear system solvers.
     """
 
     def __init__(
         self,
-        operator: DenseLinearOperatorData | None = None,
+        operator: DenseLinearOperatorData[ScalarType, IndexType] | None = None,
         atol: float | None = None,
         rtol: float | None = None,
-        dtype: FloatType = wp.float32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
         # Declare and initialize the internal reference to the matrix/operator data
-        self._operator: DenseLinearOperatorData | None = operator
+        self._operator: DenseLinearOperatorData[ScalarType, IndexType] | None = operator
 
         # Override dtype if linear operator is provided
         if operator is not None:
             dtype = operator.info.dtype
 
         # Declare and initialize internal meta-data
-        self._dtype: Any = dtype
+        self._dtype: type[ScalarType] = dtype
         self._atol: float = atol
         self._rtol: float = rtol
 
@@ -87,13 +87,13 @@ class LinearSolver(ABC):
     ###
 
     @property
-    def operator(self) -> DenseLinearOperatorData:
+    def operator(self) -> DenseLinearOperatorData[ScalarType, IndexType]:
         if self._operator is None:
             raise ValueError("No linear operator has been allocated!")
         return self._operator
 
     @property
-    def dtype(self) -> FloatType:
+    def dtype(self) -> type[ScalarType]:
         return self._dtype
 
     @property
@@ -113,30 +113,32 @@ class LinearSolver(ABC):
     ###
 
     @abstractmethod
-    def _allocate_impl(self, operator: DenseLinearOperatorData, **kwargs: dict[str, Any]) -> None:
+    def _allocate_impl(
+        self, operator: DenseLinearOperatorData[ScalarType, IndexType], **kwargs: dict[str, Any]
+    ) -> None:
         raise NotImplementedError("An allocation operation is not implemented.")
 
     @abstractmethod
-    def _reset_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _reset_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A reset operation is not implemented.")
 
     @abstractmethod
-    def _compute_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _compute_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A compute operation is not implemented.")
 
     @abstractmethod
-    def _solve_impl(self, b: wp.array, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_impl(self, b: wp.array[ScalarType], x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A solve operation is not implemented.")
 
     @abstractmethod
-    def _solve_inplace_impl(self, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_inplace_impl(self, x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A solve-in-place operation is not implemented.")
 
     ###
     # Public API
     ###
 
-    def finalize(self, operator: DenseLinearOperatorData, **kwargs: dict[str, Any]) -> None:
+    def finalize(self, operator: DenseLinearOperatorData[ScalarType, IndexType], **kwargs: dict[str, Any]) -> None:
         """
         Ingest a linear operator and allocate any necessary internal memory
         based on the multi-linear layout specified by the operator's info.
@@ -157,13 +159,13 @@ class LinearSolver(ABC):
         """Resets the internal solver data (e.g. possibly to zeros)."""
         self._reset_impl()
 
-    def compute(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def compute(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         """Ingest matrix data and pre-compute any rhs-independent intermediate data."""
         if not self._operator.info.is_matrix_compatible(A):
             raise ValueError("The provided flat matrix data array does not have enough memory!")
         self._compute_impl(A=A, **kwargs)
 
-    def solve(self, b: wp.array, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def solve(self, b: wp.array[ScalarType], x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         """Solves the multi-linear systems `A @ x = b`."""
         if not self._operator.info.is_rhs_compatible(b):
             raise ValueError("The provided flat rhs vector data array does not have enough memory!")
@@ -171,25 +173,25 @@ class LinearSolver(ABC):
             raise ValueError("The provided flat input vector data array does not have enough memory!")
         self._solve_impl(b=b, x=x, **kwargs)
 
-    def solve_inplace(self, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def solve_inplace(self, x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         """Solves the multi-linear systems `A @ x = b` in-place, where `x` is initialized with rhs data."""
         if not self._operator.info.is_input_compatible(x):
             raise ValueError("The provided flat input vector data array does not have enough memory!")
         self._solve_inplace_impl(x=x, **kwargs)
 
 
-class DirectSolver(LinearSolver):
+class DirectSolver(LinearSolver[ScalarType, IndexType]):
     """
     An abstract base class for direct linear system solvers based on matrix factorization.
     """
 
     def __init__(
         self,
-        operator: DenseLinearOperatorData | None = None,
+        operator: DenseLinearOperatorData[ScalarType, IndexType] | None = None,
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = wp.float32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
@@ -224,11 +226,11 @@ class DirectSolver(LinearSolver):
     ###
 
     @abstractmethod
-    def _factorize_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _factorize_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A matrix factorization implementation is not provided.")
 
     @abstractmethod
-    def _reconstruct_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _reconstruct_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         raise NotImplementedError("A matrix reconstruction implementation is not provided.")
 
     ###
@@ -236,10 +238,10 @@ class DirectSolver(LinearSolver):
     ###
 
     @override
-    def _compute_impl(self, A: wp.array, **kwargs: dict[str, Any]):
+    def _compute_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]):
         self._factorize(A, **kwargs)
 
-    def _factorize(self, A: wp.array, ftol: float | None = None, **kwargs: dict[str, Any]) -> None:
+    def _factorize(self, A: wp.array[ScalarType], ftol: float | None = None, **kwargs: dict[str, Any]) -> None:
         # Override the current tolerance if provided otherwise ensure
         # it does not exceed machine precision for the current dtype
         if ftol is not None:
@@ -255,39 +257,44 @@ class DirectSolver(LinearSolver):
     # Public API
     ###
 
-    def reconstruct(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def reconstruct(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         """Reconstructs the original matrix from the current factorization."""
         self._check_has_factorization()
         self._reconstruct_impl(A, **kwargs)
 
 
-class IterativeSolver(LinearSolver):
+class IterativeSolver(LinearSolver[ScalarType, IndexType]):
     """
     An abstract base class for iterative linear system solvers.
     """
 
     def __init__(
         self,
-        operator: conjugate.BatchedLinearOperator | DenseLinearOperatorData | BlockSparseLinearOperators | None = None,
-        atol: float | wp.array | None = None,
-        rtol: float | wp.array | None = None,
-        dtype: FloatType = wp.float32,
+        operator: (
+            conjugate.BatchedLinearOperator[ScalarType, IndexType]
+            | DenseLinearOperatorData[ScalarType, IndexType]
+            | BlockSparseLinearOperators[ScalarType, IndexType]
+            | None
+        ) = None,
+        atol: float | wp.array[ScalarType] | None = None,
+        rtol: float | wp.array[ScalarType] | None = None,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike | None = None,
-        maxiter: int | wp.array | None = None,
+        maxiter: int | wp.array[wp.int32] | None = None,
         world_active: wp.array[wp.bool] | None = None,
         preconditioner: Any = None,
         loop_granularity: int = 1,
         **kwargs: dict[str, Any],
     ):
-        self._maxiter: int | wp.array | None = maxiter
+        self._maxiter: int | wp.array[wp.int32] | None = maxiter
         self._preconditioner: Any = preconditioner
         self._world_active: wp.array[wp.bool] | None = world_active
-        self.atol: float | wp.array | None = atol
-        self.rtol: float | wp.array | None = rtol
+        self.atol: float | wp.array[ScalarType] | None = atol
+        self.rtol: float | wp.array[ScalarType] | None = rtol
 
         self._num_worlds: int | None = None
         self._max_dim: int | None = None
-        self._batched_operator: conjugate.BatchedLinearOperator | None = None
+        self._batched_operator: conjugate.BatchedLinearOperator[ScalarType, IndexType] | None = None
         self._use_graph_conditionals: bool = kwargs.pop("use_graph_conditionals", True)
         self.loop_granularity = loop_granularity
 
@@ -295,8 +302,8 @@ class IterativeSolver(LinearSolver):
         self._discover_sparse: bool = kwargs.pop("discover_sparse", False)
         self._sparse_block_size: int = kwargs.pop("sparse_block_size", 4)
         self._sparse_threshold: float = kwargs.pop("sparse_threshold", 0.5)
-        self._sparse_bsm: BlockSparseMatrices | None = None
-        self._sparse_operator: conjugate.BatchedLinearOperator | None = None
+        self._sparse_bsm: BlockSparseMatrices[ScalarType, IndexType, Any] | None = None
+        self._sparse_operator: conjugate.BatchedLinearOperator[ScalarType, IndexType] | None = None
         self._sparse_solver: Any = None  # Set by concrete classes
 
         super().__init__(
@@ -309,8 +316,13 @@ class IterativeSolver(LinearSolver):
         )
 
     def _to_batched_operator(
-        self, operator: conjugate.BatchedLinearOperator | DenseLinearOperatorData | BlockSparseLinearOperators
-    ) -> conjugate.BatchedLinearOperator:
+        self,
+        operator: (
+            conjugate.BatchedLinearOperator[ScalarType, IndexType]
+            | DenseLinearOperatorData[ScalarType, IndexType]
+            | BlockSparseLinearOperators[ScalarType, IndexType]
+        ),
+    ) -> conjugate.BatchedLinearOperator[ScalarType, IndexType]:
         """Convert various operator types to BatchedLinearOperator."""
         if isinstance(operator, conjugate.BatchedLinearOperator):
             return operator
@@ -325,8 +337,12 @@ class IterativeSolver(LinearSolver):
     @override
     def finalize(
         self,
-        operator: conjugate.BatchedLinearOperator | DenseLinearOperatorData | BlockSparseLinearOperators,
-        maxiter: int | wp.array | None = None,
+        operator: (
+            conjugate.BatchedLinearOperator[ScalarType, IndexType]
+            | DenseLinearOperatorData[ScalarType, IndexType]
+            | BlockSparseLinearOperators[ScalarType, IndexType]
+        ),
+        maxiter: int | wp.array[wp.int32] | None = None,
         world_active: wp.array[wp.bool] | None = None,
         preconditioner: Any = None,
         **kwargs: dict[str, Any],
@@ -366,8 +382,8 @@ class IterativeSolver(LinearSolver):
         self._num_worlds = self._batched_operator.n_worlds
         self._max_dim = self._batched_operator.max_dim
         self._total_vec_size = self._batched_operator.total_vec_size
-        self._solve_iterations: wp.array | None = None
-        self._solve_residual_norm: wp.array | None = None
+        self._solve_iterations: wp.array[wp.int32] | None = None
+        self._solve_residual_norm: wp.array[ScalarType] | None = None
 
         with wp.ScopedDevice(self._device):
             if self._world_active is None:
@@ -399,7 +415,9 @@ class IterativeSolver(LinearSolver):
         self._allocate_impl(operator, **kwargs)
 
     @override
-    def solve(self, b: wp.array, x: wp.array, zero_x: bool = False, **kwargs: dict[str, Any]) -> None:
+    def solve(
+        self, b: wp.array[ScalarType], x: wp.array[ScalarType], zero_x: bool = False, **kwargs: dict[str, Any]
+    ) -> None:
         """Solves the multi-linear systems `A @ x = b`."""
         if self._operator is not None:
             if not self._operator.info.is_rhs_compatible(b):
@@ -428,7 +446,7 @@ class IterativeSolver(LinearSolver):
 ###
 
 
-class LLTSequentialSolver(DirectSolver):
+class LLTSequentialSolver(DirectSolver[ScalarType, IndexType]):
     """
     A LLT (i.e. Cholesky) factorization class computing each matrix block sequentially.
     This parallelizes the factorization and solve operations over each block
@@ -437,18 +455,18 @@ class LLTSequentialSolver(DirectSolver):
 
     def __init__(
         self,
-        operator: DenseLinearOperatorData | None = None,
+        operator: DenseLinearOperatorData[ScalarType, IndexType] | None = None,
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = wp.float32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
         # Declare LLT-specific internal data
-        self._L: wp.array | None = None
+        self._L: wp.array[ScalarType] | None = None
         """A flat array containing the Cholesky factorization of each matrix block."""
-        self._y: wp.array | None = None
+        self._y: wp.array[ScalarType] | None = None
         """A flat array containing the intermediate results for the solve operation."""
 
         # Initialize base class members
@@ -467,13 +485,13 @@ class LLTSequentialSolver(DirectSolver):
     ###
 
     @property
-    def L(self) -> wp.array:
+    def L(self) -> wp.array[ScalarType]:
         if self._L is None:
             raise ValueError("The factorization array has not been allocated!")
         return self._L
 
     @property
-    def y(self) -> wp.array:
+    def y(self) -> wp.array[ScalarType]:
         if self._y is None:
             raise ValueError("The intermediate result array has not been allocated!")
         return self._y
@@ -483,7 +501,7 @@ class LLTSequentialSolver(DirectSolver):
     ###
 
     @override
-    def _allocate_impl(self, A: DenseLinearOperatorData, **kwargs: dict[str, Any]) -> None:
+    def _allocate_impl(self, A: DenseLinearOperatorData[ScalarType, IndexType], **kwargs: dict[str, Any]) -> None:
         # Check the operator has info
         if A.info is None:
             raise ValueError("The provided operator does not have any associated info!")
@@ -505,7 +523,7 @@ class LLTSequentialSolver(DirectSolver):
         self._has_factors = False
 
     @override
-    def _factorize_impl(self, A: wp.array) -> None:
+    def _factorize_impl(self, A: wp.array[ScalarType]) -> None:
         factorize.llt_sequential_factorize(
             num_blocks=self._operator.info.num_blocks,
             dim=self._operator.info.dim,
@@ -515,11 +533,11 @@ class LLTSequentialSolver(DirectSolver):
         )
 
     @override
-    def _reconstruct_impl(self, A: wp.array) -> None:
+    def _reconstruct_impl(self, A: wp.array[ScalarType]) -> None:
         raise NotImplementedError("LLT matrix reconstruction is not yet implemented.")
 
     @override
-    def _solve_impl(self, b: wp.array, x: wp.array) -> None:
+    def _solve_impl(self, b: wp.array[ScalarType], x: wp.array[ScalarType]) -> None:
         # Solve the system L * y = b and L^T * x = y
         factorize.llt_sequential_solve(
             num_blocks=self._operator.info.num_blocks,
@@ -533,7 +551,7 @@ class LLTSequentialSolver(DirectSolver):
         )
 
     @override
-    def _solve_inplace_impl(self, x: wp.array) -> None:
+    def _solve_inplace_impl(self, x: wp.array[ScalarType]) -> None:
         # Solve the system L * y = x and L^T * x = y
         factorize.llt_sequential_solve_inplace(
             num_blocks=self._operator.info.num_blocks,
@@ -545,28 +563,28 @@ class LLTSequentialSolver(DirectSolver):
         )
 
 
-class LLTBlockedSolver(DirectSolver):
+class LLTBlockedSolver(DirectSolver[ScalarType, IndexType]):
     """
     A Blocked LLT (i.e. Cholesky) factorization class computing each matrix block with Tile-based parallelism.
     """
 
     def __init__(
         self,
-        operator: DenseLinearOperatorData | None = None,
+        operator: DenseLinearOperatorData[ScalarType, IndexType] | None = None,
         block_size: int = 32,
         solve_block_dim: int = 128,
         factortize_block_dim: int = 128,
         atol: float | None = None,
         rtol: float | None = None,
         ftol: float | None = None,
-        dtype: FloatType = wp.float32,
+        dtype: type[ScalarType] = wp.float32,  # type: ignore[assignment]
         device: wp.DeviceLike | None = None,
         **kwargs: dict[str, Any],
     ):
         # Declare LLT-specific internal data
-        self._L: wp.array | None = None
+        self._L: wp.array[ScalarType] | None = None
         """A flat array containing the Cholesky factorization of each matrix block."""
-        self._y: wp.array | None = None
+        self._y: wp.array[ScalarType] | None = None
         """A flat array containing the intermediate results for the solve operation."""
 
         # Cache the fixed block size
@@ -595,13 +613,13 @@ class LLTBlockedSolver(DirectSolver):
     ###
 
     @property
-    def L(self) -> wp.array:
+    def L(self) -> wp.array[ScalarType]:
         if self._L is None:
             raise ValueError("The factorization array has not been allocated!")
         return self._L
 
     @property
-    def y(self) -> wp.array:
+    def y(self) -> wp.array[ScalarType]:
         if self._y is None:
             raise ValueError("The intermediate result array has not been allocated!")
         return self._y
@@ -611,7 +629,7 @@ class LLTBlockedSolver(DirectSolver):
     ###
 
     @override
-    def _allocate_impl(self, A: DenseLinearOperatorData, **kwargs: dict[str, Any]) -> None:
+    def _allocate_impl(self, A: DenseLinearOperatorData[ScalarType, IndexType], **kwargs: dict[str, Any]) -> None:
         # Check the operator has info
         if A.info is None:
             raise ValueError("The provided operator does not have any associated info!")
@@ -633,7 +651,7 @@ class LLTBlockedSolver(DirectSolver):
         self._has_factors = False
 
     @override
-    def _factorize_impl(self, A: wp.array) -> None:
+    def _factorize_impl(self, A: wp.array[ScalarType]) -> None:
         factorize.llt_blocked_factorize(
             kernel=self._factorize_kernel,
             num_blocks=self._operator.info.num_blocks,
@@ -645,11 +663,11 @@ class LLTBlockedSolver(DirectSolver):
         )
 
     @override
-    def _reconstruct_impl(self, A: wp.array) -> None:
+    def _reconstruct_impl(self, A: wp.array[ScalarType]) -> None:
         raise NotImplementedError("LLT matrix reconstruction is not yet implemented.")
 
     @override
-    def _solve_impl(self, b: wp.array, x: wp.array) -> None:
+    def _solve_impl(self, b: wp.array[ScalarType], x: wp.array[ScalarType]) -> None:
         # Solve the system L * y = b and L^T * x = y
         factorize.llt_blocked_solve(
             kernel=self._solve_kernel,
@@ -665,7 +683,7 @@ class LLTBlockedSolver(DirectSolver):
         )
 
     @override
-    def _solve_inplace_impl(self, x: wp.array) -> None:
+    def _solve_inplace_impl(self, x: wp.array[ScalarType]) -> None:
         # Solve the system L * y = b and L^T * x = y
         factorize.llt_blocked_solve_inplace(
             kernel=self._solve_inplace_kernel,
@@ -685,7 +703,7 @@ class LLTBlockedSolver(DirectSolver):
 ###
 
 
-class ConjugateGradientSolver(IterativeSolver):
+class ConjugateGradientSolver(IterativeSolver[ScalarType, IndexType]):
     """
     A wrapper around the batched Conjugate Gradient implementation in `conjugate.cg`.
 
@@ -696,9 +714,9 @@ class ConjugateGradientSolver(IterativeSolver):
         self,
         **kwargs: dict[str, Any],
     ):
-        self._Mi = None
-        self._jacobi_preconditioner = None
-        self.solver = None
+        self._Mi: conjugate.BatchedLinearOperator[ScalarType, IndexType] | None = None
+        self._jacobi_preconditioner: wp.array[ScalarType] | None = None
+        self.solver: conjugate.CGSolver[ScalarType, IndexType] | None = None
         super().__init__(**kwargs)
 
     @override
@@ -751,14 +769,14 @@ class ConjugateGradientSolver(IterativeSolver):
             )
 
     @override
-    def _reset_impl(self, A: wp.array | None = None, **kwargs: dict[str, Any]) -> None:
+    def _reset_impl(self, A: wp.array[ScalarType] | None = None, **kwargs: dict[str, Any]) -> None:
         if self._jacobi_preconditioner is not None:
             self._jacobi_preconditioner.zero_()
-        self._solve_iterations: wp.array = None
-        self._solve_residual_norm: wp.array = None
+        self._solve_iterations: wp.array[wp.int32] | None = None
+        self._solve_residual_norm: wp.array[ScalarType] | None = None
 
     @override
-    def _compute_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _compute_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         if self._operator is not None and A.ptr != self._operator.mat.ptr:
             raise ValueError(f"{self.__class__.__name__} cannot be re-used with a different matrix.")
         if self._Mi is not None:
@@ -766,11 +784,11 @@ class ConjugateGradientSolver(IterativeSolver):
         self._update_sparse_bsm()
 
     @override
-    def _solve_inplace_impl(self, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_inplace_impl(self, x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         self._solve_impl(x, x, **kwargs)
 
     @override
-    def _solve_impl(self, b: wp.array, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_impl(self, b: wp.array[ScalarType], x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         solver = self._sparse_solver or self.solver
         if solver is None:
             raise ValueError("ConjugateGradientSolver.allocate() must be called before solve().")
@@ -798,7 +816,7 @@ class ConjugateGradientSolver(IterativeSolver):
         )
 
 
-class ConjugateResidualSolver(IterativeSolver):
+class ConjugateResidualSolver(IterativeSolver[ScalarType, IndexType]):
     """
     A wrapper around the batched Conjugate Residual implementation in `conjugate.cr`.
 
@@ -809,9 +827,9 @@ class ConjugateResidualSolver(IterativeSolver):
         self,
         **kwargs: dict[str, Any],
     ):
-        self._Mi = None
-        self._jacobi_preconditioner = None
-        self.solver = None
+        self._Mi: conjugate.BatchedLinearOperator[ScalarType, IndexType] | None = None
+        self._jacobi_preconditioner: wp.array[ScalarType] | None = None
+        self.solver: conjugate.CRSolver[ScalarType, IndexType] | None = None
         super().__init__(**kwargs)
 
     @override
@@ -863,14 +881,14 @@ class ConjugateResidualSolver(IterativeSolver):
             )
 
     @override
-    def _reset_impl(self, A: wp.array | None = None, **kwargs: dict[str, Any]) -> None:
+    def _reset_impl(self, A: wp.array[ScalarType] | None = None, **kwargs: dict[str, Any]) -> None:
         if self._jacobi_preconditioner is not None:
             self._jacobi_preconditioner.zero_()
-        self._solve_iterations: wp.array = None
-        self._solve_residual_norm: wp.array = None
+        self._solve_iterations: wp.array[wp.int32] | None = None
+        self._solve_residual_norm: wp.array[ScalarType] | None = None
 
     @override
-    def _compute_impl(self, A: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _compute_impl(self, A: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         if self._operator is not None and A.ptr != self._operator.mat.ptr:
             raise ValueError(f"{self.__class__.__name__} cannot be re-used with a different matrix.")
         if self._Mi is not None:
@@ -878,11 +896,11 @@ class ConjugateResidualSolver(IterativeSolver):
         self._update_sparse_bsm()
 
     @override
-    def _solve_inplace_impl(self, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_inplace_impl(self, x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         self._solve_impl(x, x)
 
     @override
-    def _solve_impl(self, b: wp.array, x: wp.array, **kwargs: dict[str, Any]) -> None:
+    def _solve_impl(self, b: wp.array[ScalarType], x: wp.array[ScalarType], **kwargs: dict[str, Any]) -> None:
         solver = self._sparse_solver or self.solver
         if solver is None:
             raise ValueError("ConjugateResidualSolver.allocate() must be called before solve().")

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_matrix.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import functools
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, get_args
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
 import warp as wp
@@ -20,6 +20,7 @@ from warp.types import type_size_in_bytes
 
 from ..core.types import FloatType, IntType
 from .core import DenseSquareMultiLinearInfo
+from .types import BlockScalarType, BlockType, IndexType, ScalarType
 
 if TYPE_CHECKING:
     from .core import DenseLinearOperatorData
@@ -41,10 +42,10 @@ __all__ = [
 ###
 
 
-class BlockDType:
+class BlockDType(Generic[BlockScalarType]):
     """A utility type for bundling meta-data about sparse-block types."""
 
-    def __init__(self, dtype: FloatType | IntType, shape: int | tuple[int] | tuple[int, int] | None = None):
+    def __init__(self, dtype: type[BlockScalarType], shape: int | tuple[int] | tuple[int, int] | None = None):
         """
         Constructs a new BlockDType descriptor given scalar Warp data-type and the block shape.
 
@@ -58,7 +59,7 @@ class BlockDType:
             ValueError: If the `shape` field is not a positive integer or a tuple of one or two positive integers.
         """
         # Ensure the underlying scalar dtype is valid
-        if (dtype not in get_args(FloatType)) and (dtype not in get_args(IntType)):
+        if not issubclass(dtype, FloatType | IntType):
             raise TypeError("The `dtype` field must be a valid FloatType or IntType such as wp.float32 or wp.int32.")
 
         # If no shape is provided, default to scalar blocks
@@ -84,14 +85,14 @@ class BlockDType:
         else:
             raise TypeError("The `shape` field must be an int or a tuple of ints.")
 
-        self._dtype: FloatType | IntType = dtype
+        self._dtype: type[BlockScalarType] = dtype
         """The underlying data type of the sparse blocks."""
 
         self._shape: int | tuple[int] | tuple[int, int] = shape
         """The shape of each sparse block."""
 
     @property
-    def dtype(self) -> FloatType | IntType:
+    def dtype(self) -> type[BlockScalarType]:
         """Returns the underlying data type of the sparse blocks."""
         return self._dtype
 
@@ -139,9 +140,15 @@ class BlockDType:
 
 
 @dataclass
-class BlockSparseMatrices:
+class BlockSparseMatrices(Generic[BlockScalarType, IndexType, BlockType]):
     """
     A container to represent multiple block-sparse matrices of fixed non-zero block size.
+
+    The generic parameters describe:
+
+    - ``BlockScalarType``: scalar dtype of each block element (float or int).
+    - ``IndexType``: integer type for index arrays (e.g. ``wp.int32``).
+    - ``BlockType``: Warp dtype of a non-zero block (matching ``BlockDType.warp_type``).
     """
 
     ###
@@ -151,10 +158,10 @@ class BlockSparseMatrices:
     device: wp.DeviceLike | None = None
     """Host-side cache of the device on which all data arrays are allocated."""
 
-    nzb_dtype: BlockDType | None = None
+    nzb_dtype: BlockDType[BlockScalarType] | None = None
     """Host-side cache of the fixed non-zero block data type contained in all sparse matrices."""
 
-    index_dtype: IntType = wp.int32
+    index_dtype: type[IndexType] = wp.int32  # type: ignore[assignment]
     """Host-side cache of the integer type used for indexing the underlying data arrays."""
 
     num_matrices: int = 0
@@ -194,34 +201,34 @@ class BlockSparseMatrices:
 
     # These arrays are expected to stay constant once this object is finalized
 
-    max_dims: wp.array | None = None
+    max_dims: wp.array2d[IndexType] | None = None
     """
     The maximum dimensions of each sparse matrices.
-    Shape of ``(num_matrices,)`` and type :class:`vec2i`.
+    Shape of ``(num_matrices, 2)``.
     """
 
-    max_nzb: wp.array | None = None
+    max_nzb: wp.array[IndexType] | None = None
     """
     The maximum number of non-zero blocks per sparse matrices.
-    Shape of ``(num_matrices,)`` and type :class:`int`.
+    Shape of ``(num_matrices,)``.
     """
 
-    nzb_start: wp.array | None = None
+    nzb_start: wp.array[IndexType] | None = None
     """
     The index of the first non-zero block of each sparse matrices.
-    Shape of ``(num_matrices,)`` and type :class:`int`.
+    Shape of ``(num_matrices,)``.
     """
 
-    row_start: wp.array | None = None
+    row_start: wp.array[IndexType] | None = None
     """
     The start index of each row vector block in a flattened data array of size sum_of_max_rows.
-    Shape of ``(num_matrices,)`` and type :class:`int`.
+    Shape of ``(num_matrices,)``.
     """
 
-    col_start: wp.array | None = None
+    col_start: wp.array[IndexType] | None = None
     """
     The start index of each column vector block in a flattened data array of size sum_of_max_cols.
-    Shape of ``(num_matrices,)`` and type :class:`int`.
+    Shape of ``(num_matrices,)``.
     """
 
     ###
@@ -230,28 +237,28 @@ class BlockSparseMatrices:
 
     # These are the arrays to update when assembling the matrices
 
-    dims: wp.array | None = None
+    dims: wp.array2d[IndexType] | None = None
     """
     The active dimensions of each sparse matrices.
-    Shape of ``(num_matrices,)`` and type :class:`vec2i`.
+    Shape of ``(num_matrices, 2)``.
     """
 
-    num_nzb: wp.array | None = None
+    num_nzb: wp.array[IndexType] | None = None
     """
     The active number of non-zero blocks per sparse matrices.
-    Shape of ``(num_matrices,)`` and type :class:`int`.
+    Shape of ``(num_matrices,)``.
     """
 
-    nzb_coords: wp.array | None = None
+    nzb_coords: wp.array2d[IndexType] | None = None
     """
     The row-column coordinates of each non-zero block within its corresponding sparse matrix.
-    Shape of ``(sum_of_num_nzb,)`` and type :class:`vec2i`.
+    Shape of ``(sum_of_num_nzb, 2)``.
     """
 
-    nzb_values: wp.array | None = None
+    nzb_values: wp.array[BlockType] | None = None
     """
     The flattened array containing all non-zero blocks over all sparse matrices.
-    Shape of ``(sum_of_num_nzb,)`` and type :class:`float | vector | matrix`.
+    Shape of ``(sum_of_num_nzb,)``.
     """
 
     ###
@@ -259,7 +266,7 @@ class BlockSparseMatrices:
     ###
 
     @property
-    def max_rows(self) -> wp.array:
+    def max_rows(self) -> wp.array[IndexType]:
         assert self.max_dims is not None and self.max_dims.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -271,7 +278,7 @@ class BlockSparseMatrices:
         )
 
     @property
-    def max_cols(self) -> wp.array:
+    def max_cols(self) -> wp.array[IndexType]:
         assert self.max_dims is not None and self.max_dims.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -283,7 +290,7 @@ class BlockSparseMatrices:
         )
 
     @property
-    def num_rows(self) -> wp.array:
+    def num_rows(self) -> wp.array[IndexType]:
         assert self.dims is not None and self.dims.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -296,7 +303,7 @@ class BlockSparseMatrices:
         )
 
     @property
-    def num_cols(self) -> wp.array:
+    def num_cols(self) -> wp.array[IndexType]:
         assert self.dims is not None and self.dims.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -309,7 +316,7 @@ class BlockSparseMatrices:
         )
 
     @property
-    def nzb_row(self) -> wp.array:
+    def nzb_row(self) -> wp.array[IndexType]:
         assert self.nzb_coords is not None and self.nzb_coords.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -322,7 +329,7 @@ class BlockSparseMatrices:
         )
 
     @property
-    def nzb_col(self) -> wp.array:
+    def nzb_col(self) -> wp.array[IndexType]:
         assert self.nzb_coords is not None and self.nzb_coords.ptr is not None
         index_dtype_size_bytes = type_size_in_bytes(self.index_dtype)
         return wp.array(
@@ -342,8 +349,8 @@ class BlockSparseMatrices:
         self,
         max_dims: list[tuple[int, int]],
         capacities: list[int],
-        nzb_dtype: BlockDType | None = None,
-        index_dtype: IntType | None = None,
+        nzb_dtype: BlockDType[BlockScalarType] | None = None,
+        index_dtype: type[IndexType] | None = None,
         device: wp.DeviceLike | None = None,
     ):
         """
@@ -379,7 +386,7 @@ class BlockSparseMatrices:
             raise TypeError("The `nzb_dtype` field must be a valid BlockDType instance.")
         if self.index_dtype is None:
             raise RuntimeError("The `index_type` field must be specified before finalizing the data arrays.")
-        elif self.index_dtype not in get_args(IntType):
+        elif not issubclass(self.index_dtype, IntType):
             raise TypeError("The `index_type` field must be a valid IntType such as wp.int32 or wp.int64.")
 
         # Ensure that the max dimensions are valid
@@ -739,11 +746,11 @@ def _make_dense_to_bsm_copy_kernel(block_size: int):
 
 
 def allocate_block_sparse_from_dense(
-    dense_op: DenseLinearOperatorData,
+    dense_op: DenseLinearOperatorData[ScalarType, IndexType],
     block_size: int,
     sparsity_threshold: float = 1.0,
     device: wp.DeviceLike | None = None,
-) -> BlockSparseMatrices:
+) -> BlockSparseMatrices[ScalarType, IndexType, Any]:
     """
     Allocates a BlockSparseMatrices container sized for converting from a dense operator.
 
@@ -793,8 +800,8 @@ def allocate_block_sparse_from_dense(
 
 
 def dense_to_block_sparse_copy_values(
-    dense_op: DenseLinearOperatorData,
-    bsm: BlockSparseMatrices,
+    dense_op: DenseLinearOperatorData[ScalarType, IndexType],
+    bsm: BlockSparseMatrices[ScalarType, IndexType, Any],
     block_size: int,
 ) -> None:
     """

--- a/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
+++ b/newton/_src/solvers/kamino/_src/linalg/sparse_operator.py
@@ -9,10 +9,10 @@ independent linear systems, including rectangular and square systems.
 """
 
 from collections.abc import Callable
+from typing import Any, Generic
 
 import warp as wp
 
-from ..core.types import FloatType
 from .blas import (
     block_sparse_gemv,
     block_sparse_matvec,
@@ -20,6 +20,7 @@ from .blas import (
     block_sparse_transpose_matvec,
 )
 from .sparse_matrix import BlockSparseMatrices
+from .types import IndexType, ScalarType
 
 ###
 # Module interface
@@ -30,18 +31,18 @@ __all__ = [
 ]
 
 
-class BlockSparseLinearOperators:
+class BlockSparseLinearOperators(Generic[ScalarType, IndexType]):
     """
     A Block-Sparse Linear Operator container for representing
     and operating on multiple independent sparse linear systems.
     """
 
-    def __init__(self, bsm: BlockSparseMatrices | None = None):
+    def __init__(self, bsm: BlockSparseMatrices[ScalarType, IndexType, Any] | None = None):
         self.bsm = bsm
         self.initialize_default_operators()
 
-        self._active_rows: wp.array | None = None
-        self._active_cols: wp.array | None = None
+        self._active_rows: wp.array[IndexType] | None = None
+        self._active_cols: wp.array[IndexType] | None = None
 
         if self.bsm is not None:
             self._active_rows = self.bsm.num_rows
@@ -51,7 +52,7 @@ class BlockSparseLinearOperators:
     # On-device Data
     ###
 
-    bsm: BlockSparseMatrices | None = None
+    bsm: BlockSparseMatrices[ScalarType, IndexType, Any] | None = None
     """
     The underlying block-sparse matrix used by this operator.
     """
@@ -63,31 +64,55 @@ class BlockSparseLinearOperators:
     precompute_op: Callable | None = None
     """
     The operator function for precomputing any necessary data for the operators.
-    Signature: ``precompute_op(A: BlockSparseLinearOperators)``.
+    Signature: ``precompute_op(A: BlockSparseLinearOperators[ScalarType, IndexType])``.
     """
 
     Ax_op: Callable | None = None
     """
     The operator function for performing sparse matrix-vector products `y = A @ x`.
-    Example signature: ``Ax_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool])``.
+    Signature: ``Ax_op(
+                     A: BlockSparseMatrices[ScalarType, IndexType, Any],
+                     x: wp.array[ScalarType],
+                     y: wp.array[ScalarType],
+                     matrix_mask: wp.array[wp.bool],
+                 )``.
     """
 
     ATy_op: Callable | None = None
     """
     The operator function for performing sparse matrix-transpose-vector products `x = A^T @ y`.
-    Example signature: ``ATy_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool])``.
+    Signature: ``ATy_op(
+                     A: BlockSparseMatrices[ScalarType, IndexType, Any],
+                     y: wp.array[ScalarType],
+                     x: wp.array[ScalarType],
+                     matrix_mask: wp.array[wp.bool],
+                 )``.
     """
 
     gemv_op: Callable | None = None
     """
     The operator function for performing generalized sparse matrix-vector products `y = alpha * A @ x + beta * y`.
-    Example signature: ``gemv_op(A: BlockSparseLinearMatrices, x: wp.array, y: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
+    Signature: ``gemv_op(
+                     A: BlockSparseMatrices[ScalarType, IndexType, Any],
+                     x: wp.array[ScalarType],
+                     y: wp.array[ScalarType],
+                     alpha: ScalarType,
+                     beta: ScalarType,
+                     matrix_mask: wp.array[wp.bool],
+                 )``.
     """
 
     gemvt_op: Callable | None = None
     """
     The operator function for performing generalized sparse matrix-transpose-vector products `x = alpha * A^T @ y + beta * x`.
-    Example signature: ``gemvt_op(A: BlockSparseLinearMatrices, y: wp.array, x: wp.array, alpha: float, beta: float, matrix_mask: wp.array[wp.bool])``.
+    Signature: ``gemvt_op(
+                     A: BlockSparseMatrices[ScalarType, IndexType, Any],
+                     y: wp.array[ScalarType],
+                     x: wp.array[ScalarType],
+                     alpha: ScalarType,
+                     beta: ScalarType,
+                     matrix_mask: wp.array[wp.bool],
+                 )``.
     """
 
     ###
@@ -103,7 +128,7 @@ class BlockSparseLinearOperators:
         return self.bsm.max_of_max_dims
 
     @property
-    def dtype(self) -> FloatType:
+    def dtype(self) -> type[ScalarType]:
         return self.bsm.nzb_dtype.dtype
 
     @property
@@ -111,11 +136,11 @@ class BlockSparseLinearOperators:
         return self.bsm.device
 
     @property
-    def active_rows(self) -> wp.array:
+    def active_rows(self) -> wp.array[IndexType]:
         return self._active_rows
 
     @property
-    def active_cols(self) -> wp.array:
+    def active_cols(self) -> wp.array[IndexType]:
         return self._active_cols
 
     ###
@@ -142,26 +167,38 @@ class BlockSparseLinearOperators:
         self.gemv_op = block_sparse_gemv
         self.gemvt_op = block_sparse_transpose_gemv
 
-    def matvec(self, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool]):
+    def matvec(self, x: wp.array[ScalarType], y: wp.array[ScalarType], matrix_mask: wp.array[wp.bool]):
         """Performs the sparse matrix-vector product `y = A @ x`."""
         if self.Ax_op is None:
             raise RuntimeError("No `A@x` operator has been assigned.")
         self.Ax_op(self.bsm, x, y, matrix_mask)
 
-    def matvec_transpose(self, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool]):
+    def matvec_transpose(self, y: wp.array[ScalarType], x: wp.array[ScalarType], matrix_mask: wp.array[wp.bool]):
         """Performs the sparse matrix-transpose-vector product `x = A^T @ y`."""
         if self.ATy_op is None:
             raise RuntimeError("No `A^T@y` operator has been assigned.")
         self.ATy_op(self.bsm, y, x, matrix_mask)
 
-    def gemv(self, x: wp.array, y: wp.array, matrix_mask: wp.array[wp.bool], alpha: float = 1.0, beta: float = 0.0):
+    def gemv(
+        self,
+        x: wp.array[ScalarType],
+        y: wp.array[ScalarType],
+        matrix_mask: wp.array[wp.bool],
+        alpha: ScalarType = 1.0,
+        beta: ScalarType = 0.0,
+    ):
         """Performs a BLAS-like generalized sparse matrix-vector product `y = alpha * A @ x + beta * y`."""
         if self.gemv_op is None:
             raise RuntimeError("No BLAS-like `GEMV` operator has been assigned.")
         self.gemv_op(self.bsm, x, y, alpha, beta, matrix_mask)
 
     def gemv_transpose(
-        self, y: wp.array, x: wp.array, matrix_mask: wp.array[wp.bool], alpha: float = 1.0, beta: float = 0.0
+        self,
+        y: wp.array[ScalarType],
+        x: wp.array[ScalarType],
+        matrix_mask: wp.array[wp.bool],
+        alpha: ScalarType = 1.0,
+        beta: ScalarType = 0.0,
     ):
         """Performs a BLAS-like generalized sparse matrix-transpose-vector product `x = alpha * A^T @ y + beta * x`."""
         if self.gemvt_op is None:

--- a/newton/_src/solvers/kamino/_src/linalg/types.py
+++ b/newton/_src/solvers/kamino/_src/linalg/types.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+KAMINO: Linear Algebra: Type parameters for generic linalg classes.
+
+Provides shared :class:`TypeVar` symbols used to statically parameterize
+the linalg classes (``DenseSquareMultiLinearInfo``, ``BlockSparseMatrices``,
+``LinearSolver``, ...) so that ``wp.array`` annotations carry precise dtypes.
+
+Runtime behavior is unaffected: the existing ``FloatType`` / ``IntType`` /
+``VecIntType`` unions in :mod:`newton._src.solvers.kamino._src.core.types`
+remain the source of truth for ``issubclass`` / ``get_args`` checks; these
+TypeVars live alongside them as static-only siblings.
+"""
+
+from typing import TypeVar
+
+import warp as wp
+
+__all__ = [
+    "BlockScalarType",
+    "BlockType",
+    "IndexType",
+    "ScalarType",
+]
+
+
+ScalarType = TypeVar("ScalarType", wp.float16, wp.float32, wp.float64)
+"""Float-only scalar element type. Mirrors ``FloatType``."""
+
+BlockScalarType = TypeVar(
+    "BlockScalarType",
+    wp.float16,
+    wp.float32,
+    wp.float64,
+    wp.int16,
+    wp.int32,
+    wp.int64,
+)
+"""Float or integer scalar element type. Mirrors ``FloatType | IntType``"""
+
+IndexType = TypeVar("IndexType", wp.int16, wp.int32, wp.int64)
+"""Integer type used for index types. Mirrors ``IntType``."""
+
+BlockType = TypeVar("BlockType")
+"""
+Warp dtype of a non-zero block in a block-sparse matrix.
+
+Unconstrained because the concrete block class is built dynamically at runtime.
+"""

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -17,7 +17,7 @@ import warp as wp
 from ....config import ForwardKinematicsSolverConfig
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.model import ModelKamino
-from ...core.types import assign_to_warp_int32_array, to_warp_int32_array
+from ...core.types import assign_to_warp_int32_array, to_warp_int32_array, vec7f
 from ...linalg.blas import (
     block_sparse_ATA_blockwise_3_4_inv_diagonal_2d,
     block_sparse_ATA_inv_diagonal_2d,
@@ -760,8 +760,10 @@ class ForwardKinematicsSolver:
 
         # Compute sparsity pattern and initialize linear solver for sparse case
         if self.config.use_sparsity:
-            self.sparse_jacobian = BlockSparseMatrices(
-                device=self.device, nzb_dtype=BlockDType(dtype=wp.float32, shape=(7,)), num_matrices=self.num_worlds
+            self.sparse_jacobian: BlockSparseMatrices[wp.float32, wp.int32, vec7f] = BlockSparseMatrices(
+                device=self.device,
+                nzb_dtype=BlockDType[wp.float32](dtype=wp.float32, shape=(7,)),
+                num_matrices=self.num_worlds,
             )
             jacobian_dims = list(zip(num_constraints.tolist(), (7 * num_bodies).tolist(), strict=True))
 
@@ -831,7 +833,7 @@ class ForwardKinematicsSolver:
             )
 
             # Initialize Jacobian linear operator
-            self.sparse_jacobian_op = BlockSparseLinearOperators(self.sparse_jacobian)
+            self.sparse_jacobian_op = BlockSparseLinearOperators[wp.float32, wp.int32](self.sparse_jacobian)
 
             # Compute flat-array offsets for the CG solver (uniform world dimensions)
             cg_vio = wp.from_numpy(np.arange(self.num_worlds, dtype=np.int32) * self.num_states_max, device=self.device)


### PR DESCRIPTION
## Description

As follow-up of the previous types annotations PR, this is an attempt to add type annotations also to the linalg library and classes with parametric scalar/index/block type, making use of generics.

Python is a bit limited for this (e.g. building a type annotation for a vec2i from an index type, of for a block type given the scalar type and shape, is not possible), but I end up being able to specify an array type that is not Any almost everywhere, helping readibility.

The code gets a bit more verbose as a tradeoff (although all these annotations remain optional and don't impact the runtime), but I like being explicit. It now appears more clearly what is generic (the linalg classes) and what is a concrete specialization for wp.float32 (e.g. the Delassus operator). Let me know what you think!

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

All Kamino-internal unit tests still run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new 6×1 Warp matrix type to support Jacobian and solver workflows.

* **Refactor**
  * Enhanced linear-solver and sparse-operator APIs with stronger numeric and index typing for dense and block-sparse paths.

* **Bug Fixes**
  * Improved consistency across sparse matrix, Jacobian, and solver components by tightening the declared input/output types to better prevent mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->