### PR TITLE
Disable unavailable USD inventory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,7 +193,9 @@ intersphinx_mapping = {
     "jax": ("https://docs.jax.dev/en/latest", None),
     "pytorch": ("https://pytorch.org/docs/stable", None),
     "warp": ("https://nvidia.github.io/warp/stable", None),
-    "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
+    # Disabled because objects.inv currently returns "Access Denied".
+    # Restore this mapping if NVIDIA makes the inventory available again.
+    # "usd": ("https://docs.omniverse.nvidia.com/kit/docs/pxr-usd-api/latest", None),
 }
 
 # Map short USD type names (from ``from pxr import Usd``) to their fully-qualified


### PR DESCRIPTION
## Description

Disable the USD intersphinx inventory mapping because the Omniverse
`objects.inv` endpoint currently returns "Access Denied." Keep the endpoint
commented out with restoration guidance so the mapping can be re-enabled if
NVIDIA republishes the inventory.

This prevents Sphinx from fetching an unavailable inventory while preserving
the existing USD type aliases.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not user-facing)

## Test plan

```console
uvx pre-commit run -a
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

## Bug fix

**Steps to reproduce:**

1. Configure the Omniverse USD API URL in `intersphinx_mapping`.
2. Build the documentation with Sphinx.
3. Observe that fetching the USD `objects.inv` inventory fails with
   "Access Denied."

**Minimal reproduction:**

```console
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Temporarily disabled links to the USD external documentation inventory because it is currently unavailable.
  * Added notes to restore the integration when the documentation inventory becomes accessible again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->