### PR TITLE
Fix intermittent ADMM particle grid reset crash

### DIFF
--- a/newton/_src/solvers/coupled/solver_coupled_admm.py
+++ b/newton/_src/solvers/coupled/solver_coupled_admm.py
@@ -663,7 +663,6 @@ class SolverCoupledADMM(SolverCoupled):
         self._admm_particle_particle_contact_specs: list[_AdmmParticleParticleContactSpec] = []
         self._admm_collision_pipeline = None
         self._admm_internal_contacts = None
-        self._admm_particle_contact_grid = None
         self._admm_particle_contact_query_radius = 0.0
         self._entry_body_sets: dict[str, set[int]] = {}
         self._entry_particle_sets: dict[str, set[int]] = {}
@@ -1107,14 +1106,14 @@ class SolverCoupledADMM(SolverCoupled):
 
         if self._admm_particle_particle_contact_specs:
             self._validate_particle_particle_contact_specs()
-            self._admm_dynamic_pp_contact_groups = self._build_collision_particle_particle_contact_groups()
-            if self._admm_dynamic_pp_contact_groups:
-                self._admm_particle_contact_query_radius = max(
-                    group.query_radius for group in self._admm_dynamic_pp_contact_groups
-                )
-                with wp.ScopedDevice(self.model.device):
-                    self._admm_particle_contact_grid = wp.HashGrid(128, 128, 128)
-                    self._admm_particle_contact_grid.reserve(self.model.particle_count)
+            if self.model.particle_grid is not None:
+                self._admm_dynamic_pp_contact_groups = self._build_collision_particle_particle_contact_groups()
+                if self._admm_dynamic_pp_contact_groups:
+                    self._admm_particle_contact_query_radius = max(
+                        group.query_radius for group in self._admm_dynamic_pp_contact_groups
+                    )
+                    with wp.ScopedDevice(self.model.device):
+                        self.model.particle_grid.reserve(self.model.particle_count)
 
         # Eagerly allocate the internal contact buffer so it exists before any
         # CUDA graph capture. Lazy allocation during capture leaves a bogus
@@ -3039,10 +3038,11 @@ class SolverCoupledADMM(SolverCoupled):
                 )
 
         if self._admm_dynamic_pp_contact_groups:
-            self._admm_particle_contact_grid.build(
-                state_in.particle_q,
-                radius=self._admm_particle_contact_query_radius,
-            )
+            with wp.ScopedDevice(self.model.device):
+                self.model.particle_grid.build(
+                    state_in.particle_q,
+                    radius=self._admm_particle_contact_query_radius,
+                )
 
         for group in self._admm_dynamic_pp_contact_groups:
             if group.count == 0:
