### PR TITLE
Update FAQ for coupled solvers

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -28,7 +28,12 @@ What is the difference between ``warp.sim`` and Newton?
 Does Newton support coupling of solvers for multiphysics or co-simulation?
 --------------------------------------------------------------------------
 
-Yes, Newton is explicitly designed to be extensible with multiple solver implementations for rich multiphysics scenarios. Newton provides APIs for users to implement coupling between solvers, and we have successfully demonstrated one-way coupling in examples such as cloth manipulation by a robotic arm and a quadruped walking through non-rigid terrain. Two-way coupling and implicit coupling between select solvers are on the Newton roadmap.
+Yes. Newton provides an experimental coupled-solver framework for partitioning a
+shared :class:`Model` across multiple solver backends. It supports two-way proxy
+coupling through virtual bodies or particles, and symmetric ADMM coupling for
+joints, body-particle attachments, and frictional contacts. See
+:doc:`Coupled Solvers <concepts/coupling>` for the architecture, examples,
+solver-specific behavior, and current limitations.
 
 Does Newton support MuJoCo simulation?
 --------------------------------------


### PR DESCRIPTION
## Description

Update the FAQ answer about multiphysics solver coupling to describe Newton's
current experimental coupled-solver framework. The previous answer still
described two-way and implicit coupling as roadmap items.

Summarize the available proxy and ADMM coupling paths and link readers to the
Coupled Solvers guide for architecture, examples, solver-specific behavior, and
current limitations.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not applicable: documentation-only fix)

## Test plan

```text
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
uvx pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the FAQ with details on experimental multiphysics and co-simulation solver coupling.
  * Clarified supported two-way coupling methods, shared model partitioning, and ADMM coupling scenarios.
  * Added a link to Coupled Solvers documentation for architecture, examples, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->