### PR TITLE
Normalize GitHub Action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build a binary wheel
         run: uv build --wheel
       - name: Store the distribution packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -57,7 +57,7 @@ jobs:
           egress-policy: audit
 
       - name: Download wheel and source tarball
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: python-package-distributions
           path: dist/
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Download wheel and source tarball
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Description

Audit the GitHub Actions workflows for inconsistent action versions. The release workflow used older `actions/upload-artifact` and `actions/download-artifact` versions than the CI and test workflows. Update it to the newer, already-pinned versions while preserving the version comments and immutable SHA references.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uvx pre-commit run -a`
- `git diff --check`
- Audited all external workflow actions to confirm each action uses one annotated version and a 40-character SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use newer artifact upload and download tooling.
  * Improved reliability when preparing and publishing distribution packages and GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->