### PR TITLE
Update code to adapt to free joint fixes in newton

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -1132,7 +1132,22 @@ class ModelBuilderKamino:
                 joints_F_r_Fj.append(joint.F_r_Fj)
                 joints_X_Bj.append(joint.X_Bj)
                 joints_X_Fj.append(joint.X_Fj)
-                joints_q_j_0.extend(joint.dof_type.reference_coords)
+                if joint.dof_type == JointDoFType.FREE:
+                    # For free joints, the frame of the joint on the base and follower body might not
+                    # coincide on the initial pose (this allows e.g. joint_q to directly represent the
+                    # follower body pose for a unary free joint with the base frame at the origin).
+                    # We therefore deduce here the initial joint_q
+                    q_B = wp.transform_identity() if joint.bid_B < 0 else self.bodies[joint.wid][joint.bid_B].q_i_0
+                    q_F = self.bodies[joint.wid][joint.bid_F].q_i_0
+                    quat_X_B = wp.quat_from_matrix(joint.X_Bj)
+                    quat_X_F = wp.quat_from_matrix(joint.X_Fj) if joint.X_Fj is not None else quat_X_B
+                    T_B = wp.transformf(joint.B_r_Bj, quat_X_B)
+                    T_F = wp.transformf(joint.F_r_Fj, quat_X_F)
+                    q_j_0 = wp.transform_inverse(q_B * T_B) * q_F * T_F
+                    wp.transform_set_rotation(q_j_0, wp.normalize(wp.transform_get_rotation(q_j_0)))
+                    joints_q_j_0.extend(list(q_j_0))
+                else:
+                    joints_q_j_0.extend(joint.dof_type.reference_coords)
                 joints_dq_j_0.extend(joint.dof_type.num_dofs * [0.0])
                 joints_q_j_min.extend(joint.q_j_min)
                 joints_q_j_max.extend(joint.q_j_max)

--- a/newton/_src/solvers/kamino/_src/models/builders/basics.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/basics.py
@@ -22,7 +22,7 @@ from ......core.types import Axis
 from ...core import ModelBuilderKamino, inertia
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.math import FLOAT32_MAX, FLOAT32_MIN, I_3, axis_to_mat33
-from ...core.shapes import BoxShape, SphereShape
+from ...core.shapes import BoxShape, PlaneShape, SphereShape
 
 ###
 # Module interface
@@ -859,6 +859,7 @@ def build_boxes_fourbar(
     new_world: bool = True,
     world_index: int = 0,
     actuator_ids: list[int] | None = None,
+    use_plane_shape: bool = False,
 ) -> ModelBuilderKamino:
     """
     Constructs a basic model of a four-bar linkage.
@@ -866,20 +867,33 @@ def build_boxes_fourbar(
     Args:
         builder: An optional existing model builder to populate.
             If `None`, a new builder is created.
-        z_offset: A vertical offset to apply to the initial position of the box.
+        z_offset: A vertical offset to apply to the initial position of the first box.
+        fixedbase: Whether to add a fixed joint between the first box and the world.
+        floatingbase: Whether to add a free joint between the first box and the world.
+        limits: Whether to set finite position limits to revolute joints.
         ground: Whether to add a static ground plane to the model.
+        dynamic_joints: Whether to set non-trivial armature and damping to the first revolute joint.
+        implicit_pd: Whether to set non-trivial implicit PD gains to the first revolute joint.
+        verbose: Whether to print debug information such as body/joint positions.
         new_world: Whether to create a new world in the builder for this model.
             If `False`, the model is added to the existing world specified by `world_index`.
             If `True`, a new world is created and added to the builder. In this case the `world_index`
             argument is ignored, and the index of the newly created world will be used instead.
         world_index: The index of the world to which the model should be added if `new_world` is False.
-            If `new_world` is True, this argument is ignored.
+            If `new_world` is `True`, this argument is ignored.
             If the value does not correspond to an existing world, an error will be raised.
             Defaults to `0`.
+        actuator_ids: List of revolute joint indices in [1, 2, 3, 4] to make into actuators.
+            If not provided, defaults to [1, 3]
+        use_plane_shape: If `True`, and `ground` is `True`, will use a plane shape for the ground instead
+            of a wide and thin box. Note that planes are not supported in the primitive collision pipeline.
 
     Returns:
         A model builder containing the four-bar linkage.
     """
+    if fixedbase and floatingbase:
+        raise ValueError("At most one of fixedbase or floatingbase can be enabled.")
+
     # Create a new builder if none is provided
     if builder is None:
         _builder = ModelBuilderKamino(default_world=False)
@@ -1040,7 +1054,7 @@ def build_boxes_fourbar(
             bid_B=-1,
             bid_F=bid1,
             B_r_Bj=wp.vec3f(0.0),
-            F_r_Fj=-r_b1,
+            F_r_Fj=wp.vec3f(0.0),
             X_Bj=I_3,
             world_index=world_index,
         )
