### PR TITLE
Fix flaky friction stopping-distance test

### DIFF
--- a/newton/tests/test_rigid_friction_ramp.py
+++ b/newton/tests/test_rigid_friction_ramp.py
@@ -98,6 +98,7 @@ STOPPING_PATCH_HX = 5.0  # comfortably exceeds d_stop(mu_min) ~ 1.02 m
 STOPPING_PATCH_HY = 0.6
 STOPPING_PATCH_HZ = 0.05
 STOPPING_BOX_PITCH_Y = 5.0
+STOPPING_SETTLE_FRAMES = 30
 STOPPING_V_FINAL_MAX = 0.05  # m/s - sanity bound: box must have come to rest
 
 _ROW_COLORS = (
@@ -259,10 +260,10 @@ def build_stopping_distance_scene(device):
 def test_friction_stopping_distance(test, device, solver_fn, rel_tol, v_final_max):
     """Kinetic-friction oracle: a sliding box stops at d = v0^2 / (2 mu g).
 
-    Three boxes at mu in STOPPING_MUS each start with v0 along world-X on a
-    matching ground patch. Run for 1.5 * t_stop(mu_min) so every box has come
-    to rest for Coulomb-cone solvers, then compare measured stopping distance
-    against the analytical value with per-solver bounds.
+    Three boxes at mu in STOPPING_MUS settle on matching ground patches, then
+    start with v0 along world-X. Run for 1.5 * t_stop(mu_min) so every box has
+    come to rest for Coulomb-cone solvers, then compare measured stopping
+    distance against the analytical value with per-solver bounds.
     """
     model, box_ids = build_stopping_distance_scene(device)
     solver = solver_fn(model)
@@ -273,10 +274,13 @@ def test_friction_stopping_distance(test, device, solver_fn, rel_tol, v_final_ma
     is_mujoco = isinstance(solver, newton.solvers.SolverMuJoCo)
     contacts = model.contacts() if not is_mujoco else None
 
+    # Establish resting contacts so the measurement excludes landing impulses.
+    state_0, state_1 = simulate(solver, model, state_0, state_1, control, contacts, STOPPING_SETTLE_FRAMES)
     initial_q = state_0.body_q.numpy().copy()
 
     qd = state_0.body_qd.numpy()
     for bid in box_ids:
+        qd[bid] = 0.0
         qd[bid, 0] = STOPPING_V0  # body_qd: [v_lin (0:3), omega (3:6)]
     state_0.body_qd.assign(qd)
 


### PR DESCRIPTION
## Description

Fixes #3266.

Settle the friction-test boxes on their ground patches before applying the
horizontal launch velocity, and clear any residual motion after settling.

The boxes previously started 1 mm above the patches while already moving at
2 m/s. Their initial free fall and landing friction impulse were not represented
by the analytical stopping-distance oracle, and small variations in that impact
occasionally pushed the MuJoCo-Warp CUDA result beyond the 1% tolerance. The
settled initial condition matches the oracle and keeps the original tolerance.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (test-only change)
- [x] `CHANGELOG.md` has been updated (not applicable; no user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_friction_stopping_distance --no-cache-clear
uv run --extra dev -m newton.tests -k test_friction_stopping_distance_mujoco_warp_cuda_0 --no-cache-clear
uvx pre-commit run -a
```

The MuJoCo-Warp CUDA test also passed five consecutive separate-process runs.

## Bug fix

**Steps to reproduce:**

1. Run the MuJoCo-Warp CUDA stopping-distance test repeatedly.
2. Observe intermittent `mu=0.70` stopping-distance errors above 1%.

**Minimal reproduction:**

```bash
for i in {1..20}; do
  uv run --extra dev -m newton.tests \
    -k test_friction_stopping_distance_mujoco_warp_cuda_0 || break
done
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the kinetic-friction stopping-distance test to include a short settling phase before measurements begin.
  * Reset object motion after settling so the stopping-distance check starts from a clean, consistent initial velocity.
  * Updated the test description to match the new flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->