### PR TITLE
Isolate Codecov uploads from test jobs

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -232,10 +232,21 @@ jobs:
       # The workflow-level HOME targets the EC2 runner filesystem.
       HOME: /home/runner
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
+      # uses rotating productionresultssaN hosts and harden-runner only supports
+      # leading full-label wildcards.
+      - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            cli.codecov.io:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Download coverage artifact
         id: download-coverage
         continue-on-error: true

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -24,7 +24,7 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: 'Git ref to checkout'
+        description: 'Commit SHA to checkout and attribute coverage uploads to'
         required: false
         type: string
         default: ''
@@ -174,15 +174,14 @@ jobs:
           paths: "rspec.xml"
           show: "fail"
 
-      - name: Upload coverage reports to Codecov
+      - name: Upload coverage artifact
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          disable_search: true
-          env_vars: AWS_INSTANCE_TYPE
-          files: ./coverage.xml
-          flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-gpu
+          path: coverage.xml
+          retention-days: 1
+          overwrite: true
 
       - name: Re-run instructions
         if: failure()
@@ -221,6 +220,38 @@ jobs:
           ================================================================================
 
           EOF
+
+  codecov-upload:
+    name: Upload coverage to Codecov
+    needs: gpu-unit-tests
+    if: ${{ !cancelled() && needs.gpu-unit-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
+    permissions: {}
+    env:
+      # The workflow-level HOME targets the EC2 runner filesystem.
+      HOME: /home/runner
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Download coverage artifact
+        id: download-coverage
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: coverage-gpu
+      - name: Upload coverage reports to Codecov
+        if: ${{ steps.download-coverage.outcome == 'success' }}
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        with:
+          disable_search: true
+          env_vars: AWS_INSTANCE_TYPE
+          files: ./coverage.xml
+          flags: unittests
+          override_commit: ${{ inputs.ref || github.sha }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,10 +189,21 @@ jobs:
     env:
       OS: ${{ matrix.os }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
+      # uses rotating productionresultssaN hosts and harden-runner only supports
+      # leading full-label wildcards.
+      - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            cli.codecov.io:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Download test results artifact
         id: download-test-results
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,14 +153,67 @@ jobs:
           paths: "rspec.xml"
           show: "fail"
         if: always()
-      - name: Upload test results to Codecov
+      - name: Upload test results artifact
         if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: test-results-${{ matrix.os }}
+          path: rspec.xml
+          retention-days: 1
+          overwrite: true
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: coverage-${{ matrix.os }}
+          path: coverage.xml
+          retention-days: 1
+          overwrite: true
+
+  codecov-upload:
+    name: Upload reports to Codecov
+    needs: newton-unittests
+    if: ${{ !cancelled() && needs.newton-unittests.result != 'skipped' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            windows-latest,
+            macos-latest,
+          ]
+    runs-on: ubuntu-latest
+    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
+    permissions: {}
+    env:
+      OS: ${{ matrix.os }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Download test results artifact
+        id: download-test-results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: test-results-${{ matrix.os }}
+      - name: Download coverage artifact
+        id: download-coverage
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: coverage-${{ matrix.os }}
+      - name: Upload test results to Codecov
+        if: ${{ steps.download-test-results.outcome == 'success' }}
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
         with:
           files: ./rspec.xml
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage reports to Codecov
+        if: ${{ steps.download-coverage.outcome == 'success' }}
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
         with:
           disable_search: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           retention-days: 1
           overwrite: true
       - name: Upload coverage artifact
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-${{ matrix.os }}

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Upload test results artifact
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-min-deps

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -131,16 +131,14 @@ jobs:
           paths: "rspec.xml"
           show: "fail"
 
-      - name: Upload test results to Codecov
+      - name: Upload test results artifact
         if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          disable_search: true
-          files: ./rspec.xml
-          flags: minimum-deps-nightly
-          report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test-results-min-deps
+          path: rspec.xml
+          retention-days: 1
+          overwrite: true
 
       - name: Re-run instructions
         if: failure()
@@ -157,6 +155,38 @@ jobs:
           | ❌ | **Re-run failed jobs** | Runner no longer exists → job queued forever |
           | ✅ | **Re-run all jobs** | Starts new EC2 runner → tests re-run |
           EOF
+
+  codecov-upload:
+    name: Upload test results to Codecov
+    needs: minimum-deps-tests
+    if: ${{ !cancelled() && needs.minimum-deps-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
+    permissions: {}
+    env:
+      # The workflow-level HOME targets the EC2 runner filesystem.
+      HOME: /home/runner
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Download test results artifact
+        id: download-test-results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: test-results-min-deps
+      - name: Upload test results to Codecov
+        if: ${{ steps.download-test-results.outcome == 'success' }}
+        continue-on-error: true
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          flags: minimum-deps-nightly
+          report_type: test_results
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -167,10 +167,21 @@ jobs:
       # The workflow-level HOME targets the EC2 runner filesystem.
       HOME: /home/runner
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
+      # uses rotating productionresultssaN hosts and harden-runner only supports
+      # leading full-label wildcards.
+      - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            cli.codecov.io:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Download test results artifact
         id: download-test-results
         continue-on-error: true

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -174,10 +174,21 @@ jobs:
       # The workflow-level HOME targets the EC2 runner filesystem.
       HOME: /home/runner
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
+      # uses rotating productionresultssaN hosts and harden-runner only supports
+      # leading full-label wildcards.
+      - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            cli.codecov.io:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Download test results artifact
         id: download-test-results
         continue-on-error: true

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -140,6 +140,7 @@ jobs:
 
       - name: Upload test results artifact
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-mujoco-warp-nightly

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -138,16 +138,14 @@ jobs:
           paths: "rspec.xml"
           show: "fail"
 
-      - name: Upload test results to Codecov
+      - name: Upload test results artifact
         if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          disable_search: true
-          files: ./rspec.xml
-          flags: mujoco-warp-nightly
-          report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test-results-mujoco-warp-nightly
+          path: rspec.xml
+          retention-days: 1
+          overwrite: true
 
       - name: Re-run instructions
         if: failure()
@@ -164,6 +162,38 @@ jobs:
           | ❌ | **Re-run failed jobs** | Runner no longer exists → job queued forever |
           | ✅ | **Re-run all jobs** | Starts new EC2 runner → tests re-run |
           EOF
+
+  codecov-upload:
+    name: Upload test results to Codecov
+    needs: mujoco-warp-tests
+    if: ${{ !cancelled() && needs.mujoco-warp-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
+    permissions: {}
+    env:
+      # The workflow-level HOME targets the EC2 runner filesystem.
+      HOME: /home/runner
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Download test results artifact
+        id: download-test-results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: test-results-mujoco-warp-nightly
+      - name: Upload test results to Codecov
+        if: ${{ steps.download-test-results.outcome == 'success' }}
+        continue-on-error: true
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          flags: mujoco-warp-nightly
+          report_type: test_results
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -133,16 +133,14 @@ jobs:
           paths: "rspec.xml"
           show: "fail"
 
-      - name: Upload test results to Codecov
+      - name: Upload test results artifact
         if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          disable_search: true
-          files: ./rspec.xml
-          flags: warp-nightly
-          report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: test-results-warp-nightly
+          path: rspec.xml
+          retention-days: 1
+          overwrite: true
 
       - name: Re-run instructions
         if: failure()
@@ -159,6 +157,38 @@ jobs:
           | ❌ | **Re-run failed jobs** | Runner no longer exists → job queued forever |
           | ✅ | **Re-run all jobs** | Starts new EC2 runner → tests re-run |
           EOF
+
+  codecov-upload:
+    name: Upload test results to Codecov
+    needs: warp-nightly-tests
+    if: ${{ !cancelled() && needs.warp-nightly-tests.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
+    permissions: {}
+    env:
+      # The workflow-level HOME targets the EC2 runner filesystem.
+      HOME: /home/runner
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
+        with:
+          egress-policy: audit
+      - name: Download test results artifact
+        id: download-test-results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: test-results-warp-nightly
+      - name: Upload test results to Codecov
+        if: ${{ steps.download-test-results.outcome == 'success' }}
+        continue-on-error: true
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          flags: warp-nightly
+          report_type: test_results
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   stop-runner:
     name: Stop self-hosted EC2 runner

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -169,10 +169,21 @@ jobs:
       # The workflow-level HOME targets the EC2 runner filesystem.
       HOME: /home/runner
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
+      # uses rotating productionresultssaN hosts and harden-runner only supports
+      # leading full-label wildcards.
+      - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            cli.codecov.io:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            results-receiver.actions.githubusercontent.com:443
+            storage.googleapis.com:443
       - name: Download test results artifact
         id: download-test-results
         continue-on-error: true

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -135,6 +135,7 @@ jobs:
 
       - name: Upload test results artifact
         if: ${{ !cancelled() }}
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: test-results-warp-nightly


### PR DESCRIPTION
## Description

Category: CI hardening.

Moves Codecov uploads out of the test jobs (`newton-unittests` and equivalents) and into new, isolated `codecov-upload` jobs across five workflows (`ci.yml`, `aws_gpu_tests.yml`, `minimum_deps_tests.yml`, `mujoco_warp_tests.yml`, `warp_nightly_tests.yml`).

Previously, `CODECOV_TOKEN` was exposed directly to the same runner that checked out and executed repository/PR code (compiling and running the test suite). Coverage (`coverage.xml`) and test-result (`rspec.xml`) files are now handed off via `actions/upload-artifact` from the test job and consumed by a separate `codecov-upload` job via `actions/download-artifact`, which then calls `codecov/codecov-action` using `secrets.CODECOV_TOKEN`. This isolation job runs no repo/PR-supplied code, so the token is never available to a runner that executes untrusted code.

Each download step uses `continue-on-error: true`, and the corresponding upload step is gated on `steps.<download>.outcome == 'success'`, so a missing/failed artifact skips only that upload without failing the whole job.

`step-security/harden-runner` is currently configured in **audit** mode on the new `codecov-upload` jobs to harvest the egress endpoints they call; it will be flipped to **block** mode in a follow-up change before merge review.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

This is a CI-only change; it is verified by observing live GitHub Actions runs on this PR:

- The "Pull Request" workflow (`pr.yml` -> `ci.yml`) runs the `newton-unittests` matrix (ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest), each uploading `coverage-<os>` and `test-results-<os>` artifacts.
- The new `codecov-upload` job matrix downloads those artifacts and uploads them to Codecov, one job per OS.
- Artifact list, per-OS `codecov-upload` job conclusions, and the Codecov CLI upload logs are inspected via `gh run view --log` and `gh api .../artifacts`.
- The Codecov PR comment/status check is confirmed to appear, as on pre-change PRs.

## Post-merge verification

- [ ] Dispatch `aws_gpu_tests.yml` from `main` once after merge (same API call `scheduled_nightly.yml` uses) and confirm the `codecov-upload` job passes under `egress-policy: block` with the org `CODECOV_TOKEN`.
- [ ] First member PR after merge: confirm the GPU `codecov-upload` job runs on a GitHub-hosted runner and coverage attaches to the PR head SHA (`override_commit` with `inputs.ref`).
- [ ] First scheduled nightly after merge: confirm the three nightly `codecov-upload` jobs pass under block mode.
- [ ] Check the codecov-upload harden-runner steps for blocked-endpoint annotations on the first nightly and first member PR (detects Codecov CLI endpoint drift), and confirm a "Re-run all jobs" attempt overwrites artifacts cleanly.

The ci.yml token-backed path (`newton-unittests` -> `codecov-upload` on `ubuntu-latest`/`ubuntu-24.04-arm`/`windows-latest`/`macos-latest`) is exercised automatically by the merge queue. Pre-merge verification evidence for the block-mode allowlist came from PR run 29035060580 (tokenless, fork PR, audit-mode harvest) plus fork-side EC2 experiment runs 29053268183 / 29053270766 (token-backed, `override_commit` verified, failure-path verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI Codecov reporting reliability by decoupling direct uploads from test execution across GPU and nightly workflows.
  * Test results and coverage are now passed through short-lived artifacts before upload.
  * Codecov uploads are conditional on successful artifact retrieval to prevent missing/invalid reports.
  * GPU/nightly uploads now use the intended commit SHA for more accurate attribution in Codecov.
* **Chores**
  * Hardened the Codecov upload workflow with restricted outbound access and safer execution gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Residual risk note

The upload jobs' egress allowlist includes `*.blob.core.windows.net:443` (any Azure blob account) because GitHub artifact downloads use rotating `productionresultssaN` hosts and harden-runner supports only leading full-label wildcards. A compromised upload-path dependency could still exfiltrate to attacker-controlled Azure storage; the tradeoff is documented in the workflow files. Possible future narrowing: drop Codecov CLI Sentry telemetry (`o26192.ingest.us.sentry.io`) if the CLI grows a supported off-switch.
