### PR TITLE
Promote mujoco KPI benchmarks to the Fast suite

### DIFF
--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -9,7 +9,7 @@ import warp as wp
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
-from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
+from asv_runner.benchmarks.mark import skip_benchmark_if
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
@@ -17,56 +17,6 @@ sys.path.append(parent_dir)
 from benchmark_mujoco import Example
 
 from newton.utils import EventTracer
-
-
-class _FastBenchmark:
-    """Utility base class for fast benchmarks."""
-
-    num_frames = None
-    robot = None
-    number = 1
-    rounds = 2
-    repeat = None
-    world_count = None
-    random_init = None
-    environment = "None"
-
-    def setup(self):
-        if not hasattr(self, "builder") or self.builder is None:
-            self.builder = Example.create_model_builder(
-                self.robot, self.world_count, randomize=self.random_init, seed=123
-            )
-
-        self.example = Example(
-            stage_path=None,
-            robot=self.robot,
-            randomize=self.random_init,
-            headless=True,
-            actuation="None",
-            use_cuda_graph=True,
-            builder=self.builder,
-            environment=self.environment,
-        )
-
-        wp.synchronize_device()
-
-        # Recapture the graph with control application included
-        cuda_graph_comp = wp.get_device().is_cuda and wp.is_mempool_enabled(wp.get_device())
-        if not cuda_graph_comp:
-            raise SkipNotImplemented
-        else:
-            self.example.init_waypoint_control()
-            with wp.ScopedCapture() as capture:
-                self.example.apply_waypoint_control()
-                self.example.simulate()
-            self.graph = capture.graph
-
-        wp.synchronize_device()
-
-    def time_simulate(self):
-        for _ in range(self.num_frames):
-            wp.capture_launch(self.graph)
-        wp.synchronize_device()
 
 
 class _KpiBenchmark:
@@ -165,16 +115,7 @@ class _NewtonOverheadBenchmark:
     track_simulate.unit = "%"
 
 
-class FastCartpole(_FastBenchmark):
-    num_frames = 50
-    robot = "cartpole"
-    repeat = 8
-    world_count = 256
-    random_init = True
-    environment = "None"
-
-
-class KpiCartpole(_KpiBenchmark):
+class FastCartpole(_KpiBenchmark):
     params = [[8192]]
     num_frames = 50
     robot = "cartpole"
@@ -184,16 +125,7 @@ class KpiCartpole(_KpiBenchmark):
     environment = "None"
 
 
-class FastG1(_FastBenchmark):
-    num_frames = 25
-    robot = "g1"
-    repeat = 2
-    world_count = 256
-    random_init = True
-    environment = "None"
-
-
-class KpiG1(_KpiBenchmark):
+class FastG1(_KpiBenchmark):
     params = [[8192]]
     num_frames = 50
     robot = "g1"
@@ -205,15 +137,6 @@ class KpiG1(_KpiBenchmark):
 
 
 class FastNewtonOverheadG1(_NewtonOverheadBenchmark):
-    params = [[256]]
-    num_frames = 25
-    robot = "g1"
-    repeat = 2
-    samples = 1
-    random_init = True
-
-
-class KpiNewtonOverheadG1(_NewtonOverheadBenchmark):
     params = [[8192]]
     num_frames = 50
     robot = "g1"
@@ -223,16 +146,7 @@ class KpiNewtonOverheadG1(_NewtonOverheadBenchmark):
     random_init = True
 
 
-class FastHumanoid(_FastBenchmark):
-    num_frames = 50
-    robot = "humanoid"
-    repeat = 8
-    world_count = 256
-    random_init = True
-    environment = "None"
-
-
-class KpiHumanoid(_KpiBenchmark):
+class FastHumanoid(_KpiBenchmark):
     params = [[8192]]
     num_frames = 100
     robot = "humanoid"
@@ -243,15 +157,6 @@ class KpiHumanoid(_KpiBenchmark):
 
 
 class FastNewtonOverheadHumanoid(_NewtonOverheadBenchmark):
-    params = [[256]]
-    num_frames = 50
-    robot = "humanoid"
-    repeat = 8
-    samples = 1
-    random_init = True
-
-
-class KpiNewtonOverheadHumanoid(_NewtonOverheadBenchmark):
     params = [[8192]]
     num_frames = 100
     robot = "humanoid"
@@ -260,35 +165,18 @@ class KpiNewtonOverheadHumanoid(_NewtonOverheadBenchmark):
     random_init = True
 
 
