### PR TITLE
Add runtime texture swapping to the tiled-camera sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add `CollisionPipeline.soft_rigid_contact_pair_count` for the number of precomputed soft-rigid (particle-shape) candidate pairs, filtered to compatible worlds, launched for soft-contact generation; this is the default capacity for `soft_contact_max`
 - Add user-defined pressure laws to hydroelastic SDF contact via `HydroelasticSDF.Config.pressure_func` (a `@wp.func` mapping `(signed_depth, shape_idx, data) -> pressure`) and `pressure_data` (a `@wp.struct` carrying per-shape state). The contact patch is the iso-pressure surface `p_a == p_b`; the default linear law `pressure = -kh * signed_depth` is preserved when no callback is supplied.
 - Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` for applying the checkerboard texture to selected shapes.
+- Add `SensorTiledCamera.utils.register_textures(sources)` and `SensorTiledCamera.utils.set_shape_texture_ids(shape_indices, texture_ids)` for runtime texture swapping: register candidate textures into the texture pool once up front, then reassign per-shape texture indices at runtime (e.g. per-reset domain randomization) with a single scatter-kernel launch and no texture I/O.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 - Expose `MeshAdjacencyData` (the device-resident soft-mesh adjacency struct returned by `MeshAdjacency.to()`) as public API for use in custom Warp kernels
 - Add `Model.AttributeSpec` and `Model.attribute_specs` for declaring model-attribute indexing, references, and view/compaction behavior in one metadata registry.

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -166,7 +166,9 @@ class RenderContext:
         if self.texture_data is None:
             raise RuntimeError("register_textures() requires init_from_model() to have been called first.")
 
-        indices = []
+        # build locally and commit after the loop, so a failing source leaves the pool
+        # (and the indices handed to earlier callers) untouched
+        new_entries = []
         for source in sources:
             if isinstance(source, np.ndarray):
                 pixels = source
@@ -189,9 +191,10 @@ class RenderContext:
                 device=self.device,
             )
             data.repeat = wp.vec2f(1.0, 1.0)
-            indices.append(len(self.__texture_data))
-            self.__texture_data.append(data)
+            new_entries.append(data)
 
+        indices = list(range(len(self.__texture_data), len(self.__texture_data) + len(new_entries)))
+        self.__texture_data.extend(new_entries)
         self.texture_data = wp.array(self.__texture_data, dtype=TextureData, device=self.device)
         # sampling registered textures requires the textured kernel variant; the config
         # is part of the kernel cache key, so this at most compiles once on next render.
@@ -222,21 +225,18 @@ class RenderContext:
         if self.shape_texture_ids is None:
             raise RuntimeError("set_shape_texture_ids() requires init_from_model() to have been called first.")
 
+        # host inputs are bounds-checked before upload: the scatter kernel writes (and the
+        # render kernel reads) unguarded, so out-of-range indices would corrupt GPU memory
         if not isinstance(shape_indices, wp.array):
-            shape_indices = np.asarray(shape_indices, dtype=np.int32).reshape(-1)
-            texture_ids_np = np.asarray(texture_ids, dtype=np.int32).reshape(-1)
-            if shape_indices.shape != texture_ids_np.shape:
-                raise ValueError("shape_indices and texture_ids must have the same length")
-            if ((shape_indices < 0) | (shape_indices >= self.shape_count_total)).any():
+            host_indices = np.asarray(shape_indices, dtype=np.int32).reshape(-1)
+            if ((host_indices < 0) | (host_indices >= self.shape_count_total)).any():
                 raise ValueError("shape_indices contains an out-of-range shape index")
-            if ((texture_ids_np < -1) | (texture_ids_np >= len(self.__texture_data))).any():
+            shape_indices = wp.array(host_indices, dtype=wp.int32, device=self.device)
+        if not isinstance(texture_ids, wp.array):
+            host_ids = np.asarray(texture_ids, dtype=np.int32).reshape(-1)
+            if ((host_ids < -1) | (host_ids >= len(self.__texture_data))).any():
                 raise ValueError("texture_ids contains an out-of-range texture-pool index")
-            shape_indices = wp.array(shape_indices, dtype=wp.int32, device=self.device)
-            texture_ids = wp.array(texture_ids_np, dtype=wp.int32, device=self.device)
-        elif not isinstance(texture_ids, wp.array):
-            texture_ids = wp.array(
-                np.asarray(texture_ids, dtype=np.int32).reshape(-1), dtype=wp.int32, device=self.device
-            )
+            texture_ids = wp.array(host_ids, dtype=wp.int32, device=self.device)
         if shape_indices.shape[0] != texture_ids.shape[0]:
             raise ValueError("shape_indices and texture_ids must have the same length")
 

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -16,6 +16,17 @@ from .types import ClearData, MeshData, RenderConfig, RenderOrder, TextureData
 from .utils import Utils
 
 
+@wp.kernel(enable_backward=False)
+def _scatter_shape_texture_ids_kernel(
+    shape_indices: wp.array[wp.int32],
+    texture_ids: wp.array[wp.int32],
+    shape_texture_ids: wp.array[wp.int32],
+):
+    """Scatter ``texture_ids[i]`` into ``shape_texture_ids[shape_indices[i]]``."""
+    tid = wp.tid()
+    shape_texture_ids[shape_indices[tid]] = texture_ids[tid]
+
+
 class RenderContext:
     Config = RenderConfig
     ClearData = ClearData
@@ -131,6 +142,110 @@ class RenderContext:
         self.gaussians_data = model.gaussians_data
 
         self.__load_texture_and_mesh_data(model, load_textures)
+
+    def register_textures(self, sources: list[str | np.ndarray]) -> list[int]:
+        """Append textures to the texture pool and return their pool indices.
+
+        The returned indices are valid targets for :meth:`set_shape_texture_ids`.
+        Registration reallocates the pool array once per call, so register all
+        candidate textures up front (e.g. at scene construction); per-frame swaps
+        then reduce to index writes with no texture I/O.
+
+        Args:
+            sources: Texture sources. Each entry is either a filesystem path
+                accepted by :func:`newton.utils.load_texture` or an RGBA/RGB
+                ``np.ndarray`` of pixels.
+
+        Returns:
+            Pool index of each registered texture, aligned with ``sources``.
+
+        Raises:
+            RuntimeError: If called before :meth:`init_from_model`.
+            ValueError: If a texture source cannot be loaded.
+        """
+        if self.texture_data is None:
+            raise RuntimeError("register_textures() requires init_from_model() to have been called first.")
+
+        indices = []
+        for source in sources:
+            if isinstance(source, np.ndarray):
+                pixels = source
+            else:
+                pixels = load_texture(source)
+                if pixels is None:
+                    raise ValueError(f"Failed to load texture: {source}")
+            pixels = normalize_texture(pixels, require_channels=True)
+            if pixels.dtype != np.uint8:
+                pixels = pixels.astype(np.uint8, copy=False)
+
+            data = TextureData()
+            data.texture = wp.Texture2D(
+                pixels,
+                filter_mode=wp.TextureFilterMode.LINEAR,
+                address_mode=wp.TextureAddressMode.WRAP,
+                normalized_coords=True,
+                dtype=wp.uint8,
+                num_channels=4,
+                device=self.device,
+            )
+            data.repeat = wp.vec2f(1.0, 1.0)
+            indices.append(len(self.__texture_data))
+            self.__texture_data.append(data)
+
+        self.texture_data = wp.array(self.__texture_data, dtype=TextureData, device=self.device)
+        # sampling registered textures requires the textured kernel variant; the config
+        # is part of the kernel cache key, so this at most compiles once on next render.
+        self.config.enable_textures = True
+        return indices
+
+    def set_shape_texture_ids(
+        self,
+        shape_indices: wp.array | np.ndarray | list[int],
+        texture_ids: wp.array | np.ndarray | list[int],
+    ):
+        """Reassign texture-pool indices for a subset of shapes in place.
+
+        When both arguments are device-resident ``wp.array[wp.int32]``, this
+        is a single scatter-kernel launch with no host synchronization — suitable
+        for per-reset randomization loops. NumPy arrays or sequences are validated
+        and uploaded for convenience.
+
+        Args:
+            shape_indices: Shape indices to modify, shape (K,), int32.
+            texture_ids: Texture-pool index per shape (from :meth:`register_textures`
+                or ``-1`` for untextured), shape (K,), int32.
+
+        Raises:
+            RuntimeError: If called before :meth:`init_from_model`.
+            ValueError: If host-provided indices are out of range or lengths differ.
+        """
+        if self.shape_texture_ids is None:
+            raise RuntimeError("set_shape_texture_ids() requires init_from_model() to have been called first.")
+
+        if not isinstance(shape_indices, wp.array):
+            shape_indices = np.asarray(shape_indices, dtype=np.int32).reshape(-1)
+            texture_ids_np = np.asarray(texture_ids, dtype=np.int32).reshape(-1)
+            if shape_indices.shape != texture_ids_np.shape:
+                raise ValueError("shape_indices and texture_ids must have the same length")
+            if ((shape_indices < 0) | (shape_indices >= self.shape_count_total)).any():
+                raise ValueError("shape_indices contains an out-of-range shape index")
+            if ((texture_ids_np < -1) | (texture_ids_np >= len(self.__texture_data))).any():
+                raise ValueError("texture_ids contains an out-of-range texture-pool index")
+            shape_indices = wp.array(shape_indices, dtype=wp.int32, device=self.device)
+            texture_ids = wp.array(texture_ids_np, dtype=wp.int32, device=self.device)
+        elif not isinstance(texture_ids, wp.array):
+            texture_ids = wp.array(
+                np.asarray(texture_ids, dtype=np.int32).reshape(-1), dtype=wp.int32, device=self.device
+            )
+        if shape_indices.shape[0] != texture_ids.shape[0]:
+            raise ValueError("shape_indices and texture_ids must have the same length")
+
+        wp.launch(
+            _scatter_shape_texture_ids_kernel,
+            dim=shape_indices.shape[0],
+            inputs=[shape_indices, texture_ids, self.shape_texture_ids],
+            device=self.shape_texture_ids.device,
+        )
 
     def update(self, model: Model, state: State):
         """Synchronize triangle-mesh points from the current simulation state.

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -816,6 +816,39 @@ class Utils:
             device=self.__render_context.device,
         )
 
+    def register_textures(self, sources: list[str | np.ndarray]) -> list[int]:
+        """Append textures to the render context's texture pool.
+
+        See :meth:`RenderContext.register_textures`. Register all candidate
+        textures once up front; per-frame swaps via :meth:`set_shape_texture_ids`
+        are then pure index writes with no texture I/O.
+
+        Args:
+            sources: Texture file paths or RGBA/RGB pixel ``np.ndarray`` entries.
+
+        Returns:
+            Pool index of each registered texture, aligned with ``sources``.
+        """
+        return self.__render_context.register_textures(sources)
+
+    def set_shape_texture_ids(
+        self,
+        shape_indices: wp.array | np.ndarray | list[int],
+        texture_ids: wp.array | np.ndarray | list[int],
+    ):
+        """Reassign texture-pool indices for a subset of shapes in place.
+
+        See :meth:`RenderContext.set_shape_texture_ids`. With device-resident
+        ``wp.array[wp.int32]`` inputs this is a single scatter-kernel
+        launch with no host synchronization.
+
+        Args:
+            shape_indices: Shape indices to modify, shape (K,), int32.
+            texture_ids: Texture-pool index per shape (``-1`` = untextured),
+                shape (K,), int32.
+        """
+        self.__render_context.set_shape_texture_ids(shape_indices, texture_ids)
+
     def assign_checkerboard_material(
         self,
         *,

--- a/newton/tests/test_sensor_tiled_camera_texture_swap.py
+++ b/newton/tests/test_sensor_tiled_camera_texture_swap.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.sensors import SensorTiledCamera
+
+
+def _solid_texture(rgb: tuple[int, int, int], size: int = 8) -> np.ndarray:
+    pixels = np.zeros((size, size, 4), dtype=np.uint8)
+    pixels[..., 0] = rgb[0]
+    pixels[..., 1] = rgb[1]
+    pixels[..., 2] = rgb[2]
+    pixels[..., 3] = 255
+    return pixels
+
+
+_RED = (255, 0, 0)
+_GREEN = (0, 255, 0)
+_BLUE = (0, 0, 255)
+_WHITE = (255, 255, 255)
+
+
+@unittest.skipUnless(wp.is_cuda_available(), "Texture sampling requires CUDA")
+class TestSensorTiledCameraTextureSwap(unittest.TestCase):
+    """Runtime texture swapping from a pre-registered texture pool."""
+
+    @staticmethod
+    def _build_textured_quad_model(texture: np.ndarray | None) -> tuple[newton.Model, int]:
+        """One camera-facing unit quad at z=-2 with UVs; returns (model, quad shape index)."""
+        vertices = np.array([[-1.0, -1.0, 0.0], [1.0, -1.0, 0.0], [1.0, 1.0, 0.0], [-1.0, 1.0, 0.0]], dtype=np.float32)
+        indices = np.array([0, 1, 2, 0, 2, 3], dtype=np.int32)
+        uvs = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float32)
+        mesh = newton.Mesh(vertices, indices, uvs=uvs, texture=texture)
+
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        body = builder.add_body(xform=wp.transform(p=wp.vec3(0.0, 0.0, -2.0), q=wp.quat_identity()))
+        shape_index = builder.add_shape_mesh(body, mesh=mesh, color=(1.0, 1.0, 1.0))
+        return builder.finalize(), shape_index
+
+    def _center_rgb(self, sensor: SensorTiledCamera, state) -> np.ndarray:
+        camera_transforms = wp.array(
+            [[wp.transformf(wp.vec3f(0.0), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
+            dtype=wp.transformf,
+            device=sensor._SensorTiledCamera__render_context.device,
+        )
+        camera_rays = sensor.utils.compute_pinhole_camera_rays(1, 1, math.radians(30.0))
+        albedo_image = sensor.utils.create_albedo_image_output(1, 1, camera_count=1)
+        sensor.update(state, camera_transforms, camera_rays, albedo_image=albedo_image)
+        packed = int(albedo_image.numpy()[0, 0, 0, 0])
+        return np.array([packed & 0xFF, (packed >> 8) & 0xFF, (packed >> 16) & 0xFF], dtype=np.uint8)
+
+    def _assert_rgb(self, actual: np.ndarray, expected: tuple[int, int, int]) -> None:
+        np.testing.assert_allclose(actual.astype(np.int64), np.array(expected, dtype=np.int64), atol=2)
+
+    def test_swap_between_registered_pool_textures(self) -> None:
+        """Swaps re-point a shape at pre-registered textures without reloading anything."""
+        model, quad = self._build_textured_quad_model(_solid_texture(_RED))
+        sensor = SensorTiledCamera(model=model, config=SensorTiledCamera.RenderConfig(enable_textures=True))
+        state = model.state()
+
+        self._assert_rgb(self._center_rgb(sensor, state), _RED)
+
+        green_id, blue_id = sensor.utils.register_textures([_solid_texture(_GREEN), _solid_texture(_BLUE)])
+
+        sensor.utils.set_shape_texture_ids([quad], [green_id])
+        self._assert_rgb(self._center_rgb(sensor, state), _GREEN)
+
+        # device-resident fast path: pure warp-array scatter, no host validation
+        render_context = sensor._SensorTiledCamera__render_context
+        device = render_context.device
+        sensor.utils.set_shape_texture_ids(
+            wp.array([quad], dtype=wp.int32, device=device),
+            wp.array([blue_id], dtype=wp.int32, device=device),
+        )
+        self._assert_rgb(self._center_rgb(sensor, state), _BLUE)
+
+        # -1 restores the untextured base shape color
+        sensor.utils.set_shape_texture_ids([quad], [-1])
+        self._assert_rgb(self._center_rgb(sensor, state), _WHITE)
+
+    def test_register_textures_enables_texturing_on_untextured_model(self) -> None:
+        """Registering into an untextured build flips enable_textures and recompiles once."""
+        model, quad = self._build_textured_quad_model(texture=None)
+        sensor = SensorTiledCamera(model=model)
+        state = model.state()
+
+        self._assert_rgb(self._center_rgb(sensor, state), _WHITE)
+
+        (red_id,) = sensor.utils.register_textures([_solid_texture(_RED)])
+        sensor.utils.set_shape_texture_ids([quad], [red_id])
+        self._assert_rgb(self._center_rgb(sensor, state), _RED)
+
+    def test_host_inputs_are_validated(self) -> None:
+        model, quad = self._build_textured_quad_model(_solid_texture(_RED))
+        sensor = SensorTiledCamera(model=model, config=SensorTiledCamera.RenderConfig(enable_textures=True))
+
+        with self.assertRaises(ValueError):
+            sensor.utils.set_shape_texture_ids([quad], [99])  # texture id out of range
+        with self.assertRaises(ValueError):
+            sensor.utils.set_shape_texture_ids([10_000], [0])  # shape index out of range
+        with self.assertRaises(ValueError):
+            sensor.utils.set_shape_texture_ids([quad], [0, 0])  # length mismatch
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The tiled-camera raytracer already stores textures as a deduplicated `wp.array[TextureData]` pool indexed per shape through `shape_texture_ids`, but both structures were frozen at `init_from_model`: the only mutation path (`assign_checkerboard_material`) clobbers the whole pool. Visual domain randomization (texture randomization per reset across thousands of environments) needs to change per-shape textures at runtime without paying decode/upload costs in the loop.

This PR exposes the two missing operations, following the pool design the renderer already uses:

- `RenderContext.register_textures(sources)` appends file- or ndarray-sourced textures to the pool and returns their indices; intended to be called once up front so all candidates are resident.
- `RenderContext.set_shape_texture_ids(shape_indices, texture_ids)` scatters in place. With device-resident int32 warp arrays this is a single kernel launch with no host sync, so per-reset swaps across many shapes cost the same as a `shape_color` write. Host inputs are bounds-validated for convenience.

Both are also exposed on `SensorTiledCamera.utils`, next to `assign_checkerboard_material`. Registering into an untextured build flips `config.enable_textures`; the config keys the kernel cache, so that costs one recompile on the next render.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

`test_sensor_tiled_camera_texture_swap.py` covers pool registration/index alignment, device-array and host-input scatter paths, and out-of-range validation.

```
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera_texture_swap
```

Also exercised end to end from Isaac Lab: a visual-randomization demo registering a 10-texture pool at scene build and swapping textures across environments per reset; steady-state reset cost is unchanged from color-only randomization.

## New feature / API change

```python
import newton

camera = newton.sensors.SensorTiledCamera(model, ...)

# once, up front: make all candidate textures resident in the pool
pool = camera.utils.register_textures(["wood.png", "marble.png", "rust.png"])

# per reset: reassign textures for chosen shapes — one kernel launch, no texture I/O
camera.utils.set_shape_texture_ids(
    shape_indices=[3, 4, 5],
    texture_ids=[pool[2], pool[0], pool[1]],
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime texture swapping for tiled camera rendering without reloading assets.
  * Introduced APIs to register new texture sources and reassign texture IDs for selected shapes.
  * Enabled textured rendering for models that previously started without textures.

* **Tests**
  * Added CUDA-gated unit tests validating texture swapping via registered texture pools, untextured model activation, and host input validation for shape/texture ID updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->