### PR TITLE
Fix a few coupling examples

### DIFF
--- a/newton/examples/multiphysics/example_franka_cable_ik_pick_place.py
+++ b/newton/examples/multiphysics/example_franka_cable_ik_pick_place.py
@@ -118,7 +118,7 @@ class Example:
         self.collision_pipeline = newton.CollisionPipeline(
             self.model,
             broad_phase="explicit",
-            shape_pairs_filtered=self._payload_ground_shape_pairs(),
+            shape_pairs_filtered=self._ground_shape_pairs(),
         )
         self.contacts = self.collision_pipeline.contacts()
         self.solver.prepare_contacts(self.contacts)
@@ -307,7 +307,6 @@ class Example:
                     ),
                     bodies=self.franka_bodies,
                     joints=self.franka_joints,
-                    shapes=self.franka_shapes,
                 ),
                 SolverCoupled.Entry(
                     name="vbd",
@@ -320,7 +319,6 @@ class Example:
                     ),
                     bodies=self.payload_bodies,
                     joints=self.payload_joints,
-                    shapes=self.payload_shapes + self.ground_shapes,
                 ),
             ],
             coupling=SolverCoupledProxy.Config(
@@ -341,16 +339,16 @@ class Example:
             ),
         )
 
-    def _payload_ground_shape_pairs(self) -> wp.array:
-        payload_shapes = set(self.payload_shapes)
+    def _ground_shape_pairs(self) -> wp.array:
+        dynamic_shapes = set(self.franka_shapes) | set(self.payload_shapes)
         ground_shapes = set(self.ground_shapes)
         pairs = [
             (int(a), int(b))
             for a, b in self.model.shape_contact_pairs.numpy()
-            if ({int(a), int(b)} & payload_shapes) and ({int(a), int(b)} & ground_shapes)
+            if ({int(a), int(b)} & dynamic_shapes) and ({int(a), int(b)} & ground_shapes)
         ]
         if not pairs:
-            raise RuntimeError("No cable-ground contact pairs were generated")
+            raise RuntimeError("No robot- or cable-ground contact pairs were generated")
         return wp.array(np.asarray(pairs, dtype=np.int32), dtype=wp.vec2i, device=self.model.device)
 
     # ------------------------------------------------------------------

--- a/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
+++ b/newton/examples/multiphysics/example_kamino_mujoco_admm_solver.py
@@ -132,6 +132,8 @@ class Example:
 
         builder.color()
         self.model = builder.finalize()
+        self.model.rigid_contact_max = 96
+
         self.device = self.model.device
 
         kamino_config = _make_kamino_config()

--- a/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
@@ -119,6 +119,7 @@ class Example:
         self.payload_kind = str(args.payload_kind)
         self.payload_segments = max(2, int(args.payload_segments))
         self.payload_radius = float(args.payload_radius)
+        self.surface_z = float(PAYLOAD_CENTER[2]) - self.payload_radius
         self.grip_hold = min(GRIP_OPEN, max(GRIP_CLOSE, GRIP_HOLD_FACTOR * self.payload_radius))
 
         template = newton.ModelBuilder(gravity=-9.81)
@@ -239,7 +240,7 @@ class Example:
         franka_joint_start = builder.joint_count
         franka_shape_start = builder.shape_count
 
-        self._add_franka(builder)
+        self._add_franka(builder, self.surface_z)
         builder.joint_target_ke[:7] = [900.0] * 7
         builder.joint_target_kd[:7] = [90.0] * 7
         builder.joint_target_ke[7:9] = [GRIP_STIFFNESS, GRIP_STIFFNESS]
@@ -276,9 +277,10 @@ class Example:
         self.payload_mid_body_offset = self.payload_body_count_per_world // 2
 
     @staticmethod
