### PR TITLE
Fix flaky nut-bolt hydro rotation threshold

### DIFF
--- a/newton/examples/contacts/example_nut_bolt_hydro.py
+++ b/newton/examples/contacts/example_nut_bolt_hydro.py
@@ -432,9 +432,9 @@ class Example:
                 f"Displacement={displacement:.4f} (max allowed={max_bolt_displacement:.4f})"
             )
 
-        # The 60 degree threshold catches stalled thread engagement while
-        # tolerating small solver/contact-count variation.
-        min_rotation_threshold = np.radians(60.0)
+        # The 45 degree threshold catches stalled thread engagement while
+        # allowing observed solver/contact-count variation.
+        min_rotation_threshold = np.radians(45.0)
         min_descent = 0.005
         for i in range(len(self.nut_body_indices)):
             # Check rotation occurred


### PR DESCRIPTION
## Summary

Fixes #3267 by lowering the nut-bolt hydro example minimum rotation threshold from 60 degrees to 45 degrees.

The previous threshold occasionally rejected healthy simulations because of solver/contact-count variation. The new threshold continues to detect stalled thread engagement while providing sufficient margin for observed healthy runs.

The independent validation checks remain unchanged:

- Nut descent must exceed 5 mm.
- Bolt displacement must remain below 2 cm.

## Validation

- Targeted CUDA test passed:

  ```bash
  uv run --extra dev -m newton.tests \
    -k test_contacts.example_nut_bolt_hydro_cuda_0
  ```

- File-scoped pre-commit checks passed:

  ```bash
  uvx pre-commit run --files \
    newton/examples/contacts/example_nut_bolt_hydro.py
  ```

- Ran 200 simulations in 10 batches of 20 fresh processes:

  - Minimum rotation: 57.32 degrees
  - Mean rotation: 118.22 degrees
  - Maximum rotation: 171.76 degrees
  - Failures at or below 45 degrees: 0/200
  - Runs that would fail the previous 60-degree threshold: 1/200
  - Nut-descent failures: 0/200
  - Bolt-displacement failures: 0/200
  - Maximum bolt displacement: 10.02 mm

This reproduces the residual variability behind #3267 while confirming that 45 degrees accepts healthy runs without weakening the independent descent and displacement checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed the nut-rotation validation threshold in the contact example, making the simulation check less strict while preserving the same movement and displacement verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->