### PR TITLE
Tiled Camera Sensor Improvements (DRAFT)

### DIFF
--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
@@ -207,11 +207,21 @@ class ScenePreset:
     camera_target: tuple[float, float, float]
     """Point the camera looks at [m]."""
 
+    light_direction: tuple[float, float, float] | None = None
+    """Directional-light travel direction; ``None`` uses the sensor default."""
+
 
 SCENES: dict[str, ScenePreset] = {
     "franka": ScenePreset(_build_franka, camera_eye=(2.4, 0.0, 0.8), camera_target=(0.0, 0.0, 0.4)),
     "quadruped": ScenePreset(_build_quadruped, camera_eye=(2.2, 2.2, 1.1), camera_target=(0.0, 0.0, 0.45)),
-    "franka_cabinet": ScenePreset(_build_franka_cabinet, camera_eye=(2.4, 1.8, 1.3), camera_target=(0.4, 0.0, 0.5)),
+    # Light comes from the camera-facing upper-front octant so it lands on the
+    # cabinet drawers (which face +x) and top, both visible to the camera.
+    "franka_cabinet": ScenePreset(
+        _build_franka_cabinet,
+        camera_eye=(2.4, 1.8, 1.3),
+        camera_target=(0.4, 0.0, 0.5),
+        light_direction=(-1.0, -0.4, -0.45),
+    ),
     "shapes_256": ScenePreset(_build_shapes_256, camera_eye=(9.0, 9.0, 6.0), camera_target=(0.0, 0.0, 0.0)),
 }
 
@@ -241,14 +251,15 @@ class _TiledCameraSceneRig:
 
         scene = newton.ModelBuilder()
         scene.replicate(world, world_count)
-        scene.add_ground_plane()
+        scene.add_ground_plane(color=(0.6, 0.6, 0.6))
 
         self.model = scene.finalize()
         self.state = self.model.state()
         newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state)
 
+        light_direction = wp.vec3f(*preset.light_direction) if preset.light_direction is not None else None
         self.sensor = SensorTiledCamera(model=self.model)
-        self.sensor.utils.create_default_light(enable_shadows=False)
+        self.sensor.utils.create_default_light(enable_shadows=True, direction=light_direction)
         self.sensor.utils.assign_checkerboard_material(shape_indices=np.arange(self.model.shape_count))
 
         camera = _look_at_transform(preset.camera_eye, preset.camera_target)
@@ -321,10 +332,8 @@ class TiledCameraFrankaCabinet(_SceneBenchmark):
 
 
 class TiledCameraShapes256(_SceneBenchmark):
-    # 256 shapes per world; fewer worlds keep total shape instances comparable
-    # to the other scenes and model build time manageable.
     scene = "shapes_256"