-    def _add_franka(builder: newton.ModelBuilder) -> None:
+    def _add_franka(builder: newton.ModelBuilder, base_z: float) -> None:
         builder.add_urdf(
             newton.utils.download_asset("franka_emika_panda") / "urdf/fr3_franka_hand.urdf",
+            xform=wp.transform(wp.vec3(0.0, 0.0, base_z), wp.quat_identity()),
             floating=False,
             enable_self_collisions=False,
             parse_visuals_as_colliders=False,
@@ -288,10 +290,9 @@ class Example:
         builder.joint_target_q[: len(FRANKA_Q)] = FRANKA_Q
 
     def _emit_ground_plane(self, builder: newton.ModelBuilder) -> int:
-        top_z = 0.256 - self.payload_radius
         plane_cfg = newton.ModelBuilder.ShapeConfig(ke=8.0e4, kd=2.0e1, mu=0.8, margin=0.001, gap=0.002)
         return builder.add_ground_plane(
-            height=top_z,
+            height=self.surface_z,
             cfg=plane_cfg,
             label="payload_ground_plane",
         )
@@ -440,7 +441,7 @@ class Example:
     def _build_ik(self) -> None:
         # IK runs on a Franka-only model so payload coordinates do not enter the solve.
         ik_builder = newton.ModelBuilder(gravity=-9.81)
-        self._add_franka(ik_builder)
+        self._add_franka(ik_builder, self.surface_z)
         self.ik_model = ik_builder.finalize(device=self.device)
 
         self.n_coords = self.ik_model.joint_coord_count

--- a/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
@@ -163,14 +163,12 @@ class Example:
                     ),
                     bodies=self.franka_bodies,
                     joints=self.franka_joints,
-                    shapes=self.franka_shapes,
                 ),
                 SolverCoupled.Entry(
                     name=payload_name,
                     solver=payload_solver,
                     bodies=self.payload_bodies,
                     joints=self.payload_joints,
-                    shapes=self.payload_shapes + self.ground_shapes,
                 ),
             ],
             coupling=SolverCoupledADMM.Config(

--- a/newton/examples/multiphysics/example_mujoco_vbd_coupled_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_vbd_coupled_solver.py
@@ -111,6 +111,7 @@ class Example:
         self.rigid_solver = getattr(args, "rigid_solver", "mujoco")
 
         builder = newton.ModelBuilder()
+        builder.default_shape_cfg.ke = 2.0e4
         _register_rigid_solver_custom_attributes(builder, self.rigid_solver)
         builder.add_ground_plane()
 
@@ -134,12 +135,7 @@ class Example:
 
         # Contact parameters
         self.model.soft_contact_ke = 1.0e5
-        self.model.soft_contact_kd = 0.0
         self.model.soft_contact_mu = 0.5
-        # VBD now damps body-particle contacts from full relative body/particle
-        # motion. Keep material damping disabled here so proxy impact forces stay
-        # close to the pre-rebase penalty-contact behavior.
-        self.model.shape_material_kd.fill_(0.0)
 
         vbd_kwargs = {
             "iterations": 10,
@@ -147,18 +143,6 @@ class Example:
             "particle_enable_self_contact": True,
             "particle_self_contact_radius": 0.01,
             "particle_self_contact_margin": 0.01,
-            # Match the pre-AVBD-hard-constraint defaults used by this scene by
-            # default, while allowing hard-contact experiments from the CLI.
-            "rigid_contact_hard": args.rigid_contact_hard,
-            "rigid_avbd_beta": 1.0e5,
-            "rigid_avbd_gamma": 0.99,
-            "rigid_contact_k_start": 1.0e2,
-            "rigid_joint_linear_k_start": 1.0e4,
-            "rigid_joint_angular_k_start": 1.0e1,
-            "rigid_joint_linear_ke": 1.0e9,
-            "rigid_joint_angular_ke": 1.0e9,
-            "rigid_joint_linear_kd": 1.0e2,
-            "rigid_joint_angular_kd": 0.0,
         }
 
         if self.use_coupled:
@@ -400,11 +384,6 @@ class Example:
             help="Number of proxy relaxation passes per substep",
             type=int,
             default=1,
-        )
-        parser.add_argument(
-            "--rigid-contact-hard",
-            help="Use VBD hard augmented-Lagrangian rigid contacts instead of soft penalty contacts",
-            action="store_true",
         )
         return parser
 

