### PR TITLE
Remove gimbal joint in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -393,22 +393,7 @@ class JointDoFType(IntEnum):
         3D vector: {`T_x`, `T_y`, `T_z`}
     """
 
-    GIMBAL = 6
-    """
-    A 3-DoF gimbal joint, with rotational DoFs along {`R_x`, `R_y`, `R_z`}.
-
-    **DISCLAIMER**: This joint is not yet fully supported, and currently behaves
-    identically to the SPHERICAL joint. We do not recommend using it at present time.
-
-    Coordinates:
-        3D euler angles: {`R_x`, `R_y`, `R_z`}
-    DoFs:
-        3D angular velocities: {`R_x`, `R_y`, `R_z`}
-    Constraints:
-        3D vector: {`T_x`, `T_y`, `T_z`}
-    """
-
-    CARTESIAN = 7
+    CARTESIAN = 6
     """
     A 3-DoF Cartesian joint, with translational DoFs along {`T_x`, `T_y`, `T_z`}.
 
@@ -420,7 +405,7 @@ class JointDoFType(IntEnum):
         3D vector: {`R_x`, `R_y`, `R_z`}
     """
 
-    FIXED = 8
+    FIXED = 7
     """
     A 0-DoF fixed joint, fully constraining the relative motion between the connected bodies.
 
@@ -463,8 +448,6 @@ class JointDoFType(IntEnum):
             return 2  # 2D angles
         elif self.value == self.SPHERICAL:
             return 4  # 4D unit-quaternion
-        elif self.value == self.GIMBAL:
-            return 3  # 3D euler angles
         elif self.value == self.CARTESIAN:
             return 3  # 3D distances
         elif self.value == self.FIXED:
@@ -488,8 +471,6 @@ class JointDoFType(IntEnum):
         elif self.value == self.UNIVERSAL:
             return 2  # 2D angular velocities
         elif self.value == self.SPHERICAL:
-            return 3  # 3D angular velocities
-        elif self.value == self.GIMBAL:
             return 3  # 3D angular velocities
         elif self.value == self.CARTESIAN:
             return 3  # 3D linear velocities
@@ -515,8 +496,6 @@ class JointDoFType(IntEnum):
             return 4  # 4D vector for `{R_x, R_y, R_z, R_w}`
         elif self.value == self.SPHERICAL:
             return 3  # 3D vector for `{R_x, R_y, R_z}`
-        elif self.value == self.GIMBAL:
-            return 3  # 3D vector for `{R_x, R_y, R_z}`
         elif self.value == self.CARTESIAN:
             return 3  # 3D vector for `{T_x, T_y, T_z}`
         elif self.value == self.FIXED:
@@ -540,8 +519,6 @@ class JointDoFType(IntEnum):
         elif self.value == self.UNIVERSAL:
             return wp.constant(wp.vec4i(0, 1, 2, 5))
         elif self.value == self.SPHERICAL:
-            return wp.constant(wp.vec3i(0, 1, 2))
-        elif self.value == self.GIMBAL:
             return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.CARTESIAN:
             return wp.constant(wp.vec3i(3, 4, 5))
@@ -567,8 +544,6 @@ class JointDoFType(IntEnum):
             return wp.constant(wp.vec2i(3, 4))
         elif self.value == self.SPHERICAL:
             return wp.constant(wp.vec3i(3, 4, 5))
-        elif self.value == self.GIMBAL:
-            return wp.constant(wp.vec3i(3, 4, 5))
         elif self.value == self.CARTESIAN:
             return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.FIXED:
@@ -593,8 +568,6 @@ class JointDoFType(IntEnum):
             return wp.vec2f
         elif self.value == self.SPHERICAL:
             return wp.vec4f
-        elif self.value == self.GIMBAL:
-            return wp.vec3f
         elif self.value == self.CARTESIAN:
             return wp.vec3f
         elif self.value == self.FIXED:
@@ -619,8 +592,6 @@ class JointDoFType(IntEnum):
             return wp.vec2f
         elif self.value == self.SPHERICAL:
             return wp.quatf