-    params = ([64], [1024], [50])
+    params = ([64], [4096], [50])
 
 
 BENCHMARKS = {

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
@@ -1,0 +1,412 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Scene-based rendering benchmarks for the tiled camera sensor.
+
+Complements ``bench_sensor_tiled_camera.py`` (render-order variants on a single
+Franka scene) with scenes of varying visual complexity, all rendered with the
+default render order. Intended for hill-climbing renderer performance:
+
+- ``franka``: a fixed-base Franka FR3 arm.
+- ``quadruped``: an ANYmal D quadruped in its nominal standing pose.
+- ``franka_cabinet``: Isaac Lab's Franka cabinet (open-drawer) scene.
+- ``shapes_256``: a grid of 256 primitive shapes.
+
+Each scene is described once as a :class:`ScenePreset` in :data:`SCENES` and is
+shared between the ASV benchmark classes and the preview image generator, so
+previews show exactly what is benchmarked.
+
+Run directly to benchmark, or to write PNG previews of each scene (a
+single-world view and a 4x4 grid of 16 worlds)::
+
+    uv run asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
+    uv run asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py --preview
+"""
+
+import warp as wp
+from asv_runner.benchmarks.mark import skip_benchmark_if
+
+wp.config.enable_backward = False
+wp.config.log_level = wp.LOG_WARNING
+
+import math
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+import newton
+import newton.examples
+import newton.utils
+from newton import ShapeFlags
+from newton.sensors import SensorTiledCamera
+
+ISAACGYM_ENVS_REPO_URL = "https://github.com/isaac-sim/IsaacGymEnvs.git"
+ISAACGYM_SEKTION_CABINET_FOLDER = "assets/urdf/sektion_cabinet_model"
+
+# Arm "ready" pose facing the cabinet drawer, from Isaac Lab's
+# FrankaCabinetDirectEnvCfg (panda_joint* values mapped to the FR3 URDF names).
+_FRANKA_CABINET_ARM_POSE = {
+    "fr3_joint1": 1.157,
+    "fr3_joint2": -1.066,
+    "fr3_joint3": -0.155,
+    "fr3_joint4": -2.239,
+    "fr3_joint5": -1.841,
+    "fr3_joint6": 1.003,
+    "fr3_joint7": 0.469,
+    "fr3_finger_joint1": 0.035,
+    "fr3_finger_joint2": 0.035,
+}
+
+# Nominal standing configuration, from Isaac Lab's ANYmal locomotion configs.
+_ANYMAL_STANDING_POSE = {
+    "LF_HAA": 0.0,
+    "LF_HFE": 0.4,
+    "LF_KFE": -0.8,
+    "RF_HAA": 0.0,
+    "RF_HFE": 0.4,
+    "RF_KFE": -0.8,
+    "LH_HAA": 0.0,
+    "LH_HFE": -0.4,
+    "LH_KFE": 0.8,
+    "RH_HAA": 0.0,
+    "RH_HFE": -0.4,
+    "RH_KFE": 0.8,
+}
+
+_MANY_SHAPES_COUNT = 256
+_MANY_SHAPES_COLORS = (
+    (0.27, 0.47, 0.67),
+    (0.40, 0.80, 0.93),
+    (0.13, 0.53, 0.20),
+    (0.80, 0.73, 0.27),
+    (0.93, 0.40, 0.47),
+)
+
+
+def _set_joint_positions(builder: newton.ModelBuilder, joint_positions: dict[str, float]) -> None:
+    """Set initial positions of single-DOF joints by joint name.
+
+    Importers produce hierarchical labels like ``"fr3/fr3_joint1"``, so names
+    are matched against the last path component of each joint label.
+    """
+    remaining = dict(joint_positions)
+    for joint_index, label in enumerate(builder.joint_label):
+        value = remaining.pop(label.rsplit("/", 1)[-1], None)
+        if value is not None:
+            builder.joint_q[builder.joint_q_start[joint_index]] = value
+    if remaining:
+        raise ValueError(f"Joints not found in builder: {sorted(remaining)}")
+
+
+def _disable_collision_handling(builder: newton.ModelBuilder) -> None:
+    """Strip collision flags so finalization skips collision-pair generation.
+
+    Rendering does not consume collision state, and pair enumeration dominates
+    model build time at benchmark world counts.
+    """
+    collide = int(ShapeFlags.COLLIDE_SHAPES) | int(ShapeFlags.COLLIDE_PARTICLES)
+    builder.shape_flags = [int(flags) & ~collide for flags in builder.shape_flags]
+    builder.shape_collision_filter_pairs = []
+
+
+def _build_franka() -> newton.ModelBuilder:
+    """A fixed-base Franka FR3 arm (same content as the fast tiled camera benchmark)."""
+    builder = newton.ModelBuilder()
+    builder.add_urdf(
+        newton.utils.download_asset("franka_emika_panda") / "urdf/fr3_franka_hand.urdf",
+        floating=False,
+    )
+    return builder
+
+
+def _build_quadruped() -> newton.ModelBuilder:
+    """An ANYmal D quadruped standing on the ground."""
+    builder = newton.ModelBuilder()
+    asset_path = newton.utils.download_asset("anybotics_anymal_d")
+    builder.add_usd(
+        str(asset_path / "usd" / "anymal_d.usda"),
+        enable_self_collisions=False,
+        hide_collision_shapes=True,
+    )
+    builder.joint_q[:3] = [0.0, 0.0, 0.62]
+    _set_joint_positions(builder, _ANYMAL_STANDING_POSE)
+    return builder
+
+
+def _build_franka_cabinet() -> newton.ModelBuilder:
+    """Isaac Lab's Franka cabinet (open-drawer) scene.
+
+    Layout follows FrankaCabinetDirectEnvCfg: the Sektion cabinet sits at the
+    origin raised 0.4 m, with the arm 1 m away rotated to face the drawers.
+    The cabinet URDF comes from IsaacGymEnvs (Isaac Lab itself references a
+    Nucleus-hosted USD of the same asset).
+    """
+    cabinet_folder = newton.examples.download_external_git_folder(
+        ISAACGYM_ENVS_REPO_URL, ISAACGYM_SEKTION_CABINET_FOLDER
+    )
+    builder = newton.ModelBuilder()
+    builder.add_urdf(
+        cabinet_folder / "urdf" / "sektion_cabinet_2.urdf",
+        xform=wp.transform(wp.vec3(0.0, 0.0, 0.4), wp.quat_identity()),
+        floating=False,
+    )
+    builder.add_urdf(
+        newton.utils.download_asset("franka_emika_panda") / "urdf/fr3_franka_hand.urdf",
+        xform=wp.transform(wp.vec3(1.0, 0.0, 0.0), wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), math.pi)),
+        floating=False,
+    )
+    _set_joint_positions(builder, _FRANKA_CABINET_ARM_POSE)
+    return builder
+
+
+def _build_shapes_256() -> newton.ModelBuilder:
+    """A 16x16 grid of primitive shapes (spheres, boxes, capsules, cylinders)."""
+    builder = newton.ModelBuilder()
+    rng = random.Random(1234)
+    grid = math.isqrt(_MANY_SHAPES_COUNT)
+    spacing = 0.8
+    for index in range(_MANY_SHAPES_COUNT):
+        row, col = divmod(index, grid)
+        position = wp.vec3(
+            (col - (grid - 1) / 2.0) * spacing,
+            (row - (grid - 1) / 2.0) * spacing,
+            0.3 + 0.4 * rng.random(),
+        )
+        orientation = wp.quat_rpy(
+            rng.uniform(-math.pi, math.pi),
+            rng.uniform(-math.pi, math.pi),
+            rng.uniform(-math.pi, math.pi),
+        )
+        body = builder.add_body(xform=wp.transform(position, orientation))
+        color = rng.choice(_MANY_SHAPES_COLORS)
+        kind = index % 4
+        if kind == 0:
+            builder.add_shape_sphere(body, radius=0.18, color=color)
+        elif kind == 1:
+            builder.add_shape_box(body, hx=0.16, hy=0.16, hz=0.16, color=color)
+        elif kind == 2:
+            builder.add_shape_capsule(body, radius=0.1, half_height=0.15, color=color)
+        else:
+            builder.add_shape_cylinder(body, radius=0.14, half_height=0.15, color=color)
+    return builder
+
+
+@dataclass(frozen=True)
+class ScenePreset:
+    """A benchmark scene: one world's worth of content plus a camera pose."""
+
+    build: Callable[[], newton.ModelBuilder]
+    """Builds a ModelBuilder holding a single world of scene content."""
+
+    camera_eye: tuple[float, float, float]
+    """Camera position [m]."""
+
+    camera_target: tuple[float, float, float]
+    """Point the camera looks at [m]."""
+
+
+SCENES: dict[str, ScenePreset] = {
+    "franka": ScenePreset(_build_franka, camera_eye=(2.4, 0.0, 0.8), camera_target=(0.0, 0.0, 0.4)),
+    "quadruped": ScenePreset(_build_quadruped, camera_eye=(2.2, 2.2, 1.1), camera_target=(0.0, 0.0, 0.45)),
+    "franka_cabinet": ScenePreset(_build_franka_cabinet, camera_eye=(2.4, 1.8, 1.3), camera_target=(0.4, 0.0, 0.5)),
+    "shapes_256": ScenePreset(_build_shapes_256, camera_eye=(9.0, 9.0, 6.0), camera_target=(0.0, 0.0, 0.0)),
+}
+
+
+def _look_at_transform(
+    eye: tuple[float, float, float],
+    target: tuple[float, float, float],
+    up: tuple[float, float, float] = (0.0, 0.0, 1.0),
+) -> wp.transformf:
+    """Camera-to-world transform at *eye* looking toward *target* (camera space: -Z forward, +Y up)."""
+    eye_v = np.asarray(eye, dtype=np.float64)
+    forward = np.asarray(target, dtype=np.float64) - eye_v
+    forward /= np.linalg.norm(forward)
+    right = np.cross(forward, np.asarray(up, dtype=np.float64))
+    right /= np.linalg.norm(right)
+    camera_up = np.cross(right, forward)
+    rotation = np.stack([right, camera_up, -forward], axis=1)
+    return wp.transformf(wp.vec3f(*eye), wp.quat_from_matrix(wp.mat33f(rotation.flatten())))
+
+
+class _TiledCameraSceneRig:
+    """A scene replicated across worlds with a tiled camera sensor ready to render."""
+
+    def __init__(self, preset: ScenePreset, world_count: int, resolution: int, camera_fov_deg: float = 45.0):
+        world = preset.build()
+        _disable_collision_handling(world)
+
+        scene = newton.ModelBuilder()
+        scene.replicate(world, world_count)
+        scene.add_ground_plane()
+
+        self.model = scene.finalize()
+        self.state = self.model.state()
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state)
+
+        self.sensor = SensorTiledCamera(model=self.model)
+        self.sensor.utils.create_default_light(enable_shadows=False)
+        self.sensor.utils.assign_checkerboard_material(shape_indices=np.arange(self.model.shape_count))
+
+        camera = _look_at_transform(preset.camera_eye, preset.camera_target)
+        self.camera_transforms = wp.array([[camera] * world_count], dtype=wp.transformf)
+        self.camera_rays = self.sensor.utils.compute_camera_rays_pinhole(
+            resolution, resolution, camera_fovs=math.radians(camera_fov_deg)
+        )
+        self.color_image = self.sensor.utils.create_color_image_output(resolution, resolution)
+        self.depth_image = self.sensor.utils.create_depth_image_output(resolution, resolution)
+
+        self.model.bvh_build_shapes(self.state)
+        self.model.bvh_build_particles(self.state)
+        self.sensor.sync_transforms(self.state)
+
+    def render(self, color: bool = True, depth: bool = True):
+        self.sensor.update(
+            self.state,
+            self.camera_transforms,
+            self.camera_rays,
+            color_image=self.color_image if color else None,
+            depth_image=self.depth_image if depth else None,
+        )
+
+
+class _SceneBenchmark:
+    """Shared ASV harness; subclasses pick a scene from :data:`SCENES` and their params."""
+
+    param_names = ["resolution", "world_count", "iterations"]
+    scene: str
+
+    def setup(self, resolution: int, world_count: int, iterations: int):
+        self.rig = _TiledCameraSceneRig(SCENES[self.scene], world_count, resolution)
+        # Compile and warm the render kernels for every output combination measured below.
+        for color, depth in ((True, True), (True, False), (False, True)):
+            self.rig.render(color=color, depth=depth)
+        wp.synchronize()
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_render_color_depth(self, resolution: int, world_count: int, iterations: int):
+        for _ in range(iterations):
+            self.rig.render(color=True, depth=True)
+        wp.synchronize()
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_render_color_only(self, resolution: int, world_count: int, iterations: int):
+        for _ in range(iterations):
+            self.rig.render(color=True, depth=False)
+        wp.synchronize()
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_render_depth_only(self, resolution: int, world_count: int, iterations: int):
+        for _ in range(iterations):
+            self.rig.render(color=False, depth=True)
+        wp.synchronize()
+
+
+class TiledCameraFranka(_SceneBenchmark):
+    scene = "franka"
+    params = ([64], [4096], [50])
+
+
+class TiledCameraQuadruped(_SceneBenchmark):
+    scene = "quadruped"
+    params = ([64], [4096], [50])
+
+
+class TiledCameraFrankaCabinet(_SceneBenchmark):
+    scene = "franka_cabinet"
+    params = ([64], [4096], [50])
+
+
+class TiledCameraShapes256(_SceneBenchmark):
+    # 256 shapes per world; fewer worlds keep total shape instances comparable
+    # to the other scenes and model build time manageable.
+    scene = "shapes_256"
+    params = ([64], [1024], [50])
+
+
+BENCHMARKS = {
+    cls.scene: cls for cls in (TiledCameraFranka, TiledCameraQuadruped, TiledCameraFrankaCabinet, TiledCameraShapes256)
+}
+
+PREVIEW_WORLD_COUNTS = (1, 16)
+
+
+def write_preview_images(scene_names: list[str], output_dir: Path, image_size: int = 1024) -> list[Path]:
+    """Write a PNG preview of each scene for every entry in :data:`PREVIEW_WORLD_COUNTS`.
+
+    Single-world previews render at ``image_size``; multi-world previews tile a
+    square grid of per-world renders into the same overall image size.
+    """
+    from PIL import Image  # noqa: PLC0415  # only needed for previews (part of the examples extra)
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written = []
+    for name in scene_names:
+        for world_count in PREVIEW_WORLD_COUNTS:
+            worlds_per_row = math.isqrt(world_count)
+            rig = _TiledCameraSceneRig(SCENES[name], world_count, image_size // worlds_per_row)
+            rig.render(color=True, depth=False)
+            rgba = rig.sensor.utils.flatten_color_image_to_rgba(rig.color_image, worlds_per_row=worlds_per_row)
+            path = output_dir / f"{name}_{world_count}_world{'s' if world_count > 1 else ''}.png"
+            # Drop alpha: background pixels have alpha 0 and would turn transparent.
+            Image.fromarray(rgba.numpy()[..., :3]).save(path)
+            written.append(path)
+    return written
+
+
+def _print_fps_results(scene: str, results: dict[tuple[str, tuple[int, int, int]], float]) -> None:
+    print(f"\n=== {scene} ===")
+    for (method_name, (resolution, world_count, iterations)), duration in results.items():
+        title = f"{method_name} [{resolution}x{resolution}, {world_count} worlds]"
+        average = f"{duration * 1000.0 / iterations:.2f} ms"
+        fps = world_count * iterations / duration
+        print(f"{title} {'.' * max(1, 60 - len(title) - len(average))} {average} ({fps:,.2f} fps)")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from newton.utils import run_benchmark
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "-s",
+        "--scene",
+        default=None,
+        action="append",
+        choices=sorted(SCENES),
+        help="Scene to benchmark or preview; may be repeated. Defaults to all scenes.",
+    )
+    parser.add_argument(
+        "--preview",
+        action="store_true",
+        help="Write PNG previews of each scene (single world and 4x4 world grid) instead of benchmarking.",
+    )
+    parser.add_argument(
+        "--preview-dir",
+        type=Path,
+        default=Path("tiled_camera_previews"),
+        help="Directory for preview images.",
+    )
+    parser.add_argument(
+        "--preview-size",
+        type=int,
+        default=1024,
+        help="Preview image width and height [px].",
+    )
+    args = parser.parse_known_args()[0]
+
+    scene_names = args.scene or sorted(SCENES)
+
+    if args.preview:
+        for path in write_preview_images(scene_names, args.preview_dir, image_size=args.preview_size):
+            print(f"Wrote {path}")
+    else:
+        for name in scene_names:
+            results = run_benchmark(BENCHMARKS[name], print_results=False)
+            _print_fps_results(name, results)

--- a/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
+++ b/asv/benchmarks/simulation/bench_sensor_tiled_camera_scenes.py
@@ -46,6 +46,16 @@ from newton.sensors import SensorTiledCamera
 ISAACGYM_ENVS_REPO_URL = "https://github.com/isaac-sim/IsaacGymEnvs.git"
 ISAACGYM_SEKTION_CABINET_FOLDER = "assets/urdf/sektion_cabinet_model"
 
