### PR TITLE
Fix flakiness of proxy joint example (#3348)

### DIFF
--- a/newton/examples/multiphysics/example_proxy_joint_gripper.py
+++ b/newton/examples/multiphysics/example_proxy_joint_gripper.py
@@ -335,7 +335,7 @@ class Example:
             default="default",
             help="Scene configuration to run.",
         )
-        parser.add_argument("--substeps", type=int, default=4, help="Simulation substeps per rendered frame.")
+        parser.add_argument("--substeps", type=int, default=5, help="Simulation substeps per rendered frame.")
         newton.examples.add_coupled_view_args(parser)
         parser.add_argument("--vbd-iterations", type=int, default=8, help="VBD iterations per substep.")
         parser.add_argument("--mujoco-iterations", type=int, default=60, help="MuJoCo solver iterations.")


### PR DESCRIPTION
   ## Stabilize proxy joint gripper with smaller timestep (#3348)
  
  Increase the example’s default substeps from four to five, reducing the simulation timestep from 1/240 s to 1/300 s.

  Repeated testing showed that the original failure was an unstable contact trajectory rather than an overly strict drift tolerance. With four substeps, Ampere
  produced up to 0.13995 m of drift, placing the object outside the gripper. Increasing the tolerance would mask that invalid state. Proxy mass scaling, feedback
  relaxation, and deterministic contact options either failed to remove the instability or introduced joint-limit failures.

  Five substeps preserved the existing validation criteria and passed:

  - 60 instrumented runs across Blackwell and Ampere, with maximum drift 0.000299 m.
  - The exact 20-run regression loop on each GPU using the new default.

  This adds approximately 25% more solver work per frame while leaving the physical parameters and test tolerance unchanged.

  Changed newton/examples/multiphysics/example_proxy_joint_gripper.py:338.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default simulation substeps per rendered frame, which may improve stability and consistency in the gripper example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->