### PR TITLE
Start Newton 1.5 development

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.4.0.dev0``
+     - ``1.5.0.dev0``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/docs/guide/release.rst
+++ b/docs/guide/release.rst
@@ -107,8 +107,10 @@ Code freeze and release branch creation
        to RC or stable versions where applicable and remove the NVIDIA package
        index (``[[tool.uv.index]]`` entry for ``nvidia`` **and** the
        ``warp-lang`` entry in ``[tool.uv.sources]`` that references it) so the
-       release wheel installs purely from PyPI, then regenerate ``uv.lock``
-       (``uv lock``) and commit.
+       release wheel installs purely from PyPI.  Update the Warp install command
+       in ``asv.conf.json`` to the same stable release from public PyPI, without
+       ``--pre`` or the NVIDIA index.  Then regenerate ``uv.lock`` (``uv lock``)
+       and commit.
    * - ☐
      - Run the ``release-audit`` skill in **release-candidate mode** against
        ``release-X.Y``; address or acknowledge flagged entries before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.4.0.dev0"
+version = "1.5.0.dev0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3691,7 +3691,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.4.0.dev0"
+version = "1.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Start Newton 1.5 development on `main` after cutting `release-1.4`.

- Bump the project version to `1.5.0.dev0`.
- Regenerate the public API version and `uv.lock`.
- Update the release guide to require pinning `asv.conf.json` to the same
  stable public-PyPI Warp release used by an RC.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable; release metadata only)

## Test plan

```bash
uv lock
uv run --extra dev python -m unittest newton.tests.test_generate_api
uvx --python 3.12 pre-commit run -a
uv run --extra docs --extra sim sphinx-build -W --keep-going -b html \
  -d /tmp/newton-1.5-doctrees docs /tmp/newton-1.5-html
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference to show the new development version.
  * Clarified the release checklist with updated steps for preparing release builds and dependency lockfiles.

* **Chores**
  * Bumped the project version to `1.5.0.dev0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->