### PR TITLE
Forward --warp-config to example subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` for applying the checkerboard texture to selected shapes.
 - Add support for pt2 neural-network checkpoints (saved via `torch.export.save`) in `ControllerNeuralMLP` and `ControllerNeuralLSTM`.
 - Add `SensorContact.position_matrix` alongside `force_matrix`, reporting per-counterpart world-frame contact positions (force-weighted average of contact midpoints).
+- Forward `--warp-config KEY=VALUE` from `python -m newton.tests` to example subprocesses so `warp.config` overrides apply during example tests.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 - Add `basic_dzhanibekov` example demonstrating free rigid-body intermediate-axis instability across VBD, XPBD, and MuJoCo solvers
 - Add inverse-dynamics evaluation for articulated systems: `Model.inverse_dynamics()` returns an `InverseDynamics` container that `eval_inverse_dynamics` populates with the joint-space mass matrix `M(q)`, gravity bias `g(q)`, and Coriolis bias `C(q, q_dot)*q_dot` (selected via `InverseDynamics.EvalType` flags); `eval_inverse_dynamics_force` combines them with a user-supplied `qddot` into the manipulator-equation joint force `tau = M*qddot + C*q_dot + g`; `ArticulationView.eval_inverse_dynamics` masks the computation to a selected subset of articulations via the selection API

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -181,6 +181,10 @@ def add_example_test(
         # Append Warp commands
         command.extend(["-m", f"newton.examples.{name}", "--device", str(device), "--test", "--quiet"])
 
+        # Forward any --warp-config overrides from the test runner
+        for entry in newton.tests.unittest_utils.warp_config_overrides:
+            command.extend(["--warp-config", entry])
+
         if not use_viewer:
             stage_path = (
                 options.pop(

--- a/newton/tests/thirdparty/unittest_parallel.py
+++ b/newton/tests/thirdparty/unittest_parallel.py
@@ -185,6 +185,13 @@ def main(argv=None):
         help="Skip clearing the Warp kernel cache before running tests. "
         "Useful for faster iteration and avoiding interference with parallel sessions.",
     )
+    group_warp.add_argument(
+        "--warp-config",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Forward a warp.config override to example subprocesses (repeatable).",
+    )
     args = parser.parse_args(args=argv)
     if args.parallel_timeout <= 0:
         parser.error("--parallel-timeout must be greater than 0")
@@ -530,6 +537,7 @@ class ParallelTestManager:
         newton.tests.unittest_utils.coverage_enabled = self.args.coverage
         newton.tests.unittest_utils.coverage_temp_dir = self.temp_dir
         newton.tests.unittest_utils.coverage_branch = self.args.coverage_branch
+        newton.tests.unittest_utils.warp_config_overrides = self.args.warp_config
 
         # Publish the flag for subprocess-based tests (e.g. test_examples.py).
         # Filters are applied earlier (pre-discovery and in the worker

--- a/newton/tests/unittest_utils.py
+++ b/newton/tests/unittest_utils.py
@@ -40,6 +40,9 @@ coverage_branch = None
 # the user cannot act on.
 strict_warnings = False
 
+# Extra --warp-config KEY=VALUE entries forwarded to example subprocesses.
+warp_config_overrides: list[str] = []
+
 try:
     if sys.platform == "win32":
         LIBC = ctypes.CDLL("ucrtbase.dll")


### PR DESCRIPTION
## Description

Adds a repeatable `--warp-config KEY=VALUE` option to the Newton test runner and forwards those overrides to example subprocesses.

This lets developers run example tests under non-default `warp.config` settings, such as `llvm_cuda=True`, without manually editing each spawned example command.

Follow-up of #2205.

## Checklist

- [~] New or existing tests cover these changes
- [~] The documentation is up to date with these changes
- [~] `CHANGELOG.md` has been updated

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_basic.example_basic_shapes --warp-config llvm_cuda=True
```

Verify that the example subprocess receives `--warp-config llvm_cuda=True` and runs with the requested Warp configuration override.

## New feature / API change

The test runner can now forward Warp configuration overrides to example subprocesses:

```bash
uv run --extra dev -m newton.tests -k test_basic.example_basic_shapes --warp-config llvm_cuda=True
```

Multiple overrides can be passed by repeating the option:

```bash
uv run --extra dev -m newton.tests -k test_basic.example_basic_shapes --warp-config llvm_cuda=True --warp-config verify_cuda=True
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable `--warp-config KEY=VALUE` option to forward Warp configuration overrides into example and parallel test subprocess runs.
* **Behavior Changes**
  * Example workloads now use computation-graph capture more consistently across devices (including non-CUDA), improving the likelihood of graph-based execution paths.
* **Tests**
  * Added an automated APIC capture-and-replay matrix test covering registered examples, and regenerated the corresponding results documentation.
* **Documentation**
  * Updated the Unreleased changelog to reflect `--warp-config` forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->