### PR TITLE
Attempt to make sdf cooking benchmarks more reliable

### DIFF
--- a/asv/benchmarks/setup/bench_sdf.py
+++ b/asv/benchmarks/setup/bench_sdf.py
@@ -54,7 +54,6 @@ _BUILDS_PER_SAMPLE = {
     32: 20,
     64: 20,
     128: 10,
-    256: 5,
 }
 
 # Number of untimed warm-up builds in ``setup`` to push the GPU into a stable
@@ -146,7 +145,7 @@ def _create_icosphere(radius: float, subdivisions: int) -> tuple[np.ndarray, np.
 
 
 class FastBuildSdf:
-    """Time ``Mesh.build_sdf`` across a range of grid resolutions.
+    """Time ``Mesh.build_sdf`` across stable grid resolutions.
 
     Uses an icosphere with ~5120 triangles (subdivision 4), representative of
     typical collision meshes used with Newton's SDF contact path.
@@ -159,7 +158,7 @@ class FastBuildSdf:
     runs (see #2534).
     """
 
-    params = ([32, 64, 128, 256],)
+    params = ([32, 64, 128],)
     param_names = ["max_resolution"]
 
     rounds = 2
@@ -189,8 +188,7 @@ class FastBuildSdf:
         self._mesh.clear_sdf()
         wp.synchronize_device()
 
-    # Disabled, see #2534.
-    @skip_benchmark_if(True)
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_build_sdf(self, max_resolution):
         for _ in range(_BUILDS_PER_SAMPLE[max_resolution]):
             _build_sdf(self._mesh, max_resolution=max_resolution)


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->
Attempt to make sdf cooking benchmarks more reliable

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined one benchmark’s tested resolution range to focus on smaller, faster sample sizes.
  * Updated the benchmark to run only when CUDA devices are available, instead of always being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->