### PR TITLE
Modernize neural-actuator checkpoint loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add `CollisionPipeline.soft_rigid_contact_pair_count` for the number of precomputed soft-rigid (particle-shape) candidate pairs, filtered to compatible worlds, launched for soft-contact generation; this is the default capacity for `soft_contact_max`
 - Add user-defined pressure laws to hydroelastic SDF contact via `HydroelasticSDF.Config.pressure_func` (a `@wp.func` mapping `(signed_depth, shape_idx, data) -> pressure`) and `pressure_data` (a `@wp.struct` carrying per-shape state). The contact patch is the iso-pressure surface `p_a == p_b`; the default linear law `pressure = -kh * signed_depth` is preserved when no callback is supplied.
 - Add `SensorTiledCamera.utils.assign_checkerboard_material(shape_indices=...)` for applying the checkerboard texture to selected shapes.
+- Add support for pt2 neural-network checkpoints (saved via `torch.export.save`) in `ControllerNeuralMLP` and `ControllerNeuralLSTM`.
 - Add `--render-fps` to cap example rendering rate without changing simulation frame timing
 - Expose `MeshAdjacencyData` (the device-resident soft-mesh adjacency struct returned by `MeshAdjacency.to()`) as public API for use in custom Warp kernels
 - Add `Model.AttributeSpec` and `Model.attribute_specs` for declaring model-attribute indexing, references, and view/compaction behavior in one metadata registry.
@@ -46,6 +47,7 @@
 - Deprecate passing solver constructor options positionally after stable positional inputs such as `model` and explicit solver configs; migrate calls such as `SolverVBD(model, 10)` to `SolverVBD(model, iterations=10)`.
 - Deprecate `newton.EqType` in favor of `newton.solvers.SolverMuJoCo.EqType`; migrate equality-constraint type references to the MuJoCo-scoped enum.
 - Deprecate passing option-heavy helper API parameters positionally, including `ModelBuilder.ShapeConfig`, `ModelBuilder.JointDofConfig`, `Contacts`, `ArticulationView`, and selected `ModelBuilder` body, joint, shape, rod, cloth, soft-body, and FEM helpers. Keep stable identifiers such as `body`, `parent`/`child`, capacity counts, and topology indices positional; migrate calls such as `add_shape_box(body, xform, hx=...)` to `add_shape_box(body, xform=xform, hx=...)`.
+- Deprecate loading TorchScript (`torch.jit.save`) and dict (`torch.save`) neural-network checkpoints in `ControllerNeuralMLP` and `ControllerNeuralLSTM` in favor of pt2 archives saved via `torch.export.save`.
 - Deprecate omitting `body_frame_origin` in `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()`; the implicit behavior still uses the existing start-node body-frame convention during the deprecation window, but the implicit default will change to `body_frame_origin="com"` in a future release. Pass `body_frame_origin="start"` to preserve the legacy frame or `body_frame_origin="com"` to opt into the future COM-centered frame.
 - Change VBD Neo-Hookean membrane/tet damping to an objective metric based on the rate of `C = FᵀF`, so rigid-body rotations no longer generate damping force.
 - Change VBD spring damping to act only along the spring axis (damping edge-length rate), so transverse and rigid-rotational motion is no longer damped by springs.

--- a/docs/concepts/actuators.rst
+++ b/docs/concepts/actuators.rst
@@ -202,9 +202,22 @@ Whether an actuator supports differentiability and CUDA graph capture depends on
 its controller.  :class:`ControllerPD` and :class:`ControllerPID` are fully
 graphable.  Neural-network controllers (:class:`ControllerNeuralMLP`,
 :class:`ControllerNeuralLSTM`) support two checkpoint backends: ONNX checkpoints
-use Warp-NN's Warp-backed runtime and are graphable, while TorchScript
-checkpoints (``.pt`` / ``.pth``) use the Torch backend, require PyTorch, and are
-not graphable due to framework interop overhead.
+use Warp-NN's Warp-backed runtime and are graphable, while Torch checkpoints
+use the Torch backend, require PyTorch, and are not graphable due to framework
+interop overhead.
+
+Torch checkpoints are pt2 archives (``.pt2``) saved with ``torch.export.save``.
+Checkpoint metadata (scales and network configuration) is stored as a JSON
+extra file::
+
+   metadata = {"effort_scale": 2.0, "num_layers": 2, "hidden_size": 8}
+   torch.export.save(exported, "policy.pt2", extra_files={"metadata.json": json.dumps(metadata)})
+
+:class:`ControllerNeuralLSTM` requires ``num_layers`` and ``hidden_size`` in
+the metadata of pt2 checkpoints, since exported modules no longer expose the
+``torch.nn.LSTM`` submodule that legacy checkpoints are inspected for.  The
+legacy TorchScript (``.pt`` / ``.pth``, saved with ``torch.jit.save``) and
+dict (saved with ``torch.save``) formats still load but are deprecated.
 
 :meth:`Actuator.is_graphable` returns ``True`` when all components can be
 captured in a CUDA graph.

--- a/docs/concepts/actuators.rst
+++ b/docs/concepts/actuators.rst
@@ -208,8 +208,14 @@ interop overhead.
 
 Torch checkpoints are pt2 archives (``.pt2``) saved with ``torch.export.save``.
 Checkpoint metadata (scales and network configuration) is stored as a JSON
-extra file::
+extra file:
 
+.. code-block:: python
+
+   import json
+   import torch
+
+   exported = torch.export.export(net, example_inputs)
    metadata = {"effort_scale": 2.0, "num_layers": 2, "hidden_size": 8}
    torch.export.save(exported, "policy.pt2", extra_files={"metadata.json": json.dumps(metadata)})
 

--- a/docs/concepts/actuators.rst
+++ b/docs/concepts/actuators.rst
@@ -195,16 +195,13 @@ state objects — simply omit them:
 
    m2.actuators[0].step(m2.state(), m2.control())
 
-Differentiability and Graph Capture
------------------------------------
+Neural-Network Checkpoints
+--------------------------
 
-Whether an actuator supports differentiability and CUDA graph capture depends on
-its controller.  :class:`ControllerPD` and :class:`ControllerPID` are fully
-graphable.  Neural-network controllers (:class:`ControllerNeuralMLP`,
-:class:`ControllerNeuralLSTM`) support two checkpoint backends: ONNX checkpoints
-use Warp-NN's Warp-backed runtime and are graphable, while Torch checkpoints
-use the Torch backend, require PyTorch, and are not graphable due to framework
-interop overhead.
+Neural-network controllers (:class:`ControllerNeuralMLP`,
+:class:`ControllerNeuralLSTM`) support two checkpoint backends: ONNX
+checkpoints (``.onnx``) run on Warp-NN's Warp-backed runtime, while Torch
+checkpoints use the Torch backend and require PyTorch.
 
 Torch checkpoints are pt2 archives (``.pt2``) saved with ``torch.export.save``.
 Checkpoint metadata (scales and network configuration) is stored as a JSON
@@ -220,13 +217,20 @@ extra file:
    torch.export.save(exported, "policy.pt2", extra_files={"metadata.json": json.dumps(metadata)})
 
 :class:`ControllerNeuralLSTM` requires ``num_layers`` and ``hidden_size`` in
