### PR TITLE
Add world mask support in warmstarting reset operation

### DIFF
--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -854,11 +854,10 @@ class SolverKaminoImpl(SolverBase):
         # on the first call to `step()`
         self._solver_fd.reset(problem=self._problem_fd, world_mask=world_mask)
 
-        # TODO: Enable this when world-masking is implemented
         # Reset the warm-starting caches if enabled
-        # if self._warmstart_mode == PADMMWarmStartMode.CONTAINERS:
-        #     self._ws_limits.reset()
-        #     self._ws_contacts.reset()
+        if self._warmstart_mode == PADMMWarmStartMode.CONTAINERS:
+            self._ws_limits.reset(world_mask=world_mask)
+            self._ws_contacts.reset(world_mask=world_mask)
 
     ###
     # Internals - Step Operations

--- a/newton/_src/solvers/kamino/_src/solvers/warmstart.py
+++ b/newton/_src/solvers/kamino/_src/solvers/warmstart.py
@@ -30,7 +30,7 @@ from ..core.data import DataKamino
 from ..core.math import contact_wrench_matrix_from_points
 from ..core.model import ModelKamino
 from ..geometry.contacts import ContactsKamino, ContactsKaminoData
-from ..geometry.keying import KeySorter, binary_search_find_range_start, make_bitmask
+from ..geometry.keying import KeySorter, binary_search_find_range_start, make_bitmask, uint64_sentinel_value
 from ..kinematics.limits import LimitsKamino, LimitsKaminoData
 from ..solvers.padmm.math import project_to_coulomb_cone
 
@@ -55,6 +55,19 @@ wp.set_module_options({"enable_backward": False})
 ###
 # Kernels
 ###
+
+
+@wp.kernel
+def _invalidate_keys_from_select_worlds(
+    world_id: wp.array[wp.int32],
+    keys: wp.array[wp.uint64],
+    world_mask: wp.array[wp.bool],
+):
+    """Reset contact/limit keys to the sentinel value in select worlds."""
+    tid = wp.tid()  # Contact or limit id
+    wid = world_id[tid]
+    if world_mask[wid]:
+        keys[tid] = uint64_sentinel_value()
 
 
 @wp.kernel
@@ -786,6 +799,7 @@ class WarmstarterLimits:
                 key=wp.zeros_like(limits.key),
                 velocity=wp.zeros_like(limits.velocity),
                 reaction=wp.zeros_like(limits.reaction),
+                wid=wp.zeros_like(limits.wid),
             )
 
         # Create a key sorter that can handle the maximum number of contacts
@@ -843,17 +857,31 @@ class WarmstarterLimits:
         wp.copy(self._cache.key, limits.key)
         wp.copy(self._cache.velocity, limits.velocity)
         wp.copy(self._cache.reaction, limits.reaction)
+        wp.copy(self._cache.wid, limits.wid)
 
-    def reset(self):
+    def reset(self, world_mask: wp.array[wp.bool] | None = None):
         """
-        Resets the warmstarter's internal cache by zeroing out all data.
+        Resets the warmstarter's internal cache, for all or a subset of the worlds.
+
+        Args:
+            world_mask: If provided, cached data is invalidated for designated worlds (`True` in the mask),
+                so that new active limits in these worlds won't match any cached active limit.
+                Otherwise, the entire cache is zeroed out.
         """
         if self._cache is None:
             return
-        self._cache.model_active_limits.zero_()
-        self._cache.key.fill_(make_bitmask(63))
-        self._cache.reaction.zero_()
-        self._cache.velocity.zero_()
+        if world_mask is not None:
+            wp.launch(
+                _invalidate_keys_from_select_worlds,
+                dim=self._cache.model_max_limits_host,
+                inputs=[self._cache.wid, self._cache.key, world_mask],
+                device=self.device,
+            )
+        else:
+            self._cache.model_active_limits.zero_()
+            self._cache.key.fill_(make_bitmask(63))
+            self._cache.reaction.zero_()
+            self._cache.velocity.zero_()
 
 
 class WarmstarterContacts:
@@ -972,6 +1000,7 @@ class WarmstarterContacts:
                 key=wp.zeros_like(contacts.key),
                 velocity=wp.zeros_like(contacts.velocity),
                 reaction=wp.zeros_like(contacts.reaction),
+                wid=wp.zeros_like(contacts.wid),
             )
 
         # Create a key sorter that can handle the maximum number of contacts
@@ -1077,18 +1106,32 @@ class WarmstarterContacts:
         wp.copy(self._cache.key, contacts.key)
         wp.copy(self._cache.velocity, contacts.velocity)
         wp.copy(self._cache.reaction, contacts.reaction)
+        wp.copy(self._cache.wid, contacts.wid)
 
-    def reset(self):
+    def reset(self, world_mask: wp.array[wp.bool] | None = None):
         """
-        Resets the warmstarter's internal cache by zeroing out all data.
+        Resets the warmstarter's internal cache, for all or a subset of the worlds.
+
+        Args:
+            world_mask: If provided, cached data is invalidated for designated worlds (`True` in the mask),
+                so that new contacts in these worlds won't match any cached contact.
+                Otherwise, the entire cache is zeroed out.
         """
         if self._cache is None or self._cache.model_active_contacts is None:
             return
