### PR TITLE
Clear all render layers when users change the example in the gui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Raise an error when `SolverVBD(rigid_contact_history=True)` would allocate or grow contact-history buffers during CUDA graph capture; construct `CollisionPipeline` before `SolverVBD`, or run one uncaptured solver step before capture.
 - Fix `SensorTiledCamera.utils.convert_ray_depth_to_forward_depth()` to preserve the clear-depth sentinel for zero-direction rays and non-positive depths.
 - Fix `ViewerGL.get_frame()` crashing when a CPU model is rendered while a CUDA context is active.
+- Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Fix XPBD particle-particle contacts to avoid non-finite particle state for exact-overlap contacts. (#1562)
 - Refer to `kf` consistently as contact friction gain in public documentation. (#2988)
 - Fix `SolverMuJoCo` dropping the authored `actuator_ctrlrange`/`actuator_ctrllimited`/`actuator_forcerange`/`actuator_forcelimited` when rebuilding USD/MJCF position/velocity actuators imported as `JOINT_TARGET`, so the compiled `mj_model` now clamps control targets and actuator forces like native MuJoCo.

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -295,6 +295,18 @@ class ViewerBase(ABC):
             self.activate(prev_active)
         del self._layers[layer_id]
 
+    def clear_all_layers(self) -> None:
+        """Reset all model-dependent state across every registered layer.
+
+        This is the whole-scene counterpart to :meth:`clear_model`, which is
+        intentionally scoped to the active layer. Use this when discarding an
+        entire viewer scene, such as when the example browser switches to a
+        different example.
+        """
+        for layer_id in [lid for lid in self._layers if lid != _DEFAULT_LAYER_ID]:
+            self.remove_layer(layer_id)
+        self.clear_model()
+
     def set_layer_visible(self, layer_id: str, visible: bool) -> None:
         """Set the visibility of a layer.
 

--- a/newton/_src/viewer/viewer_rtx.py
+++ b/newton/_src/viewer/viewer_rtx.py
@@ -1986,6 +1986,15 @@ void main() {
 
     # ----------------------------------------------------------- viewer API
 
+    @override
+    def clear_all_layers(self) -> None:
+        """Reset the RTX viewer as one complete layered scene."""
+        for layer_id in [lid for lid in self._layers if lid != _DEFAULT_LAYER_ID]:
+            del self._layers[layer_id]
+        self._active_layer_id = _DEFAULT_LAYER_ID
+        self._load_layer_state(self._layers[_DEFAULT_LAYER_ID])
+        self.clear_model()
+
     def clear_model(self) -> None:
         """Reset RTX-specific model-dependent state to defaults.
 

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -397,7 +397,10 @@ class _ExampleBrowser:
         """Switch to the selected example. Returns (new_example, new_class) or (None, example_class)."""
         module_path, self.switch_target = self.switch_target, None
         self._show_splash(f"Loading {module_path.rsplit('.', 1)[-1]}...")
-        self.viewer.clear_model()
+        if hasattr(self.viewer, "clear_all_layers"):
+            self.viewer.clear_all_layers()
+        else:
+            self.viewer.clear_model()
         try:
             mod = importlib.import_module(module_path)
             parser = getattr(mod.Example, "create_parser", create_parser)()
@@ -423,7 +426,10 @@ class _ExampleBrowser:
         """
         self._reset_requested = False
         self._show_splash("Resetting...")
-        self.viewer.clear_model()
+        if hasattr(self.viewer, "clear_all_layers"):
+            self.viewer.clear_all_layers()
+        else:
+            self.viewer.clear_model()
         try:
             if self._initial_args is not None:
                 # Re-create the example with the user's original CLI args so

--- a/newton/examples/__init__.py
+++ b/newton/examples/__init__.py
@@ -393,14 +393,17 @@ class _ExampleBrowser:
         if hasattr(self.viewer, "hide_loading_splash"):
             self.viewer.hide_loading_splash()
 
-    def switch(self, example_class):
-        """Switch to the selected example. Returns (new_example, new_class) or (None, example_class)."""
-        module_path, self.switch_target = self.switch_target, None
-        self._show_splash(f"Loading {module_path.rsplit('.', 1)[-1]}...")
+    def _clear_viewer_scene(self):
         if hasattr(self.viewer, "clear_all_layers"):
             self.viewer.clear_all_layers()
         else:
             self.viewer.clear_model()
+
+    def switch(self, example_class):
+        """Switch to the selected example. Returns (new_example, new_class) or (None, example_class)."""
+        module_path, self.switch_target = self.switch_target, None
+        self._show_splash(f"Loading {module_path.rsplit('.', 1)[-1]}...")
+        self._clear_viewer_scene()
         try:
             mod = importlib.import_module(module_path)
             parser = getattr(mod.Example, "create_parser", create_parser)()
@@ -426,10 +429,7 @@ class _ExampleBrowser:
         """
         self._reset_requested = False
         self._show_splash("Resetting...")
-        if hasattr(self.viewer, "clear_all_layers"):
-            self.viewer.clear_all_layers()
-        else:
-            self.viewer.clear_model()
+        self._clear_viewer_scene()
         try:
             if self._initial_args is not None:
                 # Re-create the example with the user's original CLI args so

--- a/newton/tests/test_example_browser_args.py
+++ b/newton/tests/test_example_browser_args.py
@@ -22,6 +22,10 @@ class _StubViewer:
 
     def __init__(self):
         self.cleared = 0
+        self.cleared_all_layers = 0
+
+    def clear_all_layers(self):
+        self.cleared_all_layers += 1
 
     def clear_model(self):
         self.cleared += 1
@@ -70,7 +74,8 @@ class TestExampleBrowserReset(unittest.TestCase):
 
         self.assertIsNotNone(new_example)
         self.assertEqual(new_example.args.world_count, 2)
-        self.assertEqual(viewer.cleared, 1)
+        self.assertEqual(viewer.cleared_all_layers, 1)
+        self.assertEqual(viewer.cleared, 0)
 
     def test_reset_falls_back_to_defaults_when_no_args(self):
         viewer = _StubViewer()
@@ -102,7 +107,8 @@ class TestExampleBrowserReset(unittest.TestCase):
     def test_reset_after_switch_uses_new_example_args(self):
         # Original launch: _StubExample with --world-count 2.
         args = _StubExample.create_parser().parse_args(["--world-count", "2"])
-        browser = _ExampleBrowser(_StubViewer(), args)
+        viewer = _StubViewer()
+        browser = _ExampleBrowser(viewer, args)
 
         # Simulate the user picking _OtherStubExample from the browser tree.
         browser.switch_target = "fake.module.path"
@@ -112,6 +118,8 @@ class TestExampleBrowserReset(unittest.TestCase):
 
         self.assertIs(new_class, _OtherStubExample)
         self.assertEqual(new_example.args.world_count, 7)
+        self.assertEqual(viewer.cleared_all_layers, 1)
+        self.assertEqual(viewer.cleared, 0)
 
         # Reset after switch must use the new example's args (its parser
         # defaults), not the originally launched _StubExample's args.

--- a/newton/tests/test_viewer_layers.py
+++ b/newton/tests/test_viewer_layers.py
@@ -262,6 +262,27 @@ class TestViewerLayers(unittest.TestCase):
 
         self.assertIn("X", clear_calls, "remove_layer must run clear_model under the removed layer")
 
+    def test_clear_all_layers_clears_every_layer(self):
+        """Full-scene clearing must release inactive layers, not only the active one."""
+        clear_calls: list[str] = []
+
+        class _ClearTrackingViewer(_RecordingViewer):
+            def clear_model(self):
+                clear_calls.append(self._active_layer_id)
+                super().clear_model()
+
+        viewer = _ClearTrackingViewer()
+        for layer_id in ("A", "B", "C"):
+            viewer.activate(layer_id)
+            viewer.set_model(_build_box_model())
+        clear_calls.clear()
+
+        viewer.clear_all_layers()
+
+        self.assertEqual(clear_calls, ["A", "B", "C", "__default__"])
+        self.assertEqual(list(viewer.layers), ["__default__"])
+        self.assertEqual(viewer.layer.name_prefix, "")
+
     def test_rtx_remove_layer_with_sibling_fails_loudly(self):
         """RTX should not silently wipe sibling layers during clear_model()."""
         viewer = _MinimalRTXViewer()
@@ -273,6 +294,17 @@ class TestViewerLayers(unittest.TestCase):
 
         self.assertIn("A", viewer.layers)
         self.assertIn("B", viewer.layers)
+
+    def test_rtx_clear_all_layers_allows_layered_scene_reset(self):
+        """RTX can reset a complete layered scene while keeping single-layer clear guarded."""
+        viewer = _MinimalRTXViewer()
+        viewer.activate("A")
+        viewer.activate("B")
+
+        viewer.clear_all_layers()
+
+        self.assertEqual(list(viewer.layers), ["__default__"])
+        self.assertEqual(viewer.layer.name_prefix, "")
 
     def test_activate_rejects_default_layer_id(self):
         """The internal default-layer id is reserved for legacy unprefixed output."""


### PR DESCRIPTION
## Description
Clear all render layers when users change the example in the GUI so stale overlay geometry from the previous example is removed.
## Checklist
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)
## Test plan
```bash
uv run --extra dev -m newton.tests -k test_viewer_layers
uvx pre-commit run -a
```
## Bug fix
**Steps to reproduce:**
1. Run `python -m newton.examples basic_multi_solver_overlay`.
2. In the OpenGL GUI, switch to another example.
3. Observe that two pendulums from the overlay example remain visible.
**Minimal reproduction:**
```python
import newton

# Reproduce interactively by switching from basic_multi_solver_overlay
# to another example in the OpenGL example browser.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching examples and resetting the viewer now fully clears leftover overlay layers, preventing stale content from staying visible.
  * Layered viewer scenes now reset more reliably across viewer modes, returning to the default view state.

* **Tests**
  * Added coverage for `clear_all_layers()` behavior across viewer backends, including verification that only the default layer remains active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->