### PR TITLE
Fix/coupled stale contact generation

### DIFF
--- a/newton/_src/solvers/coupled/solver_coupled.py
+++ b/newton/_src/solvers/coupled/solver_coupled.py
@@ -2320,6 +2320,7 @@ class SolverCoupled(SolverBase, CouplingInterface):
                 dim=contact_update_dim,
                 inputs=[
                     contacts.contact_generation,
+                    filtered.contact_generation,
                     self._entry_rigid_contact_generation[entry.name],
                     self._entry_soft_contact_generation[entry.name],
                     self._entry_rigid_contact_update[entry.name],
@@ -3035,6 +3036,7 @@ def _add_mapped_particle_forces_kernel(
 @wp.kernel(enable_backward=False)
 def _prepare_filtered_contact_update_kernel(
     src_generation: wp.array[wp.int32],
+    dst_generation: wp.array[wp.int32],
     rigid_generation: wp.array[wp.int32],
     soft_generation: wp.array[wp.int32],
     rigid_update_out: wp.array[wp.int32],
@@ -3057,6 +3059,13 @@ def _prepare_filtered_contact_update_kernel(
     if tid == 0:
         rigid_update_out[0] = rigid_update
         soft_update_out[0] = soft_update
+        if rigid_update != 0 or soft_update != 0:
+            generation = dst_generation[0]
+            if generation == 2147483647:
+                generation = 0
+            else:
+                generation = generation + 1
+            dst_generation[0] = generation
         if rigid_update != 0:
             rigid_generation[0] = src_generation[0]
         if soft_update != 0:

--- a/newton/examples/multiphysics/example_mujoco_xpbd_coupled_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_xpbd_coupled_solver.py
@@ -122,9 +122,8 @@ class Example:
         self.model = builder.finalize()
 
         # Contact parameters
-        # self.model.soft_contact_ke = 1.0e6
-        # self.model.soft_contact_kd = 1.03
-        # self.model.soft_contact_mu = 0.5
+        self.model.soft_contact_ke = 1.0e2
+        self.model.soft_contact_kd = 1.0
 
         xpbd_kwargs = {
             "iterations": 40,
@@ -134,7 +133,7 @@ class Example:
             # ---------- Coupled path: rigid solver + XPBD ----------
             rigid_name, rigid_solver, rigid_kwargs = _rigid_solver_entry_args(
                 self.rigid_solver,
-                mujoco_kwargs={"use_mujoco_contacts": False, "njmax": 200, "nconmax": 200},
+                mujoco_kwargs={"use_mujoco_contacts": False, "njmax": 300, "nconmax": 200},
             )
             rigid_body_indices = wp.array(list(range(rigid_body_start, rigid_body_end)), dtype=int)
             xpbd_body_indices = wp.array(
@@ -251,13 +250,13 @@ class Example:
             cell_y=1.0 / 30.0,
             mass=0.1,
             add_springs=True,
-            spring_ke=1.0e4,
+            spring_ke=1.0e2,
             spring_kd=1.0,
-            tri_ke=1.0e4,
-            tri_ka=1.0e4,
-            tri_kd=0.0,
+            tri_ke=1.0e2,
+            tri_ka=1.0e2,
+            tri_kd=1.0e-1,
             edge_ke=1.0e2,
-            edge_kd=0.0,
+            edge_kd=1.0e-1,
             particle_radius=0.01,
         )
 


### PR DESCRIPTION
## Description

Fix #3474 

Mujoco coupled contact view could have its generation number not being incremented, leading to stale contact processing

Also tune example parameters 

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact filtering updates in coupled simulations by ensuring regenerated contact data is tracked correctly.

* **Examples**
  * Updated the coupled rigid-body and cloth simulation example with softer, more stable contact and material settings.
  * Increased the available MuJoCo constraint capacity for the example simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->