### PR TITLE
Fix batched MuJoCo site poses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fix `SolverMuJoCo` inertia randomization for bodies initialized with diagonal inertia.
 - Fix `SolverMuJoCo` static worldbody geometry poses so offset batched worlds collide with their local geometry.
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled
+- Fix `SolverMuJoCo` site poses for offset batched worlds and runtime shape-transform updates.
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)
 - Fix mesh-SDF contacts with positive contact gaps by making contact reduction prefer margin-depth contacts over gap-only directional fallbacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - Fix `SolverMuJoCo` inertia randomization for bodies initialized with diagonal inertia.
 - Fix `SolverMuJoCo` static worldbody geometry poses so offset batched worlds collide with their local geometry.
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled
-- Fix `SolverMuJoCo` site poses for offset batched worlds and runtime shape-transform updates.
+- Fix `SolverMuJoCo` site poses for offset batched worlds and site poses and sizes for runtime shape updates.
 - Limit mouse-picking torque using each body's rotational inertia to prevent unstable angular acceleration on low-inertia bodies.
 - Fix `newton.eval_jacobian`, `SolverFeatherstone`, and the IK analytic Jacobian building `JointType.D6` angular motion-subspace columns from raw axes, so `J @ joint_qd` now matches `State.body_qd` for two- or three-angular-DOF joints at non-identity configurations.
 - Fix mesh inertia computation to produce deterministic results across repeated CUDA runs. (#3136)

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2493,15 +2493,22 @@ def update_geom_properties_kernel(
 @wp.kernel
 def update_site_properties_kernel(
     shape_transform: wp.array[wp.transform],
-    mjc_site_to_newton_shape: wp.array2d[wp.int32],
+    site_shape_index: wp.array[wp.int32],
+    site_is_global: wp.array[bool],
+    shapes_per_world: int,
+    first_env_shape_base: int,
     site_pos: wp.array2d[wp.vec3],
     site_quat: wp.array2d[wp.quat],
 ):
     """Update MuJoCo site poses from Newton shape transforms."""
     world, site = wp.tid()
-    shape = mjc_site_to_newton_shape[world, site]
-    if shape < 0:
+    template_or_global_shape = site_shape_index[site]
+    if template_or_global_shape < 0:
         return
+
+    shape = template_or_global_shape
+    if not site_is_global[site]:
+        shape = first_env_shape_base + template_or_global_shape + world * shapes_per_world
 
     tf = shape_transform[shape]
     site_pos[world, site] = tf.p

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2493,14 +2493,16 @@ def update_geom_properties_kernel(
 @wp.kernel
 def update_site_properties_kernel(
     shape_transform: wp.array[wp.transform],
+    shape_scale: wp.array[wp.vec3],
     site_shape_index: wp.array[wp.int32],
     site_is_global: wp.array[bool],
     shapes_per_world: int,
     first_env_shape_base: int,
     site_pos: wp.array2d[wp.vec3],
     site_quat: wp.array2d[wp.quat],
+    site_size: wp.array[wp.vec3],
 ):
-    """Update MuJoCo site poses from Newton shape transforms."""
+    """Update MuJoCo site poses and sizes from Newton shape properties."""
     world, site = wp.tid()
     template_or_global_shape = site_shape_index[site]
     if template_or_global_shape < 0:
@@ -2513,6 +2515,27 @@ def update_site_properties_kernel(
     tf = shape_transform[shape]
     site_pos[world, site] = tf.p
     site_quat[world, site] = quat_xyzw_to_wxyz(tf.q)
+
+    # site_size has no world dimension in mujoco_warp, so world 0 is the
+    # source of truth; per-world site sizes are not representable.
+    if world == 0:
+        scale = shape_scale[shape]
+        # Mirror export: fill zero components with the first positive one.
+        nonzero = 0.0
+        if scale[0] > 0.0:
+            nonzero = scale[0]
+        elif scale[1] > 0.0:
+            nonzero = scale[1]
+        elif scale[2] > 0.0:
+            nonzero = scale[2]
+        if nonzero > 0.0:
+            site_size[site] = wp.vec3(
+                wp.where(scale[0] == 0.0, nonzero, scale[0]),
+                wp.where(scale[1] == 0.0, nonzero, scale[1]),
+                wp.where(scale[2] == 0.0, nonzero, scale[2]),
+            )
+        else:
+            site_size[site] = wp.vec3(0.01, 0.01, 0.01)
 
 
 @wp.kernel

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -2491,6 +2491,24 @@ def update_geom_properties_kernel(
 
 
 @wp.kernel
+def update_site_properties_kernel(
+    shape_transform: wp.array[wp.transform],
+    mjc_site_to_newton_shape: wp.array2d[wp.int32],
+    site_pos: wp.array2d[wp.vec3],
+    site_quat: wp.array2d[wp.quat],
+):
+    """Update MuJoCo site poses from Newton shape transforms."""
+    world, site = wp.tid()
+    shape = mjc_site_to_newton_shape[world, site]
+    if shape < 0:
+        return
+
+    tf = shape_transform[shape]
+    site_pos[world, site] = tf.p
+    site_quat[world, site] = quat_xyzw_to_wxyz(tf.q)
+
+
+@wp.kernel
 def sync_worldbody_geom_xposes_kernel(
     geom_bodyid: wp.array[int],
     geom_pos: wp.array2d[wp.vec3],
@@ -2506,6 +2524,25 @@ def sync_worldbody_geom_xposes_kernel(
     geom_q = quat_wxyz_to_xyzw(geom_quat[world, geom])
     geom_xpos[world, geom] = geom_pos[world, geom]
     geom_xmat[world, geom] = wp.quat_to_matrix(geom_q)
+
+
+@wp.kernel
+def sync_site_xposes_kernel(
+    site_bodyid: wp.array[int],
+    site_pos: wp.array2d[wp.vec3],
+    site_quat: wp.array2d[wp.quat],
+    body_xpos: wp.array2d[wp.vec3],
+    body_xquat: wp.array2d[wp.quat],
+    site_xpos: wp.array2d[wp.vec3],
+    site_xmat: wp.array2d[wp.mat33],
+):
+    """Refresh derived site poses after per-world model updates."""
+    world, site = wp.tid()
+    body = site_bodyid[site]
+    body_q = quat_wxyz_to_xyzw(body_xquat[world, body])
+    site_q = quat_wxyz_to_xyzw(site_quat[world, site])
+    site_xpos[world, site] = body_xpos[world, body] + wp.quat_rotate(body_q, site_pos[world, site])
+    site_xmat[world, site] = wp.quat_to_matrix(body_q * site_q)
 
 
 @wp.kernel

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3267,8 +3267,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         """Mapping from MuJoCo [world, body] to Newton body index. Shape [nworld, nbody], dtype int32."""
         self.mjc_geom_to_newton_shape: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, geom] to Newton shape index. Shape [nworld, ngeom], dtype int32."""
-        self.mjc_site_to_newton_shape: wp.array2d[wp.int32] | None = None
-        """Mapping from MuJoCo [world, site] to Newton shape index. Shape [nworld, nsite], dtype int32."""
+        # Template-relative for per-world sites and absolute for global sites.
+        self._mjc_site_shape_index: wp.array[wp.int32] | None = None
+        self._mjc_site_is_global: wp.array[bool] | None = None
         self.mjc_jnt_to_newton_jnt: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, joint] to Newton joint index. Shape [nworld, njnt], dtype int32."""
         self.mjc_jnt_to_newton_dof: wp.array2d[wp.int32] | None = None
@@ -6516,30 +6517,16 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 )
 
             site_to_shape_idx_np = np.full((self.mj_model.nsite,), -1, dtype=np.int32)
-            site_is_static_np = np.zeros((self.mj_model.nsite,), dtype=bool)
+            site_is_global_np = np.zeros((self.mj_model.nsite,), dtype=bool)
             for site_idx, abs_shape_idx in site_to_shape_idx.items():
                 if shape_world[abs_shape_idx] < 0:
                     site_to_shape_idx_np[site_idx] = abs_shape_idx
-                    site_is_static_np[site_idx] = True
+                    site_is_global_np[site_idx] = True
                 else:
                     site_to_shape_idx_np[site_idx] = abs_shape_idx - first_env_shape_base
 
-            self.mjc_site_to_newton_shape = wp.full((nworld, self.mj_model.nsite), -1, dtype=wp.int32)
-            if self.mjw_model.site_pos.size:
-                site_to_shape_idx_wp = wp.array(site_to_shape_idx_np, dtype=wp.int32)
-                site_is_static_wp = wp.array(site_is_static_np, dtype=bool)
-                wp.launch(
-                    update_shape_mappings_kernel,
-                    dim=(nworld, self.mj_model.nsite),
-                    inputs=[
-                        site_to_shape_idx_wp,
-                        site_is_static_wp,
-                        self._shapes_per_world,
-                        first_env_shape_base,
-                    ],
-                    outputs=[self.mjc_site_to_newton_shape],
-                    device=model.device,
-                )
+            self._mjc_site_shape_index = wp.array(site_to_shape_idx_np, dtype=wp.int32)
+            self._mjc_site_is_global = wp.array(site_is_global_np, dtype=bool)
 
             # Create mjc_body_to_newton: MuJoCo[world, body] -> Newton body
             # body_mapping is {newton_body_id: mjc_body_id}, we need to invert it
@@ -7768,10 +7755,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
         wp.launch(
             update_site_properties_kernel,
-            dim=(self.mjc_site_to_newton_shape.shape[0], self.mj_model.nsite),
+            dim=(self.mjw_data.nworld, self.mj_model.nsite),
             inputs=[
                 self.model.shape_transform,
-                self.mjc_site_to_newton_shape,
+                self._mjc_site_shape_index,
+                self._mjc_site_is_global,
+                self._shapes_per_world,
+                self._first_env_shape_base,
             ],
             outputs=[
                 self.mjw_model.site_pos,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7889,7 +7889,11 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         )
 
     def _update_site_properties(self) -> None:
-        """Update MuJoCo site poses from Newton shape transforms."""
+        """Update MuJoCo site poses and sizes from Newton shape properties.
+
+        ``site_size`` is unbatched in mujoco_warp, so sizes are synced from
+        the first world; per-world scale differences are not supported.
+        """
         if self.mj_model.nsite == 0:
             return
 
@@ -7898,6 +7902,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             dim=(self.mjw_data.nworld, self.mj_model.nsite),
             inputs=[
                 self.model.shape_transform,
+                self.model.shape_scale,
                 self._mjc_site_shape_index,
                 self._mjc_site_is_global,
                 self._shapes_per_world,
@@ -7906,6 +7911,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             outputs=[
                 self.mjw_model.site_pos,
                 self.mjw_model.site_quat,
+                self.mjw_model.site_size,
             ],
             device=self.model.device,
         )

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -74,6 +74,7 @@ from .kernels import (
     reset_joint_state_kernel,
     reset_world_buffers_kernel,
     sync_qpos0_kernel,
+    sync_site_xposes_kernel,
     sync_worldbody_geom_xposes_kernel,
     update_axis_properties_kernel,
     update_body_inertia_kernel,
@@ -96,6 +97,7 @@ from .kernels import (
     update_model_properties_kernel,
     update_pair_properties_kernel,
     update_shape_mappings_kernel,
+    update_site_properties_kernel,
     update_solver_options_kernel,
     update_tendon_properties_kernel,
 )
@@ -3265,6 +3267,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         """Mapping from MuJoCo [world, body] to Newton body index. Shape [nworld, nbody], dtype int32."""
         self.mjc_geom_to_newton_shape: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, geom] to Newton shape index. Shape [nworld, ngeom], dtype int32."""
+        self.mjc_site_to_newton_shape: wp.array2d[wp.int32] | None = None
+        """Mapping from MuJoCo [world, site] to Newton shape index. Shape [nworld, nsite], dtype int32."""
         self.mjc_jnt_to_newton_jnt: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, joint] to Newton joint index. Shape [nworld, njnt], dtype int32."""
         self.mjc_jnt_to_newton_dof: wp.array2d[wp.int32] | None = None
@@ -3977,6 +3981,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             need_length_range = True
         if flags & ModelFlags.SHAPE_PROPERTIES:
             self._update_geom_properties()
+            self._update_site_properties()
             self._update_pair_properties()
             self._invalidate_contact_fast_path()
         if flags & ModelFlags.MODEL_PROPERTIES:
@@ -4075,6 +4080,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
             if flags & ModelFlags.SHAPE_PROPERTIES:
                 self._sync_worldbody_geom_xposes()
+                self._sync_site_xposes()
 
     def _sync_equality_properties_to_mujoco_cpu(self) -> None:
         """Mirror equality properties from MJWarp buffers to MuJoCo-C CPU buffers."""
@@ -4107,6 +4113,27 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             outputs=[
                 self.mjw_data.geom_xpos,
                 self.mjw_data.geom_xmat,
+            ],
+            device=self.model.device,
+        )
+
+    def _sync_site_xposes(self) -> None:
+        """Refresh derived site poses after per-world model updates."""
+        if self.mj_model.nsite == 0:
+            return
+        wp.launch(
+            sync_site_xposes_kernel,
+            dim=(self.mjw_data.nworld, self.mj_model.nsite),
+            inputs=[
+                self.mjw_model.site_bodyid,
+                self.mjw_model.site_pos,
+                self.mjw_model.site_quat,
+                self.mjw_data.xpos,
+                self.mjw_data.xquat,
+            ],
+            outputs=[
+                self.mjw_data.site_xpos,
+                self.mjw_data.site_xmat,
             ],
             device=self.model.device,
         )
@@ -6423,6 +6450,12 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 shape_to_geom_idx[shape] = geom_idx
                 geom_to_shape_idx[geom_idx] = shape
 
+        site_to_shape_idx = {}
+        for shape, site_name in site_mapping.items():
+            site_idx = mujoco.mj_name2id(self.mj_model, mujoco.mjtObj.mjOBJ_SITE, site_name)
+            if site_idx >= 0:
+                site_to_shape_idx[site_idx] = shape
+
         with wp.ScopedDevice(model.device):
             # create the MuJoCo Warp model
             self.mjw_model = mujoco_warp.put_model(self.mj_model)
@@ -6479,6 +6512,32 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     outputs=[
                         self.mjc_geom_to_newton_shape,
                     ],
+                    device=model.device,
+                )
+
+            site_to_shape_idx_np = np.full((self.mj_model.nsite,), -1, dtype=np.int32)
+            site_is_static_np = np.zeros((self.mj_model.nsite,), dtype=bool)
+            for site_idx, abs_shape_idx in site_to_shape_idx.items():
+                if shape_world[abs_shape_idx] < 0:
+                    site_to_shape_idx_np[site_idx] = abs_shape_idx
+                    site_is_static_np[site_idx] = True
+                else:
+                    site_to_shape_idx_np[site_idx] = abs_shape_idx - first_env_shape_base
+
+            self.mjc_site_to_newton_shape = wp.full((nworld, self.mj_model.nsite), -1, dtype=wp.int32)
+            if self.mjw_model.site_pos.size:
+                site_to_shape_idx_wp = wp.array(site_to_shape_idx_np, dtype=wp.int32)
+                site_is_static_wp = wp.array(site_is_static_np, dtype=bool)
+                wp.launch(
+                    update_shape_mappings_kernel,
+                    dim=(nworld, self.mj_model.nsite),
+                    inputs=[
+                        site_to_shape_idx_wp,
+                        site_is_static_wp,
+                        self._shapes_per_world,
+                        first_env_shape_base,
+                    ],
+                    outputs=[self.mjc_site_to_newton_shape],
                     device=model.device,
                 )
 
@@ -6796,8 +6855,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             "geom_margin",
             "geom_gap",
             # "geom_rgba",
-            # "site_pos",
-            # "site_quat",
+            "site_pos",
+            "site_quat",
             # "cam_pos",
             # "cam_quat",
             # "cam_poscom0",
@@ -7698,6 +7757,25 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 self.mjw_model.geom_solmix,
                 self.mjw_model.geom_gap,
                 self.mjw_model.geom_margin,
+            ],
+            device=self.model.device,
+        )
+
+    def _update_site_properties(self) -> None:
+        """Update MuJoCo site poses from Newton shape transforms."""
+        if self.mj_model.nsite == 0:
+            return
+
+        wp.launch(
+            update_site_properties_kernel,
+            dim=(self.mjc_site_to_newton_shape.shape[0], self.mj_model.nsite),
+            inputs=[
+                self.model.shape_transform,
+                self.mjc_site_to_newton_shape,
+            ],
+            outputs=[
+                self.mjw_model.site_pos,
+                self.mjw_model.site_quat,
             ],
             device=self.model.device,
         )

--- a/newton/tests/test_sites_mujoco_export.py
+++ b/newton/tests/test_sites_mujoco_export.py
@@ -55,8 +55,11 @@ class TestMuJoCoSiteExport(unittest.TestCase):
         assert_site_poses_match_model()
 
         transforms = [
-            wp.transform(wp.vec3(-0.2, 0.4, 0.3), wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 0.2)),
-            wp.transform(wp.vec3(3.0, 1.5, -0.1), wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), -0.3)),
+            wp.transform(
+                wp.vec3(-0.2 + i, 0.4 + 0.5 * i, 0.3 - 0.1 * i),
+                wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.2 + 0.15 * i),
+            )
+            for i in range(model.shape_count)
         ]
         model.shape_transform.assign(wp.array(transforms, dtype=wp.transform, device=model.device))
         solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)

