### PR TITLE
Fix velocity-level FK solve in Kamino for universal actuators

### DIFF
--- a/newton/_src/solvers/kamino/_src/models/builders/testing.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/testing.py
@@ -1331,7 +1331,6 @@ def build_all_joints_test_model(
     actuated: bool = False,
     damped: bool = True,
     floating_base: bool = False,
-    exclude_universal: bool = False,
 ) -> ModelBuilderKamino:
     """
     Constructs a model builder containing a world for each joint type.
@@ -1342,7 +1341,6 @@ def build_all_joints_test_model(
         actuated: Whether to make the joints actuated (passive otherwise).
         damped: Whether to add slight damping to the joints to increase realism.
         floating_base: Whether to replace the fixed with a free base joint for binary examples.
-        exclude_universal: Whether to skip universal joints.
 
     Returns:
         The populated model builder.
@@ -1406,9 +1404,7 @@ def build_all_joints_test_model(
 
     # Add a new world for each joint type
     folder_path = os.path.join(utils.get_testing_usd_assets_path(), "joints")
-    joint_names = ["cartesian", "cylindrical", "fixed", "prismatic", "revolute", "spherical"]
-    if not exclude_universal:
-        joint_names.append("universal")
+    joint_names = ["cartesian", "cylindrical", "fixed", "prismatic", "revolute", "spherical", "universal"]
     need_alteration = actuated or damped or floating_base
     for name in joint_names:
         builder_in = USDImporter().import_from(source=os.path.join(folder_path, f"test_{name}/test_{name}.usda"))

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -34,6 +34,7 @@ __all__ = [
     "_add_regularizer_to_diagonal",
     "_apply_line_search_step",
     "_correct_actuator_coords",
+    "_correct_universal_constraint_velocities",
     "_eval_actuator_coords",
     "_eval_body_velocities",
     "_eval_fk_actuated_dofs_or_coords",
@@ -1977,6 +1978,84 @@ def _eval_target_constraint_velocities(
             target_cts_u[wd_id, offset_cts_j + 4] = actuators_u[offset_u_j + 1]
         else:
             assert False, "Unexpected actuator dof type"  # noqa: B011
+
+
+@wp.kernel
+def _correct_universal_constraint_velocities(
+    # Inputs
+    num_joints: wp.array[wp.int32],
+    first_joint_id: wp.array[wp.int32],
+    joints_dof_type: wp.array[wp.int32],
+    joints_act_type: wp.array[wp.int32],
+    joints_bid_B: wp.array[wp.int32],
+    joints_bid_F: wp.array[wp.int32],
+    joints_X_Bj: wp.array[wp.mat33f],
+    joints_X_Fj: wp.array[wp.mat33f],
+    ct_full_to_red_map: wp.array[wp.int32],
+    bodies_q: wp.array[wp.transformf],
+    world_mask: wp.array[wp.bool],
+    # Outputs
+    target_cts_u: wp.array2d[wp.float32],
+):
+    """
+    A kernel correcting the prescribed target velocities for universal actuators.
+    This is needed because for universal joints, the dof-space velocity is expressed in the frame of the
+    intermediary body, rather than in the frame on the base body.
+
+    Inputs:
+        num_joints: Num joints per world
+        first_joint_id: First joint id per world
+        joints_dof_type: Joint dof type (i.e. revolute, spherical, ...)
+        joints_act_type: Joint actuation type (i.e. passive or actuated)
+        joints_bid_B: Joint base body id
+        joints_bid_F: Joint follower body id
+        joints_X_Bj: Joint local frame on base body
+        joints_X_Fj: Joint local frame on follower body
+        ct_full_to_red_map: Map from full to reduced constraint id
+        bodies_q: Current body poses.
+        world_mask: Per-world boolean flag to perform the computation (False = skip)
+    Outputs:
+        target_cts_u: Corrected target constraint velocities (provided uncorrected as input).
+    """
+    # Retrieve the thread indices (= world index, joint index)
+    wd_id, jt_id_loc = wp.tid()
+
+    if wd_id < world_mask.shape[0] and world_mask[wd_id] and jt_id_loc < num_joints[wd_id]:
+        # Early return if this is not a universal actuator
+        jt_id_tot = first_joint_id[wd_id] + jt_id_loc
+        if (
+            joints_act_type[jt_id_tot] == JointActuationType.PASSIVE
+            or joints_dof_type[jt_id_tot] != FKJointDoFType.UNIVERSAL
+        ):
+            return
+
+        # Read target angular velocity (currently, in dof space i.e. in the frame of the intermediary body)
+        offset_cts_j = ct_full_to_red_map[6 * jt_id_tot]
+        omega_curr = wp.vec3f(target_cts_u[wd_id, offset_cts_j + 3], target_cts_u[wd_id, offset_cts_j + 4], 0.0)
+
+        # Compute relative orientation of joint frame on follower body w.r.t. joint frame on base body
+        bid_B = joints_bid_B[jt_id_tot]
+        bid_F = joints_bid_F[jt_id_tot]
+        q_B = wp.quatf(0.0, 0.0, 0.0, 1.0) if bid_B < 0 else wp.transform_get_rotation(bodies_q[bid_B])
+        q_F = wp.transform_get_rotation(bodies_q[bid_F])
+        q_X_B = wp.quat_from_matrix(joints_X_Bj[jt_id_tot])
+        q_X_F = wp.quat_from_matrix(joints_X_Fj[jt_id_tot])
+        q_rel = wp.quat_inverse(q_B * q_X_B) * q_F * q_X_F
+
+        # Compute intermediary body axes, in the joint frame on the base body
+        e_x = wp.vec3f(1.0, 0.0, 0.0)
+        e_y = wp.vec3f(0.0, 1.0, 0.0)
+        a_x = e_x  # x axis on base
+        a_y_raw = wp.quat_rotate(q_rel, e_y)  #  y axis on follower (constrained to be orthogonal to a_x)
+        a_y = a_y_raw - wp.dot(a_y_raw, a_x) * a_x  # orthogonalize (in case of constraint violations)
+        a_y = wp.normalize(a_y)
+        a_z = wp.cross(a_x, a_y)
+
+        # Convert target angular velocity back to joint frame on the base body
+        omega = omega_curr[0] * a_x + omega_curr[1] * a_y + omega_curr[2] * a_z
+        target_cts_u[wd_id, offset_cts_j + 3] = omega[0]
+        target_cts_u[wd_id, offset_cts_j + 4] = omega[1]
+        target_cts_u[wd_id, offset_cts_j + 5] = omega[2]
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -33,6 +33,7 @@ from .kernels import (
     _add_regularizer_to_diagonal,
     _apply_line_search_step,
     _correct_actuator_coords,
+    _correct_universal_constraint_velocities,
     _eval_actuator_coords,
     _eval_body_velocities,
     _eval_fk_actuated_dofs_or_coords,
@@ -407,7 +408,8 @@ class ForwardKinematicsSolver:
 
         # Retrieve / compute dimensions - Constraints
         num_constraints = num_bodies.copy()  # Number of kinematic constraints per world (unit quat. + joints)
-        has_universal_joints = False  # Whether the model has a least one passive universal joint
+        has_universal_joints = False  # Whether the model has at least one passive universal joint
+        self.has_universal_actuators = False  # Whether the model has at least one actuated universal joint
         constraint_full_to_red_map = np.full(6 * self.num_joints_tot, -1, dtype=np.int32)
         for eq_class in classes:
             # Count constraints for first world in equivalence class
@@ -415,12 +417,14 @@ class ForwardKinematicsSolver:
             ct_count = num_constraints[wd_id]
             for jt_id in range(first_joint_id[wd_id], first_joint_id[wd_id + 1]):
                 act_type = joints_act_type[jt_id]
+                dof_type = joints_dof_type[jt_id]
                 if act_type != JointActuationType.PASSIVE:  # Actuator: select all six constraints
                     for i in range(6):
                         constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
                     ct_count += 6
+                    if dof_type == FKJointDoFType.UNIVERSAL:
+                        self.has_universal_actuators = True
                 else:
-                    dof_type = joints_dof_type[jt_id]
                     if dof_type == FKJointDoFType.AXIS:
                         constraint_full_to_red_map[6 * jt_id + 3] = ct_count
                         ct_count += 1
@@ -1735,6 +1739,29 @@ class ForwardKinematicsSolver:
             ],
             device=self.device,
         )
+        if self.has_universal_actuators:
+            wp.launch(
+                _correct_universal_constraint_velocities,
+                dim=(
+                    self.num_worlds,
+                    self.num_joints_max,
+                ),
+                inputs=[
+                    self.num_joints,
+                    self.first_joint_id,
+                    self.joints_dof_type,
+                    self.joints_act_type,
+                    self.joints_bid_B,
+                    self.joints_bid_F,
+                    self.joints_X_Bj,
+                    self.joints_X_Fj,
+                    self.constraint_full_to_red_map,
+                    bodies_q,
+                    world_mask,
+                    self.target_cts_u,
+                ],
+                device=self.device,
+            )
 
         # Update constraints Jacobian
         self._update_jacobian(bodies_q, target_rel_transforms, world_mask)

--- a/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_resets.py
@@ -565,9 +565,7 @@ class TestJointBodyStateConversions(unittest.TestCase):
         rng = np.random.default_rng(self.seed)
 
         # Setup a model with all joint types
-        builder = build_all_joints_test_model(
-            binary_joints=True, unary_joints=False, actuated=True, floating_base=True, exclude_universal=True
-        )
+        builder = build_all_joints_test_model(binary_joints=True, unary_joints=False, actuated=True, floating_base=True)
         model = builder.finalize(device=self.default_device)
 
         # Set the model into a non-trivial pose

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -19,6 +19,7 @@ from newton._src.solvers.kamino._src.core.joints import JointActuationType, Join
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.kinematics.joints import compute_joints_data
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_fourbar
+from newton._src.solvers.kamino._src.models.builders.testing import build_all_joints_test_model
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.solvers.fk import ForwardKinematicsSolver
 from newton._src.solvers.kamino._src.utils.io.usd import USDImporter
@@ -574,6 +575,50 @@ class FourBarTieRodRandomPosesCheckForwardKinematics(unittest.TestCase):
 
         # Simulate random poses, using regularization to handle tie rod (sparse solver)
         success = simulate_function(add_axis_joints=False, use_regularization=True, tolerance=1e-5, use_sparsity=True)
+        self.assertTrue(success)
+
+
+class AllJointsExampleRandomPosesCheckForwardKinematics(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.default_device = wp.get_device(test_context.device)
+        self.has_cuda = self.default_device.is_cuda
+        self.verbose = test_context.verbose
+
+    def tearDown(self):
+        self.default_device = None
+
+    def test_all_joints_example_FK_random_poses(self):
+        # Initialize RNG
+        test_name = "All-joints example FK random poses check"
+        seed = int(hashlib.sha256(test_name.encode("utf8")).hexdigest(), 16)
+        rng = np.random.default_rng(seed)
+
+        # Build model with all joint types, unary and binary (actuated so the FK problem is well-posed)
+        builder = build_all_joints_test_model(unary_joints=True, binary_joints=True, actuated=True, floating_base=False)
+        model = builder.finalize(device=self.default_device)
+
+        # Generate helper function to simulate random poses
+        num_poses = 30
+        simulate_function = partial(
+            simulate_random_poses,
+            model,
+            num_poses,
+            rng,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            tolerance=1e-6,
+        )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
         self.assertTrue(success)
 
 

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -621,6 +621,51 @@ class AllJointsExampleRandomPosesCheckForwardKinematics(unittest.TestCase):
         success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
         self.assertTrue(success)
 
+    def test_all_joints_example_asymmetric_frames_FK_random_poses(self):
+        # Initialize RNG
+        test_name = "All-joints example FK random poses check with asymmetric frames"
+        seed = int(hashlib.sha256(test_name.encode("utf8")).hexdigest(), 16)
+        rng = np.random.default_rng(seed)
+
+        # Build model with all joint types, unary and binary (actuated so the FK problem is well-posed)
+        builder = build_all_joints_test_model(unary_joints=True, binary_joints=True, actuated=True, floating_base=False)
+
+        # Set asymmetric joint frames (X_B != X_F) into joints (while preserving initial pose)
+        num_joints = builder.num_joints
+        random_quats = np.resize(rng.uniform(-1.0, 1.0, 4 * num_joints), (num_joints, 4))
+        random_quats /= np.linalg.norm(random_quats, axis=1)[:, None]
+        for jid, joint in enumerate(builder.all_joints):
+            wid = joint.wid
+            q_B = wp.transform_identity() if joint.bid_B < 0 else builder.bodies[wid][joint.bid_B].q_i_0
+            q_F = builder.bodies[wid][joint.bid_F].q_i_0
+            R_B = wp.quat_to_matrix(wp.transform_get_rotation(q_B))
+            R_F = wp.quat_to_matrix(wp.transform_get_rotation(q_F))
+            joint.X_Fj = wp.quat_to_matrix(wp.quatf(random_quats[jid]))
+            joint.X_Bj = wp.transpose(R_B) * R_F * joint.X_Fj  # Compute X_B given X_F to preserve a valid pose
+        model = builder.finalize(device=self.default_device)
+
+        # Generate helper function to simulate random poses
+        num_poses = 30
+        simulate_function = partial(
+            simulate_random_poses,
+            model,
+            num_poses,
+            rng,
+            use_graph=self.has_cuda,
+            verbose=self.verbose,
+            reset_state=True,
+            use_incremental_solve=True,
+            tolerance=1e-6,
+        )
+
+        # Simulate random poses with dense solver
+        success = simulate_function(use_sparsity=False)
+        self.assertTrue(success)
+
+        # Simulate random poses with sparse solver
+        success = simulate_function(use_sparsity=True, preconditioner="jacobi_block_diagonal")
+        self.assertTrue(success)
+
 
 class HeterogenousModelSparseJacobianAssemblyCheck(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

This fixes the incorrect handling of universal actuators in the FK velocity-level solve, adding the missing conversion from the intermediary frame to the frame on the base body.

Resolves vastsoun#378

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

A unit test was added in FK unit tests, that simulates and validates random poses for the model with all joint types (including universal). Additionally, a version of this test with asymmetric joint frames (X_B != X_F) is also added, to make sure we cover all cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forward-kinematics velocity handling for **actuated universal joints** by correcting universal constraint rotational velocity components to match joint orientation.
* **Tests**
  * Expanded forward-kinematics validation with new random-pose checks covering **all joint types**, including asymmetric joint-frame setups.
  * Updated joint test-model building so universal joints are included by default (removing the previous option to exclude them).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->