### PR TITLE
Cherry-pick ADMM particle grid reset fix (#3467) onto release-1.4

### DIFF
--- a/newton/_src/solvers/coupled/solver_coupled_admm.py
+++ b/newton/_src/solvers/coupled/solver_coupled_admm.py
@@ -663,7 +663,6 @@ class SolverCoupledADMM(SolverCoupled):
         self._admm_particle_particle_contact_specs: list[_AdmmParticleParticleContactSpec] = []
         self._admm_collision_pipeline = None
         self._admm_internal_contacts = None
-        self._admm_particle_contact_grid = None
         self._admm_particle_contact_query_radius = 0.0
         self._entry_body_sets: dict[str, set[int]] = {}
         self._entry_particle_sets: dict[str, set[int]] = {}
@@ -1107,14 +1106,14 @@ class SolverCoupledADMM(SolverCoupled):
 
         if self._admm_particle_particle_contact_specs:
             self._validate_particle_particle_contact_specs()
-            self._admm_dynamic_pp_contact_groups = self._build_collision_particle_particle_contact_groups()
-            if self._admm_dynamic_pp_contact_groups:
-                self._admm_particle_contact_query_radius = max(
-                    group.query_radius for group in self._admm_dynamic_pp_contact_groups
-                )
-                with wp.ScopedDevice(self.model.device):
-                    self._admm_particle_contact_grid = wp.HashGrid(128, 128, 128)
-                    self._admm_particle_contact_grid.reserve(self.model.particle_count)
+            if self.model.particle_grid is not None:
+                self._admm_dynamic_pp_contact_groups = self._build_collision_particle_particle_contact_groups()
+                if self._admm_dynamic_pp_contact_groups:
+                    self._admm_particle_contact_query_radius = max(
+                        group.query_radius for group in self._admm_dynamic_pp_contact_groups
+                    )
+                    with wp.ScopedDevice(self.model.device):
+                        self.model.particle_grid.reserve(self.model.particle_count)
 
         # Eagerly allocate the internal contact buffer so it exists before any
         # CUDA graph capture. Lazy allocation during capture leaves a bogus
@@ -3039,10 +3038,11 @@ class SolverCoupledADMM(SolverCoupled):
                 )
 
         if self._admm_dynamic_pp_contact_groups:
-            self._admm_particle_contact_grid.build(
-                state_in.particle_q,
-                radius=self._admm_particle_contact_query_radius,
-            )
+            with wp.ScopedDevice(self.model.device):
+                self.model.particle_grid.build(
+                    state_in.particle_q,
+                    radius=self._admm_particle_contact_query_radius,
+                )
 
         for group in self._admm_dynamic_pp_contact_groups:
             if group.count == 0:
@@ -3094,7 +3094,7 @@ class SolverCoupledADMM(SolverCoupled):
                 particle_particle_contacts_hashgrid_kernel,
                 dim=self.model.particle_count,
                 inputs=[
-                    self._admm_particle_contact_grid.id,
+                    self.model.particle_grid.id,
                     state_in.particle_q,
                     self.model.particle_radius,
                     self.model.particle_flags,

--- a/newton/tests/test_admm_coupled_solver.py
+++ b/newton/tests/test_admm_coupled_solver.py
@@ -190,9 +190,7 @@ def _build_two_particle_contact_scene(
     builder.add_particle(pos=(gap, 0.0, 0.0), vel=vel_a, mass=1.0, radius=radius)
     builder.add_particle(pos=(0.0, 0.0, 0.0), vel=vel_b, mass=1.0, radius=radius)
     builder.color()
-    model = builder.finalize(device="cpu")
-    model.particle_grid = None
-    return model
+    return builder.finalize(device="cpu")
 
 
 def _run_particles(solver, model: newton.Model, n_steps: int = 5, dt: float = 1.0 / 60.0):
@@ -1141,6 +1139,32 @@ class TestAdmmCollisionDetection(unittest.TestCase):
 
         self.assertGreater(solver.collision_contact_count_max, 0)
         self.assertGreater(q_contact[1, 0] - q_contact[0, 0], 0.08 + 1.0e-3)
+
+    def test_collision_particle_particle_contacts_respect_disabled_model_particle_grid(self):
+        model = _build_two_particle_contact_scene(gap=-0.08)
+        model.particle_grid = None
+        solver = SolverCoupledADMM(
+            model=model,
+            entries=[
+                SolverCoupled.Entry(
+                    name="a",
+                    solver=lambda v: SolverSemiImplicit(model=v, enable_tri_contact=False),
+                    particles=[0],
+                ),
+                SolverCoupled.Entry(
+                    name="b",
+                    solver=lambda v: SolverSemiImplicit(model=v, enable_tri_contact=False),
+                    particles=[1],
+                ),
+            ],
+            coupling=SolverCoupledADMM.Config(
+                contact_pairs=[SolverCoupledADMM.ContactPair(source="a", destination="b")],
+            ),
+        )
+
+        _run_particles(solver, model, n_steps=1)
+
+        self.assertEqual(solver.collision_contact_count_max, 0)
 
     def test_collision_frictional_contact_matches_inclined_plane_box_motion(self):
         friction = 0.4


### PR DESCRIPTION
## Description

Fixes #3433. Cherry-picks #3467 (main commit `4ab14bd`) onto `release-1.4` — it merged the day after the branch cut, so 1.4.0rc1 is missing it. Clean pick, no conflicts; the commit keeps its original author and subject. Scoped to one solver file plus its regression tests, already reviewed and merged on main.

The `wp_cuda_load_module` error in #3433 is a deferred report of an earlier async illegal access, not a load problem. On `release-1.4`, `SolverCoupledADMM` still builds a private particle `wp.HashGrid` in addition to `Model.particle_grid` inside the same captured CUDA graph — same defect as #3464. After the example switch, the first replay of the new example's graph faults asynchronously in `step()`; the example module's only kernel (`_gather_particles`) then loads lazily in `render()`, and that module load is simply the first synchronizing call to observe the fault. Confirmed on hardware: rerunning with `CUDA_LAUNCH_BLOCKING=1` moves the 700 out of `wp_cuda_load_module` and into `wp.capture_launch(self.graph)` in `Example.step()`. The visualization toggles are a sensitizer, not the cause — their viewer buffers get freed en masse by `clear_model()` at switch time, which is enough to make the latent fault deterministic (the same switch without the toggles survives, and #3464 hit the same fault intermittently on plain Reset).

The pick follows the same particle-grid pattern as `SolverXPBD` / `SolverSemiImplicit`: use `Model.particle_grid` (reserved before capture), treat `Model.particle_grid = None` as disabling particle-particle contacts, drop the solver-local grid.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

#3467 landed on main without a `CHANGELOG.md` entry, so there is nothing to reconcile on the release branch.

## Test plan

All on this branch (`release-1.4` + this pick), RTX 3090 (driver 580.159.03), Warp 1.15.0 (release pin), Ubuntu 24.04:

```bash
uv run --extra dev -m newton.tests -k test_admm_coupled_solver
uvx pre-commit run --files newton/_src/solvers/coupled/solver_coupled_admm.py newton/tests/test_admm_coupled_solver.py
```

- All 18 ADMM coupled-solver tests pass (includes the new `Model.particle_grid = None` coverage from #3467).
- Scripted the exact #3433 sequence — `robot_g1`, enable Show Joints + Show Contacts + Show Inertia Boxes, switch to `admm_contact_solver` — driving the same code paths the GUI clicks use (`viewer.show_*`, `_ExampleBrowser.switch_target`): **5/5 runs clean**, 400 post-switch frames each. Without the pick, the same script crashes on the first switch with the exact #3433 signature (module hash `bdca494`).
- **10 consecutive Reset cycles** in `admm_contact_solver`: clean (regression check for #3464).
- One `CUDA_LAUNCH_BLOCKING=1` switch run: no relocated faults.
- Controls on unfixed `release-1.4`: toggles on → non-coupled `basic_pendulum` is clean; toggles off → `admm_contact_solver` is clean. Consistent with the toggles sensitizing the #3464 defect rather than being a separate bug.

## Bug fix

**Steps to reproduce** (on `release-1.4` without this PR):

1. `python -m newton.examples robot_g1`
2. In the _Visualization_ panel enable _Show Joints_, _Show Contacts_ or _Show Inertia Boxes_.
3. Under _Examples → multiphysics_ select _admm_contact_solver_.
4. Crash: `Warp CUDA error 700: an illegal memory access was encountered (in function wp_cuda_load_module, ...)` → `Exception: Failed to load CUDA module 'newton.examples.multiphysics.example_admm_contact_solver'`.
