### PR TITLE
Fix recording example contact gap

### DIFF
--- a/newton/examples/basic/example_recording.py
+++ b/newton/examples/basic/example_recording.py
@@ -22,7 +22,7 @@ import newton.examples
 
 
 class Example:
-    def __init__(self, viewer, _args):
+    def __init__(self, viewer, args):
         # Setup simulation parameters
         self.fps = 60
         self.frame_dt = 1.0 / self.fps
@@ -31,7 +31,7 @@ class Example:
         self.sim_dt = self.frame_dt / self.sim_substeps
 
         self.viewer = viewer
-        self.world_count = 100
+        self.world_count = args.world_count
 
         # Set numpy random seed for reproducibility
         self.seed = 123
@@ -42,7 +42,6 @@ class Example:
         mjcf_filename = newton.examples.get_asset("nv_humanoid.xml")
 
         articulation_builder = newton.ModelBuilder()
-        # Preserve MuJoCo's zero default for the unauthored geom gaps in this asset.
         articulation_builder.default_shape_cfg.gap = 0.0
         articulation_builder.add_mjcf(
             mjcf_filename,
@@ -109,41 +108,45 @@ class Example:
             lambda q, qd: q[2] > -0.1,
         )
 
+    @staticmethod
+    def create_parser():
+        parser = newton.examples.create_parser()
+        newton.examples.add_world_count_arg(parser)
+        parser.add_argument("recording_file", nargs="?", default="humanoid_recording.bin")
+        parser.set_defaults(num_frames=1000, world_count=100)
+        return parser
+
 
 if __name__ == "__main__":
-    # Create ViewerFile for automatic recording
-    import sys
+    parser = Example.create_parser()
+    test_args, _ = parser.parse_known_args()
 
-    recording_file = "humanoid_recording.bin"
+    if test_args.test:
+        viewer, args = newton.examples.init(parser)
+        newton.examples.run(Example(viewer, args), args)
+        raise SystemExit(0)
 
-    # Check if user wants a different filename from command line
-    if len(sys.argv) > 1 and not sys.argv[1].startswith("-"):
-        recording_file = sys.argv[1]
-
-    print(f"Recording simulation to: {recording_file}")
+    args = parser.parse_args()
+    print(f"Recording simulation to: {args.recording_file}")
     print("ViewerFile will automatically save when the simulation ends.")
 
-    parser = newton.examples.create_parser()
-    args = parser.parse_args()
-
     # Create ViewerFile with auto_save=False to only save at the end
-    viewer = newton.viewer.ViewerFile(recording_file, auto_save=False)
+    viewer = newton.viewer.ViewerFile(args.recording_file, auto_save=False)
 
     # Create example
     example = Example(viewer, args)
 
     # Run for a reasonable number of frames
-    max_frames = 1000
     frame_count = 0
 
-    while frame_count < max_frames:
+    while frame_count < args.num_frames:
         example.step()
         example.render()
         frame_count += 1
 
         if frame_count % 100 == 0:
-            print(f"Frame {frame_count}/{max_frames}")
+            print(f"Frame {frame_count}/{args.num_frames}")
 
     # Close viewer (automatically saves recording)
     viewer.close()
-    print(f"Recording completed: {recording_file}")
+    print(f"Recording completed: {args.recording_file}")

--- a/newton/examples/basic/example_recording.py
+++ b/newton/examples/basic/example_recording.py
@@ -42,6 +42,8 @@ class Example:
         mjcf_filename = newton.examples.get_asset("nv_humanoid.xml")
 
         articulation_builder = newton.ModelBuilder()
