### PR TITLE
Export fully-locked D6 roots as MuJoCo mocap bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)
 - Raise an error when `SolverVBD(rigid_contact_history=True)` would allocate or grow contact-history buffers during CUDA graph capture; construct `CollisionPipeline` before `SolverVBD`, or run one uncaptured solver step before capture.
 - Fix `SensorTiledCamera.utils.convert_ray_depth_to_forward_depth()` to preserve the clear-depth sentinel for zero-direction rays and non-positive depths.
+- Fix `SolverMuJoCo` placing articulations whose root is a fully-locked D6 joint (e.g. imported from a generic USD `PhysicsJoint`) at the first world's root pose in every world; such roots now become mocap bodies like fixed-joint roots. (#3430)
 - Fix `ViewerGL.get_frame()` crashing when a CPU model is rendered while a CUDA context is active.
 - Fix `eval_inverse_dynamics()` and `SolverFeatherstone` intermittently dropping descendant wrench contributions during the articulated-body backward pass on CUDA.
 - Fix XPBD particle-particle contacts to avoid non-finite particle state for exact-overlap contacts. (#1562)

--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -714,7 +714,9 @@ by joint type:
 - **Roots attached to world with a fixed joint** become MuJoCo mocap
   bodies (whether kinematic or not). MuJoCo has no joint coordinates
   for a fixed root, so Newton drives the pose through
-  ``mjData.mocap_pos`` and ``mjData.mocap_quat`` instead.
+  ``mjData.mocap_pos`` and ``mjData.mocap_quat`` instead. A D6 root
+  with all axes locked (e.g. imported from a generic USD
+  ``PhysicsJoint``) is treated the same way.
 - **World-attached shapes that are not part of an articulation**
   remain ordinary static MuJoCo geometry rather than mocap bodies.
 

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5795,8 +5795,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             parent = int(joint_parent[j])
             j_type = int(joint_type[j])
             # Articulated fixed roots remain mocap bodies because Newton can
-            # update their root transform at runtime.
-            is_fixed_root = parent == -1 and j_type == JointType.FIXED
+            # update their root transform at runtime. Fully-locked D6 roots
+            # (e.g. imported from a generic USD PhysicsJoint) are equivalent;
+            # without mocap they would be baked at the template world's pose
+            # for every world.
+            is_fixed_root = parent == -1 and (
+                j_type == JointType.FIXED or (j_type == JointType.D6 and joint_dof_dim[j][0] + joint_dof_dim[j][1] == 0)
+            )
             body, parent, child, child_is_kinematic, j_type, child_xform = add_body_from_joint(
                 int(j), mocap=is_fixed_root
             )
@@ -6667,7 +6672,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
             # Create mjc_mocap_to_newton_jnt: MuJoCo[world, mocap] -> Newton joint index.
             # These mocap bodies are Newton roots attached to world by a
-            # FIXED joint. Static world shapes are not represented here.
+            # FIXED or fully-locked D6 joint. Static world shapes are not
+            # represented here.
             nmocap = self.mj_model.nmocap
             if nmocap > 0:
                 mjc_mocap_to_newton_jnt_np = np.full((nworld, nmocap), -1, dtype=np.int32)

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
 import math
 import os
 import tempfile
@@ -2238,8 +2239,8 @@ class TestMuJoCoSolverKinematicBodyProperties(unittest.TestCase):
         self._assert_armature_matches_flags(model, solver)
 
     def test_fixed_root_attached_to_world_uses_mocap_and_tracks_pose(self):
-        for is_kinematic in (False, True):
-            with self.subTest(is_kinematic=is_kinematic):
+        for root_joint_kind, is_kinematic in itertools.product(("fixed", "locked_d6"), (False, True)):
+            with self.subTest(root_joint_kind=root_joint_kind, is_kinematic=is_kinematic):
                 builder = newton.ModelBuilder()
                 root = builder.add_link(
                     mass=1.0,
@@ -2248,7 +2249,11 @@ class TestMuJoCoSolverKinematicBodyProperties(unittest.TestCase):
                     is_kinematic=is_kinematic,
                     label="fixed_root",
                 )
-                root_joint = builder.add_joint_fixed(parent=-1, child=root)
+                if root_joint_kind == "fixed":
+                    root_joint = builder.add_joint_fixed(parent=-1, child=root)
+                else:
+                    # zero-DOF D6, as imported from a generic USD PhysicsJoint
+                    root_joint = builder.add_joint_d6(parent=-1, child=root)
                 builder.add_articulation([root_joint])
 
                 model = builder.finalize(requires_grad=False)
@@ -2323,6 +2328,64 @@ class TestMuJoCoSolverKinematicBodyProperties(unittest.TestCase):
                     atol=1e-6,
                     err_msg=f"xquat should track the fixed-root {body_kind} transform",
                 )
