### PR TITLE
[Kamino] Add support for configurable per-shape material property mixing modes

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -22,6 +22,7 @@ material properties that can be queried at simulation runtime. It includes:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
 
@@ -46,6 +47,7 @@ __all__ = [
     "MaterialPairProperties",
     "MaterialPairsModel",
     "MaterialsModel",
+    "make_get_mixed_material_pair_property",
 ]
 
 ###
@@ -75,7 +77,7 @@ Equals ``0.7``.
 ###
 
 
-class MaterialMuxMode(IntEnum):
+class MaterialMixMode(IntEnum):
     """
     An enumeration defining the heuristic modes for deriving
     pairwise material properties from individual materials.
@@ -87,11 +89,32 @@ class MaterialMuxMode(IntEnum):
     AVERAGE = 0
     """Pairwise property is the average of the two material properties."""
 
-    MAX = 1
+    MULTIPLY = 1
+    """Pairwise property is the product of the two material properties."""
+
+    MAX = 2
     """Pairwise property is the maximum of the two material properties."""
 
-    MIN = 2
+    MIN = 3
     """Pairwise property is the minimum of the two material properties."""
+
+    @classmethod
+    def from_string(cls, s: str) -> MaterialMixMode:
+        """Converts a string to a MaterialMixMode enum value."""
+        try:
+            return cls[s.upper()]
+        except KeyError as e:
+            raise ValueError(f"Invalid MaterialMixMode: {s}. Valid options are: {[e.name for e in cls]}") from e
+
+    @override
+    def __str__(self):
+        """Returns a string representation of the MaterialMixMode."""
+        return f"MaterialMixMode.{self.name} ({self.value})"
+
+    @override
+    def __repr__(self):
+        """Returns a string representation of the MaterialMixMode."""
+        return self.__str__()
 
 
 @dataclass
@@ -339,6 +362,24 @@ def material_average(
 
 
 @wp.func
+def material_multiply(
+    value1: wp.float32,
+    value2: wp.float32,
+) -> wp.float32:
+    """
+    Computes the product of two material property values.
+
+    Args:
+        value1: The first material property value.
+        value2: The second material property value.
+
+    Returns:
+        The product of the two material property values.
+    """
+    return value1 * value2
+
+
+@wp.func
 def material_max(
     value1: wp.float32,
     value2: wp.float32,
@@ -374,27 +415,78 @@ def material_min(
     return wp.min(value1, value2)
 
 
-def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode.MAX):
+def get_material_mixing_function(
+    muxmode: MaterialMixMode = MaterialMixMode.AVERAGE,
+) -> Callable[[wp.float32, wp.float32], wp.float32]:
+    """
+    Returns the appropriate material mix function based on the specified mixing mode.
+    """
+    # Select the appropriate mixing function based on the mixing mode
+    match muxmode:
+        case MaterialMixMode.AVERAGE:
+            mix_func = material_average
+        case MaterialMixMode.MULTIPLY:
+            mix_func = material_multiply
+        case MaterialMixMode.MAX:
+            mix_func = material_max
+        case MaterialMixMode.MIN:
+            mix_func = material_min
+        case _:
+            raise ValueError(f"Unsupported material mixing mode: {muxmode}")
+
+    # Return the selected mixing function
+    return mix_func
+
+
+def make_get_mixed_material_pair_property(muxmode: MaterialMixMode = MaterialMixMode.AVERAGE):
     """
     Generates a Warp function to retrieve material pair
-    properties based on the specified muxing mode.
+    property based on the specified mixing mode.
 
     Args:
-        muxmode: The muxing mode to use for material pair properties.
+        muxmode: The mixing mode to use for material pair property.
+
+    Returns:
+        A Warp function that retrieves material pair property.
+    """
+    # Select the appropriate mixing function based on the mixing mode
+    mix_func = get_material_mixing_function(muxmode)
+
+    # Define the Warp function to retrieve material pair properties
+    @wp.func
+    def _get_mixed_material_pair_property(
+        property_0: wp.float32,
+        property_1: wp.float32,
+    ) -> wp.float32:
+        """
+        Retrieves the mixed properties of a material pair given the properties of the two materials.
+
+        Args:
+            property_0: The property of the first material.
+            property_1: The property of the second material.
+
+        Returns:
+            The mixed property of the two materials.
+        """
+        return mix_func(property_0, property_1)
+
+    # Return the generated Warp function
+    return _get_mixed_material_pair_property
+
+
+def make_get_material_pair_properties(muxmode: MaterialMixMode = MaterialMixMode.AVERAGE):
+    """
+    Generates a Warp function to retrieve material pair
+    properties based on the specified mixing mode.
+
+    Args:
+        muxmode: The mixing mode to use for material pair properties.
 
     Returns:
         A Warp function that retrieves material pair properties.
     """
-    # Select the appropriate muxing function based on the muxing mode
-    match muxmode:
-        case MaterialMuxMode.AVERAGE:
-            mix_func = material_average
-        case MaterialMuxMode.MAX:
-            mix_func = material_max
-        case MaterialMuxMode.MIN:
-            mix_func = material_min
-        case _:
-            raise ValueError(f"Unsupported material muxing mode: {muxmode}")
+    # Select the appropriate mixing function based on the mixing mode
+    mix_func = get_material_mixing_function(muxmode)
 
     # Define the Warp function to retrieve material pair properties
     @wp.func
@@ -413,7 +505,7 @@ def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode
 
         If material-pair properties are not defined (i.e., negative values) for the given
         material indices `mid1, mid2`, the properties are computed from the individual
-        materials using the configured muxing method.
+        materials using the configured mixing method.
 
         Args:
             mid1: The index of the first material.
@@ -436,7 +528,7 @@ def make_get_material_pair_properties(muxmode: MaterialMuxMode = MaterialMuxMode
         static_friction = material_pair_static_friction[mid_tril_idx]
         dynamic_friction = material_pair_dynamic_friction[mid_tril_idx]
 
-        # If any property is negative, compute the material pair properties using the set muxing method
+        # If any property is negative, compute the material pair properties using the set mixing method
         if restitution < 0.0:
             restitution = mix_func(material_restitution[mid1], material_restitution[mid2])
         if static_friction < 0.0:

--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -416,13 +416,13 @@ def material_min(
 
 
 def get_material_mixing_function(
-    muxmode: MaterialMixMode = MaterialMixMode.AVERAGE,
+    mixmode: MaterialMixMode = MaterialMixMode.AVERAGE,
 ) -> Callable[[wp.float32, wp.float32], wp.float32]:
     """
     Returns the appropriate material mix function based on the specified mixing mode.
     """
     # Select the appropriate mixing function based on the mixing mode
-    match muxmode:
+    match mixmode:
         case MaterialMixMode.AVERAGE:
             mix_func = material_average
         case MaterialMixMode.MULTIPLY:
@@ -432,25 +432,25 @@ def get_material_mixing_function(
         case MaterialMixMode.MIN:
             mix_func = material_min
         case _:
-            raise ValueError(f"Unsupported material mixing mode: {muxmode}")
+            raise ValueError(f"Unsupported material mixing mode: {mixmode}")
 
     # Return the selected mixing function
     return mix_func
 
 
-def make_get_mixed_material_pair_property(muxmode: MaterialMixMode = MaterialMixMode.AVERAGE):
+def make_get_mixed_material_pair_property(mixmode: MaterialMixMode = MaterialMixMode.AVERAGE):
     """
     Generates a Warp function to retrieve material pair
     property based on the specified mixing mode.
 
     Args:
-        muxmode: The mixing mode to use for material pair property.
+        mixmode: The mixing mode to use for material pair property.
 
     Returns:
         A Warp function that retrieves material pair property.
     """
     # Select the appropriate mixing function based on the mixing mode
-    mix_func = get_material_mixing_function(muxmode)
+    mix_func = get_material_mixing_function(mixmode)
 
     # Define the Warp function to retrieve material pair properties
     @wp.func
@@ -474,19 +474,19 @@ def make_get_mixed_material_pair_property(muxmode: MaterialMixMode = MaterialMix
     return _get_mixed_material_pair_property
 
 
-def make_get_material_pair_properties(muxmode: MaterialMixMode = MaterialMixMode.AVERAGE):
+def make_get_material_pair_properties(mixmode: MaterialMixMode = MaterialMixMode.AVERAGE):
     """
     Generates a Warp function to retrieve material pair
     properties based on the specified mixing mode.
 
     Args:
-        muxmode: The mixing mode to use for material pair properties.
+        mixmode: The mixing mode to use for material pair properties.
 
     Returns:
         A Warp function that retrieves material pair properties.
     """
     # Select the appropriate mixing function based on the mixing mode
-    mix_func = get_material_mixing_function(muxmode)
+    mix_func = get_material_mixing_function(mixmode)
 
     # Define the Warp function to retrieve material pair properties
     @wp.func

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -25,6 +25,7 @@ supporting both a Z-up and X-up convention.
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass, field
 from enum import IntEnum
 
@@ -34,6 +35,7 @@ from .....math import safe_div
 from .....sim.contacts import Contacts, contact_surface_point, contact_surface_separation
 from .....sim.model import Model
 from .....sim.state import State
+from ..core.materials import MaterialMixMode, make_get_mixed_material_pair_property
 from ..core.math import COS_PI_6, UNIT_X, UNIT_Y
 from ..core.model import ModelKamino
 from ..core.types import (
@@ -848,199 +850,222 @@ class ContactsKamino:
 ###
 
 
-@wp.kernel
-def _convert_contacts_newton_to_kamino(
-    # Inputs:
-    num_worlds: wp.int32,
-    kamino_model_max_contacts: wp.array[wp.int32],
-    kamino_world_max_contacts: wp.array[wp.int32],
-    newton_count: wp.array[wp.int32],
-    newton_shape0: wp.array[wp.int32],
-    newton_shape1: wp.array[wp.int32],
-    newton_point0: wp.array[wp.vec3f],
-    newton_point1: wp.array[wp.vec3f],
-    newton_offset0: wp.array[wp.vec3f],
-    newton_offset1: wp.array[wp.vec3f],
-    newton_normal: wp.array[wp.vec3f],
-    newton_margin0: wp.array[wp.float32],
-    newton_margin1: wp.array[wp.float32],
-    newton_force: wp.array[wp.spatial_vectorf],
-    newton_shape_margin: wp.array[wp.float32],
-    shape_body: wp.array[wp.int32],
-    shape_world: wp.array[wp.int32],
-    shape_mu: wp.array[wp.float32],
-    shape_restitution: wp.array[wp.float32],
-    body_q: wp.array[wp.transformf],
-    # Outputs:
-    kamino_model_active: wp.array[wp.int32],
-    kamino_world_active: wp.array[wp.int32],
-    kamino_wid: wp.array[wp.int32],
-    kamino_cid: wp.array[wp.int32],
-    kamino_gid_AB: wp.array[wp.vec2i],
-    kamino_bid_AB: wp.array[wp.vec2i],
-    kamino_position_A: wp.array[wp.vec3f],
-    kamino_position_B: wp.array[wp.vec3f],
-    kamino_gapfunc: wp.array[wp.vec4f],
-    kamino_frame: wp.array[wp.quatf],
-    kamino_material: wp.array[wp.vec2f],
-    kamino_margins: wp.array[wp.vec2f],
-    kamino_key: wp.array[wp.uint64],
-    kamino_reaction: wp.array[wp.vec3f],
-    kamino_remap: wp.array[wp.int32],
+@functools.cache
+def make_convert_contacts_newton_to_kamino(
+    friction_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
+    restitution_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
 ):
     """
