### PR TITLE
[Kamino] Fix Kamino Joint damping

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -177,7 +177,7 @@ def joint_conversion_kernel(
     model_joint_q_start: wp.array[wp.int32],
     model_joint_qd_start: wp.array[wp.int32],
     model_joint_armature: wp.array[wp.float32],
-    model_joint_friction: wp.array[wp.float32],
+    model_joint_damping: wp.array[wp.float32],
     model_joint_target_ke: wp.array[wp.float32],
     model_joint_target_kd: wp.array[wp.float32],
     joint_limit_lower: wp.array[wp.float32],
@@ -237,7 +237,7 @@ def joint_conversion_kernel(
     # Infer if the joint requires dynamic constraints
     for dof_id in range(ndofs_j):
         a_j = model_joint_armature[dofs_start_j + dof_id]
-        b_j = model_joint_friction[dofs_start_j + dof_id]
+        b_j = model_joint_damping[dofs_start_j + dof_id]
         ke_j = model_joint_target_ke[dofs_start_j + dof_id]
         kd_j = model_joint_target_kd[dofs_start_j + dof_id]
         is_dynamic_j = is_dynamic_j or (a_j > 0.0) or (b_j > 0.0) or (ke_j > 0.0) or (kd_j > 0.0)
@@ -873,7 +873,7 @@ def convert_joints(
             model.joint_q_start,
             model.joint_qd_start,
             model.joint_armature,
-            model.joint_friction,
+            model.joint_damping,
             model.joint_target_ke,
             model.joint_target_kd,
             joint_limit_lower,
@@ -1232,7 +1232,7 @@ def convert_joints(
         dq_j_max=joint_velocity_limit,
         tau_j_max=joint_effort_limit,
         a_j=model.joint_armature,
-        b_j=model.joint_friction,  # TODO: Is this the right attribute?
+        b_j=model.joint_damping,
         k_p_j=model.joint_target_ke,
         k_d_j=model.joint_target_kd,
         q_j_0=model.joint_q,

--- a/newton/tests/test_joint_damping.py
+++ b/newton/tests/test_joint_damping.py
@@ -122,6 +122,7 @@ devices = get_test_devices()
 solvers = {
     "featherstone": (lambda model: newton.solvers.SolverFeatherstone(model, angular_damping=0.0), False),
     "semi_implicit": (lambda model: newton.solvers.SolverSemiImplicit(model, angular_damping=0.0), True),
+    "kamino": (newton.solvers.SolverKamino, False),
 }
 
 for device in devices:


### PR DESCRIPTION
## Description

Fixes which Newton model parameter Kamino reads for its joint viscous friction. It should read from `joint_damping`, not `joint_friction`.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Added a kamino case to the existing joint-damping regression suite (newton/tests/test_joint_damping.py).
     ```
    uv run --extra dev -m newton.tests -k test_joint_damping
     ``` -->

## Bug fix

**Steps to reproduce:**

Run the extended test without the fix. It will fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved joint conversion so joint damping is handled correctly when moving between supported solvers, resulting in more accurate joint behavior.
  * Expanded revolute joint damping test coverage to include the affected solver option, helping ensure damping decays velocity as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->