-        self._cache.model_active_contacts.zero_()
-        self._cache.bid_AB.fill_(wp.vec2i(-1, -1))
-        self._cache.position_A.zero_()
-        self._cache.position_B.zero_()
-        self._cache.frame.zero_()
-        self._cache.key.fill_(make_bitmask(63))
-        self._cache.reaction.zero_()
-        self._cache.velocity.zero_()
+        if world_mask is not None:
+            wp.launch(
+                _invalidate_keys_from_select_worlds,
+                dim=self._cache.model_max_contacts_host,
+                inputs=[self._cache.wid, self._cache.key, world_mask],
+                device=self.device,
+            )
+        else:
+            self._cache.model_active_contacts.zero_()
+            self._cache.bid_AB.fill_(wp.vec2i(-1, -1))
+            self._cache.position_A.zero_()
+            self._cache.position_B.zero_()
+            self._cache.frame.zero_()
+            self._cache.key.fill_(make_bitmask(63))
+            self._cache.reaction.zero_()
+            self._cache.velocity.zero_()

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino.py
@@ -14,12 +14,15 @@ from newton._src.solvers.kamino._src.core.control import ControlKamino
 from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.joints import JointActuationType
 from newton._src.solvers.kamino._src.core.model import ModelKamino
+from newton._src.solvers.kamino._src.core.shapes import GeoType
 from newton._src.solvers.kamino._src.core.state import StateKamino
 from newton._src.solvers.kamino._src.dynamics import DualProblem
 from newton._src.solvers.kamino._src.geometry.contacts import ContactsKamino
+from newton._src.solvers.kamino._src.geometry.detector import CollisionDetector
 from newton._src.solvers.kamino._src.kinematics.jacobians import DenseSystemJacobians, SparseSystemJacobians
 from newton._src.solvers.kamino._src.kinematics.joints import JointCorrectionMode, compute_joints_data
 from newton._src.solvers.kamino._src.kinematics.limits import LimitsKamino
+from newton._src.solvers.kamino._src.models.builders import testing
 from newton._src.solvers.kamino._src.models.builders.basics import build_boxes_fourbar
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.solver_kamino_impl import SolverKaminoImpl
@@ -28,6 +31,7 @@ from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino.examples import print_progress_bar
 from newton._src.solvers.kamino.solver_kamino import SolverKamino
 from newton._src.solvers.kamino.tests import setup_tests, test_context
+from newton._src.solvers.kamino.tests.utils.sampling import sample_world_mask
 
 ###
 # Kernels
@@ -312,12 +316,13 @@ def step_solver(
     state_n: StateKamino,
     control: ControlKamino,
     contacts: ContactsKamino | None = None,
+    detector: CollisionDetector | None = None,
     dt: float = 0.001,
     show_progress: bool = False,
 ):
     start_time = time.time()
     for step in range(num_steps):
-        solver.step(state_in=state_p, state_out=state_n, control=control, contacts=contacts, dt=dt)
+        solver.step(state_in=state_p, state_out=state_n, control=control, contacts=contacts, detector=detector, dt=dt)
         wp.synchronize()
         state_p.copy_from(state_n)
         if show_progress:
@@ -968,11 +973,69 @@ class TestSolverKaminoImpl(unittest.TestCase):
         # Check that state was correctly preserved or reset based on mask
         assert_states_close_masked(model, state_n, state_n_reset_ref, state_n_stepped_ref, world_mask)
 