@@ -3094,7 +3094,7 @@ class SolverCoupledADMM(SolverCoupled):
                 particle_particle_contacts_hashgrid_kernel,
                 dim=self.model.particle_count,
                 inputs=[
-                    self._admm_particle_contact_grid.id,
+                    self.model.particle_grid.id,
                     state_in.particle_q,
                     self.model.particle_radius,
                     self.model.particle_flags,

--- a/newton/tests/test_admm_coupled_solver.py
+++ b/newton/tests/test_admm_coupled_solver.py
@@ -190,9 +190,7 @@ def _build_two_particle_contact_scene(
     builder.add_particle(pos=(gap, 0.0, 0.0), vel=vel_a, mass=1.0, radius=radius)
     builder.add_particle(pos=(0.0, 0.0, 0.0), vel=vel_b, mass=1.0, radius=radius)
     builder.color()
-    model = builder.finalize(device="cpu")
-    model.particle_grid = None
-    return model
+    return builder.finalize(device="cpu")
 
 
 def _run_particles(solver, model: newton.Model, n_steps: int = 5, dt: float = 1.0 / 60.0):
@@ -1141,6 +1139,32 @@ class TestAdmmCollisionDetection(unittest.TestCase):
 
         self.assertGreater(solver.collision_contact_count_max, 0)
         self.assertGreater(q_contact[1, 0] - q_contact[0, 0], 0.08 + 1.0e-3)
+
+    def test_collision_particle_particle_contacts_respect_disabled_model_particle_grid(self):
+        model = _build_two_particle_contact_scene(gap=-0.08)
+        model.particle_grid = None
+        solver = SolverCoupledADMM(
+            model=model,
+            entries=[
+                SolverCoupled.Entry(
+                    name="a",
+                    solver=lambda v: SolverSemiImplicit(model=v, enable_tri_contact=False),
+                    particles=[0],
+                ),
+                SolverCoupled.Entry(
+                    name="b",
+                    solver=lambda v: SolverSemiImplicit(model=v, enable_tri_contact=False),
+                    particles=[1],
+                ),
+            ],
+            coupling=SolverCoupledADMM.Config(
+                contact_pairs=[SolverCoupledADMM.ContactPair(source="a", destination="b")],
+            ),
+        )
+
+        _run_particles(solver, model, n_steps=1)
+
+        self.assertEqual(solver.collision_contact_count_max, 0)
 
     def test_collision_frictional_contact_matches_inclined_plane_box_motion(self):
         friction = 0.4


### PR DESCRIPTION
  Fix #3464 

  ## Description

  Fix an intermittent illegal CUDA memory access when resetting the
  `admm_contact_solver` example.

  `SolverCoupledADMM` previously allocated a private particle hash grid in
  addition to `Model.particle_grid`. Both grids could be rebuilt within the same
  captured CUDA graph. Repeatedly destroying and recreating the example could
  leave a captured hash-grid descriptor referring to released storage, with the
  error surfacing later at the viewer synchronization point.

  This change follows the same particle-grid pattern as `SolverXPBD` and
  `SolverSemiImplicit`:

  - Use `Model.particle_grid` directly.
  - Reserve and rebuild the grid under `wp.ScopedDevice`.
  - Treat `Model.particle_grid = None` as disabling particle-particle contacts.
  - Remove the solver-local ADMM particle grid.

  This is compatible with coupled compact views because particles currently
  retain their global layout. Views containing particles use identity particle
  index mappings, while non-owned particles are made inactive and massless.
  The shared grid is rebuilt and consumed sequentially on the same stream.

  ## Checklist

  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [x] `CHANGELOG.md` has been updated (if user-facing change)

  ## Test plan

  ```bash
  uv run --extra dev -m newton.tests -k test_admm_coupled_solver
  uvx pre-commit run --files \
      CHANGELOG.md \
      newton/_src/solvers/coupled/solver_coupled_admm.py \
      newton/tests/test_admm_coupled_solver.py

  Results:

  - All 18 ADMM coupled-solver tests pass.
  - Added coverage verifying that Model.particle_grid = None disables ADMM
    particle-particle contacts.

  - Completed 30 consecutive reset cycles with three simulation/render frames
    between resets on an sm_86 RTX 3080 Ti.

  - All relevant pre-commit hooks pass.

  ## Bug fix

  Steps to reproduce:

  1. Run the ADMM contact example:

     uv run -m newton.examples admm_contact_solver

  2. Click Reset repeatedly. The failure was typically observed within
     approximately 10 resets.

  3. Observe an illegal CUDA memory access, commonly reported while the GL viewer
     copies shape colors to the host:

     Warp CUDA error 700: an illegal memory access was encountered
     RuntimeError: Warp copy error

  The viewer copy is the synchronization point that reports the earlier
  asynchronous failure; it is not the source of the invalid access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved particle–particle collision contact handling in the coupled ADMM solver.
  * The solver now respects when the model’s particle collision grid is disabled, preventing unintended collision contacts.

* **Tests**
  * Added coverage verifying that disabling the particle collision grid produces no particle–particle collision contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->