### PR TITLE
[Kamino] Fix runtime model changes of joint limits and body inertia.

### DIFF
--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -11,7 +11,10 @@ from .core.bodies import (
     convert_body_origin_to_com,
 )
 from .core.control import ControlKamino
-from .core.conversions import convert_model_joint_transforms
+from .core.conversions import (
+    convert_model_joint_limits,
+    convert_model_joint_transforms,
+)
 from .core.gravity import convert_model_gravity
 from .core.model import ModelKamino
 from .core.state import StateKamino
@@ -41,6 +44,7 @@ __all__ = [
     "convert_contacts_kamino_to_newton",
     "convert_contacts_newton_to_kamino",
     "convert_model_gravity",
+    "convert_model_joint_limits",
     "convert_model_joint_transforms",
     "msg",
 ]

--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -11,10 +11,7 @@ from .core.bodies import (
     convert_body_origin_to_com,
 )
 from .core.control import ControlKamino
-from .core.conversions import (
-    convert_model_joint_limits,
-    convert_model_joint_transforms,
-)
+from .core.conversions import convert_model_joint_transforms
 from .core.gravity import convert_model_gravity
 from .core.model import ModelKamino
 from .core.state import StateKamino
@@ -44,7 +41,6 @@ __all__ = [
     "convert_contacts_kamino_to_newton",
     "convert_contacts_newton_to_kamino",
     "convert_model_gravity",
-    "convert_model_joint_limits",
     "convert_model_joint_transforms",
     "msg",
 ]

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -20,10 +20,6 @@ from .bodies import (
 from .builder import JointActuationType
 from .geometry import GeometriesModel
 from .joints import (
-    JOINT_DQMAX,
-    JOINT_QMAX,
-    JOINT_QMIN,
-    JOINT_TAUMAX,
     JointDoFType,
     JointsModel,
 )
@@ -42,7 +38,6 @@ if TYPE_CHECKING:
 __all__ = [
     "convert_geometries",
     "convert_joints",
-    "convert_model_joint_limits",
     "convert_model_joint_transforms",
     "convert_rigid_bodies",
     "convert_target_coords_to_target_dofs",
@@ -183,8 +178,6 @@ def joint_conversion_kernel(
     model_joint_target_kd: wp.array[wp.float32],
     joint_limit_lower: wp.array[wp.float32],
     joint_limit_upper: wp.array[wp.float32],
-    joint_velocity_limit: wp.array[wp.float32],
-    joint_effort_limit: wp.array[wp.float32],
     # Outputs:
     joint_jid: wp.array[wp.int32],
     joint_dof_type: wp.array[wp.int32],
@@ -248,17 +241,6 @@ def joint_conversion_kernel(
     if is_dynamic_j:
         joint_num_dynamic_cts[joint_id] = ndofs_j
     joint_num_cts[joint_id] = joint_num_dynamic_cts[joint_id] + joint_num_kinematic_cts[joint_id]
-
-    # Clip joint limits and effort/velocity limits to supported ranges
-    for i in range(qd_count_j):
-        joint_limit_lower[dofs_start_j + i] = wp.clamp(joint_limit_lower[dofs_start_j + i], JOINT_QMIN, JOINT_QMAX)
-        joint_limit_upper[dofs_start_j + i] = wp.clamp(joint_limit_upper[dofs_start_j + i], JOINT_QMIN, JOINT_QMAX)
-        joint_velocity_limit[dofs_start_j + i] = wp.clamp(
-            joint_velocity_limit[dofs_start_j + i], -JOINT_DQMAX, JOINT_DQMAX
-        )
-        joint_effort_limit[dofs_start_j + i] = wp.clamp(
-            joint_effort_limit[dofs_start_j + i], -JOINT_TAUMAX, JOINT_TAUMAX
-        )
 
 
 @wp.kernel
@@ -697,62 +679,6 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     )
 
 
-@wp.kernel
-def joint_limits_conversion_kernel(
-    # Inputs:
-    joint_limit_lower: wp.array[wp.float32],
-    joint_limit_upper: wp.array[wp.float32],
-    joint_velocity_limit: wp.array[wp.float32],
-    joint_effort_limit: wp.array[wp.float32],
-    # Outputs:
-    q_j_min: wp.array[wp.float32],
-    q_j_max: wp.array[wp.float32],
-    dq_j_max: wp.array[wp.float32],
-    tau_j_max: wp.array[wp.float32],
-):
-    i = wp.tid()
-    q_j_min[i] = wp.clamp(joint_limit_lower[i], JOINT_QMIN, JOINT_QMAX)
-    q_j_max[i] = wp.clamp(joint_limit_upper[i], JOINT_QMIN, JOINT_QMAX)
-    dq_j_max[i] = wp.clamp(joint_velocity_limit[i], -JOINT_DQMAX, JOINT_DQMAX)
-    tau_j_max[i] = wp.clamp(joint_effort_limit[i], -JOINT_TAUMAX, JOINT_TAUMAX)
-
-
-def convert_model_joint_limits(model: Model, joints: JointsModel) -> None:
-    """
-    Copies Newton's joint DoF limits into Kamino's format.
-
-    Reads Newton's ``model.joint_limit_lower`` / ``joint_limit_upper`` /
-    ``joint_velocity_limit`` / ``joint_effort_limit`` and writes clamped values
-    into :attr:`JointsModel.q_j_min`, :attr:`JointsModel.q_j_max`,
-    :attr:`JointsModel.dq_j_max` and :attr:`JointsModel.tau_j_max` in-place. The
-    Kamino limit arrays are per-DoF clones of Newton's arrays (not aliases), so
-    this must be re-run whenever the Newton limits change at runtime. Clamping to
-    Kamino's supported ranges mirrors the construction-time conversion in
-    :func:`convert_joints`.
-
-    Args:
-        model: The input Newton model whose joint limits are read (never modified).
-        joints: The output JointsModel instance to update in-place.
-    """
-    wp.launch(
-        kernel=joint_limits_conversion_kernel,
-        dim=joints.q_j_min.shape[0],
-        inputs=[
-            # Inputs:
-            model.joint_limit_lower,
-            model.joint_limit_upper,
-            model.joint_velocity_limit,
-            model.joint_effort_limit,
-            # Outputs:
-            joints.q_j_min,
-            joints.q_j_max,
-            joints.dq_j_max,
-            joints.tau_j_max,
-        ],
-        device=model.device,
-    )
-
-
 def convert_rigid_bodies(
     model: Model,
     model_size: SizeKamino,
@@ -911,12 +837,6 @@ def convert_joints(
         joint_X_B = wp.empty(shape=(model.joint_count,), dtype=wp.mat33f)
         joint_X_F = wp.empty(shape=(model.joint_count,), dtype=wp.mat33f)
 
-    # Copy limit arrays
-    joint_limit_lower = wp.clone(model.joint_limit_lower)
-    joint_limit_upper = wp.clone(model.joint_limit_upper)
-    joint_velocity_limit = wp.clone(model.joint_velocity_limit)
-    joint_effort_limit = wp.clone(model.joint_effort_limit)
-
     wp.launch(
         kernel=joint_conversion_kernel,
         dim=model.joint_count,
@@ -933,10 +853,8 @@ def convert_joints(
             model.joint_damping,
             model.joint_target_ke,
             model.joint_target_kd,
-            joint_limit_lower,
-            joint_limit_upper,
-            joint_velocity_limit,
-            joint_effort_limit,
+            model.joint_limit_lower,
+            model.joint_limit_upper,
             # Outputs:
             joint_jid,
             joint_dof_type,
@@ -1284,10 +1202,10 @@ def convert_joints(
         F_r_Fj=joint_F_r_F,
         X_Bj=joint_X_B,
         X_Fj=joint_X_F,
-        q_j_min=joint_limit_lower,
-        q_j_max=joint_limit_upper,
-        dq_j_max=joint_velocity_limit,
-        tau_j_max=joint_effort_limit,
+        q_j_min=model.joint_limit_lower,
+        q_j_max=model.joint_limit_upper,
+        dq_j_max=model.joint_velocity_limit,
+        tau_j_max=model.joint_effort_limit,
         a_j=model.joint_armature,
         b_j=model.joint_damping,
         k_p_j=model.joint_target_ke,
@@ -1420,7 +1338,6 @@ def convert_geometries(
     sorted_excluded_pairs = model.shape_collision_filter_pairs_array()
     excluded_pairs = wp.array(sorted_excluded_pairs, dtype=wp.vec2i, device=model.device)
 
-    # Construct and return the converted geometries model
     return GeometriesModel(
         num_geoms=model.shape_count,
         num_collidable=model_num_collidable_geoms.numpy()[0],

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 __all__ = [
     "convert_geometries",
     "convert_joints",
+    "convert_model_joint_limits",
     "convert_model_joint_transforms",
     "convert_rigid_bodies",
     "convert_target_coords_to_target_dofs",
@@ -696,6 +697,62 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     )
 
 
+@wp.kernel
+def joint_limits_conversion_kernel(
+    # Inputs:
+    joint_limit_lower: wp.array[wp.float32],
+    joint_limit_upper: wp.array[wp.float32],
+    joint_velocity_limit: wp.array[wp.float32],
+    joint_effort_limit: wp.array[wp.float32],
+    # Outputs:
+    q_j_min: wp.array[wp.float32],
+    q_j_max: wp.array[wp.float32],
+    dq_j_max: wp.array[wp.float32],
+    tau_j_max: wp.array[wp.float32],
+):
+    i = wp.tid()
+    q_j_min[i] = wp.clamp(joint_limit_lower[i], JOINT_QMIN, JOINT_QMAX)
+    q_j_max[i] = wp.clamp(joint_limit_upper[i], JOINT_QMIN, JOINT_QMAX)
+    dq_j_max[i] = wp.clamp(joint_velocity_limit[i], -JOINT_DQMAX, JOINT_DQMAX)
+    tau_j_max[i] = wp.clamp(joint_effort_limit[i], -JOINT_TAUMAX, JOINT_TAUMAX)
+
+
+def convert_model_joint_limits(model: Model, joints: JointsModel) -> None:
+    """
+    Copies Newton's joint DoF limits into Kamino's format.
+
+    Reads Newton's ``model.joint_limit_lower`` / ``joint_limit_upper`` /
+    ``joint_velocity_limit`` / ``joint_effort_limit`` and writes clamped values
+    into :attr:`JointsModel.q_j_min`, :attr:`JointsModel.q_j_max`,
+    :attr:`JointsModel.dq_j_max` and :attr:`JointsModel.tau_j_max` in-place. The
+    Kamino limit arrays are per-DoF clones of Newton's arrays (not aliases), so
+    this must be re-run whenever the Newton limits change at runtime. Clamping to
+    Kamino's supported ranges mirrors the construction-time conversion in
+    :func:`convert_joints`.
+
+    Args:
+        model: The input Newton model whose joint limits are read (never modified).
+        joints: The output JointsModel instance to update in-place.
+    """
+    wp.launch(
+        kernel=joint_limits_conversion_kernel,
+        dim=joints.q_j_min.shape[0],
+        inputs=[
+            # Inputs:
+            model.joint_limit_lower,
+            model.joint_limit_upper,
+            model.joint_velocity_limit,
+            model.joint_effort_limit,
+            # Outputs:
+            joints.q_j_min,
+            joints.q_j_max,
+            joints.dq_j_max,
+            joints.tau_j_max,
+        ],
+        device=model.device,
+    )
+
+
 def convert_rigid_bodies(
     model: Model,
     model_size: SizeKamino,
@@ -807,9 +864,9 @@ def convert_rigid_bodies(
         bid=body_bid,  # TODO: Remove
         m_i=model.body_mass,
         inv_m_i=model.body_inv_mass,
-        i_r_com_i=wp.clone(model.body_com, device=model.device),
-        i_I_i=wp.clone(model.body_inertia, device=model.device),
-        inv_i_I_i=wp.clone(model.body_inv_inertia, device=model.device),
+        i_r_com_i=model.body_com,
+        i_I_i=model.body_inertia,
+        inv_i_I_i=model.body_inv_inertia,
         q_i_0=q_i_0,
         u_i_0=wp.clone(model.body_qd, device=model.device),
     )

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -882,9 +882,9 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._update_joint_transforms()
 
         if flags & ModelFlags.JOINT_DOF_PROPERTIES:
-            # Joint limits (q_j_min, q_j_max, dq_j_max, tau_j_max) are clamped
-            # clones of Newton's arrays, not references, so they must be re-copied.
-            self._update_joint_limits()
+            # Kamino's joint limits (q_j_min, q_j_max, dq_j_max, tau_j_max) reference
+            # Newton's arrays directly, so no copy needed.
+            pass
 
         if flags & ModelFlags.ACTUATOR_PROPERTIES:
             pass  # TODO: ???
@@ -1095,15 +1095,3 @@ class SolverKamino(SolverBase, CouplingInterface):
         changed at runtime (e.g. animated root transforms).
         """
         self._kamino.convert_model_joint_transforms(self.model, self._model_kamino.joints)
-
-    def _update_joint_limits(self):
-        """
-        Re-copy Kamino joint DoF limits from Newton's joint limit arrays.
-
-        Called when :data:`~newton.ModelFlags.JOINT_DOF_PROPERTIES` is raised,
-        indicating that ``model.joint_limit_lower`` / ``joint_limit_upper`` /
-        ``joint_velocity_limit`` / ``joint_effort_limit`` may have changed at
-        runtime. The Kamino limits are clamped clones (not aliases) of Newton's
-        arrays, so they must be re-derived here.
-        """
-        self._kamino.convert_model_joint_limits(self.model, self._model_kamino.joints)

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -882,9 +882,9 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._update_joint_transforms()
 
         if flags & ModelFlags.JOINT_DOF_PROPERTIES:
-            # Joint limits (q_j_min, q_j_max, dq_j_max, tau_j_max) are direct
-            # references to Newton's arrays, so no copy needed.
-            pass
+            # Joint limits (q_j_min, q_j_max, dq_j_max, tau_j_max) are clamped
+            # clones of Newton's arrays, not references, so they must be re-copied.
+            self._update_joint_limits()
 
         if flags & ModelFlags.ACTUATOR_PROPERTIES:
             pass  # TODO: ???
@@ -1095,3 +1095,15 @@ class SolverKamino(SolverBase, CouplingInterface):
         changed at runtime (e.g. animated root transforms).
         """
         self._kamino.convert_model_joint_transforms(self.model, self._model_kamino.joints)
+
+    def _update_joint_limits(self):
+        """
+        Re-copy Kamino joint DoF limits from Newton's joint limit arrays.
+
+        Called when :data:`~newton.ModelFlags.JOINT_DOF_PROPERTIES` is raised,
+        indicating that ``model.joint_limit_lower`` / ``joint_limit_upper`` /
+        ``joint_velocity_limit`` / ``joint_effort_limit`` may have changed at
+        runtime. The Kamino limits are clamped clones (not aliases) of Newton's
+        arrays, so they must be re-derived here.
+        """
+        self._kamino.convert_model_joint_limits(self.model, self._model_kamino.joints)

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -1,18 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression tests for SolverKamino runtime model-property propagation.
-
-SolverKamino builds its internal :class:`ModelKamino` once from a Newton model.
-The joint DoF limits are *clamped clones* of Newton's arrays, so runtime changes
-require ``notify_model_changed(JOINT_DOF_PROPERTIES)`` to re-copy them. The body
-inertial arrays (``i_r_com_i`` / ``i_I_i`` / ``inv_i_I_i``, like ``m_i`` /
-``inv_m_i``) instead *reference* Newton's arrays directly, so in-place edits
-propagate without any notify call.
-
-These tests are pure white-box assertions on the internal ``_model_kamino`` --
-no ``solver.step`` / simulation is performed.
-"""
+"""Tests for SolverKamino runtime model-property propagation."""
 
 from __future__ import annotations
 
@@ -59,23 +48,19 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
             setup_tests(clear_cache=False)
         self.device = wp.get_device(test_context.device)
 
-    def test_joint_dof_limits_propagate(self):
-        """``notify_model_changed(JOINT_DOF_PROPERTIES)`` must re-copy the DoF limits.
-
-        Pre-fix, the ``JOINT_DOF_PROPERTIES`` branch was a no-op that wrongly
-        assumed the Kamino limit arrays aliased Newton's arrays. They are clamped
-        clones, so runtime limit changes were silently dropped and the solver kept
-        enforcing the build-time limits.
-        """
+    def test_joint_dof_limits_reference_newton(self):
+        """Joint DoF limits alias Newton's arrays, so runtime changes need no notify."""
         model = _build_limited_revolute()
         solver = SolverKamino(model)
         joints = solver._model_kamino.joints
 
-        # Baseline: Kamino limits captured at construction (from limit_lower/upper=-1/1).
-        baseline_min = joints.q_j_min.numpy().copy()
-        np.testing.assert_allclose(baseline_min, -1.0)
+        # The Kamino limit arrays share storage with Newton's model arrays.
+        self.assertEqual(joints.q_j_min.ptr, model.joint_limit_lower.ptr)
+        self.assertEqual(joints.q_j_max.ptr, model.joint_limit_upper.ptr)
+        self.assertEqual(joints.dq_j_max.ptr, model.joint_velocity_limit.ptr)
+        self.assertEqual(joints.tau_j_max.ptr, model.joint_effort_limit.ptr)
 
-        # New in-range limits (no clamping applied, so propagated == assigned).
+        # In-place updates to Newton's arrays are reflected without any notify call.
         new_lower = np.full_like(model.joint_limit_lower.numpy(), -0.3)
         new_upper = np.full_like(model.joint_limit_upper.numpy(), 0.3)
         new_vel = np.full_like(model.joint_velocity_limit.numpy(), 7.0)
@@ -85,24 +70,17 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         model.joint_velocity_limit.assign(new_vel)
         model.joint_effort_limit.assign(new_effort)
 
-        # Negative control: without notify, the Kamino limits are still stale.
-        np.testing.assert_allclose(joints.q_j_min.numpy(), baseline_min)
-
-        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
-
         np.testing.assert_allclose(joints.q_j_min.numpy(), new_lower)
         np.testing.assert_allclose(joints.q_j_max.numpy(), new_upper)
         np.testing.assert_allclose(joints.dq_j_max.numpy(), new_vel)
         np.testing.assert_allclose(joints.tau_j_max.numpy(), new_effort)
 
-    def test_body_inertial_properties_reference_newton(self):
-        """Body inertial arrays alias Newton's, so runtime changes need no notify.
+        # notify_model_changed(JOINT_DOF_PROPERTIES) is a harmless no-op.
+        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+        np.testing.assert_allclose(joints.q_j_min.numpy(), new_lower)
 
-        ``i_r_com_i`` / ``i_I_i`` / ``inv_i_I_i`` (like ``m_i`` / ``inv_m_i``)
-        reference Newton's arrays directly. Kamino never mutates them, so in-place
-        edits to the Newton model are seen by the solver without a
-        ``notify_model_changed(BODY_INERTIAL_PROPERTIES)`` call.
-        """
+    def test_body_inertial_properties_reference_newton(self):
+        """Body inertial arrays alias Newton's, so runtime changes need no notify."""
         model = _build_limited_revolute()
         solver = SolverKamino(model)
         bodies = solver._model_kamino.bodies
@@ -130,15 +108,10 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         np.testing.assert_allclose(bodies.i_I_i.numpy(), new_inertia, atol=1e-6)
 
     def test_notify_does_not_mutate_newton_arrays(self):
-        """``notify_model_changed`` must only read Newton's arrays, never write them.
-
-        The update copies Newton -> Kamino; it must never write back into Newton's
-        model arrays.
-        """
+        """``notify_model_changed`` must only read Newton's arrays, never write them."""
         model = _build_limited_revolute()
         solver = SolverKamino(model)
 
-        # Assign fresh values, then snapshot them as the expected (unchanged) state.
         model.joint_limit_lower.assign(np.full_like(model.joint_limit_lower.numpy(), -0.3))
         model.joint_limit_upper.assign(np.full_like(model.joint_limit_upper.numpy(), 0.3))
         model.body_inertia.assign(model.body_inertia.numpy() * 2.0)

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for SolverKamino runtime model-property propagation.
+
+SolverKamino builds its internal :class:`ModelKamino` once from a Newton model.
+The joint DoF limits are *clamped clones* of Newton's arrays, so runtime changes
+require ``notify_model_changed(JOINT_DOF_PROPERTIES)`` to re-copy them. The body
+inertial arrays (``i_r_com_i`` / ``i_I_i`` / ``inv_i_I_i``, like ``m_i`` /
+``inv_m_i``) instead *reference* Newton's arrays directly, so in-place edits
+propagate without any notify call.
+
+These tests are pure white-box assertions on the internal ``_model_kamino`` --
+no ``solver.step`` / simulation is performed.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton._src.solvers.kamino.solver_kamino import SolverKamino
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+
+def _build_limited_revolute() -> newton.Model:
+    """Build a tiny model: world to a single body via a limited revolute joint."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+
+    builder.begin_world()
+    bid = builder.add_link(
+        label="link",
+        mass=1.0,
+        xform=wp.transformf(wp.vec3f(0.0, 0.0, 1.0), wp.quat_identity(dtype=wp.float32)),
+        lock_inertia=True,
+    )
+    builder.add_shape_box(label="box", body=bid, hx=0.1, hy=0.1, hz=0.1)
+    jid = builder.add_joint_revolute(
+        label="world_to_link",
+        parent=-1,
+        child=bid,
+        axis=newton.Axis.Y,
+        limit_lower=-1.0,
+        limit_upper=1.0,
+    )
+    builder.add_articulation([jid])
+    builder.end_world()
+
+    return builder.finalize()
+
+
+class TestKaminoNotifyModelChanged(unittest.TestCase):
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def test_joint_dof_limits_propagate(self):
+        """``notify_model_changed(JOINT_DOF_PROPERTIES)`` must re-copy the DoF limits.
+
+        Pre-fix, the ``JOINT_DOF_PROPERTIES`` branch was a no-op that wrongly
+        assumed the Kamino limit arrays aliased Newton's arrays. They are clamped
+        clones, so runtime limit changes were silently dropped and the solver kept
+        enforcing the build-time limits.
+        """
+        model = _build_limited_revolute()
+        solver = SolverKamino(model)
+        joints = solver._model_kamino.joints
+
+        # Baseline: Kamino limits captured at construction (from limit_lower/upper=-1/1).
+        baseline_min = joints.q_j_min.numpy().copy()
+        np.testing.assert_allclose(baseline_min, -1.0)
+
+        # New in-range limits (no clamping applied, so propagated == assigned).
+        new_lower = np.full_like(model.joint_limit_lower.numpy(), -0.3)
+        new_upper = np.full_like(model.joint_limit_upper.numpy(), 0.3)
+        new_vel = np.full_like(model.joint_velocity_limit.numpy(), 7.0)
+        new_effort = np.full_like(model.joint_effort_limit.numpy(), 70.0)
+        model.joint_limit_lower.assign(new_lower)
+        model.joint_limit_upper.assign(new_upper)
+        model.joint_velocity_limit.assign(new_vel)
+        model.joint_effort_limit.assign(new_effort)
+
+        # Negative control: without notify, the Kamino limits are still stale.
+        np.testing.assert_allclose(joints.q_j_min.numpy(), baseline_min)
+
+        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+        np.testing.assert_allclose(joints.q_j_min.numpy(), new_lower)
+        np.testing.assert_allclose(joints.q_j_max.numpy(), new_upper)
+        np.testing.assert_allclose(joints.dq_j_max.numpy(), new_vel)
+        np.testing.assert_allclose(joints.tau_j_max.numpy(), new_effort)
+
+    def test_body_inertial_properties_reference_newton(self):
+        """Body inertial arrays alias Newton's, so runtime changes need no notify.
+
+        ``i_r_com_i`` / ``i_I_i`` / ``inv_i_I_i`` (like ``m_i`` / ``inv_m_i``)
+        reference Newton's arrays directly. Kamino never mutates them, so in-place
+        edits to the Newton model are seen by the solver without a
+        ``notify_model_changed(BODY_INERTIAL_PROPERTIES)`` call.
+        """
+        model = _build_limited_revolute()
+        solver = SolverKamino(model)
+        bodies = solver._model_kamino.bodies
+
+        # The Kamino arrays share storage with Newton's model arrays.
+        self.assertEqual(bodies.i_r_com_i.ptr, model.body_com.ptr)
+        self.assertEqual(bodies.i_I_i.ptr, model.body_inertia.ptr)
+        self.assertEqual(bodies.inv_i_I_i.ptr, model.body_inv_inertia.ptr)
+        self.assertEqual(bodies.m_i.ptr, model.body_mass.ptr)
+
+        # In-place updates to Newton's arrays are reflected without any notify call.
+        new_com = model.body_com.numpy() + np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        new_inertia = model.body_inertia.numpy() * 2.0
+        new_inv_inertia = model.body_inv_inertia.numpy() * 0.5
+        model.body_com.assign(new_com)
+        model.body_inertia.assign(new_inertia)
+        model.body_inv_inertia.assign(new_inv_inertia)
+
+        np.testing.assert_allclose(bodies.i_r_com_i.numpy(), new_com, atol=1e-6)
+        np.testing.assert_allclose(bodies.i_I_i.numpy(), new_inertia, atol=1e-6)
+        np.testing.assert_allclose(bodies.inv_i_I_i.numpy(), new_inv_inertia, atol=1e-6)
+
+        # notify_model_changed(BODY_INERTIAL_PROPERTIES) is a harmless no-op.
+        solver.notify_model_changed(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+        np.testing.assert_allclose(bodies.i_I_i.numpy(), new_inertia, atol=1e-6)
+
+    def test_notify_does_not_mutate_newton_arrays(self):
+        """``notify_model_changed`` must only read Newton's arrays, never write them.
+
+        The update copies Newton -> Kamino; it must never write back into Newton's
+        model arrays.
+        """
+        model = _build_limited_revolute()
+        solver = SolverKamino(model)
+
+        # Assign fresh values, then snapshot them as the expected (unchanged) state.
+        model.joint_limit_lower.assign(np.full_like(model.joint_limit_lower.numpy(), -0.3))
+        model.joint_limit_upper.assign(np.full_like(model.joint_limit_upper.numpy(), 0.3))
+        model.body_inertia.assign(model.body_inertia.numpy() * 2.0)
+
+        snapshot = {
+            "joint_limit_lower": model.joint_limit_lower.numpy().copy(),
+            "joint_limit_upper": model.joint_limit_upper.numpy().copy(),
+            "joint_velocity_limit": model.joint_velocity_limit.numpy().copy(),
+            "joint_effort_limit": model.joint_effort_limit.numpy().copy(),
+            "body_com": model.body_com.numpy().copy(),
+            "body_inertia": model.body_inertia.numpy().copy(),
+            "body_inv_inertia": model.body_inv_inertia.numpy().copy(),
+        }
+
+        solver.notify_model_changed(newton.ModelFlags.JOINT_DOF_PROPERTIES | newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+        for name, before in snapshot.items():
+            after = getattr(model, name).numpy()
+            np.testing.assert_array_equal(after, before, err_msg=f"notify_model_changed mutated model.{name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Kamino was not correctly handling model changes for joint limits and body inertias.

Related issue https://github.com/vastsoun/newton/issues/382

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Test added to verify the parameter update. This lives in the Kamino test folder for now because it uses details of the Kamino model directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Joint-limit and rigid-body inertial data now stay synchronized with the model without requiring manual refreshes.
  * Updated model properties are reflected immediately and safely without mutating existing model data.
  * Removed unnecessary limit normalization during joint conversion.

* **Tests**
  * Added regression coverage for live joint-limit and inertial-property updates.
  * Verified model-change notifications remain safe and read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->