--- a/newton/tests/test_sites_mujoco_export.py
+++ b/newton/tests/test_sites_mujoco_export.py
@@ -66,6 +66,48 @@ class TestMuJoCoSiteExport(unittest.TestCase):
 
         assert_site_poses_match_model()
 
+    def test_site_size_updates_at_runtime(self):
+        """Propagate runtime shape_scale changes to MuJoCo site sizes."""
+        builder = newton.ModelBuilder()
+        body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        builder.add_site(body, type=GeoType.BOX, scale=(0.1, 0.2, 0.3), label="box_site")
+        builder.add_site(body, type=GeoType.SPHERE, scale=(0.05, 0.05, 0.05), label="sphere_site")
+
+        model = builder.finalize()
+        solver = SolverMuJoCo(model)
+
+        np.testing.assert_allclose(solver.mjw_model.site_size.numpy(), [[0.1, 0.2, 0.3], [0.05, 0.05, 0.05]], atol=1e-6)
+
+        model.shape_scale.assign(wp.array([[0.4, 0.5, 0.6], [0.07, 0.0, 0.0]], dtype=wp.vec3, device=model.device))
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        # Zero components fall back to the first nonzero one, matching export.
+        np.testing.assert_allclose(solver.mjw_model.site_size.numpy(), [[0.4, 0.5, 0.6], [0.07, 0.07, 0.07]], atol=1e-6)
+
+    def test_site_size_updates_batched_worlds(self):
+        """Sync site sizes from uniform runtime scale updates across batched worlds."""
+        world = newton.ModelBuilder()
+        body = world.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        joint = world.add_joint_free(child=body)
+        world.add_articulation([joint])
+        world.add_site(body, type=GeoType.BOX, scale=(0.1, 0.2, 0.3), label="body_site")
+
+        builder = newton.ModelBuilder()
+        builder.add_world(world)
+        builder.add_world(world, xform=wp.transform(wp.vec3(4.0, 0.0, 0.0), wp.quat_identity()))
+        model = builder.finalize()
+        solver = SolverMuJoCo(model, separate_worlds=True, disable_contacts=True)
+
+        np.testing.assert_allclose(solver.mjw_model.site_size.numpy(), [[0.1, 0.2, 0.3]], atol=1e-6)
+
+        site_shapes = np.flatnonzero(model.shape_flags.numpy() & int(newton.ShapeFlags.SITE))
+        scales = model.shape_scale.numpy()
+        scales[site_shapes] = [0.4, 0.5, 0.6]
+        model.shape_scale.assign(scales)
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        np.testing.assert_allclose(solver.mjw_model.site_size.numpy(), [[0.4, 0.5, 0.6]], atol=1e-6)
+
     def test_export_single_site(self):
         """Test that a site is exported to both MuJoCo Warp and regular MuJoCo models."""
         builder = newton.ModelBuilder()

