### PR TITLE
Scope EC2 runner HOME to EC2 jobs

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -15,7 +15,6 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
   AWS_RUNNER_RESOURCE_TAG: newton-github-runner
-  HOME: /actions-runner
 
 on:
   workflow_call:
@@ -105,6 +104,8 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     permissions:
       contents: read
+    env:
+      HOME: /actions-runner
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -18,7 +18,6 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 7200
   AWS_RUNNER_RESOURCE_TAG: newton-github-runner
-  HOME: /actions-runner
 
 on:
   workflow_call:
@@ -128,6 +127,7 @@ jobs:
     permissions:
       contents: read
     env:
+      HOME: /actions-runner
       PYTHONFAULTHANDLER: "1" # Dump tracebacks on fatal signals (SIGSEGV, SIGABRT, etc.)
     steps:
       - name: Checkout repository
@@ -228,9 +228,6 @@ jobs:
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
     permissions: {}
-    env:
-      # The workflow-level HOME targets the EC2 runner filesystem.
-      HOME: /home/runner
     steps:
       # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
       # uses rotating productionresultssaN hosts and harden-runner only supports

--- a/.github/workflows/minimum_deps_tests.yml
+++ b/.github/workflows/minimum_deps_tests.yml
@@ -14,7 +14,6 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
   AWS_RUNNER_RESOURCE_TAG: newton-github-runner
-  HOME: /actions-runner
 
 on:
   workflow_call:
@@ -94,6 +93,7 @@ jobs:
     permissions:
       contents: read
     env:
+      HOME: /actions-runner
       PYTHONFAULTHANDLER: "1"
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -164,9 +164,6 @@ jobs:
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
     permissions: {}
-    env:
-      # The workflow-level HOME targets the EC2 runner filesystem.
-      HOME: /home/runner
     steps:
       # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
       # uses rotating productionresultssaN hosts and harden-runner only supports

--- a/.github/workflows/mujoco_warp_tests.yml
+++ b/.github/workflows/mujoco_warp_tests.yml
@@ -13,7 +13,6 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
   AWS_RUNNER_RESOURCE_TAG: newton-github-runner
-  HOME: /actions-runner
 
 on:
   workflow_call:
@@ -93,6 +92,7 @@ jobs:
     permissions:
       contents: read
     env:
+      HOME: /actions-runner
       PYTHONFAULTHANDLER: "1"
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -171,9 +171,6 @@ jobs:
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
     permissions: {}
-    env:
-      # The workflow-level HOME targets the EC2 runner filesystem.
-      HOME: /home/runner
     steps:
       # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
       # uses rotating productionresultssaN hosts and harden-runner only supports

--- a/.github/workflows/warp_nightly_tests.yml
+++ b/.github/workflows/warp_nightly_tests.yml
@@ -13,7 +13,6 @@ env:
   AWS_ROLE_ARN: arn:aws:iam::968945269301:role/newton-physics-newton-ec2-github-runner-role
   AWS_ROLE_DURATION: 3600
   AWS_RUNNER_RESOURCE_TAG: newton-github-runner
-  HOME: /actions-runner
 
 on:
   workflow_call:
@@ -93,6 +92,7 @@ jobs:
     permissions:
       contents: read
     env:
+      HOME: /actions-runner
       PYTHONFAULTHANDLER: "1"
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -166,9 +166,6 @@ jobs:
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
     permissions: {}
-    env:
-      # The workflow-level HOME targets the EC2 runner filesystem.
-      HOME: /home/runner
     steps:
       # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
       # uses rotating productionresultssaN hosts and harden-runner only supports


### PR DESCRIPTION
## Description

Category: CI reliability.

Scope `HOME: /actions-runner` to the EC2 execution jobs in the five AWS workflows. Previously, the workflow-level setting also applied to hosted `start-runner`, `stop-runner`, and Codecov upload jobs, where `/actions-runner` does not exist.

The EC2 test and benchmark jobs retain their NVMe-backed home and cache behavior. Hosted jobs now inherit the runner-native home, and the four defensive `HOME: /home/runner` Codecov overrides are no longer needed.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not user-facing; no entry required)

## Test plan

```bash
uvx pre-commit run -a
git diff --check
rg -n 'HOME: /(actions-runner|home/runner)' .github/workflows
```

A targeted invariant check was also run before and after the change. It failed against the workflow-level settings and passed after confirming that only the five EC2 execution jobs set `HOME: /actions-runner`.

## Bug fix

**Steps to reproduce:**

1. Inspect the top-level `env` blocks in the AWS EC2 workflows.
2. Observe that `HOME: /actions-runner` is inherited by every job, including jobs running on `ubuntu-latest`.
3. Add any hosted-runner step that writes beneath `$HOME`; it resolves paths beneath the nonexistent `/actions-runner` directory instead of the hosted runner's native home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment handling by scoping the runner `HOME` override to the jobs that require it across GPU benchmarks, GPU unit tests, minimum-dependency checks, MuJoCo Warp tests, and nightly validation.
  * Removed redundant workflow-level and coverage upload job `HOME` overrides to prevent unintended configuration effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->