### PR TITLE
Update pre-commit hooks and CI tool versions

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: Test minimal import (Python 3.10)
         run: uv run --python 3.10 python -c "import newton; print(f'Newton {newton.__version__} imported successfully')"
       - name: Test minimal import (Python 3.11)
@@ -74,7 +74,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: Test dependency resolution (Python 3.10)
         run: uv sync --dry-run --python 3.10 --extra dev
       - name: Test dependency resolution (Python 3.11)
@@ -117,7 +117,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         if: steps.version.outputs.SHOULD_DEPLOY == 'true'

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -61,7 +61,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: "Set up Python"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
       - name: Set up Python
         run: uv python install
       - name: Build a binary wheel

--- a/.github/workflows/scheduled_nightly.yml
+++ b/.github/workflows/scheduled_nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Update warp-lang in lock file
         run: uv lock -P warp-lang --prerelease allow
@@ -83,7 +83,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
-          version: "0.11.4"
+          version: "0.11.26"
 
       - name: Set up Python
         run: uv python install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.9
+    rev: v0.15.20
     hooks:
       # Run the linter.
       - id: ruff
@@ -40,12 +40,12 @@ repos:
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.4
+    rev: 0.11.26
     hooks:
       # Update the uv lockfile
       - id: uv-lock
   - repo: https://github.com/crate-ci/typos
-    rev: v1.45.0
+    rev: v1.48.0
     hooks:
       - id: typos
         args: []


### PR DESCRIPTION
## Description

Update pre-commit hooks and CI tool versions:
- Bump ruff from v0.15.9 to v0.15.20
- Bump uv from 0.11.4 to 0.11.26 in pre-commit and CI workflows
- Bump typos from v1.45.0 to v1.48.0

Supersedes #3370, which switched typos to the floating `v1` tag instead of an exact pin.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uvx pre-commit run -a
```

All hooks pass with no formatting, lint, typos, or lockfile changes from the new versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned tooling versions across CI, release, docs, benchmark, and test workflows for more consistent and up-to-date builds.
  * Refreshed pre-commit tool versions, including linting, formatting, and typo-checking hooks.
  * Aligned nightly and GPU-related automation with the newer toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->