### PR TITLE
Keep ViewerGL event loop alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 
 ### Fixed
 
+- Fix `ViewerGL` so it can be closed and recreated in the same process without shutting down Pyglet's shared event loop. (#3225)
 - Fix USD import ignoring ancestor material bindings with `strongerThanDescendants` strength when a mesh authors `material:binding` without applying `MaterialBindingAPI`: material resolution now uses UsdShade's canonical `ComputeBoundMaterial` unconditionally, which also adds collection-based binding support. Prims authoring bindings without the applied schema are invalid USD and now surface USD's own warning (once per prim per import) — fix such assets with `usdchecker` or `usd-validation-nvidia`.
 - Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3406)
 - Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1369,10 +1369,6 @@ class RendererGL:
     def close(self):
         self._make_current()
 
-        if not self.headless:
-            self.app.event_loop.dispatch_event("on_exit")
-            self.app.platform_event_loop.stop()
-
         RendererGL._fallback_texture = None
         self.window.close()
 

--- a/newton/tests/test_viewer_renderer_lifecycle.py
+++ b/newton/tests/test_viewer_renderer_lifecycle.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the OpenGL renderer lifecycle."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from newton._src.viewer.gl.opengl import RendererGL
+
+
+class TestRendererGLClose(unittest.TestCase):
+    def test_close_keeps_pyglet_event_loop_available_for_next_viewer(self):
+        """Closing one viewer must not stop Pyglet's shared event loop."""
+        renderer = RendererGL.__new__(RendererGL)
+        renderer._make_current = mock.Mock()
+        renderer.window = mock.Mock()
+        renderer.app = SimpleNamespace(event_loop=mock.Mock(), platform_event_loop=mock.Mock())
+        renderer.headless = False
+        RendererGL._fallback_texture = object()
+
+        renderer.close()
+
+        renderer._make_current.assert_called_once_with()
+        renderer.window.close.assert_called_once_with()
+        renderer.app.event_loop.dispatch_event.assert_not_called()
+        renderer.app.platform_event_loop.stop.assert_not_called()
+        self.assertIsNone(RendererGL._fallback_texture)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Keep Pyglet’s process-wide event loop alive when an individual `ViewerGL` instance closes. This allows a viewer to be closed and recreated in the same process.

Closes #3225.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_viewer_renderer_lifecycle
uvx pre-commit run --files newton/_src/viewer/gl/opengl.py newton/tests/test_viewer_renderer_lifecycle.py CHANGELOG.md
```

Also created, rendered with, closed, and recreated `ViewerGL` twice in one process on macOS.

## Bug fix

**Steps to reproduce:**

1. Create and render a `ViewerGL` instance.
2. Call `close()`.
3. Create a second `ViewerGL` instance in the same process.

**Root cause:**

`RendererGL.close()` dispatched Pyglet’s application-wide exit event and stopped the shared platform event loop even though only one viewer window was closing. The second viewer reused that global lifecycle state and could render as a blank window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenGL viewers failing to close and be recreated in the same process.
  * Viewer shutdown now reliably keeps Pyglet’s shared event loop available for subsequent viewers.
  * Improved OpenGL renderer cleanup to reset cached textures and close the window consistently.
* **Tests**
  * Added a regression test covering the OpenGL renderer close lifecycle behavior and ensuring the shared event loop remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->