--- a/newton/tests/test_sites_mujoco_export.py
+++ b/newton/tests/test_sites_mujoco_export.py
@@ -16,6 +16,53 @@ from newton.solvers import SolverMuJoCo
 class TestMuJoCoSiteExport(unittest.TestCase):
     """Test exporting sites to MuJoCo models."""
 
+    def test_worldbody_site_poses_across_worlds(self):
+        """Keep batched worldbody site poses synchronized with Newton."""
+        world = newton.ModelBuilder()
+        body = world.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        joint = world.add_joint_free(child=body)
+        world.add_articulation([joint])
+        world.add_shape_sphere(body, radius=0.1)
+        world.add_site(
+            -1,
+            xform=wp.transform(wp.vec3(0.5, 0.25, 0.1), wp.quat_identity()),
+            label="world_site",
+        )
+
+        builder = newton.ModelBuilder()
+        builder.add_world(world)
+        builder.add_world(
+            world,
+            xform=wp.transform(
+                wp.vec3(4.0, -1.0, 0.2),
+                wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.5),
+            ),
+        )
+        model = builder.finalize()
+        solver = SolverMuJoCo(model, separate_worlds=True, disable_contacts=True)
+
+        def assert_site_poses_match_model() -> None:
+            site_shapes = solver.mjc_site_to_newton_shape.numpy()[:, 0]
+            shape_transforms = model.shape_transform.numpy()[site_shapes]
+            np.testing.assert_allclose(solver.mjw_model.site_pos.numpy()[:, 0], shape_transforms[:, :3], atol=1.0e-6)
+            np.testing.assert_allclose(solver.mjw_data.site_xpos.numpy()[:, 0], shape_transforms[:, :3], atol=1.0e-6)
+
+            expected_xmat = np.stack(
+                [np.asarray(wp.quat_to_matrix(wp.quat(*transform[3:]))).reshape(3, 3) for transform in shape_transforms]
+            )
+            np.testing.assert_allclose(solver.mjw_data.site_xmat.numpy()[:, 0], expected_xmat, atol=1.0e-6)
+
+        assert_site_poses_match_model()
+
+        transforms = [
+            wp.transform(wp.vec3(-0.2, 0.4, 0.3), wp.quat_from_axis_angle(wp.vec3(1.0, 0.0, 0.0), 0.2)),
+            wp.transform(wp.vec3(3.0, 1.5, -0.1), wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), -0.3)),
+        ]
+        model.shape_transform.assign(wp.array(transforms, dtype=wp.transform, device=model.device))
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        assert_site_poses_match_model()
+
     def test_export_single_site(self):
         """Test that a site is exported to both MuJoCo Warp and regular MuJoCo models."""
         builder = newton.ModelBuilder()