-the metadata of pt2 checkpoints, since exported modules no longer expose the
-``torch.nn.LSTM`` submodule that legacy checkpoints are inspected for.  The
-legacy TorchScript (``.pt`` / ``.pth``, saved with ``torch.jit.save``) and
-dict (saved with ``torch.save``) formats still load but are deprecated.
+the metadata of both pt2 and ONNX checkpoints.  Only legacy Torch checkpoints
+may omit them: they contain the original module, whose ``torch.nn.LSTM``
+submodule is inspected directly, while ``torch.export`` flattens the network
+into a computation graph that no longer exposes it.
 
-:meth:`Actuator.is_graphable` returns ``True`` when all components can be
-captured in a CUDA graph.
+Differentiability and Graph Capture
+-----------------------------------
+
+Whether an actuator supports differentiability and CUDA graph capture depends on
+its controller.  :class:`ControllerPD` and :class:`ControllerPID` are fully
+graphable.  For neural-network controllers it depends on the checkpoint
+backend: ONNX checkpoints are graphable, while Torch checkpoints are not due
+to framework interop overhead.  :meth:`Actuator.is_graphable` returns ``True``
+when all components can be captured in a CUDA graph.
 
 Available Components
 --------------------

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -229,9 +229,9 @@ Additional optional dependency sets are defined in ``pyproject.toml``:
    * - ``examples``
      - Dependencies for running examples, including visualization and ONNX policy inference (includes ``sim`` + ``importers`` + ``onnx``)
    * - ``torch-cu12``
-     - PyTorch (CUDA 12.8+) for workflows that explicitly need PyTorch, such as training or running Torch ``.pt`` / ``.pth`` policies (includes ``examples``)
+     - PyTorch (CUDA 12.8+) for workflows that explicitly need PyTorch, such as training or running Torch ``.pt2`` / ``.pt`` / ``.pth`` policies (includes ``examples``)
    * - ``torch-cu13``
-     - PyTorch (CUDA 13) for workflows that explicitly need PyTorch, such as training or running Torch ``.pt`` / ``.pth`` policies (includes ``examples``)
+     - PyTorch (CUDA 13) for workflows that explicitly need PyTorch, such as training or running Torch ``.pt2`` / ``.pt`` / ``.pth`` policies (includes ``examples``)
    * - ``notebook``
      - Jupyter notebook support with Rerun visualization (includes ``examples``)
    * - ``dev``

--- a/newton/_src/actuators/controllers/controller_neural_lstm.py
+++ b/newton/_src/actuators/controllers/controller_neural_lstm.py
@@ -78,10 +78,10 @@ class ControllerNeuralLSTM(Controller):
     saved with ``torch.jit.save``) and module-bundle
     (``{"model": <network module>, "metadata": {...}}`` saved with
     ``torch.save``) formats. ``num_layers`` and ``hidden_size`` are taken from
-    checkpoint metadata when present, otherwise from a live ``lstm`` attribute
-    (``torch.nn.LSTM``). Exported pt2 modules no longer expose that attribute,
-    so their checkpoints must record ``num_layers`` and ``hidden_size`` in
-    metadata.
+    a live ``lstm`` attribute (``torch.nn.LSTM``) when the network exposes
+    one, otherwise from checkpoint metadata. Exported pt2 modules no longer
+    expose that attribute, so their checkpoints must record ``num_layers``
+    and ``hidden_size`` in metadata.
 
     ``.onnx`` checkpoints use Warp-NN. The exported ONNX model must have three
     inputs: input, initial hidden, and initial cell. It must have three graph
@@ -160,11 +160,8 @@ class ControllerNeuralLSTM(Controller):
             self.vel_scale = metadata.get("vel_scale", 1.0)
             self.effort_scale = metadata.get("effort_scale", metadata.get("torque_scale", 1.0))
 
-            if "num_layers" in metadata and "hidden_size" in metadata:
-                self._num_layers = metadata["num_layers"]
-                self._hidden_size = metadata["hidden_size"]
-            elif hasattr(self.network, "lstm") and hasattr(self.network.lstm, "num_layers"):
-                lstm = self.network.lstm
+            lstm = getattr(self.network, "lstm", None)
+            if lstm is not None and hasattr(lstm, "num_layers"):
                 if not lstm.batch_first:
                     raise ValueError("network.lstm.batch_first must be True")
                 if lstm.input_size != 2:
@@ -176,13 +173,21 @@ class ControllerNeuralLSTM(Controller):
 
                 self._num_layers = lstm.num_layers
                 self._hidden_size = lstm.hidden_size
+                for key, expected in (("num_layers", self._num_layers), ("hidden_size", self._hidden_size)):
+                    if key in metadata and int(metadata[key]) != expected:
+                        raise ValueError(
+                            f"Metadata '{key}' in '{model_path}' is {metadata[key]}, "
+                            f"but the network's LSTM has {key}={expected}"
+                        )
+            elif "num_layers" in metadata and "hidden_size" in metadata:
+                self._num_layers = int(metadata["num_layers"])
+                self._hidden_size = int(metadata["hidden_size"])
             else:
                 raise ValueError(
                     f"Cannot determine the LSTM configuration for '{model_path}': the checkpoint "
-                    f"does not expose an 'lstm' module (torch.nn.LSTM), so 'num_layers' and "
-                    f"'hidden_size' must be provided in the checkpoint metadata. Add them when "
-                    f"exporting, e.g. torch.export.save(exported, path, extra_files="
-                    f"{{'metadata.json': json.dumps({{'num_layers': 2, 'hidden_size': 8}})}})."
+                    f"does not expose an 'lstm' module (torch.nn.LSTM) and its metadata does not "
+                    f"provide 'num_layers' and 'hidden_size'. Record both in the checkpoint "
+                    f"metadata when exporting pt2 archives."
                 )
         else:
             self.pos_scale = _parse_metadata_scale(metadata, "pos_scale", model_path)

--- a/newton/_src/actuators/controllers/controller_neural_lstm.py
+++ b/newton/_src/actuators/controllers/controller_neural_lstm.py
@@ -72,11 +72,21 @@ class ControllerNeuralLSTM(Controller):
     error and velocity error. Hidden and cell state are maintained across
     timesteps.
 
-    ``.pt`` and ``.pth`` checkpoints use the Torch backend and preserve the
-    Torch state interface. ``.onnx`` checkpoints use Warp-NN. The exported ONNX
-    model must have three inputs: input, initial hidden, and initial cell. It
-    must have three graph outputs: effort, hidden output, and cell output.
-    Metadata properties map those names to controller roles.
+    Torch checkpoints use the Torch backend and preserve the Torch state
+    interface. They accept pt2 archives (``.pt2`` saved with
+    ``torch.export.save``; preferred) and the deprecated TorchScript (``.pt``
+    saved with ``torch.jit.save``) and module-bundle
+    (``{"model": <network module>, "metadata": {...}}`` saved with
+    ``torch.save``) formats. ``num_layers`` and ``hidden_size`` are taken from
+    checkpoint metadata when present, otherwise from a live ``lstm`` attribute
+    (``torch.nn.LSTM``). Exported pt2 modules no longer expose that attribute,
+    so their checkpoints must record ``num_layers`` and ``hidden_size`` in
+    metadata.
+
+    ``.onnx`` checkpoints use Warp-NN. The exported ONNX model must have three
+    inputs: input, initial hidden, and initial cell. It must have three graph
+    outputs: effort, hidden output, and cell output. Metadata properties map
+    those names to controller roles.
     """
 
     SHARED_PARAMS: ClassVar[set[str]] = {"model_path"}
@@ -129,7 +139,8 @@ class ControllerNeuralLSTM(Controller):
         """Initialize LSTM controller from a checkpoint file.
 
         Args:
-            model_path: Path to the ``.onnx``, ``.pt``, or ``.pth`` checkpoint.
+            model_path: Path to the ``.onnx``, ``.pt2``, ``.pt``, or ``.pth``
+                checkpoint.
         """
         self.model_path = model_path
 
@@ -149,22 +160,30 @@ class ControllerNeuralLSTM(Controller):
             self.vel_scale = metadata.get("vel_scale", 1.0)
             self.effort_scale = metadata.get("effort_scale", metadata.get("torque_scale", 1.0))
 
-            if not hasattr(self.network, "lstm"):
-                raise ValueError("network must expose a 'lstm' attribute (torch.nn.LSTM)")
-            lstm = self.network.lstm
-            if not hasattr(lstm, "num_layers"):
-                raise ValueError("network.lstm must be a torch.nn.LSTM (missing num_layers)")
-            if not lstm.batch_first:
-                raise ValueError("network.lstm.batch_first must be True")
-            if lstm.input_size != 2:
-                raise ValueError(f"network.lstm.input_size must be 2 (pos_error, vel_error); got {lstm.input_size}")
-            if lstm.bidirectional:
-                raise ValueError("network.lstm must not be bidirectional")
-            if getattr(lstm, "proj_size", 0) != 0:
-                raise ValueError(f"network.lstm.proj_size must be 0; got {lstm.proj_size}")
+            if "num_layers" in metadata and "hidden_size" in metadata:
+                self._num_layers = metadata["num_layers"]
+                self._hidden_size = metadata["hidden_size"]
+            elif hasattr(self.network, "lstm") and hasattr(self.network.lstm, "num_layers"):
+                lstm = self.network.lstm
+                if not lstm.batch_first:
+                    raise ValueError("network.lstm.batch_first must be True")
+                if lstm.input_size != 2:
+                    raise ValueError(f"network.lstm.input_size must be 2 (pos_error, vel_error); got {lstm.input_size}")
+                if lstm.bidirectional:
+                    raise ValueError("network.lstm must not be bidirectional")
+                if getattr(lstm, "proj_size", 0) != 0:
+                    raise ValueError(f"network.lstm.proj_size must be 0; got {lstm.proj_size}")
 
-            self._num_layers = lstm.num_layers
-            self._hidden_size = lstm.hidden_size
+                self._num_layers = lstm.num_layers
+                self._hidden_size = lstm.hidden_size
+            else:
+                raise ValueError(
+                    f"Cannot determine the LSTM configuration for '{model_path}': the checkpoint "
+                    f"does not expose an 'lstm' module (torch.nn.LSTM), so 'num_layers' and "
+                    f"'hidden_size' must be provided in the checkpoint metadata. Add them when "
+                    f"exporting, e.g. torch.export.save(exported, path, extra_files="
+                    f"{{'metadata.json': json.dumps({{'num_layers': 2, 'hidden_size': 8}})}})."
+                )
         else:
             self.pos_scale = _parse_metadata_scale(metadata, "pos_scale", model_path)
             self.vel_scale = _parse_metadata_scale(metadata, "vel_scale", model_path)

--- a/newton/_src/actuators/controllers/controller_neural_lstm.py
+++ b/newton/_src/actuators/controllers/controller_neural_lstm.py
@@ -77,16 +77,16 @@ class ControllerNeuralLSTM(Controller):
     ``torch.export.save``; preferred) and the deprecated TorchScript (``.pt``
     saved with ``torch.jit.save``) and module-bundle
     (``{"model": <network module>, "metadata": {...}}`` saved with
-    ``torch.save``) formats. ``num_layers`` and ``hidden_size`` are taken from
-    a live ``lstm`` attribute (``torch.nn.LSTM``) when the network exposes
-    one, otherwise from checkpoint metadata. Exported pt2 modules no longer
-    expose that attribute, so their checkpoints must record ``num_layers``
-    and ``hidden_size`` in metadata.
+    ``torch.save``) formats.
+
+    ``.pt2`` and ``.onnx`` checkpoints must record ``num_layers`` and
+    ``hidden_size`` in metadata; only legacy Torch checkpoints may omit them,
+    since their loaded networks expose a live ``lstm`` attribute to inspect.
 
     ``.onnx`` checkpoints use Warp-NN. The exported ONNX model must have three
-    inputs: input, initial hidden, and initial cell. It must have three graph
-    outputs: effort, hidden output, and cell output. Metadata properties map
-    those names to controller roles.
+    inputs (input, initial hidden, and initial cell) and three graph outputs
+    (effort, hidden output, and cell output). Metadata properties map those
+    names to controller roles.
     """
 
     SHARED_PARAMS: ClassVar[set[str]] = {"model_path"}

--- a/newton/_src/actuators/controllers/controller_neural_mlp.py
+++ b/newton/_src/actuators/controllers/controller_neural_mlp.py
@@ -125,7 +125,11 @@ class ControllerNeuralMLP(Controller):
     Configuration parameters (``input_order``, ``input_idx``,
     ``pos_scale``, ``vel_scale``, ``effort_scale``) are read from checkpoint
     metadata, falling back to defaults when absent. ``.onnx`` checkpoints run
-    through Warp-NN. ``.pt`` and ``.pth`` checkpoints keep the Torch backend.
+    through Warp-NN. Torch checkpoints keep the Torch backend and accept pt2
+    archives (``.pt2`` saved with ``torch.export.save``; preferred) and the
+    deprecated TorchScript (``.pt`` saved with ``torch.jit.save``) and
+    module-bundle (``{"model": <network module>, "metadata": {...}}`` saved
+    with ``torch.save``) formats.
     """
 
     SHARED_PARAMS: ClassVar[set[str]] = {"model_path"}
@@ -174,7 +178,8 @@ class ControllerNeuralMLP(Controller):
         """Initialize MLP controller from a checkpoint file.
 
         Args:
-            model_path: Path to the ``.onnx``, ``.pt``, or ``.pth`` checkpoint.
+            model_path: Path to the ``.onnx``, ``.pt2``, ``.pt``, or ``.pth``
+                checkpoint.
         """
         self.model_path = model_path
         self._is_torch_checkpoint = _looks_like_torch_checkpoint(model_path)

--- a/newton/_src/actuators/utils.py
+++ b/newton/_src/actuators/utils.py
@@ -15,14 +15,16 @@ import warp as wp
 _METADATA_FILE = "metadata.json"
 
 
-def _is_pt2_archive(path: str) -> bool:
+def _torch_archive_entries(path: str) -> set[str]:
+    """Zip entry names with the archive-name prefix PyTorch adds stripped.
+
+    Returns an empty set for non-zip files (e.g. legacy pickle checkpoints).
+    """
     try:
         with zipfile.ZipFile(path) as zf:
-            # PyTorch zip archives prefix entries with the archive name;
-            # compare the path below that prefix.
-            return any(name.split("/", 1)[-1] == "archive_format" for name in zf.namelist())
+            return {name.split("/", 1)[-1] for name in zf.namelist()}
     except (OSError, zipfile.BadZipFile):
-        return False
+        return set()
 
 
 def _require_onnx():
@@ -81,7 +83,7 @@ def load_checkpoint(
 ):
     """Load a neural-network checkpoint as ``(model, metadata)``.
 
-    Both ONNX (``.onnx``) and TorchScript / Torch (``.pt`` / ``.pth``)
+    Both ONNX (``.onnx``) and Torch (``.pt2`` / ``.pt`` / ``.pth``)
     checkpoints are accepted. ONNX checkpoints return a Warp-NN runtime;
     Torch checkpoints return the loaded Torch module.
 
