### PR TITLE
Slew benchmark targets toward random waypoints

### DIFF
--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -38,21 +38,45 @@ def _target_q(owner):
     return target
 
 
-# Randomized actuation slews targets toward per-joint random waypoints at a
-# bounded rate instead of teleporting them each frame: unbounded setpoint jumps
-# push a rotating tail of worlds into solves the MuJoCo Newton solver cannot
-# finish within any iteration budget (exposed by mujoco_warp#1374), so the
-# benchmark measured the iteration cap instead of converged stepping.
+# Slew targets toward per-joint random waypoints instead of teleporting them:
+# unbounded setpoint jumps create solves the MuJoCo Newton solver cannot finish
+# within any iteration budget (exposed by mujoco_warp#1374), so the benchmark
+# measured the iteration cap instead of converged stepping.
 TARGET_SLEW_PER_FRAME = 0.01  # fraction of each target's range per frame
 TARGET_WAYPOINT_FRAMES = 50  # frames between waypoint draws
 
 
-def _target_bounds(model):
-    """Bounds for randomized position targets, in the ``_target_q`` layout.
+@wp.kernel
+def _waypoint_control(
+    seed: int,
+    frame: wp.array[int],
+    lo: wp.array[float],
+    hi: wp.array[float],
+    slew_per_frame: float,
+    waypoint_frames: int,
+    joint_target: wp.array[float],
+):
+    # The waypoint is a pure function of (seed, leg, tid): deterministic, and
+    # no state beyond the frame counter, so the kernel is graph-capturable.
+    tid = wp.tid()
+    leg = frame[0] // waypoint_frames
+    state = wp.rand_init(seed, leg * joint_target.shape[0] + tid)
+    span = hi[tid] - lo[tid]
+    waypoint = lo[tid] + wp.randf(state) * span
+    slew = slew_per_frame * span
+    joint_target[tid] = joint_target[tid] + wp.clamp(waypoint - joint_target[tid], -slew, slew)
 
-    Single-dof joints use their limits intersected with the historical [-1, 1]
-    command range; other entries keep the initial target so free/ball
-    coordinates stay inert.
+
+@wp.kernel
+def _advance_frame(frame: wp.array[int]):
+    frame[0] = frame[0] + 1
+
+
+def _target_bounds(model):
+    """Per-entry bounds for randomized position targets in the ``_target_q``
+    layout. Joints whose coords map 1:1 to dofs get their limits intersected
+    with the historical [-1, 1] command range (sentinel/unlimited sides fall
+    back to +-1); free/ball/distance coordinates keep the initial target.
     """
     init = _target_q(model).numpy().astype(np.float32)
     lo, hi = init.copy(), init.copy()
@@ -61,18 +85,23 @@ def _target_bounds(model):
     qd_starts = model.joint_qd_start.numpy()
     limit_lo = model.joint_limit_lower.numpy()
     limit_hi = model.joint_limit_upper.numpy()
+    dof_total = limit_lo.shape[0]
     coord_layout = init.shape[0] == model.joint_coord_count
+    quat_joints = (int(newton.JointType.FREE), int(newton.JointType.BALL), int(newton.JointType.DISTANCE))
     for j, jt in enumerate(joint_types):
-        if jt not in (int(newton.JointType.REVOLUTE), int(newton.JointType.PRISMATIC)):
+        if jt in quat_joints:
             continue
-        d = int(qd_starts[j])
-        i = int(q_starts[j]) if coord_layout else d
-        low = max(float(limit_lo[d]), -1.0)
-        high = min(float(limit_hi[d]), 1.0)
-        if low >= high:  # limit range lies outside [-1, 1]
-            low, high = float(limit_lo[d]), float(limit_hi[d])
-        lo[i], hi[i] = low, high
-    return init, lo, hi
+        d0 = int(qd_starts[j])
+        d1 = int(qd_starts[j + 1]) if j + 1 < len(qd_starts) else dof_total
+        for d in range(d0, d1):
+            i = int(q_starts[j]) + (d - d0) if coord_layout else d
+            l = max(float(limit_lo[d]), -1.0) if limit_lo[d] > -1.0e6 else -1.0
+            h = min(float(limit_hi[d]), 1.0) if limit_hi[d] < 1.0e6 else 1.0
+            if l >= h:  # limit range lies outside [-1, 1]
+                l, h = float(limit_lo[d]), float(limit_hi[d])
+            if l < h:
+                lo[i], hi[i] = l, h
+    return lo, hi
 
 
 ROBOT_CONFIGS = {
@@ -352,9 +381,7 @@ class Example:
         self.use_mujoco_cpu = use_mujoco_cpu
         self.actuation = actuation
 
-        # set numpy random seed
         self.seed = 123
-        self.rng = np.random.default_rng(self.seed)
 
         if not stage_path:
             stage_path = "example_" + robot + ".usd"
@@ -390,10 +417,8 @@ class Example:
         self.state_0, self.state_1 = self.model.state(), self.model.state()
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
-        self._target_frame = 0
         if self.actuation == "random":
-            _, self._target_lo, self._target_hi = _target_bounds(self.model)
-            self._target_cur = _target_q(self.control).numpy().astype(np.float32)
+            self.init_waypoint_control()
 
         self.sensor_contact = None
         sensing_bodies = ROBOT_CONFIGS.get(robot, {}).get("sensing_bodies", None)
@@ -426,15 +451,33 @@ class Example:
             self.solver.update_contacts(self.contacts, self.state_0)
             self.sensor_contact.update(self.state_0, self.contacts)
 
+    def init_waypoint_control(self):
+        lo, hi = _target_bounds(self.model)
+        self._target_lo = wp.array(lo, dtype=wp.float32)
+        self._target_hi = wp.array(hi, dtype=wp.float32)
+        self._target_frame = wp.zeros(1, dtype=int)
+
+    def apply_waypoint_control(self):
+        """Enqueue one frame of waypoint target tracking; safe to graph-capture."""
+        target_q = _target_q(self.control)
+        wp.launch(
+            _waypoint_control,
+            dim=(target_q.shape[0],),
+            inputs=[
+                self.seed,
+                self._target_frame,
+                self._target_lo,
+                self._target_hi,
+                TARGET_SLEW_PER_FRAME,
+                TARGET_WAYPOINT_FRAMES,
+            ],
+            outputs=[target_q],
+        )
+        wp.launch(_advance_frame, dim=1, inputs=[self._target_frame])
+
     def step(self):
         if self.actuation == "random":
-            target_q = _target_q(self.control)
-            leg_rng = np.random.default_rng(self.seed + self._target_frame // TARGET_WAYPOINT_FRAMES)
-            waypoint = leg_rng.uniform(self._target_lo, self._target_hi).astype(np.float32)
-            slew = TARGET_SLEW_PER_FRAME * (self._target_hi - self._target_lo)
-            self._target_cur = self._target_cur + np.clip(waypoint - self._target_cur, -slew, slew)
-            self._target_frame += 1
-            wp.copy(target_q, wp.array(self._target_cur, dtype=wp.float32))
+            self.apply_waypoint_control()
 
         wp.synchronize_device()
         start_time = time.time()

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -38,6 +38,43 @@ def _target_q(owner):
     return target
 
 
+# Randomized actuation slews targets toward per-joint random waypoints at a
+# bounded rate instead of teleporting them each frame: unbounded setpoint jumps
+# push a rotating tail of worlds into solves the MuJoCo Newton solver cannot
+# finish within any iteration budget (exposed by mujoco_warp#1374), so the
+# benchmark measured the iteration cap instead of converged stepping.
+TARGET_SLEW_PER_FRAME = 0.01  # fraction of each target's range per frame
+TARGET_WAYPOINT_FRAMES = 50  # frames between waypoint draws
+
+
+def _target_bounds(model):
+    """Bounds for randomized position targets, in the ``_target_q`` layout.
+
+    Single-dof joints use their limits intersected with the historical [-1, 1]
+    command range; other entries keep the initial target so free/ball
+    coordinates stay inert.
+    """
+    init = _target_q(model).numpy().astype(np.float32)
+    lo, hi = init.copy(), init.copy()
+    joint_types = model.joint_type.numpy()
+    q_starts = model.joint_q_start.numpy()
+    qd_starts = model.joint_qd_start.numpy()
+    limit_lo = model.joint_limit_lower.numpy()
+    limit_hi = model.joint_limit_upper.numpy()
+    coord_layout = init.shape[0] == model.joint_coord_count
+    for j, jt in enumerate(joint_types):
+        if jt not in (int(newton.JointType.REVOLUTE), int(newton.JointType.PRISMATIC)):
+            continue
+        d = int(qd_starts[j])
+        i = int(q_starts[j]) if coord_layout else d
+        low = max(float(limit_lo[d]), -1.0)
+        high = min(float(limit_hi[d]), 1.0)
+        if low >= high:  # limit range lies outside [-1, 1]
+            low, high = float(limit_lo[d]), float(limit_hi[d])
+        lo[i], hi[i] = low, high
+    return init, lo, hi
+
+
 ROBOT_CONFIGS = {
     "humanoid": {
         "solver": "newton",
@@ -353,16 +390,10 @@ class Example:
         self.state_0, self.state_1 = self.model.state(), self.model.state()
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
 
-        self._quat_target_q_offsets: list[int] = []
-        target_q = _target_q(self.model)
-        if target_q is not None and target_q.shape[0] == self.model.joint_coord_count:
-            joint_types = self.model.joint_type.numpy()
-            q_starts = self.model.joint_q_start.numpy()
-            for j, jt in enumerate(joint_types):
-                if jt == int(newton.JointType.BALL):
-                    self._quat_target_q_offsets.append(int(q_starts[j]))
-                elif jt in (int(newton.JointType.FREE), int(newton.JointType.DISTANCE)):
-                    self._quat_target_q_offsets.append(int(q_starts[j]) + 3)
+        self._target_frame = 0
+        if self.actuation == "random":
+            _, self._target_lo, self._target_hi = _target_bounds(self.model)
+            self._target_cur = _target_q(self.control).numpy().astype(np.float32)
 
         self.sensor_contact = None
         sensing_bodies = ROBOT_CONFIGS.get(robot, {}).get("sensing_bodies", None)
@@ -398,12 +429,12 @@ class Example:
     def step(self):
         if self.actuation == "random":
             target_q = _target_q(self.control)
-            target_size = target_q.shape[0]
-            samples = self.rng.uniform(-1.0, 1.0, size=target_size).astype(np.float32)
-            for offset in self._quat_target_q_offsets:
-                samples[offset : offset + 4] = (0.0, 0.0, 0.0, 1.0)
-            joint_target = wp.array(samples, dtype=wp.float32)
-            wp.copy(target_q, joint_target)
+            leg_rng = np.random.default_rng(self.seed + self._target_frame // TARGET_WAYPOINT_FRAMES)
+            waypoint = leg_rng.uniform(self._target_lo, self._target_hi).astype(np.float32)
+            slew = TARGET_SLEW_PER_FRAME * (self._target_hi - self._target_lo)
+            self._target_cur = self._target_cur + np.clip(waypoint - self._target_cur, -slew, slew)
+            self._target_frame += 1
+            wp.copy(target_q, wp.array(self._target_cur, dtype=wp.float32))
 
         wp.synchronize_device()
         start_time = time.time()

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -95,12 +95,14 @@ def _target_bounds(model):
         d1 = int(qd_starts[j + 1]) if j + 1 < len(qd_starts) else dof_total
         for d in range(d0, d1):
             i = int(q_starts[j]) + (d - d0) if coord_layout else d
-            l = max(float(limit_lo[d]), -1.0) if limit_lo[d] > -1.0e6 else -1.0
-            h = min(float(limit_hi[d]), 1.0) if limit_hi[d] < 1.0e6 else 1.0
-            if l >= h:  # limit range lies outside [-1, 1]
-                l, h = float(limit_lo[d]), float(limit_hi[d])
-            if l < h:
-                lo[i], hi[i] = l, h
+            lower_raw = float(limit_lo[d])
+            upper_raw = float(limit_hi[d])
+            lower = max(lower_raw, -1.0) if lower_raw > -1.0e6 else -1.0
+            upper = min(upper_raw, 1.0) if upper_raw < 1.0e6 else 1.0
+            if lower >= upper and -1.0e6 < lower_raw < upper_raw < 1.0e6:
+                lower, upper = lower_raw, upper_raw  # bounded range outside [-1, 1]
+            if lower < upper:
+                lo[i], hi[i] = lower, upper
     return lo, hi
 
 

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -14,35 +14,9 @@ from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
-from benchmark_mujoco import TARGET_SLEW_PER_FRAME, TARGET_WAYPOINT_FRAMES, Example, _target_bounds, _target_q
+from benchmark_mujoco import Example
 
 from newton.utils import EventTracer
-
-
-@wp.kernel
-def apply_waypoint_control(
-    seed: int,
-    frame: wp.array[int],
-    lo: wp.array[float],
-    hi: wp.array[float],
-    slew_per_frame: float,
-    waypoint_frames: int,
-    joint_target: wp.array[float],
-):
-    # Device-side twin of Example.step()'s waypoint tracking: the waypoint is a
-    # pure function of (seed, leg, tid), so no extra state survives the graph.
-    tid = wp.tid()
-    leg = frame[0] // waypoint_frames
-    state = wp.rand_init(seed, leg * joint_target.shape[0] + tid)
-    span = hi[tid] - lo[tid]
-    waypoint = lo[tid] + wp.randf(state) * span
-    slew = slew_per_frame * span
-    joint_target[tid] = joint_target[tid] + wp.clamp(waypoint - joint_target[tid], -slew, slew)
-
-
-@wp.kernel
-def _advance_frame(frame: wp.array[int]):
-    frame[0] = frame[0] + 1
 
 
 class _FastBenchmark:
@@ -81,26 +55,9 @@ class _FastBenchmark:
         if not cuda_graph_comp:
             raise SkipNotImplemented
         else:
-            target_q = _target_q(self.example.control)
-            _, lo, hi = _target_bounds(self.example.model)
-            self._target_lo = wp.array(lo, dtype=wp.float32)
-            self._target_hi = wp.array(hi, dtype=wp.float32)
-            self._target_frame = wp.zeros(1, dtype=int)
+            self.example.init_waypoint_control()
             with wp.ScopedCapture() as capture:
-                wp.launch(
-                    apply_waypoint_control,
-                    dim=(target_q.shape[0],),
-                    inputs=[
-                        self.example.seed,
-                        self._target_frame,
-                        self._target_lo,
-                        self._target_hi,
-                        TARGET_SLEW_PER_FRAME,
-                        TARGET_WAYPOINT_FRAMES,
-                    ],
-                    outputs=[target_q],
-                )
-                wp.launch(_advance_frame, dim=1, inputs=[self._target_frame])
+                self.example.apply_waypoint_control()
                 self.example.simulate()
             self.graph = capture.graph
 

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -14,44 +14,35 @@ from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
-from benchmark_mujoco import Example, _target_q
+from benchmark_mujoco import TARGET_SLEW_PER_FRAME, TARGET_WAYPOINT_FRAMES, Example, _target_bounds, _target_q
 
-import newton
 from newton.utils import EventTracer
 
 
 @wp.kernel
-def apply_random_control(state: wp.uint32, joint_target: wp.array[float]):
+def apply_waypoint_control(
+    seed: int,
+    frame: wp.array[int],
+    lo: wp.array[float],
+    hi: wp.array[float],
+    slew_per_frame: float,
+    waypoint_frames: int,
+    joint_target: wp.array[float],
+):
+    # Device-side twin of Example.step()'s waypoint tracking: the waypoint is a
+    # pure function of (seed, leg, tid), so no extra state survives the graph.
     tid = wp.tid()
-
-    joint_target[tid] = wp.randf(state) * 2.0 - 1.0
+    leg = frame[0] // waypoint_frames
+    state = wp.rand_init(seed, leg * joint_target.shape[0] + tid)
+    span = hi[tid] - lo[tid]
+    waypoint = lo[tid] + wp.randf(state) * span
+    slew = slew_per_frame * span
+    joint_target[tid] = joint_target[tid] + wp.clamp(waypoint - joint_target[tid], -slew, slew)
 
 
 @wp.kernel
-def restore_target_quat_identity(joint_target: wp.array[float], quat_offsets: wp.array[int]):
-    i = wp.tid()
-    o = quat_offsets[i]
-    joint_target[o + 0] = 0.0
-    joint_target[o + 1] = 0.0
-    joint_target[o + 2] = 0.0
-    joint_target[o + 3] = 1.0
-
-
-def _free_ball_quat_offsets(model) -> list[int]:
-    """Coord-space indices of the quaternion slot of every FREE/BALL/DISTANCE
-    joint in ``model.joint_target_q`` (empty under the legacy DOF layout)."""
-    offsets: list[int] = []
-    target_q = _target_q(model)
-    if target_q is None or target_q.shape[0] != model.joint_coord_count:
-        return offsets
-    joint_types = model.joint_type.numpy()
-    q_starts = model.joint_q_start.numpy()
-    for j, jt in enumerate(joint_types):
-        if jt == int(newton.JointType.BALL):
-            offsets.append(int(q_starts[j]))
-        elif jt in (int(newton.JointType.FREE), int(newton.JointType.DISTANCE)):
-            offsets.append(int(q_starts[j]) + 3)
-    return offsets
+def _advance_frame(frame: wp.array[int]):
+    frame[0] = frame[0] + 1
 
 
 class _FastBenchmark:
@@ -90,26 +81,28 @@ class _FastBenchmark:
         if not cuda_graph_comp:
             raise SkipNotImplemented
         else:
-            state = wp.rand_init(self.example.seed)
             target_q = _target_q(self.example.control)
-            quat_offsets = _free_ball_quat_offsets(self.example.model)
-            quat_offsets_wp = wp.array(quat_offsets, dtype=int, device=target_q.device) if quat_offsets else None
+            _, lo, hi = _target_bounds(self.example.model)
+            self._target_lo = wp.array(lo, dtype=wp.float32)
+            self._target_hi = wp.array(hi, dtype=wp.float32)
+            self._target_frame = wp.zeros(1, dtype=int)
             with wp.ScopedCapture() as capture:
                 wp.launch(
-                    apply_random_control,
+                    apply_waypoint_control,
                     dim=(target_q.shape[0],),
-                    inputs=[state],
+                    inputs=[
+                        self.example.seed,
+                        self._target_frame,
+                        self._target_lo,
+                        self._target_hi,
+                        TARGET_SLEW_PER_FRAME,
+                        TARGET_WAYPOINT_FRAMES,
+                    ],
                     outputs=[target_q],
                 )
-                if quat_offsets_wp is not None:
-                    wp.launch(
-                        restore_target_quat_identity,
-                        dim=(quat_offsets_wp.shape[0],),
-                        inputs=[target_q, quat_offsets_wp],
-                    )
+                wp.launch(_advance_frame, dim=1, inputs=[self._target_frame])
                 self.example.simulate()
             self.graph = capture.graph
-            self._quat_offsets_wp = quat_offsets_wp
 
         wp.synchronize_device()
 


### PR DESCRIPTION
## Description

The randomized actuation in the MuJoCo benchmarks teleported joint-position targets to fresh uniform(-1, 1) samples every frame. Since the mujoco_warp line-search precision fix (google-deepmind/mujoco_warp#1374, part of the 3.10 upgrade in #2980), such setpoint jumps push a rotating tail of worlds into Newton-solver solves that do not converge within any iteration budget: on the 8192-world Allegro benchmark at least one world hits the 100-iteration cap in ~90% of frames, and raising the budget to 300 just scales the cost without converging the tail, so `KpiAllegro` measured the solver iteration cap instead of converged stepping (the 2x step at the 3.10 upgrade). The `Fast*` benchmarks had the opposite defect: `apply_random_control` evaluated `wp.randf` on a shared scalar RNG state, so every joint in every world received the same constant target on every frame, and the benchmarks measured a settled regulation task instead of randomized actuation.

Both paths now track per-joint random waypoints, redrawn every 50 frames and approached at 1% of the target range per frame. Bounds are the joint limits intersected with the historical [-1, 1] command range; joints whose coordinates map 1:1 to dofs (including D6 joints created by the MJCF importer merging a body's hinges) are covered, while free/ball/distance coordinates keep their initial targets, which replaces the quat-restore machinery. A single warp kernel implements the schedule for both paths: the Fast benchmarks capture it into their graph, the Kpi path enqueues it per frame outside the timed region, and the waypoint is a pure function of (seed, leg, tid) so trajectories are deterministic across runs and asv repeats.

The bounded per-frame setpoint delta keeps the solver converged on the pathological benchmark (8192-world Allegro drops from ~90% of frames containing a cap-pegged world to ~10%, with median per-frame max iterations ~14 instead of 100) while joints still sweep their full range. The healthy benchmarks keep converging as before (G1/Humanoid/Cartpole stay below 10 iterations, verified with the humanoid's D6 dofs actuated).

Benchmark values will re-baseline on the dashboard: Kpi numbers now measure converged contact-rich stepping, and Fast numbers actuate for the first time (FastAllegro rises notably since it now measures active manipulation instead of a settled grasp). The `Fast*` setup rewrite also changes those benchmarks' asv version hashes, so the results repo needs the usual hash-continuity rewrite after this merges; the Kpi hashes are unchanged and their series continue with a visible step.

## Checklist

- [x] New or existing tests cover these changes (benchmark-only change; validated by running the benchmarks, see test plan)
- [x] The documentation is up to date with these changes (no docs affected)
- [x] `CHANGELOG.md` has been updated (if user-facing change) (not user-facing)

## Test plan

Validated on an RTX PRO 6000 (mujoco 3.10.0, mujoco-warp 3.10.0.1):

- Drove the Kpi configurations (allegro 8192 worlds x 300 frames, humanoid 8192 x 100 with `random_init`, g1 2048 x 50) through `Example(actuation="random")` while reading `mjw_data.solver_niter` per frame: allegro converges (median per-frame max ~14, previously pegged at 100), humanoid/g1 unchanged at <10 iterations with zero capped frames.
- Instantiated `FastAllegro` directly and ran `time_simulate`: targets move every frame, differ across worlds, stay within bounds, and the solver converges.
- Verified per-world target trajectories are bit-identical across two independent runs (allegro and humanoid), and that 21/28 humanoid target entries per world are actuated (the 7-coordinate free root stays at its initial target).
- `uvx pre-commit run` on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Random benchmark actuation now follows deterministic per-joint waypoint targets, updating smoothly over time (via controlled slew and a waypoint refresh interval) instead of jumping to a new target each step.
  * Benchmark simulation startup and CUDA graph capture now use the same built-in waypoint control flow, ensuring consistent target preparation and application during runs.
  * Improved repeatability and stability of the MuJoCo benchmark’s “random” control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->