@@ -77,7 +124,16 @@ class TestMuJoCoSiteExport(unittest.TestCase):
     def test_export_site_transforms(self):
         """Test that site transforms are correctly exported."""
         builder = newton.ModelBuilder()
-        body = builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        body = builder.add_link(
+            xform=wp.transform(
+                wp.vec3(1.0, 0.2, 0.3),
+                wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.4),
+            ),
+            mass=1.0,
+            inertia=wp.mat33(np.eye(3)),
+        )
+        joint = builder.add_joint_free(child=body)
+        builder.add_articulation([joint])
 
         site_xform = wp.transform(wp.vec3(0.5, 0.3, 0.1), wp.quat_from_axis_angle(wp.vec3(0, 0, 1), 1.57))
         builder.add_site(body, type=GeoType.SPHERE, xform=site_xform, label="positioned_site")
@@ -91,6 +147,10 @@ class TestMuJoCoSiteExport(unittest.TestCase):
         self.assertGreater(mjw_model.nsite, 0, "Site should exist")
         site_pos = mjw_model.site_pos.numpy()[0, 0]  # First world, first site
         np.testing.assert_allclose(site_pos[:3], [0.5, 0.3, 0.1], atol=1e-5)
+        np.testing.assert_allclose(solver.mjw_data.site_xpos.numpy()[0, 0], solver.mj_data.site_xpos[0], atol=1e-6)
+        np.testing.assert_allclose(
+            solver.mjw_data.site_xmat.numpy()[0, 0], solver.mj_data.site_xmat[0].reshape(3, 3), atol=1e-6
+        )
 
     def test_export_site_types(self):
         """Test that site types are exported correctly."""

