### PR TITLE
Deprecated render_config from SensorTiledCamera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Deprecate reading legacy vendor-namespaced deformable material attributes (`omniphysics:`, `physxDeformableBody:`) off any bound material in `newton.usd.get_tetmesh()`, `newton.TetMesh.create_from_usd()`, and `ModelBuilder.add_usd()`. They are still read during the deprecation window, with a `DeprecationWarning`; a future release will read only canonical `physics:` attributes from a material applying `PhysicsVolumeDeformableMaterialAPI`. Migrate by authoring the canonical attributes, or keep the old behavior without the warning via `compat_namespaces=newton.usd.DEFORMABLE_LEGACY_NAMESPACES` (`get_tetmesh` / `create_from_usd`) or `schema_resolvers=[..., SchemaResolverPhysx()]` (`add_usd`). `compat_namespaces` is now keyword-only; pass `()` to opt into the canonical-only behavior today.
 - Deprecate the `indices` argument of `MeshAdjacency` in favor of `tri_indices`
 - Deprecate `MeshAdjacency.add_edge`; construct a `MeshAdjacency` with `edge_indices` (`[o0, o1, v0, v1]` rows) instead
+- Deprecate implicit render-config updates in `SensorTiledCamera.utils.create_default_light()` and `SensorTiledCamera.utils.assign_checkerboard_material()`; set `sensor.render_config.enable_shadows` or `sensor.render_config.enable_textures` explicitly instead.
 - Deprecate `SensorTiledCamera.utils.compute_pinhole_camera_rays()` in favor of `SensorTiledCamera.utils.compute_camera_rays_pinhole()`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,9 @@
 - Deprecate reading legacy vendor-namespaced deformable material attributes (`omniphysics:`, `physxDeformableBody:`) off any bound material in `newton.usd.get_tetmesh()`, `newton.TetMesh.create_from_usd()`, and `ModelBuilder.add_usd()`. They are still read during the deprecation window, with a `DeprecationWarning`; a future release will read only canonical `physics:` attributes from a material applying `PhysicsVolumeDeformableMaterialAPI`. Migrate by authoring the canonical attributes, or keep the old behavior without the warning via `compat_namespaces=newton.usd.DEFORMABLE_LEGACY_NAMESPACES` (`get_tetmesh` / `create_from_usd`) or `schema_resolvers=[..., SchemaResolverPhysx()]` (`add_usd`). `compat_namespaces` is now keyword-only; pass `()` to opt into the canonical-only behavior today.
 - Deprecate the `indices` argument of `MeshAdjacency` in favor of `tri_indices`
 - Deprecate `MeshAdjacency.add_edge`; construct a `MeshAdjacency` with `edge_indices` (`[o0, o1, v0, v1]` rows) instead
-- Deprecate implicit render-config updates in `SensorTiledCamera.utils.create_default_light()` and `SensorTiledCamera.utils.assign_checkerboard_material()`; set `sensor.render_config.enable_shadows` or `sensor.render_config.enable_textures` explicitly instead.
+- Deprecate implicit render-config updates in `SensorTiledCamera.utils.create_default_light()` and `SensorTiledCamera.utils.assign_checkerboard_material()`; set `sensor.default_render_config.enable_shadows` or `sensor.default_render_config.enable_textures` explicitly instead.
+- Deprecate `SensorTiledCamera(..., config=...)` in favor of `SensorTiledCamera(..., default_config=...)`; migrate constructor calls that pass a render config to the new keyword.
+- Deprecate `SensorTiledCamera.render_config` in favor of `SensorTiledCamera.default_render_config`; migrate `sensor.render_config.enable_shadows = True` to `sensor.default_render_config.enable_shadows = True`.
 - Deprecate `SensorTiledCamera.utils.compute_pinhole_camera_rays()` in favor of `SensorTiledCamera.utils.compute_camera_rays_pinhole()`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,7 +154,7 @@
 - Remove body armature: drop `ModelBuilder.default_body_armature`, the `armature` parameter of `ModelBuilder.add_link()` and `add_body()`, and USD-authored body `newton:armature` (deprecated in 1.1.0); add any isotropic artificial inertia directly to `inertia` instead. All `add_link()` and `add_body()` parameters are now keyword-only
 - Remove support for passing a `Gaussian` as the second positional argument to `ModelBuilder.add_shape_gaussian()` (deprecated in 1.1.0); pass it via the `gaussian=` keyword instead
 - Remove support for `worlds_per_row=0` in `SensorTiledCamera.flatten_*_to_rgba()` (deprecated in 1.2.0); pass `worlds_per_row=None` for automatic layout (values below 1 now raise `ValueError`) (#3149)
-- Remove the deprecated SensorTiledCamera 1.1 API surface: `Config`, `RenderContext`, `render_context`, image helper methods, and random color helpers; use `RenderConfig`, `render_config`, `SensorTiledCamera.utils.*`, and per-shape colors instead
+- Remove the deprecated SensorTiledCamera 1.1 API surface: `Config`, `RenderContext`, `render_context`, image helper methods, and random color helpers; use `RenderConfig`, `default_render_config`, `SensorTiledCamera.utils.*`, and per-shape colors instead
 - Remove the deprecated `SensorRaycast`; use `SensorTiledCamera` (`SensorTiledCamera.utils.compute_camera_rays_pinhole()` and `create_depth_image_output()` for single-camera depth) instead
 - Remove the deprecated `max_worlds` parameter of `ViewerBase.set_model()`; call `ViewerBase.set_visible_worlds()` after `set_model()` instead
 - Remove the deprecated `a`, `b`, `c` parameters of `ModelBuilder.add_shape_ellipsoid()` (deprecated in 1.1.0); use `rx`, `ry`, `rz` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@
 - Deprecate the `indices` argument of `MeshAdjacency` in favor of `tri_indices`
 - Deprecate `MeshAdjacency.add_edge`; construct a `MeshAdjacency` with `edge_indices` (`[o0, o1, v0, v1]` rows) instead
 - Deprecate implicit render-config updates in `SensorTiledCamera.utils.create_default_light()` and `SensorTiledCamera.utils.assign_checkerboard_material()`; set `sensor.default_render_config.enable_shadows` or `sensor.default_render_config.enable_textures` explicitly instead.
-- Deprecate `SensorTiledCamera(..., config=...)` in favor of `SensorTiledCamera(..., default_config=...)`; migrate constructor calls that pass a render config to the new keyword.
+- Deprecate `SensorTiledCamera(..., config=...)` in favor of `SensorTiledCamera(..., default_render_config=...)`; migrate constructor calls that pass a render config to the new keyword.
 - Deprecate `SensorTiledCamera.render_config` in favor of `SensorTiledCamera.default_render_config`; migrate `sensor.render_config.enable_shadows = True` to `sensor.default_render_config.enable_shadows = True`.
 - Deprecate `SensorTiledCamera.utils.compute_pinhole_camera_rays()` in favor of `SensorTiledCamera.utils.compute_camera_rays_pinhole()`.
 

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -92,9 +92,9 @@ class FastSensorTiledCamera:
         )
 
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
-        self.tiled_camera_sensor.default_render_config.enable_shadows = True
+        self.tiled_camera_sensor.default_render_config.enable_shadows = False
         self.tiled_camera_sensor.default_render_config.enable_textures = True