-    Convert Newton :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
+    Generates a kernel to Newton contacts to the Kamino format.
 
-    Reads body-local contact points from Newton, transforms them to world space,
-    and populates the Kamino contact arrays under the A/B convention that
-    Kamino's solver core expects: ``bid_B >= 0``, normal points A -> B. When
-    Newton's ``shape1`` is world-static (``bid_1 < 0``), shape1 becomes Kamino A
-    and shape0 becomes Kamino B (the A<->B swap); otherwise A=shape0, B=shape1.
+    Args:
+        friction_mixing_mode: The mixing mode to use for friction.
+        restitution_mixing_mode: The mixing mode to use for restitution.
 
-    Newton's ``rigid_contact_normal`` points from shape0 toward shape1 (A -> B in
-    the no-swap case, B -> A in the swap case, which is negated to restore the
-    Kamino A->B convention).
-
-    Optionally also converts Newton's :attr:`Contacts.force` (the wrench on body0
-    by body1 at the CoM of body0, in world) into Kamino's ``reaction`` (the linear
-    force on body B by body A in the local contact frame). The linear part is
-    invariant to reference-point shifts, so this is a pure rotation into the
-    contact frame, with a sign flip in the no-swap case to convert "force on A"
-    into "force on B".
+    Returns:
+        A kernel function that converts Newton contacts to the Kamino format.
     """
-    # Retrieve the contact index for this thread
-    cid = wp.tid()
 
-    # Skip conversion if this contact index exceeds the number
-    # of contacts to convert.
-    num_active = newton_count[0]
-    if cid >= num_active:
-        return
+    @wp.kernel
+    def _convert_contacts_newton_to_kamino(
+        # Inputs:
+        num_worlds: wp.int32,
+        kamino_model_max_contacts: wp.array[wp.int32],
+        kamino_world_max_contacts: wp.array[wp.int32],
+        newton_count: wp.array[wp.int32],
+        newton_shape0: wp.array[wp.int32],
+        newton_shape1: wp.array[wp.int32],
+        newton_point0: wp.array[wp.vec3f],
+        newton_point1: wp.array[wp.vec3f],
+        newton_offset0: wp.array[wp.vec3f],
+        newton_offset1: wp.array[wp.vec3f],
+        newton_normal: wp.array[wp.vec3f],
+        newton_margin0: wp.array[wp.float32],
+        newton_margin1: wp.array[wp.float32],
+        newton_force: wp.array[wp.spatial_vectorf],
+        newton_shape_margin: wp.array[wp.float32],
+        shape_body: wp.array[wp.int32],
+        shape_world: wp.array[wp.int32],
+        shape_mu: wp.array[wp.float32],
+        shape_restitution: wp.array[wp.float32],
+        body_q: wp.array[wp.transformf],
+        # Outputs:
+        kamino_model_active: wp.array[wp.int32],
+        kamino_world_active: wp.array[wp.int32],
+        kamino_wid: wp.array[wp.int32],
+        kamino_cid: wp.array[wp.int32],
+        kamino_gid_AB: wp.array[wp.vec2i],
+        kamino_bid_AB: wp.array[wp.vec2i],
+        kamino_position_A: wp.array[wp.vec3f],
+        kamino_position_B: wp.array[wp.vec3f],
+        kamino_gapfunc: wp.array[wp.vec4f],
+        kamino_frame: wp.array[wp.quatf],
+        kamino_material: wp.array[wp.vec2f],
+        kamino_margins: wp.array[wp.vec2f],
+        kamino_key: wp.array[wp.uint64],
+        kamino_reaction: wp.array[wp.vec3f],
+        kamino_remap: wp.array[wp.int32],
+    ):
+        """
+        Convert Newton :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
 
