### PR TITLE
Fix Featherstone parent force accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - Raise an error when `SolverVBD(rigid_contact_history=True)` would allocate or grow contact-history buffers during CUDA graph capture; construct `CollisionPipeline` before `SolverVBD`, or run one uncaptured solver step before capture.
 - Fix `SensorTiledCamera.utils.convert_ray_depth_to_forward_depth()` to preserve the clear-depth sentinel for zero-direction rays and non-positive depths.
 - Fix `ViewerGL.get_frame()` crashing when a CPU model is rendered while a CUDA context is active.
+- Fix `eval_inverse_dynamics()` and `SolverFeatherstone` intermittently dropping descendant wrench contributions during the articulated-body backward pass on CUDA.
 - Fix XPBD particle-particle contacts to avoid non-finite particle state for exact-overlap contacts. (#1562)
 - Refer to `kf` consistently as contact friction gain in public documentation. (#2988)
 - Fix `SolverMuJoCo` dropping the authored `actuator_ctrlrange`/`actuator_ctrllimited`/`actuator_forcerange`/`actuator_forcelimited` when rebuilding USD/MJCF position/velocity actuators imported as `JOINT_TARGET`, so the compiled `mj_model` now clamps control targets and actuator forces like native MuJoCo.

--- a/newton/_src/sim/inverse_dynamics.py
+++ b/newton/_src/sim/inverse_dynamics.py
@@ -240,7 +240,7 @@ def _rnea_compensation_pass(
     device = model.device
     bc = model.body_count
 
-    # ``eval_rigid_tau`` reads body_ft_s[child] before atomic-adding into
+    # ``eval_rigid_tau`` reads body_ft_s[child] before accumulating into
     # body_ft_s[parent], so this buffer must start zero on every pass. The
     # other RNEA scratch arrays are fully overwritten by their producing
     # kernels (jcalc_motion, compute_link_velocity, jcalc_tau) and don't

--- a/newton/_src/solvers/featherstone/kernels.py
+++ b/newton/_src/solvers/featherstone/kernels.py
@@ -1409,9 +1409,11 @@ def eval_rigid_tau(
             tau,
         )
 
-        # update parent forces, todo: check that this is valid for the backwards pass
+        # Each articulation is traversed serially by one thread, so an ordinary
+        # read-modify-write keeps the accumulated wrench visible to the next
+        # iteration of the backward pass.
         if parent >= 0:
-            wp.atomic_add(body_ft_s, parent, f_s)
+            body_ft_s[parent] = body_ft_s[parent] + f_s
 
 
 # builds spatial Jacobian J which is an (joint_count*6)x(dof_count) matrix


### PR DESCRIPTION
## Description

Addresses #3419.

Replace the atomic descendant-wrench accumulation in `eval_rigid_tau()` with an explicit serial read-modify-write.

Each articulation is traversed by one kernel thread, and the next reverse-pass iteration immediately consumes the accumulated parent wrench. On the RTX PRO 6000 Blackwell CI runner, the vector atomic update can intermittently remain invisible to that following read, causing the upstream joint to lose descendant Coriolis and centrifugal contributions while distal joints remain correct.

This fixes both `eval_inverse_dynamics()` and `SolverFeatherstone`, which share the backward-pass kernel, and adds an Unreleased changelog entry.

## Investigation findings (RTX PRO 6000 Blackwell, sm_120)

**Failure signature.** All CI failures in #3419 and the linked runs share one pattern: an upstream DOF is short by exactly the descendant contribution while distal DOFs are correct (e.g. Coriolis `[0, 28.125]` instead of `[-84.375, 28.125]`; gravity-comp `10 vs 30`, `70 vs 150`). In `eval_rigid_tau` the same thread walks the articulation in reverse and `tau[parent]` is the only consumer of the `wp.atomic_add`-accumulated `body_ft_s[parent]`, so a lost accumulation is the only flaky-capable operation in that data path.

**Hypotheses ruled out.**
- *Uninitialized scratch memory:* poisoned every `wp.empty` allocation with garbage and ran the full `test_inverse_dynamics.py` — all 70 tests still pass, so no kernel in this path reads uninitialized memory.
- *Cross-thread race:* body indices are disjoint per articulation; one thread owns the whole chain.
- *Static miscompile:* disassembled the kernel with ptxas 12.8 and 13.2 (matching the CI driver 13.2 JIT) for sm_120 — the atomic compiles to 6x `REDG.E.ADD.F32.STRONG.GPU` (L2 reduction) correctly placed at the end of the loop body, reads are coherent `LDG` (not `.nc`), no reordering or unrolling. If the stated mechanism is real, it is a dynamic same-thread RED-to-LDG visibility issue, not a visible miscompile.

**Local reproduction was not achieved** (MIG 1g.24gb slice, driver 13.0 vs CI full GPU, driver 13.2): 30x `test_inverse_dynamics.py` on main, 3000 iterations of `eval_inverse_dynamics()` on the exact failing test models, and a stress probe covering ~137M same-thread `atomic_add`-then-read pairs were all clean. The root cause therefore remains plausible-but-unconfirmed; if the flake recurs after merge, the bug is elsewhere.

**Fix verification.**
- Forward results bit-match the CPU reference and are stable over 3000 iterations; 10x full `test_inverse_dynamics.py` green on this branch.
- The new code compiles to plain `LDG`/`STG`, whose same-thread same-address program order is architecturally guaranteed — the L2-atomic vs. L1-load interaction is removed entirely.
- Autodiff is unaffected: Warp's `adj_array_store` zeroes the element adjoint, making the serial read-modify-write adjoint mathematically identical to `adj_atomic_add`. Verified empirically with a 3-link `SolverFeatherstone` tape-vs-finite-difference gradient check: gradients are bit-identical between `main` and this branch and match finite differences.
- The only other `atomic_add` in the Featherstone kernels (`body_f_ext`) is a per-joint kernel with no same-kernel read-back, so no other instance of this pattern exists.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests --no-cache-clear -p test_inverse_dynamics.py
# 70 tests passed (10 consecutive runs on RTX PRO 6000 Blackwell)

uv run --extra dev -m newton.tests --no-cache-clear -p test_parent_force.py
# 12 tests passed

uvx pre-commit run -a
# passed
```

Additional verification on an RTX PRO 6000 Blackwell (sm_120): 3000-iteration determinism loop of `eval_inverse_dynamics()` on the failing test models (bit-identical to CPU reference), poisoned-`wp.empty` run to exclude uninitialized reads, and a Featherstone tape-vs-finite-difference gradient check (bit-identical gradients vs. `main`).

The existing analytical inverse-dynamics tests provide regression coverage and failed without this change in:
- https://github.com/newton-physics/newton/actions/runs/29040033621/job/86195046150
- https://github.com/newton-physics/newton/actions/runs/29017015325/job/86114793653

## Bug fix

**Steps to reproduce:**

1. Run the inverse-dynamics CUDA tests on the `g7e.2xlarge` RTX PRO 6000 Blackwell runner.
2. Exercise a multi-link articulation with nonzero generalized velocities.
3. Observe that the distal Coriolis force is correct while an upstream force intermittently loses the descendant contribution, for example expected `[-84.375, 28.125]` but received `[0, 28.125]`.

**Minimal reproduction:**

```bash
uv run --extra dev -m newton.tests --no-cache-clear \
  -k test_coriolis_double_pendulum_matches_analytical \
  -k test_articulation_view_masks_inverse_dynamics \
  -k test_bias_forces_flag_populates_both
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an intermittent issue on CUDA where some descendant force contributions could be lost during inverse dynamics calculations.
  * Improved the reliability of articulated-body backward passes, helping results stay consistent across runs.
* **Documentation**
  * Updated release notes to record the CUDA inverse dynamics fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