+# Renderer configuration applied to every scene benchmark. These are benchmark
+# settings, not library defaults: SAH builds a higher-quality shape BVH
+# (slower one-time build, faster ray traversal), and rendering uses the tiled
+# traversal order with 8x8 pixel tiles.
+BVH_CONSTRUCTOR = "sah"
+KERNEL_BLOCK_DIM = 64
+RENDER_ORDER = SensorTiledCamera.RenderOrder.TILED
+RENDER_TILE_WIDTH = 8
+RENDER_TILE_HEIGHT = 8
+
 # Arm "ready" pose facing the cabinet drawer, from Isaac Lab's
 # FrankaCabinetDirectEnvCfg (panda_joint* values mapped to the FR3 URDF names).
 _FRANKA_CABINET_ARM_POSE = {
@@ -250,6 +260,7 @@ class _TiledCameraSceneRig:
         _disable_collision_handling(world)
 
         scene = newton.ModelBuilder()
+        scene.default_bvh_cfg.mesh_constructor = "cubql"
         scene.replicate(world, world_count)
         scene.add_ground_plane(color=(0.6, 0.6, 0.6))
 
@@ -259,6 +270,9 @@ class _TiledCameraSceneRig:
 
         light_direction = wp.vec3f(*preset.light_direction) if preset.light_direction is not None else None
         self.sensor = SensorTiledCamera(model=self.model)
+        self.sensor.render_config.render_order = RENDER_ORDER
+        self.sensor.render_config.tile_width = RENDER_TILE_WIDTH
+        self.sensor.render_config.tile_height = RENDER_TILE_HEIGHT
         self.sensor.utils.create_default_light(enable_shadows=True, direction=light_direction)
         self.sensor.utils.assign_checkerboard_material(shape_indices=np.arange(self.model.shape_count))
 
@@ -270,8 +284,8 @@ class _TiledCameraSceneRig:
         self.color_image = self.sensor.utils.create_color_image_output(resolution, resolution)
         self.depth_image = self.sensor.utils.create_depth_image_output(resolution, resolution)
 
-        self.model.bvh_build_shapes(self.state)
-        self.model.bvh_build_particles(self.state)
+        self.model.bvh_build_shapes(self.state, bvh_constructor=BVH_CONSTRUCTOR)
+        self.model.bvh_build_particles(self.state, bvh_constructor=BVH_CONSTRUCTOR)
         self.sensor.sync_transforms(self.state)
 
     def render(self, color: bool = True, depth: bool = True):
@@ -281,6 +295,7 @@ class _TiledCameraSceneRig:
             self.camera_rays,
             color_image=self.color_image if color else None,
             depth_image=self.depth_image if depth else None,
+            kernel_block_dim=KERNEL_BLOCK_DIM,
         )
 
 

