### PR TITLE
Skip flaky MuJoCo Warp friction ramp

### DIFF
--- a/newton/tests/test_rigid_friction_ramp.py
+++ b/newton/tests/test_rigid_friction_ramp.py
@@ -189,7 +189,10 @@ def assert_grid_behavior(test, settle_q, final_q, final_qd, mus, angles_deg, box
         test.fail("\n  ".join([f"{len(failures)} friction-ramp cell(s) failed:", *failures]))
 
 
-def test_friction_ramp(test, device, solver_fn, mus, angles_deg, thresholds):
+def test_friction_ramp(test, device, solver_name, solver_fn, mus, angles_deg, thresholds):
+    if solver_name == "mujoco_warp" and device.is_cuda:
+        test.skipTest("Flaky on CUDA (GH-3391), pending google-deepmind/mujoco_warp#1512")
+
     model, box_ids = build_friction_grid(device, mus, angles_deg)
 
     solver = solver_fn(model)
@@ -516,6 +519,7 @@ for device in devices:
             test_friction_ramp,
             devices=[device],
             check_output=False,
+            solver_name=solver_name,
             solver_fn=cfg["factory"],
             mus=cfg["mus"],
             angles_deg=cfg["angles_deg"],


### PR DESCRIPTION
## Description

Temporarily skip the MuJoCo Warp CUDA friction-ramp test while its known elliptic line-search flakiness is unresolved.

This is intentionally narrow: MuJoCo CPU, XPBD, VBD, and the MuJoCo Warp CUDA stopping-distance test remain enabled. The underlying failure is tracked by #3391 and google-deepmind/mujoco_warp#1512.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (not applicable; test-only change)
- [x] `CHANGELOG.md` has been updated (not applicable; no user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_friction_ramp --strict-warnings --no-cache-clear --serial-fallback
uv run --extra dev -m newton.tests -k test_friction_stopping_distance_mujoco_warp_cuda_0 --strict-warnings --no-cache-clear --serial-fallback
uvx pre-commit run -a
```

The friction-ramp selection passes with only `test_friction_ramp_mujoco_warp_cuda_0` skipped. The MuJoCo Warp CUDA stopping-distance test passes and all pre-commit hooks pass.

## Bug fix

**Steps to reproduce:**

1. Run `test_friction_ramp_mujoco_warp_cuda_0` repeatedly on CUDA.
2. Observe intermittent static-friction displacement or velocity threshold failures caused by the MuJoCo Warp elliptic line search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved friction ramp test reliability by skipping a known-flaky CUDA configuration.
  * Updated test configuration to correctly identify the selected solver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->