### PR TITLE
Extend CPU graph capture coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
+- Fix `SolverKamino` CG/CR solves silently under-iterating on CPU graph capture; the capture-safe loop path now runs on any capturing device, not only CUDA, so CPU captures no longer record a stale host-readback convergence decision at record time.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.
 - Fix `cloth_franka` example rendering particles at simulation scale (cm) instead of viewer scale (m)
 - Fix `ModelBuilder` merges to accept array-valued transform fields and plain-list particle color groups.

--- a/docs/concepts/simulation_tuning_solvers.rst
+++ b/docs/concepts/simulation_tuning_solvers.rst
@@ -157,15 +157,21 @@ repository examples spend tuning effort, not a shared solver API.
        ``particle_topological_contact_filter_threshold``,
        ``particle_rest_shape_contact_exclusion_radius``.
      - Contact history requires matched contacts, for example
-       ``CollisionPipeline(contact_matching="latest")``. When recording VBD
-       steps in a CUDA graph, construct :class:`~newton.CollisionPipeline`
-       before :class:`~newton.solvers.SolverVBD` so contact history is
-       pre-allocated, or run one uncaptured solver step before capture. Buffer
-       sizes that are too small can drop contacts; sizes that are too large cost
-       memory and performance. Examples commonly tune ``iterations``, particle
-       self-contact radius and margin, particle contact buffers and filters,
-       ``particle_collision_detection_interval``, ``particle_enable_tile_solve``,
-       ``rigid_body_contact_buffer_size``,
+       ``CollisionPipeline(contact_matching="latest")``. Contact history is
+       cross-replay-persistent state, so it must always be pre-allocated
+       before graph capture on any device: allocating it inside a graph
+       records a ``wp.zeros`` fill that wipes the warm-start buffers on every
+       replay. Construct :class:`~newton.CollisionPipeline` before
+       :class:`~newton.solvers.SolverVBD` so contact history is pre-allocated,
+       or run one uncaptured solver step before capture. Ordinary contact
+       buffers can still grow on demand during graph capture on CPU and on
+       CUDA with the memory pool enabled; only CUDA capture without a memory
+       pool requires that they also be pre-allocated. Buffer sizes that are
+       too small can drop contacts; sizes that are too large cost memory and
+       performance. Examples commonly tune
+       ``iterations``, particle self-contact radius and margin, particle
+       contact buffers and filters, ``particle_collision_detection_interval``,
+       ``particle_enable_tile_solve``, ``rigid_body_contact_buffer_size``,
        ``rigid_body_particle_contact_buffer_size``, ``rigid_contact_hard``,
        ``rigid_contact_history``, and ``rigid_avbd_contact_alpha``.
    * - :class:`~newton.solvers.SolverFeatherstone`