--- a/newton/examples/multiphysics/example_proxy_joint_gripper.py
+++ b/newton/examples/multiphysics/example_proxy_joint_gripper.py
@@ -45,6 +45,7 @@ class Example:
         self.frame_dt = 1.0 / self.fps
         self.sim_substeps = int(args.substeps)
         self.sim_dt = self.frame_dt / float(self.sim_substeps)
+        self.use_graph = bool(args.graph_capture)
         self.sim_time = 0.0
         self.scenario = args.scenario
         self.close_distance = (
@@ -78,7 +79,7 @@ class Example:
         self.model.soft_contact_ke = 1.5e5 if self.scenario == "harsh" else 5.0e4
         self.model.soft_contact_kd = 1.0e-4
         self.model.soft_contact_kf = 1.0e3
-        self.model.soft_contact_mu = 0.6
+        self.model.soft_contact_mu = 2.0
 
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()
@@ -99,8 +100,8 @@ class Example:
             "particle_enable_tile_solve": False,
             "rigid_contact_hard": False,
             "rigid_body_particle_contact_buffer_size": 1024 if self.scenario == "harsh" else 512,
-            "rigid_joint_linear_ke": 5.0e5 if self.scenario == "harsh" else 2.0e5,
-            "rigid_joint_angular_ke": 5.0e5 if self.scenario == "harsh" else 2.0e5,
+            "rigid_joint_linear_ke": 5.0e5 if self.scenario == "harsh" else 2.0e7,
+            "rigid_joint_angular_ke": 5.0e5 if self.scenario == "harsh" else 2.0e6,
         }
 
         self.solver = SolverCoupledProxy(
@@ -147,6 +148,18 @@ class Example:
             ),
         )
         newton.examples.configure_coupled_view(self, args)
+        self.capture()
+
+    def capture(self) -> None:
+        self.graph = None
+        if not self.use_graph or not self.model.device.is_cuda:
+            return
+
+        with wp.ScopedDevice(self.model.device), wp.ScopedCapture() as capture:
+            self.simulate()
+        self.graph = capture.graph
+        if self.graph is None:
+            raise RuntimeError(f"CUDA graph capture failed on device {self.model.device}")
 
     def _emit_soft_object(self, builder: newton.ModelBuilder) -> None:
         size = 0.1 if self.scenario == "harsh" else 0.09
@@ -284,7 +297,6 @@ class Example:
         return np.min(particle_q, axis=0), np.max(particle_q, axis=0)
 
     def simulate(self) -> None:
-        self._update_gripper_target()
         self.model.collide(self.state_0, self.contacts)
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()
@@ -292,7 +304,12 @@ class Example:
             self.state_0, self.state_1 = self.state_1, self.state_0
 
     def step(self) -> None:
-        self.simulate()
+        self._update_gripper_target()
+        if self.graph is not None:
+            with wp.ScopedDevice(self.model.device):
+                wp.capture_launch(self.graph)
+        else:
+            self.simulate()
         self.sim_time += self.frame_dt
 
     def test_final(self) -> None:
@@ -337,8 +354,8 @@ class Example:
         )
         parser.add_argument("--substeps", type=int, default=5, help="Simulation substeps per rendered frame.")
         newton.examples.add_coupled_view_args(parser)
-        parser.add_argument("--vbd-iterations", type=int, default=8, help="VBD iterations per substep.")
-        parser.add_argument("--mujoco-iterations", type=int, default=60, help="MuJoCo solver iterations.")
+        parser.add_argument("--vbd-iterations", type=int, default=40, help="VBD iterations per substep.")
+        parser.add_argument("--mujoco-iterations", type=int, default=20, help="MuJoCo solver iterations.")
         parser.add_argument("--proxy-iterations", type=int, default=1, help="Proxy coupling iterations per substep.")
         parser.add_argument(
             "--mass-scale",
@@ -375,6 +392,13 @@ class Example:
         )
         parser.add_argument("--close-distance", type=float, default=None, help="Final inward finger target [m].")
         parser.add_argument("--close-time", type=float, default=None, help="Finger closing ramp duration [s].")