+        # Preserve MuJoCo's zero default for the unauthored geom gaps in this asset.
+        articulation_builder.default_shape_cfg.gap = 0.0
         articulation_builder.add_mjcf(
             mjcf_filename,
             ignore_names=["floor", "ground"],
@@ -52,6 +54,7 @@ class Example:
         articulation_builder.joint_q[:7] = [0.0, 0.0, 1.5, *start_rot]
 
         builder = newton.ModelBuilder()
+        builder.default_shape_cfg.gap = 0.0
         for _i in range(self.world_count):
             articulation_builder.joint_q[7:] = self.rng.uniform(
                 -1.0, 1.0, size=(len(articulation_builder.joint_q) - 7,)
@@ -99,7 +102,12 @@ class Example:
         self.viewer.end_frame()
 
     def test_final(self):
-        pass
+        newton.examples.test_body_state(
+            self.model,
+            self.state_0,
+            "body origins remain above the ground",
+            lambda q, qd: q[2] > -0.1,
+        )
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -27,6 +27,7 @@ from typing import Any
 import warp as wp
 
 import newton.tests.unittest_utils
+from newton.examples.basic.example_recording import Example as RecordingExample
 from newton.tests.unittest_utils import (
     USD_AVAILABLE,
     NewtonTestCase,
@@ -291,10 +292,55 @@ class TestBasicExamples(NewtonTestCase):
     pass
 
 
+class TestRecordingExample(NewtonTestCase):
+    pass
+
+
+def test_recording_body_stability(test, device):
+    original_quiet = wp.config.quiet
+    wp.config.quiet = True
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir, wp.ScopedDevice(device):
+            recording_path = os.path.join(temp_dir, "humanoid_recording.bin")
+            recorder = newton.viewer.ViewerFile(recording_path, auto_save=False)
+            example = RecordingExample(recorder, None)
+            for _ in range(120):
+                example.step()
+
+            example.render()
+            example.test_final()
+            recorder.save_recording(verbose=False)
+
+            replay = newton.viewer.ViewerFile(recording_path, auto_save=False)
+            replay.load_recording()
+            test.assertEqual(replay.get_frame_count(), 1)
+
+            replay_model = newton.Model()
+            replay.load_model(replay_model)
+            replay_state = replay_model.state()
+            replay.load_state(replay_state, 0)
+            newton.examples.test_body_state(
+                replay_model,
+                replay_state,
+                "recorded body origins remain above the ground",
+                lambda q, qd: q[2] > -0.1,
+            )
+    finally:
+        wp.config.quiet = original_quiet
+
+
 def add_basic_example_test(**kwargs):
     extra_allow_output_regexes = kwargs.pop("allow_output_regexes", None) or ()
     allow_output_regexes = [*_BASIC_EXAMPLE_ALLOW_OUTPUT_REGEXES, *extra_allow_output_regexes]
     add_example_test(TestBasicExamples, allow_output_regexes=allow_output_regexes, **kwargs)
+
+
+add_function_test(
+    TestRecordingExample,
+    "test_basic.example_recording_body_stability",
+    test_recording_body_stability,
+    devices=cuda_test_devices,
+)
 
 
 add_basic_example_test(name="basic.example_basic_pendulum", devices=test_devices, use_viewer=True)

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -27,7 +27,6 @@ from typing import Any
 import warp as wp
 
 import newton.tests.unittest_utils
-from newton.examples.basic.example_recording import Example as RecordingExample
 from newton.tests.unittest_utils import (
     USD_AVAILABLE,
     NewtonTestCase,
@@ -292,58 +291,20 @@ class TestBasicExamples(NewtonTestCase):
     pass
 
 
-class TestRecordingExample(NewtonTestCase):
-    pass
-
-
-def test_recording_body_stability(test, device):
-    original_quiet = wp.config.quiet
-    wp.config.quiet = True
-    try:
-        with tempfile.TemporaryDirectory() as temp_dir, wp.ScopedDevice(device):
-            recording_path = os.path.join(temp_dir, "humanoid_recording.bin")
-            recorder = newton.viewer.ViewerFile(recording_path, auto_save=False)
-            example = RecordingExample(recorder, None)
-            for _ in range(120):
-                example.step()
-
-            example.render()
-            example.test_final()
-            recorder.save_recording(verbose=False)
-
-            replay = newton.viewer.ViewerFile(recording_path, auto_save=False)
-            replay.load_recording()
-            test.assertEqual(replay.get_frame_count(), 1)
-
-            replay_model = newton.Model()
-            replay.load_model(replay_model)
-            replay_state = replay_model.state()
-            replay.load_state(replay_state, 0)
-            newton.examples.test_body_state(
-                replay_model,
-                replay_state,
-                "recorded body origins remain above the ground",
-                lambda q, qd: q[2] > -0.1,
-            )
-    finally:
-        wp.config.quiet = original_quiet
-
-
 def add_basic_example_test(**kwargs):
     extra_allow_output_regexes = kwargs.pop("allow_output_regexes", None) or ()
     allow_output_regexes = [*_BASIC_EXAMPLE_ALLOW_OUTPUT_REGEXES, *extra_allow_output_regexes]
     add_example_test(TestBasicExamples, allow_output_regexes=allow_output_regexes, **kwargs)
 
 
-add_function_test(
-    TestRecordingExample,
-    "test_basic.example_recording_body_stability",
-    test_recording_body_stability,
-    devices=cuda_test_devices,
-)
-
-
 add_basic_example_test(name="basic.example_basic_pendulum", devices=test_devices, use_viewer=True)
+
+add_basic_example_test(
+    name="basic.example_recording",
+    devices=test_devices,
+    use_viewer=True,
+    test_options={"num-frames": 120, "world-count": 8},
+)
 
 add_basic_example_test(
     name="basic.example_basic_urdf",


### PR DESCRIPTION
## Description

Closes #3493.

Fix the `recording` example humanoids falling through the ground after Newton started forwarding `Model.shape_gap` to MuJoCo.

The humanoid MJCF does not author geometry gaps, so its shapes inherited Newton's `0.1 m` default. This generated enough inactive contacts to overflow MuJoCo Warp's contact and constraint buffers, producing invalid recorded states.

This PR sets the humanoid and ground gaps to zero, matching the asset's MuJoCo behavior without increasing `nconmax` or `njmax`.

It also registers the example with the standard test harness. The regression runs eight humanoids for 120 frames on CPU and CUDA and verifies that their bodies remain above the ground. Recording serialization remains covered by `test_recorder.py`.

## Checklist

- [x] New or existing tests cover these changes
- [x] No documentation changes are required
- [x] No changelog entry is needed because this fixes an unreleased regression

## Test plan

```bash
uv run --extra dev -m newton.tests --strict-warnings -k test_basic.example_recording
```

```bash
uv run -m newton.examples recording
```

For visual verification:

```bash
uv run -m newton.examples replay_viewer
```

Load `humanoid_recording.bin` and verify that the humanoids remain on or above the ground throughout playback.

Results:

- The focused regression passes on CPU and CUDA.
- Removing the zero-gap assignments causes both variants to fail with contact-capacity warnings.
- The 1,000-frame manual recording completes without broadphase or `nefc` overflow warnings.

## Bug fix

**Steps to reproduce:**

1. Run `uv run -m newton.examples recording`.
2. Observe repeated broadphase and `nefc` overflow warnings.
3. Run `uv run -m newton.examples replay_viewer`.
4. Load `humanoid_recording.bin`.
5. Observe some humanoids penetrating or falling through the ground.

**Minimal reproduction:**

```bash
uv run -m newton.examples recording
```
