### PR TITLE
Expose public viewer camera speed parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add three VBD contact examples — `vbd_rigid_rigid_contact`, `vbd_soft_rigid_contact`, and `vbd_soft_rigid_mix_contact` — demonstrating rigid-rigid, soft (particle-rigid), and mixed cloth-bag contacts
 - Add masked rigid-body reset support to `SolverVBD`; particle resets are not yet supported. (#3256)
 - Add viewer layer system to overlay multiple solvers/models in supported rendering viewers; call `ViewerBase.activate(layer_id)` to route subsequent `set_model` / `log_state` / `log_*` calls into a named layer, `ViewerBase.set_layer_visible()` to toggle layers independently, and `ViewerBase.set_layer_transform()` to position layers side-by-side. See `example_basic_multi_solver_overlay.py`
+- Add `ViewerBase.camera_speed` to configure keyboard translation speed for interactive viewers. (#3439)
 - Add SDF contact support for convex-hull shapes with mesh-attached SDFs and opt-in SDF contact generation for box shapes.
 - Add opt-in filtering of static-static, static-kinematic, and kinematic-kinematic contacts during broad-phase collision detection. Set `CollisionPipeline(include_static_kinematic_pairs=False)` to enable filtering; the default preserves existing contact generation. `Model.shape_contact_pairs` remains an unfiltered superset for direct consumers such as `SolverKamino` and hydroelastic SDF setup.
 - Add opt-in `body_frame_origin="com"` to `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()` for COM-centered cable capsule body frames.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -27,6 +27,7 @@ All viewer backends inherit from :class:`~newton.viewer.ViewerBase` and share a 
 **Camera and layout:**
 
 - :meth:`~newton.viewer.ViewerBase.set_camera` — set camera position, pitch, and yaw
+- :attr:`~newton.viewer.ViewerBase.camera_speed` — set keyboard camera translation speed in m/s
 - :meth:`~newton.viewer.ViewerBase.set_world_offsets` — arrange multiple worlds in a grid with a given spacing along each axis
 
 **Custom visualization** — draw debug overlays on top of the simulation:
@@ -614,6 +615,7 @@ Set the camera programmatically with :meth:`~newton.viewer.ViewerBase.set_camera
 .. code-block:: python
 
     viewer.set_camera(pos=wp.vec3(5.0, 2.0, 3.0), pitch=-0.3, yaw=0.5)
+    viewer.camera_speed = 0.2  # m/s
 
 When visualizing multiple worlds, use :meth:`~newton.viewer.ViewerBase.set_world_offsets` to arrange them in a grid
 (must be called after :meth:`~newton.viewer.ViewerBase.set_model`):

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import enum
+import math
 import os
 import sys
 from abc import ABC, abstractmethod
@@ -106,6 +107,7 @@ class ViewerBase(ABC):
         self.time = 0.0
         self.device = wp.get_device()
         self.picking_enabled = True
+        self._camera_speed = 4.0
 
         # Layer registry. The default layer is always present and has an
         # empty name prefix to keep backward compatibility for code that
@@ -740,6 +742,18 @@ class ViewerBase(ABC):
         )
         self._isomesh_cache[sdf_idx] = isomesh
         return isomesh
+
+    @property
+    def camera_speed(self) -> float:
+        """Keyboard camera translation speed [m/s]."""
+        return self._camera_speed
+
+    @camera_speed.setter
+    def camera_speed(self, value: float) -> None:
+        value = float(value)
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError("camera_speed must be finite and nonnegative")
+        self._camera_speed = value
 
     def set_camera(self, pos: wp.vec3, pitch: float, yaw: float):
         """Set the camera position and orientation.

--- a/newton/_src/viewer/viewer_gui.py
+++ b/newton/_src/viewer/viewer_gui.py
@@ -48,7 +48,6 @@ class ViewerGui:
 
         # Camera keyboard movement (shared with GL/RTX)
         self._cam_vel = np.zeros(3, dtype=np.float32)
-        self._cam_speed = 4.0
         self._cam_damp_tau = 0.083
         self._camera_orbit_sensitivity = 0.1
         self._camera_dolly_scroll_sensitivity = 0.15
@@ -181,7 +180,7 @@ class ViewerGui:
 
         dn = float(np.linalg.norm(desired))
         if dn > 1.0e-6:
-            desired = desired / dn * self._cam_speed
+            desired = desired / dn * self._viewer.camera_speed
         else:
             desired[:] = 0.0
 

--- a/newton/examples/contacts/example_contacts_rj45_plug.py
+++ b/newton/examples/contacts/example_contacts_rj45_plug.py
@@ -386,8 +386,7 @@ class Example:
             pitch=-10.0,
             yaw=180.0,
         )
-        if hasattr(self.viewer, "_cam_speed"):
-            self.viewer._cam_speed = 0.2
+        self.viewer.camera_speed = 0.2
 
         self.state_0 = self.model.state()
         self.state_1 = self.model.state()

--- a/newton/tests/test_viewer_controls.py
+++ b/newton/tests/test_viewer_controls.py
@@ -1,11 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 import unittest
+from collections import namedtuple
 from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
 
 from newton._src.viewer.viewer_gl import ViewerGL
+from newton._src.viewer.viewer_gui import ViewerGui
 from newton._src.viewer.viewer_null import ViewerNull
+
+_Vec3 = namedtuple("_Vec3", ("x", "y", "z"))
 
 
 def _make_gl_state(paused: bool = False, step_requested: bool = False) -> "ViewerGL":
@@ -24,6 +32,50 @@ class TestViewerBaseShouldStep(unittest.TestCase):
         viewer = ViewerNull()
         for _ in range(3):
             self.assertTrue(viewer.should_step())
+
+
+class TestViewerCameraSpeed(unittest.TestCase):
+    def test_defaults_to_four_meters_per_second(self):
+        self.assertEqual(ViewerNull().camera_speed, 4.0)
+
+    def test_accepts_finite_nonnegative_values(self):
+        viewer = ViewerNull()
+
+        viewer.camera_speed = 0.2
+        self.assertEqual(viewer.camera_speed, 0.2)
+
+        viewer.camera_speed = 0.0
+        self.assertEqual(viewer.camera_speed, 0.0)
+
+    def test_rejects_negative_and_nonfinite_values(self):
+        viewer = ViewerNull()
+
+        for value in (-1.0, float("inf"), float("-inf"), float("nan")):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                viewer.camera_speed = value
+
+    def test_gui_keyboard_movement_uses_viewer_camera_speed(self):
+        camera = SimpleNamespace(
+            pos=_Vec3(0.0, 0.0, 0.0),
+            get_front=lambda: (1.0, 0.0, 0.0),
+            get_right=lambda: (0.0, 1.0, 0.0),
+            get_up=lambda: (0.0, 0.0, 1.0),
+        )
+        viewer = SimpleNamespace(camera=camera, camera_speed=2.0)
+        gui = ViewerGui.__new__(ViewerGui)
+        gui._viewer = viewer
+        gui.ui = None
+        gui._cam_vel = np.zeros(3, dtype=np.float32)
+        gui._cam_damp_tau = 0.1
+
+        key = SimpleNamespace(W=1, UP=2, S=3, DOWN=4, A=5, LEFT=6, D=7, RIGHT=8, Q=9, E=10)
+        pyglet = SimpleNamespace(window=SimpleNamespace(key=key))
+        with patch.dict(sys.modules, {"pyglet": pyglet}):
+            gui.update_camera_from_keys(0.1, lambda code: code == key.W)
+
+        self.assertAlmostEqual(camera.pos.x, 0.2)
+        self.assertAlmostEqual(camera.pos.y, 0.0)
+        self.assertAlmostEqual(camera.pos.z, 0.0)
 
 
 class TestViewerGLShouldStep(unittest.TestCase):


### PR DESCRIPTION
## Description

Add `ViewerBase.camera_speed` as the public API for configuring WASD/QE camera translation speed in meters per second. Interactive GL and RTX viewers now read this viewer-level setting instead of backend-specific `ViewerGui._cam_speed` state.

Update the RJ45 contact example to use the public property, document the API, and add regression coverage for its default, validation, zero-speed behavior, and GUI integration.

This fixes the regression caused when camera navigation state moved from `ViewerGL` to `ViewerGui`, leaving the example's private `_cam_speed` access ineffective.

Closes #3439.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_viewer_controls
uv run --extra dev -m newton.tests -k test_viewer_camera
uv run --extra dev -m newton.tests -k test_generate_api
```

## Bug fix

**Steps to reproduce:**

1. Run `python -m newton.examples contacts_rj45_plug` from current main.
2. Move the camera with WASD/QE.
3. Observe that the example's intended `0.2` m/s camera speed is not applied because `_cam_speed` is no longer an attribute of `ViewerGL`.

**Minimal reproduction:**

```python
from newton.viewer import ViewerGL

viewer = ViewerGL()
assert not hasattr(viewer, "_cam_speed")
```

## New feature / API change

```python
from newton.viewer import ViewerGL

viewer = ViewerGL()
viewer.camera_speed = 0.2
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable viewer camera speed setting for keyboard navigation.
  - Camera speed defaults to 4.0 meters per second and supports custom non-negative, finite values.
  - Keyboard camera movement now uses the configured speed.

- **Documentation**
  - Updated the visualization guide with camera speed details and an example configuration.
  - Added the feature to the unreleased changelog.

- **Bug Fixes**
  - Invalid camera speed values are rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->