-        elif self.value == self.GIMBAL:
-            return wp.vec3f
         elif self.value == self.CARTESIAN:
             return wp.vec3f
         elif self.value == self.FIXED:
@@ -645,8 +616,6 @@ class JointDoFType(IntEnum):
             return [0.0, 0.0]
         elif self.value == self.SPHERICAL:
             return [0.0, 0.0, 0.0, 1.0]
-        elif self.value == self.GIMBAL:
-            return [0.0, 0.0, 0.0]
         elif self.value == self.CARTESIAN:
             return [0.0, 0.0, 0.0]
         elif self.value == self.FIXED:
@@ -673,8 +642,6 @@ class JointDoFType(IntEnum):
             return [rotation_bound, rotation_bound]
         elif self.value == self.SPHERICAL:
             return [JOINT_QMAX] * 4
-        elif self.value == self.GIMBAL:
-            return [rotation_bound] * 3
         elif self.value == self.CARTESIAN:
             return [JOINT_QMAX] * 3
         elif self.value == self.FIXED:
@@ -708,7 +675,6 @@ class JointDoFType(IntEnum):
             JointDoFType.CARTESIAN: JointType.D6,
             JointDoFType.CYLINDRICAL: JointType.D6,
             JointDoFType.UNIVERSAL: JointType.D6,
-            JointDoFType.GIMBAL: JointType.D6,
         }
         joint_type = _MAP_TO_NEWTON.get(dof_type, None)
         if joint_type is None:
@@ -803,7 +769,6 @@ class JointDoFType(IntEnum):
             elif q_count == 3 and qd_count == 3 and dof_dim == (3, 0):
                 dof_type = JointDoFType.CARTESIAN
             elif q_count == 3 and qd_count == 3 and dof_dim == (0, 3):
-                # TODO: dof_type = JointDoFType.GIMBAL
                 raise ValueError("Unsupported joint type: GIMBAL joints are not currently supported.")
             elif q_count == 4 and qd_count == 3 and dof_dim == (0, 3):
                 dof_type = JointDoFType.SPHERICAL
@@ -885,7 +850,6 @@ class JointDoFType(IntEnum):
         elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(3, 0):
             return JointDoFType.CARTESIAN
         elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
-            # TODO: dof_type = JointDoFType.GIMBAL
             return -1
         elif q_count == 4 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
             return JointDoFType.SPHERICAL
@@ -924,8 +888,6 @@ class JointDoFType(IntEnum):
             return 2  # 2D angles
         elif dof_type == JointDoFType.SPHERICAL:
             return 4  # 4D unit-quaternion
-        elif dof_type == JointDoFType.GIMBAL:
-            return 3  # 3D euler angles
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D distances
         elif dof_type == JointDoFType.FIXED:
@@ -957,8 +919,6 @@ class JointDoFType(IntEnum):
             return 2  # 2D angular velocities
         elif dof_type == JointDoFType.SPHERICAL:
             return 3  # 3D angular velocities
-        elif dof_type == JointDoFType.GIMBAL:
-            return 3  # 3D angular velocities
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D linear velocities
         elif dof_type == JointDoFType.FIXED:
@@ -989,8 +949,6 @@ class JointDoFType(IntEnum):
         elif dof_type == JointDoFType.UNIVERSAL:
             return 4  # 4D vector for `{R_x, R_y, R_z, R_w}`
         elif dof_type == JointDoFType.SPHERICAL:
-            return 3  # 3D vector for `{R_x, R_y, R_z}`
-        elif dof_type == JointDoFType.GIMBAL:
             return 3  # 3D vector for `{R_x, R_y, R_z}`
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D vector for `{T_x, T_y, T_z}`

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -205,11 +205,6 @@ def store_joint_cts_jacobian_dense(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
         )
 