-    # Retrieve the shape and body indices for this contact
-    sid_0 = newton_shape0[cid]
-    sid_1 = newton_shape1[cid]
-    bid_0 = shape_body[sid_0]
-    bid_1 = shape_body[sid_1]
-    wid_0 = shape_world[sid_0]
-    wid_1 = shape_world[sid_1]
+        Reads body-local contact points from Newton, transforms them to world space,
+        and populates the Kamino contact arrays under the A/B convention that
+        Kamino's solver core expects: ``bid_B >= 0``, normal points A -> B. When
+        Newton's ``shape1`` is world-static (``bid_1 < 0``), shape1 becomes Kamino A
+        and shape0 becomes Kamino B (the A<->B swap); otherwise A=shape0, B=shape1.
 
-    # Determine the world index.  Global shapes (shape_world == -1) can
-    # collide with shapes from any world, so fall back to the other shape.
-    wid = wid_0
-    if wid_0 < 0:
-        wid = wid_1
-    if wid < 0 or wid >= num_worlds:
-        return
+        Newton's ``rigid_contact_normal`` points from shape0 toward shape1 (A -> B in
+        the no-swap case, B -> A in the swap case, which is negated to restore the
+        Kamino A->B convention).
 
-    # Retrieve per-world/global contact capacities
-    world_max_contacts = kamino_world_max_contacts[wid]
-    model_max_contacts = kamino_model_max_contacts[0]
+        Optionally also converts Newton's :attr:`Contacts.force` (the wrench on body0
+        by body1 at the CoM of body0, in world) into Kamino's ``reaction`` (the linear
+        force on body B by body A in the local contact frame). The linear part is
+        invariant to reference-point shifts, so this is a pure rotation into the
+        contact frame, with a sign flip in the no-swap case to convert "force on A"
+        into "force on B".
+        """
+        # Retrieve the contact index for this thread
+        cid = wp.tid()
 
-    # Body-local → world-space
-    X_0 = wp.transform_identity()
-    if bid_0 >= 0:
-        X_0 = body_q[bid_0]
-    X_1 = wp.transform_identity()
-    if bid_1 >= 0:
-        X_1 = body_q[bid_1]
+        # Skip conversion if this contact index exceeds the number
+        # of contacts to convert.
+        num_active = newton_count[0]
+        if cid >= num_active:
+            return
 
-    # Skeleton points for the normal gap; physical surface points for the contact anchors.
-    p0_world = wp.transform_point(X_0, newton_point0[cid])
-    p1_world = wp.transform_point(X_1, newton_point1[cid])
-    margin_0 = newton_margin0[cid]
-    margin_1 = newton_margin1[cid]
-    offset_scale0 = safe_div(margin_0 - newton_shape_margin[sid_0], margin_0)
-    offset_scale1 = safe_div(margin_1 - newton_shape_margin[sid_1], margin_1)
-    p0_surf = contact_surface_point(X_0, newton_point0[cid], newton_offset0[cid] * offset_scale0)
-    p1_surf = contact_surface_point(X_1, newton_point1[cid], newton_offset1[cid] * offset_scale1)
+        # Retrieve the shape and body indices for this contact
+        sid_0 = newton_shape0[cid]
+        sid_1 = newton_shape1[cid]
+        bid_0 = shape_body[sid_0]
+        bid_1 = shape_body[sid_1]
+        wid_0 = shape_world[sid_0]
+        wid_1 = shape_world[sid_1]
 
-    # Newton normal points from shape0 → shape1 (A → B).
-    # Kamino convention: normal points A → B, with bid_B >= 0.
-    normal = newton_normal[cid]
+        # Determine the world index.  Global shapes (shape_world == -1) can
+        # collide with shapes from any world, so fall back to the other shape.
+        wid = wid_0
+        if wid_0 < 0:
+            wid = wid_1
+        if wid < 0 or wid >= num_worlds:
+            return
 
-    # Reconstruct the Newton signed contact distance from exported fields:
-    # d = dot((p1 - p0), n_a_to_b) - (margin0 + margin1), with n_newton = n_a_to_b
-    # and the per-shape surface thicknesses stored in rigid_contact_margin*.
-    distance = contact_surface_separation(p0_world, p1_world, normal, margin_0, margin_1)
+        # Retrieve per-world/global contact capacities
+        world_max_contacts = kamino_world_max_contacts[wid]
+        model_max_contacts = kamino_model_max_contacts[0]
 
-    # Ensure static body is always Kamino A, dynamic body is Kamino B
-    if bid_1 < 0:
-        # shape1 is world-static → make it Kamino A, shape0 becomes Kamino B.
-        # Kamino A→B = shape1→shape0, opposite of Newton's shape0→shape1, so negate.
-        gid_A = sid_1
-        gid_B = sid_0
-        bid_A = bid_1
-        bid_B = bid_0
-        pos_A = p1_surf
-        pos_B = p0_surf
-        margin_A = margin_1
-        margin_B = margin_0
-        normal = -normal
-    else:
-        # Both dynamic or shape0 is static → keep A=shape0, B=shape1.
-        # Newton normal already points A→B, matching Kamino convention.
-        gid_A = sid_0
-        gid_B = sid_1
-        bid_A = bid_0
-        bid_B = bid_1
-        pos_A = p0_surf
-        pos_B = p1_surf
-        margin_A = margin_0
-        margin_B = margin_1
+        # Body-local → world-space
+        X_0 = wp.transform_identity()
+        if bid_0 >= 0:
+            X_0 = body_q[bid_0]
+        X_1 = wp.transform_identity()
+        if bid_1 >= 0:
+            X_1 = body_q[bid_1]
 
-    # Retrieve the material properties for this contact
-    # TODO: Integrate use of material manager to retrieve material properties
-    mu = 0.5 * (shape_mu[sid_0] + shape_mu[sid_1])
-    epsilon = 0.5 * (shape_restitution[sid_0] + shape_restitution[sid_1])
+        # Skeleton points for the normal gap; physical surface points for the contact anchors.
+        p0_world = wp.transform_point(X_0, newton_point0[cid])
+        p1_world = wp.transform_point(X_1, newton_point1[cid])
+        margin_0 = newton_margin0[cid]
+        margin_1 = newton_margin1[cid]
+        offset_scale0 = safe_div(margin_0 - newton_shape_margin[sid_0], margin_0)
+        offset_scale1 = safe_div(margin_1 - newton_shape_margin[sid_1], margin_1)
+        p0_surf = contact_surface_point(X_0, newton_point0[cid], newton_offset0[cid] * offset_scale0)
+        p1_surf = contact_surface_point(X_1, newton_point1[cid], newton_offset1[cid] * offset_scale1)
 
-    # Store the contact data in the Kamino format
-    gapfunc = wp.vec4f(normal[0], normal[1], normal[2], distance)
-    q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
+        # Newton normal points from shape0 → shape1 (A → B).
+        # Kamino convention: normal points A → B, with bid_B >= 0.
+        normal = newton_normal[cid]
 
-    # Safely increment the active contact counters (see notes in _write_contact_unified_kamino in unified.py)
-    wcid = wp.atomic_add(kamino_world_active, wid, 1)
-    if wcid >= world_max_contacts:
-        wp.atomic_sub(kamino_world_active, wid, 1)
-        return
-    mcid = wp.atomic_add(kamino_model_active, 0, 1)
-    if mcid >= model_max_contacts:
-        wp.atomic_sub(kamino_model_active, 0, 1)
-        wp.atomic_sub(kamino_world_active, wid, 1)
-        return
+        # Reconstruct the Newton signed contact distance from exported fields:
+        # d = dot((p1 - p0), n_a_to_b) - (margin0 + margin1), with n_newton = n_a_to_b
+        # and the per-shape surface thicknesses stored in rigid_contact_margin*.
+        distance = contact_surface_separation(p0_world, p1_world, normal, margin_0, margin_1)
 
-    # Store the contact data in the Kamino format if the contact is valid
-    kamino_wid[mcid] = wid
-    kamino_cid[mcid] = wcid
-    kamino_gid_AB[mcid] = wp.vec2i(gid_A, gid_B)
-    kamino_bid_AB[mcid] = wp.vec2i(bid_A, bid_B)
-    kamino_position_A[mcid] = pos_A
-    kamino_position_B[mcid] = pos_B
-    kamino_gapfunc[mcid] = gapfunc
-    kamino_frame[mcid] = q_frame
-    kamino_material[mcid] = wp.vec2f(mu, epsilon)
-    kamino_margins[mcid] = wp.vec2f(margin_A, margin_B)
-    kamino_key[mcid] = build_pair_key2(wp.uint32(gid_A), wp.uint32(gid_B))
-
-    # Store the contact source index in the remap array if provided
-    if kamino_remap:
-        kamino_remap[mcid] = cid
-
-    # Optional contact wrench from Newton convention.
-    # Newton stores `force[cid]` as the wrench on body0 by body1 at the CoM
-    # of body0 in world coordinates. Kamino's `reaction` is the linear
-    # force on body B by body A in the local contact frame. The linear
-    # part is invariant under reference-point shifts, so we only need to
-    # rotate to the local frame and choose the sign based on the swap:
-    #   - no-swap (bid_1 >= 0): Newton body0 = Kamino A, sign = -1
-    #   - swap   (bid_1 <  0): Newton body0 = Kamino B, sign = +1
-    if newton_force:
-        f_world = wp.spatial_top(newton_force[cid])
-        f_local = wp.quat_rotate(wp.quat_inverse(q_frame), f_world)
+        # Ensure static body is always Kamino A, dynamic body is Kamino B
         if bid_1 < 0:
-            kamino_reaction[mcid] = f_local
+            # shape1 is world-static → make it Kamino A, shape0 becomes Kamino B.
+            # Kamino A→B = shape1→shape0, opposite of Newton's shape0→shape1, so negate.
+            gid_A = sid_1
+            gid_B = sid_0
+            bid_A = bid_1
+            bid_B = bid_0
+            pos_A = p1_surf
+            pos_B = p0_surf
+            margin_A = margin_1
+            margin_B = margin_0
+            normal = -normal
         else:
-            kamino_reaction[mcid] = -f_local
+            # Both dynamic or shape0 is static → keep A=shape0, B=shape1.
+            # Newton normal already points A→B, matching Kamino convention.
+            gid_A = sid_0
+            gid_B = sid_1
+            bid_A = bid_0
+            bid_B = bid_1
+            pos_A = p0_surf
+            pos_B = p1_surf
+            margin_A = margin_0
+            margin_B = margin_1
+
+        # Retrieve the material properties for this contact
+        # TODO: Integrate use of material manager to retrieve material properties
+        mu_0 = shape_mu[sid_0]
+        mu_1 = shape_mu[sid_1]
+        epsilon_0 = shape_restitution[sid_0]
+        epsilon_1 = shape_restitution[sid_1]
+        mu = wp.static(make_get_mixed_material_pair_property(friction_mix_mode))(mu_0, mu_1)
+        epsilon = wp.static(make_get_mixed_material_pair_property(restitution_mix_mode))(epsilon_0, epsilon_1)
+
+        # Store the contact data in the Kamino format
+        gapfunc = wp.vec4f(normal[0], normal[1], normal[2], distance)
+        q_frame = wp.quat_from_matrix(make_contact_frame_znorm(normal))
+
+        # Safely increment the active contact counters (see notes in _write_contact_unified_kamino in unified.py)
+        wcid = wp.atomic_add(kamino_world_active, wid, 1)
+        if wcid >= world_max_contacts:
+            wp.atomic_sub(kamino_world_active, wid, 1)
+            return
+        mcid = wp.atomic_add(kamino_model_active, 0, 1)
+        if mcid >= model_max_contacts:
+            wp.atomic_sub(kamino_model_active, 0, 1)
+            wp.atomic_sub(kamino_world_active, wid, 1)
+            return
+
+        # Store the contact data in the Kamino format if the contact is valid
+        kamino_wid[mcid] = wid
+        kamino_cid[mcid] = wcid
+        kamino_gid_AB[mcid] = wp.vec2i(gid_A, gid_B)
+        kamino_bid_AB[mcid] = wp.vec2i(bid_A, bid_B)
+        kamino_position_A[mcid] = pos_A
+        kamino_position_B[mcid] = pos_B
+        kamino_gapfunc[mcid] = gapfunc
+        kamino_frame[mcid] = q_frame
+        kamino_material[mcid] = wp.vec2f(mu, epsilon)
+        kamino_margins[mcid] = wp.vec2f(margin_A, margin_B)
+        kamino_key[mcid] = build_pair_key2(wp.uint32(gid_A), wp.uint32(gid_B))
+
+        # Store the contact source index in the remap array if provided
+        if kamino_remap:
+            kamino_remap[mcid] = cid
+
+        # Optional contact wrench from Newton convention.
+        # Newton stores `force[cid]` as the wrench on body0 by body1 at the CoM
+        # of body0 in world coordinates. Kamino's `reaction` is the linear
+        # force on body B by body A in the local contact frame. The linear
+        # part is invariant under reference-point shifts, so we only need to
+        # rotate to the local frame and choose the sign based on the swap:
+        #   - no-swap (bid_1 >= 0): Newton body0 = Kamino A, sign = -1
+        #   - swap   (bid_1 <  0): Newton body0 = Kamino B, sign = +1
+        if newton_force:
+            f_world = wp.spatial_top(newton_force[cid])
+            f_local = wp.quat_rotate(wp.quat_inverse(q_frame), f_world)
+            if bid_1 < 0:
+                kamino_reaction[mcid] = f_local
+            else:
+                kamino_reaction[mcid] = -f_local
+
+    # Return the generated kernel function
+    return _convert_contacts_newton_to_kamino
 
 
 @wp.kernel
@@ -1258,6 +1283,8 @@ def convert_contacts_newton_to_kamino(
     contacts_in: Contacts,
     contacts_out: ContactsKamino,
     convert_forces: bool = False,
+    friction_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
+    restitution_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
 ):
     """
     Converts Newton's :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
