### PR TITLE
Bump version to 1.4.0rc2

### DIFF
--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -74,6 +74,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.4.0rc1``
+     - ``1.4.0rc2``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.4.0rc1"
+version = "1.4.0rc2"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3691,7 +3691,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.4.0rc1"
+version = "1.4.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare the second Newton 1.4 release candidate after the stabilization
backports in #3511. Bump the project version to `1.4.0rc2` and regenerate the
derived API version table and lockfile.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` does not require an update for this release-metadata-only change

## Test plan

```text
uv run docs/generate_api.py
uv lock
uvx --python 3.12 pre-commit run -a
uv run --extra dev -m newton.tests -k test_api
uv build --out-dir /tmp/newton-1.4.0rc2-dist-3511
```

The generated diff is limited to `pyproject.toml`, `docs/api/newton.rst`, and
`uv.lock`, matching the prior RC convention. The build produced both
`newton-1.4.0rc2.tar.gz` and `newton-1.4.0rc2-py3-none-any.whl`.
