### PR TITLE
Add the option to customize actuation types for FK in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -1006,6 +1006,7 @@ class ModelBuilderKamino:
         joints_jid = []
         joints_dofid = []
         joints_actid = []
+        joints_fk_actid = []
         joints_q_j_0 = []
         joints_dq_j_0 = []
         joints_bid_B = []
@@ -1137,6 +1138,7 @@ class ModelBuilderKamino:
                 joints_jid.append(joint.jid)
                 joints_dofid.append(joint.dof_type.value)
                 joints_actid.append(joint.act_type.value)
+                joints_fk_actid.append(-1 if joint.fk_act_type is None else joint.fk_act_type.value)
                 joints_B_r_Bj.append(joint.B_r_Bj)
                 joints_F_r_Fj.append(joint.F_r_Fj)
                 joints_X_Bj.append(joint.X_Bj)
@@ -1275,6 +1277,10 @@ class ModelBuilderKamino:
             max_of_num_passive_joint_dofs=max([world.num_passive_joint_dofs for world in self._worlds]),
             sum_of_num_actuated_joint_coords=self._num_joint_actuated_coords,
             max_of_num_actuated_joint_coords=max([world.num_actuated_joint_coords for world in self._worlds]),
+            sum_of_num_fk_actuated_joint_coords=sum([world.num_fk_actuated_joint_coords for world in self._worlds]),
+            max_of_num_fk_actuated_joint_coords=max([world.num_fk_actuated_joint_coords for world in self._worlds]),
+            sum_of_num_fk_actuated_joint_dofs=sum([world.num_fk_actuated_joint_dofs for world in self._worlds]),
+            max_of_num_fk_actuated_joint_dofs=max([world.num_fk_actuated_joint_dofs for world in self._worlds]),
             sum_of_num_actuated_joint_dofs=self._num_joint_actuated_dofs,
             max_of_num_actuated_joint_dofs=max([world.num_actuated_joint_dofs for world in self._worlds]),
             sum_of_num_joint_cts=self._num_joint_cts,
@@ -1400,6 +1406,9 @@ class ModelBuilderKamino:
                 jid=to_warp_int32_array(joints_jid),
                 dof_type=to_warp_int32_array(joints_dofid),
                 act_type=to_warp_int32_array(joints_actid),
+                fk_act_type=to_warp_int32_array(joints_fk_actid)
+                if any(actid != -1 for actid in joints_fk_actid)
+                else None,
                 bid_B=to_warp_int32_array(joints_bid_B),
                 bid_F=to_warp_int32_array(joints_bid_F),
                 B_r_Bj=wp.array(joints_B_r_Bj, dtype=wp.vec3f, requires_grad=requires_grad),

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -15,6 +15,7 @@ import warp as wp
 
 from .....core.types import Axis
 from .....geometry import ShapeFlags
+from ..utils import logger as msg
 from .bodies import RigidBodiesModel, RigidBodyDescriptor
 from .geometry import GeometriesModel, GeometryDescriptor
 from .gravity import GravityDescriptor, GravityModel
@@ -913,7 +914,10 @@ class ModelBuilderKamino:
         # Validate base body/joint data for each world, and fill in missing data if possible
         for w, world in enumerate(self._worlds):
             if world.has_base_joint:
-                follower_idx = self._joints[w][world.base_joint_idx].bid_F  # Note: index among world bodies
+                base_joint = self._joints[w][world.base_joint_idx]
+                if base_joint.dof_type != JointDoFType.FREE:
+                    raise ValueError(f"Invalid base joint for world {world.name} ({w}), must be a free joint.")
+                follower_idx = joint.bid_F  # Note: index among world bodies
                 if world.has_base_body:  # Ensure base joint & body are compatible if both were set
                     if world.base_body_idx != follower_idx:
                         raise ValueError(
@@ -922,16 +926,21 @@ class ModelBuilderKamino:
                 else:  # Set base body to be the follower of the base joint
                     world.set_base_body(follower_idx)
             elif not world.has_base_body and base_auto:
-                # Look for a non-universal unary joint connecting the world to a follower body
+                # Look for a unary free joint connecting the world to a follower body
+                has_unary_joint = False
                 for jt_idx, joint in enumerate(self._joints[w]):
-                    if joint.bid_B == -1 and joint.dof_type != JointDoFType.UNIVERSAL:
-                        world.set_base_joint(jt_idx)
-                        world.set_base_body(joint.bid_F)
-                        break
-                # As a last fallback, set body 0 in that world as base body (no base joint)
-                if not world.has_base_body:
+                    if joint.bid_B == -1:
+                        has_unary_joint = True
+                        if joint.dof_type == JointDoFType.FREE:
+                            world.set_base_joint(jt_idx)
+                            world.set_base_body(joint.bid_F)
+                            break
+                # As a last fallback, set body 0 in that world as base body (no base joint), if no unary
+                # joints were found (else this is not a floating-base model and we assign no base body).
+                if not world.has_base_body and not has_unary_joint:
                     if world.num_bodies == 0:
-                        raise RuntimeError(f"Zero bodies in world {w}, cannot set base body.")
+                        msg.warning(f"Zero bodies in world {w}, no base body assigned.")
+                        continue
                     world.set_base_body(0)
 
         ###

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -1006,7 +1006,7 @@ class ModelBuilderKamino:
         joints_jid = []
         joints_dofid = []
         joints_actid = []
-        joints_fk_actid = []
+        joints_fk_act_flag = []
         joints_q_j_0 = []
         joints_dq_j_0 = []
         joints_bid_B = []
@@ -1138,7 +1138,7 @@ class ModelBuilderKamino:
                 joints_jid.append(joint.jid)
                 joints_dofid.append(joint.dof_type.value)
                 joints_actid.append(joint.act_type.value)
-                joints_fk_actid.append(-1 if joint.fk_act_type is None else joint.fk_act_type.value)
+                joints_fk_act_flag.append(joint.fk_act_flag)
                 joints_B_r_Bj.append(joint.B_r_Bj)
                 joints_F_r_Fj.append(joint.F_r_Fj)
                 joints_X_Bj.append(joint.X_Bj)
@@ -1406,8 +1406,8 @@ class ModelBuilderKamino:
                 jid=to_warp_int32_array(joints_jid),
                 dof_type=to_warp_int32_array(joints_dofid),
                 act_type=to_warp_int32_array(joints_actid),
-                fk_act_type=to_warp_int32_array(joints_fk_actid)
-                if any(actid != -1 for actid in joints_fk_actid)
+                fk_act_flag=to_warp_int32_array(joints_fk_act_flag)
+                if any(act_flag != -1 for act_flag in joints_fk_act_flag)
                 else None,
                 bid_B=to_warp_int32_array(joints_bid_B),
                 bid_F=to_warp_int32_array(joints_bid_F),

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -309,7 +309,7 @@ def joint_indexing_kernel(
     joint_num_dofs: wp.array[wp.int32],
     joint_num_kinematic_cts: wp.array[wp.int32],
     joint_num_dynamic_cts: wp.array[wp.int32],
-    model_fk_act_type: wp.array[wp.int32],
+    model_fk_act_flag: wp.array[wp.int32],
     # Outputs:
     num_passive_joints: wp.array[wp.int32],
     num_actuated_joints: wp.array[wp.int32],
@@ -388,14 +388,14 @@ def joint_indexing_kernel(
             num_actuated_j += 1
             num_actuated_coords += ncoords_j
             num_actuated_dofs += ndofs_j
-            if not model_fk_act_type or model_fk_act_type[joint_id] == -1:
+            if not model_fk_act_flag or model_fk_act_flag[joint_id] == -1:
                 num_fk_actuated_coords += ncoords_j
                 num_fk_actuated_dofs += ndofs_j
         else:
             num_passive_j += 1
             num_passive_coords += ncoords_j
             num_passive_dofs += ndofs_j
-        if model_fk_act_type and model_fk_act_type[joint_id] > JointActuationType.PASSIVE:
+        if model_fk_act_flag and model_fk_act_flag[joint_id] == 1:
             num_fk_actuated_coords += ncoords_j
             num_fk_actuated_dofs += ndofs_j
 
@@ -941,7 +941,7 @@ def convert_joints(
             joint_num_dofs,
             joint_num_kinematic_cts,
             joint_num_dynamic_cts,
-            model.fk_actuation_type if hasattr(model, "fk_actuation_type") else None,
+            model.fk_actuation_flag if hasattr(model, "fk_actuation_flag") else None,
         ],
         outputs=[
             num_passive_joints,
@@ -1231,7 +1231,7 @@ def convert_joints(
         jid=joint_jid,  # TODO: Remove
         dof_type=joint_dof_type,
         act_type=joint_act_type,
-        fk_act_type=model.fk_actuation_type if hasattr(model, "fk_actuation_type") else None,
+        fk_act_flag=model.fk_actuation_flag if hasattr(model, "fk_actuation_flag") else None,
         bid_B=model.joint_parent,
         bid_F=model.joint_child,
         B_r_Bj=joint_B_r_B,

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -12,6 +12,7 @@ import warp as wp
 
 from .....geometry import ShapeFlags
 from .....sim.model import Model
+from ..utils import logger as msg
 from .bodies import (
     RigidBodiesModel,
     convert_body_origin_to_com,
@@ -1014,35 +1015,45 @@ def convert_joints(
     if model.articulation_count > 0:
         articulation_start_np = model.articulation_start.numpy()
         articulation_world_np = model.articulation_world.numpy()
-        # For each articulation, assign its base body and joint to the corresponding world
+        # For each articulation, assign its base body and joint to the corresponding world,
+        # if the base joint is a unary free joint.
         # NOTE: We only assign the first articulation found in each world
+        has_non_free_root = False
         for aid in range(model.articulation_count):
             wid = articulation_world_np[aid]
             base_joint = articulation_start_np[aid]
             base_body = joint_child_np[base_joint]
             if base_body_idx_np[wid] == -1 and base_joint_idx_np[wid] == -1:
-                if joint_dof_type_np[base_joint] == JointDoFType.UNIVERSAL:
-                    raise RuntimeError(
-                        "Universal joint as the base joint of an articulation isn't supported in Kamino."
-                    )
+                if joint_dof_type_np[base_joint] != JointDoFType.FREE:
+                    has_non_free_root = True
+                    continue
                 base_body_idx_np[wid] = base_body
                 base_joint_idx_np[wid] = base_joint
+        if has_non_free_root:
+            msg.warning(
+                "Model has articulations with a non-free joint as root, disabling floating base resets for those worlds."
+            )
 
-    # For worlds without articulations, look for a unary joint, or else use the first body
+    # For worlds without articulations, look for a unary free joint, or use the first body
     for wid in range(model.world_count):
         if base_body_idx_np[wid] != -1:  # World already has a base body
             continue
-        # Look for a unary non-universal joint connecting the world to a follower body
+        # Look for a unary joint, and use it as base joint if it is a free joint
+        has_unary_joint = False
         for jid in range(joint_world_start_np[wid], joint_world_start_np[wid + 1]):
-            if joint_parent_np[jid] == -1 and joint_dof_type_np[jid] != JointDoFType.UNIVERSAL:
-                base_joint_idx_np[wid] = jid
-                base_body_idx_np[wid] = int(joint_child_np[jid])
-                break
-        # As a last fallback, set first body in that world as base body (no base joint)
-        if base_body_idx_np[wid] == -1:
-            base_body_idx_np[wid] = body_world_start_np[wid]
+            if joint_parent_np[jid] == -1:
+                has_unary_joint = True
+                if joint_dof_type_np[jid] == JointDoFType.FREE:
+                    base_joint_idx_np[wid] = jid
+                    base_body_idx_np[wid] = int(joint_child_np[jid])
+                    break
+        # As a last fallback, set first body in that world as base body (no base joint), if no unary
+        # joints were found (else this is not a floating-base model and we assign no base body).
+        if base_body_idx_np[wid] == -1 and not has_unary_joint:
             if body_world_start_np[wid] == body_world_start_np[wid + 1]:
-                raise RuntimeError(f"Zero bodies in world {wid}, cannot set base body.")
+                msg.warning(f"Zero bodies in world {wid}, no base body assigned.")
+                continue
+            base_body_idx_np[wid] = body_world_start_np[wid]
 
     # Update size object
     model_size.sum_of_num_joints = int(num_joints_np.sum())

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -309,6 +309,7 @@ def joint_indexing_kernel(
     joint_num_dofs: wp.array[wp.int32],
     joint_num_kinematic_cts: wp.array[wp.int32],
     joint_num_dynamic_cts: wp.array[wp.int32],
+    model_fk_act_type: wp.array[wp.int32],
     # Outputs:
     num_passive_joints: wp.array[wp.int32],
     num_actuated_joints: wp.array[wp.int32],
@@ -318,7 +319,9 @@ def joint_indexing_kernel(
     num_joint_passive_coords: wp.array[wp.int32],
     num_joint_passive_dofs: wp.array[wp.int32],
     num_joint_actuated_coords: wp.array[wp.int32],
+    num_joint_fk_actuated_coords: wp.array[wp.int32],
     num_joint_actuated_dofs: wp.array[wp.int32],
+    num_joint_fk_actuated_dofs: wp.array[wp.int32],
     num_joint_cts: wp.array[wp.int32],
     num_joint_dynamic_cts: wp.array[wp.int32],
     num_joint_kinematic_cts: wp.array[wp.int32],
@@ -344,7 +347,9 @@ def joint_indexing_kernel(
     num_coords = int(0)
     num_dofs = int(0)
     num_actuated_coords = int(0)
+    num_fk_actuated_coords = int(0)
     num_actuated_dofs = int(0)
+    num_fk_actuated_dofs = int(0)
     num_passive_coords = int(0)
     num_passive_dofs = int(0)
     num_cts = int(0)
@@ -383,10 +388,16 @@ def joint_indexing_kernel(
             num_actuated_j += 1
             num_actuated_coords += ncoords_j
             num_actuated_dofs += ndofs_j
+            if not model_fk_act_type or model_fk_act_type[joint_id] == -1:
+                num_fk_actuated_coords += ncoords_j
+                num_fk_actuated_dofs += ndofs_j
         else:
             num_passive_j += 1
             num_passive_coords += ncoords_j
             num_passive_dofs += ndofs_j
+        if model_fk_act_type and model_fk_act_type[joint_id] > JointActuationType.PASSIVE:
+            num_fk_actuated_coords += ncoords_j
+            num_fk_actuated_dofs += ndofs_j
 
         # Update sizes based on whether joint is dynamic
         if n_dyn_cts_j > 0:
@@ -404,7 +415,9 @@ def joint_indexing_kernel(
     num_joint_kinematic_cts[world_id] = num_kinematic_cts
     num_joint_dynamic_cts[world_id] = num_dynamic_cts
     num_joint_actuated_coords[world_id] = num_actuated_coords
+    num_joint_fk_actuated_coords[world_id] = num_fk_actuated_coords
     num_joint_actuated_dofs[world_id] = num_actuated_dofs
+    num_joint_fk_actuated_dofs[world_id] = num_fk_actuated_dofs
     num_joint_passive_coords[world_id] = num_passive_coords
     num_joint_passive_dofs[world_id] = num_passive_dofs
 
@@ -902,7 +915,9 @@ def convert_joints(
         num_joint_passive_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_passive_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_actuated_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_fk_actuated_coords = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_actuated_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
+        num_joint_fk_actuated_dofs = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_dynamic_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
         num_joint_kinematic_cts = wp.zeros(shape=(model.world_count,), dtype=wp.int32)
@@ -926,6 +941,7 @@ def convert_joints(
             joint_num_dofs,
             joint_num_kinematic_cts,
             joint_num_dynamic_cts,
+            model.fk_actuation_type if hasattr(model, "fk_actuation_type") else None,
         ],
         outputs=[
             num_passive_joints,
@@ -936,7 +952,9 @@ def convert_joints(
             num_joint_passive_coords,
             num_joint_passive_dofs,
             num_joint_actuated_coords,
+            num_joint_fk_actuated_coords,
             num_joint_actuated_dofs,
+            num_joint_fk_actuated_dofs,
             num_joint_cts,
             num_joint_dynamic_cts,
             num_joint_kinematic_cts,
@@ -962,7 +980,9 @@ def convert_joints(
     num_joint_passive_coords_np = num_joint_passive_coords.numpy()
     num_joint_passive_dofs_np = num_joint_passive_dofs.numpy()
     num_joint_actuated_coords_np = num_joint_actuated_coords.numpy()
+    num_joint_fk_actuated_coords_np = num_joint_fk_actuated_coords.numpy()
     num_joint_actuated_dofs_np = num_joint_actuated_dofs.numpy()
+    num_joint_fk_actuated_dofs_np = num_joint_fk_actuated_dofs.numpy()
     num_joint_cts_np = num_joint_cts.numpy()
     num_joint_dynamic_cts_np = num_joint_dynamic_cts.numpy()
     num_joint_kinematic_cts_np = num_joint_kinematic_cts.numpy()
@@ -1074,8 +1094,12 @@ def convert_joints(
     model_size.max_of_num_passive_joint_dofs = int(num_joint_passive_dofs_np.max())
     model_size.sum_of_num_actuated_joint_coords = int(num_joint_actuated_coords_np.sum())
     model_size.max_of_num_actuated_joint_coords = int(num_joint_actuated_coords_np.max())
+    model_size.sum_of_num_fk_actuated_joint_coords = int(num_joint_fk_actuated_coords_np.sum())
+    model_size.max_of_num_fk_actuated_joint_coords = int(num_joint_fk_actuated_coords_np.max())
     model_size.sum_of_num_actuated_joint_dofs = int(num_joint_actuated_dofs_np.sum())
     model_size.max_of_num_actuated_joint_dofs = int(num_joint_actuated_dofs_np.max())
+    model_size.sum_of_num_fk_actuated_joint_dofs = int(num_joint_fk_actuated_dofs_np.sum())
+    model_size.max_of_num_fk_actuated_joint_dofs = int(num_joint_fk_actuated_dofs_np.max())
     model_size.sum_of_num_joint_cts = int(num_joint_cts_np.sum())
     model_size.max_of_num_joint_cts = int(num_joint_cts_np.max())
     model_size.sum_of_num_dynamic_joint_cts = int(num_joint_dynamic_cts_np.sum())
@@ -1207,6 +1231,7 @@ def convert_joints(
         jid=joint_jid,  # TODO: Remove
         dof_type=joint_dof_type,
         act_type=joint_act_type,
+        fk_act_type=model.fk_actuation_type if hasattr(model, "fk_actuation_type") else None,
         bid_B=model.joint_parent,
         bid_F=model.joint_child,
         B_r_Bj=joint_B_r_B,

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -1025,8 +1025,15 @@ class JointDescriptor(Descriptor):
     act_type: JointActuationType = JointActuationType.PASSIVE
     """Actuation type of the joint."""
 
-    fk_act_type: JointActuationType | None = None
-    """Actuation type of the joint for the FK solver, if it differs from `act_type`."""
+    fk_act_flag: int = -1
+    """
+    Integer flag indicating whether this joint should be considered actuated (1) or passive (0) by the
+    Forward Kinematics solver, or to infer this from `act_type` (-1).
+
+    Actuating more joints in FK than in dynamics can be used, e.g., to make the FK problem well-posed for
+    under-actuated systems.
+    Note that all actuator types are treated equally in FK (only passive vs actuated matters).
+    """
 
     dof_type: JointDoFType = JointDoFType.FREE
     """DoF type of the joint."""
@@ -1502,7 +1509,7 @@ class JointDescriptor(Descriptor):
             f"uid: {self.uid},\n"
             "----------------------------------------------\n"
             f"act_type: {self.act_type},\n"
-            f"fk_act_type: {self.fk_act_type},\n"
+            f"fk_act_flag: {self.fk_act_flag},\n"
             f"dof_type: {self.dof_type},\n"
             "----------------------------------------------\n"
             f"bid_B: {self.bid_B},\n"
@@ -1689,14 +1696,15 @@ class JointsModel:
     Shape of ``(num_joints,)``.
     """
 
-    fk_act_type: wp.array[wp.int32] | None = None
+    fk_act_flag: wp.array[wp.int32] | None = None
     """
-    Joint actuation type ID of each joint for the FK solver.
-    A -1 entry is interpreted as equal to the corresponding entry in `act_type`.
-    If not set, considered to match `act_type` for all joints.
-    Shape of ``(num_joints,)``.
+    Integer flag per joint, indicating whether it should be considered actuated (1) or passive (0) by the
+    Forward Kinematics solver, or to infer this from `act_type` (-1).
+    Shape of ``(num_joints,)`` if set; else considered to be -1 for all joints.
 
-    Actuating more joints in FK can be used, e.g., to make the FK problem well-posed for under-actuated systems.
+    Actuating more joints in FK than in dynamics can be used, e.g., to make the FK problem well-posed for
+    under-actuated systems.
+    Note that all actuator types are treated equally in FK (only passive vs actuated matters).
     """
 
     bid_B: wp.array[wp.int32] | None = None

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -1025,6 +1025,9 @@ class JointDescriptor(Descriptor):
     act_type: JointActuationType = JointActuationType.PASSIVE
     """Actuation type of the joint."""
 
+    fk_act_type: JointActuationType | None = None
+    """Actuation type of the joint for the FK solver, if it differs from `act_type`."""
+
     dof_type: JointDoFType = JointDoFType.FREE
     """DoF type of the joint."""
 
@@ -1499,6 +1502,7 @@ class JointDescriptor(Descriptor):
             f"uid: {self.uid},\n"
             "----------------------------------------------\n"
             f"act_type: {self.act_type},\n"
+            f"fk_act_type: {self.fk_act_type},\n"
             f"dof_type: {self.dof_type},\n"
             "----------------------------------------------\n"
             f"bid_B: {self.bid_B},\n"
@@ -1683,6 +1687,16 @@ class JointsModel:
     """
     Joint actuation type ID of each joint.
     Shape of ``(num_joints,)``.
+    """
+
+    fk_act_type: wp.array[wp.int32] | None = None
+    """
+    Joint actuation type ID of each joint for the FK solver.
+    A -1 entry is interpreted as equal to the corresponding entry in `act_type`.
+    If not set, considered to match `act_type` for all joints.
+    Shape of ``(num_joints,)``.
+
+    Actuating more joints in FK can be used, e.g., to make the FK problem well-posed for under-actuated systems.
     """
 
     bid_B: wp.array[wp.int32] | None = None

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -387,7 +387,8 @@ class ModelKaminoInfo:
 
     base_body_index: wp.array[wp.int32] | None = None
     """
-    The index of the base body assigned in each world w.r.t the model.
+    The index of the base body assigned in each world w.r.t the model (-1 if not assigned).
+    Must be assigned to enable setting the base pose/velocity in reset operations.
     If a base joint is also assigned, must be the follower body of that joint.
     Shape of ``(num_worlds,)``.
     """
@@ -395,7 +396,8 @@ class ModelKaminoInfo:
     base_joint_index: wp.array[wp.int32] | None = None
     """
     The index of the base joint assigned in each world w.r.t the model (-1 if not assigned).
-    If assigned, must be a unary, non-universal, joint.
+    If assigned, reset operations will interpret the base pose/velocity in the base joint frame.
+    If assigned, must be a unary free joint.
     Shape of ``(num_worlds,)``.
     """
 

--- a/newton/_src/solvers/kamino/_src/core/size.py
+++ b/newton/_src/solvers/kamino/_src/core/size.py
@@ -140,11 +140,23 @@ class SizeKamino:
     max_of_num_actuated_joint_coords: int = 0
     """The maximum number of actuated joint coordinates in any world."""
 
+    sum_of_num_fk_actuated_joint_coords: int = 0
+    """The total number of actuated joint coordinates, for FK actuation types, across all worlds."""
+
+    max_of_num_fk_actuated_joint_coords: int = 0
+    """The maximum number of actuated joint coordinates, for FK actuation types, in any world."""
+
     sum_of_num_actuated_joint_dofs: int = 0
     """The total number of actuated joint DoFs in the model across all worlds."""
 
     max_of_num_actuated_joint_dofs: int = 0
     """The maximum number of actuated joint DoFs in any world."""
+
+    sum_of_num_fk_actuated_joint_dofs: int = 0
+    """The total number of actuated joint DoFs, for FK actuation types, across all worlds."""
+
+    max_of_num_fk_actuated_joint_dofs: int = 0
+    """The maximum number of actuated joint DoFs, for FK actuation types, in any world."""
 
     sum_of_num_joint_cts: int = 0
     """The total number of joint constraints in the model across all worlds."""

--- a/newton/_src/solvers/kamino/_src/core/world.py
+++ b/newton/_src/solvers/kamino/_src/core/world.py
@@ -500,11 +500,11 @@ class WorldDescriptor(Descriptor):
             self.num_actuated_joint_dofs += joint.num_dofs
             self.joint_actuated_coords.append(joint.num_coords)
             self.joint_actuated_dofs.append(joint.num_dofs)
-            if joint.fk_act_type is None:
+            if joint.fk_act_flag < 0:
                 self.num_fk_actuated_joint_coords += joint.num_coords
                 self.num_fk_actuated_joint_dofs += joint.num_dofs
             self.actuated_joint_names.append(joint.name)
-        if joint.fk_act_type is not None and joint.fk_act_type != JointActuationType.PASSIVE:
+        if joint.fk_act_flag == 1:
             self.num_fk_actuated_joint_coords += joint.num_coords
             self.num_fk_actuated_joint_dofs += joint.num_dofs
 

--- a/newton/_src/solvers/kamino/_src/core/world.py
+++ b/newton/_src/solvers/kamino/_src/core/world.py
@@ -143,6 +143,16 @@ class WorldDescriptor(Descriptor):
     in the world, and is always less than or equal to `num_joint_dofs`.
     """
 
+    num_fk_actuated_joint_coords: int = 0
+    """
+    The number of actuated joint coordinates, for FK actuation types.
+    """
+
+    num_fk_actuated_joint_dofs: int = 0
+    """
+    The number of actuated joint DoFs, for FK actuation types.
+    """
+
     num_joint_cts: int = 0
     """
     The total number of joint constraints.
@@ -490,7 +500,13 @@ class WorldDescriptor(Descriptor):
             self.num_actuated_joint_dofs += joint.num_dofs
             self.joint_actuated_coords.append(joint.num_coords)
             self.joint_actuated_dofs.append(joint.num_dofs)
+            if joint.fk_act_type is None:
+                self.num_fk_actuated_joint_coords += joint.num_coords
+                self.num_fk_actuated_joint_dofs += joint.num_dofs
             self.actuated_joint_names.append(joint.name)
+        if joint.fk_act_type is not None and joint.fk_act_type != JointActuationType.PASSIVE:
+            self.num_fk_actuated_joint_coords += joint.num_coords
+            self.num_fk_actuated_joint_dofs += joint.num_dofs
 
         # Append joint dynamics group info
         if joint.num_dynamic_cts > 0:

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -10,7 +10,6 @@ from typing import Any
 import warp as wp
 
 from ..core.joints import JointDoFType
-from ..core.math import quat_from_x_rot, quat_from_y_rot, screw, screw_angular, screw_linear
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
 from ..kinematics.joints import (
@@ -18,7 +17,7 @@ from ..kinematics.joints import (
     convert_angular_vel_to_universal_joint_intermediary_frame,
     get_joint_coords_mapping_function,
 )
-from ..solvers.fk.kernels import _correct_joint_angle, _correct_joint_quaternion, read_quat_from_array
+from ..solvers.fk.kernels import _correct_joint_angle, _correct_joint_quaternion
 
 ###
 # Module interface
@@ -198,138 +197,11 @@ def _compute_and_write_joint_coords_and_vel(
         wp.static(make_compute_and_write_joint_vel(JointDoFType.UNIVERSAL))(q_j, u_j, dofs_offset, joint_u)
 
 
-@wp.func
-def _get_joint_rel_transform_from_coords(
-    dof_type: wp.int32,
-    coord_offset: wp.int32,
-    joint_q: wp.array[wp.float32],
-) -> wp.transformf:
-    """Compute the joint-frame relative body pose at a joint, from the joint coords."""
-    # Initialize transform to identity
-    t = wp.vec3f(0.0, 0.0, 0.0)
-    q = wp.quatf(0.0, 0.0, 0.0, 1.0)
-
-    # Overwrite transform base on joint type and coords
-    if dof_type == JointDoFType.CARTESIAN:
-        t[0] = joint_q[coord_offset]
-        t[1] = joint_q[coord_offset + 1]
-        t[2] = joint_q[coord_offset + 2]
-    elif dof_type == JointDoFType.CYLINDRICAL:
-        t[0] = joint_q[coord_offset]
-        q = quat_from_x_rot(joint_q[coord_offset + 1])
-    elif dof_type == JointDoFType.FIXED:
-        pass  # No dofs to apply
-    elif dof_type == JointDoFType.FREE:
-        t[0] = joint_q[coord_offset]
-        t[1] = joint_q[coord_offset + 1]
-        t[2] = joint_q[coord_offset + 2]
-        q = read_quat_from_array(joint_q, coord_offset + 3, True)
-    elif dof_type == JointDoFType.PRISMATIC:
-        t[0] = joint_q[coord_offset]
-    elif dof_type == JointDoFType.REVOLUTE:
-        q = quat_from_x_rot(joint_q[coord_offset])
-    elif dof_type == JointDoFType.SPHERICAL:
-        q = read_quat_from_array(joint_q, coord_offset, True)
-    elif dof_type == JointDoFType.UNIVERSAL:
-        q_x = quat_from_x_rot(joint_q[coord_offset])
-        q_y = quat_from_y_rot(joint_q[coord_offset + 1])
-        q = q_x * q_y
-    else:
-        assert False, "Unexpected joint dof type"  # noqa: B011
-
-    return wp.transformf(t, q)
-
-
-@wp.func
-def convert_angular_vel_from_universal_joint_intermediary_frame(
-    j_q_j: wp.quatf, j_u_j: wp.spatial_vectorf
-) -> wp.spatial_vectorf:
-    """
-    Convert the angular part of a relative body velocity at a universal joint, from the
-    intermediary frame to the joint frame on the base body.
-    """
-    # Compute intermediary body axes, in the joint frame on the base body
-    e_x = wp.vec3f(1.0, 0.0, 0.0)
-    e_y = wp.vec3f(0.0, 1.0, 0.0)
-    a_x = e_x  # x axis on base
-    a_y_raw = wp.quat_rotate(j_q_j, e_y)  #  y axis on follower (constrained to be orthogonal to a_x)
-    a_y = a_y_raw - wp.dot(a_y_raw, a_x) * a_x  # orthogonalize (in case of constraint violations)
-    a_y = wp.normalize(a_y)
-    a_z = wp.cross(a_x, a_y)
-
-    # Transform angular velocity by rotation corresponding to intermediary frame
-    omega = screw_angular(j_u_j)
-    return screw(screw_linear(j_u_j), omega[0] * a_x + omega[1] * a_y + omega[2] * a_z)
-
-
-def make_typed_get_joint_rel_velocity_from_dofs(dof_type: JointDoFType):
-    """
-    Generate a function computing the joint-frame relative body velocity from the dof-space
-    joint velocity (and from the joint-frame relative body orientation, for universal joints).
-    """
-    num_dofs = dof_type.num_dofs
-    assert num_dofs > 0
-    dof_axes = dof_type.dofs_axes
-
-    @wp.func
-    def _get_joint_rel_velocity_from_dofs(
-        q_j: wp.quatf,
-        dofs_offset: wp.int32,
-        joint_u: wp.array[wp.float32],
-    ) -> wp.spatial_vectorf:
-        # Expand dof-space velocity to 6D screw (with zero along constrained axes)
-        u_j = wp.spatial_vectorf(0.0)
-        for i in range(num_dofs):
-            u_j[dof_axes[i]] = joint_u[dofs_offset + i]
-
-        # Convert back angular velocity from intermediary body frame for universal joint
-        if wp.static(dof_type == JointDoFType.UNIVERSAL):
-            u_j = convert_angular_vel_from_universal_joint_intermediary_frame(q_j, u_j)
-
-        return u_j
-
-    return _get_joint_rel_velocity_from_dofs
-
-
-@wp.func
-def _get_joint_rel_velocity_from_dofs(
-    dof_type: wp.int32,
-    q_j: wp.quatf,
-    dofs_offset: wp.int32,
-    joint_u: wp.array[wp.float32],
-) -> wp.spatial_vectorf:
-    """
-    Compute the joint-frame relative body velocity at a joint, from the dof-space velocity.
-    For universal joints, also requires the joint_frame relative body orientation.
-    """
-    if dof_type == JointDoFType.CARTESIAN:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.CARTESIAN))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.CYLINDRICAL:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.CYLINDRICAL))(
-            q_j, dofs_offset, joint_u
-        )
-    elif dof_type == JointDoFType.FIXED:
-        return wp.spatial_vectorf(0.0)
-    elif dof_type == JointDoFType.FREE:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.FREE))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.PRISMATIC:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.PRISMATIC))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.REVOLUTE:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.REVOLUTE))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.SPHERICAL:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.SPHERICAL))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.UNIVERSAL:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.UNIVERSAL))(q_j, dofs_offset, joint_u)
-    else:
-        assert False, "Unexpected joint dof type"  # noqa: B011
-
-
 @wp.kernel
 def _get_base_q_from_joint_q_and_body_q(
     # Inputs:
     model_base_joint_index: wp.array[wp.int32],
     model_base_body_index: wp.array[wp.int32],
-    model_joint_dof_type: wp.array[wp.int32],
     model_joint_coords_offset: wp.array[wp.int32],
     state_joint_q: wp.array[wp.float32],
     state_body_q: wp.array[wp.transformf],
@@ -347,15 +219,23 @@ def _get_base_q_from_joint_q_and_body_q(
     # Read base_q from joint_q if a base joint was set for this world
     base_joint_id = model_base_joint_index[wid]
     if base_joint_id >= 0:
-        dof_type = model_joint_dof_type[base_joint_id]
         coords_offset = model_joint_coords_offset[base_joint_id]
-        base_q[wid] = _get_joint_rel_transform_from_coords(dof_type, coords_offset, state_joint_q)
+        assert model_joint_coords_offset[base_joint_id + 1] - coords_offset == 7  # Base joint must be free
+        base_q[wid] = wp.transformf(
+            state_joint_q[coords_offset],
+            state_joint_q[coords_offset + 1],
+            state_joint_q[coords_offset + 2],
+            state_joint_q[coords_offset + 3],
+            state_joint_q[coords_offset + 4],
+            state_joint_q[coords_offset + 5],
+            state_joint_q[coords_offset + 6],
+        )
 
     # Otherwise read base_q from body_q if a base body was set for this world
     else:
         base_body_id = model_base_body_index[wid]
-        assert base_body_id >= 0
-        base_q[wid] = state_body_q[base_body_id]
+        if base_body_id >= 0:
+            base_q[wid] = state_body_q[base_body_id]
 
 
 @wp.kernel
@@ -363,7 +243,6 @@ def _get_base_u_from_joint_u_and_body_u(
     # Inputs:
     model_base_joint_index: wp.array[wp.int32],
     model_base_body_index: wp.array[wp.int32],
-    model_joint_dof_type: wp.array[wp.int32],
     model_joint_dofs_offset: wp.array[wp.int32],
     state_joint_u: wp.array[wp.float32],
     state_body_u: wp.array[wp.spatial_vectorf],
@@ -382,17 +261,21 @@ def _get_base_u_from_joint_u_and_body_u(
     base_joint_id = model_base_joint_index[wid]
     if base_joint_id >= 0:
         dofs_offset = model_joint_dofs_offset[base_joint_id]
-        dof_type = model_joint_dof_type[base_joint_id]
-        assert dof_type != JointDoFType.UNIVERSAL  # Universal base joints are not supported
-        # Relative body orientation would be needed to interpret dof-space velocity,
-        # complicating the code significantly for a corner case without clear usecase.
-        base_u[wid] = _get_joint_rel_velocity_from_dofs(dof_type, wp.quatf(), dofs_offset, state_joint_u)
+        assert model_joint_dofs_offset[base_joint_id + 1] - dofs_offset == 6  # Base joint must be free
+        base_u[wid] = wp.spatial_vectorf(
+            state_joint_u[dofs_offset],
+            state_joint_u[dofs_offset + 1],
+            state_joint_u[dofs_offset + 2],
+            state_joint_u[dofs_offset + 3],
+            state_joint_u[dofs_offset + 4],
+            state_joint_u[dofs_offset + 5],
+        )
 
     # Otherwise read base_u from body_u if a base body was set for this world
     else:
         base_body_id = model_base_body_index[wid]
-        assert base_body_id >= 0
-        base_u[wid] = state_body_u[base_body_id]
+        if base_body_id >= 0:
+            base_u[wid] = state_body_u[base_body_id]
 
 
 @wp.kernel
@@ -573,6 +456,8 @@ def _eval_floating_base_relative_transform(
     # Determine new pose of the base body (= follower of the base joint if there is a base joint)
     base_joint_id = model_base_joint_index[wid]
     base_body_id = model_base_body_index[wid]
+    if base_body_id < 0:  # No floating base prescribed
+        return
     base_body_curr_pose = body_q[base_body_id]
     if not base_q:  # No prescribed base_q: take new base body pose as its current pose
         base_body_pose = base_body_curr_pose
@@ -587,7 +472,7 @@ def _eval_floating_base_relative_transform(
         T_F = wp.transformf(r_F, wp.quat_from_matrix(X_F))
         T_F_inv = wp.transform_inverse(T_F)
         base_body_pose = wp.transform_multiply(wp.transform_multiply(T_B, base_q[wid]), T_F_inv)
-    else:  # Directly interpret base_q as the new base body pose if no base joint
+    else:  # Directly interpret base_q as the new base body pose if base body but not base joint
         base_body_pose = base_q[wid]
     new_base_pos[wid] = wp.transform_get_translation(base_body_pose)
 
@@ -638,6 +523,7 @@ def _eval_floating_base_relative_transform(
 @wp.kernel
 def _apply_floating_base_transform(
     # Inputs:
+    model_base_body_index: wp.array[wp.int32],
     body_world_id: wp.array[wp.int32],
     rel_transform: wp.array[wp.transformf],
     rel_velocity: wp.array[wp.spatial_vectorf],
@@ -650,9 +536,9 @@ def _apply_floating_base_transform(
     # Get thread id as body id
     body_id = wp.tid()
 
-    # Early return based on mask
+    # Early return based on mask or absence of floating base
     wid = body_world_id[body_id]
-    if not world_mask[wid]:
+    if not world_mask[wid] or model_base_body_index[wid] < 0:
         return
 
     # Transform body pose
@@ -723,7 +609,6 @@ def get_base_q_from_joint_q_and_body_q(
         inputs=[
             model.info.base_joint_index,
             model.info.base_body_index,
-            model.joints.dof_type,
             model.joints.coords_offset,
             joint_q,
             body_q,
@@ -758,7 +643,6 @@ def get_base_u_from_joint_u_and_body_u(
         inputs=[
             model.info.base_joint_index,
             model.info.base_body_index,
-            model.joints.dof_type,
             model.joints.dofs_offset,
             joint_u,
             body_u,
@@ -854,6 +738,7 @@ def set_floating_base(
         _apply_floating_base_transform,
         dim=model.size.sum_of_num_bodies,
         inputs=[
+            model.info.base_body_index,
             model.bodies.wid,
             rel_transform,
             rel_velocity,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -426,7 +426,7 @@ class SolverKaminoImpl(SolverBase):
             _check_length(
                 config.body_poses.actuator_q,
                 "config.body_poses.actuator_q",
-                self._model.size.sum_of_num_actuated_joint_coords,
+                self._model.size.sum_of_num_fk_actuated_joint_coords,
             )
         if isinstance(config.body_velocities, SolverKamino.ResetConfig.FromJointU):
             _check_length(
@@ -438,7 +438,7 @@ class SolverKaminoImpl(SolverBase):
             _check_length(
                 config.body_velocities.actuator_u,
                 "config.body_velocities.actuator_u",
-                self._model.size.sum_of_num_actuated_joint_dofs,
+                self._model.size.sum_of_num_fk_actuated_joint_dofs,
             )
         if isinstance(config.base_pose, SolverKamino.ResetConfig.FromJointQ):
             _check_length(

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -384,6 +384,7 @@ class SolverKaminoImpl(SolverBase):
         state: StateKamino,
         world_mask: wp.array[wp.bool] | None = None,
         config: SolverKamino.ResetConfig | None = None,
+        success_mask: wp.array[wp.bool] | None = None,
     ):
         """
         Reset the Kamino solver state.
@@ -404,6 +405,9 @@ class SolverKaminoImpl(SolverBase):
             config: Optional reset configuration, controlling the reset behavior
                 for body poses/velocities as well as floating base pose/velocity.
                 If not provided, all components are reset to default (initial) values.
+            success_mask: Optional mask, filled with a success boolean per world if provided
+                (True if reset successfully, False if not reset due to world_mask, or if reset
+                was unsuccessful, e.g. due to an unconverged FK solve).
         """
 
         def _check_length(data: wp.array[Any], name: str, expected: int):
@@ -621,6 +625,14 @@ class SolverKaminoImpl(SolverBase):
 
         # Reset solver internals
         self._reset_solver_data(world_mask=world_mask)
+
+        # Fill success mask
+        if success_mask is not None:
+            # Currently, only the position-level (iterative) FK solve can fail
+            if actuator_q is not None:
+                wp.copy(success_mask, self._solver_fk.newton_success)
+            else:
+                wp.copy(success_mask, world_mask)
 
         # Run the post-reset callback if it has been set
         self._run_post_reset_callback(state_out=state)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -184,13 +184,15 @@ class ForwardKinematicsSolver:
 
         # Resolve custom actuation types
         joints_act_type_prev = self.model.joints.act_type.numpy().copy()
-        if self.model.joints.fk_act_type is not None:
-            joints_fk_act_type = self.model.joints.fk_act_type.numpy()
-            overwrite_mask = joints_fk_act_type != -1
+        if self.model.joints.fk_act_flag is not None:
+            joints_fk_act_flag = self.model.joints.fk_act_flag.numpy()
+            mapping = np.array([-1, JointActuationType.PASSIVE, JointActuationType.FORCE])
+            joints_fk_act_type = mapping[joints_fk_act_flag + 1]  # Map 0/1 flags to enum constants
+            overwrite_mask = joints_fk_act_flag != -1
             joints_act_type_prev[overwrite_mask] = joints_fk_act_type[overwrite_mask]
 
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
-        if self.model.joints.fk_act_type is None:
+        if self.model.joints.fk_act_flag is None:
             actuated_coord_offsets_prev = self.model.joints.actuated_coords_offset.numpy().copy()
             actuated_dof_offsets_prev = self.model.joints.actuated_dofs_offset.numpy().copy()
         else:
@@ -2230,13 +2232,13 @@ def compute_fk_equivalence_classes(model: ModelKamino) -> list[list[int]]:
         sig_base_joint,
     ]
 
-    if model.joints.fk_act_type is not None:
-        sig_joint_fk_act_type = DiscreteSignature(
+    if model.joints.fk_act_flag is not None:
+        sig_joint_fk_act_flag = DiscreteSignature(
             num_worlds=model.size.num_worlds,
-            data=model.joints.fk_act_type,
+            data=model.joints.fk_act_flag,
             world_offset=model.info.joints_offset,
             world_size=model.info.num_joints,
         )
-        signatures.append(sig_joint_fk_act_type)
+        signatures.append(sig_joint_fk_act_flag)
 
     return compute_equivalence_classes(signatures)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -182,9 +182,25 @@ class ForwardKinematicsSolver:
         num_joints_prev = self.model.info.num_joints.numpy().copy()  # Number of joints per world
         first_joint_id_prev = np.concatenate(([0], num_joints_prev.cumsum()))  # Index of first joint per world
 
+        # Resolve custom actuation types
+        joints_act_type_prev = self.model.joints.act_type.numpy().copy()
+        if self.model.joints.fk_act_type is not None:
+            joints_fk_act_type = self.model.joints.fk_act_type.numpy()
+            overwrite_mask = joints_fk_act_type != -1
+            joints_act_type_prev[overwrite_mask] = joints_fk_act_type[overwrite_mask]
+
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
-        actuated_coord_offsets_prev = self.model.joints.actuated_coords_offset.numpy().copy()
-        actuated_dof_offsets_prev = self.model.joints.actuated_dofs_offset.numpy().copy()
+        if self.model.joints.fk_act_type is None:
+            actuated_coord_offsets_prev = self.model.joints.actuated_coords_offset.numpy().copy()
+            actuated_dof_offsets_prev = self.model.joints.actuated_dofs_offset.numpy().copy()
+        else:
+            num_coords = self.model.joints.num_coords.numpy()
+            num_dofs = self.model.joints.num_dofs.numpy()
+            actuator_mask = joints_act_type_prev != JointActuationType.PASSIVE
+            num_act_coords = num_coords[actuator_mask]
+            num_act_dofs = num_dofs[actuator_mask]
+            actuated_coord_offsets_prev = np.concatenate(([0], num_act_coords.cumsum()))
+            actuated_dof_offsets_prev = np.concatenate(([0], num_act_dofs.cumsum()))
 
         # Determine which worlds are equivalent for FK (at least discrete data)
         classes = compute_fk_equivalence_classes(self.model)
@@ -194,7 +210,6 @@ class ForwardKinematicsSolver:
         # - actuated free joints to reset the base position/orientation
         # - axis joints to factor out superfluous DoFs at tie rods
         joints_dof_type_prev = self.model.joints.dof_type.numpy().copy()
-        joints_act_type_prev = self.model.joints.act_type.numpy().copy()
         joints_bid_B_prev = self.model.joints.bid_B.numpy().copy()
         joints_bid_F_prev = self.model.joints.bid_F.numpy().copy()
         joints_B_r_Bj_prev = self.model.joints.B_r_Bj.numpy().copy()
@@ -1909,7 +1924,7 @@ class ForwardKinematicsSolver:
 
         Args:
             actuators_u: Array of actuated joint velocities.
-                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+                Expects shape of ``(sum_of_num_fk_actuated_joint_dofs,)``.
             bodies_q: Array of rigid body poses. Must be the solution of FK given the position-control transforms.
                 Expects shape of ``(num_bodies,)``.
             bodies_u: Array of rigid body velocities (twists), written out by the solver.
@@ -1972,7 +1987,7 @@ class ForwardKinematicsSolver:
 
         Args:
             actuators_q: Array of actuated joint coordinates.
-                Expects shape of ``(sum_of_num_actuated_joint_coords,)``.
+                Expects shape of ``(sum_of_num_fk_actuated_joint_coords,)``.
             bodies_q: Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
                 solver setting is False.
                 Expects shape of ``(num_bodies,)``.
@@ -1984,7 +1999,7 @@ class ForwardKinematicsSolver:
             actuators_u: Array of actuated joint velocities.
                 Must be provided when solving for body velocities, i.e. if bodies_u is provided.
                 If this function is captured in a graph, must be either always or never provided.
-                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+                Expects shape of ``(sum_of_num_fk_actuated_joint_dofs,)``.
             base_u: Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
                 absolute otherwise.
                 If not provided, will default to zero. Ignored if no base body or joint was set for this model.
@@ -2096,7 +2111,7 @@ class ForwardKinematicsSolver:
 
         Args:
             actuators_q: Array of actuated joint coordinates.
-                Expects shape of ``(sum_of_num_actuated_joint_coords,)``.
+                Expects shape of ``(sum_of_num_fk_actuated_joint_coords,)``.
             bodies_q: Array of rigid body poses, written out by the solver and read in as initial guess if the reset_state
                 solver setting is False.
                 Expects shape of ``(num_bodies,)``.
@@ -2106,7 +2121,7 @@ class ForwardKinematicsSolver:
                 Expects shape of ``(num_worlds,)``.
             actuators_u: Array of actuated joint velocities.
                 Must be provided when solving for body velocities, i.e. if bodies_u is provided.
-                Expects shape of ``(sum_of_num_actuated_joint_dofs,)``.
+                Expects shape of ``(sum_of_num_fk_actuated_joint_dofs,)``.
             base_u: Velocity (twist) of the base body for each world, in the frame of the base joint if it was set, or
                 absolute otherwise.
                 If not provided, will default to zero. Ignored if no base body or joint was set for this model.
@@ -2205,14 +2220,23 @@ def compute_fk_equivalence_classes(model: ModelKamino) -> list[list[int]]:
         world_delta=model.info.joints_offset,
         ignore_negative=True,
     )
-    return compute_equivalence_classes(
-        [
-            sig_num_bodies,
-            sig_joint_act_type,
-            sig_joint_dof_type,
-            sig_joint_bid_B,
-            sig_joint_bid_F,
-            sig_base_body,
-            sig_base_joint,
-        ]
-    )
+    signatures = [
+        sig_num_bodies,
+        sig_joint_act_type,
+        sig_joint_dof_type,
+        sig_joint_bid_B,
+        sig_joint_bid_F,
+        sig_base_body,
+        sig_base_joint,
+    ]
+
+    if model.joints.fk_act_type is not None:
+        sig_joint_fk_act_type = DiscreteSignature(
+            num_worlds=model.size.num_worlds,
+            data=model.joints.fk_act_type,
+            world_offset=model.info.joints_offset,
+            world_size=model.info.num_joints,
+        )
+        signatures.append(sig_joint_fk_act_type)
+
+    return compute_equivalence_classes(signatures)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -194,11 +194,11 @@ class ForwardKinematicsSolver:
             actuated_coord_offsets_prev = self.model.joints.actuated_coords_offset.numpy().copy()
             actuated_dof_offsets_prev = self.model.joints.actuated_dofs_offset.numpy().copy()
         else:
-            num_coords = self.model.joints.num_coords.numpy()
-            num_dofs = self.model.joints.num_dofs.numpy()
-            actuator_mask = joints_act_type_prev != JointActuationType.PASSIVE
-            num_act_coords = num_coords[actuator_mask]
-            num_act_dofs = num_dofs[actuator_mask]
+            num_act_coords = self.model.joints.num_coords.numpy()
+            num_act_dofs = self.model.joints.num_dofs.numpy()
+            passive_mask = joints_act_type_prev == JointActuationType.PASSIVE
+            num_act_coords[passive_mask] = 0
+            num_act_dofs[passive_mask] = 0
             actuated_coord_offsets_prev = np.concatenate(([0], num_act_coords.cumsum()))
             actuated_dof_offsets_prev = np.concatenate(([0], num_act_dofs.cumsum()))
 

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -29,6 +29,7 @@ from ..coupled.interface import CouplingInterface
 from ..solver import SolverBase
 
 if TYPE_CHECKING:
+    from ._src.core.joints import JointActuationType
     from .config import (
         CollisionDetectorConfig,
         ConfigBase,
@@ -949,12 +950,21 @@ class SolverKamino(SolverBase, CouplingInterface):
 
     @override
     @staticmethod
-    def register_custom_attributes(builder: ModelBuilder) -> None:
+    def register_custom_attributes(
+        builder: ModelBuilder,
+        *,
+        fk_actuation_types: dict[int, JointActuationType] | None = None,
+    ) -> None:
         """
         Register custom attributes for SolverKamino.
 
         Args:
             builder: The model builder to register the custom attributes to.
+            fk_actuation_types: Optional dictionary of {joint_index: new_actuation_type} custom actuation
+                types, that the FK solver should use during reset() operations.
+                This can be used e.g. for systems with under-actuated DoFs, to make the FK problem well-posed.
+                Note: only joints that the FK solver should consider to have a different actuation type
+                need to be listed; if unspecified, the joint actuation type from the model is used.
         """
         # Register State attributes
         builder.add_custom_attribute(
@@ -984,6 +994,19 @@ class SolverKamino(SolverBase, CouplingInterface):
                 default=0.0,
             )
         )
+
+        # Register FK custom actuation types
+        if fk_actuation_types is not None:
+            builder.add_custom_attribute(
+                ModelBuilder.CustomAttribute(
+                    name="fk_actuation_type",
+                    assignment=Model.AttributeAssignment.MODEL,
+                    frequency=Model.AttributeFrequency.JOINT,
+                    dtype=wp.int32,
+                    default=-1,
+                    values=fk_actuation_types,
+                )
+            )
 
         # Register KaminoSceneAPI attributes so the USD importer will store them on the model
         SolverKamino.Config.register_custom_attributes(builder)

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -29,7 +29,6 @@ from ..coupled.interface import CouplingInterface
 from ..solver import SolverBase
 
 if TYPE_CHECKING:
-    from ._src.core.joints import JointActuationType
     from .config import (
         CollisionDetectorConfig,
         ConfigBase,
@@ -958,18 +957,18 @@ class SolverKamino(SolverBase, CouplingInterface):
     def register_custom_attributes(
         builder: ModelBuilder,
         *,
-        fk_actuation_types: dict[int, JointActuationType] | None = None,
+        fk_actuation_flags: dict[int, int] | None = None,
     ) -> None:
         """
         Register custom attributes for SolverKamino.
 
         Args:
             builder: The model builder to register the custom attributes to.
-            fk_actuation_types: Optional dictionary of {joint_index: new_actuation_type} custom actuation
-                types, that the FK solver should use during reset() operations.
-                This can be used e.g. for systems with under-actuated DoFs, to make the FK problem well-posed.
-                Note: only joints that the FK solver should consider to have a different actuation type
-                need to be listed; if unspecified, the joint actuation type from the model is used.
+            fk_actuation_flags: Optional dictionary of {joint_index: fk_actuation_flag} integer flags,
+                overwriting what joints should be considered actuated (flag = 1) or passive (flag = 0)
+                by the Forward Kinematics solver during reset() operations.
+                Joints not listed or with a flag of -1 use the joint actuation type from the model
+                (treating all actuator types equally, as only passive vs actuated matters in FK).
         """
         # Register State attributes
         builder.add_custom_attribute(
@@ -1001,17 +1000,16 @@ class SolverKamino(SolverBase, CouplingInterface):
         )
 
         # Register FK custom actuation types
-        if fk_actuation_types is not None:
-            builder.add_custom_attribute(
-                ModelBuilder.CustomAttribute(
-                    name="fk_actuation_type",
-                    assignment=Model.AttributeAssignment.MODEL,
-                    frequency=Model.AttributeFrequency.JOINT,
-                    dtype=wp.int32,
-                    default=-1,
-                    values=fk_actuation_types,
-                )
+        builder.add_custom_attribute(
+            ModelBuilder.CustomAttribute(
+                name="fk_actuation_flag",
+                assignment=Model.AttributeAssignment.MODEL,
+                frequency=Model.AttributeFrequency.JOINT,
+                dtype=wp.int32,
+                default=-1,
+                values=fk_actuation_flags,
             )
+        )
 
         # Register KaminoSceneAPI attributes so the USD importer will store them on the model
         SolverKamino.Config.register_custom_attributes(builder)

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -471,8 +471,6 @@ class SolverKamino(SolverBase, CouplingInterface):
             Reset option, to set a new pose for the base body, and transform all bodies accordingly.
             If a base joint is set, the prescribed pose is interpreted in the frame of the base joint;
             else it is directly interpreted as the new pose of the base body.
-            Note: if a base joint is set that is not a free joint, no check is made that the new pose is
-            compatible with the base joint's DoFs. To guarantee a feasible pose, use instead FromJointQ.
             """
 
             base_q: wp.array[wp.transformf]
@@ -484,8 +482,6 @@ class SolverKamino(SolverBase, CouplingInterface):
             Reset option, to set a new velocity for the base body, and compose with body velocities accordingly.
             If a base joint is set, the prescribed velocity is interpreted in the frame of the base joint;
             else it is directly interpreted as the new velocity of the base body.
-            Note: if a base joint is set that is not a free joint, no check is made that the new velocity is
-            compatible with the base joint's DoFs. To guarantee a feasible velocity, use instead FromJointU.
             """
 
             base_u: wp.array[wp.spatial_vectorf]
@@ -530,6 +526,7 @@ class SolverKamino(SolverBase, CouplingInterface):
 
         Body poses and velocities are transformed (if needed) to match the prescribed base pose, while
         preserving relative poses and velocities.
+        All options are ignored for worlds for which no base body is set.
         """
 
         base_velocity: ToDefault | Preserve | FromJointU | FromBaseU = ToDefault()
@@ -544,6 +541,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         - FromBaseU: use the provided base velocity.
 
         Body velocities are updated to match the prescribed base velocity, while preserving relative velocities.
+        All options are ignored for worlds for which no base body is set.
         """
 
         @classmethod

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -671,6 +671,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         flags: StateFlags | int | None = None,
         *,
         config: SolverKamino.ResetConfig | None = None,
+        success_mask: wp.array[wp.bool] | None = None,
     ):
         """
         Reset the Kamino solver state.
@@ -697,6 +698,9 @@ class SolverKamino(SolverBase, CouplingInterface):
             config: Optional reset configuration, controlling the reset behavior
                 for body poses/velocities as well as floating base pose/velocity.
                 If not provided, all components are reset to default (initial) values.
+            success_mask: Optional mask, filled with a success boolean per world if provided
+                (True if reset successfully, False if not reset due to world_mask, or if reset
+                was unsuccessful, e.g. due to an unconverged FK solve).
         """
         if state is None:
             raise ValueError("'state' argument is required.")
@@ -759,6 +763,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             state=state_kamino,
             world_mask=world_mask,
             config=config,
+            success_mask=success_mask,
         )
 
         # Restore fields excluded from the reset op

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -675,9 +675,9 @@ class TestModelConversions(unittest.TestCase):
         )
         builder_newton.add_shape_box(label="box2", body=bid2, hx=0.05, hy=0.05, hz=0.05)
 
-        # Fix body 0 to world
+        # Add free joint to body 0
         if with_base_joint:
-            builder_newton.add_joint_fixed(
+            builder_newton.add_joint_free(
                 label="world_to_body0",
                 parent=-1,
                 child=bid0,

--- a/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
@@ -138,7 +138,8 @@ def validate_base_pose_reset(
             continue
         if base_q is None:  # Check that base body pose is preserved if base_q is not provided
             bid = base_body_id_np[wid]
-            assert_rigid_poses_close(body_q_new_np[bid], body_q_prev_np[bid])
+            if bid >= 0:
+                assert_rigid_poses_close(body_q_new_np[bid], body_q_prev_np[bid])
         else:
             jid = base_joint_id_np[wid]
             if jid >= 0:  # If a base joint was set, check that base_q matches joint_q for that joint
@@ -151,7 +152,8 @@ def validate_base_pose_reset(
                 )
             else:  # If no base joint was set, check that base_q matches body_q for the base body
                 bid = base_body_id_np[wid]
-                assert_rigid_poses_close(body_q_new_np[bid], base_q_np[wid])
+                if bid >= 0:
+                    assert_rigid_poses_close(body_q_new_np[bid], base_q_np[wid])
 
 
 def validate_base_velocity_reset(
@@ -192,13 +194,14 @@ def validate_base_velocity_reset(
             continue
         if base_u is None:  # Check that base body velocity is preserved up to base rotation
             bid = base_body_id_np[wid]
-            base_body_q_prev = wp.quatf(body_q_prev_np[bid, 3:])
-            base_body_q_new = wp.quatf(body_q_new_np[bid, 3:])
-            R_rel_wp = wp.quat_to_matrix(base_body_q_new * wp.quat_inverse(base_body_q_prev))
-            R_rel = np.array([*R_rel_wp])
-            body_u_prev_rotated = rotate_twist(R_rel, body_u_prev_np[bid])
-            np.testing.assert_allclose(body_u_new_np[bid], body_u_prev_rotated, rtol=rtol, atol=atol)
-            continue
+            if bid >= 0:
+                base_body_q_prev = wp.quatf(body_q_prev_np[bid, 3:])
+                base_body_q_new = wp.quatf(body_q_new_np[bid, 3:])
+                R_rel_wp = wp.quat_to_matrix(base_body_q_new * wp.quat_inverse(base_body_q_prev))
+                R_rel = np.array([*R_rel_wp])
+                body_u_prev_rotated = rotate_twist(R_rel, body_u_prev_np[bid])
+                np.testing.assert_allclose(body_u_new_np[bid], body_u_prev_rotated, rtol=rtol, atol=atol)
+                continue
         else:
             jid = base_joint_id_np[wid]
             if jid >= 0:  # If a base joint was set, check that target base_u matches joint_u for that joint
@@ -214,7 +217,8 @@ def validate_base_velocity_reset(
                 )
             else:  # If no base joint was set, check that target base_u matches body_u for the base body
                 bid = base_body_id_np[wid]
-                np.testing.assert_allclose(body_u_new_np[bid], base_u_np[wid], rtol=rtol, atol=atol)
+                if bid >= 0:
+                    np.testing.assert_allclose(body_u_new_np[bid], base_u_np[wid], rtol=rtol, atol=atol)
 
 
 def run_set_floating_base_check(
@@ -533,6 +537,46 @@ class TestSetFloatingBase(unittest.TestCase):
         )
         np.testing.assert_allclose(body_q.numpy(), body_q_check.numpy(), rtol=rtol, atol=atol)
         np.testing.assert_allclose(body_u.numpy(), body_u_check.numpy(), rtol=rtol, atol=atol)
+
+    def test_05_set_floating_base_without_base_body(self):
+        """
+        Validate that set_floating_base() is a no-op if no base body is set.
+        """
+        # Initialize rng
+        rng = np.random.default_rng(self.seed)
+
+        # Set up an actuated four-bar model with a fixed base
+        num_worlds = 3
+        build_fn = functools.partial(
+            build_boxes_fourbar, actuator_ids=[1], floatingbase=False, fixedbase=True, ground=False
+        )
+        builder = make_homogeneous_builder(num_worlds=num_worlds, build_fn=build_fn, limits=False)
+        model = builder.finalize(device=self.default_device)
+
+        # Double-check that no floating base is set for this model
+        np.testing.assert_equal(model.info.base_joint_index.numpy(), -1)
+        np.testing.assert_equal(model.info.base_body_index.numpy(), -1)
+
+        # Set model into non-trivial pose
+        data = set_model_to_random_pose(self, model, rng)
+
+        # Sample non-trivial world mask and base state
+        world_mask = wp.array(sample_world_mask(num_worlds, rng)[0], dtype=wp.bool, device=self.default_device)
+        base_q, base_u = sample_base_state_wp(model, rng)
+
+        # Check that set_floating_base is a no-op
+        body_q = wp.clone(data.bodies.q_i, device=self.default_device)
+        body_u = wp.clone(data.bodies.u_i, device=self.default_device)
+        set_floating_base(
+            model=model,
+            base_q=base_q,
+            base_u=base_u,
+            body_q=body_q,
+            body_u=body_u,
+            world_mask=world_mask,
+        )
+        np.testing.assert_equal(body_q.numpy(), data.bodies.q_i.numpy())
+        np.testing.assert_equal(body_u.numpy(), data.bodies.u_i.numpy())
 
 
 class TestJointBodyStateConversions(unittest.TestCase):

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -630,12 +630,13 @@ class TestSolverKaminoImpl(unittest.TestCase):
         base_body_idx = model.info.base_body_index.numpy().copy()
         for wid in range(model.size.num_worlds):
             base_idx = base_body_idx[wid]
-            np.testing.assert_allclose(
-                state_n.q_i.numpy()[base_idx],
-                base_q_0_np[wid],
-                rtol=rtol,
-                atol=atol,
-            )
+            if base_idx >= 0:
+                np.testing.assert_allclose(
+                    state_n.q_i.numpy()[base_idx],
+                    base_q_0_np[wid],
+                    rtol=rtol,
+                    atol=atol,
+                )
 
         # Step the solver a few times to change the state
         solver._reset()

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -200,10 +200,10 @@ def compute_actuated_coords_and_dofs_data(model: ModelKamino):
 
     # Filter for actuators only
     joint_is_actuator = model.joints.act_type.numpy() != JointActuationType.PASSIVE
-    if model.joints.fk_act_type is not None:
-        fk_act_type_np = model.joints.fk_act_type.numpy()
-        joint_is_actuator_fk = fk_act_type_np != JointActuationType.PASSIVE
-        overwrite_mask = fk_act_type_np != -1
+    if model.joints.fk_act_flag is not None:
+        fk_act_flag_np = model.joints.fk_act_flag.numpy()
+        joint_is_actuator_fk = fk_act_flag_np == 1
+        overwrite_mask = fk_act_flag_np != -1
         joint_is_actuator[overwrite_mask] = joint_is_actuator_fk[overwrite_mask]
     actuated_coord_offsets = coord_offsets[joint_is_actuator]
     actuated_coords_sizes = joint_num_coords[joint_is_actuator]
@@ -648,7 +648,7 @@ class AllJointsExampleRandomPosesCheckForwardKinematics(unittest.TestCase):
         self.assertTrue(success)
 
 
-class CarpoleRandomPosesCheckForwardKinematics(unittest.TestCase):
+class CartpoleRandomPosesCheckForwardKinematics(unittest.TestCase):
     def setUp(self):
         if not test_context.setup_done:
             setup_tests(clear_cache=False)
@@ -667,8 +667,8 @@ class CarpoleRandomPosesCheckForwardKinematics(unittest.TestCase):
 
         # Get builder for the cartpole model
         robot_builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
-        fk_actuation_types = {1: JointActuationType.FORCE}  # Actuate the revolute joint for FK
-        newton.solvers.SolverKamino.register_custom_attributes(robot_builder, fk_actuation_types=fk_actuation_types)
+        fk_actuation_flags = {1: 1}  # Actuate the revolute joint for FK
+        newton.solvers.SolverKamino.register_custom_attributes(robot_builder, fk_actuation_flags=fk_actuation_flags)
         build_cartpole(builder=robot_builder, ground=False)
 
         # Finalize model and convert to ModelKamino

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -252,28 +252,6 @@ def extract_segments(array, offsets, sizes):
     return np.array(res)
 
 
-def compute_constraint_residual_mask(model: ModelKamino):
-    """
-    Computes a boolean mask for constraint residuals, True for most constraints but False
-    for base joints (to filter out residuals for fixed base models if the base is reset
-    to a different pose)
-    """
-    mask = np.array(model.size.sum_of_num_joint_cts * [True])
-
-    # Exclude base joints
-    first_joint_ct_id = model.joints.kinematic_cts_offset.numpy().copy()  # Cts offset per joint
-    num_joint_cts = model.joints.num_kinematic_cts.numpy()  # Num cts per joint
-    base_joint_index = model.info.base_joint_index.numpy().tolist()
-    for wd_id in range(model.size.num_worlds):
-        if base_joint_index[wd_id] < 0:
-            continue
-        base_jt_id = base_joint_index[wd_id]
-        ct_offset = first_joint_ct_id[base_jt_id]
-        mask[ct_offset : ct_offset + num_joint_cts[base_jt_id]] = False
-
-    return mask
-
-
 def simulate_random_poses(
     model: ModelKamino,
     num_poses: int,
@@ -298,9 +276,6 @@ def simulate_random_poses(
     actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes, actuator_dof_types = (
         compute_actuated_coords_and_dofs_data(model)
     )
-
-    # Precompute boolean mask for extracting relevant constraint residuals
-    residual_mask = compute_constraint_residual_mask(model)
 
     # Run forward kinematics on all random poses
     config = ForwardKinematicsSolver.Config(**config_kwargs)
@@ -344,7 +319,7 @@ def simulate_random_poses(
         compute_joints_data(model=model, data=data, q_j_p=model.joints.q_j_0, correction=JointCorrectionMode.CONTINUOUS)
 
         # Validate positions computation
-        residual_ct_pos = np.max(np.abs(data.joints.r_j.numpy()[residual_mask]))
+        residual_ct_pos = np.max(np.abs(data.joints.r_j.numpy()))
         if residual_ct_pos > epsilon:
             print(f"Large constraint residual ({residual_ct_pos}) for pose {pose_id}")
             success_flags[-1] = False
@@ -359,7 +334,7 @@ def simulate_random_poses(
             success_flags[-1] = False
 
         # Validate velocities computation
-        residual_ct_vel = np.max(np.abs(data.joints.dr_j.numpy()[residual_mask]))
+        residual_ct_vel = np.max(np.abs(data.joints.dr_j.numpy()))
         if residual_ct_vel > epsilon:
             print(f"Large constraint velocity residual ({residual_ct_vel}) for pose {pose_id}")
             success_flags[-1] = False
@@ -399,7 +374,6 @@ class DRTestMechanismRandomPosesCheckForwardKinematics(unittest.TestCase):
 
         # Load model
         builder = USDImporter().import_from(asset_file)
-        builder.set_base_joint("base")
         model = builder.finalize(device=self.default_device, requires_grad=False)
 
         # Generate helper function to simulate random poses
@@ -495,7 +469,6 @@ class HeterogenousModelRandomPosesCheckForwardKinematics(unittest.TestCase):
         asset_file_0 = str(asset_path / "dr_testmech" / "usd" / "dr_testmech.usda")
         asset_file_1 = str(asset_path / "dr_legs" / "usd" / "dr_legs_with_boxes.usda")
         builder = USDImporter().import_from(asset_file_0)
-        builder.set_base_joint("base")
         builder1 = USDImporter().import_from(asset_file_1)
         builder1.set_base_body("pelvis")
         builder.add_builder(builder1)
@@ -689,7 +662,6 @@ class HeterogenousModelSparseJacobianAssemblyCheck(unittest.TestCase):
         asset_file_0 = str(asset_path / "dr_testmech" / "usd" / "dr_testmech.usda")
         asset_file_1 = str(asset_path / "dr_legs" / "usd" / "dr_legs_with_boxes.usda")
         builder = USDImporter().import_from(asset_file_0)
-        builder.set_base_joint("base")
         builder1 = USDImporter().import_from(asset_file_1)
         builder1.set_base_body("pelvis")
         builder.add_builder(builder1)

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -34,6 +34,7 @@ from newton._src.solvers.kamino.tests.utils.sampling import (
     sample_base_state,
     sample_body_poses,
 )
+from newton.tests.utils.basics import build_cartpole
 
 ###
 # Module configs
@@ -199,6 +200,11 @@ def compute_actuated_coords_and_dofs_data(model: ModelKamino):
 
     # Filter for actuators only
     joint_is_actuator = model.joints.act_type.numpy() != JointActuationType.PASSIVE
+    if model.joints.fk_act_type is not None:
+        fk_act_type_np = model.joints.fk_act_type.numpy()
+        joint_is_actuator_fk = fk_act_type_np != JointActuationType.PASSIVE
+        overwrite_mask = fk_act_type_np != -1
+        joint_is_actuator[overwrite_mask] = joint_is_actuator_fk[overwrite_mask]
     actuated_coord_offsets = coord_offsets[joint_is_actuator]
     actuated_coords_sizes = joint_num_coords[joint_is_actuator]
     actuated_dof_offsets = dof_offsets[joint_is_actuator]
@@ -268,9 +274,11 @@ def simulate_random_poses(
     # Generate random inputs
     base_q_np, base_u_np = sample_base_state(model.size.num_worlds, rng, num_poses)
     actuators_q_np = sample_actuator_coords(
-        model, rng, num_poses, max_pos=max_pos, max_angle=max_angle, max_quat=max_quat
+        model, rng, num_poses, max_pos=max_pos, max_angle=max_angle, max_quat=max_quat, use_fk_actuators=True
     )
-    actuators_u_np = sample_actuator_velocities(model, rng, num_poses, max_lin_vel=max_lin_vel, max_ang_vel=max_ang_vel)
+    actuators_u_np = sample_actuator_velocities(
+        model, rng, num_poses, max_lin_vel=max_lin_vel, max_ang_vel=max_ang_vel, use_fk_actuators=True
+    )
 
     # Precompute offset arrays for extracting actuator coordinates/dofs
     actuated_coord_offsets, actuated_coords_sizes, actuated_dof_offsets, actuated_dofs_sizes, actuator_dof_types = (
@@ -616,6 +624,60 @@ class AllJointsExampleRandomPosesCheckForwardKinematics(unittest.TestCase):
             joint.X_Fj = wp.quat_to_matrix(wp.quatf(random_quats[jid]))
             joint.X_Bj = wp.transpose(R_B) * R_F * joint.X_Fj  # Compute X_B given X_F to preserve a valid pose
         model = builder.finalize(device=self.default_device)
+
+        # Generate helper function to simulate random poses
+        num_poses = 30
+        simulate_function = partial(
+            simulate_random_poses,
+            model,
+            num_poses,
+            rng,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            tolerance=1e-6,
+        )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
+        self.assertTrue(success)
+
+
+class CarpoleRandomPosesCheckForwardKinematics(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.default_device = wp.get_device(test_context.device)
+        self.has_cuda = self.default_device.is_cuda
+        self.verbose = test_context.verbose
+
+    def tearDown(self):
+        self.default_device = None
+
+    def test_cartpole_FK_random_poses(self):
+        # Initialize RNG
+        test_name = "Cartpole FK random poses check"
+        seed = int(hashlib.sha256(test_name.encode("utf8")).hexdigest(), 16)
+        rng = np.random.default_rng(seed)
+
+        # Get builder for the cartpole model
+        robot_builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        fk_actuation_types = {1: JointActuationType.FORCE}  # Actuate the revolute joint for FK
+        newton.solvers.SolverKamino.register_custom_attributes(robot_builder, fk_actuation_types=fk_actuation_types)
+        build_cartpole(builder=robot_builder, ground=False)
+
+        # Finalize model and convert to ModelKamino
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        num_worlds = 10
+        for _ in range(num_worlds):
+            builder.add_world(robot_builder)
+        model_newton = builder.finalize(skip_validation_joints=True)
+        model = ModelKamino.from_newton(model_newton)
 
         # Generate helper function to simulate random poses
         num_poses = 30

--- a/newton/_src/solvers/kamino/tests/utils/joints.py
+++ b/newton/_src/solvers/kamino/tests/utils/joints.py
@@ -138,9 +138,11 @@ def run_test_single_joint_examples(
 def get_actuators_q_quaternion_first_ids(model: ModelKamino, use_fk_actuators: bool = False):
     """Lists the first index of every unit quaternion 4-segment in the model's actuated coordinates."""
     act_types = model.joints.act_type.numpy()
-    if use_fk_actuators and model.joints.fk_act_type is not None:
-        fk_act_types = model.joints.fk_act_type.numpy()
-        overwrite_mask = fk_act_types != -1
+    if use_fk_actuators and model.joints.fk_act_flag is not None:
+        fk_act_flags = model.joints.fk_act_flag.numpy()
+        mapping = np.array([-1, JointActuationType.PASSIVE, JointActuationType.FORCE])
+        fk_act_types = mapping[fk_act_flags + 1]  # Map 0/1 flags to enum constants
+        overwrite_mask = fk_act_flags != -1
         act_types[overwrite_mask] = fk_act_types[overwrite_mask]
     dof_types = model.joints.dof_type.numpy()
     num_coords = model.joints.num_coords.numpy()
@@ -168,10 +170,12 @@ def actuator_coords_from_units(
     coords = []
     joint_dof_type_np = model.joints.dof_type.numpy()
     joint_act_type_np = model.joints.act_type.numpy()
-    if use_fk_actuators and model.joints.fk_act_type is not None:
-        fk_act_type_np = model.joints.fk_act_type.numpy()
-        overwrite_mask = fk_act_type_np != -1
-        joint_act_type_np[overwrite_mask] = fk_act_type_np[overwrite_mask]
+    if use_fk_actuators and model.joints.fk_act_flag is not None:
+        fk_act_flags = model.joints.fk_act_flag.numpy()
+        mapping = np.array([-1, JointActuationType.PASSIVE, JointActuationType.FORCE])
+        fk_act_types = mapping[fk_act_flags + 1]  # Map 0/1 flags to enum constants
+        overwrite_mask = fk_act_flags != -1
+        joint_act_type_np[overwrite_mask] = fk_act_types[overwrite_mask]
     for jid in range(model.size.sum_of_num_joints):
         if joint_act_type_np[jid] == JointActuationType.PASSIVE:
             continue
@@ -205,10 +209,12 @@ def actuator_dofs_from_units(
     dofs = []
     joint_dof_type_np = model.joints.dof_type.numpy()
     joint_act_type_np = model.joints.act_type.numpy()
-    if use_fk_actuators and model.joints.fk_act_type is not None:
-        fk_act_type_np = model.joints.fk_act_type.numpy()
-        overwrite_mask = fk_act_type_np != -1
-        joint_act_type_np[overwrite_mask] = fk_act_type_np[overwrite_mask]
+    if use_fk_actuators and model.joints.fk_act_flag is not None:
+        fk_act_flags = model.joints.fk_act_flag.numpy()
+        mapping = np.array([-1, JointActuationType.PASSIVE, JointActuationType.FORCE])
+        fk_act_types = mapping[fk_act_flags + 1]  # Map 0/1 flags to enum constants
+        overwrite_mask = fk_act_flags != -1
+        joint_act_type_np[overwrite_mask] = fk_act_types[overwrite_mask]
     for jid in range(model.size.sum_of_num_joints):
         if joint_act_type_np[jid] == JointActuationType.PASSIVE:
             continue

--- a/newton/_src/solvers/kamino/tests/utils/joints.py
+++ b/newton/_src/solvers/kamino/tests/utils/joints.py
@@ -135,9 +135,13 @@ def run_test_single_joint_examples(
     return success
 
 
-def get_actuators_q_quaternion_first_ids(model: ModelKamino):
+def get_actuators_q_quaternion_first_ids(model: ModelKamino, use_fk_actuators: bool = False):
     """Lists the first index of every unit quaternion 4-segment in the model's actuated coordinates."""
     act_types = model.joints.act_type.numpy()
+    if use_fk_actuators and model.joints.fk_act_type is not None:
+        fk_act_types = model.joints.fk_act_type.numpy()
+        overwrite_mask = fk_act_types != -1
+        act_types[overwrite_mask] = fk_act_types[overwrite_mask]
     dof_types = model.joints.dof_type.numpy()
     num_coords = model.joints.num_coords.numpy()
     coord_id = 0
@@ -158,11 +162,16 @@ def actuator_coords_from_units(
     pos_val: float = 0.1,
     angle_val: float = np.radians(20.0),
     quat_val: float = 1.0,
+    use_fk_actuators: bool = False,
 ) -> np.ndarray:
     """Helper generating actuator coords for a model, given one value to use per type of physical unit."""
     coords = []
     joint_dof_type_np = model.joints.dof_type.numpy()
     joint_act_type_np = model.joints.act_type.numpy()
+    if use_fk_actuators and model.joints.fk_act_type is not None:
+        fk_act_type_np = model.joints.fk_act_type.numpy()
+        overwrite_mask = fk_act_type_np != -1
+        joint_act_type_np[overwrite_mask] = fk_act_type_np[overwrite_mask]
     for jid in range(model.size.sum_of_num_joints):
         if joint_act_type_np[jid] == JointActuationType.PASSIVE:
             continue
@@ -190,11 +199,16 @@ def actuator_dofs_from_units(
     model: ModelKamino,
     lin_vel_val: float = 0.5,
     ang_vel_val: float = np.radians(90.0),
+    use_fk_actuators: bool = False,
 ) -> np.ndarray:
     """Helper generating actuator dofs for a model, given one value to use per type of physical unit."""
     dofs = []
     joint_dof_type_np = model.joints.dof_type.numpy()
     joint_act_type_np = model.joints.act_type.numpy()
+    if use_fk_actuators and model.joints.fk_act_type is not None:
+        fk_act_type_np = model.joints.fk_act_type.numpy()
+        overwrite_mask = fk_act_type_np != -1
+        joint_act_type_np[overwrite_mask] = fk_act_type_np[overwrite_mask]
     for jid in range(model.size.sum_of_num_joints):
         if joint_act_type_np[jid] == JointActuationType.PASSIVE:
             continue

--- a/newton/_src/solvers/kamino/tests/utils/sampling.py
+++ b/newton/_src/solvers/kamino/tests/utils/sampling.py
@@ -107,6 +107,7 @@ def sample_actuator_coords(
     max_angle: float = np.radians(20.0),
     max_quat: float = 1.0,
     unit_quaternions: bool = True,
+    use_fk_actuators: bool = False,
 ) -> np.ndarray:
     """
     Helper sampling random actuator coords for a given model.
@@ -119,21 +120,22 @@ def sample_actuator_coords(
         max_angle: maximal absolute sample value, for coordinates that are angles.
         max_quat: maximal absolute sample value, for coordinates that are unit quaternion coefficients.
         unit_quaternions: whether to normalize sampled quaternions.
+        use_fk_actuators: whether to consider FK actuation types rather than regular actuation types.
 
     Returns:
         actuator_q: sampled coordinates, with shape (num_samples, num_actuator_coords)
     """
     # Generate sampling bounds
-    max_coords = actuator_coords_from_units(model, max_pos, max_angle, max_quat)
+    max_coords = actuator_coords_from_units(model, max_pos, max_angle, max_quat, use_fk_actuators)
 
     # Sample coordinates
-    actuator_q = np.zeros((num_samples, model.size.sum_of_num_actuated_joint_coords), dtype=np.float32)
+    actuator_q = np.zeros((num_samples, max_coords.shape[0]), dtype=np.float32)
     for i in range(actuator_q.shape[1]):
         actuator_q[:, i] = rng.uniform(-max_coords[i], max_coords[i], size=num_samples)
 
     # Normalize quaternions
     if unit_quaternions:
-        quat_ids = get_actuators_q_quaternion_first_ids(model)
+        quat_ids = get_actuators_q_quaternion_first_ids(model, use_fk_actuators)
         for i in quat_ids:
             actuator_q[:, i : i + 4] /= np.linalg.norm(actuator_q[:, i : i + 4], axis=1)[:, None]
 
@@ -146,6 +148,7 @@ def sample_actuator_velocities(
     num_samples: int = 1,
     max_lin_vel: float = 0.5,
     max_ang_vel: float = np.radians(90.0),
+    use_fk_actuators: bool = False,
 ) -> np.ndarray:
     """
     Helper sampling random actuator velocities for a given model.
@@ -161,10 +164,10 @@ def sample_actuator_velocities(
         actuator_u: sampled velocities, with shape (num_samples, num_actuator_dofs)
     """
     # Generate sampling bounds
-    max_vel = actuator_dofs_from_units(model, max_lin_vel, max_ang_vel)
+    max_vel = actuator_dofs_from_units(model, max_lin_vel, max_ang_vel, use_fk_actuators)
 
     # Sample velocities
-    actuator_u = np.zeros((num_samples, model.size.sum_of_num_actuated_joint_dofs), dtype=np.float32)
+    actuator_u = np.zeros((num_samples, max_vel.shape[0]), dtype=np.float32)
     for i in range(actuator_u.shape[1]):
         actuator_u[:, i] = rng.uniform(-max_vel[i], max_vel[i], size=num_samples)
 


### PR DESCRIPTION
## Description

This implements a few missing features for FK-based resets in Kamino, in particular:
- using separate actuation types for the FK solver than in the model
- exposing a success mask for the reset operation (in particular, to track unconverged FK)

The separate actuation types can be useful for systems with passive DoFs that make the FK system ill-posed. While the regularizer in FK can already make the problem well-posed by trying to preserve the initial pose, one may wish to control the passive DoFs during the reset (e.g. angle of the pole at the passive revolute joint for the cartpole example). With this PR, these passive joints can then be flagged as actuated for FK only.

In order for the cartpole example to work well, this PR also implements the cleaning plan for base joint/body (earlier than expected). Otherwise the unary prismatic joint was being replaced by a free joint in FK. More specifically, it is now assumed and enforced that base joints can only be unary free joints. Base resets do not make sense for systems attached to the world with a non-free unary joint (these are not floating base systems). For such systems, we simply do not assign a base body or joint.

Resolves vastsoun#373
Resolves vastsoun#315
Resolves vastsoun#380

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

The cartpole example was added to the FK unit tests. A test was also added that validates that set_floating_base() is a no-op if no base is set (to validate that the base body is indeed optional now).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-joint FK actuation type overrides and FK-specific actuator sizing/outputs (coords/dofs).
  * `reset` can now optionally return a per-world `success_mask`.
* **Bug Fixes**
  * Improved floating-base handling for models with no base body/joint (warnings/no-ops instead of failures).
  * Strengthened base-joint validation and updated base body/joint fallback behavior.
  * Reset/sizing/validation now uses FK-actuated joint coordinate/dof totals.
* **Documentation**
  * Updated FK solver entry-point tensor shape docs to reflect FK-specific totals.
* **Tests**
  * Expanded FK and floating-base reset coverage, including no-base-body scenarios and FK actuator sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->