### PR TITLE
Prevent deterministic MuJoCo test leakage

### DIFF
--- a/newton/tests/determinism/test_solver_determinism.py
+++ b/newton/tests/determinism/test_solver_determinism.py
@@ -121,7 +121,7 @@ def _build_branching_articulation(device):
     return model
 
 
-def test_mujoco_sparse_articulation_construction(test, device):
+def _check_mujoco_sparse_articulation_construction(device):
     with wp.ScopedDevice(device):
         builder = newton.ModelBuilder(gravity=0.0)
         newton.solvers.SolverMuJoCo.register_custom_attributes(builder)
@@ -146,7 +146,30 @@ def test_mujoco_sparse_articulation_construction(test, device):
         )
 
         solver.step(state_in, state_out, model.control(), None, 1.0 / 240.0)
-        test.assertTrue(np.isfinite(state_out.joint_q.numpy()).all())
+        if not np.isfinite(state_out.joint_q.numpy()).all():
+            raise AssertionError("MuJoCo sparse articulation produced non-finite joint coordinates")
+
+
+def test_mujoco_sparse_articulation_construction(test, device):
+    # MJWarp and Warp keep generated kernels and GPU runtime state globally.
+    # Keep this deterministic configuration test isolated from later simulations.
+    code = (
+        "from newton.tests.determinism.test_solver_determinism "
+        "import _check_mujoco_sparse_articulation_construction; "
+        f"_check_mujoco_sparse_articulation_construction({str(device)!r})"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    test.assertEqual(
+        result.returncode,
+        0,
+        f"MuJoCo sparse articulation subprocess failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
 
 
 def _make_articulation_solver(model, solver_name):

--- a/newton/tests/determinism/test_solver_determinism.py
+++ b/newton/tests/determinism/test_solver_determinism.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import subprocess
 import sys
 import unittest
@@ -10,6 +11,7 @@ import numpy as np
 import warp as wp
 
 import newton
+import newton.tests.unittest_utils
 from newton._src.solvers.semi_implicit import kernels_particle as semi_implicit_particle_kernels
 from newton._src.solvers.solver import _set_module_options_if_changed
 from newton._src.solvers.vbd import particle_vbd_kernels, vbd_coupling_kernels
@@ -17,6 +19,33 @@ from newton._src.solvers.xpbd import kernels as xpbd_kernels
 from newton.tests.unittest_utils import add_function_test, get_cuda_test_devices
 
 DETERMINISTIC_MODE = wp.DeterministicMode.RUN_TO_RUN
+
+
+def _run_isolated(test, function_name, *args):
+    # Deterministic kernels and GPU runtime state persist for the life of the process.
+    call_args = ", ".join(repr(arg) for arg in args)
+    code = f"from newton.tests.determinism.test_solver_determinism import {function_name}; {function_name}({call_args})"
+
+    env = os.environ.copy()
+    env.pop("PYTHONWARNINGS", None)
+    warning_args = []
+    if newton.tests.unittest_utils.strict_warnings:
+        warning_args = ["-W", "error::DeprecationWarning"]
+        code = f"import warnings; warnings.filterwarnings('error', module=r'newton(\\.|$)'); {code}"
+
+    result = subprocess.run(
+        [sys.executable, *warning_args, "-c", code],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    test.assertEqual(
+        result.returncode,
+        0,
+        f"{function_name} subprocess failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
 
 
 def _snapshot(state, fields):
@@ -86,11 +115,15 @@ def _run_particle_rollout(device, solver_name):
     return _snapshot(state_0, ("particle_q", "particle_qd"))
 
 
-def test_particle_determinism(test, device, solver_name):
+def _check_particle_determinism(device, solver_name):
     with wp.ScopedDevice(device):
         first = _run_particle_rollout(device, solver_name)
         second = _run_particle_rollout(device, solver_name)
     _assert_snapshots_equal(first, second)
+
+
+def test_particle_determinism(test, device, solver_name):
+    _run_isolated(test, "_check_particle_determinism", str(device), solver_name)
 
 
 def _build_branching_articulation(device):
@@ -151,25 +184,7 @@ def _check_mujoco_sparse_articulation_construction(device):
 
 
 def test_mujoco_sparse_articulation_construction(test, device):
-    # MJWarp and Warp keep generated kernels and GPU runtime state globally.
-    # Keep this deterministic configuration test isolated from later simulations.
-    code = (
-        "from newton.tests.determinism.test_solver_determinism "
-        "import _check_mujoco_sparse_articulation_construction; "
-        f"_check_mujoco_sparse_articulation_construction({str(device)!r})"
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=600,
-        check=False,
-    )
-    test.assertEqual(
-        result.returncode,
-        0,
-        f"MuJoCo sparse articulation subprocess failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
-    )
+    _run_isolated(test, "_check_mujoco_sparse_articulation_construction", str(device))
 
 
 def _make_articulation_solver(model, solver_name):
@@ -211,29 +226,7 @@ def _check_articulation_determinism(device, solver_name):
 
 
 def test_articulation_determinism(test, device, solver_name):
-    if solver_name != "mujoco":
-        _check_articulation_determinism(device, solver_name)
-        return
-
-    # MJWarp and Warp cache generated kernels and GPU runtime state globally.
-    # Keep this configuration-changing test isolated from unrelated simulations.
-    code = (
-        "from newton.tests.determinism.test_solver_determinism "
-        "import _check_articulation_determinism; "
-        f"_check_articulation_determinism({str(device)!r}, {solver_name!r})"
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=600,
-        check=False,
-    )
-    test.assertEqual(
-        result.returncode,
-        0,
-        f"MuJoCo determinism subprocess failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
-    )
+    _run_isolated(test, "_check_articulation_determinism", str(device), solver_name)
 
 
 class TestSolverDeterminism(unittest.TestCase):

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -41,9 +41,8 @@ MAX_ROTATION_DEG = 10.0
 # Devices and solvers
 cuda_devices = get_selected_cuda_test_devices()
 
-
-def _make_mujoco_warp_solver(model):
-    return newton.solvers.SolverMuJoCo(
+solvers = {
+    "mujoco_warp": lambda model: newton.solvers.SolverMuJoCo(
         model,
         use_mujoco_cpu=False,
         use_mujoco_contacts=False,
@@ -51,12 +50,7 @@ def _make_mujoco_warp_solver(model):
         nconmax=200,
         solver="newton",
         ls_iterations=100,
-        deterministic=wp.DeterministicMode.NOT_GUARANTEED,
-    )
-
-
-solvers = {
-    "mujoco_warp": _make_mujoco_warp_solver,
+    ),
     "xpbd": lambda model: newton.solvers.SolverXPBD(model, iterations=10),
 }
 
@@ -1340,7 +1334,6 @@ def test_mujoco_hydroelastic_penetration_depth(test, device):
         iterations=20,
         ls_iterations=100,
         impratio=1000.0,
-        deterministic=wp.DeterministicMode.NOT_GUARANTEED,
     )
 
     state_0 = model.state()

--- a/newton/tests/test_hydroelastic.py
+++ b/newton/tests/test_hydroelastic.py
@@ -41,8 +41,9 @@ MAX_ROTATION_DEG = 10.0
 # Devices and solvers
 cuda_devices = get_selected_cuda_test_devices()
 
-solvers = {
-    "mujoco_warp": lambda model: newton.solvers.SolverMuJoCo(
+
+def _make_mujoco_warp_solver(model):
+    return newton.solvers.SolverMuJoCo(
         model,
         use_mujoco_cpu=False,
         use_mujoco_contacts=False,
@@ -50,7 +51,12 @@ solvers = {
         nconmax=200,
         solver="newton",
         ls_iterations=100,
-    ),
+        deterministic=wp.DeterministicMode.NOT_GUARANTEED,
+    )
+
+
+solvers = {
+    "mujoco_warp": _make_mujoco_warp_solver,
     "xpbd": lambda model: newton.solvers.SolverXPBD(model, iterations=10),
 }
 
@@ -1334,6 +1340,7 @@ def test_mujoco_hydroelastic_penetration_depth(test, device):
         iterations=20,
         ls_iterations=100,
         impratio=1000.0,
+        deterministic=wp.DeterministicMode.NOT_GUARANTEED,
     )
 
     state_0 = model.state()


### PR DESCRIPTION
## Description

Prevent deterministic MuJoCo-Warp test configuration from affecting later
hydroelastic tests in the same Python process.

`test_mujoco_sparse_articulation_construction_cuda_0` opts into deterministic
MuJoCo-Warp execution. Warp and MuJoCo-Warp retain generated kernels and GPU
runtime state at process scope, so this configuration can affect tests that
run afterward. Depending on test ordering, the hydroelastic tests then use
the contaminated solver state and fail with incorrect penetration depth and
repeated `nefc overflow` messages.

This PR:

- Runs only the deterministic sparse-articulation test in a subprocess, so
  its generated kernels and runtime state are discarded when the test exits.
- Explicitly configures the affected hydroelastic solvers with
  `DeterministicMode.NOT_GUARANTEED`. Without this argument, `SolverMuJoCo`
  inherits `wp.config.deterministic`.
- Keeps the hydroelastic tests in the normal test process and does not isolate
  other deterministic MuJoCo tests.

This is a test-only change and does not modify production solver behavior.

Closes #3420.
Closes #3421.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (no documentation changes required)
- [x] `CHANGELOG.md` has been updated (not applicable; no user-facing change)

## Test plan

Run the deterministic sparse-articulation test immediately before the two
affected hydroelastic tests:

```bash
uv run --no-sync -m newton.tests \
  -k test_mujoco_sparse_articulation_construction_cuda_0 \
  -k test_mujoco_hydroelastic_penetration_depth_cuda_0 \
  -k test_stacked_small_primitive_cubes_hydroelastic_mujoco_warp_cuda_0 \
  --strict-warnings \
  --no-cache-clear \
  --serial-fallback
```

Results over 10 independent runs:

| Revision | Passed | Failed |
| --- | ---: | ---: |
| `main` | 0 | 10 |
| This PR | 10 | 0 |

On `main`, both hydroelastic tests failed in every run and produced roughly
2,986-2,998 `nefc overflow` messages per run. Running the two hydroelastic
tests without the preceding deterministic test passed, confirming that the
failure depends on process-local deterministic state.

Additional verification:

```bash
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Check out `main`.
2. Run the three-test command above in one Python process.
3. Observe that the deterministic test passes.
4. Observe that both subsequent hydroelastic tests fail:
   - The penetration-depth ratio is approximately `0.54`, below the required
     minimum of `1.0`.
   - The stacked-cubes test reports repeated `nefc overflow` output.

Although the failures appear flaky in CI because they depend on test ordering,
the ordered reproduction above failed in 10 out of 10 local runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved determinism test isolation by running checks in independent processes.
  * Reduced cross-test interference from persisted runtime state.
  * Standardized failure reporting with captured subprocess output.
  * Expanded consistent isolation across particle, articulation, and sparse construction determinism checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->