+
+    def test_world_attached_root_multi_world_placement(self):
+        """Replicated world-attached roots must sit at each world's own root transform."""
+        world_count = 3
+        for root_joint_kind in ("fixed", "locked_d6"):
+            with self.subTest(root_joint_kind=root_joint_kind):
+                template = newton.ModelBuilder()
+                root = template.add_link(
+                    mass=1.0,
+                    com=wp.vec3(0.0, 0.0, 0.0),
+                    inertia=wp.mat33(np.eye(3)),
+                    label="root",
+                )
+                root_xform = wp.transform(wp.vec3(0.0, 0.0, 1.0), wp.quat_identity())
+                if root_joint_kind == "fixed":
+                    root_joint = template.add_joint_fixed(parent=-1, child=root, parent_xform=root_xform)
+                else:
+                    # zero-DOF D6, as imported from a generic USD PhysicsJoint
+                    root_joint = template.add_joint_d6(parent=-1, child=root, parent_xform=root_xform)
+                link = template.add_link(
+                    mass=1.0,
+                    com=wp.vec3(0.0, 0.0, 0.0),
+                    inertia=wp.mat33(np.eye(3)),
+                    label="link",
+                )
+                hinge = template.add_joint_revolute(root, link, axis=wp.vec3(0.0, 1.0, 0.0))
+                template.add_articulation([root_joint, hinge])
+
+                builder = newton.ModelBuilder()
+                builder.replicate(template, world_count, spacing=(2.0, 0.0, 0.0))
+                model = builder.finalize(requires_grad=False)
+                solver = SolverMuJoCo(model, iterations=1, disable_contacts=True)
+
+                self.assertEqual(solver.mj_model.nmocap, 1, "World-attached root should be exported as mocap")
+
+                # Refresh derived poses from the per-world root placement.
+                solver._mujoco_warp.kinematics(solver.mjw_model, solver.mjw_data)
+
+                joint_parent = model.joint_parent.numpy()
+                joint_world = model.joint_world.numpy()
+                joint_child = model.joint_child.numpy()
+                joint_X_p = model.joint_X_p.numpy()
+                mjc_body_to_newton = solver.mjc_body_to_newton.numpy()
+                xpos = solver.mjw_data.xpos.numpy()
+
+                root_joints = np.where(joint_parent == -1)[0]
+                self.assertEqual(len(root_joints), world_count)
+                for j in root_joints:
+                    world = int(joint_world[j])
+                    newton_root = int(joint_child[j])
+                    matching = np.where(mjc_body_to_newton[world] == newton_root)[0]
+                    self.assertEqual(len(matching), 1, "Expected a unique MuJoCo body for the root")
+                    np.testing.assert_allclose(
+                        xpos[world, matching[0]],
+                        joint_X_p[j][:3],
+                        atol=1e-6,
+                        err_msg=f"world {world} root must sit at its own joint_X_p, not the template world's",
+                    )
 
 
 class TestMuJoCoSolverGeomProperties(TestMuJoCoSolverPropertiesBase):


### PR DESCRIPTION
## Description

Articulation roots attached to the world by a D6 joint with all axes locked were exported as plain MuJoCo worldbody children whose `body_pos` came from the single-world template. In separate-worlds mode every world then simulated the articulation at the first world's root pose, while per-world static shapes and free bodies were placed at their true per-world transforms — so robots in worlds > 0 never collided with their own static geometry.

This is exactly what the UR10 asset produces: its root is authored as a generic USD `PhysicsJoint` (`def PhysicsJoint "rootJoint"`), which OpenUSD classifies as a D6 joint, not a `PhysicsFixedJoint`. Closes #3430: the arm/pedestal overlap reported there is not a 1.4 regression (bit-identical behavior on 1.3.0) — `robot_ur10` runs with `disable_contacts=True`, so visual interpenetration is expected in that example. This PR fixes the underlying engine bug found while verifying it: enabling contacts only worked for world 0 because all worlds' robots were simulated at the first world's pose.

The fix treats fully-locked D6 world-attached roots the same as `FIXED` roots: they become mocap bodies, so the existing per-world mocap path places each world at its own `joint_X_p`, and runtime root-transform updates via `notify_model_changed(JOINT_PROPERTIES)` now work for these assets as well.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev python -m unittest \
  newton.tests.test_mujoco_solver.TestMuJoCoSolverKinematicBodyProperties.test_world_attached_root_multi_world_placement \
  newton.tests.test_mujoco_solver.TestMuJoCoSolverKinematicBodyProperties.test_fixed_root_attached_to_world_uses_mocap_and_tracks_pose
uv run --extra dev -m newton.tests -k test_mujoco_solver
uv run --extra dev -m newton.tests -k test_robot.example_robot_ur10
uv run --extra dev -m newton.tests -k test_robot.example_robot_allegro_hand
```

## Bug fix

**Steps to reproduce:**

1. Build an articulation whose root joint is a zero-DOF D6 to world (or import a USD asset with a generic `PhysicsJoint` root, e.g. `universal_robots_ur10`).
2. Replicate it across multiple worlds with non-zero spacing and create a `SolverMuJoCo`.
3. Observe that every world's root sits at the first world's pose in MuJoCo (`mjw_data.xpos`), so worlds > 0 do not collide with their own static geometry.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton

template = newton.ModelBuilder()
root = template.add_link(mass=1.0, com=wp.vec3(0.0, 0.0, 0.0), inertia=wp.mat33(np.eye(3)))
root_joint = template.add_joint_d6(parent=-1, child=root, parent_xform=wp.transform(wp.vec3(0.0, 0.0, 1.0)))
template.add_articulation([root_joint])

builder = newton.ModelBuilder()
builder.replicate(template, 2, spacing=(2.0, 0.0, 0.0))
model = builder.finalize()

solver = newton.solvers.SolverMuJoCo(model)
print(solver.mj_model.nmocap)  # 0 without this PR, 1 with it
print(solver.mjw_data.xpos.numpy()[:, 1])  # both worlds at (0, 0, 1) without this PR
```