+        parser.add_argument(
+            "--no-graph-capture",
+            action="store_false",
+            dest="graph_capture",
+            default=True,
+            help="Disable CUDA graph capture.",
+        )
         return parser
 
 

--- a/newton/examples/multiphysics/example_proxy_joint_gripper.py
+++ b/newton/examples/multiphysics/example_proxy_joint_gripper.py
@@ -44,8 +44,10 @@ class Example:
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
         self.sim_substeps = int(args.substeps)
-        self.sim_dt = self.frame_dt / float(self.sim_substeps)
         self.use_graph = bool(args.graph_capture)
+        if self.use_graph and self.sim_substeps % 2 != 0:
+            raise ValueError("Graph capture requires an even number of simulation substeps")
+        self.sim_dt = self.frame_dt / float(self.sim_substeps)
         self.sim_time = 0.0
         self.scenario = args.scenario
         self.close_distance = (
@@ -352,9 +354,9 @@ class Example:
             default="default",
             help="Scene configuration to run.",
         )
-        parser.add_argument("--substeps", type=int, default=5, help="Simulation substeps per rendered frame.")
+        parser.add_argument("--substeps", type=int, default=6, help="Simulation substeps per rendered frame.")
         newton.examples.add_coupled_view_args(parser)
-        parser.add_argument("--vbd-iterations", type=int, default=40, help="VBD iterations per substep.")
+        parser.add_argument("--vbd-iterations", type=int, default=30, help="VBD iterations per substep.")
         parser.add_argument("--mujoco-iterations", type=int, default=20, help="MuJoCo solver iterations.")
         parser.add_argument("--proxy-iterations", type=int, default=1, help="Proxy coupling iterations per substep.")
         parser.add_argument(

--- a/newton/examples/multiphysics/example_xpbd_vbd_coupled_solver.py
+++ b/newton/examples/multiphysics/example_xpbd_vbd_coupled_solver.py
@@ -9,8 +9,10 @@
 # proxy particles, and the harvested proxy impulse is applied back to the VBD
 # particles on the next coupled step.
 #
-# Pass ``--solver xpbd`` to run a contact-only XPBD reference, or
-# ``--solver vbd`` to run the same particles with VBD only.
+# Pass ``--solver xpbd`` to run a monolithic XPBD reference, or``--solver vbd``
+# to run the same scene with VBD only.
+# Those baselines are provided for comparison purposes, it is expected that the
+# behavior will differ as they support different features and/or parameters.
 #
 # Command: python -m newton.examples xpbd_vbd_coupled_solver
 #          python -m newton.examples xpbd_vbd_coupled_solver --solver xpbd


### PR DESCRIPTION
## Description

Fix #3432 : add floor collider to MJC + move robot base above floor. Also add robot-floor collider to the cable_pick_place example for consistency. 
Fix #3431: reduce Newton-side rigid_contact_max 

Mitigate / Close #3438 : improve stability but there is still some small drift, hopefully this will get better when the "full surface" collisions PR is merged. Acceptable since this example is not part of the publicly advertised ones 

Edit:
Fix #3436 : Increase default_shape.ke so that VBD rigid-floor contacts are stiffer. I still kept the same value for both Mujoco and VBD in the interest of comparison, but for the same behavior VBD seems to require 100x stiffer contacts
 
Close #3437 : clarify baseline solver flags in description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added optional CUDA graph capture for faster gripper simulation, with a command-line flag to disable it.
* **Bug Fixes**
  * Improved ground-contact pair selection so the right shapes participate in ground interactions.
  * Made Franka base and ground plane alignment consistent between coupled and IK-only models.
  * Increased rigid contact capacity to improve simulation stability.
* **Updates**
  * Refined VBD/MuJoCo coupling defaults and simplified VBD solver configuration; updated related CLI options and iteration defaults.
* **Documentation**
  * Clarified XPBD/VBD option descriptions in example usage comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->