--- a/newton/_src/solvers/kamino/_src/linalg/conjugate.py
+++ b/newton/_src/solvers/kamino/_src/linalg/conjugate.py
@@ -338,7 +338,7 @@ def _run_capturable_loop(
     maxiter: wp.array[int],
     atol_sq: wp.array[Any],
     callback: Callable | None,
-    use_cuda_graph: bool,
+    use_graph: bool,
     use_graph_conditionals: bool = True,
     maxiter_host: int | None = None,
     loop_granularity: int = 1,
@@ -384,7 +384,7 @@ def _run_capturable_loop(
         if callback_launch is not None:
             callback_launch.launch()
 
-    if use_cuda_graph and device.is_cuda and device.is_capturing:
+    if use_graph and device.is_capturing:
         if use_graph_conditionals:
             wp.capture_while(global_condition, do_cycle_with_condition)
         else:
@@ -541,7 +541,7 @@ class ConjugateSolver(Generic[ScalarType, IndexType]):
         maxiter: Maximum iterations per world. If None, defaults to 1.5 * maxdims.
         Mi: Operator applying the inverse preconditioner M^-1, such that Mi @ A has a smaller condition number than A.
         callback: Optional callback kernel invoked each iteration.
-        use_cuda_graph: Whether to use CUDA graph capture for the solve loop.
+        use_graph: Whether to use graph capture for the solve loop.
         loop_granularity: Number of iterations before termination criteria are checked.
     """
 
@@ -555,7 +555,7 @@ class ConjugateSolver(Generic[ScalarType, IndexType]):
         maxiter: wp.array[wp.int32] | None = None,
         Mi: BatchedLinearOperator[ScalarType, IndexType] | None = None,
         callback: Callable | None = None,
-        use_cuda_graph: bool = True,
+        use_graph: bool = True,
         use_graph_conditionals: bool = True,
         loop_granularity: int = 1,
     ):
@@ -593,7 +593,7 @@ class ConjugateSolver(Generic[ScalarType, IndexType]):
         self.loop_granularity = loop_granularity
 
         self.callback = callback
-        self.use_cuda_graph = use_cuda_graph
+        self.use_graph = use_graph
 
         self.dot_tile_size = min(2048, 2 ** math.ceil(math.log(self.maxdims, 2)))
         self.tiled_dot_kernel = make_dot_kernel(self.dot_tile_size, self.maxdims)
@@ -756,7 +756,7 @@ class CGSolver(ConjugateSolver[ScalarType, IndexType]):
             self.maxiter,
             self.atol_sq,
             self.callback,
-            self.use_cuda_graph,
+            self.use_graph,
             use_graph_conditionals=self.use_graph_conditionals,
             maxiter_host=self.maxiter_host,
             loop_granularity=min(self.loop_granularity, self.maxiter_host),
@@ -890,7 +890,7 @@ class CRSolver(ConjugateSolver[ScalarType, IndexType]):
             self.maxiter,
             self.atol_sq,
             self.callback,
-            self.use_cuda_graph,
+            self.use_graph,
             use_graph_conditionals=self.use_graph_conditionals,
             maxiter_host=self.maxiter_host,
             loop_granularity=min(self.loop_granularity, self.maxiter_host),

--- a/newton/_src/solvers/kamino/_src/linalg/linear.py
+++ b/newton/_src/solvers/kamino/_src/linalg/linear.py
@@ -749,7 +749,7 @@ class ConjugateGradientSolver(IterativeSolver[ScalarType, IndexType]):
             maxiter=self._maxiter,
             Mi=self._Mi,
             callback=None,
-            use_cuda_graph=True,
+            use_graph=True,
             use_graph_conditionals=self._use_graph_conditionals,
             loop_granularity=self.loop_granularity,
         )
@@ -763,7 +763,7 @@ class ConjugateGradientSolver(IterativeSolver[ScalarType, IndexType]):
                 maxiter=self._maxiter,
                 Mi=self._Mi,
                 callback=None,
-                use_cuda_graph=True,
+                use_graph=True,
                 use_graph_conditionals=self._use_graph_conditionals,
                 loop_granularity=self.loop_granularity,
             )
@@ -861,7 +861,7 @@ class ConjugateResidualSolver(IterativeSolver[ScalarType, IndexType]):
             maxiter=self._maxiter,
             Mi=self._Mi,
             callback=None,
-            use_cuda_graph=True,
+            use_graph=True,
             use_graph_conditionals=self._use_graph_conditionals,
             loop_granularity=self.loop_granularity,
         )
@@ -875,7 +875,7 @@ class ConjugateResidualSolver(IterativeSolver[ScalarType, IndexType]):
                 maxiter=self._maxiter,
                 Mi=self._Mi,
                 callback=None,
-                use_cuda_graph=True,
+                use_graph=True,
                 use_graph_conditionals=self._use_graph_conditionals,
                 loop_granularity=self.loop_granularity,
             )

--- a/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
@@ -75,7 +75,7 @@ class TestLinalgConjugate(unittest.TestCase):
             maxiter=maxiter,
             Mi=None,
             callback=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         cur_iter, r_norm_sq, atol_sq = solver.solve(b_wp, x_wp)
 
@@ -223,7 +223,7 @@ class TestLinalgConjugate(unittest.TestCase):
             maxiter=None,
             Mi=None,
             callback=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         solver_dense.solve(b_wp, x_dense)
 
@@ -237,7 +237,7 @@ class TestLinalgConjugate(unittest.TestCase):
             maxiter=None,
             Mi=None,
             callback=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         solver_sparse.solve(b_wp, x_sparse)
 
@@ -335,7 +335,7 @@ class TestLinalgConjugate(unittest.TestCase):
             rtol=rtol,
             maxiter=None,
             Mi=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         solver.solve(b_wp, x_wp)
 
@@ -477,7 +477,7 @@ class TestLinalgConjugate(unittest.TestCase):
             maxiter=maxiter,
             Mi=None,
             callback=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         solver.solve(b, x_wp)
 
@@ -570,7 +570,7 @@ class TestLinalgConjugate(unittest.TestCase):
             maxiter=maxiter,
             Mi=Mi,
             callback=None,
-            use_cuda_graph=False,
+            use_graph=False,
         )
         solver.solve(b, x_wp)
 

--- a/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
@@ -139,6 +139,98 @@ class TestLinalgConjugate(unittest.TestCase):
             with self.subTest(problem=problem_name, solver=solver_cls.__name__):
                 self._test_solve(solver_cls, problem_params, device)
 
+    def _test_capture_replay_matches_eager(self, solver_cls, device):
+        """Regression: capture-and-replay must match an eager solve.
+
+        Guards against the class of bug where the capture-safe path in
+        ``_run_capturable_loop`` silently under-iterates. Concretely, if the
+        break decision is frozen at record time via a host readback of stale
+        pre-capture memory, the recorded graph bakes in a fixed cycle count
+        and ``cur_iter`` under capture will be far below the eager count.
+        """
+        device = wp.get_device(device)
+        problem = RandomProblemLLT(
+            maxdims=8,
+            dims=[5, 8],
+            seed=self.seed,
+            np_dtype=np.float32,
+            wp_dtype=wp.float32,
+            device=device,
+        )
+        n_worlds = problem.num_blocks
+
+        info = DenseSquareMultiLinearInfo()
+        info.finalize(dimensions=problem.maxdims, dtype=wp.float32, device=device)
+        info.dim = problem.dim_wp
+        operator = DenseLinearOperatorData(info=info, mat=problem.A_wp)
+        A = BatchedLinearOperator.from_dense(operator)
+
+        world_active = wp.full(n_worlds, True, dtype=wp.bool, device=device)
+        maxdim = max(problem.maxdims)
+        atol = wp.full(n_worlds, 1.0e-4, dtype=problem.wp_dtype, device=device)
+        rtol = wp.full(n_worlds, 1.0e-5, dtype=problem.wp_dtype, device=device)
+        maxiter = wp.full(n_worlds, max(3 * maxdim, 50), dtype=int, device=device)
+
+        def new_solver(*, use_graph):
+            return solver_cls(
+                A=A,
+                world_active=world_active,
+                atol=atol,
+                rtol=rtol,
+                maxiter=maxiter,
+                Mi=None,
+                callback=None,
+                use_graph=use_graph,
+            )
+
+        # Eager reference.
+        x_eager = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
+        eager_cur, _, _ = new_solver(use_graph=False).solve(problem.b_wp, x_eager)
+
+        # Captured replay. Warm up outside capture so kernels compile before
+        # recording; zero the output between the warmup and the capture body
+        # so both solves see the same initial state.
+        solver = new_solver(use_graph=True)
+        x_capture = wp.zeros(info.total_vec_size, dtype=wp.float32, device=device)
+        solver.solve(problem.b_wp, x_capture)
+        x_capture.zero_()
+        # Warp CPU graph capture currently rejects wp.copy() on non-contiguous
+        # arrays. Both the buggy pre-fix eager path (via strided
+        # ``dot_partial_sums[:, :, 0]`` in ``dot_product``) and the fixed
+        # capture path (via ``rz_old.assign(rz_new)`` in ``do_iteration``)
+        # hit that limitation on CPU, so the parity assertions below only
+        # activate once Warp lifts it. The CUDA counterparts exercise the
+        # same gate on a path where the dot buffer is contiguous and no
+        # skip is needed.
+        try:
+            with wp.ScopedCapture(device) as cap:
+                cap_cur, _, _ = solver.solve(problem.b_wp, x_capture)
+        except NotImplementedError as e:
+            if "non-contiguous" not in str(e):
+                raise
+            self.skipTest(f"Warp graph capture limitation on {device}: {e}")
+        assert cap.graph is not None
+        wp.capture_launch(cap.graph)
+
+        np.testing.assert_array_equal(cap_cur.numpy(), eager_cur.numpy())
+        np.testing.assert_array_equal(x_capture.numpy(), x_eager.numpy())
+
+    def test_capture_replay_cg_cpu(self):
+        self._test_capture_replay_matches_eager(CGSolver, "cpu")
+
+    def test_capture_replay_cr_cpu(self):
+        self._test_capture_replay_matches_eager(CRSolver, "cpu")
+
+    def test_capture_replay_cg_cuda(self):
+        if not wp.get_cuda_devices():
+            self.skipTest("No CUDA devices found")
+        self._test_capture_replay_matches_eager(CGSolver, wp.get_cuda_device())
+
+    def test_capture_replay_cr_cuda(self):
+        if not wp.get_cuda_devices():
+            self.skipTest("No CUDA devices found")
+        self._test_capture_replay_matches_eager(CRSolver, wp.get_cuda_device())
+
     def _test_sparse_solve(self, solver_cls, dims, block_size, device):
         """Test CG/CR with sparse matrices built from random SPD matrices.
 

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -22,6 +22,7 @@ from ...sim import (
     State,
     StateFlags,
 )
+from ...utils import is_graph_capture_allocation_enabled
 from ...utils.deprecation import deprecate_nonkeyword_arguments
 from ..coupled.interface import CouplingInterface
 from ..solver import SolverBase
@@ -1156,8 +1157,6 @@ class SolverVBD(SolverBase, CouplingInterface):
         self._prev_contact_normal = wp.zeros(cap, dtype=wp.vec3, device=self.device)
 
     def _raise_if_capturing_resize(self, name: str, current: int, required: int) -> None:
-        from ...utils import is_graph_capture_allocation_enabled  # noqa: PLC0415
-
         if self.device.is_capturing and not is_graph_capture_allocation_enabled(self.device):
             raise RuntimeError(
                 f"SolverVBD {name} buffer needs to grow from {current} to {required} "

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -131,13 +131,16 @@ class SolverVBD(SolverBase, CouplingInterface):
     Buffer sizing:
         SolverVBD pre-allocates contact state from capacities populated by
         :class:`~newton.CollisionPipeline` when available; otherwise, the first
-        :meth:`step` lazily sizes buffers from ``Contacts``. During CUDA graph
-        recording, ordinary lazy resizing is supported only when Warp's memory pool
-        is enabled; otherwise, the solver raises with guidance to pre-size before
-        capture. Rigid contact history must be allocated before capture regardless
-        of memory-pool support. With ``rigid_contact_history=True``, construct
-        :class:`~newton.CollisionPipeline` before ``SolverVBD``, or run one
-        uncaptured solver step before capture.
+        :meth:`step` lazily sizes buffers from ``Contacts``. During graph capture,
+        ordinary lazy resizing is supported on CPU and on CUDA with Warp's
+        stream-ordered memory pool enabled; otherwise the solver raises with
+        guidance to pre-size before capture. Rigid contact history is
+        cross-replay-persistent state, so it must always be allocated before
+        capture regardless of the device's allocation-during-capture support --
+        allocating it inside a graph records a `wp.zeros` fill that wipes the
+        warm-start buffers on every replay. With ``rigid_contact_history=True``,
+        construct :class:`~newton.CollisionPipeline` before ``SolverVBD``, or run
+        one uncaptured solver step before capture.
 
     References:
         - Anka He Chen, Ziheng Liu, Yin Yang, and Cem Yuksel. 2024. Vertex Block Descent. ACM Trans. Graph. 43, 4, Article 116 (July 2024), 16 pages.
@@ -328,7 +331,7 @@ class SolverVBD(SolverBase, CouplingInterface):
                 Requires contacts with ``rigid_contact_match_index`` populated; use
                 ``CollisionPipeline(contact_matching="latest")`` for VBD warm-starting. Ignored
                 when ``integrate_with_external_rigid_solver=True`` or ``model.body_count == 0``.
-                For CUDA graph capture, construct :class:`~newton.CollisionPipeline` before
+                During graph capture, construct :class:`~newton.CollisionPipeline` before
                 ``SolverVBD`` so history is pre-allocated, or run one uncaptured solver step
                 before capture.
             rigid_contact_stick_motion_eps: Tangential contact residual threshold for marking hard
@@ -1724,7 +1727,7 @@ class SolverVBD(SolverBase, CouplingInterface):
 
         Raises:
             RuntimeError: If required rigid contact-matching data is unavailable, or contact-history storage would
-                need to be allocated or grown during CUDA graph capture.
+                need to be allocated or grown during graph capture.
         """
         self._apply_module_options()
         update_rigid = self._update_rigid_history
@@ -2056,11 +2059,17 @@ class SolverVBD(SolverBase, CouplingInterface):
         internal_rigid = model.body_count > 0 and not self.integrate_with_external_rigid_solver
         rigid_capacity = contacts.rigid_contact_max if contacts is not None else 0
 
+        # Rigid contact history is cross-replay-persistent state: allocating it
+        # during capture records a `wp.zeros` fill into the graph, which then
+        # re-zeros the warm-start buffers on every replay -- silently
+        # equivalent to `rigid_contact_history=False`. So this guard fires
+        # unconditionally when capturing, regardless of the device's
+        # allocation-during-capture support.
         if self.device.is_capturing and internal_rigid and self.rigid_contact_history:
             history_capacity = 0 if self._prev_contact_lambda is None else self._prev_contact_lambda.shape[0]
             if history_capacity < rigid_capacity:
                 raise RuntimeError(
-                    "SolverVBD contact history must be allocated before CUDA graph capture. "
+                    "SolverVBD contact history must be allocated before graph capture. "
                     "Construct CollisionPipeline before SolverVBD, or run one uncaptured solver step before capture."
                 )
 

--- a/newton/examples/cable/example_cable_cross_slide_table.py
+++ b/newton/examples/cable/example_cable_cross_slide_table.py
@@ -768,7 +768,7 @@ class Example:
         self.collision_pipeline = newton.CollisionPipeline(self.model)
         self.contacts = self.collision_pipeline.contacts()
 
-        # Device arrays used by kernels during simulation and CUDA graph replay.
+        # Device arrays used by kernels during simulation and captured replay.
         self.kinematic_body_indices = wp.array(
             kinematic_body_indices,
             dtype=wp.int32,
@@ -827,13 +827,10 @@ class Example:
         self.capture()
 
     def capture(self):
-        """Capture the simulation update when running on CUDA."""
-        if self.solver.device.is_cuda:
-            with wp.ScopedCapture() as capture:
-                self.simulate()
-            self.graph = capture.graph
-        else:
-            self.graph = None
+        """Capture the simulation update into a graph for replay."""
+        with wp.ScopedCapture() as capture:
+            self.simulate()
+        self.graph = capture.graph
 
     def simulate(self):
         """Advance the XY table simulation by one rendered frame."""

--- a/newton/examples/cable/example_cable_pile.py
+++ b/newton/examples/cable/example_cable_pile.py
@@ -159,7 +159,7 @@ class Example:
         builder.color()
 
         self.model = builder.finalize()
-        # Size persistent contact history before CUDA graph capture.
+        # Size persistent contact history before graph capture.
         self.collision_pipeline = newton.CollisionPipeline(self.model, contact_matching="latest")
         self.contacts = self.collision_pipeline.contacts()
 

--- a/newton/examples/cable/example_cable_twist.py
+++ b/newton/examples/cable/example_cable_twist.py
@@ -218,13 +218,10 @@ class Example:
         self.capture()
 
     def capture(self):
-        """Capture simulation loop into a CUDA graph for optimal GPU performance."""
-        if self.solver.device.is_cuda:
-            with wp.ScopedCapture() as capture:
-                self.simulate()
-            self.graph = capture.graph
-        else:
-            self.graph = None
+        """Capture simulation loop into a graph for optimal replay performance."""
+        with wp.ScopedCapture() as capture:
+            self.simulate()
+        self.graph = capture.graph
 
     def simulate(self):
         """Execute all simulation substeps for one frame."""

--- a/newton/examples/cable/example_cable_y_junction.py
+++ b/newton/examples/cable/example_cable_y_junction.py
@@ -142,12 +142,9 @@ class Example:
         self.capture()
 
     def capture(self):
-        if self.solver.device.is_cuda:
-            with wp.ScopedCapture() as capture:
-                self.simulate()
-            self.graph = capture.graph
-        else:
-            self.graph = None
+        with wp.ScopedCapture() as capture:
+            self.simulate()
+        self.graph = capture.graph
 
     def simulate(self):
         for _ in range(self.sim_substeps):

--- a/newton/examples/diffsim/example_diffsim_drone.py
+++ b/newton/examples/diffsim/example_diffsim_drone.py
@@ -467,7 +467,7 @@ class Example:
         # We start with -1 since it'll be incremented on the first frame.
         self.target_idx = -1
         # use a Warp array to store the current target so that we can assign
-        # a new target to it while retaining the original CUDA graph.
+        # a new target to it while retaining the original graph.
         self.current_target = wp.array([self.targets[self.target_idx + 1]], dtype=wp.vec3)
 
         # Number of steps to run at each frame for the optimisation pass.

--- a/newton/examples/multiphysics/example_proxy_joint_gripper.py
+++ b/newton/examples/multiphysics/example_proxy_joint_gripper.py
@@ -155,14 +155,14 @@ class Example:
 
     def capture(self) -> None:
         self.graph = None
-        if not self.use_graph or not self.model.device.is_cuda:
+        if not self.use_graph:
             return
 
         with wp.ScopedDevice(self.model.device), wp.ScopedCapture() as capture:
             self.simulate()
         self.graph = capture.graph
         if self.graph is None:
-            raise RuntimeError(f"CUDA graph capture failed on device {self.model.device}")
+            raise RuntimeError(f"Graph capture failed on device {self.model.device}")
 
     def _emit_soft_object(self, builder: newton.ModelBuilder) -> None:
         size = 0.1 if self.scenario == "harsh" else 0.09
@@ -400,7 +400,7 @@ class Example:
             action="store_false",
             dest="graph_capture",
             default=True,
-            help="Disable CUDA graph capture.",
+            help="Disable graph capture.",
         )
         return parser
 

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -1109,7 +1109,7 @@ add_example_test(
 add_example_test(
     TestMultiphysicsExamples,
     name="multiphysics.example_proxy_joint_gripper",
-    devices=cuda_test_devices,
+    devices=test_devices,
     test_options={"num-frames": 120},
     use_viewer=True,
 )

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -1047,7 +1047,7 @@ def _rigid_contact_history_capture_requires_preallocation(test, device):
         return pipeline, solver, contacts, state_in, state_out, control
 
     pipeline, solver, contacts, state_in, state_out, control = make_scene(pipeline_first=False)
-    with test.assertRaisesRegex(RuntimeError, "contact history must be allocated before CUDA graph capture"):
+    with test.assertRaisesRegex(RuntimeError, "contact history must be allocated before graph capture"):
         with wp.ScopedCapture(device=device):
             solver.step(state_in, state_out, control, contacts, 1.0e-3)
 


### PR DESCRIPTION
## Description

This PR finishes several CPU graph-capture follow-ups:

- Fix Kamino CG/CR capture control flow so captured solves use the capture-safe loop path on any capturing device, not only CUDA. This avoids recording a host-readback convergence decision from stale CPU capture data.
- Enable graph capture on CPU in `proxy_joint_gripper` and the remaining cable examples that were still CUDA-gated.
- Update SolverVBD graph-capture guidance and errors to describe device-specific allocation behavior instead of CUDA-only behavior.
- Move the SolverVBD graph-capture allocation helper import to module scope and rename internal Kamino CG/CR graph flags from CUDA-specific wording to device-agnostic wording.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m unittest newton._src.solvers.kamino.tests.test_linalg_solve_cg -v
uv run --extra dev -m newton.tests -k proxy_joint_gripper
uv run --extra dev -m newton.tests -k cable_y_junction_cpu
uv run --extra dev -m newton.tests -k cable_twist_cpu
uv run --extra dev -m newton.tests -k cable_cross_slide_table_cpu
git diff --check origin/main...HEAD
```

The Kamino CG/CR capture-replay tests currently skip on CPU when Warp raises its known non-contiguous CPU `wp.copy()` APIC limitation; any other capture failure is still treated as a test failure.

## Bug fix

**Steps to reproduce:**

1. Capture a Kamino iterative CG/CR solve on CPU.
2. Replay the graph for a solve that requires dynamic convergence.

Without this PR, the loop can record the eager host-readback branch and bake in a stale record-time convergence decision. With this PR, captured solves use the graph-capture loop path whenever the device is capturing.

## New feature / API change

Examples that were already graph-capturable now use the same device-agnostic capture idiom on CPU and CUDA:

```python
with wp.ScopedCapture() as capture:
    self.simulate()
self.graph = capture.graph
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified conjugate-solver graph-capture control via a `use_graph` option (replacing CUDA-specific naming).

- **Bug Fixes**
  - Clarified and fixed behavior differences between graph-captured and eager execution for CG/CR (including potential under-iteration on CPU capture-and-replay).
  - Improved VBD rigid contact-history graph-capture resizing/allocation handling and corresponding guidance/error text.

- **Documentation**
  - Updated capture-time requirements and buffer pre-sizing notes for rigid contact history.

- **Tests**
  - Added CPU capture-and-replay regression tests for CG/CR matching eager results; updated to `use_graph`.

- **Chores**
  - Simplified example graph-capture to run consistently across devices; adjusted related test device coverage and help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->