@@ -1053,7 +1067,7 @@ def build_boxes_fourbar(
             bid_B=-1,
             bid_F=bid1,
             B_r_Bj=wp.vec3f(0.0),
-            F_r_Fj=-r_b1,
+            F_r_Fj=wp.vec3f(0.0),
             X_Bj=I_3,
             world_index=world_index,
         )
@@ -1143,8 +1157,8 @@ def build_boxes_fourbar(
         _builder.add_geometry(
             name="ground",
             body=-1,
-            shape=BoxShape(10.0, 10.0, 0.5),
-            offset=wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
+            shape=PlaneShape() if use_plane_shape else BoxShape(10.0, 10.0, 0.5),
+            offset=None if use_plane_shape else wp.transformf(0.0, 0.0, -0.5, 0.0, 0.0, 0.0, 1.0),
             world_index=world_index,
         )
 

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -17,6 +17,7 @@ from newton._src.sim import Control, Model, ModelBuilder, State
 from newton._src.solvers.kamino._src.core.bodies import convert_body_com_to_origin, convert_body_origin_to_com
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.control import ControlKamino
+from newton._src.solvers.kamino._src.core.conversions import convert_target_coords_to_target_dofs
 from newton._src.solvers.kamino._src.core.materials import MaterialDescriptor
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.core.state import StateKamino
@@ -221,17 +222,17 @@ class TestModelConversions(unittest.TestCase):
             implicit_pd=False,
             new_world=True,
             actuator_ids=[1, 3],
+            use_plane_shape=True,
         )
 
         # Duplicate the world to test multi-world handling
         builder_kamino.add_builder(copy.deepcopy(builder_kamino))
 
         # Create models from the builders and conversion operations, and check for consistency
-        # TODO: re-enable the check below once the free-joint handling is fixed in Newton
-        # model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        # model_kamino: ModelKamino = builder_kamino.finalize()
-        # model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
-        # test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
+        model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
+        test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
 
     def test_01_model_conversions_fourbar_from_usd(self):
         """
@@ -273,8 +274,8 @@ class TestModelConversions(unittest.TestCase):
         )
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
         excluded = ["base_joint_index"]
         test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino, excluded=excluded)
@@ -328,8 +329,8 @@ class TestModelConversions(unittest.TestCase):
         )
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
         # NOTE: We don't check:
         # - mesh geometry pointers since they have been loaded separately
@@ -381,8 +382,8 @@ class TestModelConversions(unittest.TestCase):
         )
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
         # NOTE: We don't check:
         # - mesh geometry pointers since they have been loaded separately
@@ -443,8 +444,8 @@ class TestModelConversions(unittest.TestCase):
         )
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize()
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
         # NOTE: We don't check mesh geometry pointers since they have been loaded separately
         excluded = [
@@ -521,7 +522,7 @@ class TestModelConversions(unittest.TestCase):
 
         builder_newton.end_world()
 
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
 
         # Conversion must succeed (previously raised ValueError)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
@@ -614,7 +615,7 @@ class TestModelConversions(unittest.TestCase):
 
         builder_newton.end_world()
 
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
 
         q_i_0_np = model_kamino_converted.bodies.q_i_0.numpy()  # shape (N, 7)
@@ -706,7 +707,7 @@ class TestModelConversions(unittest.TestCase):
 
         builder_newton.end_world()
 
-        return builder_newton.finalize(skip_validation_joints=True)
+        return builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
 
     def test_12_reset_produces_body_origin_frame(self):
         """
@@ -859,7 +860,7 @@ class TestModelConversions(unittest.TestCase):
         )
         builder_newton.end_world()
 
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
         offset_np = model_kamino_converted.geoms.offset.numpy()
 
@@ -930,6 +931,7 @@ class TestModelConversions(unittest.TestCase):
             implicit_pd=False,
             new_world=True,
             actuator_ids=[1, 3],
+            use_plane_shape=True,
         )
 
         # Setting material properties
@@ -949,11 +951,10 @@ class TestModelConversions(unittest.TestCase):
         builder_kamino.add_builder(copy.deepcopy(builder_kamino))
 
         # Create models from the builders and conversion operations, and check for consistency