@@ -1334,6 +1361,9 @@ def convert_contacts_newton_to_kamino(
     # Clear the output contacts to reset the active contact
     # counts and reset contact data to sentinel values.
     contacts_out.clear()
+
+    # Generate the conversion kernel
+    _convert_contacts_newton_to_kamino = make_convert_contacts_newton_to_kamino(friction_mix_mode, restitution_mix_mode)
 
     # Launch the conversion kernel to convert Newton contacts to Kamino's format
     # NOTE: To reduce overhead, the total thread count is set to the smallest of

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -857,7 +857,7 @@ def make_convert_contacts_newton_to_kamino(
     restitution_mix_mode: MaterialMixMode = MaterialMixMode.MIN,
 ):
     """
-    Generates a kernel to Newton contacts to the Kamino format.
+    Generates a kernel to convert Newton contacts to the Kamino format.
 
     Args:
         friction_mix_mode: The mixing mode to use for friction.
@@ -867,7 +867,7 @@ def make_convert_contacts_newton_to_kamino(
         A kernel function that converts Newton contacts to the Kamino format.
     """
 
-    @wp.kernel
+    @wp.kernel(module="unique", enable_backward=False)
     def _convert_contacts_newton_to_kamino(
         # Inputs:
         num_worlds: wp.int32,

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import functools
 from dataclasses import dataclass, field
 from enum import IntEnum
+from typing import Literal
 
 import warp as wp
 
@@ -853,14 +854,14 @@ class ContactsKamino:
 @functools.cache
 def make_convert_contacts_newton_to_kamino(
     friction_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
-    restitution_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
+    restitution_mix_mode: MaterialMixMode = MaterialMixMode.MIN,
 ):
     """
     Generates a kernel to Newton contacts to the Kamino format.
 
     Args:
-        friction_mixing_mode: The mixing mode to use for friction.
-        restitution_mixing_mode: The mixing mode to use for restitution.
+        friction_mix_mode: The mixing mode to use for friction.
+        restitution_mix_mode: The mixing mode to use for restitution.
 
     Returns:
         A kernel function that converts Newton contacts to the Kamino format.
@@ -1283,8 +1284,8 @@ def convert_contacts_newton_to_kamino(
     contacts_in: Contacts,
     contacts_out: ContactsKamino,
     convert_forces: bool = False,
-    friction_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
-    restitution_mix_mode: MaterialMixMode = MaterialMixMode.AVERAGE,
+    friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average",
+    restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "average",
 ):
     """
     Converts Newton's :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
@@ -1363,7 +1364,10 @@ def convert_contacts_newton_to_kamino(
     contacts_out.clear()
 
     # Generate the conversion kernel
-    _convert_contacts_newton_to_kamino = make_convert_contacts_newton_to_kamino(friction_mix_mode, restitution_mix_mode)
+    _convert_contacts_newton_to_kamino = make_convert_contacts_newton_to_kamino(
+        friction_mix_mode=MaterialMixMode.from_string(friction_mix_mode),
+        restitution_mix_mode=MaterialMixMode.from_string(restitution_mix_mode),
+    )
 
     # Launch the conversion kernel to convert Newton contacts to Kamino's format
     # NOTE: To reduce overhead, the total thread count is set to the smallest of

--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -1285,7 +1285,7 @@ def convert_contacts_newton_to_kamino(
     contacts_out: ContactsKamino,
     convert_forces: bool = False,
     friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average",
-    restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "average",
+    restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "min",
 ):
     """
     Converts Newton's :class:`Contacts` to Kamino's :class:`ContactsKamino` format.
@@ -1323,6 +1323,10 @@ def convert_contacts_newton_to_kamino(
         convert_forces:
             If ``True``, also convert ``contacts_in.force`` into``contacts_out.reaction``.
             If ``False`` or ``contacts_in.force`` is missing, ``contacts_out.reaction`` is left untouched.
+        friction_mix_mode:
+            The mixing mode to use for contact friction. Defaults to `"average"`.
+        restitution_mix_mode:
+            The mixing mode to use for contact restitution. Defaults to `"min"`.
     """
     # Skip conversion if there are no contacts to convert or no capacity to store them.
     if contacts_out.model_max_contacts_host == 0 or contacts_in.rigid_contact_max == 0:

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -959,15 +959,13 @@ class MaterialManagerConfig(ConfigBase):
     friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average"
     """
     The mixing mode to use for friction.\n
-    See :class:`MaterialMixMode` for available options.\n
-    Defaults to `MaterialMixMode.AVERAGE`.
+    Defaults to `average`.
     """
 
     restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "min"
     """
     The mixing mode to use for restitution.\n
-    See :class:`MaterialMixMode` for available options.\n
-    Defaults to `MaterialMixMode.AVERAGE`.
+    Defaults to `min`.
     """
 
     @override

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -948,3 +948,71 @@ class ForwardKinematicsSolverConfig:
     def __post_init__(self):
         """Post-initialization to validate configurations."""
         self.validate()
+
+
+@dataclass
+class MaterialManagerConfig(ConfigBase):
+    """
+    A container to hold configurations for the internal material manager and material property mixing.
+    """
+
+    friction_mix_mode: Literal["average", "multiply", "max", "min"] = "average"
+    """
+    The mixing mode to use for friction.\n
+    See :class:`MaterialMixMode` for available options.\n
+    Defaults to `MaterialMixMode.AVERAGE`.
+    """
+
+    restitution_mix_mode: Literal["average", "multiply", "max", "min"] = "min"
+    """
+    The mixing mode to use for restitution.\n
+    See :class:`MaterialMixMode` for available options.\n
+    Defaults to `MaterialMixMode.AVERAGE`.
+    """
+
+    @override
+    @staticmethod
+    def register_custom_attributes(builder: ModelBuilder) -> None:
+        """
+        Registers custom attributes for the MaterialManagerConfig with the given builder.
+
+        Note: Currently, this class does not have any custom attributes registered,
+        as only those supported by the Kamino USD scene API have been included. More
+        will be added in the future as latter is being developed.
+
+        Args:
+            builder: The model builder instance with which to register the custom attributes.
+        """
+        pass  # TODO: Add custom attributes for the MaterialManager when supported by the Kamino USD scene API
+
+    @override
+    @staticmethod
+    def from_model(model: Model, **kwargs: dict[str, Any]) -> MaterialManagerConfig:
+        """
+        Creates a :class:`MaterialManagerConfig` by attempting to
+        parse custom attributes from a :class:`Model` if available.
+
+        Args:
+            model: The Newton model from which to parse configurations.
+        """
+        # Return the fully constructed config with configurations
+        # parsed from the model's custom attributes if available,
+        # otherwise using defaults or provided kwargs.
+        return MaterialManagerConfig(**kwargs)
+
+    @override
+    def validate(self) -> None:
+        """
+        Validates the current values held by the :class:`MaterialManagerConfig` instance.
+        """
+        # Import here to avoid module-level imports and circular dependencies
+        from ._src.core.materials import MaterialMixMode  # noqa: PLC0415
+
+        # Ensure that the enum-valued parameters are valid options
+        MaterialMixMode.from_string(self.friction_mix_mode)
+        MaterialMixMode.from_string(self.restitution_mix_mode)
+
+    @override
+    def __post_init__(self):
+        """Post-initialization to validate configurations."""
+        self.validate()

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
         ConstrainedDynamicsConfig,
         ConstraintStabilizationConfig,
         ForwardKinematicsSolverConfig,
+        MaterialManagerConfig,
         PADMMSolverConfig,
     )
 
@@ -166,6 +167,13 @@ class SolverKamino(SolverBase, CouplingInterface):
         If `None`, default values will be used.
         """
 
+        materials: MaterialManagerConfig | None = None
+        """
+        Configurations for the material manager and material property mixing.
+        See :class:`MaterialManagerConfig` for more details.
+        If `None`, default values will be used.
+        """
+
         rotation_correction: Literal["twopi", "continuous", "none"] = "twopi"
         """
         The rotation correction mode to use for rotational DoFs.\n
@@ -223,6 +231,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             config.ConstrainedDynamicsConfig.register_custom_attributes(builder)
             config.CollisionDetectorConfig.register_custom_attributes(builder)
             config.PADMMSolverConfig.register_custom_attributes(builder)
+            config.MaterialManagerConfig.register_custom_attributes(builder)
 
             # Register KaminoSceneAPI custom attributes for each individual solver-level configurations
             builder.add_custom_attribute(
@@ -276,6 +285,7 @@ class SolverKamino(SolverBase, CouplingInterface):
                 "dynamics": config.ConstrainedDynamicsConfig,
                 "padmm": config.PADMMSolverConfig,
                 "fk": config.ForwardKinematicsSolverConfig,
+                "materials": config.MaterialManagerConfig,
             }
             for attr_name, config_cls in subconfigs.items():
                 nested_config = kwargs.get(attr_name, None)
@@ -319,6 +329,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             self.constraints.validate()
             self.dynamics.validate()
             self.padmm.validate()
+            self.materials.validate()
 
             # Conversion to JointCorrectionMode will raise an error if the input string is invalid.
             JointCorrectionMode.from_string(self.rotation_correction)
@@ -354,6 +365,8 @@ class SolverKamino(SolverBase, CouplingInterface):
                 self.dynamics = config.ConstrainedDynamicsConfig()
             if self.padmm is None:
                 self.padmm = config.PADMMSolverConfig()
+            if self.materials is None:
+                self.materials = config.MaterialManagerConfig()
 
             # Validate the config values after all default-initialization is done
             # to ensure that any inter-dependent parameters are properly checked.
@@ -808,6 +821,8 @@ class SolverKamino(SolverBase, CouplingInterface):
                 contacts_in=contacts,
                 contacts_out=self._contacts_kamino,
                 convert_forces=False,
+                friction_mix_mode=self._config.materials.friction_mix_mode,
+                restitution_mix_mode=self._config.materials.restitution_mix_mode,
             )
         # Otherwise, use Kamino's internal collision detector to generate contacts
         else:

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -1019,7 +1019,7 @@ class TestModelConversions(unittest.TestCase):
         #       pair properties based on the list of materials, using the average of the material
         #       properties. The Newton-to-Kamino conversion will leave the material pair properties
         #       uninitialized, leaving the choice of how to combine materials for a pair to the
-        #       runtime material resolution system (see :class:`MaterialMuxMode`).
+        #       runtime material resolution system (see :class:`MaterialMixMode`).
         # test_util_checks.assert_model_material_pairs_equal(self, model_kamino_converted.material_pairs, model_kamino.material_pairs)
 
     def test_30_state_conversions(self):


### PR DESCRIPTION
## Description

This PR introduces configurable per-shape material property mixing when using generating contacts using the external CollisionPipeline. It does so by:
1. Adding back-end support within the corresponding conversion operation/kernel
2. Exposing high-level user-facing string literals to support the min/max/multiply/average operations on contact friction and restitution.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable material mixing modes for friction and restitution (average, multiply, max, min), with friction defaulting to average and restitution to min.
  * Newton-to-Kamino contact conversion now uses the selected mixing modes when deriving friction and restitution.
  * Exposed these settings through solver/model configuration inputs.
* **Bug Fixes**
  * Made mixing behavior more explicit and consistent, including the new multiply option.
* **Tests**
  * Updated test terminology to match the new mixing-mode naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->