-        self.tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
+        self.tiled_camera_sensor.utils.create_default_light(enable_shadows=False)
         self.tiled_camera_sensor.utils.assign_checkerboard_material(
             shape_indices=np.arange(self.model.shape_count, dtype=np.int32)
         )
@@ -111,9 +111,9 @@ class FastSensorTiledCamera:
 
         # Warmup Kernels
         if run_tiled_camera_benchmarks():
-            self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
-            self.tiled_camera_sensor.render_config.tile_width = 8
-            self.tiled_camera_sensor.render_config.tile_height = 8
+            self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.TILED
+            self.tiled_camera_sensor.default_render_config.tile_width = 8
+            self.tiled_camera_sensor.default_render_config.tile_height = 8
             for out_color, out_depth in [(True, True), (True, False), (False, True)]:
                 for _ in range(iterations):
                     self.tiled_camera_sensor.update(
@@ -124,7 +124,7 @@ class FastSensorTiledCamera:
                         depth_image=self.depth_image if out_depth else None,
                     )
 
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         for out_color, out_depth in [(True, True), (True, False), (False, True)]:
             for _ in range(iterations):
                 self.tiled_camera_sensor.update(
@@ -138,7 +138,7 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Pixel)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_rendering_pixel_priority_color_depth(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,
@@ -152,7 +152,7 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Pixel) (Color Only)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_rendering_pixel_priority_color_only(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,
@@ -165,7 +165,7 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Pixel) (Depth Only)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_rendering_pixel_priority_depth_only(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,
@@ -178,9 +178,9 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Tiled)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_color_depth(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
-        self.tiled_camera_sensor.render_config.tile_width = 8
-        self.tiled_camera_sensor.render_config.tile_height = 8
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.TILED
+        self.tiled_camera_sensor.default_render_config.tile_width = 8
+        self.tiled_camera_sensor.default_render_config.tile_height = 8
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,
@@ -194,9 +194,9 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Tiled) (Color Only)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_color_only(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
-        self.tiled_camera_sensor.render_config.tile_width = 8
-        self.tiled_camera_sensor.render_config.tile_height = 8
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.TILED
+        self.tiled_camera_sensor.default_render_config.tile_width = 8
+        self.tiled_camera_sensor.default_render_config.tile_height = 8
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,
@@ -209,9 +209,9 @@ class FastSensorTiledCamera:
     @nice_name("Rendering (Tiled) (Depth Only)")
     @skip_benchmark_if(wp.get_cuda_device_count() == 0 or not run_tiled_camera_benchmarks())
     def time_rendering_tiled_depth_only(self, resolution: int, world_count: int, iterations: int):
-        self.tiled_camera_sensor.render_config.render_order = SensorTiledCamera.RenderOrder.TILED
-        self.tiled_camera_sensor.render_config.tile_width = 8
-        self.tiled_camera_sensor.render_config.tile_height = 8
+        self.tiled_camera_sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.TILED
+        self.tiled_camera_sensor.default_render_config.tile_width = 8
+        self.tiled_camera_sensor.default_render_config.tile_height = 8
         for _ in range(iterations):
             self.tiled_camera_sensor.update(
                 self.state,

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -10,6 +10,8 @@ wp.config.log_level = wp.LOG_WARNING
 import math
 import os
 
+import numpy as np
+
 import newton
 from newton import ShapeFlags
 from newton.sensors import SensorTiledCamera
@@ -90,8 +92,11 @@ class FastSensorTiledCamera:
         )
 
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
-        self.tiled_camera_sensor.utils.create_default_light(enable_shadows=False)
-        self.tiled_camera_sensor.utils.assign_checkerboard_material_to_all_shapes()
+        self.tiled_camera_sensor.render_config.enable_textures = True
+        self.tiled_camera_sensor.utils.create_default_light()
+        self.tiled_camera_sensor.utils.assign_checkerboard_material(
+            shape_indices=np.arange(self.model.shape_count, dtype=np.int32)
+        )
 
         self.camera_rays = self.tiled_camera_sensor.utils.compute_camera_rays_pinhole(
             resolution, resolution, camera_fovs=math.radians(45.0)

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera.py
@@ -92,8 +92,9 @@ class FastSensorTiledCamera:
         )
 
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
-        self.tiled_camera_sensor.render_config.enable_textures = True
-        self.tiled_camera_sensor.utils.create_default_light()
+        self.tiled_camera_sensor.default_render_config.enable_shadows = True
+        self.tiled_camera_sensor.default_render_config.enable_textures = True
+        self.tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
         self.tiled_camera_sensor.utils.assign_checkerboard_material(
             shape_indices=np.arange(self.model.shape_count, dtype=np.int32)
         )

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -121,8 +121,8 @@ class SensorTiledCamera:
                 raise TypeError("Specify only one of `default_render_config` and deprecated `config`.")
             default_render_config = config
 
-        self.default_render_config = default_render_config if default_render_config is not None else RenderConfig()
-        self.default_clear_data = ClearData()
+        self.__default_render_config = default_render_config if default_render_config is not None else RenderConfig()
+        self.__default_clear_data = ClearData()
 
         self.__render_context = RenderContext(
             world_count=self.model.world_count,
@@ -131,6 +131,24 @@ class SensorTiledCamera:
         self.__utils = Utils(self.__render_context, self.default_render_config)
 
         self.__render_context.init_from_model(self.model, load_textures)
+
+    @property
+    def default_render_config(self) -> RenderConfig:
+        """The default render config to use if none is passed to :meth:`update`.
+
+        Returns:
+            The default :class:`RenderConfig` instance.
+        """
+        return self.__default_render_config
+
+    @property
+    def default_clear_data(self) -> ClearData:
+        """The default clear data to use if none is passed to :meth:`update`.
+
+        Returns:
+            The default :class:`ClearData` instance.
+        """
+        return self.__default_clear_data
 
     def sync_transforms(self, state: State):
         """Synchronize triangle-mesh points from the simulation state.

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -86,13 +86,14 @@ class SensorTiledCamera:
         """
         self.model = model
 
-        render_config = config if config is not None else RenderConfig()
+        self.default_render_config = config if config is not None else RenderConfig()
+        self.default_clear_data = ClearData()
 
         self.__render_context = RenderContext(
             world_count=self.model.world_count,
-            config=render_config,
             device=self.model.device,
         )
+        self.__utils = Utils(self.__render_context, self.default_render_config)
 
         self.__render_context.init_from_model(self.model, load_textures)
 
@@ -120,12 +121,13 @@ class SensorTiledCamera:
         camera_rays: wp.array4d[wp.vec3f] | None = None,
         *,
         color_image: wp.array4d[wp.uint32] | None = None,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         depth_image: wp.array4d[wp.float32] | None = None,
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
-        clear_data: ClearData | None = DEFAULT_CLEAR_DATA,
-        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
+        clear_data: ClearData | None = None,
+        render_config: RenderConfig | None = None,
         kernel_block_dim: int = 64,
     ):
         """Render output images for all worlds and cameras.
@@ -159,6 +161,8 @@ class SensorTiledCamera:
                 converted to linear when linear output is requested. See
                 :attr:`DEFAULT_CLEAR_DATA`, :attr:`GRAY_CLEAR_DATA`.
             hdr_color_image: Output for linear HDR color. None to skip.
+            render_config: Render settings for this update. If ``None``, uses
+                :attr:`render_config`.
             kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
                 for the render megakernel.
         """
@@ -168,33 +172,32 @@ class SensorTiledCamera:
         self.__render_context.render(
             self.model,
             state,
-            camera_transforms,
-            camera_rays,
-            color_image,
-            depth_image,
-            shape_index_image,
-            normal_image,
-            albedo_image,
-            clear_data=clear_data,
+            camera_transforms=camera_transforms,
+            camera_rays=camera_rays,
+            color_image=color_image,
             hdr_color_image=hdr_color_image,
+            depth_image=depth_image,
+            shape_index_image=shape_index_image,
+            normal_image=normal_image,
+            albedo_image=albedo_image,
+            clear_data=clear_data if clear_data is not None else self.default_clear_data,
+            config=render_config if render_config is not None else self.default_render_config,
             kernel_block_dim=kernel_block_dim,
         )
 
     @property
     def render_config(self) -> RenderConfig:
-        """Low-level raytrace settings on the internal :class:`RenderContext`.
+        """Default low-level raytrace settings for :meth:`update`.
 
-        Populated at construction from fixed defaults (for example global
-        world and shadow flags on the context). Attributes may be modified to
-        change behavior for subsequent :meth:`update` calls.
+        Attributes may be modified to change behavior for subsequent
+        :meth:`update` calls that do not pass an explicit ``render_config``.
 
         Returns:
-            The live :class:`RenderConfig` instance (same object as
-            ``render_context.config`` without triggering deprecation warnings).
+            The live default :class:`RenderConfig` instance.
         """
-        return self.__render_context.config
+        return self.default_render_config
 
     @property
     def utils(self) -> Utils:
         """Utility helpers for creating output buffers, computing rays, and assigning materials/lights."""
-        return self.__render_context.utils
+        return self.__utils

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import warnings
+from typing import Any
 
 import warp as wp
 
@@ -24,9 +25,17 @@ _RENDER_CONFIG_DEPRECATION_MSG = (
     "The alias will be removed in a future release."
 )
 _CONFIG_DEPRECATION_MSG = (
-    "SensorTiledCamera(..., config=...) is deprecated as of Newton 1.4; use default_config=... instead. "
+    "SensorTiledCamera(..., config=...) is deprecated as of Newton 1.4; use default_render_config=... instead. "
     "The alias will be removed in a future release."
 )
+
+
+class _ConfigUnset:
+    def __repr__(self) -> str:
+        return "_DEPRECATED_CONFIG_UNSET"
+
+
+_DEPRECATED_CONFIG_UNSET: Any = _ConfigUnset()
 
 
 class SensorTiledCamera:
@@ -83,8 +92,8 @@ class SensorTiledCamera:
         self,
         model: Model,
         *,
-        default_config: RenderConfig | None = None,
-        config: RenderConfig | None = None,
+        default_render_config: RenderConfig | None = None,
+        config: RenderConfig | None = _DEPRECATED_CONFIG_UNSET,
         load_textures: bool = True,
     ):
         """Initialize the tiled camera sensor from a simulation model.
@@ -95,24 +104,24 @@ class SensorTiledCamera:
 
         Args:
             model: Simulation model whose shapes will be rendered.
-            default_config: Rendering configuration. Pass a :class:`RenderConfig` to
+            default_render_config: Rendering configuration. Pass a :class:`RenderConfig` to
                 control raytrace settings directly, or ``None`` to use
                 defaults. Use ``RenderConfig.output_color_space`` to control
                 whether packed ``color`` and ``albedo`` outputs are
                 display-encoded or left linear.
-            config: Deprecated as of Newton 1.4; use ``default_config`` instead.
+            config: Deprecated as of Newton 1.4; use ``default_render_config`` instead.
             load_textures: Load texture data from the model. Set to ``False``
                 to skip texture loading when textures are not needed.
         """
         self.model = model
 
-        if config is not None:
+        if config is not _DEPRECATED_CONFIG_UNSET:
             warnings.warn(_CONFIG_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-            if default_config is not None:
-                raise TypeError("Specify only one of `default_config` and deprecated `config`.")
-            default_config = config
+            if default_render_config is not None:
+                raise TypeError("Specify only one of `default_render_config` and deprecated `config`.")
+            default_render_config = config
 
-        self.default_render_config = default_config if default_config is not None else RenderConfig()
+        self.default_render_config = default_render_config if default_render_config is not None else RenderConfig()
         self.default_clear_data = ClearData()
 
         self.__render_context = RenderContext(

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import warp as wp
 
 from ..sim import Model, State
@@ -14,6 +16,16 @@ from .warp_raytrace import (
     RenderLightType,
     RenderOrder,
     Utils,
+)
+
+_RENDER_CONFIG_DEPRECATION_MSG = (
+    "SensorTiledCamera.render_config is deprecated as of Newton 1.4; "
+    "use SensorTiledCamera.default_render_config instead. "
+    "The alias will be removed in a future release."
+)
+_CONFIG_DEPRECATION_MSG = (
+    "SensorTiledCamera(..., config=...) is deprecated as of Newton 1.4; use default_config=... instead. "
+    "The alias will be removed in a future release."
 )
 
 
@@ -67,7 +79,14 @@ class SensorTiledCamera:
     DEFAULT_CLEAR_DATA = ClearData()
     GRAY_CLEAR_DATA = ClearData(clear_color=0xFF666666, clear_albedo=0xFF000000)
 
-    def __init__(self, model: Model, *, config: RenderConfig | None = None, load_textures: bool = True):
+    def __init__(
+        self,
+        model: Model,
+        *,
+        default_config: RenderConfig | None = None,
+        config: RenderConfig | None = None,
+        load_textures: bool = True,
+    ):
         """Initialize the tiled camera sensor from a simulation model.
 
         Builds the internal :class:`RenderContext`, loads shape geometry (and
@@ -76,17 +95,24 @@ class SensorTiledCamera:
 
         Args:
             model: Simulation model whose shapes will be rendered.
-            config: Rendering configuration. Pass a :class:`RenderConfig` to
+            default_config: Rendering configuration. Pass a :class:`RenderConfig` to
                 control raytrace settings directly, or ``None`` to use
                 defaults. Use ``RenderConfig.output_color_space`` to control
                 whether packed ``color`` and ``albedo`` outputs are
                 display-encoded or left linear.
+            config: Deprecated as of Newton 1.4; use ``default_config`` instead.
             load_textures: Load texture data from the model. Set to ``False``
                 to skip texture loading when textures are not needed.
         """
         self.model = model
 
-        self.default_render_config = config if config is not None else RenderConfig()
+        if config is not None:
+            warnings.warn(_CONFIG_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if default_config is not None:
+                raise TypeError("Specify only one of `default_config` and deprecated `config`.")
+            default_config = config
+
+        self.default_render_config = default_config if default_config is not None else RenderConfig()
         self.default_clear_data = ClearData()
 
         self.__render_context = RenderContext(
@@ -149,7 +175,7 @@ class SensorTiledCamera:
                 ``(camera_count, height, width, 2)``.
             color_image: Output for packed RGBA color. The bytes are
                 display/sRGB by default, or linear when
-                ``self.render_config.output_color_space`` is
+                ``self.default_render_config.output_color_space`` is
                 ``newton.utils.ColorSpace.LINEAR``. None to skip.
             depth_image: Output for ray-hit distance [m]. None to skip.
             shape_index_image: Output for per-pixel shape id. None to skip.
@@ -162,7 +188,7 @@ class SensorTiledCamera:
                 :attr:`DEFAULT_CLEAR_DATA`, :attr:`GRAY_CLEAR_DATA`.
             hdr_color_image: Output for linear HDR color. None to skip.
             render_config: Render settings for this update. If ``None``, uses
-                :attr:`render_config`.
+                :attr:`default_render_config`.
             kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
                 for the render megakernel.
         """
@@ -187,14 +213,15 @@ class SensorTiledCamera:
 
     @property
     def render_config(self) -> RenderConfig:
-        """Default low-level raytrace settings for :meth:`update`.
+        """Deprecated alias for :attr:`default_render_config`.
 
-        Attributes may be modified to change behavior for subsequent
-        :meth:`update` calls that do not pass an explicit ``render_config``.
+        .. deprecated:: 1.4
+            Use :attr:`default_render_config` instead.
 
         Returns:
             The live default :class:`RenderConfig` instance.
         """
+        warnings.warn(_RENDER_CONFIG_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
         return self.default_render_config
 
     @property

--- a/newton/_src/sensors/warp_raytrace/raytrace.py
+++ b/newton/_src/sensors/warp_raytrace/raytrace.py
@@ -379,7 +379,7 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
             camera_forward,
         )
 
-        if wp.static(config.enable_particles):
+        if wp.static(config.enable_particles) and wp.static(state.has_particles):
             closest_hit = closest_hit_particles(
                 closest_hit,
                 bvh_particles_size,
@@ -631,7 +631,7 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
             camera_forward,
         )
 
-        if wp.static(config.enable_particles):
+        if wp.static(config.enable_particles) and wp.static(state.has_particles):
             closest_hit = closest_hit_particles_depth_only(
                 closest_hit,
                 bvh_particles_size,
@@ -829,7 +829,7 @@ def create_first_hit_function(config: RenderContext.Config, state: RenderContext
         ):
             return True
 
-        if wp.static(config.enable_particles):
+        if wp.static(config.enable_particles) and wp.static(state.has_particles):
             if first_hit_particles(
                 bvh_particles_size,
                 bvh_particles_id,

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -199,6 +199,9 @@ class RenderContext:
             kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
                 for the render megakernel.
         """
+        if config is None:
+            config = RenderContext.DEFAULT_RENDER_CONFIG
+
         if model.shape_count > 0 and model.bvh_shape_enabled is None:
             raise RuntimeError(
                 "Shape BVH is missing. ModelBuilder.finalize() builds it for finalized models; "

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -127,7 +127,6 @@ class RenderContext:
             if model.tri_indices is not None and model.tri_indices.shape[0]:
                 self.triangle_points = model.particle_q
                 self.triangle_indices = model.tri_indices.flatten()
-                self.state.has_particles = False
 
         self.shape_colors = model.shape_color
         self.gaussians_data = model.gaussians_data

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -14,7 +14,6 @@ from ...sim import Model, State
 from ...utils import load_texture, normalize_texture
 from .render import create_kernel
 from .types import ClearData, MeshData, RenderConfig, RenderOrder, TextureData
-from .utils import Utils
 
 
 class RenderContext:

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -26,6 +26,7 @@ class RenderContext:
         """Mutable flags tracking which render outputs are active."""
 
         num_gaussians: int = 0
+        has_particles: bool = False
         render_color: bool = False
         render_depth: bool = False
         render_shape_index: bool = False
@@ -34,20 +35,17 @@ class RenderContext:
         render_hdr_color: bool = False
 
     DEFAULT_CLEAR_DATA = ClearData()
+    DEFAULT_RENDER_CONFIG = Config()
 
-    def __init__(self, world_count: int = 1, config: Config | None = None, device: str | None = None):
+    def __init__(self, world_count: int = 1, device: str | None = None):
         """Create a new render context.
 
         Args:
             world_count: Number of simulation worlds to render.
-            config: Render configuration. If ``None``, uses default
-                :class:`Config` settings.
             device: Warp device string (e.g. ``"cuda:0"``). If ``None``,
                 the default Warp device is used.
         """
         self.device: str | None = device
-        self.utils = Utils(self)
-        self.config = config if config else RenderContext.Config()
         self.state = RenderContext.State()
 
         self.kernel_cache: dict[int, wp.Kernel] = {}
@@ -103,6 +101,7 @@ class RenderContext:
         self.__triangle_points = None
         self.__triangle_indices = None
         self.__has_particles = False
+        self.state.has_particles = False
 
         self.shape_count_total = model.shape_count
         self.shape_world_index = model.shape_world
@@ -125,10 +124,11 @@ class RenderContext:
 
         if model.particle_q is not None and model.particle_q.shape[0]:
             self.__has_particles = True
+            self.state.has_particles = True
             if model.tri_indices is not None and model.tri_indices.shape[0]:
                 self.triangle_points = model.particle_q
                 self.triangle_indices = model.tri_indices.flatten()
-                self.config.enable_particles = False
+                self.state.has_particles = False
 
         self.shape_colors = model.shape_color
         self.gaussians_data = model.gaussians_data
@@ -154,15 +154,17 @@ class RenderContext:
         self,
         model: Model,
         state: State,
+        *,
         camera_transforms: wp.array2d[wp.transformf],
         camera_rays: wp.array4d[wp.vec3f],
         color_image: wp.array4d[wp.uint32] | None = None,
+        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
         depth_image: wp.array4d[wp.float32] | None = None,
         shape_index_image: wp.array4d[wp.uint32] | None = None,
         normal_image: wp.array4d[wp.vec3f] | None = None,
         albedo_image: wp.array4d[wp.uint32] | None = None,
         clear_data: RenderContext.ClearData | None = DEFAULT_CLEAR_DATA,
-        hdr_color_image: wp.array4d[wp.vec3f] | None = None,
+        config: RenderContext.Config | None = DEFAULT_RENDER_CONFIG,
         kernel_block_dim: int = 64,
     ):
         """Raytrace the scene into the provided output images.
@@ -193,6 +195,8 @@ class RenderContext:
             clear_data: Values used to clear output images before
                 rendering. Pass ``None`` to use :attr:`DEFAULT_CLEAR_DATA`.
             hdr_color_image: Output linear HDR color buffer.
+            config: Render settings for this render call. If ``None``, uses
+                default :class:`Config` settings.
             kernel_block_dim: Thread block dimension forwarded to ``wp.launch``
                 for the render megakernel.
         """
@@ -207,7 +211,8 @@ class RenderContext:
             raise RuntimeError("Shape BVH is incomplete; rebuild it with model.bvh_build_shapes(state).")
 
         has_particles = (
-            self.config.enable_particles
+            config.enable_particles
+            and self.state.has_particles
             and self.__has_particles
             and state.particle_q is not None
             and state.particle_q.shape[0] > 0
@@ -276,9 +281,9 @@ class RenderContext:
                     f"hdr_color_image size must match {self.world_count} x {camera_count} x {height} x {width}"
                 )
 
-            if self.config.render_order == RenderOrder.TILED:
-                assert width % self.config.tile_width == 0, "render width must be a multiple of tile_width"
-                assert height % self.config.tile_height == 0, "render height must be a multiple of tile_height"
+            if config.render_order == RenderOrder.TILED:
+                assert width % config.tile_width == 0, "render width must be a multiple of tile_width"
+                assert height % config.tile_height == 0, "render height must be a multiple of tile_height"
 
             # Reshaping output images to one dimension, slightly improves performance in the Kernel.
             if color_image is not None:
@@ -294,10 +299,10 @@ class RenderContext:
             if hdr_color_image is not None:
                 hdr_color_image = hdr_color_image.reshape(self.world_count * camera_count * width * height)
 
-            kernel_cache_key = hash((self.config, self.state, clear_data))
+            kernel_cache_key = hash((config, self.state, clear_data))
             render_kernel = self.kernel_cache.get(kernel_cache_key)
             if render_kernel is None:
-                render_kernel = create_kernel(self.config, self.state, clear_data)
+                render_kernel = create_kernel(config, self.state, clear_data)
                 self.kernel_cache[kernel_cache_key] = render_kernel
 
             particle_count = state.particle_q.shape[0] if has_particles else 0
@@ -360,12 +365,6 @@ class RenderContext:
                 device=self.device,
                 block_dim=kernel_block_dim,
             )
-
-    @property
-    def world_count_total(self) -> int:
-        if self.config.enable_global_world:
-            return self.world_count + 1
-        return self.world_count
 
     @property
     def light_count(self) -> int:

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -284,9 +284,9 @@ class Utils:
 
     def __warn_implicit_render_config_update(self, method_name: str, config_field: str, value: bool) -> None:
         warnings.warn(
-            f"SensorTiledCamera.utils.{method_name}() changed SensorTiledCamera.render_config.{config_field}. "
-            "This side effect is deprecated and will be removed in a future release. "
-            f"Set sensor.render_config.{config_field} = {value!r} explicitly.",
+            f"SensorTiledCamera.utils.{method_name}() changed SensorTiledCamera.default_render_config.{config_field}. "
+            "This side effect is deprecated as of Newton 1.4 and will be removed in a future release. "
+            f"Set sensor.default_render_config.{config_field} = {value!r} explicitly.",
             category=DeprecationWarning,
             stacklevel=3,
         )

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -13,7 +13,7 @@ import warp as wp
 
 from ...core import MAXVAL
 from . import camera_utils
-from .types import RenderLightType, TextureData
+from .types import RenderConfig, RenderLightType, TextureData
 
 if TYPE_CHECKING:
     from .render_context import RenderContext
@@ -278,8 +278,18 @@ def _validate_rgba_out_buffer(
 class Utils:
     """Utility functions for the RenderContext."""
 
-    def __init__(self, render_context: RenderContext):
+    def __init__(self, render_context: RenderContext, render_config: RenderConfig | None = None):
         self.__render_context = render_context
+        self.__render_config = render_config
+
+    def __warn_implicit_render_config_update(self, method_name: str, config_field: str, value: bool) -> None:
+        warnings.warn(
+            f"SensorTiledCamera.utils.{method_name}() changed SensorTiledCamera.render_config.{config_field}. "
+            "This side effect is deprecated and will be removed in a future release. "
+            f"Set sensor.render_config.{config_field} = {value!r} explicitly.",
+            category=DeprecationWarning,
+            stacklevel=3,
+        )
 
     def create_color_image_output(self, width: int, height: int, camera_count: int = 1) -> wp.array4d[wp.uint32]:
         """Create a color output array for :meth:`~newton.sensors.SensorTiledCamera.update`.
@@ -1320,7 +1330,11 @@ class Utils:
         )
         return out_buffer
 
-    def create_default_light(self, enable_shadows: bool = True, direction: wp.vec3f | None = None):
+    def create_default_light(
+        self,
+        enable_shadows: bool = True,
+        direction: wp.vec3f | None = None,
+    ):
         """Create a default directional light oriented at ``(-1, 1, -1)``.
 
         Args:
@@ -1328,7 +1342,10 @@ class Utils:
             direction: Normalized light direction. If ``None``, defaults to
                 (normalized ``(-1, 1, -1)``).
         """
-        self.__render_context.config.enable_shadows = enable_shadows
+        if self.__render_config is not None:
+            if self.__render_config.enable_shadows != enable_shadows:
+                self.__warn_implicit_render_config_update("create_default_light", "enable_shadows", enable_shadows)
+            self.__render_config.enable_shadows = enable_shadows
         self.__render_context.lights_active = wp.array([True], dtype=wp.bool, device=self.__render_context.device)
         self.__render_context.lights_type = wp.array(
             [RenderLightType.DIRECTIONAL], dtype=wp.int32, device=self.__render_context.device
@@ -1384,7 +1401,10 @@ class Utils:
 
         self.__checkerboard_data.repeat = wp.vec2f(1.0, 1.0)
 
-        self.__render_context.config.enable_textures = True
+        if self.__render_config is not None:
+            if not self.__render_config.enable_textures:
+                self.__warn_implicit_render_config_update("assign_checkerboard_material", "enable_textures", True)
+            self.__render_config.enable_textures = True
         self.__render_context.texture_data = wp.array(
             [self.__checkerboard_data], dtype=TextureData, device=self.__render_context.device
         )

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -1350,7 +1350,7 @@ class Utils:
         self.__render_context.lights_type = wp.array(
             [RenderLightType.DIRECTIONAL], dtype=wp.int32, device=self.__render_context.device
         )
-        self.__render_context.lights_cast_shadow = wp.array([True], dtype=wp.bool, device=self.__render_context.device)
+        self.__render_context.lights_cast_shadow = wp.array([enable_shadows], dtype=wp.bool, device=self.__render_context.device)
         self.__render_context.lights_position = wp.array(
             [wp.vec3f(0.0)], dtype=wp.vec3f, device=self.__render_context.device
         )

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -1350,7 +1350,9 @@ class Utils:
         self.__render_context.lights_type = wp.array(
             [RenderLightType.DIRECTIONAL], dtype=wp.int32, device=self.__render_context.device
         )
-        self.__render_context.lights_cast_shadow = wp.array([enable_shadows], dtype=wp.bool, device=self.__render_context.device)
+        self.__render_context.lights_cast_shadow = wp.array(
+            [enable_shadows], dtype=wp.bool, device=self.__render_context.device
+        )
         self.__render_context.lights_position = wp.array(
             [wp.vec3f(0.0)], dtype=wp.vec3f, device=self.__render_context.device
         )

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -199,6 +199,8 @@ class Example:
 
         # Setup Tiled Camera Sensor
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
+        self.tiled_camera_sensor.render_config.enable_shadows = True
+        self.tiled_camera_sensor.render_config.enable_textures = True
         self.tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
         self.tiled_camera_sensor.utils.assign_checkerboard_material(shape_indices=self.ground_shape_indices)
 

--- a/newton/examples/sensors/example_sensor_tiled_camera.py
+++ b/newton/examples/sensors/example_sensor_tiled_camera.py
@@ -199,8 +199,8 @@ class Example:
 
         # Setup Tiled Camera Sensor
         self.tiled_camera_sensor = SensorTiledCamera(model=self.model)
-        self.tiled_camera_sensor.render_config.enable_shadows = True
-        self.tiled_camera_sensor.render_config.enable_textures = True
+        self.tiled_camera_sensor.default_render_config.enable_shadows = True
+        self.tiled_camera_sensor.default_render_config.enable_textures = True
         self.tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
         self.tiled_camera_sensor.utils.assign_checkerboard_material(shape_indices=self.ground_shape_indices)
 
@@ -372,40 +372,51 @@ class Example:
 
         if ui.radio_button(
             "Gaussians: Fast",
-            self.tiled_camera_sensor.render_config.gaussians_mode == SensorTiledCamera.GaussianRenderMode.FAST,
+            self.tiled_camera_sensor.default_render_config.gaussians_mode == SensorTiledCamera.GaussianRenderMode.FAST,
         ):
-            if self.tiled_camera_sensor.render_config.gaussians_mode != SensorTiledCamera.GaussianRenderMode.FAST:
-                self.tiled_camera_sensor.render_config.gaussians_mode = SensorTiledCamera.GaussianRenderMode.FAST
+            if (
+                self.tiled_camera_sensor.default_render_config.gaussians_mode
+                != SensorTiledCamera.GaussianRenderMode.FAST
+            ):
+                self.tiled_camera_sensor.default_render_config.gaussians_mode = (
+                    SensorTiledCamera.GaussianRenderMode.FAST
+                )
                 show_compile_kernel_info = True
 
         if ui.radio_button(
             "Gaussians: Quality",
-            self.tiled_camera_sensor.render_config.gaussians_mode == SensorTiledCamera.GaussianRenderMode.QUALITY,
+            self.tiled_camera_sensor.default_render_config.gaussians_mode
+            == SensorTiledCamera.GaussianRenderMode.QUALITY,
         ):
-            if self.tiled_camera_sensor.render_config.gaussians_mode != SensorTiledCamera.GaussianRenderMode.QUALITY:
-                self.tiled_camera_sensor.render_config.gaussians_mode = SensorTiledCamera.GaussianRenderMode.QUALITY
+            if (
+                self.tiled_camera_sensor.default_render_config.gaussians_mode
+                != SensorTiledCamera.GaussianRenderMode.QUALITY
+            ):
+                self.tiled_camera_sensor.default_render_config.gaussians_mode = (
+                    SensorTiledCamera.GaussianRenderMode.QUALITY
+                )
                 show_compile_kernel_info = True
 
         changed, value = ui.slider_float(
             "Min Transmittance",
-            self.tiled_camera_sensor.render_config.gaussians_min_transmittance,
+            self.tiled_camera_sensor.default_render_config.gaussians_min_transmittance,
             0.0,
             1.0,
             "%.2f",
         )
         if changed:
-            self.tiled_camera_sensor.render_config.gaussians_min_transmittance = value
+            self.tiled_camera_sensor.default_render_config.gaussians_min_transmittance = value
             show_compile_kernel_info = True
 
         changed, value = ui.slider_int(
             "Max Num Hits",
-            self.tiled_camera_sensor.render_config.gaussians_max_num_hits,
+            self.tiled_camera_sensor.default_render_config.gaussians_max_num_hits,
             1,
             40,
             "%d",
         )
         if changed:
-            self.tiled_camera_sensor.render_config.gaussians_max_num_hits = value
+            self.tiled_camera_sensor.default_render_config.gaussians_max_num_hits = value
             show_compile_kernel_info = True
 
         if show_compile_kernel_info:

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -4,6 +4,7 @@
 import math
 import os
 import unittest
+import warnings
 
 import numpy as np
 import warp as wp
@@ -123,6 +124,36 @@ class TestSensorTiledCamera(unittest.TestCase):
         linear = newton.utils.color_srgb_to_linear((0.5, 0.25, 0.1))
         np.testing.assert_allclose(newton.utils.color_linear_to_srgb(linear), (0.5, 0.25, 0.1), atol=1e-6)
 
+    def test_utils_implicit_default_render_config_update_warns(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        sensor = SensorTiledCamera(model=model)
+
+        self.assertFalse(sensor.render_config.enable_shadows)
+        self.assertFalse(sensor.render_config.enable_textures)
+
+        with self.assertWarnsRegex(DeprecationWarning, "create_default_light.*render_config"):
+            sensor.utils.create_default_light(enable_shadows=True)
+        with self.assertWarnsRegex(DeprecationWarning, "assign_checkerboard_material.*render_config"):
+            sensor.utils.assign_checkerboard_material(shape_indices=[0])
+
+        self.assertTrue(sensor.render_config.enable_shadows)
+        self.assertTrue(sensor.render_config.enable_textures)
+
+    def test_utils_explicit_render_config_field_update_does_not_warn(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        sensor = SensorTiledCamera(model=model)
+        sensor.render_config.enable_shadows = True
+        sensor.render_config.enable_textures = True
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            sensor.utils.create_default_light(enable_shadows=True)
+            sensor.utils.assign_checkerboard_material(shape_indices=[0])
+
+        self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
+        self.assertTrue(sensor.render_config.enable_shadows)
+        self.assertTrue(sensor.render_config.enable_textures)
+
     def test_albedo_output_follows_output_color_space(self) -> None:
         color = (0.25, 0.5, 0.75)
         model = self._build_single_sphere_scene(color)
@@ -224,6 +255,8 @@ class TestSensorTiledCamera(unittest.TestCase):
         )
 
         tiled_camera_sensor = SensorTiledCamera(model=model)
+        tiled_camera_sensor.render_config.enable_shadows = True
+        tiled_camera_sensor.render_config.enable_textures = True
         tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
         tiled_camera_sensor.utils.assign_checkerboard_material(
             shape_indices=np.arange(model.shape_count, dtype=np.int32)

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -212,6 +212,30 @@ class TestSensorTiledCamera(unittest.TestCase):
             np.testing.assert_array_equal(packed[:3], expected_rgb)
             self.assertEqual(packed[3], 255)
 
+    def test_render_context_none_config_uses_default(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        sensor = SensorTiledCamera(model=model)
+        render_context = sensor._SensorTiledCamera__render_context
+
+        camera_transforms = wp.array(
+            [[wp.transformf(wp.vec3f(0.0), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
+            dtype=wp.transformf,
+            device="cpu",
+        )
+        camera_rays = sensor.utils.compute_camera_rays_pinhole(1, 1, camera_fovs=math.radians(30.0))
+        depth_image = sensor.utils.create_depth_image_output(1, 1, camera_count=1)
+
+        render_context.render(
+            model,
+            model.state(),
+            camera_transforms=camera_transforms,
+            camera_rays=camera_rays,
+            depth_image=depth_image,
+            config=None,
+        )
+
+        self.assertGreater(depth_image.numpy()[0, 0, 0, 0], 0.0)
+
     def test_cloth_renders_via_triangle_mesh_construction(self) -> None:
         """wp.Mesh must be lazily constructed on the first render call for cloth models.
 

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -104,6 +104,23 @@ class TestSensorTiledCamera(unittest.TestCase):
         return builder.finalize(device="cpu")
 
     @staticmethod
+    def _build_mixed_cloth_particle_scene() -> newton.Model:
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        builder.add_cloth_grid(
+            pos=wp.vec3(2.0, 0.0, 0.0),
+            rot=wp.quat_identity(),
+            vel=wp.vec3(0.0),
+            dim_x=2,
+            dim_y=2,
+            cell_x=0.1,
+            cell_y=0.1,
+            mass=0.1,
+            fix_top=True,
+        )
+        builder.add_particle(pos=wp.vec3(0.0, 0.0, -2.0), vel=wp.vec3(0.0), mass=1.0, radius=0.25)
+        return builder.finalize(device="cpu")
+
+    @staticmethod
     def _unpack_rgba(packed: int) -> np.ndarray:
         value = int(packed)
         return np.array(
@@ -137,19 +154,27 @@ class TestSensorTiledCamera(unittest.TestCase):
         model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
         config = SensorTiledCamera.RenderConfig(output_color_space=newton.utils.ColorSpace.LINEAR)
 
-        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_config"):
+        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_render_config"):
             sensor = SensorTiledCamera(model=model, config=config)
 
         self.assertIs(sensor.default_render_config, config)
 
-    def test_constructor_rejects_default_config_and_config(self) -> None:
+    def test_constructor_config_none_warns_deprecated(self) -> None:
         model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
 
-        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_config"):
-            with self.assertRaisesRegex(TypeError, "default_config.*config"):
+        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_render_config"):
+            sensor = SensorTiledCamera(model=model, config=None)
+
+        self.assertIsInstance(sensor.default_render_config, SensorTiledCamera.RenderConfig)
+
+    def test_constructor_rejects_default_render_config_and_config(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+
+        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_render_config"):
+            with self.assertRaisesRegex(TypeError, "default_render_config.*config"):
                 SensorTiledCamera(
                     model=model,
-                    default_config=SensorTiledCamera.RenderConfig(),
+                    default_render_config=SensorTiledCamera.RenderConfig(),
                     config=SensorTiledCamera.RenderConfig(),
                 )
 
@@ -196,7 +221,7 @@ class TestSensorTiledCamera(unittest.TestCase):
         for output_color_space in (newton.utils.ColorSpace.SRGB, newton.utils.ColorSpace.LINEAR):
             sensor = SensorTiledCamera(
                 model=model,
-                default_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
+                default_render_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
             )
             camera_rays = sensor.utils.compute_camera_rays_pinhole(1, 1, camera_fovs=math.radians(30.0))
             albedo_image = sensor.utils.create_albedo_image_output(1, 1, camera_count=1)
@@ -287,6 +312,35 @@ class TestSensorTiledCamera(unittest.TestCase):
 
         # Depth hits prove the mesh was passed into the render kernel, not just created.
         self.assertGreater(int(np.sum(depth_image.numpy() > 0.0)), 0)
+
+    def test_render_config_can_enable_particles_with_triangle_mesh(self) -> None:
+        model = self._build_mixed_cloth_particle_scene()
+        sensor = SensorTiledCamera(
+            model=model,
+            default_render_config=SensorTiledCamera.RenderConfig(enable_particles=False, max_distance=10.0),
+        )
+
+        camera_transforms = wp.array(
+            [[wp.transformf(wp.vec3f(0.0), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
+            dtype=wp.transformf,
+            device="cpu",
+        )
+        camera_rays = sensor.utils.compute_camera_rays_pinhole(1, 1, camera_fovs=math.radians(30.0))
+        state = model.state()
+
+        disabled_depth_image = sensor.utils.create_depth_image_output(1, 1)
+        sensor.update(state, camera_transforms, camera_rays, depth_image=disabled_depth_image)
+        self.assertEqual(disabled_depth_image.numpy()[0, 0, 0, 0], 0.0)
+
+        enabled_depth_image = sensor.utils.create_depth_image_output(1, 1)
+        sensor.update(
+            state,
+            camera_transforms,
+            camera_rays,
+            depth_image=enabled_depth_image,
+            render_config=SensorTiledCamera.RenderConfig(enable_particles=True, max_distance=10.0),
+        )
+        self.assertGreater(enabled_depth_image.numpy()[0, 0, 0, 0], 0.0)
 
     def test_checkerboard_material_requires_keyword_arguments(self) -> None:
         model = self._build_single_sphere_scene((0.25, 0.5, 0.75))

--- a/newton/tests/test_sensor_tiled_camera.py
+++ b/newton/tests/test_sensor_tiled_camera.py
@@ -124,26 +124,55 @@ class TestSensorTiledCamera(unittest.TestCase):
         linear = newton.utils.color_srgb_to_linear((0.5, 0.25, 0.1))
         np.testing.assert_allclose(newton.utils.color_linear_to_srgb(linear), (0.5, 0.25, 0.1), atol=1e-6)
 
+    def test_render_config_alias_deprecated(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        sensor = SensorTiledCamera(model=model)
+
+        with self.assertWarnsRegex(DeprecationWarning, "SensorTiledCamera.render_config.*default_render_config"):
+            render_config = sensor.render_config
+
+        self.assertIs(render_config, sensor.default_render_config)
+
+    def test_constructor_config_alias_deprecated(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+        config = SensorTiledCamera.RenderConfig(output_color_space=newton.utils.ColorSpace.LINEAR)
+
+        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_config"):
+            sensor = SensorTiledCamera(model=model, config=config)
+
+        self.assertIs(sensor.default_render_config, config)
+
+    def test_constructor_rejects_default_config_and_config(self) -> None:
+        model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
+
+        with self.assertWarnsRegex(DeprecationWarning, r"config=.*default_config"):
+            with self.assertRaisesRegex(TypeError, "default_config.*config"):
+                SensorTiledCamera(
+                    model=model,
+                    default_config=SensorTiledCamera.RenderConfig(),
+                    config=SensorTiledCamera.RenderConfig(),
+                )
+
     def test_utils_implicit_default_render_config_update_warns(self) -> None:
         model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
         sensor = SensorTiledCamera(model=model)
 
-        self.assertFalse(sensor.render_config.enable_shadows)
-        self.assertFalse(sensor.render_config.enable_textures)
+        self.assertFalse(sensor.default_render_config.enable_shadows)
+        self.assertFalse(sensor.default_render_config.enable_textures)
 
-        with self.assertWarnsRegex(DeprecationWarning, "create_default_light.*render_config"):
+        with self.assertWarnsRegex(DeprecationWarning, "create_default_light.*default_render_config"):
             sensor.utils.create_default_light(enable_shadows=True)
-        with self.assertWarnsRegex(DeprecationWarning, "assign_checkerboard_material.*render_config"):
+        with self.assertWarnsRegex(DeprecationWarning, "assign_checkerboard_material.*default_render_config"):
             sensor.utils.assign_checkerboard_material(shape_indices=[0])
 
-        self.assertTrue(sensor.render_config.enable_shadows)
-        self.assertTrue(sensor.render_config.enable_textures)
+        self.assertTrue(sensor.default_render_config.enable_shadows)
+        self.assertTrue(sensor.default_render_config.enable_textures)
 
     def test_utils_explicit_render_config_field_update_does_not_warn(self) -> None:
         model = self._build_single_sphere_scene((0.25, 0.5, 0.75))
         sensor = SensorTiledCamera(model=model)
-        sensor.render_config.enable_shadows = True
-        sensor.render_config.enable_textures = True
+        sensor.default_render_config.enable_shadows = True
+        sensor.default_render_config.enable_textures = True
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -151,8 +180,8 @@ class TestSensorTiledCamera(unittest.TestCase):
             sensor.utils.assign_checkerboard_material(shape_indices=[0])
 
         self.assertFalse(any(issubclass(w.category, DeprecationWarning) for w in caught))
-        self.assertTrue(sensor.render_config.enable_shadows)
-        self.assertTrue(sensor.render_config.enable_textures)
+        self.assertTrue(sensor.default_render_config.enable_shadows)
+        self.assertTrue(sensor.default_render_config.enable_textures)
 
     def test_albedo_output_follows_output_color_space(self) -> None:
         color = (0.25, 0.5, 0.75)
@@ -167,7 +196,7 @@ class TestSensorTiledCamera(unittest.TestCase):
         for output_color_space in (newton.utils.ColorSpace.SRGB, newton.utils.ColorSpace.LINEAR):
             sensor = SensorTiledCamera(
                 model=model,
-                config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
+                default_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
             )
             camera_rays = sensor.utils.compute_camera_rays_pinhole(1, 1, camera_fovs=math.radians(30.0))
             albedo_image = sensor.utils.create_albedo_image_output(1, 1, camera_count=1)
@@ -255,8 +284,8 @@ class TestSensorTiledCamera(unittest.TestCase):
         )
 
         tiled_camera_sensor = SensorTiledCamera(model=model)
-        tiled_camera_sensor.render_config.enable_shadows = True
-        tiled_camera_sensor.render_config.enable_textures = True
+        tiled_camera_sensor.default_render_config.enable_shadows = True
+        tiled_camera_sensor.default_render_config.enable_textures = True
         tiled_camera_sensor.utils.create_default_light(enable_shadows=True)
         tiled_camera_sensor.utils.assign_checkerboard_material(
             shape_indices=np.arange(model.shape_count, dtype=np.int32)

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -21,7 +21,7 @@ def _build_single_sphere_model():
 def _render_tiny_color_and_hdr(model, *, output_color_space=newton.utils.ColorSpace.SRGB):
     sensor = SensorTiledCamera(
         model=model,
-        config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
+        default_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
     )
     state = model.state()
 

--- a/newton/tests/test_sensor_tiled_camera_hdr_color.py
+++ b/newton/tests/test_sensor_tiled_camera_hdr_color.py
@@ -21,7 +21,7 @@ def _build_single_sphere_model():
 def _render_tiny_color_and_hdr(model, *, output_color_space=newton.utils.ColorSpace.SRGB):
     sensor = SensorTiledCamera(
         model=model,
-        default_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
+        default_render_config=SensorTiledCamera.RenderConfig(output_color_space=output_color_space),
     )
     state = model.state()
 

--- a/newton/tests/test_sensor_tiled_camera_heightfield.py
+++ b/newton/tests/test_sensor_tiled_camera_heightfield.py
@@ -27,6 +27,7 @@ class TestSensorTiledCameraHeightfield(unittest.TestCase):
 
         res = 16
         sensor = SensorTiledCamera(model=model)
+        sensor.render_config.enable_textures = True
         sensor.utils.create_default_light(enable_shadows=False)
         sensor.utils.assign_checkerboard_material(shape_indices=[0])
         # 30-deg fov: footprint half-extent at depth 4 is 4*tan(15)=1.07 < 2,

--- a/newton/tests/test_sensor_tiled_camera_heightfield.py
+++ b/newton/tests/test_sensor_tiled_camera_heightfield.py
@@ -27,7 +27,7 @@ class TestSensorTiledCameraHeightfield(unittest.TestCase):
 
         res = 16
         sensor = SensorTiledCamera(model=model)
-        sensor.render_config.enable_textures = True
+        sensor.default_render_config.enable_textures = True
         sensor.utils.create_default_light(enable_shadows=False)
         sensor.utils.assign_checkerboard_material(shape_indices=[0])
         # 30-deg fov: footprint half-extent at depth 4 is 4*tan(15)=1.07 < 2,
@@ -45,7 +45,7 @@ class TestSensorTiledCameraHeightfield(unittest.TestCase):
             [[wp.transformf(wp.vec3f(0.0, 0.0, 5.0), wp.quatf(0.0, 0.0, 0.0, 1.0))]],
             dtype=wp.transformf,
         )
-        sensor.render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
+        sensor.default_render_config.render_order = SensorTiledCamera.RenderOrder.PIXEL_PRIORITY
         sensor.update(state, cam, rays, depth_image=depth)
 
         d = depth.numpy()[0, 0]  # .numpy() syncs the device-to-host copy

--- a/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
+++ b/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
@@ -98,7 +98,7 @@ def test_sensor_tiled_camera_multiworld_particles_consistent(test: unittest.Test
 
     sensor = SensorTiledCamera(
         model=model,
-        default_config=SensorTiledCamera.RenderConfig(max_distance=max_distance),
+        default_render_config=SensorTiledCamera.RenderConfig(max_distance=max_distance),
     )
     camera_rays = sensor.utils.compute_camera_rays_pinhole(width, height, camera_fovs=fov)
 

--- a/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
+++ b/newton/tests/test_sensor_tiled_camera_particles_multiworld.py
@@ -98,7 +98,7 @@ def test_sensor_tiled_camera_multiworld_particles_consistent(test: unittest.Test
 
     sensor = SensorTiledCamera(
         model=model,
-        config=SensorTiledCamera.RenderConfig(max_distance=max_distance),
+        default_config=SensorTiledCamera.RenderConfig(max_distance=max_distance),
     )
     camera_rays = sensor.utils.compute_camera_rays_pinhole(width, height, camera_fovs=fov)
 


### PR DESCRIPTION
## Description

Deprecate implicit render-config side effects in `SensorTiledCamera` utility helpers and make render settings explicit.

- Add `render_config` to `SensorTiledCamera.update()` so callers can override render settings per update.
- Keep `create_default_light()` and `assign_checkerboard_material()` behavior during the deprecation window, but emit `DeprecationWarning` when they implicitly change `enable_shadows` or
`enable_textures`.
- Track model render state separately from user render config so cloth/particle setup does not mutate render settings.
- Update tiled-camera tests, examples, benchmarks, and `CHANGELOG.md` for the explicit render-config path.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera

Result: 24 tests passed.

## New feature / API change

from newton.sensors import SensorTiledCamera

sensor = SensorTiledCamera(model)

# Set default render behavior explicitly instead of relying on utility side effects.
sensor.render_config.enable_shadows = True
sensor.render_config.enable_textures = True
sensor.utils.create_default_light(enable_shadows=True)
sensor.utils.assign_checkerboard_material(shape_indices=[0])

# Optionally override render settings for a specific update call.
frame_config = SensorTiledCamera.RenderConfig(enable_shadows=False, enable_textures=True)
sensor.update(
    state,
    camera_transforms,
    camera_rays,
    color_image=color_image,
    render_config=frame_config,
)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sensor tiled camera rendering is now driven by a per-sensor *default* render configuration, with optional per-update overrides (including clear-data).
* **Bug Fixes**
  * Prevented particle BVH/intersection work when no particle data is available (in addition to the particle-render setting).
  * Updated tiled camera lighting/material setup and checkerboard assignment to use sensor-side defaults and explicit per-shape indices.
* **Documentation**
  * Added/expanded deprecation guidance for `config` and `render_config` in favor of `default_render_config`, including shadow/texture flags.
* **Tests**
  * Expanded coverage for deprecations/defaulting behavior; updated examples and benchmarks to use the new configuration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->