--- a/newton/tests/test_sites_mujoco_export.py
+++ b/newton/tests/test_sites_mujoco_export.py
@@ -42,7 +42,7 @@ class TestMuJoCoSiteExport(unittest.TestCase):
         solver = SolverMuJoCo(model, separate_worlds=True, disable_contacts=True)
 
         def assert_site_poses_match_model() -> None:
-            site_shapes = solver.mjc_site_to_newton_shape.numpy()[:, 0]
+            site_shapes = np.flatnonzero(model.shape_flags.numpy() & int(newton.ShapeFlags.SITE))
             shape_transforms = model.shape_transform.numpy()[site_shapes]
             np.testing.assert_allclose(solver.mjw_model.site_pos.numpy()[:, 0], shape_transforms[:, :3], atol=1.0e-6)
             np.testing.assert_allclose(solver.mjw_data.site_xpos.numpy()[:, 0], shape_transforms[:, :3], atol=1.0e-6)


### PR DESCRIPTION
## Description

Fix MuJoCo site poses for offset batched worlds.

`separate_worlds=True` builds the MuJoCo model from the first Newton world, but `site_pos` and `site_quat` remained single-world fields. Consequently, every world inherited the template site's pose in both the model and derived `site_xpos` / `site_xmat` data.

Add per-world site-to-shape mappings, expand the site pose fields, and refresh derived poses after construction and `SHAPE_PROPERTIES` notifications.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
.venv/bin/python -m unittest newton.tests.test_sites_mujoco_export
.venv/bin/python -m unittest newton.tests.test_mujoco_solver.TestMuJoCoConversion.test_shape_offset_across_worlds
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create two structurally identical Newton worlds containing a site attached directly to the world body.
2. Offset or rotate the second world.
3. Construct `SolverMuJoCo` with `separate_worlds=True`.
4. Inspect `mjw_model.site_pos` or `mjw_data.site_xpos`.
5. Observe that both worlds use the first world's site pose.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton

world = newton.ModelBuilder()
body = world.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
joint = world.add_joint_free(child=body)
world.add_articulation([joint])
world.add_site(
    -1,
    xform=wp.transform(wp.vec3(0.5, 0.25, 0.1), wp.quat_identity()),
)

builder = newton.ModelBuilder()
builder.add_world(world)
builder.add_world(
    world,
    xform=wp.transform(wp.vec3(4.0, 0.0, 0.0), wp.quat_identity()),
)

model = builder.finalize()
solver = newton.solvers.SolverMuJoCo(
    model,
    separate_worlds=True,
    disable_contacts=True,
)

print(solver.mjw_data.site_xpos.numpy()[:, 0])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MuJoCo per-site pose synchronization for offset multi-world setups.
  * Site positions/orientations now refresh correctly after runtime shape-transform updates.
* **New Features**
  * Enhanced MuJoCo export/runtime support for sites, including correct per-site world-space pose tiling across separate worlds.
  * MuJoCo site sizes now update at runtime from shape scaling (with the documented fallback when components are zero).
* **Tests**
  * Added regression coverage for site pose behavior across separate worlds.
  * Updated site transform export assertions to validate exported derived world-space site pose outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->