### PR TITLE
Disable flaky anymal reset elliptic test on CUDA

### DIFF
--- a/newton/tests/test_anymal_reset.py
+++ b/newton/tests/test_anymal_reset.py
@@ -289,6 +289,8 @@ class TestAnymalReset(unittest.TestCase):
 
 
 def test_reset_functionality(test: TestAnymalReset, device, cone_type):
+    if cone_type == "elliptic" and device.is_cuda:
+        test.skipTest("Flaky on CUDA (GH-3397), pending google-deepmind/mujoco_warp#1512")
     test.device = device
     with wp.ScopedDevice(device):
         test._run_reset_test(cone_type)


### PR DESCRIPTION
## Description

`test_reset_functionality_elliptic_cuda_0` intermittently hits the MuJoCo Warp solver's 100-iteration cap after reset, failing merge-queue GPU runs (see #3397, latest occurrence: https://github.com/newton-physics/newton/actions/runs/29086153345/job/86340621655). The root cause is float32 rounding in the elliptic line-search cost delta, fixed upstream by google-deepmind/mujoco_warp#1512. Skip the CUDA variant until that fix ships; the CPU and pyramidal variants keep running.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_anymal_reset.TestAnymalReset
```

Ran 4 tests: the elliptic CUDA variant is skipped, the remaining three pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reset functionality testing to skip a known flaky CUDA scenario for elliptic cones.
  * Added a clear reason and issue reference for the conditional skip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->