### PR TITLE
Honor ignore_paths in custom-frequency USD traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 
 ### Fixed
 
-- Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3405)
+- Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3406)
 - Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Raise an error when `SolverVBD(rigid_contact_history=True)` would allocate or grow contact-history buffers during CUDA graph capture; construct `CollisionPipeline` before `SolverVBD`, or run one uncaptured solver step before capture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ### Fixed
 
+- Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3405)
 - Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Raise an error when `SolverVBD(rigid_contact_history=True)` would allocate or grow contact-history buffers during CUDA graph capture; construct `CollisionPipeline` before `SolverVBD`, or run one uncaptured solver step before capture.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4639,6 +4639,9 @@ def parse_usd(
     # Use TraverseInstanceProxies to include prims under instanceable prims
     if frequencies_with_filters:
         for prim in Usd.PrimRange(stage.GetPrimAtPath(root_path), Usd.TraverseInstanceProxies()):
+            prim_path = str(prim.GetPath())
+            if any(re.match(pattern, prim_path) for pattern in ignore_paths):
+                continue
             for freq_key, freq_obj, freq_attrs in frequencies_with_filters:
                 # Build per-frequency callback context and pass the same object to
                 # usd_prim_filter and usd_entry_expander.

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -8380,6 +8380,55 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
         self.assertAlmostEqual(item_values[1], default_value, places=5)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_custom_frequency_honors_ignore_paths(self):
+        """Test that custom frequency parsing skips prims matching ignore_paths.
+
+        Regression test: every other traversal in parse_usd honors ignore_paths,
+        but the custom-frequency traversal visited ignored subtrees and registered
+        spurious rows for prims that were excluded from the import.
+        """
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        # Two matching prims in the kept subtree, two more under an ignored subtree.
+        UsdGeom.Xform.Define(stage, "/World/RobotA/CustomItem0")
+        UsdGeom.Xform.Define(stage, "/World/RobotA/CustomItem1")
+        UsdGeom.Xform.Define(stage, "/World/envs/env_0/CustomItem0")
+        UsdGeom.Xform.Define(stage, "/World/envs/env_1/CustomItem0")
+
+        def is_custom_item(prim, context):
+            return prim.GetName().startswith("CustomItem")
+
+        builder = newton.ModelBuilder()
+        builder.add_custom_frequency(
+            newton.ModelBuilder.CustomFrequency(
+                name="item",
+                namespace="test",
+                usd_prim_filter=is_custom_item,
+            )
+        )
+        builder.add_custom_attribute(
+            newton.ModelBuilder.CustomAttribute(
+                name="item_value",
+                frequency="test:item",
+                dtype=wp.float32,
+                default=42.0,
+                namespace="test",
+            )
+        )
+
+        builder.add_usd(stage, ignore_paths=["/World/envs"])
+
+        model = builder.finalize()
+
+        # Only the two prims outside the ignored subtree may contribute rows.
+        self.assertEqual(model.get_custom_frequency_count("test:item"), 2)
+        self.assertEqual(len(model.test.item_value.numpy()), 2)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_custom_frequency_instance_proxy_traversal(self):
         """Test that custom frequency parsing traverses instance proxy prims.
 


### PR DESCRIPTION
## Description

Fixes #3405.

Every prim traversal in `parse_usd` skips prims matching `ignore_paths` except the custom-frequency pass, which visited ignored subtrees and registered spurious rows for prims excluded from the import. Two-pass import workflows (import the global stage with env subtrees ignored, then import env subtrees separately) ended up with misaligned custom-frequency rows — e.g. MJC tendon/actuator frequencies for MuJoCo-schema assets like the Shadow Hand under Isaac Lab's environment cloning.

The fix applies the same `ignore_paths` check used by the sibling traversals (cf. the actuator pass a few lines above) before invoking the per-frequency filters.

## Testing

- New regression test `test_custom_frequency_honors_ignore_paths`: registers a custom frequency whose filter matches prims both inside and outside an ignored subtree, imports with `ignore_paths=["/World/envs"]`, and asserts only the kept prims contribute rows. Verified it fails without the fix (4 rows instead of 2) and passes with it.
- `pytest newton/tests/test_import_usd.py -k "ignore or custom"`: 18 passed.
- pre-commit clean on both files.

Downstream context: Isaac Lab currently works around this by scoping the `usd_prim_filter` callbacks during its global-stage import (isaac-sim/IsaacLab#6411); that workaround can be dropped once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom-frequency imports to respect `ignore_paths` during prim traversal, so prims under ignored subtrees no longer generate custom-frequency rows or custom attribute values.
  * Improved correctness for two-pass import workflows by preventing spurious entries from ignored branches.
* **Tests**
  * Added a unit test (`test_custom_frequency_honors_ignore_paths`) validating expected custom-frequency counts and attribute lengths when `ignore_paths` is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->