### PR TITLE
Set zero gap in rigid friction tests

### DIFF
--- a/newton/tests/test_rigid_friction_ramp.py
+++ b/newton/tests/test_rigid_friction_ramp.py
@@ -120,6 +120,7 @@ def build_friction_grid(device, mus, angles_deg):
         cfg.ke = 1.0e5
         cfg.kd = 1.0e3
         cfg.kf = 0.0  # validate Coulomb friction only — disable viscous component
+        cfg.gap = 0.0
         cfg.color = _ROW_COLORS[row % len(_ROW_COLORS)]
 
         row_box_ids = []
@@ -226,6 +227,7 @@ def build_stopping_distance_scene(device):
         cfg.ke = 1.0e5
         cfg.kd = 0.0
         cfg.kf = 0.0
+        cfg.gap = 0.0
         cfg.color = _ROW_COLORS[i % len(_ROW_COLORS)]
 
         patch_y = float(i * STOPPING_BOX_PITCH_Y)


### PR DESCRIPTION
## Description

Partially addresses #3391 by explicitly setting the contact gap to zero in the rigid friction ramp and stopping-distance fixtures. These tests validate Coulomb friction at the physical surface, but inheriting the builder's default gap adds speculative contacts and makes the CUDA ramp result more sensitive to MuJoCo Warp's float32 elliptic line search.

This keeps the existing model geometry, timestep, `impratio=10`, and solver iteration limits unchanged.

This is a test-side mitigation rather than a complete fix for #3391. Robustness still depends on follow-up fixes in MuJoCo Warp for elliptic line-search convergence and ray exhaustion, so this PR intentionally does not close the ticket.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (not applicable; test-only change)
- [x] `CHANGELOG.md` has been updated (not applicable; test-only change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_friction_ramp_mujoco_warp_cuda_0
uv run --extra dev -m newton.tests -k test_friction_stopping_distance_mujoco_warp_cuda_0
```

## Bug fix

**Steps to reproduce:**

1. Run `test_friction_ramp_mujoco_warp_cuda_0` repeatedly on CUDA with MuJoCo Warp.
2. Observe that a ramp cell can occasionally fail its final-position assertion even though the scene and inputs are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rigid friction and stopping-distance test scenes so generated shapes now use zero gap spacing.
  * This makes the test setups more consistent for friction ramp and stopping-distance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->