### PR TITLE
Add derivative damping to Kamino POSITION actuation

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -2098,8 +2098,13 @@ class JointsData:
     Internal effective inertia of each joint (as flat array),
     used for implicit integration of joint dynamics.
 
-    ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,
-    where dt is the simulation time step.
+    Let ``m_j_0 := a_j + dt * b_j``, where ``dt`` is the simulation time step.
+    The actuation mode determines the remaining terms:
+
+    - ``PASSIVE`` or ``FORCE``: ``m_j := m_j_0``
+    - ``VELOCITY``: ``m_j := m_j_0 + dt * k_d_j``
+    - ``POSITION``, ``POSITION_VELOCITY``, or ``POSITION_VELOCITY_FORCE``:
+      ``m_j := m_j_0 + dt * k_d_j + dt^2 * k_p_j``
 
     A non-zero minimum mass is enforced to avoid a
     division-by-zero failure.
@@ -2112,9 +2117,7 @@ class JointsData:
     Internal effective inverse inertia of each joint (as flat
     array), used for implicit integration of joint dynamics.
 
-    ``inv_m_j := 1 / m_j``, computed element-wise,
-    where ``m_j := a_j + dt * (b_j + k_d_j) + dt^2 * k_p_j``,
-    and dt is the simulation time step.
+    ``inv_m_j := 1 / m_j``, computed element-wise.
 
     Note that all ``inv_m_j>0`` due to a minimum non-zero mass
     being enforced.
@@ -2128,7 +2131,7 @@ class JointsData:
 
     Each joint has local actuation and PD control dynamics:
     ```
-    m_j * dq_j^{+} = a_j * dq_j^{-} + dt * h_j
+    m_j * dq_j^{+} = h_j
     ```
     and is contributes to the dynamics of the system through the constraint equation:
     ```
@@ -2143,17 +2146,28 @@ class JointsData:
 
     This results in the following dynamic constraint equation for each joint `j`:
     ```
-    dq_j^{+} + m_j^{-1} * lambda_q_j = m_j^{-1} * (a_j * dq_j^{-} + dt * h_j)
+    dq_j^{+} + m_j^{-1} * lambda_q_j = m_j^{-1} * h_j
     dq_j^{+} + m_j^{-1} * lambda_q_j = dq_b_j
     J_q_j * u^{+} + m_j^{-1} * lambda_q_j = dq_b_j
     ```
     and thus the velocity bias term of the joint-space dynamics of each joint `j` is computed as:
     ```
-    tau_j_tot := dt * ( tau_j + tau_j_ff + k_p_j * (q_j_ref - q_j^{-} ) + k_d_j * dq_j_ref )
     h_j := a_j * dq_j^{-} + dt * tau_j_tot
     dq_b_j := inv_m_j * h_j
     ```
-    where dt is the simulation time step.
+    The actuation mode determines ``tau_j_tot``:
+
+    - ``PASSIVE``: ``tau_j``
+    - ``FORCE``: ``tau_j + tau_j_ff``
+    - ``POSITION``: ``tau_j + k_p_j * (q_j_ref - q_j^{-})``
+    - ``VELOCITY``: ``tau_j + k_d_j * dq_j_ref``
+    - ``POSITION_VELOCITY``:
+      ``tau_j + k_p_j * (q_j_ref - q_j^{-}) + k_d_j * dq_j_ref``
+    - ``POSITION_VELOCITY_FORCE``:
+      ``tau_j + tau_j_ff + k_p_j * (q_j_ref - q_j^{-}) + k_d_j * dq_j_ref``
+
+    For ``POSITION``, the ``dt * k_d_j`` term in :attr:`m_j` supplies derivative
+    damping toward zero velocity without consuming ``dq_j_ref``.
 
     Shape of ``(sum_of_num_dynamic_joint_cts,)``.
     """

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -732,7 +732,7 @@ def compute_and_write_joint_implicit_dynamics(
         if act_type == JointActuationType.FORCE:
             tau_j_tot += pd_tau_j_ff
         elif act_type == JointActuationType.POSITION:
-            m_j += dt * dt * k_p_j
+            m_j += dt * k_d_j + dt * dt * k_p_j
             tau_j_tot += k_p_j * (pd_q_j_ref - q_j)
         elif act_type == JointActuationType.VELOCITY:
             m_j += dt * k_d_j

--- a/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
@@ -330,7 +330,7 @@ class TestKinematicsJoints(unittest.TestCase):
                 m_j_exp_val = a_j_np[0] + dt * b_j_np[0]
                 tau_j_exp_val = tau_j_np[0] + tau_j_ref_np[0]
             elif act_type == JointActuationType.POSITION:
-                m_j_exp_val = a_j_np[0] + dt * b_j_np[0] + dt * dt * k_p_j_np[0]
+                m_j_exp_val = a_j_np[0] + dt * (b_j_np[0] + k_d_j_np[0]) + dt * dt * k_p_j_np[0]
                 tau_j_exp_val = tau_j_np[0] + k_p_j_np[0] * (q_j_ref_np[0] - q_j_np[0])
             elif act_type == JointActuationType.VELOCITY:
                 m_j_exp_val = a_j_np[0] + dt * (b_j_np[0] + k_d_j_np[0])


### PR DESCRIPTION
## Description

Fix SolverKamino dropping joint_target_kd in POSITION mode to match mjwarp's convention.

* POSITION actuation ignored k_d, leaving position control undamped.
* Add implicit damping dt * k_d_j to m_j for POSITION (damps toward zero velocity; still ignores Control.joint_target_qd).
* Update docstrings and test, and changelog.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved implicit joint dynamics calculations by incorporating damping contributions into effective inertia for supported actuation modes.
  * Updated resulting velocity and constraint computations for more accurate simulation behavior.

* **Documentation**
  * Clarified joint inertia, actuation-mode contributions, and implicit dynamics equations.

* **Tests**
  * Updated dynamics validation to reflect the corrected damping-aware calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->