-class FastAllegro(_FastBenchmark):
-    num_frames = 100
-    robot = "allegro"
-    repeat = 2
-    world_count = 256
-    random_init = False
-    environment = "None"
-
-
-class KpiAllegro(_KpiBenchmark):
+class FastAllegro(_KpiBenchmark):
     params = [[8192]]
     num_frames = 300
     robot = "allegro"
+    timeout = 900
     samples = 2
     ls_iteration = 10
     random_init = False
     environment = "None"
 
 
-class FastKitchenG1(_FastBenchmark):
-    num_frames = 25
-    robot = "g1"
-    repeat = 2
-    world_count = 32
-    random_init = True
-    environment = "kitchen"
-
-
-class KpiKitchenG1(_KpiBenchmark):
+class FastKitchenG1(_KpiBenchmark):
     params = [[512]]
     num_frames = 50
     robot = "g1"
@@ -312,13 +200,6 @@ if __name__ == "__main__":
         "FastKitchenG1": FastKitchenG1,
         "FastNewtonOverheadG1": FastNewtonOverheadG1,
         "FastNewtonOverheadHumanoid": FastNewtonOverheadHumanoid,
-        "KpiCartpole": KpiCartpole,
-        "KpiG1": KpiG1,
-        "KpiHumanoid": KpiHumanoid,
-        "KpiAllegro": KpiAllegro,
-        "KpiKitchenG1": KpiKitchenG1,
-        "KpiNewtonOverheadG1": KpiNewtonOverheadG1,
-        "KpiNewtonOverheadHumanoid": KpiNewtonOverheadHumanoid,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)


### PR DESCRIPTION
## Description

Rename the seven `Kpi*` mujoco benchmarks to `Fast*` and delete the small `Fast*` variants they superseded. The KPI workloads are taken over unchanged (8192 worlds, 512 for KitchenG1, `track_simulate` reporting ms/world-step); `FastAllegro` additionally gets `timeout = 900` because Jetson Orin currently runs it close to the 600 s default.

The CI benchmark job selects benchmarks with `-b Fast`, so after this change CI exercises the KPI-scale workloads instead of the small variants. Since the ModelBuilder collision filter optimization (#3187), the KPI variants cost about the same wall time as the small ones on CI-class GPUs, so maintaining two variants per workload no longer pays for itself. Per-benchmark wall-clock durations recorded by asv on the newest post-#3187 runs (L40S at 5406c68e, CI-class hardware):

| Benchmark | old Fast [s] | KPI, now Fast [s] |
|---|---|---|
| Allegro | 88 | 65 |
| Cartpole | 28 | 9 |
| G1 | 61 | 33 |
| Humanoid | 38 | 35 |
| KitchenG1 | 21 | 12 |
| NewtonOverheadG1 | 8 | 31 |
| NewtonOverheadHumanoid | 6 | 33 |
| **Total** | **250** | **218** |

The KPI variants run once per benchmark while the old Fast variants paid setup twice (`rounds = 2`) plus repeats, which is why the bigger workloads come out cheaper overall. The Allegro figures predate the actuation fix (#3394) and include its roughly 2x inflation, so the renamed benchmark gets cheaper still. On the Jetson perflab machines the KPI set costs more than the old Fast set (Thor 478 s vs 292 s, Orin 772 s vs 500 s), but those machines run the full suite, where dropping the seven duplicate small variants is a net saving per run.

The `_KpiBenchmark` and `_NewtonOverheadBenchmark` base classes are unchanged, so the renamed benchmarks keep their asv version hashes and the dashboard history can be carried over to the new names in the results repository (follow-up there once this merges).

## Checklist

- [x] New or existing tests cover these changes — n/a, benchmark definitions only
- [x] The documentation is up to date with these changes — the `--bench FastAllegro` / `FastG1` examples in `docs/guide/development.rst` remain valid
- [ ] `CHANGELOG.md` has been updated (if user-facing change) — not user-facing

## Test plan

Standalone smoke run of a renamed benchmark on GPU:

```
uv run --extra dev python asv/benchmarks/simulation/bench_mujoco.py --bench FastCartpole
```

The PR's GPU benchmark CI job (`asv run -e -b Fast`) now runs all seven renamed benchmarks and is the real end-to-end verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark for the Kitchen G1 simulation.
  * Expanded benchmark coverage with updated configurations for several fast simulation scenarios.

* **Bug Fixes**
  * Improved benchmark execution so timing now reflects repeated simulation steps across multiple runs.
  * Benchmarks now better adapt to available hardware and simulation settings.

* **Chores**
  * Simplified the benchmark selection list to include only the current fast benchmark set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->