### PR TITLE
Disable CPU graph capture in Style3D cloth examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,6 @@
 - Fix `SolverXPBD` rigid restitution activation so contact thickness is not double-counted after applying contact offsets. (#3034)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix `SolverMuJoCo` convergence tolerance scaling for models with kinematic bodies.
-- Fix Style3D cloth examples intermittently producing non-finite particle state on CPU by not using graph capture, which cannot record the solver's host-side operations.
 - Fix `SolverMuJoCo` inertia randomization for bodies initialized with diagonal inertia.
 - Fix `SolverMuJoCo` static worldbody geometry poses so offset batched worlds collide with their local geometry.
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 - Fix `SolverXPBD` rigid restitution activation so contact thickness is not double-counted after applying contact offsets. (#3034)
 - Fix `SolverKamino` contact filtering and constraint stabilization so gap/margin contacts are handled consistently, positive-distance contacts can be filtered as configured, and converted contact forces/wrenches populate matching Newton contact slots for `SensorContact`. (#2908)
 - Fix `SolverMuJoCo` convergence tolerance scaling for models with kinematic bodies.
+- Fix Style3D cloth examples intermittently producing non-finite particle state on CPU by not using graph capture, which cannot record the solver's host-side operations.
 - Fix `SolverMuJoCo` inertia randomization for bodies initialized with diagonal inertia.
 - Fix `SolverMuJoCo` static worldbody geometry poses so offset batched worlds collide with their local geometry.
 - Fix memory growth in the Style3D solver when CUDA Graph capture is disabled

--- a/newton/examples/cloth/example_cloth_h1.py
+++ b/newton/examples/cloth/example_cloth_h1.py
@@ -188,6 +188,9 @@ class Example:
     # ----------------------------------------------------------------------
     def capture(self):
         self.graph = None
+        # SolverStyle3D makes host calls (PCG dot products, BVH refit) that CPU graph capture cannot record
+        if wp.get_device().is_cpu:
+            return
         with wp.ScopedCapture() as cap:
             self.simulate()
         self.graph = cap.graph
@@ -294,8 +297,10 @@ class Example:
             self._push_targets_from_gizmos()
             if self.graph:
                 wp.capture_launch(self.graph)
-            else:
+            elif wp.get_device().is_cuda:
                 self.capture()
+            else:
+                self.simulate()
             self.sim_time += self.frame_dt
         self.frame_index += 1
 

--- a/newton/examples/cloth/example_cloth_hanging.py
+++ b/newton/examples/cloth/example_cloth_hanging.py
@@ -148,6 +148,10 @@ class Example:
         self.capture()
 
     def capture(self):
+        # SolverStyle3D makes host calls (PCG dot products, BVH refit) that CPU graph capture cannot record
+        if self.solver_type == "style3d" and wp.get_device().is_cpu:
+            self.graph = None
+            return
         with wp.ScopedCapture() as capture:
             self.simulate()
         self.graph = capture.graph

--- a/newton/examples/cloth/example_cloth_style3d.py
+++ b/newton/examples/cloth/example_cloth_style3d.py
@@ -136,6 +136,10 @@ class Example:
         self.capture()
 
     def capture(self):
+        # SolverStyle3D makes host calls (PCG dot products, BVH refit) that CPU graph capture cannot record
+        if wp.get_device().is_cpu:
+            self.graph = None
+            return
         with wp.ScopedCapture() as capture:
             self.simulate()
         self.graph = capture.graph


### PR DESCRIPTION
## Description

Since #3387 enabled CPU graph capture, `example_cloth_hanging_style3d_cpu` fails intermittently on macOS CI with `NaN members found in state_0: ['particle_q', 'particle_qd']` (first occurrence minutes after the merge; 8 of the 15 failed macOS unittest jobs since, across unrelated PRs).

Warp's CPU (APIC) capture records kernel launches, memcpys, and memsets, but `SolverStyle3D.step()` also issues raw host calls: the PCG dot products go through `runtime.core.wp_array_inner_float_host` and the self-collision BVH update through `wp.Bvh.refit()`. Those execute once at capture time — reading the still-uninitialized PCG buffers — and are absent from the replayed graph, so `rTz`/`pTAp` stay frozen at garbage-derived values for the entire run. Depending on heap contents the linear solve is either a no-op (test passes with an inert cloth) or diverges to non-finite state (test fails), which is the flakiness.

This PR runs the three Style3D examples (`cloth_hanging --solver style3d`, `cloth_style3d`, `cloth_h1`) uncaptured on CPU, mirroring the MPM examples' existing practice of gating capture when the solver does non-capturable host-side work. CUDA behavior is unchanged: the corresponding `_device` calls are stream-ordered and recorded by CUDA graph capture, which is why the CUDA variants never failed.

Follow-ups not addressed here:

- Making the Style3D PCG capture-safe by replacing the raw `array_inner` host call with a `wp.launch`-based reduction (also removes a private-API dependency of the kind that broke in #2520/#3460). `wp.Bvh.refit()` would still be unrecordable, so the gate stays until Warp adds APIC support (or a loud error) for it.
- VBD examples with `particle_enable_self_contact=True` and the coupled ADMM example hit the same class of issue under CPU capture (`Bvh.refit()` / `HashGrid.build()` never replayed, so self-contact runs against stale acceleration structures). This is silent staleness rather than a NaN flake, and gating them would remove a large part of #3387's coverage, so it deserves its own discussion.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
CUDA_VISIBLE_DEVICES= uv run --extra dev -m newton.tests -k test_cloth.example_cloth_hanging_style3d
uv run -m newton.examples cloth_style3d --device cpu --viewer null --num-frames 3
uv run -m newton.examples cloth_h1 --device cpu --viewer null --num-frames 3
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run `uv run -m newton.examples cloth_hanging --solver style3d --device cpu --viewer null --test` repeatedly on macOS ARM (warp-lang 1.15.0.dev20260626).
2. Intermittently fails with `ValueError: NaN members found in state_0: ['particle_q', 'particle_qd']`, e.g. https://github.com/newton-physics/newton/actions/runs/29237267733/job/86775022576.

**Minimal reproduction:**

```python
# Shows the mechanism: a raw host reduction is not recorded by CPU graph capture.
import warp as wp
from warp._src.context import runtime

@wp.kernel
def fill(a: wp.array(dtype=wp.vec3)):
    a[wp.tid()] = wp.vec3(1.0, 2.0, 3.0)

with wp.ScopedDevice("cpu"):
    a = wp.array(shape=8, dtype=wp.vec3)  # uninitialized, like PcgSolver's r/z/p/Ap
    out = wp.zeros(1, dtype=float)
    with wp.ScopedCapture() as capture:
        wp.launch(fill, dim=8, inputs=[a])
        # style3d's PcgSolver.array_inner:
        runtime.core.wp_array_inner_float_host(a.ptr, a.ptr, out.ptr, 8, 12, 12, 3)
    wp.capture_launch(capture.graph)
    print(out.numpy()[0])  # garbage from capture time, not 112 = 8 * |(1,2,3)|^2
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent non-finite particle states in Style3D cloth examples when running on CPU.
  * Improved CPU execution by bypassing unsupported graph capture and running simulations directly.
  * Preserved graph-capture behavior for compatible CUDA devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->