### PR TITLE
Restart macOS test workers per suite to bound memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           uv run --extra dev -m newton.tests
           --strict-warnings
           --parallel-timeout ${{ matrix.os == 'macos-latest' && 6900 || 3300 }}
+          ${{ matrix.os == 'macos-latest' && '--disable-process-pooling' || '' }}
           --no-cache-clear
           --junit-report-xml rspec.xml
           --coverage


### PR DESCRIPTION
## Description

Disable test-worker process pooling on the macOS CI job only, so workers restart per test suite with bounded memory.

Timeline analysis of the unittest jobs (per-test completion timestamps from the job logs, macOS vs ubuntu on the same commit) showed the macOS job running *faster* than ubuntu for the first ~70% of the suite, then collapsing: the last 30% of tests took ~65 minutes on macOS vs ~10 on ubuntu, with trivial pure-Python test modules stretched just as much as solver-heavy ones — the environment degrades, not specific tests. The macOS runners have 3 cores/7 GB RAM (ubuntu: 4 cores/16 GB), and the three pooled worker processes accumulate loaded Warp modules and test state across ~170 suites each, so the degradation points at memory pressure. This also explains why #3354 cut ~30% on every platform except macOS, and why the macOS job grew disproportionately as the suite grew: shorter suites used to finish before the degradation set in.

`--disable-process-pooling` already exists in the test runner (`max_tasks_per_child=1`) and bounds worker memory at a small respawn/reimport cost.

Measured on this PR's CI run vs the same suite this morning (post-#3354, pooled): the macOS job went from 84 to 24 minutes with the same test count and coverage. The mid-run collapse is gone — progress reaches 70% at the same time in both runs (~16 min), but the last 30% now takes 6 minutes instead of 65. The respawn overhead is visible only as a ~1.2× slower early phase. macOS is no longer the slowest job in the matrix.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

CI-only change: no tests, docs, or CHANGELOG entry apply.

## Test plan

Compared the `newton-unittests (macos-latest)` job on this PR's CI run against the run of the same suite on main from earlier today: identical test count (3345) and coverage (68.76%), job wall time 84m → 24m, and the per-test completion timeline in the job log shows sustained throughput with no mid-run collapse.