### PR TITLE
Initialize free-joint position targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
+- Initialize free-joint coordinate-layout position targets from the authored pose. (#3380)
+- Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2763,9 +2763,11 @@ class ModelBuilder:
 
         attribute_specs.pop("joint_X_p")
         attribute_specs.pop("joint_q")
+        attribute_specs.pop("joint_target_q")
         joint_X_p_start = len(self.joint_X_p)
         self.joint_X_p.extend(source_list("joint_X_p") * world_count)
         joint_q = np.tile(np.asarray(builder.joint_q, dtype=np.float32), world_count)
+        joint_target_q = np.tile(np.asarray(builder.joint_target_q, dtype=np.float32), world_count)
         if counts["joint"]:
             joint_types = np.asarray(builder.joint_type, dtype=np.int64)
             joint_parents = np.asarray(builder.joint_parent, dtype=np.int64)
@@ -2780,6 +2782,8 @@ class ModelBuilder:
 
             free_roots = np.flatnonzero((joint_parents == -1) & (joint_types == int(JointType.FREE)))
             if len(free_roots) and any(xform is not None for xform in xforms):
+                import newton  # noqa: PLC0415
+
                 # Per-joint frames are invariant across worlds; compute them once.
                 free_root_frames = []
                 for joint in free_roots.tolist():
@@ -2796,8 +2800,15 @@ class ModelBuilder:
                         transformed = transform_mul(xform_local, xform_prev)
                         target_q = coord_base + source_q
                         joint_q[target_q : target_q + 7] = np.asarray(transformed, dtype=np.float32)
+                        if newton.use_coord_layout_targets:
+                            target_prev = wp.transform(*builder.joint_target_q[source_q : source_q + 7])
+                            transformed_target = transform_mul(xform_local, target_prev)
+                            joint_target_q[target_q : target_q + 7] = np.asarray(
+                                transformed_target, dtype=np.float32
+                            )
 
         self.joint_q.extend(joint_q.tolist())
+        self.joint_target_q.extend(joint_target_q.tolist())
 
         for world_index, joint_start in enumerate(joint_starts.tolist()):
             body_start = int(body_starts[world_index])
@@ -4944,6 +4955,7 @@ class ModelBuilder:
         """Adds a free joint to the model.
         It has 7 positional degrees of freedom (first 3 linear and then 4 angular dimensions for the orientation quaternion in `xyzw` notation) and 6 velocity degrees of freedom (see :ref:`Twist conventions in Newton <Twist conventions>`).
         The positional dofs are initialized so that forward kinematics reproduces the child body's transform, accounting for the parent body and both joint anchor transforms (see :attr:`body_q` and the ``xform`` argument to :meth:`add_body`).
+        When :data:`newton.use_coord_layout_targets` is ``True``, :attr:`joint_target_q` is initialized to the same transform so a default :class:`newton.Control` starts at the authored pose.
 
         Args:
             child: The index of the child body.
@@ -4986,7 +4998,13 @@ class ModelBuilder:
         parent_body_xform = wp.transform_identity() if parent == -1 else self.body_q[parent]
         parent_anchor_world = parent_body_xform * self.joint_X_p[joint_id]
         joint_q = wp.transform_inverse(parent_anchor_world) * self.body_q[child] * self.joint_X_c[joint_id]
-        self.joint_q[q_start : q_start + 7] = list(joint_q)
+        joint_q_values = list(joint_q)
+        self.joint_q[q_start : q_start + 7] = joint_q_values
+
+        import newton  # noqa: PLC0415
+
+        if newton.use_coord_layout_targets:
+            self.joint_target_q[q_start : q_start + 7] = joint_q_values
         return joint_id
 
     @deprecate_nonkeyword_arguments

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -2803,9 +2803,7 @@ class ModelBuilder:
                         if newton.use_coord_layout_targets:
                             target_prev = wp.transform(*builder.joint_target_q[source_q : source_q + 7])
                             transformed_target = transform_mul(xform_local, target_prev)
-                            joint_target_q[target_q : target_q + 7] = np.asarray(
-                                transformed_target, dtype=np.float32
-                            )
+                            joint_target_q[target_q : target_q + 7] = np.asarray(transformed_target, dtype=np.float32)
 
         self.joint_q.extend(joint_q.tolist())
         self.joint_target_q.extend(joint_target_q.tolist())

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -743,6 +743,11 @@ def parse_urdf(
         builder.joint_q[start + 4] = xform.q[1]
         builder.joint_q[start + 5] = xform.q[2]
         builder.joint_q[start + 6] = xform.q[3]
+
+        import newton  # noqa: PLC0415
+
+        if newton.use_coord_layout_targets:
+            builder.joint_target_q[start : start + 7] = builder.joint_q[start : start + 7]
     else:
         # Fixed joint to world or to parent_body
         # When parent_body is set, xform is interpreted as relative to the parent body

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -991,6 +991,28 @@ class TestImportUrdfBasic(unittest.TestCase):
 
 
 class TestImportUrdfBaseJoints(unittest.TestCase):
+    def test_floating_true_initializes_coord_target_from_xform(self):
+        urdf_content = """
+<robot name="test_floating_target">
+    <link name="base_link"/>
+</robot>
+"""
+        xform = wp.transform(wp.vec3(1.0, -2.0, 3.0), wp.quat_rpy(0.2, -0.3, 0.4))
+
+        prev = newton.use_coord_layout_targets
+        newton.use_coord_layout_targets = True
+        try:
+            builder = newton.ModelBuilder()
+            parse_urdf(urdf_content, builder, floating=True, xform=xform, up_axis="Z")
+            model = builder.finalize()
+            control = model.control()
+
+            assert_np_equal(model.joint_q.numpy(), np.array(xform), tol=1.0e-6)
+            assert_np_equal(model.joint_target_q.numpy(), np.array(xform), tol=1.0e-6)
+            assert_np_equal(control.joint_target_q.numpy(), np.array(xform), tol=1.0e-6)
+        finally:
+            newton.use_coord_layout_targets = prev
+
     def test_floating_true_creates_free_joint(self):
         """Test that floating=True creates a free joint for the root body."""
         urdf_content = """<?xml version="1.0" encoding="utf-8"?>

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -992,6 +992,7 @@ class TestImportUrdfBasic(unittest.TestCase):
 
 class TestImportUrdfBaseJoints(unittest.TestCase):
     def test_floating_true_initializes_coord_target_from_xform(self):
+        """Floating URDF root targets start from the imported root transform."""
         urdf_content = """
 <robot name="test_floating_target">
     <link name="base_link"/>

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -1581,6 +1581,7 @@ class TestModelMesh(unittest.TestCase):
 
 class TestModelJoints(unittest.TestCase):
     def test_add_builder_xform_updates_root_free_joint_target(self):
+        """Transformed root free-joint targets preserve authored targets."""
         prev = newton.use_coord_layout_targets
         newton.use_coord_layout_targets = True
         try:

--- a/newton/tests/test_model.py
+++ b/newton/tests/test_model.py
@@ -1580,6 +1580,41 @@ class TestModelMesh(unittest.TestCase):
 
 
 class TestModelJoints(unittest.TestCase):
+    def test_add_builder_xform_updates_root_free_joint_target(self):
+        prev = newton.use_coord_layout_targets
+        newton.use_coord_layout_targets = True
+        try:
+            parent_xform = wp.transform(wp.vec3(0.4, -0.2, 0.1), wp.quat_rpy(0.3, -0.4, 0.2))
+            body_xform = wp.transform(wp.vec3(1.0, -2.0, 0.5), wp.quat_rpy(0.1, 0.2, -0.3))
+            offset = wp.transform(wp.vec3(-0.5, 0.7, 1.2), wp.quat_rpy(-0.3, 0.2, 0.1))
+            source_target = wp.transform(wp.vec3(0.2, -0.6, 0.9), wp.quat_rpy(0.4, -0.1, 0.2))
+
+            source = ModelBuilder()
+            body = source.add_link(xform=body_xform)
+            joint = source.add_joint_free(child=body, parent_xform=parent_xform)
+            source.add_articulation([joint])
+            q_start = source.joint_q_start[joint]
+            source.joint_target_q[q_start : q_start + 7] = list(source_target)
+
+            builder = ModelBuilder()
+            builder.add_builder(source, xform=offset)
+
+            xform_local = wp.transform_inverse(parent_xform) * offset * parent_xform
+            expected_target = xform_local * source_target
+            q_start = builder.joint_q_start[joint]
+            assert_np_equal(
+                np.array(builder.joint_target_q[q_start : q_start + 7]),
+                np.array(expected_target),
+                tol=1.0e-6,
+            )
+
+            model = builder.finalize()
+            control = model.control()
+            assert_np_equal(model.joint_target_q.numpy(), np.array(expected_target), tol=1.0e-6)
+            assert_np_equal(control.joint_target_q.numpy(), np.array(expected_target), tol=1.0e-6)
+        finally:
+            newton.use_coord_layout_targets = prev
+
     def test_add_builder_xform_updates_root_free_joint_coordinates(self):
         parent_xform = wp.transform(wp.vec3(0.4, -0.2, 0.1), wp.quat_rpy(0.3, -0.4, 0.2))
         child_xform = wp.transform(wp.vec3(-0.1, 0.3, 0.2), wp.quat_rpy(-0.2, 0.1, 0.4))
@@ -1679,6 +1714,59 @@ class TestModelJoints(unittest.TestCase):
         state = model.state()
         newton.eval_fk(model, state.joint_q, state.joint_qd, state)
         assert_np_equal(state.body_q.numpy()[child], np.array(child_body_xform), tol=1.0e-5)
+
+    def test_add_joint_free_initializes_target_from_relative_transform(self):
+        """Coordinate-layout targets start at the authored free-joint pose.
+
+        The legacy DOF layout cannot represent the free-joint quaternion and
+        retains its historical zero target.
+        """
+        parent_body_xform = wp.transform(wp.vec3(1.0, -2.0, 0.5), wp.quat_rpy(0.2, -0.3, 0.4))
+        child_body_xform = wp.transform(wp.vec3(-0.5, 1.5, 2.0), wp.quat_rpy(-0.4, 0.1, 0.3))
+        parent_xform = wp.transform(wp.vec3(0.3, -0.2, 0.1), wp.quat_rpy(0.1, 0.2, -0.1))
+        child_xform = wp.transform(wp.vec3(-0.1, 0.4, 0.2), wp.quat_rpy(-0.2, 0.3, 0.1))
+
+        for use_coord in (False, True):
+            with self.subTest(use_coord_layout_targets=use_coord):
+                prev = newton.use_coord_layout_targets
+                newton.use_coord_layout_targets = use_coord
+                try:
+                    builder = ModelBuilder()
+                    parent = builder.add_link(xform=parent_body_xform)
+                    child = builder.add_link(xform=child_body_xform)
+                    joint = builder.add_joint_free(
+                        parent=parent,
+                        child=child,
+                        parent_xform=parent_xform,
+                        child_xform=child_xform,
+                    )
+                    builder.add_articulation([joint])
+
+                    q_start = builder.joint_q_start[joint]
+                    expected_joint_q = np.array(builder.joint_q[q_start : q_start + 7])
+                    identity = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+                    self.assertFalse(np.allclose(expected_joint_q, identity))
+
+                    if use_coord:
+                        assert_np_equal(
+                            np.array(builder.joint_target_q[q_start : q_start + 7]),
+                            expected_joint_q,
+                            tol=1.0e-6,
+                        )
+                    else:
+                        assert_np_equal(
+                            np.array(builder.joint_target_q[q_start : q_start + 7]),
+                            identity,
+                            tol=1.0e-6,
+                        )
+
+                    model = builder.finalize()
+                    control = model.control()
+                    expected_target = expected_joint_q if use_coord else np.zeros(6)
+                    assert_np_equal(model.joint_target_q.numpy(), expected_target, tol=1.0e-6)
+                    assert_np_equal(control.joint_target_q.numpy(), expected_target, tol=1.0e-6)
+                finally:
+                    newton.use_coord_layout_targets = prev
 
     def test_joint_target_q_qd_shape_with_free_and_ball_joints(self):
         """``joint_target_q`` follows ``joint_q`` (coord) under


### PR DESCRIPTION
## Description

Initialize coordinate-layout free-joint position targets from the same anchor-relative transform as the joint's initial coordinates. This keeps a newly created `Control` at the authored pose instead of identity.

The mismatch had three related sources:

- `add_joint()` initialized the target before `add_joint_free()` derived the nontrivial initial transform.
- `add_builder(xform=...)` transformed a world-root free-joint state without transforming its target.
- the floating-base URDF path assigned the import transform after joint construction without updating the target.

For a root joint placement transform `T`, builder composition now applies the same anchor-frame change of coordinates to the desired pose as to the state: `q_target' = X_p^-1 * T * X_p * q_target`. Explicit targets remain distinct from the initial state, while their control error is invariant under scene placement.

The deprecated DOF-layout behavior is unchanged because its six values cannot represent a free-joint quaternion. As noted in #3380, Newton solvers do not currently actuate free joints through `joint_target_q`; this fix makes the model/control data internally consistent for converters and future consumers.

Closes #3380.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_add_joint_free_initializes_target_from_relative_transform
uv run --extra dev -m newton.tests -k test_add_builder_xform_updates_root_free_joint_target
uv run --extra dev -m newton.tests -k test_floating_true_initializes_coord_target_from_xform
uv run --extra dev -m newton.tests -k test_model
uv run --extra dev -m newton.tests -k test_import_urdf
uvx pre-commit run -a
```

Results: all focused regressions passed on CPU; all 242 model-related cases passed (133 executed, 109 fixture skips); all 62 URDF tests passed; pre-commit passed.

## Bug fix

**Steps to reproduce:**

1. Enable `newton.use_coord_layout_targets`.
2. Add a free joint whose child pose or joint anchors produce a non-identity `joint_q`.
3. Finalize the model and create `model.control()`.
4. Observe that `joint_q` contains the authored pose while `control.joint_target_q` contains identity.

**Minimal reproduction:**

```python
import newton
import warp as wp

newton.use_coord_layout_targets = True
builder = newton.ModelBuilder()
body = builder.add_link(xform=wp.transform(wp.vec3(1.0, 2.0, 3.0)))
joint = builder.add_joint_free(child=body)
builder.add_articulation([joint])
model = builder.finalize()

assert model.control().joint_target_q.numpy().tolist() == model.joint_q.numpy().tolist()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Free-joint position targets now initialize from the authored pose when coordinate-layout targets are enabled.
  * Floating-base URDF imports now preserve the provided transform across joint targets and control targets.
  * Builder merges/transformations now correctly propagate free-joint target positions.
  * Corrected USD joint collision behavior for joints with explicit bodies vs world connections.
* **Tests**
  * Added unit tests covering coord-layout initialization, builder root transformations, and floating-base URDF import behavior.
* **Documentation**
  * Updated the changelog with the free-joint target initialization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->