### PR TITLE
Fix batched static MuJoCo geometry poses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix `SolverMuJoCo` convergence tolerance scaling for models with kinematic bodies.
 - Fix `SolverMuJoCo` inertia randomization for bodies initialized with diagonal inertia.
+- Fix `SolverMuJoCo` static worldbody geometry poses so offset batched worlds collide with their local geometry.
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2496,6 +2496,31 @@ def update_geom_properties_kernel(
 
 
 @wp.kernel
+def sync_static_geom_xposes_kernel(
+    body_rootid: wp.array[int],
+    body_weldid: wp.array[int],
+    body_mocapid: wp.array[int],
+    geom_bodyid: wp.array[int],
+    geom_pos: wp.array2d[wp.vec3],
+    geom_quat: wp.array2d[wp.quat],
+    xpos: wp.array2d[wp.vec3],
+    xquat: wp.array2d[wp.quat],
+    geom_xpos: wp.array2d[wp.vec3],
+    geom_xmat: wp.array2d[wp.mat33],
+):
+    """Refresh per-world poses for geoms welded to the world body."""
+    world, geom = wp.tid()
+    body = geom_bodyid[geom]
+    if body_weldid[body] != 0 or body_mocapid[body_rootid[body]] != -1:
+        return
+
+    body_q = quat_wxyz_to_xyzw(xquat[world, body])
+    geom_q = quat_wxyz_to_xyzw(geom_quat[world, geom])
+    geom_xpos[world, geom] = xpos[world, body] + wp.quat_rotate(body_q, geom_pos[world, geom])
+    geom_xmat[world, geom] = wp.quat_to_matrix(body_q * geom_q)
+
+
+@wp.kernel
 def update_jnt_solref_from_invweight0_kernel(
     mjc_jnt_to_newton_dof: wp.array2d[wp.int32],
     joint_limit_ke: wp.array[float],

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2496,28 +2496,21 @@ def update_geom_properties_kernel(
 
 
 @wp.kernel
-def sync_static_geom_xposes_kernel(
-    body_rootid: wp.array[int],
-    body_weldid: wp.array[int],
-    body_mocapid: wp.array[int],
+def sync_worldbody_geom_xposes_kernel(
     geom_bodyid: wp.array[int],
     geom_pos: wp.array2d[wp.vec3],
     geom_quat: wp.array2d[wp.quat],
-    xpos: wp.array2d[wp.vec3],
-    xquat: wp.array2d[wp.quat],
     geom_xpos: wp.array2d[wp.vec3],
     geom_xmat: wp.array2d[wp.mat33],
 ):
-    """Refresh per-world poses for geoms welded to the world body."""
+    """Refresh per-world poses for geoms attached directly to the world body."""
     world, geom = wp.tid()
-    body = geom_bodyid[geom]
-    if body_weldid[body] != 0 or body_mocapid[body_rootid[body]] != -1:
+    if geom_bodyid[geom] != 0:
         return
 
-    body_q = quat_wxyz_to_xyzw(xquat[world, body])
     geom_q = quat_wxyz_to_xyzw(geom_quat[world, geom])
-    geom_xpos[world, geom] = xpos[world, body] + wp.quat_rotate(body_q, geom_pos[world, geom])
-    geom_xmat[world, geom] = wp.quat_to_matrix(body_q * geom_q)
+    geom_xpos[world, geom] = geom_pos[world, geom]
+    geom_xmat[world, geom] = wp.quat_to_matrix(geom_q)
 
 
 @wp.kernel

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -74,6 +74,7 @@ from .kernels import (
     reset_joint_state_kernel,
     reset_world_buffers_kernel,
     sync_qpos0_kernel,
+    sync_static_geom_xposes_kernel,
     update_axis_properties_kernel,
     update_body_inertia_kernel,
     update_body_mass_ipos_kernel,
@@ -4072,6 +4073,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         update_connect_constraint_anchors,
                     )
 
+            if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.SHAPE_PROPERTIES):
+                self._sync_static_geom_xposes()
+
     def _sync_equality_properties_to_mujoco_cpu(self) -> None:
         """Mirror equality properties from MJWarp buffers to MuJoCo-C CPU buffers."""
         if self.mj_model.neq == 0:
@@ -4081,6 +4085,36 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_model.eq_solref[:] = self.mjw_model.eq_solref.numpy()[0]
         self.mj_model.eq_solimp[:] = self.mjw_model.eq_solimp.numpy()[0]
         self.mj_data.eq_active[:] = self.mjw_data.eq_active.numpy()[0]
+
+    def _sync_static_geom_xposes(self) -> None:
+        """Refresh derived poses that MJWarp leaves fixed after data creation.
+
+        MJWarp initializes world-welded geoms from the single CPU template and
+        skips them during forward kinematics. Newton's batched model can carry
+        distinct per-world transforms, so refresh the corresponding data after
+        model geometry or fixed-body transforms change.
+        """
+        if self.mj_model.ngeom == 0:
+            return
+        wp.launch(
+            sync_static_geom_xposes_kernel,
+            dim=(self.mjw_data.nworld, self.mj_model.ngeom),
+            inputs=[
+                self.mjw_model.body_rootid,
+                self.mjw_model.body_weldid,
+                self.mjw_model.body_mocapid,
+                self.mjw_model.geom_bodyid,
+                self.mjw_model.geom_pos,
+                self.mjw_model.geom_quat,
+                self.mjw_data.xpos,
+                self.mjw_data.xquat,
+            ],
+            outputs=[
+                self.mjw_data.geom_xpos,
+                self.mjw_data.geom_xmat,
+            ],
+            device=self.model.device,
+        )
 
     def _create_inverse_shape_mapping(self):
         """

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -74,7 +74,7 @@ from .kernels import (
     reset_joint_state_kernel,
     reset_world_buffers_kernel,
     sync_qpos0_kernel,
-    sync_static_geom_xposes_kernel,
+    sync_worldbody_geom_xposes_kernel,
     update_axis_properties_kernel,
     update_body_inertia_kernel,
     update_body_mass_ipos_kernel,
@@ -4073,8 +4073,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         update_connect_constraint_anchors,
                     )
 
-            if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.SHAPE_PROPERTIES):
-                self._sync_static_geom_xposes()
+            if flags & ModelFlags.SHAPE_PROPERTIES:
+                self._sync_worldbody_geom_xposes()
 
     def _sync_equality_properties_to_mujoco_cpu(self) -> None:
         """Mirror equality properties from MJWarp buffers to MuJoCo-C CPU buffers."""
@@ -4086,28 +4086,23 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_model.eq_solimp[:] = self.mjw_model.eq_solimp.numpy()[0]
         self.mj_data.eq_active[:] = self.mjw_data.eq_active.numpy()[0]
 
-    def _sync_static_geom_xposes(self) -> None:
+    def _sync_worldbody_geom_xposes(self) -> None:
         """Refresh derived poses that MJWarp leaves fixed after data creation.
 
-        MJWarp initializes world-welded geoms from the single CPU template and
-        skips them during forward kinematics. Newton's batched model can carry
-        distinct per-world transforms, so refresh the corresponding data after
-        model geometry or fixed-body transforms change.
+        MJWarp initializes direct worldbody geoms from the single CPU template
+        and skips them during forward kinematics. Newton's batched model can
+        carry distinct per-world geometry transforms, so copy them to the
+        corresponding derived data after shape properties change.
         """
         if self.mj_model.ngeom == 0:
             return
         wp.launch(
-            sync_static_geom_xposes_kernel,
+            sync_worldbody_geom_xposes_kernel,
             dim=(self.mjw_data.nworld, self.mj_model.ngeom),
             inputs=[
-                self.mjw_model.body_rootid,
-                self.mjw_model.body_weldid,
-                self.mjw_model.body_mocapid,
                 self.mjw_model.geom_bodyid,
                 self.mjw_model.geom_pos,
                 self.mjw_model.geom_quat,
-                self.mjw_data.xpos,
-                self.mjw_data.xquat,
             ],
             outputs=[
                 self.mjw_data.geom_xpos,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -5918,6 +5918,82 @@ class TestMuJoCoConversion(unittest.TestCase):
         expected_radii = [0.1, 0.1, 0.05, 0.05]
         np.testing.assert_allclose(radii, expected_radii, atol=1e-3)
 
+    def test_static_worldbody_geoms_support_offset_worlds(self):
+        """Offset worlds collide with their own finite static worldbody geometry."""
+        world = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(world)
+        world.default_shape_cfg.ke = 1.0e5
+        world.default_shape_cfg.kd = 1.0e3
+        world.add_shape_box(
+            body=-1,
+            xform=wp.transform(wp.vec3(0.0, 0.0, -0.1), wp.quat_identity()),
+            hx=1.0,
+            hy=1.0,
+            hz=0.1,
+        )
+        body = world.add_link(
+            xform=wp.transform(wp.vec3(0.0, 0.0, 0.1), wp.quat_identity()),
+            mass=1.0,
+            inertia=wp.mat33(np.eye(3)),
+        )
+        joint = world.add_joint_free(child=body)
+        world.add_articulation([joint])
+        world.add_shape_box(body=body, hx=0.1, hy=0.1, hz=0.1)
+
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_world(world, xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()))
+        builder.add_world(
+            world,
+            xform=wp.transform(
+                wp.vec3(4.0, 0.0, 0.0),
+                wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.5),
+            ),
+        )
+        model = builder.finalize()
+
+        solver = SolverMuJoCo(
+            model,
+            separate_worlds=True,
+            use_mujoco_contacts=True,
+            integrator="implicitfast",
+            iterations=10,
+            nconmax=100,
+            njmax=200,
+        )
+
+        np.testing.assert_allclose(
+            solver.mjw_data.geom_xpos.numpy()[:, 0],
+            solver.mjw_model.geom_pos.numpy()[:, 0],
+            atol=1.0e-6,
+            rtol=0.0,
+        )
+        geom_quat_wxyz = solver.mjw_model.geom_quat.numpy()[:, 0]
+        expected_xmat = np.stack(
+            [np.asarray(wp.quat_to_matrix(wp.quat(q[1], q[2], q[3], q[0]))).reshape(3, 3) for q in geom_quat_wxyz]
+        )
+        np.testing.assert_allclose(solver.mjw_data.geom_xmat.numpy()[:, 0], expected_xmat, atol=1.0e-6, rtol=0.0)
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = model.contacts()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+        dt = 0.005
+        for _ in range(200):
+            state_0.clear_forces()
+            solver.step(state_0, state_1, control, contacts, dt)
+            state_0, state_1 = state_1, state_0
+
+        np.testing.assert_allclose(
+            state_0.body_q.numpy()[:, 2],
+            np.full(2, 0.1, dtype=np.float32),
+            atol=2.0e-3,
+            rtol=0.0,
+            err_msg="Every offset world must keep its free box supported by its local static table.",
+        )
+
     def test_mesh_geoms_across_worlds(self):
         """Test that mesh geoms work correctly across different worlds in MuJoCo solver."""
         # Create a simple model with 2 worlds, each containing a mesh


### PR DESCRIPTION
## Description

  Refresh MJWarp-derived poses for geometry attached directly to the world body after Newton applies per-world
  model transforms.

  Previously, finite static world-body colliders retained the first world’s derived pose in translated or rotated
  worlds. This could cause dynamic bodies in cloned environments to miss their local colliders and fall through.

  The fix updates `geom_xpos` and `geom_xmat` for static, non-mocap geometry after relevant model properties are
  synchronized. The regression specifically covers geometry attached directly to the world body (`body=-1`). No
  public API changes or new dependencies are introduced.

  ## Checklist

  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [x] `CHANGELOG.md` has been updated

  No documentation changes are required because this fixes internal derived-state synchronization without changing
  the public API.

  ## Test plan

  The regression test was run with and without the fix:

  - Without the fix, it fails because the second world’s derived static geometry position remains at `x=0` instead
  of using its `x=4` world offset.
  - With the fix, it passes and both dynamic boxes remain supported by their respective static colliders.

  ```bash
  uv run --extra dev -m newton.tests \
    -k test_static_worldbody_geoms_support_offset_worlds

  uvx pre-commit run -a
```
  ## Bug fix

  Steps to reproduce:

  1. Create a Newton world containing a finite static collider attached directly to the world body.
  2. Clone it into two MJWarp worlds.
  3. Apply a translation and rotation to the second world.
  4. Initialize SolverMuJoCo with separate_worlds=True.
  5. Observe that, without the fix, the second collider’s geom_xpos remains at the first world’s position.
  6. Simulate dynamic boxes above both colliders and observe the second box falling through.

  Minimal reproduction:
```bash
  import numpy as np
  import warp as wp

  import newton
  from newton.solvers import SolverMuJoCo


  world = newton.ModelBuilder()
  SolverMuJoCo.register_custom_attributes(world)

  world.add_shape_box(
      body=-1,
      xform=wp.transform(wp.vec3(0.0, 0.0, -0.1), wp.quat_identity()),
      hx=1.0,
      hy=1.0,
      hz=0.1,
  )

  body = world.add_link(
      xform=wp.transform(wp.vec3(0.0, 0.0, 0.1), wp.quat_identity()),
      mass=1.0,
      inertia=wp.mat33(np.eye(3)),
  )
  joint = world.add_joint_free(child=body)
  world.add_articulation([joint])
  world.add_shape_box(body=body, hx=0.1, hy=0.1, hz=0.1)

  builder = newton.ModelBuilder()
  SolverMuJoCo.register_custom_attributes(builder)

  builder.add_world(world)
  builder.add_world(
      world,
      xform=wp.transform(
          wp.vec3(4.0, 0.0, 0.0),
          wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.5),
      ),
  )

  model = builder.finalize()
  solver = SolverMuJoCo(
      model,
      separate_worlds=True,
      use_mujoco_contacts=True,
  )

  print("Configured positions:")
  print(solver.mjw_model.geom_pos.numpy()[:, 0])

  print("Derived positions:")
  print(solver.mjw_data.geom_xpos.numpy()[:, 0])
```
  Before the fix, the second configured position has x=4, while its derived position incorrectly has x=0. After the
  fix, the configured and derived positions agree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collision handling for static world-body geometry in offset multi-world simulations.
  * Improved consistency of geometry pose data after shape-property updates so each world uses its own correct transforms.
  * Addressed a regression where supported bodies could behave incorrectly in replicated worlds with offsets/rotations.

* **Tests**
  * Added a regression test covering offset worlds with static world-body geometry to verify correct contact behavior over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->