### PR TITLE
 Add a `joint_dof_mask` argument to `newton.ik.IKSolver`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add `sign_method` argument to `Mesh.build_sdf` and `SDF.create_from_mesh` support for a `"normal"` (angle-weighted pseudo-normal) sign strategy, for selecting the inside/outside sign of the baked SDF (`"auto"`, `"parity"`, `"winding"`, or `"normal"`).
 - Add `forward_depth_image` output support to `SensorTiledCamera.update()` and `SensorTiledCamera.utils.create_forward_depth_image_output()` for native forward-depth rendering without post-processing `depth_image`.
 - Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, timestep, and MuJoCo solver-iteration metrics to the ASV robot-learning benchmarks.
+- Add `joint_dof_mask` to `newton.ik.IKSolver` to keep selected joint DOFs fixed during LM optimization. (#3488)
 
 ### Changed
 

--- a/newton/_src/sim/ik/ik_lm_optimizer.py
+++ b/newton/_src/sim/ik/ik_lm_optimizer.py
@@ -80,6 +80,16 @@ def _update_lm_state(
         lambda_values[row] = wp.clamp(new_lambda, lambda_min, lambda_max)
 
 
+@wp.kernel
+def _apply_joint_dof_mask(
+    joint_dof_mask: wp.array[wp.bool],
+    jacobian: wp.array3d[wp.float32],
+):
+    row, residual, dof = wp.tid()
+    if not joint_dof_mask[dof]:
+        jacobian[row, residual, dof] = 0.0
+
+
 class IKOptimizerLM:
     """Levenberg-Marquardt optimizer for batched inverse kinematics.
 
@@ -103,6 +113,8 @@ class IKOptimizerLM:
             accept a step.
         problem_idx: Optional mapping from batch rows to base problem indices
             for per-problem objective data.
+        joint_dof_mask: Optional model-wide mask with one value per joint DOF.
+            False entries keep the corresponding DOFs fixed.
     """
 
     TILE_N_DOFS = None
@@ -142,6 +154,7 @@ class IKOptimizerLM:
         rho_min: float = 1e-3,
         *,
         problem_idx: wp.array[wp.int32] | None = None,
+        joint_dof_mask: wp.array[wp.bool] | None = None,
     ) -> None:
         self.model = model
         self.device = model.device
@@ -160,6 +173,7 @@ class IKOptimizerLM:
         self.lambda_min = lambda_min
         self.lambda_max = lambda_max
         self.rho_min = rho_min
+        self.joint_dof_mask = joint_dof_mask
 
         if self.TILE_N_DOFS is not None:
             assert self.n_dofs == self.TILE_N_DOFS
@@ -365,10 +379,12 @@ class IKOptimizerLM:
 
         if mode == IKJacobianType.AUTODIFF:
             self._jacobian_autodiff(ctx)
+            self._apply_joint_dof_mask(ctx.jacobian_out)
             return ctx.jacobian_out
 
         if mode == IKJacobianType.ANALYTIC:
             self._jacobian_analytic(ctx, accumulate=False)
+            self._apply_joint_dof_mask(ctx.jacobian_out)
             return ctx.jacobian_out
 
         # MIXED mode
@@ -380,7 +396,19 @@ class IKOptimizerLM:
         if self.has_analytic_objective:
             self._jacobian_analytic(ctx, accumulate=self.has_autodiff_objective)
 
+        self._apply_joint_dof_mask(ctx.jacobian_out)
         return ctx.jacobian_out
+
+    def _apply_joint_dof_mask(self, jacobian: wp.array3d[wp.float32]) -> None:
+        if self.joint_dof_mask is None:
+            return
+        wp.launch(
+            _apply_joint_dof_mask,
+            dim=(self.n_batch, self.n_residuals, self.n_dofs),
+            inputs=[self.joint_dof_mask],
+            outputs=[jacobian],
+            device=self.device,
+        )
 
     def _jacobian_autodiff(self, ctx: BatchCtx) -> None:
         if self.tape is None:

--- a/newton/_src/sim/ik/ik_lm_optimizer.py
+++ b/newton/_src/sim/ik/ik_lm_optimizer.py
@@ -81,7 +81,7 @@ def _update_lm_state(
 
 
 @wp.kernel
-def _apply_joint_dof_mask(
+def _zero_masked_jacobian_columns(
     joint_dof_mask: wp.array[wp.bool],
     jacobian: wp.array3d[wp.float32],
 ):
@@ -403,7 +403,7 @@ class IKOptimizerLM:
         if self.joint_dof_mask is None:
             return
         wp.launch(
-            _apply_joint_dof_mask,
+            _zero_masked_jacobian_columns,
             dim=(self.n_batch, self.n_residuals, self.n_dofs),
             inputs=[self.joint_dof_mask],
             outputs=[jacobian],

--- a/newton/_src/sim/ik/ik_lm_optimizer.py
+++ b/newton/_src/sim/ik/ik_lm_optimizer.py
@@ -81,13 +81,41 @@ def _update_lm_state(
 
 
 @wp.kernel
-def _zero_masked_jacobian_columns(
+def _zero_fixed_dof_jacobian_columns(
     joint_dof_mask: wp.array[wp.bool],
     jacobian: wp.array3d[wp.float32],
 ):
     row, residual, dof = wp.tid()
     if not joint_dof_mask[dof]:
         jacobian[row, residual, dof] = 0.0
+
+
+def _validate_joint_dof_mask(model: Model, joint_dof_mask: wp.array[wp.bool]) -> None:
+    if joint_dof_mask.dtype != wp.bool:
+        raise ValueError("joint_dof_mask must have dtype wp.bool")
+    if joint_dof_mask.ndim != 1 or joint_dof_mask.shape[0] != model.joint_dof_count:
+        raise ValueError("joint_dof_mask must have shape [joint_dof_count]")
+    if joint_dof_mask.device != model.device:
+        raise ValueError("joint_dof_mask must be on the model device")
+
+    # The mask acts on twist-space DOFs, but the integrator couples a
+    # quaternion-integrated joint's DOFs to its coordinates (rotation about the
+    # joint origin translates the body), so a partial mask would not keep the
+    # remaining coordinates fixed. Require all-or-nothing masks for such joints.
+    mask = joint_dof_mask.numpy()
+    joint_type = model.joint_type.numpy()
+    qd_start = model.joint_qd_start.numpy()
+    quaternion_joints = (JointType.BALL, JointType.FREE, JointType.DISTANCE)
+    for j in range(len(joint_type)):
+        if joint_type[j] not in quaternion_joints:
+            continue
+        joint_mask = mask[qd_start[j] : qd_start[j + 1]]
+        if joint_mask.any() and not joint_mask.all():
+            raise ValueError(
+                f"joint_dof_mask partially masks joint {j} "
+                f"({JointType(joint_type[j]).name}): quaternion-integrated joints "
+                "must have all of their DOFs masked together"
+            )
 
 
 class IKOptimizerLM:
@@ -113,8 +141,13 @@ class IKOptimizerLM:
             accept a step.
         problem_idx: Optional mapping from batch rows to base problem indices
             for per-problem objective data.
-        joint_dof_mask: Optional model-wide mask with one value per joint DOF.
-            False entries keep the corresponding DOFs fixed.
+        joint_dof_mask: Optional model-wide mask, shape ``[joint_dof_count]``,
+            indexed in DOF (velocity) space per :attr:`Model.joint_qd_start` —
+            a free joint has 6 entries. ``True`` entries are optimized;
+            ``False`` entries receive an exactly-zero update. Quaternion-
+            integrated joints (free/ball/distance) must be masked
+            all-or-nothing, which the constructor enforces. The mask array must
+            not be modified after construction.
     """
 
     TILE_N_DOFS = None
@@ -173,6 +206,8 @@ class IKOptimizerLM:
         self.lambda_min = lambda_min
         self.lambda_max = lambda_max
         self.rho_min = rho_min
+        if joint_dof_mask is not None:
+            _validate_joint_dof_mask(model, joint_dof_mask)
         self.joint_dof_mask = joint_dof_mask
 
         if self.TILE_N_DOFS is not None:
@@ -403,7 +438,7 @@ class IKOptimizerLM:
         if self.joint_dof_mask is None:
             return
         wp.launch(
-            _zero_masked_jacobian_columns,
+            _zero_fixed_dof_jacobian_columns,
             dim=(self.n_batch, self.n_residuals, self.n_dofs),
             inputs=[self.joint_dof_mask],
             outputs=[jacobian],

--- a/newton/_src/sim/ik/ik_solver.py
+++ b/newton/_src/sim/ik/ik_solver.py
@@ -217,6 +217,10 @@ class IKSolver:
         lambda_min: Minimum LM damping value.
         lambda_max: Maximum LM damping value.
         rho_min: Minimum LM acceptance ratio.
+        joint_dof_mask: Optional model-wide mask with one value per joint DOF.
+            False entries keep the corresponding DOFs fixed during optimization.
+            This is currently supported by the LM optimizer with sampling
+            disabled.
         history_len: Number of correction pairs retained by L-BFGS.
         h0_scale: Initial inverse-Hessian scale for L-BFGS.
         line_search_alphas: Candidate line-search step sizes for L-BFGS.
@@ -242,6 +246,7 @@ class IKSolver:
         lambda_min: float = 1e-5,
         lambda_max: float = 1e10,
         rho_min: float = 1e-3,
+        joint_dof_mask: wp.array[wp.bool] | None = None,
         # L-BFGS parameters
         history_len: int = 10,
         h0_scale: float = 1.0,
@@ -260,6 +265,17 @@ class IKSolver:
             raise ValueError("n_seeds must be >= 1")
         if sampler is IKSampler.NONE and n_seeds != 1:
             raise ValueError("sampler 'none' requires n_seeds == 1")
+        if joint_dof_mask is not None:
+            if optimizer is not IKOptimizer.LM:
+                raise ValueError("joint_dof_mask is only supported by the LM optimizer")
+            if sampler is not IKSampler.NONE:
+                raise ValueError("joint_dof_mask requires sampler='none'")
+            if joint_dof_mask.dtype != wp.bool:
+                raise ValueError("joint_dof_mask must have dtype wp.bool")
+            if joint_dof_mask.ndim != 1 or joint_dof_mask.shape[0] != model.joint_dof_count:
+                raise ValueError("joint_dof_mask must have shape [joint_dof_count]")
+            if joint_dof_mask.device != model.device:
+                raise ValueError("joint_dof_mask must be on the model device")
 
         self.model = model
         self.device = model.device
@@ -310,6 +326,7 @@ class IKSolver:
                 lambda_min=lambda_min,
                 lambda_max=lambda_max,
                 rho_min=rho_min,
+                joint_dof_mask=joint_dof_mask,
             )
         elif optimizer is IKOptimizer.LBFGS:
             self._impl = IKOptimizerLBFGS(

--- a/newton/_src/sim/ik/ik_solver.py
+++ b/newton/_src/sim/ik/ik_solver.py
@@ -217,10 +217,14 @@ class IKSolver:
         lambda_min: Minimum LM damping value.
         lambda_max: Maximum LM damping value.
         rho_min: Minimum LM acceptance ratio.
-        joint_dof_mask: Optional model-wide mask with one value per joint DOF.
-            False entries keep the corresponding DOFs fixed during optimization.
-            This is currently supported by the LM optimizer with sampling
-            disabled.
+        joint_dof_mask: Optional model-wide mask, shape ``[joint_dof_count]``,
+            indexed in DOF (velocity) space per :attr:`Model.joint_qd_start` —
+            a free joint has 6 entries. ``True`` entries are optimized;
+            ``False`` entries receive an exactly-zero update. Quaternion-
+            integrated joints (free/ball/distance) must be masked
+            all-or-nothing, which the constructor enforces. The mask array
+            must not be modified after construction. Currently supported by
+            the LM optimizer with sampling disabled.
         history_len: Number of correction pairs retained by L-BFGS.
         h0_scale: Initial inverse-Hessian scale for L-BFGS.
         line_search_alphas: Candidate line-search step sizes for L-BFGS.
@@ -270,12 +274,7 @@ class IKSolver:
                 raise ValueError("joint_dof_mask is only supported by the LM optimizer")
             if sampler is not IKSampler.NONE:
                 raise ValueError("joint_dof_mask requires sampler='none'")
-            if joint_dof_mask.dtype != wp.bool:
-                raise ValueError("joint_dof_mask must have dtype wp.bool")
-            if joint_dof_mask.ndim != 1 or joint_dof_mask.shape[0] != model.joint_dof_count:
-                raise ValueError("joint_dof_mask must have shape [joint_dof_count]")
-            if joint_dof_mask.device != model.device:
-                raise ValueError("joint_dof_mask must be on the model device")
+            # remaining mask validation happens in IKOptimizerLM
 
         self.model = model
         self.device = model.device

--- a/newton/tests/test_ik.py
+++ b/newton/tests/test_ik.py
@@ -374,30 +374,88 @@ def test_convergence_mixed_d6(test, device):
 
 
 def test_joint_dof_mask(test, device, mode: ik.IKJacobianType):
-    """The LM solver must leave masked joint DOFs unchanged."""
+    """The LM solver must leave masked joint DOFs exactly unchanged while the
+    free DOFs still converge, across the batch dimension."""
     with wp.ScopedDevice(device):
         model = _build_two_link_planar(device)
         requires_grad = mode in (ik.IKJacobianType.AUTODIFF, ik.IKJacobianType.MIXED)
-        joint_q = wp.array([[0.4, 0.0]], dtype=wp.float32, device=device, requires_grad=requires_grad)
-        target = wp.array([[1.0, 1.0, 0.0]], dtype=wp.vec3, device=device)
+        seeds = np.array([[0.4, 0.0], [-0.2, 0.1]], dtype=np.float32)
+        targets = wp.array([[1.0, 1.0, 0.0], [0.5, 1.2, 0.0]], dtype=wp.vec3, device=device)
+        position_objective = ik.IKObjectivePosition(
+            link_index=1,
+            link_offset=wp.vec3(0.5, 0.0, 0.0),
+            target_positions=targets,
+        )
+
+        def solve(mask):
+            joint_q = wp.array(seeds, dtype=wp.float32, device=device, requires_grad=requires_grad)
+            solver = ik.IKSolver(
+                model,
+                2,
+                [position_objective],
+                jacobian_mode=mode,
+                joint_dof_mask=mask,
+            )
+            solver.step(joint_q, joint_q, iterations=40)
+            return joint_q.numpy()
+
+        result = solve(wp.array([False, True], dtype=wp.bool, device=device))
+
+        # Masked deltas are exactly zero by construction (zeroed Jacobian
+        # columns + lambda damping), so fixedness is bit-exact, per problem.
+        for row in range(2):
+            test.assertEqual(float(result[row, 0]), float(seeds[row, 0]))
+        # The free DOF must actually converge, not merely move: compare the
+        # end-effector error against the 1-DOF optimum found by a dense scan.
+        for row in range(2):
+            theta0 = float(seeds[row, 0])
+            tx, ty = float(targets.numpy()[row][0]), float(targets.numpy()[row][1])
+            thetas = np.linspace(-np.pi, np.pi, 20001)
+            ee_x = np.cos(theta0) + np.cos(theta0 + thetas)
+            ee_y = np.sin(theta0) + np.sin(theta0 + thetas)
+            best = float(np.min(np.hypot(ee_x - tx, ee_y - ty)))
+            x = np.cos(theta0) + np.cos(theta0 + result[row, 1])
+            y = np.sin(theta0) + np.sin(theta0 + result[row, 1])
+            achieved = float(np.hypot(x - tx, y - ty))
+            test.assertLess(achieved, best + 1.0e-3)
+
+        # An all-True mask must be exactly equivalent to no mask.
+        all_true = solve(wp.ones(model.joint_dof_count, dtype=wp.bool, device=device))
+        no_mask = solve(None)
+        assert_np_equal(all_true, no_mask, tol=0.0)
+
+
+def test_joint_dof_mask_free_joint(test, device):
+    """A fully-masked FREE joint must keep its pose fixed (up to quaternion
+    renormalization roundoff) while the remaining revolute DOF still updates."""
+    with wp.ScopedDevice(device):
+        model = _build_free_plus_revolute(device)
+        seed = np.zeros((1, model.joint_coord_count), dtype=np.float32)
+        seed[0, 0:3] = [0.1, -0.2, 0.3]
+        rot = wp.quat_from_axis_angle(wp.normalize(wp.vec3(1.0, 2.0, 3.0)), 0.7)
+        seed[0, 3:7] = [rot[0], rot[1], rot[2], rot[3]]
+        joint_q = wp.array(seed, dtype=wp.float32, device=device)
+        target = wp.array([[1.0, 0.5, 0.0]], dtype=wp.vec3, device=device)
         position_objective = ik.IKObjectivePosition(
             link_index=1,
             link_offset=wp.vec3(0.5, 0.0, 0.0),
             target_positions=target,
         )
+        mask = np.ones(model.joint_dof_count, dtype=bool)
+        mask[0:6] = False  # freeze the free joint (6 DOFs, 7 coordinates)
         solver = ik.IKSolver(
             model,
             1,
             [position_objective],
-            jacobian_mode=mode,
-            joint_dof_mask=wp.array([False, True], dtype=wp.bool, device=device),
+            jacobian_mode=ik.IKJacobianType.ANALYTIC,
+            joint_dof_mask=wp.array(mask, dtype=wp.bool, device=device),
         )
 
         solver.step(joint_q, joint_q, iterations=40)
 
         result = joint_q.numpy()[0]
-        test.assertAlmostEqual(float(result[0]), 0.4, places=6)
-        test.assertGreater(abs(float(result[1])), 1.0e-3)
+        assert_np_equal(result[0:7], seed[0, 0:7], tol=1.0e-6)
+        test.assertGreater(abs(float(result[7])), 1.0e-3)
 
 
 def test_joint_dof_mask_validation(test, device):
@@ -440,6 +498,31 @@ def test_joint_dof_mask_validation(test, device):
                 [objective],
                 sampler=ik.IKSampler.GAUSS,
                 joint_dof_mask=wp.ones(model.joint_dof_count, dtype=wp.bool, device=device),
+            )
+        if device.is_cuda:
+            with test.assertRaisesRegex(ValueError, "model device"):
+                ik.IKSolver(
+                    model,
+                    1,
+                    [objective],
+                    joint_dof_mask=wp.ones(model.joint_dof_count, dtype=wp.bool, device="cpu"),
+                )
+
+        free_model = _build_free_plus_revolute(device)
+        free_target = wp.array([[1.0, 0.5, 0.0]], dtype=wp.vec3, device=device)
+        free_objective = ik.IKObjectivePosition(
+            link_index=1,
+            link_offset=wp.vec3(0.5, 0.0, 0.0),
+            target_positions=free_target,
+        )
+        partial = np.ones(free_model.joint_dof_count, dtype=bool)
+        partial[0:3] = False  # linear DOFs of the free joint only
+        with test.assertRaisesRegex(ValueError, "masked together"):
+            ik.IKSolver(
+                free_model,
+                1,
+                [free_objective],
+                joint_dof_mask=wp.array(partial, dtype=wp.bool, device=device),
             )
 
 
@@ -670,6 +753,7 @@ for mode in ik.IKJacobianType:
         devices,
         mode=mode,
     )
+add_function_test(TestIKModes, "test_joint_dof_mask_free_joint", test_joint_dof_mask_free_joint, devices)
 add_function_test(TestIKModes, "test_joint_dof_mask_validation", test_joint_dof_mask_validation, devices)
 
 # Jacobian equality

--- a/newton/tests/test_ik.py
+++ b/newton/tests/test_ik.py
@@ -373,6 +373,76 @@ def test_convergence_mixed_d6(test, device):
     _convergence_test_d6(test, device, ik.IKJacobianType.MIXED)
 
 
+def test_joint_dof_mask(test, device, mode: ik.IKJacobianType):
+    """The LM solver must leave masked joint DOFs unchanged."""
+    with wp.ScopedDevice(device):
+        model = _build_two_link_planar(device)
+        requires_grad = mode in (ik.IKJacobianType.AUTODIFF, ik.IKJacobianType.MIXED)
+        joint_q = wp.array([[0.4, 0.0]], dtype=wp.float32, device=device, requires_grad=requires_grad)
+        target = wp.array([[1.0, 1.0, 0.0]], dtype=wp.vec3, device=device)
+        position_objective = ik.IKObjectivePosition(
+            link_index=1,
+            link_offset=wp.vec3(0.5, 0.0, 0.0),
+            target_positions=target,
+        )
+        solver = ik.IKSolver(
+            model,
+            1,
+            [position_objective],
+            jacobian_mode=mode,
+            joint_dof_mask=wp.array([False, True], dtype=wp.bool, device=device),
+        )
+
+        solver.step(joint_q, joint_q, iterations=40)
+
+        result = joint_q.numpy()[0]
+        test.assertAlmostEqual(float(result[0]), 0.4, places=6)
+        test.assertGreater(abs(float(result[1])), 1.0e-3)
+
+
+def test_joint_dof_mask_validation(test, device):
+    """IKSolver must reject incompatible joint DOF masks and modes."""
+    with wp.ScopedDevice(device):
+        model = _build_two_link_planar(device)
+        target = wp.array([[1.0, 1.0, 0.0]], dtype=wp.vec3, device=device)
+        objective = ik.IKObjectivePosition(
+            link_index=1,
+            link_offset=wp.vec3(0.5, 0.0, 0.0),
+            target_positions=target,
+        )
+
+        with test.assertRaisesRegex(ValueError, "dtype wp.bool"):
+            ik.IKSolver(
+                model,
+                1,
+                [objective],
+                joint_dof_mask=wp.ones(model.joint_dof_count, dtype=wp.int32, device=device),
+            )
+        with test.assertRaisesRegex(ValueError, "shape"):
+            ik.IKSolver(
+                model,
+                1,
+                [objective],
+                joint_dof_mask=wp.ones(model.joint_dof_count + 1, dtype=wp.bool, device=device),
+            )
+        with test.assertRaisesRegex(ValueError, "LM optimizer"):
+            ik.IKSolver(
+                model,
+                1,
+                [objective],
+                optimizer=ik.IKOptimizer.LBFGS,
+                joint_dof_mask=wp.ones(model.joint_dof_count, dtype=wp.bool, device=device),
+            )
+        with test.assertRaisesRegex(ValueError, "sampler='none'"):
+            ik.IKSolver(
+                model,
+                1,
+                [objective],
+                sampler=ik.IKSampler.GAUSS,
+                joint_dof_mask=wp.ones(model.joint_dof_count, dtype=wp.bool, device=device),
+            )
+
+
 def test_convergence_analytic_descendant_free_distance(test, device, joint_type):
     with wp.ScopedDevice(device):
         n_problems = 2
@@ -592,6 +662,15 @@ for joint_type in (newton.JointType.FREE, newton.JointType.DISTANCE):
 add_function_test(TestIKModes, "test_convergence_autodiff_d6", test_convergence_autodiff_d6, cuda_devices)
 add_function_test(TestIKModes, "test_convergence_analytic_d6", test_convergence_analytic_d6, devices)
 add_function_test(TestIKModes, "test_convergence_mixed_d6", test_convergence_mixed_d6, devices)
+for mode in ik.IKJacobianType:
+    add_function_test(
+        TestIKModes,
+        f"test_joint_dof_mask_{mode.value}",
+        test_joint_dof_mask,
+        devices,
+        mode=mode,
+    )
+add_function_test(TestIKModes, "test_joint_dof_mask_validation", test_joint_dof_mask_validation, devices)
 
 # Jacobian equality
 add_function_test(TestIKModes, "test_position_jacobian_compare", test_position_jacobian_compare, devices)


### PR DESCRIPTION
 ## Description

  - Add a `joint_dof_mask` argument to `newton.ik.IKSolver`.
  - Allow selected joint DOFs to remain fixed while the LM optimizer updates the
  remaining DOFs.
  - Apply the mask consistently to analytic, autodiff, and mixed Jacobians.
  - Validate the mask dtype, shape, device, optimizer, and sampler
  configuration.
  - Add tests covering mask behavior and invalid configurations.

https://github.com/user-attachments/assets/6c634297-35da-436e-b3ea-c35925ccb6bb

  This is useful for humanoid control and other IK tasks where only a subset of
  the model's joint DOFs should be optimized, without rebuilding the model or
  modifying the IK objectives.

  ## Checklist

  - [x] New or existing tests cover these changes
  - [x] The documentation is up to date with these changes
  - [x] `CHANGELOG.md` has been updated (if user-facing change)

  ## Test plan

  ```bash
  uv run --extra dev -m newton.tests -k test_joint_dof_mask

  ## New feature / API change

  joint_dof_mask is a model-wide boolean array with one entry per joint DOF. A
  False entry keeps the corresponding DOF fixed, while a True entry allows it to
  be optimized.

  The mask currently supports the LM optimizer with sampling disabled.

  import warp as wp

  from newton import ik

  joint_dof_mask = wp.array(
      [False, True, True],
      dtype=wp.bool,
      device=model.device,
  )

  solver = ik.IKSolver(
      model,
      n_problems=1,
      objectives=objectives,
      optimizer=ik.IKOptimizer.LM,
      sampler=ik.IKSampler.NONE,
      joint_dof_mask=joint_dof_mask,
  )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional joint DOF mask to the inverse kinematics solver.
  * Selected joint degrees of freedom can now remain fixed during Levenberg–Marquardt optimization.

* **Bug Fixes**
  * Masking is now applied to Jacobian sensitivity so masked DOFs do not affect the LM linear solve.

* **Tests**
  * Added coverage for masked joint behavior across Jacobian modes and for rejecting invalid mask configurations.

* **Documentation**
  * Documented the new option in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->