--- a/newton/_src/geometry/raycast.py
+++ b/newton/_src/geometry/raycast.py
@@ -77,28 +77,30 @@ def map_ray_to_local_scaled(
 
 
 @wp.func
-def ray_intersect_sphere(
-    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float
+def ray_intersect_sphere_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, r: float
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-sphere intersection.
+    """Ray-sphere intersection in the sphere's local frame (center at origin).
+
+    The returned normal is in local space and not normalized; callers map it
+    to world space with ``wp.normalize(wp.transform_vector(...))``. Sharing the
+    local-frame ray lets traversal loops map a ray into a shape's frame once
+    and reuse it across shape-type intersectors.
 
     Args:
-        geom_to_world: The world transform of the sphere.
-        ray_origin: The origin of the ray in world space.
-        ray_direction: The direction of the ray in world space.
+        ray_origin_local: Ray origin in the sphere's local frame.
+        ray_direction_local: Ray direction in the sphere's local frame.
         r: The radius of the sphere.
 
     Returns:
-        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
     """
     t_hit = -1.0
-    normal = wp.vec3(0.0)
-
-    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    normal_local = wp.vec3(0.0)
 
     d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
     if d_len_sq < MINVAL:
-        return t_hit, normal
+        return t_hit, normal_local
 
     inv_d_len = 1.0 / wp.sqrt(d_len_sq)
     d_local_norm = ray_direction_local * inv_d_len
@@ -119,9 +121,31 @@ def ray_intersect_sphere(
                 t_hit = t2 * inv_d_len
 
     if t_hit >= 0.0:
-        hit_point = ray_origin + t_hit * ray_direction
-        normal = wp.normalize(hit_point - wp.transform_get_translation(geom_to_world))
+        normal_local = ray_origin_local + t_hit * ray_direction_local
 
+    return t_hit, normal_local
+
+
+@wp.func
+def ray_intersect_sphere(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float
+) -> tuple[float, wp.vec3]:
+    """Computes ray-sphere intersection.
+
+    Args:
+        geom_to_world: The world transform of the sphere.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        r: The radius of the sphere.
+
+    Returns:
+        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+    """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_sphere_local(ray_origin_local, ray_direction_local, r)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
     return t_hit, normal
 
 
@@ -165,38 +189,37 @@ def ray_intersect_particle_sphere(
 
 
 @wp.func
-def ray_intersect_ellipsoid(
-    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, semi_axes: wp.vec3
+def ray_intersect_ellipsoid_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, semi_axes: wp.vec3
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-ellipsoid intersection.
+    """Ray-ellipsoid intersection in the ellipsoid's local frame.
 
-    The ellipsoid is defined by semi-axes (a, b, c) along the local X, Y, Z axes respectively.
-    Based on Inigo Quilez's ellipsoid intersection algorithm.
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
 
     Args:
-        geom_to_world: The world transform of the ellipsoid.
-        ray_origin: The origin of the ray in world space.
-        ray_direction: The direction of the ray in world space.
+        ray_origin_local: Ray origin in the ellipsoid's local frame.
+        ray_direction_local: Ray direction in the ellipsoid's local frame.
         semi_axes: The semi-axes (a, b, c) of the ellipsoid.
 
     Returns:
-        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
     """
     t_hit = -1.0
-    normal = wp.vec3(0.0)
+    normal_local = wp.vec3(0.0)
 
-    ro, rd = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    ro = ray_origin_local
+    rd = ray_direction_local
 
     # Reject degenerate rays (matching sphere/capsule pattern)
     d_len_sq = wp.dot(rd, rd)
     if d_len_sq < MINVAL:
-        return t_hit, normal
+        return t_hit, normal_local
 
     ra = semi_axes
 
     # Ensure semi-axes are valid
     if ra[0] < MINVAL or ra[1] < MINVAL or ra[2] < MINVAL:
-        return t_hit, normal
+        return t_hit, normal_local
 
     # Scale by inverse semi-axes (transforms ellipsoid to unit sphere)
     ocn = wp.cw_div(ro, ra)
@@ -208,7 +231,7 @@ def ray_intersect_ellipsoid(
 
     h = b * b - a * (c - 1.0)
     if h < 0.0:
-        return t_hit, normal  # No intersection
+        return t_hit, normal_local  # No intersection
 
     h = wp.sqrt(h)
 
@@ -227,8 +250,33 @@ def ray_intersect_ellipsoid(
         inv_size = safe_div_vec3(wp.vec3(1.0), semi_axes)
         inv_size_sq = wp.cw_mul(inv_size, inv_size)
         normal_local = wp.cw_mul(hit_local, inv_size_sq)
-        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
 
+    return t_hit, normal_local
+
+
+@wp.func
+def ray_intersect_ellipsoid(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, semi_axes: wp.vec3
+) -> tuple[float, wp.vec3]:
+    """Computes ray-ellipsoid intersection.
+
+    The ellipsoid is defined by semi-axes (a, b, c) along the local X, Y, Z axes respectively.
+    Based on Inigo Quilez's ellipsoid intersection algorithm.
+
+    Args:
+        geom_to_world: The world transform of the ellipsoid.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        semi_axes: The semi-axes (a, b, c) of the ellipsoid.
+
+    Returns:
+        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+    """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_ellipsoid_local(ray_origin_local, ray_direction_local, semi_axes)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
     return t_hit, normal
 
 
@@ -236,22 +284,21 @@ _IFACE = wp.types.matrix((3, 2), dtype=wp.int32)(1, 2, 0, 2, 0, 1)
 
 
 @wp.func
-def ray_intersect_box(
-    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3
+def ray_intersect_box_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, size: wp.vec3
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-box intersection.
+    """Ray-box intersection in the box's local frame.
+
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
 
     Args:
-        geom_to_world: The world transform of the box.
-        ray_origin: The origin of the ray in world space.
-        ray_direction: The direction of the ray in world space.
+        ray_origin_local: Ray origin in the box's local frame.
+        ray_direction_local: Ray direction in the box's local frame.
         size: The half-extents of the box.
 
     Returns:
-        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
     """
-    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
-
     t_hit = -1.0
     normal = wp.vec3(0.0)
     t_near = -1.0e10
@@ -296,31 +343,53 @@ def ray_intersect_box(
                         if wp.abs(p0) <= size[id0] and wp.abs(p1) <= size[id1]:
                             if wp.abs(sol - t_hit) < EPSILON:
                                 normal_local[i] = -1.0 if side < 0 else 1.0
-        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+        normal = normal_local
 
     return t_hit, normal
 
 
 @wp.func
-def ray_intersect_capsule(
-    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float
+def ray_intersect_box(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, size: wp.vec3
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-capsule intersection.
+    """Computes ray-box intersection.
 
     Args:
-        geom_to_world: The world transform of the capsule.
+        geom_to_world: The world transform of the box.
         ray_origin: The origin of the ray in world space.
         ray_direction: The direction of the ray in world space.
-        r: The radius of the capsule.
-        h: The half-height of the capsule's cylindrical part.
+        size: The half-extents of the box.
 
     Returns:
         The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
     """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_box_local(ray_origin_local, ray_direction_local, size)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+    return t_hit, normal
+
+
+@wp.func
+def ray_intersect_capsule_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, r: float, h: float
+) -> tuple[float, wp.vec3]:
+    """Ray-capsule intersection in the capsule's local frame.
+
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
+
+    Args:
+        ray_origin_local: Ray origin in the capsule's local frame.
+        ray_direction_local: Ray direction in the capsule's local frame.
+        r: The radius of the capsule.
+        h: The half-height of the capsule's cylindrical part.
+
+    Returns:
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
+    """
     t_hit = -1.0
     normal = wp.vec3(0.0)
-
-    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
 
     d_len_sq = wp.dot(ray_direction_local, ray_direction_local)
     if d_len_sq < MINVAL:
@@ -393,30 +462,52 @@ def ray_intersect_capsule(
         hit_local = ray_origin_local + t_hit * ray_direction_local
         z_clamped = wp.min(h, wp.max(-h, hit_local[2]))
         axis_point = wp.vec3(0.0, 0.0, z_clamped)
-        normal_local = wp.normalize(hit_local - axis_point)
-        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+        normal = hit_local - axis_point
 
     return t_hit, normal
 
 
 @wp.func
-def ray_intersect_cylinder(
+def ray_intersect_capsule(
     geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-cylinder intersection.
+    """Computes ray-capsule intersection.
 
     Args:
-        geom_to_world: The world transform of the cylinder.
+        geom_to_world: The world transform of the capsule.
         ray_origin: The origin of the ray in world space.
         ray_direction: The direction of the ray in world space.
-        r: The radius of the cylinder.
-        h: The half-height of the cylinder.
+        r: The radius of the capsule.
+        h: The half-height of the capsule's cylindrical part.
 
     Returns:
         The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
     """
     ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_capsule_local(ray_origin_local, ray_direction_local, r, h)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+    return t_hit, normal
 
+
+@wp.func
+def ray_intersect_cylinder_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, r: float, h: float
+) -> tuple[float, wp.vec3]:
+    """Ray-cylinder intersection in the cylinder's local frame.
+
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
+
+    Args:
+        ray_origin_local: Ray origin in the cylinder's local frame.
+        ray_direction_local: Ray direction in the cylinder's local frame.
+        r: The radius of the cylinder.
+        h: The half-height of the cylinder.
+
+    Returns:
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
+    """
     t_hit = -1.0
     normal = wp.vec3(0.0)
     min_t = 1.0e10
@@ -468,36 +559,57 @@ def ray_intersect_cylinder(
         hit_local = ray_origin_local + t_hit * ray_direction_local
         z_clamped = wp.min(h, wp.max(-h, hit_local[2]))
         if z_clamped >= (h - EPSILON) or z_clamped <= (-h + EPSILON):
-            normal_local = wp.vec3(0.0, 0.0, z_clamped)
+            normal = wp.vec3(0.0, 0.0, z_clamped)
         else:
-            normal_local = wp.normalize(hit_local - wp.vec3(0.0, 0.0, z_clamped))
-        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+            normal = hit_local - wp.vec3(0.0, 0.0, z_clamped)
 
     return t_hit, normal
 
 
 @wp.func
-def ray_intersect_cone(
-    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, radius: float, half_height: float
+def ray_intersect_cylinder(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, r: float, h: float
 ) -> tuple[float, wp.vec3]:
-    """Computes ray-cone intersection.
-
-    The cone is oriented along the Z-axis with the tip at +half_height and base at -half_height.
+    """Computes ray-cylinder intersection.
 
     Args:
-        geom_to_world: The world transform of the cone.
+        geom_to_world: The world transform of the cylinder.
         ray_origin: The origin of the ray in world space.
         ray_direction: The direction of the ray in world space.
-        radius: The radius of the cone's base.
-        half_height: Half the height of the cone (distance from center to tip/base).
+        r: The radius of the cylinder.
+        h: The half-height of the cylinder.
 
     Returns:
         The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
     """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_cylinder_local(ray_origin_local, ray_direction_local, r, h)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+    return t_hit, normal
+
+
+@wp.func
+def ray_intersect_cone_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, radius: float, half_height: float
+) -> tuple[float, wp.vec3]:
+    """Ray-cone intersection in the cone's local frame.
+
+    The cone is oriented along the Z-axis with the tip at +half_height and base at -half_height.
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
+
+    Args:
+        ray_origin_local: Ray origin in the cone's local frame.
+        ray_direction_local: Ray direction in the cone's local frame.
+        radius: The radius of the cone's base.
+        half_height: Half the height of the cone (distance from center to tip/base).
+
+    Returns:
+        The distance along the ray and the unnormalized local-space normal, or -1.0 and a zero vector if there is no intersection.
+    """
     t_hit = -1.0
     normal = wp.vec3(0.0)
-
-    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
 
     if wp.abs(half_height) < MINVAL:
         return t_hit, normal
@@ -555,19 +667,92 @@ def ray_intersect_cone(
     if t_hit >= 0.0:
         hit_local = ray_origin_local + t_hit * ray_direction_local
         if wp.abs(hit_local[2] - half_height) <= EPSILON:
-            normal_local = wp.vec3(0.0, 0.0, 1.0)
+            normal = wp.vec3(0.0, 0.0, 1.0)
         elif wp.abs(hit_local[2] + half_height) <= EPSILON:
-            normal_local = wp.vec3(0.0, 0.0, -1.0)
+            normal = wp.vec3(0.0, 0.0, -1.0)
         else:
             radial_sq = hit_local[0] * hit_local[0] + hit_local[1] * hit_local[1]
             radial = wp.sqrt(radial_sq)
             if radial <= EPSILON:
-                normal_local = wp.vec3(0.0, 0.0, 1.0)
+                normal = wp.vec3(0.0, 0.0, 1.0)
             else:
                 denom = wp.max(2.0 * wp.abs(half_height), EPSILON)
                 slope = radius / denom
-                normal_local = wp.normalize(wp.vec3(hit_local[0], hit_local[1], slope * radial))
+                normal = wp.normalize(wp.vec3(hit_local[0], hit_local[1], slope * radial))
+
+    return t_hit, normal
+
+
+@wp.func
+def ray_intersect_cone(
+    geom_to_world: wp.transform, ray_origin: wp.vec3, ray_direction: wp.vec3, radius: float, half_height: float
+) -> tuple[float, wp.vec3]:
+    """Computes ray-cone intersection.
+
+    The cone is oriented along the Z-axis with the tip at +half_height and base at -half_height.
+
+    Args:
+        geom_to_world: The world transform of the cone.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        radius: The radius of the cone's base.
+        half_height: Half the height of the cone (distance from center to tip/base).
+
+    Returns:
+        The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
+    """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_cone_local(ray_origin_local, ray_direction_local, radius, half_height)
+    normal = wp.vec3(0.0)
+    if t_hit >= 0.0:
         normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
+    return t_hit, normal
+
+
+@wp.func
+def ray_intersect_plane_local(
+    ray_origin_local: wp.vec3, ray_direction_local: wp.vec3, size: wp.vec3
+) -> tuple[float, wp.vec3]:
+    """Ray-plane intersection in the plane's local frame (plane at z = 0, normal +Z).
+
+    See :func:`ray_intersect_plane` for the plane conventions and
+    :func:`ray_intersect_sphere_local` for the local-frame convention.
+
+    Args:
+        ray_origin_local: Ray origin in the plane's local frame.
+        ray_direction_local: Ray direction in the plane's local frame.
+        size: ``(width, length, 0)`` -- full extents; ``0`` = infinite.
+
+    Returns:
+        The distance along the ray and the local-space normal ``(0, 0, 1)``, or -1.0 and a zero vector if there is no intersection.
+    """
+    t_hit = -1.0
+    normal = wp.vec3(0.0)
+
+    ro = ray_origin_local
+    rd = ray_direction_local
+
+    # Ray parallel to the plane (or degenerate)
+    if wp.abs(rd[2]) < PARALLEL_TOL:
+        return t_hit, normal
+
+    t = -ro[2] / rd[2]
+    if t < 0.0:
+        return t_hit, normal
+
+    hit_x = ro[0] + t * rd[0]
+    hit_y = ro[1] + t * rd[1]
+
+    half_w = size[0] * 0.5
+    half_l = size[1] * 0.5
+
+    if half_w > 0.0 and wp.abs(hit_x) > half_w:
+        return t_hit, normal
+    if half_l > 0.0 and wp.abs(hit_y) > half_l:
+        return t_hit, normal
+
+    t_hit = t
+    normal = wp.vec3(0.0, 0.0, 1.0)
 
     return t_hit, normal
 
@@ -592,34 +777,93 @@ def ray_intersect_plane(
     Returns:
         The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection.
     """
-    t_hit = -1.0
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_local = ray_intersect_plane_local(ray_origin_local, ray_direction_local, size)
     normal = wp.vec3(0.0)
-
-    ro, rd = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
-
-    # Ray parallel to the plane (or degenerate)
-    if wp.abs(rd[2]) < PARALLEL_TOL:
-        return t_hit, normal
-
-    t = -ro[2] / rd[2]
-    if t < 0.0:
-        return t_hit, normal
-
-    hit_x = ro[0] + t * rd[0]
-    hit_y = ro[1] + t * rd[1]
-
-    half_w = size[0] * 0.5
-    half_l = size[1] * 0.5
-
-    if half_w > 0.0 and wp.abs(hit_x) > half_w:
-        return t_hit, normal
-    if half_l > 0.0 and wp.abs(hit_y) > half_l:
-        return t_hit, normal
-
-    t_hit = t
-    normal = wp.normalize(wp.transform_vector(geom_to_world, wp.vec3(0.0, 0.0, 1.0)))
-
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, normal_local))
     return t_hit, normal
+
+
+@wp.func
+def ray_intersect_mesh_local(
+    ray_origin_local: wp.vec3,
+    ray_direction_local: wp.vec3,
+    size: wp.vec3,
+    mesh_id: wp.uint64,
+    enable_backface_culling: bool,
+    max_t: float,
+) -> tuple[float, wp.vec3, float, float, int]:
+    """Ray-mesh intersection in the mesh's (unscaled) local frame.
+
+    Applies the per-axis mesh ``size`` scaling internally. The returned normal
+    is the triangle face normal in the *scaled* local frame; callers map it to
+    world space with ``wp.normalize(wp.transform_vector(tf, safe_div_vec3(n, size)))``.
+    See :func:`ray_intersect_sphere_local` for the local-frame convention.
+
+    Args:
+        ray_origin_local: Ray origin in the mesh's local frame (before scaling).
+        ray_direction_local: Ray direction in the mesh's local frame (before scaling).
+        size: The 3D scale of the mesh.
+        mesh_id: The Warp mesh ID for raycasting.
+        enable_backface_culling: When ``True``, reject hits whose triangle normal
+            is aligned with the ray direction (back faces).
+        max_t: Maximum parameter ``t`` along the (local, scaled) ray to consider.
+
+    Returns:
+        Tuple ``(distance, normal, u, v, face_index)`` with the normal in scaled-local space, or ``(-1.0, 0-vector, 0, 0, -1)`` on miss.
+    """
+    if mesh_id == wp.uint64(0):
+        return -1.0, wp.vec3(0.0), 0.0, 0.0, -1
+
+    inv_size = safe_div_vec3(wp.vec3(1.0), size)
+    ray_origin_scaled = wp.cw_mul(ray_origin_local, inv_size)
+    ray_direction_scaled = wp.cw_mul(ray_direction_local, inv_size)
+
+    query = wp.mesh_query_ray(mesh_id, ray_origin_scaled, ray_direction_scaled, max_t)
+
+    if query.result:
+        if not enable_backface_culling or wp.dot(ray_direction_scaled, query.normal) < 0.0:
+            return query.t, query.normal, query.u, query.v, query.face
+
+    return -1.0, wp.vec3(0.0), 0.0, 0.0, -1
+
+
+@wp.func
+def ray_intersect_mesh_anyhit_local(
+    ray_origin_local: wp.vec3,
+    ray_direction_local: wp.vec3,
+    size: wp.vec3,
+    mesh_id: wp.uint64,
+    max_t: float,
+) -> float:
+    """Any-hit ray-mesh test in the mesh's (unscaled) local frame.
+
+    See :func:`ray_intersect_mesh_local` for the frame conventions.
+
+    Args:
+        ray_origin_local: Ray origin in the mesh's local frame (before scaling).
+        ray_direction_local: Ray direction in the mesh's local frame (before scaling).
+        size: The 3D scale of the mesh.
+        mesh_id: The Warp mesh ID for raycasting.
+        max_t: Maximum parameter ``t`` along the (local, scaled) ray to consider.
+
+    Returns:
+        ``0.0`` if any intersection exists within ``max_t``, otherwise ``-1.0``.
+    """
+    if mesh_id == wp.uint64(0):
+        return -1.0
+
+    inv_size = safe_div_vec3(wp.vec3(1.0), size)
+    ray_origin_scaled = wp.cw_mul(ray_origin_local, inv_size)
+    ray_direction_scaled = wp.cw_mul(ray_direction_local, inv_size)
+
+    hit = wp.mesh_query_ray_anyhit(mesh_id, ray_origin_scaled, ray_direction_scaled, max_t)
+
+    if hit:
+        return 0.0
+
+    return -1.0
 
 
 @wp.func
@@ -645,21 +889,46 @@ def ray_intersect_mesh(
         max_t: Maximum parameter ``t`` along the (local, scaled) ray to consider.
 
     Returns:
-        Tuple ``(distance, normal, u, v, face_index)``. The distance and normal of the intersection point along the ray, or -1.0 and a zero vector if there is no intersection; on miss, ``u`` and ``v`` are ``0.0`` and ``face_index`` is -1.
+        Tuple ``(distance, normal, u, v, face_index)``. The distance and normal of the intersection point along the ray, or -1.0 if there is no intersection.
     """
     if mesh_id == wp.uint64(0):
         return -1.0, wp.vec3(0.0), 0.0, 0.0, -1
 
-    ray_origin_local, ray_direction_local = map_ray_to_local_scaled(geom_to_world, size, ray_origin, ray_direction)
-
-    query = wp.mesh_query_ray(mesh_id, ray_origin_local, ray_direction_local, max_t)
-
-    if query.result:
-        if not enable_backface_culling or wp.dot(ray_direction_local, query.normal) < 0.0:
-            normal = wp.normalize(wp.transform_vector(geom_to_world, safe_div_vec3(query.normal, size)))
-            return query.t, normal, query.u, query.v, query.face
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    t_hit, normal_scaled, u, v, face = ray_intersect_mesh_local(
+        ray_origin_local, ray_direction_local, size, mesh_id, enable_backface_culling, max_t
+    )
+    if t_hit >= 0.0:
+        normal = wp.normalize(wp.transform_vector(geom_to_world, safe_div_vec3(normal_scaled, size)))
+        return t_hit, normal, u, v, face
 
     return -1.0, wp.vec3(0.0), 0.0, 0.0, -1
+
+
+@wp.func
+def ray_intersect_mesh_anyhit(
+    geom_to_world: wp.transform,
+    ray_origin: wp.vec3,
+    ray_direction: wp.vec3,
+    size: wp.vec3,
+    mesh_id: wp.uint64,
+    max_t: float,
+) -> float:
+    """Computes ray-mesh intersection using Warp's built-in mesh query.
+
+    Args:
+        geom_to_world: The world transform of the mesh.
+        ray_origin: The origin of the ray in world space.
+        ray_direction: The direction of the ray in world space.
+        size: The 3D scale of the mesh.
+        mesh_id: The Warp mesh ID for raycasting.
+        max_t: Maximum parameter ``t`` along the (local, scaled) ray to consider.
+
+    Returns:
+        Tuple ``(distance, normal, u, v, face_index)``. The distance and normal of the intersection point along the ray, or -1.0 if there is no intersection.
+    """
+    ray_origin_local, ray_direction_local = map_ray_to_local(geom_to_world, ray_origin, ray_direction)
+    return ray_intersect_mesh_anyhit_local(ray_origin_local, ray_direction_local, size, mesh_id, max_t)
 
 
 @wp.func

--- a/newton/_src/sensors/warp_raytrace/raytrace.py
+++ b/newton/_src/sensors/warp_raytrace/raytrace.py
@@ -35,64 +35,121 @@ class ClosestHit:
 
 
 @wp.func
-def _ray_intersect_mesh_smooth(
-    transform: wp.transformf,
-    scale: wp.vec3f,
-    ray_origin: wp.vec3f,
-    ray_direction: wp.vec3f,
-    mesh_id: wp.uint64,
-    shape_mesh_data_id: wp.int32,
-    mesh_data: wp.array[MeshData],
+def _plane_hit_with_culling_local(
+    ray_origin_local: wp.vec3f,
+    ray_direction_local: wp.vec3f,
+    size: wp.vec3f,
     enable_backface_culling: wp.bool,
-    max_t: wp.float32,
-) -> tuple[wp.float32, wp.vec3f, wp.float32, wp.float32, wp.int32]:
-    """Ray-mesh intersection with optional per-vertex normal interpolation.
-
-    When ``shape_mesh_data_id`` is non-negative and the referenced ``mesh_data`` entry
-    supplies per-vertex normals, the returned normal is the barycentric interpolation
-    of those vertex normals (for smooth shading); otherwise the triangle's face normal
-    is used.
-    """
-    ray_origin_local, ray_direction_local = raycast.map_ray_to_local_scaled(transform, scale, ray_origin, ray_direction)
-
-    query = wp.mesh_query_ray(mesh_id, ray_origin_local, ray_direction_local, max_t)
-
-    if query.result:
-        if not enable_backface_culling or wp.dot(ray_direction_local, query.normal) < 0.0:
-            normal_local = query.normal
-
-            if shape_mesh_data_id > -1:
-                normals = mesh_data[shape_mesh_data_id].normals
-                if normals.shape[0] > 0:
-                    n0 = wp.mesh_get_index(mesh_id, query.face * 3 + 0)
-                    n1 = wp.mesh_get_index(mesh_id, query.face * 3 + 1)
-                    n2 = wp.mesh_get_index(mesh_id, query.face * 3 + 2)
-                    normal_local = (
-                        normals[n0] * query.u + normals[n1] * query.v + normals[n2] * (1.0 - query.u - query.v)
-                    )
-
-            normal_world = wp.transform_vector(transform, raycast.safe_div_vec3(normal_local, scale))
-            normal_world = wp.normalize(normal_world)
-            return query.t, normal_world, query.u, query.v, query.face
-
-    return wp.float32(-1.0), wp.vec3f(0.0), wp.float32(0.0), wp.float32(0.0), wp.int32(-1)
+) -> tuple[wp.float32, wp.vec3f]:
+    """Local-frame ray-plane intersection; when ``enable_backface_culling`` is set,
+    rejects rays that approach the plane from behind. The plane normal is +Z in
+    local space, so the world-space test ``dot(ray_dir, normal) > -eps`` reduces
+    to the local ray direction's Z component (rigid transforms preserve dot
+    products)."""
+    hit_distance, hit_normal = raycast.ray_intersect_plane_local(ray_origin_local, ray_direction_local, size)
+    if enable_backface_culling and hit_distance >= 0.0:
+        if ray_direction_local[2] > -_BACKFACE_EPS:
+            return wp.float32(-1.0), wp.vec3f(0.0)
+    return hit_distance, hit_normal
 
 
 @wp.func
-def _plane_hit_with_culling(
-    transform: wp.transformf,
+def _intersect_primitive_local(
+    shape_type: wp.int32,
+    ray_origin_local: wp.vec3f,
+    ray_direction_local: wp.vec3f,
     size: wp.vec3f,
-    ray_origin: wp.vec3f,
-    ray_direction: wp.vec3f,
     enable_backface_culling: wp.bool,
 ) -> tuple[wp.float32, wp.vec3f]:
-    """Ray-plane intersection; when ``enable_backface_culling`` is set, rejects rays that
-    approach the plane from behind (ray direction aligned with the plane normal)."""
-    hit_distance, hit_normal = raycast.ray_intersect_plane(transform, ray_origin, ray_direction, size)
-    if enable_backface_culling and hit_distance >= 0.0:
-        if wp.dot(ray_direction, hit_normal) > -_BACKFACE_EPS:
-            return wp.float32(-1.0), wp.vec3f(0.0)
-    return hit_distance, hit_normal
+    """Dispatch a local-frame ray against one primitive's local-frame intersector.
+
+    The ray is mapped into the shape's frame once by the caller and shared by
+    every branch, so the divergent shape-type switch only contains the
+    per-primitive math. The returned normal is local-space and unnormalized;
+    callers convert the *winning* hit to a world normal once after traversal
+    instead of per candidate. Meshes are handled separately by callers
+    (they additionally produce barycentrics and a face index, and shadow rays
+    use the cheaper any-hit query).
+    """
+    hit_distance = wp.float32(-1.0)
+    hit_normal_local = wp.vec3f(0.0)
+
+    if shape_type == GeoType.PLANE:
+        hit_distance, hit_normal_local = _plane_hit_with_culling_local(
+            ray_origin_local,
+            ray_direction_local,
+            size,
+            enable_backface_culling,
+        )
+    elif shape_type == GeoType.SPHERE:
+        hit_distance, hit_normal_local = raycast.ray_intersect_sphere_local(
+            ray_origin_local, ray_direction_local, size[0]
+        )
+    elif shape_type == GeoType.ELLIPSOID:
+        hit_distance, hit_normal_local = raycast.ray_intersect_ellipsoid_local(
+            ray_origin_local, ray_direction_local, size
+        )
+    elif shape_type == GeoType.CAPSULE:
+        hit_distance, hit_normal_local = raycast.ray_intersect_capsule_local(
+            ray_origin_local, ray_direction_local, size[0], size[1]
+        )
+    elif shape_type == GeoType.CYLINDER:
+        hit_distance, hit_normal_local = raycast.ray_intersect_cylinder_local(
+            ray_origin_local, ray_direction_local, size[0], size[1]
+        )
+    elif shape_type == GeoType.CONE:
+        hit_distance, hit_normal_local = raycast.ray_intersect_cone_local(
+            ray_origin_local, ray_direction_local, size[0], size[1]
+        )
+    elif shape_type == GeoType.BOX:
+        hit_distance, hit_normal_local = raycast.ray_intersect_box_local(ray_origin_local, ray_direction_local, size)
+
+    return hit_distance, hit_normal_local
+
+
+@wp.func
+def _finalize_shape_normal(
+    closest_hit: ClosestHit,
+    shape_types: wp.array[wp.int32],
+    shape_sizes: wp.array[wp.vec3f],
+    shape_transforms: wp.array[wp.transformf],
+    shape_source_ptr: wp.array[wp.uint64],
+    shape_mesh_data_ids: wp.array[wp.int32],
+    mesh_data: wp.array[MeshData],
+) -> ClosestHit:
+    """Convert the winning shape hit's local normal to a world-space normal.
+
+    Runs once per ray after traversal, so per-vertex normal interpolation
+    (smooth shading) and the local-to-world normal transform are paid only for
+    the visible hit instead of for every BVH candidate along the ray.
+    """
+    if closest_hit.shape_index < MAX_SHAPE_ID:
+        si = wp.int32(closest_hit.shape_index)
+        shape_type = shape_types[si]
+
+        # Gaussian hits already carry a world-space normal from shading.
+        if shape_type != GeoType.GAUSSIAN:
+            normal_local = closest_hit.normal
+
+            if shape_type == GeoType.MESH:
+                shape_mesh_data_id = shape_mesh_data_ids[si]
+                if shape_mesh_data_id > -1:
+                    normals = mesh_data[shape_mesh_data_id].normals
+                    if normals.shape[0] > 0:
+                        mesh_id = shape_source_ptr[si]
+                        n0 = wp.mesh_get_index(mesh_id, closest_hit.face_idx * 3 + 0)
+                        n1 = wp.mesh_get_index(mesh_id, closest_hit.face_idx * 3 + 1)
+                        n2 = wp.mesh_get_index(mesh_id, closest_hit.face_idx * 3 + 2)
+                        normal_local = (
+                            normals[n0] * closest_hit.bary_u
+                            + normals[n1] * closest_hit.bary_v
+                            + normals[n2] * (1.0 - closest_hit.bary_u - closest_hit.bary_v)
+                        )
+                normal_local = raycast.safe_div_vec3(normal_local, shape_sizes[si])
+
+            closest_hit.normal = wp.normalize(wp.transform_vector(shape_transforms[si], normal_local))
+
+    return closest_hit
 
 
 @wp.func
@@ -138,109 +195,63 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
 
                 while wp.bvh_query_next(query, shape_index, closest_hit.distance):
                     si = shape_enabled[shape_index]
+                    shape_type = shape_types[si]
+
+                    if wp.static(state.num_gaussians > 0):
+                        if shape_type == GeoType.GAUSSIAN:
+                            # Gaussians are shaded after traversal (see below).
+                            if num_gaussians_hit < wp.static(state.num_gaussians):
+                                gaussians_hit[num_gaussians_hit] = si
+                                num_gaussians_hit += 1
+
+                    # Map the ray into the shape's frame once; every shape-type
+                    # intersector shares it (see _intersect_primitive_local).
+                    ray_origin_local, ray_dir_local = raycast.map_ray_to_local(
+                        shape_transforms[si], ray_origin_world, ray_dir_world
+                    )
+                    shape_size = shape_sizes[si]
 
                     hit_distance = wp.float32(-1.0)
-                    hit_normal = wp.vec3f(0.0)
+                    hit_normal_local = wp.vec3f(0.0)
                     hit_u = wp.float32(0.0)
                     hit_v = wp.float32(0.0)
                     hit_face_id = wp.int32(-1)
-                    hit_color = wp.vec3f(0.0)
 
-                    shape_type = shape_types[si]
                     # Heightfields are triangulated meshes; RenderContext remaps
                     # HFIELD -> MESH, so this branch renders them too.
                     if shape_type == GeoType.MESH:
-                        hit_distance, hit_normal, hit_u, hit_v, hit_face_id = _ray_intersect_mesh_smooth(
-                            shape_transforms[si],
-                            shape_sizes[si],
-                            ray_origin_world,
-                            ray_dir_world,
+                        hit_distance, hit_normal_local, hit_u, hit_v, hit_face_id = raycast.ray_intersect_mesh_local(
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             shape_source_ptr[si],
-                            shape_mesh_data_ids[si],
-                            mesh_data,
                             wp.static(config.enable_backface_culling),
                             closest_hit.distance,
                         )
-                    elif shape_type == GeoType.PLANE:
-                        hit_distance, hit_normal = _plane_hit_with_culling(
-                            shape_transforms[si],
-                            shape_sizes[si],
-                            ray_origin_world,
-                            ray_dir_world,
+                    else:
+                        hit_distance, hit_normal_local = _intersect_primitive_local(
+                            shape_type,
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             wp.static(config.enable_backface_culling),
                         )
-                    elif shape_type == GeoType.SPHERE:
-                        hit_distance, hit_normal = raycast.ray_intersect_sphere(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                        )
-                    elif shape_type == GeoType.ELLIPSOID:
-                        hit_distance, hit_normal = raycast.ray_intersect_ellipsoid(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si],
-                        )
-                    elif shape_type == GeoType.CAPSULE:
-                        hit_distance, hit_normal = raycast.ray_intersect_capsule(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CYLINDER:
-                        hit_distance, hit_normal = raycast.ray_intersect_cylinder(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CONE:
-                        hit_distance, hit_normal = raycast.ray_intersect_cone(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.BOX:
-                        hit_distance, hit_normal = raycast.ray_intersect_box(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si],
-                        )
-                    elif shape_type == GeoType.GAUSSIAN:
-                        if num_gaussians_hit < wp.static(state.num_gaussians):
-                            gaussians_hit[num_gaussians_hit] = si
-                            num_gaussians_hit += 1
-                            # gaussian_id = shape_source_ptr[si]
-                            # hit_distance, hit_normal, hit_color = shade_gaussians(
-                            #     shape_transforms[si],
-                            #     shape_sizes[si],
-                            #     ray_origin_world,
-                            #     ray_dir_world,
-                            #     gaussians_data[gaussian_id],
-                            #     closest_hit.distance
-                            # )
 
                     if hit_distance >= 0.0 and hit_distance < closest_hit.distance:
+                        # The normal stays in local space until the traversal
+                        # ends; _finalize_shape_normal converts the winner.
                         closest_hit.distance = hit_distance
-                        closest_hit.normal = hit_normal
+                        closest_hit.normal = hit_normal_local
                         closest_hit.shape_index = si
                         closest_hit.bary_u = hit_u
                         closest_hit.bary_v = hit_v
                         closest_hit.face_idx = hit_face_id
-                        closest_hit.color = hit_color
+                        closest_hit.color = wp.vec3f(0.0)
 
                 # Temporary workaround. Warp BVH queries share some stack data,
                 # which breaks nested wp.bvh_query_ray calls.
-                # Once it is fixed in Warp, remove this code block and put
-                # the commented out block above back in.
+                # Once it is fixed in Warp, remove this code block and shade
+                # gaussians inside the traversal loop.
                 # Although, this workaround may actually be a performance improvement
                 # since it only renders gaussians if they are not blocked by other
                 # objects.
@@ -264,6 +275,16 @@ def create_closest_hit_function(config: RenderContext.Config, state: RenderConte
                             closest_hit.normal = hit_normal
                             closest_hit.shape_index = si
                             closest_hit.color = hit_color
+
+            closest_hit = _finalize_shape_normal(
+                closest_hit,
+                shape_types,
+                shape_sizes,
+                shape_transforms,
+                shape_source_ptr,
+                shape_mesh_data_ids,
+                mesh_data,
+            )
 
         return closest_hit
 
@@ -433,70 +454,44 @@ def create_closest_hit_depth_only_function(config: RenderContext.Config, state: 
 
                 while wp.bvh_query_next(query, shape_index, closest_hit.distance):
                     si = shape_enabled[shape_index]
-
-                    hit_dist = -1.0
-
                     shape_type = shape_types[si]
+
+                    if wp.static(state.num_gaussians > 0):
+                        if shape_type == GeoType.GAUSSIAN:
+                            # Gaussians are shaded after traversal (see below).
+                            if num_gaussians_hit < wp.static(state.num_gaussians):
+                                gaussians_hit[num_gaussians_hit] = si
+                                num_gaussians_hit += 1
+
+                    # Map the ray into the shape's frame once; every shape-type
+                    # intersector shares it (see _intersect_primitive_local). The
+                    # normal outputs are unused here, so their computation is
+                    # eliminated by the compiler.
+                    ray_origin_local, ray_dir_local = raycast.map_ray_to_local(
+                        shape_transforms[si], ray_origin_world, ray_dir_world
+                    )
+                    shape_size = shape_sizes[si]
+
+                    hit_dist = wp.float32(-1.0)
                     # Heightfields are triangulated meshes; RenderContext remaps
                     # HFIELD -> MESH, so this branch renders them too.
                     if shape_type == GeoType.MESH:
-                        hit_dist, _normal, _u, _v, _face = raycast.ray_intersect_mesh(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si],
+                        hit_dist, _normal_local, _u, _v, _face = raycast.ray_intersect_mesh_local(
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             shape_source_ptr[si],
                             wp.static(config.enable_backface_culling),
                             closest_hit.distance,
                         )
-                    elif shape_type == GeoType.PLANE:
-                        hit_dist, _plane_normal = _plane_hit_with_culling(
-                            shape_transforms[si],
-                            shape_sizes[si],
-                            ray_origin_world,
-                            ray_dir_world,
+                    else:
+                        hit_dist, _normal_local = _intersect_primitive_local(
+                            shape_type,
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             wp.static(config.enable_backface_culling),
                         )
-                    elif shape_type == GeoType.SPHERE:
-                        hit_dist, _normal = raycast.ray_intersect_sphere(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si][0]
-                        )
-                    elif shape_type == GeoType.ELLIPSOID:
-                        hit_dist, _normal = raycast.ray_intersect_ellipsoid(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si]
-                        )
-                    elif shape_type == GeoType.CAPSULE:
-                        hit_dist, _normal = raycast.ray_intersect_capsule(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CYLINDER:
-                        hit_dist, _normal = raycast.ray_intersect_cylinder(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CONE:
-                        hit_dist, _normal = raycast.ray_intersect_cone(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.BOX:
-                        hit_dist, _normal = raycast.ray_intersect_box(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si]
-                        )
-                    elif shape_type == GeoType.GAUSSIAN:
-                        if num_gaussians_hit < wp.static(state.num_gaussians):
-                            gaussians_hit[num_gaussians_hit] = si
-                            num_gaussians_hit += 1
 
                     if hit_dist > -1.0 and hit_dist < closest_hit.distance:
                         closest_hit.distance = hit_dist
@@ -676,66 +671,39 @@ def create_first_hit_function(config: RenderContext.Config, state: RenderContext
 
                 while wp.bvh_query_next(query, shape_index, max_dist):
                     si = shape_enabled[shape_index]
+                    shape_type = shape_types[si]
+
+                    # Map the ray into the shape's frame once; every shape-type
+                    # intersector shares it (see _intersect_primitive_local). The
+                    # normal outputs are unused here, so their computation is
+                    # eliminated by the compiler.
+                    ray_origin_local, ray_dir_local = raycast.map_ray_to_local(
+                        shape_transforms[si], ray_origin_world, ray_dir_world
+                    )
+                    shape_size = shape_sizes[si]
 
                     hit_dist = wp.float32(-1)
-
-                    shape_type = shape_types[si]
                     # Heightfields are triangulated meshes; RenderContext remaps
                     # HFIELD -> MESH, so this branch renders them too.
                     if shape_type == GeoType.MESH:
-                        hit_dist, _normal, _u, _v, _face = raycast.ray_intersect_mesh(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si],
+                        # Meshes take the cheaper any-hit query: shadow rays only
+                        # need occlusion, not the closest triangle.
+                        hit_dist = raycast.ray_intersect_mesh_anyhit_local(
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             shape_source_ptr[si],
-                            False,
                             max_dist,
                         )
-                    elif shape_type == GeoType.PLANE:
-                        hit_dist, _plane_normal = _plane_hit_with_culling(
-                            shape_transforms[si],
-                            shape_sizes[si],
-                            ray_origin_world,
-                            ray_dir_world,
+                    else:
+                        hit_dist, _normal_local = _intersect_primitive_local(
+                            shape_type,
+                            ray_origin_local,
+                            ray_dir_local,
+                            shape_size,
                             wp.static(config.enable_backface_culling),
                         )
-                    elif shape_type == GeoType.SPHERE:
-                        hit_dist, _normal = raycast.ray_intersect_sphere(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si][0]
-                        )
-                    elif shape_type == GeoType.ELLIPSOID:
-                        hit_dist, _normal = raycast.ray_intersect_ellipsoid(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si]
-                        )
-                    elif shape_type == GeoType.CAPSULE:
-                        hit_dist, _normal = raycast.ray_intersect_capsule(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CYLINDER:
-                        hit_dist, _normal = raycast.ray_intersect_cylinder(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.CONE:
-                        hit_dist, _normal = raycast.ray_intersect_cone(
-                            shape_transforms[si],
-                            ray_origin_world,
-                            ray_dir_world,
-                            shape_sizes[si][0],
-                            shape_sizes[si][1],
-                        )
-                    elif shape_type == GeoType.BOX:
-                        hit_dist, _normal = raycast.ray_intersect_box(
-                            shape_transforms[si], ray_origin_world, ray_dir_world, shape_sizes[si]
-                        )
+
                     if hit_dist > -1 and hit_dist < max_dist:
                         return True
 

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -8,30 +8,17 @@ from typing import TYPE_CHECKING
 import warp as wp
 
 from ...geometry import Gaussian, GeoType
-from ...utils.color import ColorSpace, color_srgb_to_linear, linear_to_srgb_wp, srgb_to_linear_wp
+from ...utils.color import ColorSpace, linear_to_srgb_wp, srgb_to_linear_wp
 from . import lighting, raytrace, textures, tiling
-from .types import ClearData, MeshData, RenderOrder, TextureData
+from .types import MeshData, RenderOrder, TextureData
 
 if TYPE_CHECKING:
     from .render_context import RenderContext
 
 
-def _srgb_packed_rgba_to_linear(packed: int) -> int:
-    r = packed & 0xFF
-    g = (packed >> 8) & 0xFF
-    b = (packed >> 16) & 0xFF
-    a = (packed >> 24) & 0xFF
-    linear = color_srgb_to_linear((r / 255.0, g / 255.0, b / 255.0))
-    lr = min(max(int(linear[0] * 255.0), 0), 255)
-    lg = min(max(int(linear[1] * 255.0), 0), 255)
-    lb = min(max(int(linear[2] * 255.0), 0), 255)
-    return (a << 24) | (lb << 16) | (lg << 8) | lr
-
-
 def create_kernel(
     config: RenderContext.Config,
     state: RenderContext.State,
-    clear_data: RenderContext.ClearData,
     block_dim: int = 64,
 ) -> wp.kernel:
     compute_lighting = lighting.create_compute_lighting_function(config, state)
@@ -45,42 +32,6 @@ def create_kernel(
         raytrace_closest_hit = raytrace.create_closest_hit_function(config, state)
     else:
         raytrace_closest_hit = raytrace.create_closest_hit_depth_only_function(config, state)
-
-    if config.output_color_space == ColorSpace.LINEAR:
-        clear_data = ClearData(
-            clear_color=_srgb_packed_rgba_to_linear(clear_data.clear_color),
-            clear_depth=clear_data.clear_depth,
-            clear_shape_index=clear_data.clear_shape_index,
-            clear_normal=clear_data.clear_normal,
-            clear_albedo=_srgb_packed_rgba_to_linear(clear_data.clear_albedo),
-        )
-
-    @wp.func
-    def write_clear_outputs(
-        out_index: wp.int32,
-        out_color: wp.array[wp.uint32],
-        out_depth: wp.array[wp.float32],
-        out_shape_index: wp.array[wp.uint32],
-        out_normal: wp.array[wp.vec3f],
-        out_albedo: wp.array[wp.uint32],
-        out_hdr_color: wp.array[wp.vec3f],
-    ):
-        if wp.static(state.render_color):
-            out_color[out_index] = wp.uint32(wp.static(clear_data.clear_color))
-        if wp.static(state.render_albedo):
-            out_albedo[out_index] = wp.uint32(wp.static(clear_data.clear_albedo))
-        if wp.static(state.render_hdr_color):
-            out_hdr_color[out_index] = wp.vec3f(0.0)
-        if wp.static(state.render_depth):
-            out_depth[out_index] = wp.float32(wp.static(clear_data.clear_depth))
-        if wp.static(state.render_normal):
-            out_normal[out_index] = wp.vec3f(
-                wp.static(clear_data.clear_normal[0]),
-                wp.static(clear_data.clear_normal[1]),
-                wp.static(clear_data.clear_normal[2]),
-            )
-        if wp.static(state.render_shape_index):
-            out_shape_index[out_index] = wp.uint32(wp.static(clear_data.clear_shape_index))
 
     @wp.kernel(
         enable_backward=False,
@@ -172,7 +123,6 @@ def create_kernel(
             camera_forward = wp.transform_vector(camera_transform, wp.vec3f(0.0, 0.0, -1.0))
 
         if wp.dot(ray_dir_world, ray_dir_world) <= 1.0e-12:
-            write_clear_outputs(out_index, out_color, out_depth, out_shape_index, out_normal, out_albedo, out_hdr_color)
             return
 
         closest_hit = raytrace_closest_hit(
@@ -201,7 +151,6 @@ def create_kernel(
         )
 
         if closest_hit.shape_index == raytrace.NO_HIT_SHAPE_ID:
-            write_clear_outputs(out_index, out_color, out_depth, out_shape_index, out_normal, out_albedo, out_hdr_color)
             return
 
         if wp.static(state.render_depth):

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -29,7 +29,10 @@ def _srgb_packed_rgba_to_linear(packed: int) -> int:
 
 
 def create_kernel(
-    config: RenderContext.Config, state: RenderContext.State, clear_data: RenderContext.ClearData
+    config: RenderContext.Config,
+    state: RenderContext.State,
+    clear_data: RenderContext.ClearData,
+    block_dim: int = 64,
 ) -> wp.kernel:
     compute_lighting = lighting.create_compute_lighting_function(config, state)
 
@@ -79,7 +82,12 @@ def create_kernel(
         if wp.static(state.render_shape_index):
             out_shape_index[out_index] = wp.uint32(wp.static(clear_data.clear_shape_index))
 
-    @wp.kernel(enable_backward=False)
+    @wp.kernel(
+        enable_backward=False,
+        module="unique",
+        module_options={"fast_math": config.enable_fast_math},
+        launch_bounds=block_dim,
+    )
     def render_megakernel(
         # Model and Config
         world_count: wp.int32,
@@ -159,7 +167,9 @@ def create_kernel(
         camera_transform = camera_transforms[camera_index, world_index]
         ray_origin_world = wp.transform_point(camera_transform, camera_rays[camera_index, py, px, 0])
         ray_dir_world = wp.transform_vector(camera_transform, camera_rays[camera_index, py, px, 1])
-        camera_forward = wp.transform_vector(camera_transform, wp.vec3f(0.0, 0.0, -1.0))
+        camera_forward = wp.vec3f(0.0)
+        if wp.static(state.num_gaussians > 0):
+            camera_forward = wp.transform_vector(camera_transform, wp.vec3f(0.0, 0.0, -1.0))
 
         if wp.dot(ray_dir_world, ray_dir_world) <= 1.0e-12:
             write_clear_outputs(out_index, out_color, out_depth, out_shape_index, out_normal, out_albedo, out_hdr_color)
@@ -211,9 +221,10 @@ def create_kernel(
             return
 
         is_gaussian = wp.bool(False)
-        if closest_hit.shape_index < raytrace.MAX_SHAPE_ID:
-            if shape_types[closest_hit.shape_index] == GeoType.GAUSSIAN:
-                is_gaussian = wp.bool(True)
+        if wp.static(state.num_gaussians > 0):
+            if closest_hit.shape_index < raytrace.MAX_SHAPE_ID:
+                if shape_types[closest_hit.shape_index] == GeoType.GAUSSIAN:
+                    is_gaussian = wp.bool(True)
 
         albedo_color = wp.vec3f(0.0)
 

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -12,9 +12,22 @@ from ...core import Axis
 from ...geometry import Gaussian, GeoType, Mesh
 from ...sim import Model, State
 from ...utils import load_texture, normalize_texture
+from ...utils.color import ColorSpace, color_srgb_to_linear
 from .render import create_kernel
 from .types import ClearData, MeshData, RenderConfig, RenderOrder, TextureData
 from .utils import Utils
+
+
+def _srgb_packed_rgba_to_linear(packed: int) -> int:
+    r = packed & 0xFF
+    g = (packed >> 8) & 0xFF
+    b = (packed >> 16) & 0xFF
+    a = (packed >> 24) & 0xFF
+    linear = color_srgb_to_linear((r / 255.0, g / 255.0, b / 255.0))
+    lr = min(max(int(linear[0] * 255.0), 0), 255)
+    lg = min(max(int(linear[1] * 255.0), 0), 255)
+    lb = min(max(int(linear[2] * 255.0), 0), 255)
+    return (a << 24) | (lb << 16) | (lg << 8) | lr
 
 
 class RenderContext:
@@ -294,10 +307,22 @@ class RenderContext:
             if hdr_color_image is not None:
                 hdr_color_image = hdr_color_image.reshape(self.world_count * camera_count * width * height)
 
-            kernel_cache_key = hash((self.config, self.state, clear_data, kernel_block_dim))
+            # Pre-fill outputs with clear values so the render kernel only needs
+            # to write hit pixels; misses simply keep the pre-filled value.
+            self._fill_clear_outputs(
+                clear_data,
+                color_image,
+                depth_image,
+                shape_index_image,
+                normal_image,
+                albedo_image,
+                hdr_color_image,
+            )
+
+            kernel_cache_key = hash((self.config, self.state, kernel_block_dim))
             render_kernel = self.kernel_cache.get(kernel_cache_key)
             if render_kernel is None:
-                render_kernel = create_kernel(self.config, self.state, clear_data, block_dim=kernel_block_dim)
+                render_kernel = create_kernel(self.config, self.state, block_dim=kernel_block_dim)
                 self.kernel_cache[kernel_cache_key] = render_kernel
 
             particle_count = state.particle_q.shape[0] if has_particles else 0
@@ -360,6 +385,39 @@ class RenderContext:
                 device=self.device,
                 block_dim=kernel_block_dim,
             )
+
+    def _fill_clear_outputs(
+        self,
+        clear_data: RenderContext.ClearData,
+        color_image: wp.array[wp.uint32] | None,
+        depth_image: wp.array[wp.float32] | None,
+        shape_index_image: wp.array[wp.uint32] | None,
+        normal_image: wp.array[wp.vec3f] | None,
+        albedo_image: wp.array[wp.uint32] | None,
+        hdr_color_image: wp.array[wp.vec3f] | None,
+    ):
+        """Fill each active output buffer with its clear value before rendering.
+
+        Packed color and albedo are converted to linear when
+        :attr:`Config.output_color_space` is ``ColorSpace.LINEAR``, matching the
+        color space the render kernel writes hit pixels in.
+        """
+        linear = self.config.output_color_space == ColorSpace.LINEAR
+
+        if color_image is not None:
+            clear_color = _srgb_packed_rgba_to_linear(clear_data.clear_color) if linear else clear_data.clear_color
+            color_image.fill_(clear_color)
+        if depth_image is not None:
+            depth_image.fill_(clear_data.clear_depth)
+        if shape_index_image is not None:
+            shape_index_image.fill_(clear_data.clear_shape_index)
+        if normal_image is not None:
+            normal_image.fill_(wp.vec3f(*clear_data.clear_normal))
+        if albedo_image is not None:
+            clear_albedo = _srgb_packed_rgba_to_linear(clear_data.clear_albedo) if linear else clear_data.clear_albedo
+            albedo_image.fill_(clear_albedo)
+        if hdr_color_image is not None:
+            hdr_color_image.fill_(wp.vec3f(0.0))
 
     @property
     def world_count_total(self) -> int:

--- a/newton/_src/sensors/warp_raytrace/render_context.py
+++ b/newton/_src/sensors/warp_raytrace/render_context.py
@@ -294,10 +294,10 @@ class RenderContext:
             if hdr_color_image is not None:
                 hdr_color_image = hdr_color_image.reshape(self.world_count * camera_count * width * height)
 
-            kernel_cache_key = hash((self.config, self.state, clear_data))
+            kernel_cache_key = hash((self.config, self.state, clear_data, kernel_block_dim))
             render_kernel = self.kernel_cache.get(kernel_cache_key)
             if render_kernel is None:
-                render_kernel = create_kernel(self.config, self.state, clear_data)
+                render_kernel = create_kernel(self.config, self.state, clear_data, block_dim=kernel_block_dim)
                 self.kernel_cache[kernel_cache_key] = render_kernel
 
             particle_count = state.particle_q.shape[0] if has_particles else 0

--- a/newton/_src/sensors/warp_raytrace/types.py
+++ b/newton/_src/sensors/warp_raytrace/types.py
@@ -62,6 +62,9 @@ class RenderConfig:
     enable_backface_culling: bool = True
     """Cull back-facing triangles."""
 
+    enable_fast_math: bool = True
+    """Compile render kernels with CUDA fast math."""
+
     output_color_space: ColorSpace = ColorSpace.SRGB
     """Color space for packed color and albedo outputs.
 


### PR DESCRIPTION
## Description

Combination of the raytrace perf PRs including new benchmarks.

Benchmark: 4,096 worlds at 64 × 64, color + depth. Throughput improved by 18–36% across scenes.

Fast math (f076f210): +10–13%. Negligible visual differences; depth error remains below 1e-6.
Raytracing refactor (84ce2f27): Transform rays once per candidate and defer normal work until the winning hit. Reduced color-kernel instructions by 25% and global loads by 39%. Pixel-identical output.
Clear optimization (269b21a4): Replace per-pixel clears with array fills and avoid writes on misses. Identical output.

| Scene | Baseline | + Fast math (`f076f210`) | + Refactor (`84ce2f27`) | + Clear fill (`269b21a4`) | Total |
|---|---|---|---|---|---|
| Franka | 514k | 574k | 601k | 669k | **+30%** |
| Quadruped | 526k | 583k | 618k | 683k | **+30%** |
| Franka cabinet | 358k | 401k | 431k | 485k | **+36%** |
| Shapes 256 | 672k | 756k | 799k | 794k | **+18%** |

<img width="1701" height="1773" alt="image" src="https://github.com/user-attachments/assets/6a664d57-67b8-4a4d-bb2a-92bcffa59384" />

<img width="2179" height="1059" alt="image" src="https://github.com/user-attachments/assets/b5eed776-5331-49b2-a160-d7e98dc6aa0b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scene-based tiled-camera performance benchmarks for robotic, cabinet, and shape environments.
  * Added preview image generation for selected benchmark scenes.
  * Added a raytracing option to enable CUDA fast math by default.

* **Improvements**
  * Improved ray intersections across primitives and meshes through more consistent local-space calculations.
  * Improved rendering efficiency by deferring normal conversion and simplifying output clearing.
  * Added support for mesh any-hit ray queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->