+    def test_10_reset_warmstarting_for_select_worlds(self):
+        """Test resetting the contacts warmstarting cache for select worlds."""
+        # Create a heterogenous, contact-rich model
+        shape_types = [GeoType.SPHERE, GeoType.CAPSULE, GeoType.CYLINDER, GeoType.BOX, GeoType.CONE]
+        shape_types = [type_.name.lower() for type_ in shape_types]
+        shape_pairs = [(type1, type2) for type1 in shape_types for type2 in shape_types]
+        builder = testing.make_shape_pairs_builder(
+            shape_pairs=shape_pairs,
+            distance=0.0,
+            ground_box=True,
+            ground_z=-1.0,  # Ensures non-zero contact reactions after just a few steps
+        )
+        model = builder.finalize(device=self.default_device)
+
+        # Initialize the solver and step it a few times
+        contacts = ContactsKamino(model=model)
+        config = SolverKamino.Config()
+        config.padmm.warmstart_mode = "containers"
+        solver = SolverKaminoImpl(model=model, contacts=contacts, config=config)
+        state_p = model.state()
+        state_n = model.state()
+        control = model.control()
+        detector = CollisionDetector(model)
+        step_solver(
+            num_steps=10,
+            solver=solver,
+            state_p=state_p,
+            state_n=state_n,
+            control=control,
+            contacts=contacts,
+            detector=detector,
+        )
+
+        # Check that all worlds have contacts, and that most reactions / velocities are non-trivial
+        self.assertTrue(np.all(contacts.world_active_contacts.numpy() > 0))
+        num_active = contacts.model_active_contacts.numpy()[0]
+        reaction_norms = np.linalg.norm(contacts.reaction.numpy()[:num_active], axis=1)
+        velocity_norms = np.linalg.norm(contacts.velocity.numpy()[:num_active], axis=1)
+        self.assertTrue(np.count_nonzero(reaction_norms + velocity_norms) > 0.8 * num_active)
+
+        # Reset the solver internals (including warmstarting) with a non-trivial mask
+        rng = np.random.default_rng(self.seed)
+        world_mask_np = sample_world_mask(model.size.num_worlds, rng, target_inactive_rate=0.5)[0]
+        world_mask = wp.array(world_mask_np, dtype=wp.bool, device=self.default_device)
+        solver.reset(state=state_n, world_mask=world_mask, config=SolverKamino.ResetConfig.preserve())
+
+        # Run contact warmstarting, and check that contacts in reset worlds get cold-started
+        solver._ws_contacts.warmstart(model=model, data=solver.data, contacts=contacts)
+        reaction_norms = np.linalg.norm(contacts.reaction.numpy()[:num_active], axis=1)
+        velocity_norms = np.linalg.norm(contacts.velocity.numpy()[:num_active], axis=1)
+        contact_wid = contacts.wid.numpy()[:num_active]
+        contact_reset_mask = world_mask_np[contact_wid]
+        np.testing.assert_equal(reaction_norms[contact_reset_mask], 0.0)
+        np.testing.assert_equal(velocity_norms[contact_reset_mask], 0.0)
+
+        # Sanity check that not everything got cold-started
+        self.assertTrue(max(reaction_norms) + max(velocity_norms) > 0.0)
+
     ###
     # Test Step Operations
     ###
 
-    def test_09_step_multiple_worlds_from_initial_state_without_contacts(self):
+    def test_11_step_multiple_worlds_from_initial_state_without_contacts(self):
         """
         Test stepping multiple worlds solvers initialized
         uniformly from the default initial state multiple times.
@@ -1149,7 +1212,7 @@ class TestSolverKaminoImpl(unittest.TestCase):
         np.testing.assert_allclose(multi_state_n.q_j.numpy(), multi_final_q_j, rtol=rtol, atol=atol)
         np.testing.assert_allclose(multi_state_n.dq_j.numpy(), multi_final_dq_j, rtol=rtol, atol=atol)
 
-    def test_10_step_multiple_worlds_from_initial_state_with_contacts(self):
+    def test_12_step_multiple_worlds_from_initial_state_with_contacts(self):
         """
         Test stepping multiple world solvers initialized
         uniformly from the default initial state multiple times.

--- a/newton/_src/solvers/kamino/tests/utils/sampling.py
+++ b/newton/_src/solvers/kamino/tests/utils/sampling.py
@@ -29,6 +29,7 @@ def sample_world_mask(
     num_worlds: int,
     rng: np.random.Generator,
     num_samples: int = 1,
+    target_inactive_rate: float = 0.1,
 ) -> np.ndarray:
     """
     Helper sampling random non-trivial boolean world masks given the number of worlds.
@@ -38,13 +39,14 @@ def sample_world_mask(
         num_worlds: number of worlds.
         rng: Random number generator.
         num_samples: number of sample masks to generate.
+        target_inactive_rate: target rate of worlds for which the mask should be `False`
 
     Returns:
         world_masks: sampled boolean masks, with shape (num_samples, num_worlds)
     """
     # Sample ids in [0, num_worlds - 1] to set to False
-    # Target about 10% of inactive worlds, at least one, and at most num_worlds - 1
-    num_false = min(num_worlds - 1, max(1, round(0.1 * num_worlds)))
+    # Target provided rate of inactive worlds, at least one, and at most num_worlds - 1
+    num_false = min(num_worlds - 1, max(1, round(target_inactive_rate * num_worlds)))
     false_ids = rng.integers(low=0, high=num_worlds, endpoint=False, size=num_samples * num_false)
     false_ids = np.reshape(false_ids, (num_samples, num_false))
 


### PR DESCRIPTION
## Description

This enables a world_mask argument to the reset() operation of limits/contacts warmstarting, so that only select worlds get cold-started. This implemented by invalidating the key of limits/contacts in the reset worlds, so that contacts in these worlds won't get matched to any previous contacts by the warmstarter (and therefore will be considered as new, cold-started contacts).

Resolves vastsoun#276

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

A unit test was added that checks that after a reset operation with non-trivial mask, contact reactions and velocities in these world get cold-started.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved solver reset behavior so only the selected worlds are cleared, while other worlds can keep their warm-started state.
  * Fixed warm-started contact and constraint data to stay aligned with the worlds being reset, reducing unexpected carryover after partial resets.
* **Tests**
  * Added coverage for resetting a subset of worlds in contact-heavy scenarios.
  * Expanded test support for running solver steps with collision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->