### PR TITLE
Fix sdf using a recently removed private warp API

### DIFF
--- a/newton/_src/geometry/sdf_mc.py
+++ b/newton/_src/geometry/sdf_mc.py
@@ -76,18 +76,18 @@ def get_mc_tables(device):
         ]
     )
 
-    tri_range_table = wp._src.marching_cubes._get_mc_case_to_tri_range_table(device)
-    tri_local_inds_table = wp._src.marching_cubes._get_mc_tri_local_inds_table(device)
+    tri_local_inds = np.asarray(wp.MarchingCubes.TRI_LOCAL_INDICES, dtype=np.int32)
+    tri_range_table = wp.array(wp.MarchingCubes.CASE_TO_TRI_RANGE, dtype=wp.int32, device=device)
+    tri_local_inds_table = wp.array(tri_local_inds, dtype=wp.int32, device=device)
     corner_offsets_table = wp.array(wp.MarchingCubes.CUBE_CORNER_OFFSETS, dtype=wp.vec3ub, device=device)
     edge_to_verts_table = wp.array(edge_to_verts, dtype=wp.vec2ub, device=device)
 
     # Create flattened table:
     # Instead of tri_local_inds_table[i] -> edge_to_verts_table[edge_idx, 0/1],
     # we directly map tri_local_inds_table[i] -> vec2i(v_from, v_to)
-    tri_local_inds_np = tri_local_inds_table.numpy()
-    flat_edge_verts = np.zeros((len(tri_local_inds_np), 2), dtype=np.uint8)
+    flat_edge_verts = np.zeros((len(tri_local_inds), 2), dtype=np.uint8)
 
-    for i, edge_idx in enumerate(tri_local_inds_np):
+    for i, edge_idx in enumerate(tri_local_inds):
         flat_edge_verts[i, 0] = edge_to_verts[edge_idx, 0]
         flat_edge_verts[i, 1] = edge_to_verts[edge_idx, 1]
 


### PR DESCRIPTION
## Description

Sdf code currently uses a private warp MarchingCubes internal that is removed in 1.15.
Replace with equivalent public helpers

```
• The breaking commit is:

  - Main branch: ced43005a6971fcef6738ba785eba056decfd38a
  - Subject: Deprecate legacy Marching Cubes state (GH-1594)
  - It removes mc_cube_corner_offsets and the other private aliases.

  Yes, it is part of the official Warp 1.15.0 release. The release branch contains the equivalent backport 09378f90ec98c33b5f5ead65607c3e66e6c9ed6a, included in
  tag v1.15.0.
```


## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated marching-cubes table initialization to use stable public constants.
  * Preserved existing geometry-processing behavior while simplifying internal lookup-table handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->