@@ -99,7 +101,7 @@ def load_checkpoint(
         checkpoints or a Torch module for Torch checkpoints.
     """
     if _looks_like_torch_checkpoint(path):
-        return _load_torch_checkpoint(path, device=device)
+        return _load_torch_raw(path)
 
     metadata = load_metadata(path)
     OnnxRuntime = _require_warp_nn_runtime()
@@ -182,28 +184,36 @@ def _require_torch():
     return torch
 
 
-def _load_torch_raw(path: str) -> tuple[Any, dict[str, Any]]:
-    """Load a ``.pt`` / ``.pth`` checkpoint."""
-    torch = _require_torch()
+def _load_torch_raw(path: str, warn: bool = True) -> tuple[Any, dict[str, Any]]:
+    """Load a pt2 / TorchScript / dict checkpoint as ``(module, metadata)``.
 
-    if _is_pt2_archive(path):
+    TorchScript and dict modules are put in eval mode here; pt2 modules run
+    with the train/eval mode that was captured at export time.
+
+    ``warn`` controls the deprecation warnings for the legacy formats; its
+    ``stacklevel`` assumes the call chain controller ``__init__`` →
+    :func:`load_checkpoint` → here, so the warning points at the user's code.
+    """
+    torch = _require_torch()
+    entries = _torch_archive_entries(path)
+
+    if "archive_format" in entries:
         extra_files: dict[str, str] = {_METADATA_FILE: ""}
         exported = torch.export.load(path, extra_files=extra_files)
         metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
         return exported.module(), metadata
 
-    extra_files = {_METADATA_FILE: ""}
-    try:
+    if "constants.pkl" in entries:
+        # torch.jit.save always writes constants.pkl; torch.save archives don't.
+        extra_files = {_METADATA_FILE: ""}
         net = torch.jit.load(path, map_location="cpu", _extra_files=extra_files)
-    except Exception:
-        pass
-    else:
-        warnings.warn(
-            f"Loading TorchScript checkpoints (torch.jit.save) is deprecated; "
-            f"re-export '{path}' as a pt2 archive via torch.export.save().",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                f"Loading TorchScript checkpoints (torch.jit.save) is deprecated; "
+                f"re-export '{path}' as a pt2 archive via torch.export.save().",
+                DeprecationWarning,
+                stacklevel=4,
+            )
         metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
         net.eval()
         return net, metadata
@@ -212,14 +222,16 @@ def _load_torch_raw(path: str) -> tuple[Any, dict[str, Any]]:
     if isinstance(checkpoint, dict):
         if "model" not in checkpoint:
             raise ValueError(f"Cannot load checkpoint at '{path}'; dict checkpoint has no 'model' key")
-        warnings.warn(
-            f"Loading dict checkpoints (torch.save) is deprecated; "
-            f"re-export '{path}' as a pt2 archive via torch.export.save().",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+        if warn:
+            warnings.warn(
+                f"Loading dict checkpoints (torch.save) is deprecated; "
+                f"re-export '{path}' as a pt2 archive via torch.export.save().",
+                DeprecationWarning,
+                stacklevel=4,
+            )
         net = checkpoint["model"]
-        net.eval()
+        if hasattr(net, "eval"):
+            net.eval()
         return net, checkpoint.get("metadata", {})
 
     raise ValueError(
@@ -229,15 +241,21 @@ def _load_torch_raw(path: str) -> tuple[Any, dict[str, Any]]:
 
 
 def _load_torch_metadata(path: str) -> dict[str, Any]:
-    _, metadata = _load_torch_raw(path)
-    return metadata
+    """Read checkpoint metadata without deserializing the network when possible.
 
-
-def _load_torch_checkpoint(path: str, device: str | wp.Device | None = None):
-    """Load a pt2 / TorchScript / dict checkpoint as a Torch module.
-
-    The returned module is already in eval mode: :func:`_load_torch_raw`
-    exports pt2 archives in eval mode and calls ``eval()`` on the TorchScript
-    and dict variants.
+    pt2 and TorchScript archives store extra files as plain zip entries under
+    ``<archive_name>/extra/``, so metadata can be read directly. Dict
+    checkpoints keep their metadata inside the pickle and need a full load.
     """
-    return _load_torch_raw(path)
+    try:
+        with zipfile.ZipFile(path) as zf:
+            entries = {name.split("/", 1)[-1]: name for name in zf.namelist()}
+            metadata_entry = entries.get(f"extra/{_METADATA_FILE}")
+            if metadata_entry is not None:
+                return json.loads(zf.read(metadata_entry))
+            if "archive_format" in entries or "constants.pkl" in entries:
+                return {}
+    except (OSError, zipfile.BadZipFile):
+        pass
+    _, metadata = _load_torch_raw(path, warn=False)
+    return metadata

--- a/newton/_src/actuators/utils.py
+++ b/newton/_src/actuators/utils.py
@@ -6,9 +6,23 @@ from __future__ import annotations
 import json
 import math
 import os
+import warnings
+import zipfile
 from typing import Any
 
 import warp as wp
+
+_METADATA_FILE = "metadata.json"
+
+
+def _is_pt2_archive(path: str) -> bool:
+    try:
+        with zipfile.ZipFile(path) as zf:
+            # PyTorch zip archives prefix entries with the archive name;
+            # compare the path below that prefix.
+            return any(name.split("/", 1)[-1] == "archive_format" for name in zf.namelist())
+    except (OSError, zipfile.BadZipFile):
+        return False
 
 
 def _require_onnx():
@@ -36,7 +50,7 @@ def _require_warp_nn_runtime():
 
 
 def _looks_like_torch_checkpoint(path: str) -> bool:
-    return os.path.splitext(path)[1].lower() in (".pt", ".pth")
+    return os.path.splitext(path)[1].lower() in (".pt", ".pth", ".pt2")
 
 
 def load_metadata(path: str) -> dict[str, Any]:
@@ -172,22 +186,46 @@ def _load_torch_raw(path: str) -> tuple[Any, dict[str, Any]]:
     """Load a ``.pt`` / ``.pth`` checkpoint."""
     torch = _require_torch()
 
-    extra_files: dict[str, str] = {"metadata.json": ""}
+    if _is_pt2_archive(path):
+        extra_files: dict[str, str] = {_METADATA_FILE: ""}
+        exported = torch.export.load(path, extra_files=extra_files)
+        metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
+        return exported.module(), metadata
+
+    extra_files = {_METADATA_FILE: ""}
     try:
         net = torch.jit.load(path, map_location="cpu", _extra_files=extra_files)
-        meta = json.loads(extra_files["metadata.json"]) if extra_files["metadata.json"] else {}
-        return net, meta
     except Exception:
         pass
+    else:
+        warnings.warn(
+            f"Loading TorchScript checkpoints (torch.jit.save) is deprecated; "
+            f"re-export '{path}' as a pt2 archive via torch.export.save().",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
+        net.eval()
+        return net, metadata
 
     checkpoint = torch.load(path, map_location="cpu", weights_only=False)
     if isinstance(checkpoint, dict):
-        meta = checkpoint.get("metadata", {})
         if "model" not in checkpoint:
             raise ValueError(f"Cannot load checkpoint at '{path}'; dict checkpoint has no 'model' key")
-        return checkpoint["model"], meta
+        warnings.warn(
+            f"Loading dict checkpoints (torch.save) is deprecated; "
+            f"re-export '{path}' as a pt2 archive via torch.export.save().",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        net = checkpoint["model"]
+        net.eval()
+        return net, checkpoint.get("metadata", {})
 
-    raise ValueError(f"Cannot load checkpoint at '{path}'; expected a TorchScript archive or a dict with a 'model' key")
+    raise ValueError(
+        f"Cannot load checkpoint at '{path}'; expected a pt2 archive (torch.export.save), "
+        f"a TorchScript archive, or a dict with a 'model' key"
+    )
 
 
 def _load_torch_metadata(path: str) -> dict[str, Any]:
@@ -196,8 +234,10 @@ def _load_torch_metadata(path: str) -> dict[str, Any]:
 
 
 def _load_torch_checkpoint(path: str, device: str | wp.Device | None = None):
-    """Load a TorchScript / dict checkpoint as a Torch module."""
-    model, metadata = _load_torch_raw(path)
-    if hasattr(model, "eval"):
-        model = model.eval()
-    return model, metadata
+    """Load a pt2 / TorchScript / dict checkpoint as a Torch module.
+
+    The returned module is already in eval mode: :func:`_load_torch_raw`
+    exports pt2 archives in eval mode and calls ``eval()`` on the TorchScript
+    and dict variants.
+    """
+    return _load_torch_raw(path)

--- a/newton/_src/actuators/utils.py
+++ b/newton/_src/actuators/utils.py
@@ -212,7 +212,9 @@ def _load_torch_raw(path: str, warn: bool = True) -> tuple[Any, dict[str, Any]]:
     torch = _require_torch()
     entries = _torch_archive_entries(path)
 
-    if "archive_format" in entries:
+    if "archive_format" in entries or "serialized_exported_program.json" in entries:
+        # Torch <= 2.7 wrote export archives without the pt2 "archive_format"
+        # marker; torch.export.load still handles both layouts.
         extra_files: dict[str, str] = {_METADATA_FILE: ""}
         exported = torch.export.load(path, extra_files=extra_files)
         return exported.module(), _parse_metadata_json(extra_files[_METADATA_FILE], path)
@@ -258,16 +260,21 @@ def _load_torch_metadata(path: str) -> dict[str, Any]:
     """Read checkpoint metadata without deserializing the network when possible.
 
     pt2 and TorchScript archives store extra files as plain zip entries under
-    ``<archive_name>/extra/``, so metadata can be read directly. Dict
-    checkpoints keep their metadata inside the pickle and need a full load.
+    ``<archive_name>/extra/`` (``extra_files/`` for Torch <= 2.7 export
+    archives), so metadata can be read directly. Dict checkpoints keep their
+    metadata inside the pickle and need a full load.
     """
     try:
         with zipfile.ZipFile(path) as zf:
             entries = {name.split("/", 1)[-1]: name for name in zf.namelist()}
-            metadata_entry = entries.get(f"extra/{_METADATA_FILE}")
+            metadata_entry = entries.get(f"extra/{_METADATA_FILE}") or entries.get(_METADATA_FILE)
             if metadata_entry is not None:
                 return _parse_metadata_json(zf.read(metadata_entry), path)
-            if "archive_format" in entries or "constants.pkl" in entries:
+            if (
+                "archive_format" in entries
+                or "constants.pkl" in entries
+                or "serialized_exported_program.json" in entries
+            ):
                 return {}
     except (OSError, zipfile.BadZipFile):
         pass

--- a/newton/_src/actuators/utils.py
+++ b/newton/_src/actuators/utils.py
@@ -184,6 +184,21 @@ def _require_torch():
     return torch
 
 
+def _parse_metadata_json(text: str | bytes, path: str) -> dict[str, Any]:
+    """Parse a checkpoint's ``metadata.json`` payload, requiring a JSON object."""
+    if not text:
+        return {}
+    try:
+        metadata = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in checkpoint metadata for '{path}'") from exc
+    if not isinstance(metadata, dict):
+        raise ValueError(
+            f"Invalid checkpoint metadata for '{path}': expected a JSON object, got {type(metadata).__name__}"
+        )
+    return metadata
+
+
 def _load_torch_raw(path: str, warn: bool = True) -> tuple[Any, dict[str, Any]]:
     """Load a pt2 / TorchScript / dict checkpoint as ``(module, metadata)``.
 
@@ -200,8 +215,7 @@ def _load_torch_raw(path: str, warn: bool = True) -> tuple[Any, dict[str, Any]]:
     if "archive_format" in entries:
         extra_files: dict[str, str] = {_METADATA_FILE: ""}
         exported = torch.export.load(path, extra_files=extra_files)
-        metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
-        return exported.module(), metadata
+        return exported.module(), _parse_metadata_json(extra_files[_METADATA_FILE], path)
 
     if "constants.pkl" in entries:
         # torch.jit.save always writes constants.pkl; torch.save archives don't.
@@ -214,7 +228,7 @@ def _load_torch_raw(path: str, warn: bool = True) -> tuple[Any, dict[str, Any]]:
                 DeprecationWarning,
                 stacklevel=4,
             )
-        metadata = json.loads(extra_files[_METADATA_FILE]) if extra_files[_METADATA_FILE] else {}
+        metadata = _parse_metadata_json(extra_files[_METADATA_FILE], path)
         net.eval()
         return net, metadata
 
@@ -252,7 +266,7 @@ def _load_torch_metadata(path: str) -> dict[str, Any]:
             entries = {name.split("/", 1)[-1]: name for name in zf.namelist()}
             metadata_entry = entries.get(f"extra/{_METADATA_FILE}")
             if metadata_entry is not None:
-                return json.loads(zf.read(metadata_entry))
+                return _parse_metadata_json(zf.read(metadata_entry), path)
             if "archive_format" in entries or "constants.pkl" in entries:
                 return {}
     except (OSError, zipfile.BadZipFile):

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -47,6 +47,26 @@ _HAS_TORCH = importlib.util.find_spec("torch") is not None
 _HAS_WARP_NN = importlib.util.find_spec("warp_nn") is not None
 
 
+if _HAS_TORCH:
+    import torch as _torch
+
+    class _LSTMNet(_torch.nn.Module):
+        """Minimal LSTM network for exercising the Torch checkpoint path."""
+
+        def __init__(self, hidden: int = 8, layers: int = 1):
+            super().__init__()
+            self.lstm = _torch.nn.LSTM(2, hidden, layers, batch_first=True)
+            self.dec = _torch.nn.Linear(hidden, 1)
+
+        def forward(
+            self,
+            x: _torch.Tensor,
+            hc: tuple[_torch.Tensor, _torch.Tensor],
+        ) -> tuple[_torch.Tensor, tuple[_torch.Tensor, _torch.Tensor]]:
+            out, (h, c) = self.lstm(x, hc)
+            return self.dec(out[:, -1, :]), (h, c)
+
+
 def _onnx_modules():
     """Lazily import ONNX modules used by test model builders."""
     import onnx  # noqa: PLC0415
@@ -183,6 +203,11 @@ def _ignore_torchscript_deprecation(test_case):
     warnings.filterwarnings(
         "ignore",
         message=r".*torch\.jit\..* is deprecated",
+        category=DeprecationWarning,
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Loading (TorchScript|dict) checkpoints .* is deprecated",
         category=DeprecationWarning,
     )
 
@@ -525,6 +550,216 @@ class TestControllerNeuralLSTM(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "vel_scale.*invalid_lstm.onnx"):
             ControllerNeuralLSTM(model_path=path)
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class TestControllerNeuralMLPTorchFormats(unittest.TestCase):
+    """ControllerNeuralMLP loading from pt2, TorchScript, and dict checkpoints."""
+
+    def setUp(self):
+        import torch
+
+        self.device = wp.get_device()
+        if self.device.is_cuda and not torch.cuda.is_available():
+            self.skipTest("Torch not compiled with CUDA support")
+        self.torch = torch
+        _ignore_torchscript_deprecation(self)
+        self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
+        self._tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    def _make_mlp(self, bias=0.0):
+        net = self.torch.nn.Sequential(self.torch.nn.Linear(2, 1, bias=True)).to(self._torch_dev)
+        with self.torch.no_grad():
+            net[0].weight.fill_(0.0)
+            net[0].bias.fill_(bias)
+        return net
+
+    def _save_torchscript(self, net, filename="mlp.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        scripted = self.torch.jit.script(net)
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else {}
+        self.torch.jit.save(scripted, path, _extra_files=extra)
+        return path
+
+    def _save_dict(self, net, filename="mlp_dict.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        self.torch.save({"model": net, "metadata": metadata or {}}, path)
+        return path
+
+    def _save_pt2(self, net, filename="mlp.pt2", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        net.eval()
+        example = (self.torch.randn(2, 2, device=self._torch_dev),)
+        batch = self.torch.export.Dim("batch", min=1)
+        exported = self.torch.export.export(net, example, dynamic_shapes=({0: batch},))
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else None
+        self.torch.export.save(exported, path, extra_files=extra)
+        return path
+
+    def test_dict_checkpoint(self):
+        """Load MLP from a dict checkpoint with metadata."""
+        path = self._save_dict(self._make_mlp(bias=5.0), metadata={"effort_scale": 4.0})
+        ctrl = ControllerNeuralMLP(model_path=path)
+        self.assertAlmostEqual(ctrl.effort_scale, 4.0)
+
+    def test_pt2_checkpoint(self):
+        """Load MLP from a pt2 archive with metadata and run compute."""
+        path = self._save_pt2(self._make_mlp(bias=7.0), metadata={"effort_scale": 2.0})
+        n = 1
+        ctrl = ControllerNeuralMLP(model_path=path)
+        self.assertAlmostEqual(ctrl.effort_scale, 2.0)
+        ctrl.finalize(self.device, n)
+        state_a = ctrl.state(n, self.device)
+
+        indices = wp.array([0], dtype=wp.uint32, device=self.device)
+        forces = wp.zeros(n, dtype=wp.float32, device=self.device)
+        ctrl.compute(
+            wp.zeros(n, dtype=wp.float32, device=self.device),
+            wp.zeros(n, dtype=wp.float32, device=self.device),
+            wp.array([1.0], dtype=wp.float32, device=self.device),
+            wp.zeros(n, dtype=wp.float32, device=self.device),
+            None,
+            indices,
+            indices,
+            indices,
+            indices,
+            forces,
+            state_a,
+            0.01,
+            self.device,
+        )
+        self.assertAlmostEqual(forces.numpy()[0], 14.0, places=3, msg="bias=7 * effort_scale=2 -> 14")
+
+    def test_legacy_formats_warn(self):
+        """TorchScript and dict checkpoints emit a DeprecationWarning on load."""
+        ts_path = self._save_torchscript(self._make_mlp())
+        dict_path = self._save_dict(self._make_mlp())
+
+        with self.assertWarnsRegex(DeprecationWarning, "TorchScript checkpoints"):
+            ControllerNeuralMLP(model_path=ts_path)
+        with self.assertWarnsRegex(DeprecationWarning, "dict checkpoints"):
+            ControllerNeuralMLP(model_path=dict_path)
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class TestControllerNeuralLSTMTorchFormats(unittest.TestCase):
+    """ControllerNeuralLSTM loading from pt2, TorchScript, and dict checkpoints."""
+
+    def setUp(self):
+        import torch
+
+        self.device = wp.get_device()
+        if self.device.is_cuda and not torch.cuda.is_available():
+            self.skipTest("Torch not compiled with CUDA support")
+        self.torch = torch
+        _ignore_torchscript_deprecation(self)
+        self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
+        self._tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    def _make_lstm(self, hidden=8, layers=1):
+        return _LSTMNet(hidden=hidden, layers=layers).to(self._torch_dev)
+
+    def _save_torchscript(self, net, filename="lstm.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        scripted = self.torch.jit.script(net)
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else {}
+        self.torch.jit.save(scripted, path, _extra_files=extra)
+        return path
+
+    def _save_dict(self, net, filename="lstm_dict.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        self.torch.save({"model": net, "metadata": metadata or {}}, path)
+        return path
+
+    def _save_pt2(self, net, filename="lstm.pt2", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        net.eval()
+        layers, hidden = net.lstm.num_layers, net.lstm.hidden_size
+        n = 2
+        x = self.torch.randn(n, 1, 2, device=self._torch_dev)
+        h = self.torch.zeros(layers, n, hidden, device=self._torch_dev)
+        c = self.torch.zeros(layers, n, hidden, device=self._torch_dev)
+        batch = self.torch.export.Dim("batch", min=1)
+        dynamic_shapes = ({0: batch}, ({1: batch}, {1: batch}))
+        exported = self.torch.export.export(net, (x, (h, c)), dynamic_shapes=dynamic_shapes)
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else None
+        self.torch.export.save(exported, path, extra_files=extra)
+        return path
+
+    def _run_lstm_compute(self, ctrl):
+        n = 1
+        ctrl.finalize(self.device, n)
+
+        state_a = ctrl.state(n, self.device)
+        state_b = ctrl.state(n, self.device)
+        self.assertTrue(self.torch.all(state_a.hidden == 0.0).item())
+
+        indices = wp.array([0], dtype=wp.uint32, device=self.device)
+        positions = wp.zeros(n, dtype=wp.float32, device=self.device)
+        velocities = wp.array([1.0], dtype=wp.float32, device=self.device)
+        target_pos = wp.array([1.0], dtype=wp.float32, device=self.device)
+        target_vel = wp.zeros(n, dtype=wp.float32, device=self.device)
+        forces = wp.zeros(n, dtype=wp.float32, device=self.device)
+
+        ctrl.compute(
+            positions,
+            velocities,
+            target_pos,
+            target_vel,
+            None,
+            indices,
+            indices,
+            indices,
+            indices,
+            forces,
+            state_a,
+            0.01,
+            self.device,
+        )
+        ctrl.update_state(state_a, state_b)
+
+        self.assertNotAlmostEqual(forces.numpy()[0], 0.0, places=5, msg="LSTM should produce non-zero force")
+        self.assertFalse(self.torch.all(state_b.hidden == 0.0).item(), "hidden state should evolve")
+        return forces.numpy()[0]
+
+    def test_dict_checkpoint(self):
+        """Load LSTM from a dict checkpoint with metadata."""
+        path = self._save_dict(self._make_lstm(hidden=8, layers=1), metadata={"effort_scale": 5.0})
+        ctrl = ControllerNeuralLSTM(model_path=path)
+        self.assertAlmostEqual(ctrl.effort_scale, 5.0)
+        self._run_lstm_compute(ctrl)
+
+    def test_pt2_checkpoint(self):
+        """Load LSTM from a pt2 archive; layer config comes from metadata."""
+        metadata = {"effort_scale": 5.0, "num_layers": 2, "hidden_size": 8}
+        path = self._save_pt2(self._make_lstm(hidden=8, layers=2), metadata=metadata)
+        ctrl = ControllerNeuralLSTM(model_path=path)
+        self.assertAlmostEqual(ctrl.effort_scale, 5.0)
+        self.assertEqual(ctrl._num_layers, 2)
+        self.assertEqual(ctrl._hidden_size, 8)
+        self._run_lstm_compute(ctrl)
+
+    def test_pt2_without_config_metadata_raises(self):
+        """A pt2 checkpoint lacking num_layers/hidden_size fails with clear guidance."""
+        path = self._save_pt2(self._make_lstm(hidden=8, layers=2), metadata={"effort_scale": 5.0})
+        with self.assertRaisesRegex(ValueError, "num_layers.*hidden_size"):
+            ControllerNeuralLSTM(model_path=path)
+
+    def test_legacy_formats_warn(self):
+        """TorchScript and dict checkpoints emit a DeprecationWarning on load."""
+        ts_path = self._save_torchscript(self._make_lstm(hidden=8, layers=1))
+        dict_path = self._save_dict(self._make_lstm(hidden=8, layers=1))
+
+        with self.assertWarnsRegex(DeprecationWarning, "TorchScript checkpoints"):
+            ControllerNeuralLSTM(model_path=ts_path)
+        with self.assertWarnsRegex(DeprecationWarning, "dict checkpoints"):
+            ControllerNeuralLSTM(model_path=dict_path)
 
 
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")

--- a/newton/tests/test_actuators.py
+++ b/newton/tests/test_actuators.py
@@ -18,6 +18,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.actuators.utils import load_metadata
 from newton._src.utils.import_usd import parse_usd
 from newton.actuators import (
     Actuator,
@@ -53,9 +54,9 @@ if _HAS_TORCH:
     class _LSTMNet(_torch.nn.Module):
         """Minimal LSTM network for exercising the Torch checkpoint path."""
 
-        def __init__(self, hidden: int = 8, layers: int = 1):
+        def __init__(self, hidden: int = 8, layers: int = 1, bidirectional: bool = False):
             super().__init__()
-            self.lstm = _torch.nn.LSTM(2, hidden, layers, batch_first=True)
+            self.lstm = _torch.nn.LSTM(2, hidden, layers, batch_first=True, bidirectional=bidirectional)
             self.dec = _torch.nn.Linear(hidden, 1)
 
         def forward(
@@ -552,9 +553,8 @@ class TestControllerNeuralLSTM(unittest.TestCase):
             ControllerNeuralLSTM(model_path=path)
 
 
-@unittest.skipUnless(_HAS_TORCH, "torch not installed")
-class TestControllerNeuralMLPTorchFormats(unittest.TestCase):
-    """ControllerNeuralMLP loading from pt2, TorchScript, and dict checkpoints."""
+class _TorchCheckpointTestMixin:
+    """Shared helpers for saving pt2 / TorchScript / dict torch checkpoints."""
 
     def setUp(self):
         import torch
@@ -570,6 +570,31 @@ class TestControllerNeuralMLPTorchFormats(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self._tmp_dir, ignore_errors=True)
 
+    def _save_torchscript(self, net, filename="model.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        scripted = self.torch.jit.script(net)
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else {}
+        self.torch.jit.save(scripted, path, _extra_files=extra)
+        return path
+
+    def _save_dict(self, net, filename="model_dict.pt", metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        self.torch.save({"model": net, "metadata": metadata or {}}, path)
+        return path
+
+    def _export_pt2(self, net, example_inputs, dynamic_shapes, filename, metadata=None):
+        path = os.path.join(self._tmp_dir, filename)
+        net.eval()
+        exported = self.torch.export.export(net, example_inputs, dynamic_shapes=dynamic_shapes)
+        extra = {"metadata.json": json.dumps(metadata)} if metadata else None
+        self.torch.export.save(exported, path, extra_files=extra)
+        return path
+
+
+@unittest.skipUnless(_HAS_TORCH, "torch not installed")
+class TestControllerNeuralMLPTorchFormats(_TorchCheckpointTestMixin, unittest.TestCase):
+    """ControllerNeuralMLP loading from pt2, TorchScript, and dict checkpoints."""
+
     def _make_mlp(self, bias=0.0):
         net = self.torch.nn.Sequential(self.torch.nn.Linear(2, 1, bias=True)).to(self._torch_dev)
         with self.torch.no_grad():
@@ -577,27 +602,10 @@ class TestControllerNeuralMLPTorchFormats(unittest.TestCase):
             net[0].bias.fill_(bias)
         return net
 
-    def _save_torchscript(self, net, filename="mlp.pt", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        scripted = self.torch.jit.script(net)
-        extra = {"metadata.json": json.dumps(metadata)} if metadata else {}
-        self.torch.jit.save(scripted, path, _extra_files=extra)
-        return path
-
-    def _save_dict(self, net, filename="mlp_dict.pt", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        self.torch.save({"model": net, "metadata": metadata or {}}, path)
-        return path
-
     def _save_pt2(self, net, filename="mlp.pt2", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        net.eval()
         example = (self.torch.randn(2, 2, device=self._torch_dev),)
         batch = self.torch.export.Dim("batch", min=1)
-        exported = self.torch.export.export(net, example, dynamic_shapes=({0: batch},))
-        extra = {"metadata.json": json.dumps(metadata)} if metadata else None
-        self.torch.export.save(exported, path, extra_files=extra)
-        return path
+        return self._export_pt2(net, example, ({0: batch},), filename, metadata=metadata)
 
     def test_dict_checkpoint(self):
         """Load MLP from a dict checkpoint with metadata."""
@@ -643,43 +651,34 @@ class TestControllerNeuralMLPTorchFormats(unittest.TestCase):
         with self.assertWarnsRegex(DeprecationWarning, "dict checkpoints"):
             ControllerNeuralMLP(model_path=dict_path)
 
+    def test_deprecation_warning_points_at_caller(self):
+        """The legacy-format warning is attributed to the calling code, not newton internals."""
+        path = self._save_torchscript(self._make_mlp())
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ControllerNeuralMLP(model_path=path)
+        hits = [w for w in caught if "TorchScript checkpoints" in str(w.message)]
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].filename, __file__)
+
+    def test_load_metadata_reads_zip_entry_without_warning(self):
+        """Metadata-only reads do not deserialize the network or warn about legacy formats."""
+        path = self._save_torchscript(self._make_mlp(), metadata={"effort_scale": 3.0})
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            metadata = load_metadata(path)
+        self.assertEqual(metadata, {"effort_scale": 3.0})
+        self.assertFalse([w for w in caught if "checkpoints" in str(w.message)])
+
 
 @unittest.skipUnless(_HAS_TORCH, "torch not installed")
-class TestControllerNeuralLSTMTorchFormats(unittest.TestCase):
+class TestControllerNeuralLSTMTorchFormats(_TorchCheckpointTestMixin, unittest.TestCase):
     """ControllerNeuralLSTM loading from pt2, TorchScript, and dict checkpoints."""
 
-    def setUp(self):
-        import torch
-
-        self.device = wp.get_device()
-        if self.device.is_cuda and not torch.cuda.is_available():
-            self.skipTest("Torch not compiled with CUDA support")
-        self.torch = torch
-        _ignore_torchscript_deprecation(self)
-        self._torch_dev = torch.device(f"cuda:{self.device.ordinal}" if self.device.is_cuda else "cpu")
-        self._tmp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self._tmp_dir, ignore_errors=True)
-
-    def _make_lstm(self, hidden=8, layers=1):
-        return _LSTMNet(hidden=hidden, layers=layers).to(self._torch_dev)
-
-    def _save_torchscript(self, net, filename="lstm.pt", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        scripted = self.torch.jit.script(net)
-        extra = {"metadata.json": json.dumps(metadata)} if metadata else {}
-        self.torch.jit.save(scripted, path, _extra_files=extra)
-        return path
-
-    def _save_dict(self, net, filename="lstm_dict.pt", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        self.torch.save({"model": net, "metadata": metadata or {}}, path)
-        return path
+    def _make_lstm(self, hidden=8, layers=1, bidirectional=False):
+        return _LSTMNet(hidden=hidden, layers=layers, bidirectional=bidirectional).to(self._torch_dev)
 
     def _save_pt2(self, net, filename="lstm.pt2", metadata=None):
-        path = os.path.join(self._tmp_dir, filename)
-        net.eval()
         layers, hidden = net.lstm.num_layers, net.lstm.hidden_size
         n = 2
         x = self.torch.randn(n, 1, 2, device=self._torch_dev)
@@ -687,10 +686,7 @@ class TestControllerNeuralLSTMTorchFormats(unittest.TestCase):
         c = self.torch.zeros(layers, n, hidden, device=self._torch_dev)
         batch = self.torch.export.Dim("batch", min=1)
         dynamic_shapes = ({0: batch}, ({1: batch}, {1: batch}))
-        exported = self.torch.export.export(net, (x, (h, c)), dynamic_shapes=dynamic_shapes)
-        extra = {"metadata.json": json.dumps(metadata)} if metadata else None
-        self.torch.export.save(exported, path, extra_files=extra)
-        return path
+        return self._export_pt2(net, (x, (h, c)), dynamic_shapes, filename, metadata=metadata)
 
     def _run_lstm_compute(self, ctrl):
         n = 1
@@ -749,6 +745,29 @@ class TestControllerNeuralLSTMTorchFormats(unittest.TestCase):
         """A pt2 checkpoint lacking num_layers/hidden_size fails with clear guidance."""
         path = self._save_pt2(self._make_lstm(hidden=8, layers=2), metadata={"effort_scale": 5.0})
         with self.assertRaisesRegex(ValueError, "num_layers.*hidden_size"):
+            ControllerNeuralLSTM(model_path=path)
+
+    def test_pt2_metadata_config_coerced_to_int(self):
+        """JSON floats for num_layers/hidden_size are coerced to int."""
+        metadata = {"num_layers": 2.0, "hidden_size": 8.0}
+        path = self._save_pt2(self._make_lstm(hidden=8, layers=2), metadata=metadata)
+        ctrl = ControllerNeuralLSTM(model_path=path)
+        self.assertIsInstance(ctrl._num_layers, int)
+        self.assertIsInstance(ctrl._hidden_size, int)
+        self.assertEqual(ctrl._num_layers, 2)
+        self.assertEqual(ctrl._hidden_size, 8)
+
+    def test_metadata_config_mismatch_raises(self):
+        """Metadata that contradicts the network's actual LSTM fails at load."""
+        path = self._save_dict(self._make_lstm(hidden=8, layers=1), metadata={"num_layers": 2, "hidden_size": 8})
+        with self.assertRaisesRegex(ValueError, "num_layers"):
+            ControllerNeuralLSTM(model_path=path)
+
+    def test_invalid_lstm_not_masked_by_config_metadata(self):
+        """Structural validation still runs when metadata provides the LSTM config."""
+        net = self._make_lstm(hidden=8, layers=1, bidirectional=True)
+        path = self._save_dict(net, metadata={"num_layers": 1, "hidden_size": 8})
+        with self.assertRaisesRegex(ValueError, "bidirectional"):
             ControllerNeuralLSTM(model_path=path)
 
     def test_legacy_formats_warn(self):


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `.pt2` (Torch export) neural-controller checkpoint archives, including reading accompanying `metadata.json` from archive contents.
* **Bug Fixes**
  * Improved checkpoint detection/loading across `.pt2`, TorchScript, and legacy dict formats with reliable metadata-only extraction and consistent evaluation behavior.
  * Neural LSTM now derives/validates `num_layers`/`hidden_size` from exported metadata (with type coercion and clearer validation errors).
* **Documentation**
  * Updated checkpoint and graphability guidance; clarified `.pt2` metadata requirements and backend behavior.  
  * Updated installation guide formatting.
* **Tests**
  * Expanded coverage for `.pt2` metadata, validation rules, and expected deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->