-        # TODO: re-enable the check below once the free-joint handling is fixed in Newton
-        # model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        # model_kamino: ModelKamino = builder_kamino.finalize()
-        # model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
-        # test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
+        model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
+        test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
 
     def test_22_model_conversions_material_box_on_plane_from_usd(self):
         """
@@ -1008,8 +1009,8 @@ class TestModelConversions(unittest.TestCase):
         builder_kamino.add_builder(copy.deepcopy(builder_kamino))
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
 
         test_util_checks.assert_model_geoms_equal(self, model_kamino_converted.geoms, model_kamino.geoms)
@@ -1062,17 +1063,17 @@ class TestModelConversions(unittest.TestCase):
             ground=True,
             new_world=True,
             actuator_ids=[2, 4],
+            use_plane_shape=True,
         )
 
         # Duplicate the world to test multi-world handling
         builder_kamino.add_builder(copy.deepcopy(builder_kamino))
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
-        # TODO: re-enable the check below once the free-joint handling is fixed in Newton
-        # test_util_checks.assert_model_equal(self, model_kamino, model_kamino_converted)
+        test_util_checks.assert_model_equal(self, model_kamino, model_kamino_converted)
 
         # Create a Newton state container
         state_newton: State = model_newton.state()
@@ -1165,20 +1166,28 @@ class TestModelConversions(unittest.TestCase):
             ground=True,
             new_world=True,
             actuator_ids=[1, 2, 3, 4],
+            use_plane_shape=True,
         )
 
         # Duplicate the world to test multi-world handling
         builder_kamino.add_builder(copy.deepcopy(builder_kamino))
 
         # Create models from the builders and conversion operations, and check for consistency
-        model_newton: Model = builder_newton.finalize(skip_validation_joints=True)
-        model_kamino: ModelKamino = builder_kamino.finalize()
-        # TODO: re-enable the below check once the free-joint handling is fixed in Newton
-        # model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
-        # test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
+        model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+        model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
+        model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
+        test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
 
         # Create a Newton control container
         control_newton: Control = model_newton.control()
+        if newton.use_coord_layout_targets:
+            control_newton.joint_target_q = wp.clone(model_newton.joint_q, device=self.default_device)
+        else:
+            joint_target_q_dof_space = wp.zeros_like(control_newton.joint_target_q, device=self.default_device)
+            convert_target_coords_to_target_dofs(model_newton.joint_q, joint_target_q_dof_space, model_kamino)
+            control_newton.joint_target_q = joint_target_q_dof_space
+        # TODO: remove above lines if joint_target_q in newton gets updated to take into account
+        # initial pose like joint_q does (cf issue #3380 in newton)
         self.assertIsInstance(control_newton.joint_f, wp.array)
         self.assertEqual(control_newton.joint_f.size, model_newton.joint_dof_count)
 

--- a/newton/_src/solvers/kamino/tests/test_geometry_contacts.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_contacts.py
@@ -1202,7 +1202,7 @@ class TestGeometryContactConversions(unittest.TestCase):
         for margin in (0.0, 0.05):
             with self.subTest(margin=margin):
                 sphere = ModelBuilder()
-                body = sphere.add_link()
+                body = sphere.add_link(xform=wp.transform(p=wp.vec3(0.0, 0.0, radius), q=wp.quat_identity()))
                 sphere.add_shape_sphere(
                     body,
                     radius=radius,
@@ -1211,7 +1211,7 @@ class TestGeometryContactConversions(unittest.TestCase):
                 joint = sphere.add_joint_free(
                     parent=-1,
                     child=body,
-                    parent_xform=wp.transform(p=wp.vec3(0.0, 0.0, radius), q=wp.quat_identity()),
+                    parent_xform=wp.transform_identity(),
                     child_xform=wp.transform_identity(),
                 )
                 sphere.add_articulation([joint])


### PR DESCRIPTION
## Description

This updates Kamino in the aftermath of #2559 in newton, that fixes the free joint (so that parent/child transforms are taken into account, and consistent with joint_q). One note is that by default, newton will create unary free joints in a way that joint_q can be interpreted directly as the follower body pose, by having the frame on the base body (=world) at the world origin, and the frame on the follower body at the center of that body (therefore, frames do not coincide, and joint_q is non-zero, on the initial pose).

Anyway, this PR:
- re-enables some unit tests (newton <-> kamino model conversions) that could not pass due to the previous invalid handling of this joint in newton
- updates builder.py to infer the initial joint_q for free joints from initial body poses and joint frame. No update to conversions.py is needed, as joints.q_j_0 is set from newton's joint_q which correctly reflects this.
- does some additional cleaning/updates for the tests to pass (in particular, the four-bar model built programmatically in newton and kamino basics were not matching in terms of joint frame and geoms due to kamino's assumptions)

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

All Kamino-internal unit tests now pass again (included tests that are now uncommented back).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to use a plane-based ground shape in the four-bar setup.
  * Enhanced initial pose initialization for free joints to better reflect connected body transforms.

* **Bug Fixes**
  * Corrected four-bar world/joint parameterization in both fixed-base and floating-base configurations.
  * Improved Newton↔Kamino conversion consistency, including state, control, and contact anchor handling across margin settings.

* **Tests**
  * Re-enabled and stabilized conversion-consistency assertions by ensuring models are finalized on the active device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->