-    elif dof_type == JointDoFType.GIMBAL:
-        wp.static(make_store_joint_jacobian_dense_func(JointDoFType.GIMBAL.cts_axes))(
-            J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
-        )
-
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_dense_func(JointDoFType.CARTESIAN.cts_axes))(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
@@ -262,11 +257,6 @@ def store_joint_dofs_jacobian_dense(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
         )
 
-    elif dof_type == JointDoFType.GIMBAL:
-        wp.static(make_store_joint_jacobian_dense_func(JointDoFType.GIMBAL.dofs_axes))(
-            J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
-        )
-
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_dense_func(JointDoFType.CARTESIAN.dofs_axes))(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
@@ -316,11 +306,6 @@ def store_joint_cts_jacobian_sparse(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
         )
 
-    elif dof_type == JointDoFType.GIMBAL:
-        wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.GIMBAL.cts_axes))(
-            is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
-        )
-
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.CARTESIAN.cts_axes))(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
@@ -367,11 +352,6 @@ def store_joint_dofs_jacobian_sparse(
 
     elif dof_type == JointDoFType.SPHERICAL:
         wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.SPHERICAL.dofs_axes))(
-            is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
-        )
-
-    elif dof_type == JointDoFType.GIMBAL:
-        wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.GIMBAL.dofs_axes))(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
         )
 

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -17,7 +17,6 @@ from ..core.math import (
     FLOAT32_MAX,
     TWO_PI,
     quat_log,
-    quat_to_euler_xyz,
     quat_to_vec4,
     quat_twist_angle,
     screw,
@@ -140,17 +139,6 @@ def correct_joint_coord_spherical(
 
 
 @wp.func
-def correct_joint_coord_gimbal(
-    q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
-) -> wp.vec3f:
-    """Corrects each of the XYZ Euler angles individually."""
-    q_j_in[0] = correct_rotational_coord(q_j_in[0], q_j_ref[0], q_j_limit[0])
-    q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
-    q_j_in[2] = correct_rotational_coord(q_j_in[2], q_j_ref[2], q_j_limit[2])
-    return q_j_in
-
-
-@wp.func
 def correct_joint_coord_cartesian(
     q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
 ) -> wp.vec3f:
@@ -175,8 +163,6 @@ def get_joint_coord_correction_function(dof_type: JointDoFType):
         return correct_joint_coord_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return correct_joint_coord_spherical
-    elif dof_type == JointDoFType.GIMBAL:
-        return correct_joint_coord_gimbal
     elif dof_type == JointDoFType.CARTESIAN:
         return correct_joint_coord_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -245,13 +231,6 @@ def map_to_joint_coords_spherical(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec4f:
 
 
 @wp.func
-def map_to_joint_coords_gimbal(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
-    """Returns the 3D XYZ Euler angles (roll, pitch, yaw)."""
-    # How can we make this safer?
-    return quat_to_euler_xyz(j_q_j)
-
-
-@wp.func
 def map_to_joint_coords_cartesian(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the 3D translational."""
     return j_r_j
@@ -274,8 +253,6 @@ def get_joint_coords_mapping_function(dof_type: JointDoFType):
         return map_to_joint_coords_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return map_to_joint_coords_spherical
-    elif dof_type == JointDoFType.GIMBAL:
-        return map_to_joint_coords_gimbal
     elif dof_type == JointDoFType.CARTESIAN:
         return map_to_joint_coords_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -340,8 +317,6 @@ def get_joint_constraint_angular_residual_function(dof_type: JointDoFType):
     elif dof_type == JointDoFType.UNIVERSAL:
         return joint_constraint_angular_residual_universal
     elif dof_type == JointDoFType.SPHERICAL:
-        return joint_constraint_angular_residual_free
-    elif dof_type == JointDoFType.GIMBAL:
         return joint_constraint_angular_residual_free
     elif dof_type == JointDoFType.CARTESIAN:
         return joint_constraint_angular_residual_fixed
@@ -558,21 +533,6 @@ def make_write_joint_data(correction: JointCorrectionMode = JointCorrectionMode.
 
         elif dof_type == JointDoFType.SPHERICAL:
             wp.static(make_typed_write_joint_data(JointDoFType.SPHERICAL))(
-                cts_offset,
-                dofs_offset,
-                coords_offset,
-                j_r_j,
-                j_q_j,
-                j_u_j,
-                q_j_p,
-                data_r_j,
-                data_dr_j,
-                data_q_j,
-                data_dq_j,
-            )
-
-        elif dof_type == JointDoFType.GIMBAL:
-            wp.static(make_typed_write_joint_data(JointDoFType.GIMBAL, correction))(
                 cts_offset,
                 dofs_offset,
                 coords_offset,

--- a/newton/_src/solvers/kamino/_src/kinematics/limits.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/limits.py
@@ -234,12 +234,6 @@ def map_joint_coords_to_dofs_spherical(q_j: wp.vec4f) -> wp.vec3f:
 
 
 @wp.func
-def map_joint_coords_to_dofs_gimbal(q_j: wp.vec3f) -> wp.vec3f:
-    """No mapping needed for gimbal joints."""
-    return q_j
-
-
-@wp.func
 def map_joint_coords_to_dofs_cartesian(q_j: wp.vec3f) -> wp.vec3f:
     """No mapping needed for cartesian joints."""
     return q_j
@@ -262,8 +256,6 @@ def get_joint_coords_to_dofs_mapping_function(dof_type: JointDoFType):
         return map_joint_coords_to_dofs_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return map_joint_coords_to_dofs_spherical
-    elif dof_type == JointDoFType.GIMBAL:
-        return map_joint_coords_to_dofs_gimbal
     elif dof_type == JointDoFType.CARTESIAN:
         return map_joint_coords_to_dofs_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -373,15 +365,6 @@ def read_joint_coords_map_and_limits(
 
     elif dof_type == JointDoFType.SPHERICAL:
         d_j, q_j_min, q_j_max, q_j_map = wp.static(make_read_joint_coords_map_and_limits(JointDoFType.SPHERICAL))(
-            dofs_offset,
-            coords_offset,
-            model_joint_q_j_min,
-            model_joint_q_j_max,
-            state_joints_q_j,
-        )
-
-    elif dof_type == JointDoFType.GIMBAL:
-        d_j, q_j_min, q_j_max, q_j_map = wp.static(make_read_joint_coords_map_and_limits(JointDoFType.GIMBAL))(
             dofs_offset,
             coords_offset,
             model_joint_q_j_min,

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -10,7 +10,7 @@ from typing import Any
 import warp as wp
 
 from ..core.joints import JointDoFType
-from ..core.math import quat_from_x_rot, quat_from_y_rot, quat_from_z_rot, screw, screw_angular, screw_linear
+from ..core.math import quat_from_x_rot, quat_from_y_rot, screw, screw_angular, screw_linear
 from ..core.model import ModelKamino
 from ..core.state import StateKamino
 from ..kinematics.joints import (
@@ -224,11 +224,6 @@ def _get_joint_rel_transform_from_coords(
         t[1] = joint_q[coord_offset + 1]
         t[2] = joint_q[coord_offset + 2]
         q = read_quat_from_array(joint_q, coord_offset + 3, True)
-    elif dof_type == JointDoFType.GIMBAL:
-        q_x = quat_from_x_rot(joint_q[coord_offset])
-        q_y = quat_from_y_rot(joint_q[coord_offset + 1])
-        q_z = quat_from_z_rot(joint_q[coord_offset + 2])
-        q = q_x * q_y * q_z
     elif dof_type == JointDoFType.PRISMATIC:
         t[0] = joint_q[coord_offset]
     elif dof_type == JointDoFType.REVOLUTE:
@@ -317,8 +312,6 @@ def _get_joint_rel_velocity_from_dofs(
         return wp.spatial_vectorf(0.0)
     elif dof_type == JointDoFType.FREE:
         return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.FREE))(q_j, dofs_offset, joint_u)
-    elif dof_type == JointDoFType.GIMBAL:
-        return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.GIMBAL))(q_j, dofs_offset, joint_u)
     elif dof_type == JointDoFType.PRISMATIC:
         return wp.static(make_typed_get_joint_rel_velocity_from_dofs(JointDoFType.PRISMATIC))(q_j, dofs_offset, joint_u)
     elif dof_type == JointDoFType.REVOLUTE:

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -69,11 +69,6 @@ def make_correct_joint_coords(dof_type: JointDoFType):
             for i in range(4):
                 coords[3 + i] = quat_corrected[i]
 
-        elif wp.static(dof_type == JointDoFType.GIMBAL):  # Correct angles up to +/- 2 pi
-            coords[0] = _correct_joint_angle(coords[0], coords_ref[0])
-            coords[1] = _correct_joint_angle(coords[1], coords_ref[1])
-            coords[2] = _correct_joint_angle(coords[2], coords_ref[2])
-
         elif wp.static(dof_type == JointDoFType.REVOLUTE):  # Correct angle up to +/- 2 pi
             coords[0] = _correct_joint_angle(coords[0], coords_ref[0])
 
@@ -177,12 +172,6 @@ def _compute_and_write_joint_coords_and_vel(
     elif dof_type == JointDoFType.FREE:
         wp.static(make_compute_and_write_joint_coords(JointDoFType.FREE))(r_j, q_j, coords_offset, joint_q_ref, joint_q)
         wp.static(make_compute_and_write_joint_vel(JointDoFType.FREE))(q_j, u_j, dofs_offset, joint_u)
-
-    elif dof_type == JointDoFType.GIMBAL:
-        wp.static(make_compute_and_write_joint_coords(JointDoFType.GIMBAL))(
-            r_j, q_j, coords_offset, joint_q_ref, joint_q
-        )
-        wp.static(make_compute_and_write_joint_vel(JointDoFType.GIMBAL))(q_j, u_j, dofs_offset, joint_u)
 
     elif dof_type == JointDoFType.PRISMATIC:
         wp.static(make_compute_and_write_joint_coords(JointDoFType.PRISMATIC))(

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -46,10 +46,9 @@ class FKJointDoFType(IntEnum):
     CYLINDRICAL = 3
     UNIVERSAL = 4
     SPHERICAL = 5
-    GIMBAL = 6
-    CARTESIAN = 7
-    FIXED = 8
-    AXIS = 9
+    CARTESIAN = 6
+    FIXED = 7
+    AXIS = 8
 
 
 class ForwardKinematicsPreconditionerType(IntEnum):

--- a/newton/_src/solvers/kamino/tests/utils/joints.py
+++ b/newton/_src/solvers/kamino/tests/utils/joints.py
@@ -175,8 +175,6 @@ def actuator_coords_from_units(
             pass
         elif dof_type == JointDoFType.FREE:
             coords.extend([pos_val, pos_val, pos_val, quat_val, quat_val, quat_val, quat_val])
-        elif dof_type == JointDoFType.GIMBAL:
-            coords.extend([angle_val, angle_val, angle_val])
         elif dof_type == JointDoFType.PRISMATIC:
             coords.extend([pos_val])
         elif dof_type == JointDoFType.REVOLUTE:
@@ -209,8 +207,6 @@ def actuator_dofs_from_units(
             pass
         elif dof_type == JointDoFType.FREE:
             dofs.extend([lin_vel_val, lin_vel_val, lin_vel_val, ang_vel_val, ang_vel_val, ang_vel_val])
-        elif dof_type == JointDoFType.GIMBAL:
-            dofs.extend([ang_vel_val, ang_vel_val, ang_vel_val])
         elif dof_type == JointDoFType.PRISMATIC:
             dofs.extend([lin_vel_val])
         elif dof_type == JointDoFType.REVOLUTE:


### PR DESCRIPTION
## Description

This removes the gimbal joint from joint types in Kamino, as this joint was not supported throughout (several todos left) and there is no concrete need to support it.

The notes saying that gimbal joints are not supported, or the errors raised during conversion from newton, were left as-is.

Resolves vastsoun#326

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Kamino-internal unit tests are still running fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated joint handling so the former gimbal joint mode is treated as cartesian across motion, limits, Jacobian storage, resets, and Newton/warp conversions.
  * Fixed joint type mappings and reordered enum values so coordinate, velocity, constraint, and inference logic align with the new categorization.
  * Removed gimbal-specific branches from kinematics and updated test utilities to reflect the supported joint set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->