### PR TITLE
Use sys.monitoring coverage core in CI tests

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -159,6 +159,8 @@ jobs:
       - name: Run Tests
         env:
           PYTHONFAULTHANDLER: "1"
+          # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
+          COVERAGE_CORE: "sysmon"
         run: uv run --extra dev --extra torch-cu13 -m newton.tests --strict-warnings --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
       - name: Check disk space (post-test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
       - name: Run Tests
         env:
           PYTHONFAULTHANDLER: "1"
+          # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
+          COVERAGE_CORE: "sysmon"
         run: >
           uv run --extra dev -m newton.tests
           --strict-warnings


### PR DESCRIPTION
## Description

Set `COVERAGE_CORE=sysmon` for the coverage-enabled test jobs (CPU matrix in `ci.yml`, GPU tests in `aws_gpu_tests.yml`).

coverage.py's default core uses `sys.settrace`, which intercepts every Python frame entry process-wide. Coverage is already scoped to `source = ["newton"]`, but under `settrace` that scoping only controls what gets *recorded*, not what gets *intercepted*: every Warp frame still pays a tracer callback, and `wp.launch()` enters a few hundred Python frames per call. With the warp-lang `1.15.0.dev20260626` bump (#2864) the per-launch frame count grew further, which is what stepped the merge queue from ~33 to ~41 min and pushed the CPU unittest jobs up accordingly.

The `sys.monitoring` core (PEP 669, Python 3.12+, supported since coverage 7.4; CI uses 3.12 and `coverage>=7.8`) disables events per code object after first sight, so unmeasured third-party code runs untraced. This removes nearly all coverage wall-time overhead from the test jobs while producing identical coverage data. Branch coverage is not supported by the sysmon core before Python 3.14, but CI only collects line coverage.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

CI-only change: no tests, docs, or CHANGELOG entry apply.

## Test plan

Compared a fixed test slice on a GPU workstation with a cold Warp kernel cache, mirroring the CI flags:

```
COVERAGE_CORE=sysmon uv run --extra dev -m newton.tests -k test_solver_xpbd -k test_collision_pipeline -k test_cloth --no-cache-clear --coverage
```

With the sysmon core the run takes about as long as running without `--coverage` at all (the settrace core nearly doubles it), and the coverage report is identical down to the line counts. Also verified per-launch overhead with a 50k-launch microbenchmark: settrace core ~148 µs/launch, sysmon core ~9 µs/launch, no coverage ~9 µs/launch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow settings to use a different coverage mode during unit tests.
  * This helps reduce test overhead and improve coverage collection behavior in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->