### PR TITLE
Fix scaled authored USD centers of mass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Fix `SolverMuJoCo` reporting incorrect `State.body_qd` angular velocity for `JointType.D6` joints with two or three angular DOFs at non-identity configurations.
 - Fix `SolverMuJoCo` loading USD models with supported standalone body-to-world joints outside an authored articulation, including Apptronik Apollo; warn when using this fallback and report unsupported rootless mechanisms explicitly.
 - Fix USD import of MJCF weld and connect equalities that represent world with the stage's non-rigid default prim.
+- Fix USD import of authored rigid-body centers of mass to apply inherited transform scale. (#3332)
 - Fix VBD collision damping to use relative normal gap rate so uniform contact-stencil motion and tangential sliding do not create artificial normal damping.
 - Fix multi-world soft contact filtering to avoid cross-world rigid-soft particle-shape pairs and VBD soft-soft triangle/edge candidates.
 - Fix `ModelBuilder.add_usd` so a stray authored joint outside any articulation root no longer suppresses base-joint (articulation) creation for unrelated floating rigid bodies in the same call. (#3002)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3539,7 +3539,7 @@ def parse_usd(
     # overwrite inertial properties of bodies that have PhysicsMassAPI schema applied
     if UsdPhysics.ObjectType.RigidBody in ret_dict:
         paths, rigid_body_descs = ret_dict[UsdPhysics.ObjectType.RigidBody]
-        for path, _rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
+        for path, rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
             prim = stage.GetPrimAtPath(path)
             if not prim.HasAPI(UsdPhysics.MassAPI):
                 continue
@@ -3600,9 +3600,7 @@ def parse_usd(
                     # created by schema resolvers are not real USD prims). Fall back to
                     # builder-accumulated mass properties from add_shape_*() calls.
                     cmp_mass = builder.body_mass[body_id]
-                    if has_authored_com:
-                        cmp_com = mass_api.GetCenterOfMassAttr().Get()
-                    else:
+                    if not has_authored_com:
                         cmp_com = builder.body_com[body_id]
                     # When the body has an authored density, rescale accumulated mass
                     # and inertia from the builder's default shape density to the
@@ -3620,9 +3618,10 @@ def parse_usd(
                         )
                     cmp_i_diag = Gf.Vec3f(0.0, 0.0, 0.0)
                     cmp_principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
-            else:
+
+            if has_authored_com:
                 # Match the scale/frame convention used by OpenUSD's collider and joint descriptors.
-                _, _, cmp_com, _ = UsdPhysics.RigidBodyAPI(prim).ComputeMassProperties(_get_collision_mass_information)
+                cmp_com = Gf.CompMult(mass_api.GetCenterOfMassAttr().Get(), rigid_body_desc.scale)
 
             # Inertia: newton:inertia > physics:diagonalInertia + physics:principalAxes > mass computer.
             # When mass is authored but inertia is not, keep accumulated inertia

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3539,7 +3539,7 @@ def parse_usd(
     # overwrite inertial properties of bodies that have PhysicsMassAPI schema applied
     if UsdPhysics.ObjectType.RigidBody in ret_dict:
         paths, rigid_body_descs = ret_dict[UsdPhysics.ObjectType.RigidBody]
-        for path, rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
+        for path, _rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
             prim = stage.GetPrimAtPath(path)
             if not prim.HasAPI(UsdPhysics.MassAPI):
                 continue
@@ -3617,6 +3617,9 @@ def parse_usd(
                         )
                     cmp_i_diag = Gf.Vec3f(0.0, 0.0, 0.0)
                     cmp_principal_axes = Gf.Quatf(1.0, 0.0, 0.0, 0.0)
+            else:
+                # Match the scale/frame convention used by OpenUSD's collider and joint descriptors.
+                _, _, cmp_com, _ = UsdPhysics.RigidBodyAPI(prim).ComputeMassProperties(_get_collision_mass_information)
 
             # Inertia: newton:inertia > physics:diagonalInertia + physics:principalAxes > mass computer.
             # When mass is authored but inertia is not, keep accumulated inertia
@@ -3684,22 +3687,7 @@ def parse_usd(
             builder.body_mass[body_id] = mass
             builder.body_inv_mass[body_id] = 1.0 / mass if mass > 0.0 else 0.0
 
-            # Center of mass: authored value takes precedence over mass computer.
-            if has_authored_com:
-                # RigidBodyDesc excludes scale, so retain the prim's scale relative to that body frame.
-                body_xform = wp.transform(
-                    rigid_body_desc.position,
-                    usd.value_to_warp(rigid_body_desc.rotation),
-                )
-                prim_to_body_mat = wp.inverse(_xform_to_mat44(body_xform)) @ usd.get_transform_matrix(
-                    prim, local=False, xform_cache=xform_cache
-                )
-                builder.body_com[body_id] = wp.transform_point(
-                    prim_to_body_mat,
-                    usd.value_to_warp(mass_api.GetCenterOfMassAttr().Get()),
-                )
-            else:
-                builder.body_com[body_id] = wp.vec3(*cmp_com)
+            builder.body_com[body_id] = wp.vec3(*cmp_com)
 
             # Assign nonzero inertia if mass is nonzero to make sure the body can be simulated.
             I_m = np.array(builder.body_inertia[body_id])

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3539,7 +3539,7 @@ def parse_usd(
     # overwrite inertial properties of bodies that have PhysicsMassAPI schema applied
     if UsdPhysics.ObjectType.RigidBody in ret_dict:
         paths, rigid_body_descs = ret_dict[UsdPhysics.ObjectType.RigidBody]
-        for path, _rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
+        for path, rigid_body_desc in zip(paths, rigid_body_descs, strict=False):
             prim = stage.GetPrimAtPath(path)
             if not prim.HasAPI(UsdPhysics.MassAPI):
                 continue
@@ -3686,7 +3686,18 @@ def parse_usd(
 
             # Center of mass: authored value takes precedence over mass computer.
             if has_authored_com:
-                builder.body_com[body_id] = wp.vec3(*mass_api.GetCenterOfMassAttr().Get())
+                # RigidBodyDesc excludes scale, so retain the prim's scale relative to that body frame.
+                body_xform = wp.transform(
+                    rigid_body_desc.position,
+                    usd.value_to_warp(rigid_body_desc.rotation),
+                )
+                prim_to_body_mat = wp.inverse(_xform_to_mat44(body_xform)) @ usd.get_transform_matrix(
+                    prim, local=False, xform_cache=xform_cache
+                )
+                builder.body_com[body_id] = wp.transform_point(
+                    prim_to_body_mat,
+                    usd.value_to_warp(mass_api.GetCenterOfMassAttr().Get()),
+                )
             else:
                 builder.body_com[body_id] = wp.vec3(*cmp_com)
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -3600,7 +3600,10 @@ def parse_usd(
                     # created by schema resolvers are not real USD prims). Fall back to
                     # builder-accumulated mass properties from add_shape_*() calls.
                     cmp_mass = builder.body_mass[body_id]
-                    cmp_com = builder.body_com[body_id]
+                    if has_authored_com:
+                        cmp_com = mass_api.GetCenterOfMassAttr().Get()
+                    else:
+                        cmp_com = builder.body_com[body_id]
                     # When the body has an authored density, rescale accumulated mass
                     # and inertia from the builder's default shape density to the
                     # body-level density (USD body density overrides per-shape density).

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6163,6 +6163,28 @@ def Xform "Articulation" (
                     np.testing.assert_allclose(builder.body_com[body_idx], shape_pos, atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_massapi_authored_com_survives_failed_mass_computation(self):
+        """Authored body COM survives fallback when mass properties cannot be computed."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        parent = UsdGeom.Xform.Define(stage, "/World/Scaled")
+        parent.AddScaleOp().Set(Gf.Vec3d(2.0))
+
+        body = UsdGeom.Xform.Define(stage, "/World/Scaled/Body")
+        body_prim = body.GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(body_prim)
+        mass_api = UsdPhysics.MassAPI.Apply(body_prim)
+        mass_api.CreateCenterOfMassAttr().Set(Gf.Vec3f(0.3, 0.0, 0.0))
+
+        builder = newton.ModelBuilder()
+        with self.assertWarnsRegex(UserWarning, "zero mass and zero inertia"):
+            result = builder.add_usd(stage)
+
+        body_idx = result["path_body_map"]["/World/Scaled/Body"]
+        np.testing.assert_allclose(builder.body_com[body_idx], [0.3, 0.0, 0.0], atol=1e-6, rtol=1e-6)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_authored_mass_and_inertia_short_circuits_compute(self):
         """If body has authored mass+diagonalInertia, use them directly without compute fallback."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6124,12 +6124,12 @@ def Xform "Articulation" (
         UsdPhysics.Scene.Define(stage, "/physicsScene")
 
         cases = (
-            ("Nonuniform", (2.0, 3.0, 4.0), 45.0, (0.3, 0.0, 0.0), (0.6, 0.0, 0.0), True),
-            ("Negative", (-2.0, 3.0, 4.0), 30.0, (0.3, 0.2, 0.1), None, False),
+            ("Nonuniform", (2.0, 3.0, 4.0), 45.0, (0.3, 0.0, 0.0), True),
+            ("Negative", (-2.0, 3.0, 4.0), 30.0, (0.3, 0.2, 0.1), False),
         )
         mass_cases = (("Complete", True), ("Partial", False))
 
-        for case_name, scale, angle, com, _expected_shape_pos, include_partial in cases:
+        for case_name, scale, angle, com, include_partial in cases:
             parent = UsdGeom.Xform.Define(stage, f"/World/{case_name}")
             parent.AddScaleOp().Set(Gf.Vec3d(*scale))
             for mass_name, author_all_mass_properties in mass_cases if include_partial else mass_cases[:1]:
@@ -6151,15 +6151,13 @@ def Xform "Articulation" (
         builder = newton.ModelBuilder()
         result = builder.add_usd(stage)
 
-        for case_name, _scale, _angle, _com, expected_shape_pos, include_partial in cases:
+        for case_name, _scale, _angle, _com, include_partial in cases:
             for mass_name, _author_all_mass_properties in mass_cases if include_partial else mass_cases[:1]:
                 with self.subTest(case=case_name, mass=mass_name):
                     body_path = f"/World/{case_name}/{mass_name}"
                     body_idx = result["path_body_map"][body_path]
                     shape_idx = result["path_shape_map"][f"{body_path}/Collider"]
                     shape_pos = builder.shape_transform[shape_idx].p
-                    if expected_shape_pos is not None:
-                        np.testing.assert_allclose(shape_pos, expected_shape_pos, atol=1e-6, rtol=1e-6)
                     np.testing.assert_allclose(builder.body_com[body_idx], shape_pos, atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6114,6 +6114,41 @@ def Xform "Articulation" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_massapi_authored_com_applies_ancestor_scale(self):
+        """Authored body COM follows scale inherited from ancestor prims."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        parent = UsdGeom.Xform.Define(stage, "/World/Scaled")
+        parent.AddScaleOp().Set(Gf.Vec3d(2.0))
+
+        for name, author_all_mass_properties in (("Complete", True), ("Partial", False)):
+            body = UsdGeom.Xform.Define(stage, f"/World/Scaled/{name}")
+            body_prim = body.GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(body_prim)
+            mass_api = UsdPhysics.MassAPI.Apply(body_prim)
+            mass_api.CreateCenterOfMassAttr().Set(Gf.Vec3f(0.3, 0.0, 0.0))
+            if author_all_mass_properties:
+                mass_api.CreateMassAttr().Set(1.0)
+                mass_api.CreateDiagonalInertiaAttr().Set(Gf.Vec3f(0.01))
+
+            collider = UsdGeom.Cube.Define(stage, f"/World/Scaled/{name}/Collider")
+            collider.AddTranslateOp().Set(Gf.Vec3d(0.3, 0.0, 0.0))
+            UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+
+        for name in ("Complete", "Partial"):
+            with self.subTest(name=name):
+                body_idx = result["path_body_map"][f"/World/Scaled/{name}"]
+                np.testing.assert_allclose(builder.body_com[body_idx], [0.6, 0.0, 0.0], atol=1e-6, rtol=1e-6)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_authored_mass_and_inertia_short_circuits_compute(self):
         """If body has authored mass+diagonalInertia, use them directly without compute fallback."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6114,8 +6114,8 @@ def Xform "Articulation" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
-    def test_massapi_authored_com_applies_ancestor_scale(self):
-        """Authored body COM follows scale inherited from ancestor prims."""
+    def test_massapi_authored_com_matches_scaled_collider_frame(self):
+        """Authored body COM uses the same scaled frame as collider offsets."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
         stage = Usd.Stage.CreateInMemory()
@@ -6123,30 +6123,44 @@ def Xform "Articulation" (
         UsdGeom.SetStageMetersPerUnit(stage, 1.0)
         UsdPhysics.Scene.Define(stage, "/physicsScene")
 
-        parent = UsdGeom.Xform.Define(stage, "/World/Scaled")
-        parent.AddScaleOp().Set(Gf.Vec3d(2.0))
+        cases = (
+            ("Nonuniform", (2.0, 3.0, 4.0), 45.0, (0.3, 0.0, 0.0), (0.6, 0.0, 0.0), True),
+            ("Negative", (-2.0, 3.0, 4.0), 30.0, (0.3, 0.2, 0.1), None, False),
+        )
+        mass_cases = (("Complete", True), ("Partial", False))
 
-        for name, author_all_mass_properties in (("Complete", True), ("Partial", False)):
-            body = UsdGeom.Xform.Define(stage, f"/World/Scaled/{name}")
-            body_prim = body.GetPrim()
-            UsdPhysics.RigidBodyAPI.Apply(body_prim)
-            mass_api = UsdPhysics.MassAPI.Apply(body_prim)
-            mass_api.CreateCenterOfMassAttr().Set(Gf.Vec3f(0.3, 0.0, 0.0))
-            if author_all_mass_properties:
-                mass_api.CreateMassAttr().Set(1.0)
-                mass_api.CreateDiagonalInertiaAttr().Set(Gf.Vec3f(0.01))
+        for case_name, scale, angle, com, _expected_shape_pos, include_partial in cases:
+            parent = UsdGeom.Xform.Define(stage, f"/World/{case_name}")
+            parent.AddScaleOp().Set(Gf.Vec3d(*scale))
+            for mass_name, author_all_mass_properties in mass_cases if include_partial else mass_cases[:1]:
+                body_path = f"/World/{case_name}/{mass_name}"
+                body = UsdGeom.Xform.Define(stage, body_path)
+                body.AddRotateZOp().Set(angle)
+                body_prim = body.GetPrim()
+                UsdPhysics.RigidBodyAPI.Apply(body_prim)
+                mass_api = UsdPhysics.MassAPI.Apply(body_prim)
+                mass_api.CreateCenterOfMassAttr().Set(Gf.Vec3f(*com))
+                if author_all_mass_properties:
+                    mass_api.CreateMassAttr().Set(1.0)
+                    mass_api.CreateDiagonalInertiaAttr().Set(Gf.Vec3f(0.01))
 
-            collider = UsdGeom.Cube.Define(stage, f"/World/Scaled/{name}/Collider")
-            collider.AddTranslateOp().Set(Gf.Vec3d(0.3, 0.0, 0.0))
-            UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
+                collider = UsdGeom.Cube.Define(stage, f"{body_path}/Collider")
+                collider.AddTranslateOp().Set(Gf.Vec3d(*com))
+                UsdPhysics.CollisionAPI.Apply(collider.GetPrim())
 
         builder = newton.ModelBuilder()
         result = builder.add_usd(stage)
 
-        for name in ("Complete", "Partial"):
-            with self.subTest(name=name):
-                body_idx = result["path_body_map"][f"/World/Scaled/{name}"]
-                np.testing.assert_allclose(builder.body_com[body_idx], [0.6, 0.0, 0.0], atol=1e-6, rtol=1e-6)
+        for case_name, _scale, _angle, _com, expected_shape_pos, include_partial in cases:
+            for mass_name, _author_all_mass_properties in mass_cases if include_partial else mass_cases[:1]:
+                with self.subTest(case=case_name, mass=mass_name):
+                    body_path = f"/World/{case_name}/{mass_name}"
+                    body_idx = result["path_body_map"][body_path]
+                    shape_idx = result["path_shape_map"][f"{body_path}/Collider"]
+                    shape_pos = builder.shape_transform[shape_idx].p
+                    if expected_shape_pos is not None:
+                        np.testing.assert_allclose(shape_pos, expected_shape_pos, atol=1e-6, rtol=1e-6)
+                    np.testing.assert_allclose(builder.body_com[body_idx], shape_pos, atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_authored_mass_and_inertia_short_circuits_compute(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -6162,7 +6162,7 @@ def Xform "Articulation" (
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_authored_com_survives_failed_mass_computation(self):
-        """Authored body COM survives fallback when mass properties cannot be computed."""
+        """Authored body COM keeps descriptor scale when mass properties cannot be computed."""
         from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
         stage = Usd.Stage.CreateInMemory()
@@ -6180,7 +6180,7 @@ def Xform "Articulation" (
             result = builder.add_usd(stage)
 
         body_idx = result["path_body_map"]["/World/Scaled/Body"]
-        np.testing.assert_allclose(builder.body_com[body_idx], [0.3, 0.0, 0.0], atol=1e-6, rtol=1e-6)
+        np.testing.assert_allclose(builder.body_com[body_idx], [0.6, 0.0, 0.0], atol=1e-6, rtol=1e-6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_massapi_authored_mass_and_inertia_short_circuits_compute(self):


### PR DESCRIPTION
## Description

Closes #3332.

Transform authored `physics:centerOfMass` values from the USD prim's local space into the rigid-body descriptor frame so inherited transform scale is preserved. This keeps authored centers of mass aligned with scaled colliders and joint frames.

The importer previously copied authored center-of-mass values directly, even though `RigidBodyDesc` excludes scale from the body pose. Scaled USD instances therefore retained an unscaled center of mass, which could destabilize simulation.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run --extra dev -m newton.tests -k test_massapi
uv run --extra dev -m newton.tests -k test_import_usd
uvx pre-commit run -a
```

The MassAPI tests passed 8/8, the complete USD importer suite passed 224/224, and all pre-commit checks passed.

## Bug fix

**Steps to reproduce:**

1. Create a USD rigid body beneath an ancestor with scale `(2, 2, 2)`.
2. Author `physics:centerOfMass = (0.3, 0, 0)` and a collider translated by `(0.3, 0, 0)`.
3. Import the stage with `ModelBuilder.add_usd()`.
4. Observe that the collider offset becomes `0.6`, while the center of mass incorrectly remains `0.3` without this fix.

**Minimal reproduction:**

```python
import numpy as np
from pxr import Gf, Usd, UsdGeom, UsdPhysics

import newton

stage = Usd.Stage.CreateInMemory()
parent = UsdGeom.Xform.Define(stage, "/World/Scaled")
parent.AddScaleOp().Set(Gf.Vec3d(2.0))

body = UsdGeom.Xform.Define(stage, "/World/Scaled/Body")
UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
mass_api = UsdPhysics.MassAPI.Apply(body.GetPrim())
mass_api.CreateMassAttr().Set(1.0)
mass_api.CreateDiagonalInertiaAttr().Set(Gf.Vec3f(0.01))
mass_api.CreateCenterOfMassAttr().Set(Gf.Vec3f(0.3, 0.0, 0.0))

collider = UsdGeom.Cube.Define(stage, "/World/Scaled/Body/Collider")
collider.AddTranslateOp().Set(Gf.Vec3d(0.3, 0.0, 0.0))
UsdPhysics.CollisionAPI.Apply(collider.GetPrim())

builder = newton.ModelBuilder()
result = builder.add_usd(stage)
body_idx = result["path_body_map"]["/World/Scaled/Body"]
np.testing.assert_allclose(builder.body_com[body_idx], [0.6, 0.0, 0.0])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD import for rigid bodies so MassAPI-authored centers of mass correctly respect inherited transform scale and land in the proper body frame.
  * Improved behavior when mass-property computation fails: authored COM is preserved and applied with the correct scaling, instead of being overwritten by fallback values.
* **Tests**
  * Added regression tests covering scaled MassAPI-authored COM vs. collider frame translation.
  * Added a regression test ensuring authored COM survives failed mass-properties computation.
* **Documentation**
  * Updated the changelog entry for the USD import fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->