### PR TITLE
Hide guide-purpose prims in USD visual shape loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@
 - Fix `SensorTiledCamera.utils.convert_ray_depth_to_forward_depth()` to preserve the clear-depth sentinel for zero-direction rays and non-positive depths.
 - Fix `SolverMuJoCo` placing articulations whose root is a fully-locked D6 joint (e.g. imported from a generic USD `PhysicsJoint`) at the first world's root pose in every world; such roots now become mocap bodies like fixed-joint roots. (#3499; fixes #3430)
 - Fix `SensorTiledCamera` rendering cloth and volume deformable vertices as particle spheres while preserving standalone particle rendering in mixed scenes. (#3518)
+- Fix the USD importer loading `guide`-purpose prims as visible visual shapes; USD renderers do not draw guides by default, so viewers no longer overlay collision geometry from MuJoCo-converted assets on top of the render meshes.
 - Fix `ViewerGL.get_frame()` crashing when a CPU model is rendered while a CUDA context is active.
 - Fix `ViewerUSD` leaving stale particle geometry visible when the active particle count drops to zero. (#2992)
 - Fix `eval_inverse_dynamics_passive()` and `SolverFeatherstone` intermittently dropping descendant wrench contributions during the articulated-body backward pass on CUDA. (#3443)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@
 - Fix `SensorTiledCamera.utils.convert_ray_depth_to_forward_depth()` to preserve the clear-depth sentinel for zero-direction rays and non-positive depths.
 - Fix `SolverMuJoCo` placing articulations whose root is a fully-locked D6 joint (e.g. imported from a generic USD `PhysicsJoint`) at the first world's root pose in every world; such roots now become mocap bodies like fixed-joint roots. (#3499; fixes #3430)
 - Fix `SensorTiledCamera` rendering cloth and volume deformable vertices as particle spheres while preserving standalone particle rendering in mixed scenes. (#3518)
-- Fix the USD importer loading `guide`-purpose prims as visible visual shapes; USD renderers do not draw guides by default, so viewers no longer overlay collision geometry from MuJoCo-converted assets on top of the render meshes.
+- Fix the USD importer loading `guide`- and `render`-purpose prims as visible visual shapes; visual shapes and Gaussian splats now follow USD viewport semantics and are drawn only for the `default` and `proxy` purposes.
 - Fix `ViewerGL.get_frame()` crashing when a CPU model is rendered while a CUDA context is active.
 - Fix `ViewerUSD` leaving stale particle geometry visible when the active particle count drops to zero. (#2992)
 - Fix `eval_inverse_dynamics_passive()` and `SolverFeatherstone` intermittently dropping descendant wrench contributions during the articulated-body backward pass on CUDA. (#3443)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1038,6 +1038,17 @@ def parse_usd(
             return False
         return imageable.ComputeVisibility() != UsdGeom.Tokens.invisible
 
+    def _is_guide_purpose(prim: Usd.Prim) -> bool:
+        """Return whether ``prim``'s computed purpose is ``guide``.
+
+        Guide prims are viewport helpers that USD renderers do not draw by
+        default; e.g. MuJoCo-converted assets author collision geometry with
+        purpose ``guide``. They are excluded from visual shape loading but
+        remain eligible as collision shapes.
+        """
+        imageable = UsdGeom.Imageable(prim)
+        return bool(imageable) and imageable.ComputePurpose() == UsdGeom.Tokens.guide
+
     bodies_with_visual_shapes: set[int] = set()
 
     def _get_prim_world_mat(prim, articulation_root_xform, incoming_world_xform):
@@ -1114,7 +1125,9 @@ def parse_usd(
             return
 
         visual_shape_cfg_for_prim = copy.copy(visual_shape_cfg)
-        visual_shape_cfg_for_prim.is_visible = is_site or _is_effectively_visible(prim)
+        visual_shape_cfg_for_prim.is_visible = is_site or (
+            _is_effectively_visible(prim) and not _is_guide_purpose(prim)
+        )
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
 

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1038,6 +1038,21 @@ def parse_usd(
             return False
         return imageable.ComputeVisibility() != UsdGeom.Tokens.invisible
 
+    def _is_viewport_drawn(prim: Usd.Prim) -> bool:
+        """Return whether a prim is drawn under viewport semantics.
+
+        USD viewports draw the ``default`` and ``proxy`` purposes and hide ``guide`` and
+        ``render``; the allowlist also keeps any future purpose hidden until explicitly
+        handled. Colliders deliberately do not use this check: ``guide`` is the conventional
+        purpose for authored collision geometry (e.g. the MuJoCo USD exporter), and the
+        collider display policy (``force_show_colliders`` / ``hide_collision_shapes``) is the
+        explicit mechanism for revealing colliders — gating them on purpose would make
+        ``force_show_colliders`` a no-op on such assets.
+        """
+        if not _is_effectively_visible(prim):
+            return False
+        return UsdGeom.Imageable(prim).ComputePurpose() in (UsdGeom.Tokens.default_, UsdGeom.Tokens.proxy)
+
     bodies_with_visual_shapes: set[int] = set()
 
     def _get_prim_world_mat(prim, articulation_root_xform, incoming_world_xform):
@@ -1114,11 +1129,7 @@ def parse_usd(
             return
 
         visual_shape_cfg_for_prim = copy.copy(visual_shape_cfg)
-        # Guide-purpose prims are viewport helpers that USD renderers do not draw by
-        # default (e.g. MuJoCo-converted assets author collision geometry as guides).
-        imageable = UsdGeom.Imageable(prim)
-        is_guide = bool(imageable) and imageable.ComputePurpose() == UsdGeom.Tokens.guide
-        visual_shape_cfg_for_prim.is_visible = is_site or (_is_effectively_visible(prim) and not is_guide)
+        visual_shape_cfg_for_prim.is_visible = is_site or _is_viewport_drawn(prim)
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
 
@@ -3270,6 +3281,7 @@ def parse_usd(
                 collider_is_visible = (
                     show_collider_by_policy or collider_has_visual_material
                 ) and not hide_collider_for_body
+                # visibility only — see _is_viewport_drawn for why purpose does not gate colliders
                 collider_is_visible = collider_is_visible and _is_effectively_visible(prim)
 
                 # Contact response precedence:
@@ -3758,7 +3770,7 @@ def parse_usd(
             g_pos, g_rot, g_scale = wp.transform_decompose(prim_world_mat)
             gaussian = usd.get_gaussian(gaussian_prim)
             splat_cfg = copy.copy(visual_shape_cfg)
-            splat_cfg.is_visible = _is_effectively_visible(gaussian_prim)
+            splat_cfg.is_visible = _is_viewport_drawn(gaussian_prim)
             splat_material_props = _get_material_props_cached(gaussian_prim)
             shape_id = builder.add_shape_gaussian(
                 body_id,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1038,17 +1038,6 @@ def parse_usd(
             return False
         return imageable.ComputeVisibility() != UsdGeom.Tokens.invisible
 
-    def _is_guide_purpose(prim: Usd.Prim) -> bool:
-        """Return whether ``prim``'s computed purpose is ``guide``.
-
-        Guide prims are viewport helpers that USD renderers do not draw by
-        default; e.g. MuJoCo-converted assets author collision geometry with
-        purpose ``guide``. They are excluded from visual shape loading but
-        remain eligible as collision shapes.
-        """
-        imageable = UsdGeom.Imageable(prim)
-        return bool(imageable) and imageable.ComputePurpose() == UsdGeom.Tokens.guide
-
     bodies_with_visual_shapes: set[int] = set()
 
     def _get_prim_world_mat(prim, articulation_root_xform, incoming_world_xform):
@@ -1125,9 +1114,11 @@ def parse_usd(
             return
 
         visual_shape_cfg_for_prim = copy.copy(visual_shape_cfg)
-        visual_shape_cfg_for_prim.is_visible = is_site or (
-            _is_effectively_visible(prim) and not _is_guide_purpose(prim)
-        )
+        # Guide-purpose prims are viewport helpers that USD renderers do not draw by
+        # default (e.g. MuJoCo-converted assets author collision geometry as guides).
+        imageable = UsdGeom.Imageable(prim)
+        is_guide = bool(imageable) and imageable.ComputePurpose() == UsdGeom.Tokens.guide
+        visual_shape_cfg_for_prim.is_visible = is_site or (_is_effectively_visible(prim) and not is_guide)
         material_props = _get_material_props_cached(prim)
         shape_color = material_props.get("color")
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -9978,6 +9978,89 @@ def Xform "Body" (
         self.assertTrue(collision_flags & ShapeFlags.COLLIDE_SHAPES)
         self.assertTrue(collision_flags & ShapeFlags.VISIBLE)
 
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_guide_purpose_shapes_not_visible(self):
+        """Guide-purpose prims (e.g. collision geometry authored by MuJoCo-USD
+        converters) should not be loaded as visible visual shapes."""
+        from pxr import Usd
+
+        usd_content = """#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def PhysicsScene "physicsScene"
+{
+}
+
+def Xform "Body" (
+    prepend apiSchemas = ["PhysicsRigidBodyAPI"]
+)
+{
+    double3 xformOp:translate = (0, 0, 1)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Sphere "VisualSphere"
+    {
+        double radius = 0.3
+    }
+
+    def Sphere "ProxySphere"
+    {
+        uniform token purpose = "proxy"
+        double radius = 0.3
+    }
+
+    def Cube "GuideCollisionBox" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        uniform token purpose = "guide"
+        bool physics:collisionEnabled = false
+        double size = 1.0
+    }
+
+    def Cube "EnabledGuideCollisionBox" (
+        prepend apiSchemas = ["PhysicsCollisionAPI"]
+    )
+    {
+        uniform token purpose = "guide"
+        double size = 1.0
+    }
+}
+"""
+        stage = Usd.Stage.CreateInMemory()
+        stage.GetRootLayer().ImportFromString(usd_content)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+        path_shape_map = result["path_shape_map"]
+
+        # Regular visual shapes stay visible.
+        flags_visual = builder.shape_flags[path_shape_map["/Body/VisualSphere"]]
+        self.assertTrue(flags_visual & ShapeFlags.VISIBLE)
+
+        # Proxy-purpose prims are the intended preview representation and stay visible.
+        flags_proxy = builder.shape_flags[path_shape_map["/Body/ProxySphere"]]
+        self.assertTrue(flags_proxy & ShapeFlags.VISIBLE)
+
+        # A disabled guide-purpose collider is loaded as a visual-only shape but must not be drawn.
+        flags_guide = builder.shape_flags[path_shape_map["/Body/GuideCollisionBox"]]
+        self.assertFalse(flags_guide & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags_guide & ShapeFlags.VISIBLE)
+
+        # An enabled guide-purpose collider still collides; its display keeps following
+        # the collider policy (hidden here because the body has visual shapes).
+        flags_enabled_guide = builder.shape_flags[path_shape_map["/Body/EnabledGuideCollisionBox"]]
+        self.assertTrue(flags_enabled_guide & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags_enabled_guide & ShapeFlags.VISIBLE)
+
+        # force_show_colliders still reveals guide-purpose colliders for debugging.
+        builder2 = newton.ModelBuilder()
+        result2 = builder2.add_usd(stage, force_show_colliders=True)
+        flags_forced = builder2.shape_flags[result2["path_shape_map"]["/Body/EnabledGuideCollisionBox"]]
+        self.assertTrue(flags_forced & ShapeFlags.VISIBLE)
+
     @staticmethod
     def _create_stage_with_pbr_collision_mesh(color, roughness, metallic, *, add_visual_sphere=False):
         """Create a stage with a rigid body containing a collision mesh with PBR material."""

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -10011,6 +10011,18 @@ def Xform "Body" (
         double radius = 0.3
     }
 
+    def Sphere "RenderSphere"
+    {
+        uniform token purpose = "render"
+        double radius = 0.3
+    }
+
+    def Sphere "GuideVisualSphere"
+    {
+        uniform token purpose = "guide"
+        double radius = 0.3
+    }
+
     def Cube "GuideCollisionBox" (
         prepend apiSchemas = ["PhysicsCollisionAPI"]
     )
@@ -10044,6 +10056,16 @@ def Xform "Body" (
         flags_proxy = builder.shape_flags[path_shape_map["/Body/ProxySphere"]]
         self.assertTrue(flags_proxy & ShapeFlags.VISIBLE)
 
+        # Render-purpose prims are offline-renderer content: viewports (which Newton's
+        # viewer is) draw default + proxy and hide guide + render.
+        flags_render = builder.shape_flags[path_shape_map["/Body/RenderSphere"]]
+        self.assertFalse(flags_render & ShapeFlags.VISIBLE)
+
+        # The most direct case: a pure visual guide mesh, no collision API involved.
+        flags_guide_visual = builder.shape_flags[path_shape_map["/Body/GuideVisualSphere"]]
+        self.assertFalse(flags_guide_visual & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags_guide_visual & ShapeFlags.VISIBLE)
+
         # A disabled guide-purpose collider is loaded as a visual-only shape but must not be drawn.
         flags_guide = builder.shape_flags[path_shape_map["/Body/GuideCollisionBox"]]
         self.assertFalse(flags_guide & ShapeFlags.COLLIDE_SHAPES)
@@ -10055,11 +10077,16 @@ def Xform "Body" (
         self.assertTrue(flags_enabled_guide & ShapeFlags.COLLIDE_SHAPES)
         self.assertFalse(flags_enabled_guide & ShapeFlags.VISIBLE)
 
-        # force_show_colliders still reveals guide-purpose colliders for debugging.
+        # force_show_colliders still reveals guide-purpose colliders for debugging. A
+        # *disabled* guide collider is no collider at all (it imported as guide visual
+        # content), so the collider policy does not apply and it stays hidden — like any
+        # USD viewport would hide it; reveal it by changing purpose/visibility on the stage.
         builder2 = newton.ModelBuilder()
         result2 = builder2.add_usd(stage, force_show_colliders=True)
         flags_forced = builder2.shape_flags[result2["path_shape_map"]["/Body/EnabledGuideCollisionBox"]]
         self.assertTrue(flags_forced & ShapeFlags.VISIBLE)
+        flags_disabled_forced = builder2.shape_flags[result2["path_shape_map"]["/Body/GuideCollisionBox"]]
+        self.assertFalse(flags_disabled_forced & ShapeFlags.VISIBLE)
 
     @staticmethod
     def _create_stage_with_pbr_collision_mesh(color, roughness, metallic, *, add_visual_sphere=False):


### PR DESCRIPTION
## Description

USD renderers hide prims whose computed purpose is `guide` by default, but the visual-shape loader in `ModelBuilder.add_usd()` only checked computed *visibility*. Guide prims were therefore imported with the `VISIBLE` flag set.

This is very noticeable with MuJoCo-converted assets (e.g. `mujoco_menagerie` via the MuJoCo USD exporter): the converter authors collision geometry as `purpose=guide` prims with `physics:collisionEnabled=false`, so Newton viewers drew all the convex collision hulls on top of the render meshes — the robot appeared wrapped in collision geometry, while usdview/Omniverse showed the expected visuals.

The fix is scoped to visual-shape loading only:

- guide prims are still imported, just as *hidden* visual shapes — the same treatment `visibility=invisible` prims already get;
- enabled guide colliders still collide and keep following the collider display policy (`force_show_colliders`, `hide_collision_shapes`);
- `proxy`-purpose prims remain visible (they are the intended preview representation).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_guide_purpose_shapes_not_visible
uv run --extra dev -m newton.tests -k test_collision_shape_visibility_flags
uv run --extra dev -m newton.tests -k test_import_usd
```

The new regression test fails without the fix (`AssertionError: 1 is not false` on the guide prim's `VISIBLE` flag) and passes with it. The full `test_import_usd` module passes (355 tests).

## Bug fix

**Steps to reproduce:**

1. Convert a MuJoCo model that has dedicated collision geometry to USD (e.g. `mujoco_menagerie/franka_emika_panda/mjx_scene`) — collision geoms are authored with `purpose=guide` and `physics:collisionEnabled=false`.
2. Load it with `ModelBuilder.add_usd(stage)` and render with any Newton viewer.
3. The guide collision hulls are drawn on top of the render meshes.

**Minimal reproduction:**

```python
import newton
from pxr import Usd

usd_content = """#usda 1.0
def Xform "Body" (prepend apiSchemas = ["PhysicsRigidBodyAPI"])
{
    def Sphere "Visual" { double radius = 0.3 }
    def Cube "GuideHull" (prepend apiSchemas = ["PhysicsCollisionAPI"])
    {
        uniform token purpose = "guide"
        bool physics:collisionEnabled = false
        double size = 1.0
    }
}
"""
stage = Usd.Stage.CreateInMemory()
stage.GetRootLayer().ImportFromString(usd_content)

builder = newton.ModelBuilder()
result = builder.add_usd(stage)
flags = builder.shape_flags[result["path_shape_map"]["/Body/GuideHull"]]
assert not (flags & newton.ShapeFlags.VISIBLE)  # fails without this PR
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USD importing so visuals follow viewport “drawn” semantics, preventing `guide`-purpose prims from being imported as visible visual shapes (including Gaussian splats).
  * Visual-shape visibility is now limited to `default` and `proxy` purposes; `guide` visuals are suppressed unless explicitly enabled.

* **Tests**
  * Added coverage for `default`, `proxy`, `render`, and `guide`-purpose prim handling, including collider enabled/disabled behavior and how collider debugging overrides visibility.

* **Chores**
  * Updated the changelog entry for the USD importer fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->