### PR TITLE
Require collider setup keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Add `ModelBuilder.BvhConfig` for selecting Warp BVH constructors during model finalization for mesh, Gaussian, and shape BVHs.
 - Add an experimental coupled solver framework:
   - Introduce `newton.solvers.experimental.coupled` with `SolverCoupled`, `SolverCoupledProxy`, `SolverCoupledADMM`, and `ModelView` for multi-solver ownership, state mapping, and view-local model overrides.
-  - Support body and particle proxy coupling with virtual inertia, solver hooks, MPM collider/transfer proxies, and convergence diagnostics.
+  - Support body and particle proxy coupling with virtual inertia, solver hooks, MPM collider/transfer proxies, and convergence diagnostics; add `collider_particle_ids` to `SolverImplicitMPM.setup_collider()` for deformable mesh colliders and make all parameters of the method keyword-only. Positional callers must pass each argument by name.
   - Support ADMM coupling from model-derived joints, body-particle attachments, and collision-detected rigid/particle contacts with Coulomb friction.
   - Add standalone multiphysics examples and regression coverage for MuJoCo/Kamino, VBD, XPBD, MPM, and ADMM contacts.
   - Add `--coupled-view` to coupled multiphysics examples and expose `SolverCoupled` entry view/state helpers for rendering individual sub-solver views.

--- a/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
+++ b/newton/_src/solvers/implicit_mpm/solver_implicit_mpm.py
@@ -988,6 +988,7 @@ class SolverImplicitMPM(SolverBase, CouplingInterface):
 
     def setup_collider(
         self,
+        *,
         collider_meshes: list[wp.Mesh] | None = None,
         collider_body_ids: list[int] | None = None,
         collider_margins: list[float] | None = None,


### PR DESCRIPTION
## Description

Make every parameter of `SolverImplicitMPM.setup_collider()` keyword-only. The method already has a large optional parameter list, and adding `collider_particle_ids` in the middle would otherwise silently rebind positional calls.

Update the existing coupled-solver changelog entry with the keyword-only requirement and migration guidance.

## Checklist

- [ ] New or existing tests cover these changes (Python enforces keyword-only calls from the signature)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uvx pre-commit run -a
```

## New feature / API change

```python
solver.setup_collider(
    collider_meshes=meshes,
    collider_body_ids=body_ids,
    collider_particle_ids=particle_ids,
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying particle IDs when configuring collider coupling.

- **Breaking Changes**
  - Collider configuration options must now be provided using named arguments. Update any positional calls to use keyword arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->