### PR TITLE
Decouple USD import from MuJoCo runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 
 ### Fixed
 
+- Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Tune VBD contact settings in the `basic_shapes` and `cable_bundle_hysteresis` examples for more consistent friction and recovery behavior.
 - Fix USD import ignoring ancestor material bindings with `strongerThanDescendants` strength when a mesh authors `material:binding` without applying `MaterialBindingAPI`: material resolution now uses UsdShade's canonical `ComputeBoundMaterial` unconditionally, which also adds collection-based binding support. Prims authoring bindings without the applied schema are invalid USD and now surface USD's own warning (once per prim per import) — fix such assets with `usdchecker` or `usd-validation-nvidia`.
 - Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3406)

--- a/newton/_src/solvers/mujoco/constants.py
+++ b/newton/_src/solvers/mujoco/constants.py
@@ -5,17 +5,6 @@
 
 from __future__ import annotations
 
-MJC_ACTUATOR_BIAS_TYPES = {"none": 0, "affine": 1, "muscle": 2, "user": 3}
-MJC_ACTUATOR_DYNAMICS_TYPES = {
-    "none": 0,
-    "integrator": 1,
-    "filter": 2,
-    "filterexact": 3,
-    "muscle": 4,
-    "user": 5,
-}
-MJC_ACTUATOR_GAIN_TYPES = {"fixed": 0, "affine": 1, "muscle": 2, "user": 3}
-
 DEFAULT_LIMIT_GAIN_RTOL = 1.0e-5
 """Relative tolerance for detecting imported MuJoCo default joint-limit gains.
 

--- a/newton/_src/solvers/mujoco/constants.py
+++ b/newton/_src/solvers/mujoco/constants.py
@@ -5,6 +5,17 @@
 
 from __future__ import annotations
 
+MJC_ACTUATOR_BIAS_TYPES = {"none": 0, "affine": 1, "muscle": 2, "user": 3}
+MJC_ACTUATOR_DYNAMICS_TYPES = {
+    "none": 0,
+    "integrator": 1,
+    "filter": 2,
+    "filterexact": 3,
+    "muscle": 4,
+    "user": 5,
+}
+MJC_ACTUATOR_GAIN_TYPES = {"fixed": 0, "affine": 1, "muscle": 2, "user": 3}
+
 DEFAULT_LIMIT_GAIN_RTOL = 1.0e-5
 """Relative tolerance for detecting imported MuJoCo default joint-limit gains.
 

--- a/newton/_src/solvers/mujoco/enums.py
+++ b/newton/_src/solvers/mujoco/enums.py
@@ -19,4 +19,27 @@ class EqType(IntEnum):
     """Constrains one scalar joint coordinate to a quartic polynomial of another."""
 
 
+class _ActuatorBiasType(IntEnum):
+    NONE = 0
+    AFFINE = 1
+    MUSCLE = 2
+    USER = 3
+
+
+class _ActuatorDynamicsType(IntEnum):
+    NONE = 0
+    INTEGRATOR = 1
+    FILTER = 2
+    FILTER_EXACT = 3
+    MUSCLE = 4
+    USER = 5
+
+
+class _ActuatorGainType(IntEnum):
+    FIXED = 0
+    AFFINE = 1
+    MUSCLE = 2
+    USER = 3
+
+
 __all__ = ["EqType"]

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -48,6 +48,9 @@ from .constants import (
     HINGE_CONNECT_AXIS_OFFSET,
     KINEMATIC_ARMATURE,
     MJ_MINVAL,
+    MJC_ACTUATOR_BIAS_TYPES,
+    MJC_ACTUATOR_DYNAMICS_TYPES,
+    MJC_ACTUATOR_GAIN_TYPES,
     SOLREF_MODE_FORCE_SPACE,
     SOLREF_MODE_MJCF_DEFAULT,
     SOLREF_MODE_RAW,
@@ -1403,22 +1406,26 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             """Parse actuator enum values, defaulting to 0 for unknown strings."""
             return SolverMuJoCo._parse_named_int(value, mapping, fallback_on_unknown=0)
 
+        actuator_transmission_types = {
+            "joint": int(SolverMuJoCo.TrnType.JOINT),
+            "jointinparent": int(SolverMuJoCo.TrnType.JOINT_IN_PARENT),
+            "tendon": int(SolverMuJoCo.TrnType.TENDON),
+            "site": int(SolverMuJoCo.TrnType.SITE),
+            "body": int(SolverMuJoCo.TrnType.BODY),
+            "slidercrank": int(SolverMuJoCo.TrnType.SLIDERCRANK),
+        }
+
         def parse_trntype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(
-                s,
-                {"joint": 0, "jointinparent": 1, "tendon": 2, "site": 3, "body": 4, "slidercrank": 5},
-            )
+            return parse_actuator_enum(s, actuator_transmission_types)
 
         def parse_dyntype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(
-                s, {"none": 0, "integrator": 1, "filter": 2, "filterexact": 3, "muscle": 4, "user": 5}
-            )
+            return parse_actuator_enum(s, MJC_ACTUATOR_DYNAMICS_TYPES)
 
         def parse_gaintype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(s, {"fixed": 0, "affine": 1, "muscle": 2, "user": 3})
+            return parse_actuator_enum(s, MJC_ACTUATOR_GAIN_TYPES)
 
         def parse_biastype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(s, {"none": 0, "affine": 1, "muscle": 2, "user": 3})
+            return parse_actuator_enum(s, MJC_ACTUATOR_BIAS_TYPES)
 
         def parse_bool(value: Any, context: dict[str, Any] | None = None) -> bool:
             """Parse MJCF/USD boolean values to bool."""
@@ -1769,7 +1776,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=0,  # TrnType.JOINT
+                default=int(SolverMuJoCo.TrnType.JOINT),
                 namespace="mujoco",
                 mjcf_attribute_name="trntype",
                 mjcf_value_transformer=parse_trntype,
@@ -1784,7 +1791,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=0,  # DynType.NONE
+                default=MJC_ACTUATOR_DYNAMICS_TYPES["none"],
                 namespace="mujoco",
                 mjcf_attribute_name="dyntype",
                 mjcf_value_transformer=parse_dyntype,
@@ -1798,7 +1805,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=0,  # GainType.FIXED
+                default=MJC_ACTUATOR_GAIN_TYPES["fixed"],
                 namespace="mujoco",
                 mjcf_attribute_name="gaintype",
                 mjcf_value_transformer=parse_gaintype,
@@ -1812,7 +1819,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=0,  # BiasType.NONE
+                default=MJC_ACTUATOR_BIAS_TYPES["none"],
                 namespace="mujoco",
                 mjcf_attribute_name="biastype",
                 mjcf_value_transformer=parse_biastype,
@@ -3237,12 +3244,12 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
             # Map trntype integer to MuJoCo enum and override default in general_args
             trntype_enum = {
-                0: mujoco.mjtTrn.mjTRN_JOINT,
-                1: mujoco.mjtTrn.mjTRN_JOINTINPARENT,
-                2: mujoco.mjtTrn.mjTRN_TENDON,
-                3: mujoco.mjtTrn.mjTRN_SITE,
-                4: mujoco.mjtTrn.mjTRN_BODY,
-                5: mujoco.mjtTrn.mjTRN_SLIDERCRANK,
+                int(SolverMuJoCo.TrnType.JOINT): mujoco.mjtTrn.mjTRN_JOINT,
+                int(SolverMuJoCo.TrnType.JOINT_IN_PARENT): mujoco.mjtTrn.mjTRN_JOINTINPARENT,
+                int(SolverMuJoCo.TrnType.TENDON): mujoco.mjtTrn.mjTRN_TENDON,
+                int(SolverMuJoCo.TrnType.SITE): mujoco.mjtTrn.mjTRN_SITE,
+                int(SolverMuJoCo.TrnType.BODY): mujoco.mjtTrn.mjTRN_BODY,
+                int(SolverMuJoCo.TrnType.SLIDERCRANK): mujoco.mjtTrn.mjTRN_SLIDERCRANK,
             }.get(trntype, mujoco.mjtTrn.mjTRN_JOINT)
             general_args["trntype"] = trntype_enum
             act = spec.add_actuator(target=target_name, **general_args)

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -48,14 +48,12 @@ from .constants import (
     HINGE_CONNECT_AXIS_OFFSET,
     KINEMATIC_ARMATURE,
     MJ_MINVAL,
-    MJC_ACTUATOR_BIAS_TYPES,
-    MJC_ACTUATOR_DYNAMICS_TYPES,
-    MJC_ACTUATOR_GAIN_TYPES,
     SOLREF_MODE_FORCE_SPACE,
     SOLREF_MODE_MJCF_DEFAULT,
     SOLREF_MODE_RAW,
 )
 from .enums import EqType as _EqType
+from .enums import _ActuatorBiasType, _ActuatorDynamicsType, _ActuatorGainType
 from .equality import MJC_OBJ_BODY, MjcEqualityTargetKind, _register_equality_constraint_attributes
 from .kernels import (
     _snapshot_nacon_count,
@@ -1404,7 +1402,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # Note: actuator_trnid[0] stores the target index, actuator_trntype determines its meaning (joint/tendon/site)
         def parse_actuator_enum(value: Any, mapping: dict[str, int]) -> int:
             """Parse actuator enum values, defaulting to 0 for unknown strings."""
-            return SolverMuJoCo._parse_named_int(value, mapping, fallback_on_unknown=0)
+            return int(SolverMuJoCo._parse_named_int(value, mapping, fallback_on_unknown=0))
 
         actuator_transmission_types = {
             "joint": int(SolverMuJoCo.TrnType.JOINT),
@@ -1414,18 +1412,38 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             "body": int(SolverMuJoCo.TrnType.BODY),
             "slidercrank": int(SolverMuJoCo.TrnType.SLIDERCRANK),
         }
+        actuator_dynamics_types = {
+            "none": _ActuatorDynamicsType.NONE,
+            "integrator": _ActuatorDynamicsType.INTEGRATOR,
+            "filter": _ActuatorDynamicsType.FILTER,
+            "filterexact": _ActuatorDynamicsType.FILTER_EXACT,
+            "muscle": _ActuatorDynamicsType.MUSCLE,
+            "user": _ActuatorDynamicsType.USER,
+        }
+        actuator_gain_types = {
+            "fixed": _ActuatorGainType.FIXED,
+            "affine": _ActuatorGainType.AFFINE,
+            "muscle": _ActuatorGainType.MUSCLE,
+            "user": _ActuatorGainType.USER,
+        }
+        actuator_bias_types = {
+            "none": _ActuatorBiasType.NONE,
+            "affine": _ActuatorBiasType.AFFINE,
+            "muscle": _ActuatorBiasType.MUSCLE,
+            "user": _ActuatorBiasType.USER,
+        }
 
         def parse_trntype(s: str, _context: dict[str, Any] | None = None) -> int:
             return parse_actuator_enum(s, actuator_transmission_types)
 
         def parse_dyntype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(s, MJC_ACTUATOR_DYNAMICS_TYPES)
+            return parse_actuator_enum(s, actuator_dynamics_types)
 
         def parse_gaintype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(s, MJC_ACTUATOR_GAIN_TYPES)
+            return parse_actuator_enum(s, actuator_gain_types)
 
         def parse_biastype(s: str, _context: dict[str, Any] | None = None) -> int:
-            return parse_actuator_enum(s, MJC_ACTUATOR_BIAS_TYPES)
+            return parse_actuator_enum(s, actuator_bias_types)
 
         def parse_bool(value: Any, context: dict[str, Any] | None = None) -> bool:
             """Parse MJCF/USD boolean values to bool."""
@@ -1791,7 +1809,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=MJC_ACTUATOR_DYNAMICS_TYPES["none"],
+                default=int(_ActuatorDynamicsType.NONE),
                 namespace="mujoco",
                 mjcf_attribute_name="dyntype",
                 mjcf_value_transformer=parse_dyntype,
@@ -1805,7 +1823,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=MJC_ACTUATOR_GAIN_TYPES["fixed"],
+                default=int(_ActuatorGainType.FIXED),
                 namespace="mujoco",
                 mjcf_attribute_name="gaintype",
                 mjcf_value_transformer=parse_gaintype,
@@ -1819,7 +1837,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 frequency="mujoco:actuator",
                 assignment=AttributeAssignment.MODEL,
                 dtype=wp.int32,
-                default=MJC_ACTUATOR_BIAS_TYPES["none"],
+                default=int(_ActuatorBiasType.NONE),
                 namespace="mujoco",
                 mjcf_attribute_name="biastype",
                 mjcf_value_transformer=parse_biastype,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -38,14 +38,11 @@ from ..sim.builder import ModelBuilder
 from ..sim.enums import JointTargetMode
 from ..sim.model import Model
 from ..solvers.mujoco.constants import (
-    MJC_ACTUATOR_BIAS_TYPES,
-    MJC_ACTUATOR_DYNAMICS_TYPES,
-    MJC_ACTUATOR_GAIN_TYPES,
     SOLREF_MODE_FORCE_SPACE,
     SOLREF_MODE_MJCF_DEFAULT,
     SOLREF_MODE_RAW,
 )
-from ..solvers.mujoco.enums import EqType
+from ..solvers.mujoco.enums import EqType, _ActuatorBiasType, _ActuatorDynamicsType, _ActuatorGainType
 from ..solvers.mujoco.equality import _add_equality_constraint, _register_equality_constraint_attributes
 from ..solvers.mujoco.utils import (
     mjc_add_equality_loop_joint,
@@ -4738,9 +4735,6 @@ def parse_usd(
     if mjc_actuator_count > 0:
         from ..solvers.mujoco.solver_mujoco import SolverMuJoCo  # noqa: PLC0415
 
-        biastype_affine = MJC_ACTUATOR_BIAS_TYPES["affine"]
-        dyntype_none = MJC_ACTUATOR_DYNAMICS_TYPES["none"]
-        gaintype_fixed = MJC_ACTUATOR_GAIN_TYPES["fixed"]
         ctrl_source_joint_target = int(SolverMuJoCo.CtrlSource.JOINT_TARGET)
 
         def _row(key: str, row: int) -> Any:
@@ -4766,9 +4760,9 @@ def parse_usd(
             # (see joint_target_ranges in _init_actuators). Effort limit
             # (jnt_actfrcrange) comes from the joint, not the actuator.
             if (
-                int(_row("mujoco:actuator_biastype", row)) != biastype_affine
-                or int(_row("mujoco:actuator_dyntype", row)) != dyntype_none
-                or int(_row("mujoco:actuator_gaintype", row)) != gaintype_fixed
+                int(_row("mujoco:actuator_biastype", row)) != _ActuatorBiasType.AFFINE
+                or int(_row("mujoco:actuator_dyntype", row)) != _ActuatorDynamicsType.NONE
+                or int(_row("mujoco:actuator_gaintype", row)) != _ActuatorGainType.FIXED
             ):
                 continue
             gear = list(_row("mujoco:actuator_gear", row))

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -37,9 +37,16 @@ from ..geometry import GeoType, Mesh, ShapeFlags, compute_inertia_shape, compute
 from ..sim.builder import ModelBuilder
 from ..sim.enums import JointTargetMode
 from ..sim.model import Model
-from ..solvers.mujoco.constants import SOLREF_MODE_FORCE_SPACE, SOLREF_MODE_MJCF_DEFAULT, SOLREF_MODE_RAW
+from ..solvers.mujoco.constants import (
+    MJC_ACTUATOR_BIAS_TYPES,
+    MJC_ACTUATOR_DYNAMICS_TYPES,
+    MJC_ACTUATOR_GAIN_TYPES,
+    SOLREF_MODE_FORCE_SPACE,
+    SOLREF_MODE_MJCF_DEFAULT,
+    SOLREF_MODE_RAW,
+)
 from ..solvers.mujoco.enums import EqType
-from ..solvers.mujoco.equality import _add_equality_constraint
+from ..solvers.mujoco.equality import _add_equality_constraint, _register_equality_constraint_attributes
 from ..solvers.mujoco.utils import (
     mjc_add_equality_loop_joint,
     mjc_add_equality_mimic,
@@ -2238,6 +2245,7 @@ def parse_usd(
     builder_custom_attr_joint: list[ModelBuilder.CustomAttribute] = builder.get_custom_attributes_by_frequency(
         [AttributeFrequency.JOINT, AttributeFrequency.JOINT_DOF, AttributeFrequency.JOINT_COORD]
     )
+    _register_equality_constraint_attributes(builder)
     builder_custom_attr_eq: list[ModelBuilder.CustomAttribute] = builder.get_custom_attributes_by_frequency(
         ["mujoco:equality_constraint"]
     )
@@ -4161,16 +4169,6 @@ def parse_usd(
     # builder's collapse logic can remap body/joint indices and adjust anchors/relposes
     # for any bodies that get merged.
     def _parse_mjc_equality_constraints():
-        local_builder_custom_attr_eq = builder_custom_attr_eq
-        # The equality custom attributes are declared by ModelBuilder.__init__; register the
-        # remaining MuJoCo custom attributes needed to parse and convert the model.
-        # register_custom_attributes is idempotent, so re-registering the equality fields is a no-op.
-        if convert_mjc_equality_constraints:
-            from ..solvers.mujoco.solver_mujoco import SolverMuJoCo  # noqa: PLC0415
-
-            SolverMuJoCo.register_custom_attributes(builder)
-            local_builder_custom_attr_eq = builder.get_custom_attributes_by_frequency(["mujoco:equality_constraint"])
-
         def add_converted_loop_joint(
             eq_type: EqType,
             body1: int,
@@ -4224,7 +4222,7 @@ def parse_usd(
                 R.collect_prim_attrs(joint_prim)
 
             eq_custom_attrs = usd.get_custom_attribute_values(
-                joint_prim, local_builder_custom_attr_eq, context={"builder": builder}
+                joint_prim, builder_custom_attr_eq, context={"builder": builder}
             )
             enabled = bool(joint_desc.jointEnabled)
 
@@ -4738,16 +4736,11 @@ def parse_usd(
         mjc_actuator_count = 0
 
     if mjc_actuator_count > 0:
-        # Lazy imports: only needed when MuJoCo custom attributes are registered
-        # (i.e. SolverMuJoCo is in use), and avoids a top-level mujoco dependency
-        # for USD parsing in non-MuJoCo configurations.
-        import mujoco
-
         from ..solvers.mujoco.solver_mujoco import SolverMuJoCo  # noqa: PLC0415
 
-        biastype_affine = int(mujoco.mjtBias.mjBIAS_AFFINE)
-        dyntype_none = int(mujoco.mjtDyn.mjDYN_NONE)
-        gaintype_fixed = int(mujoco.mjtGain.mjGAIN_FIXED)
+        biastype_affine = MJC_ACTUATOR_BIAS_TYPES["affine"]
+        dyntype_none = MJC_ACTUATOR_DYNAMICS_TYPES["none"]
+        gaintype_fixed = MJC_ACTUATOR_GAIN_TYPES["fixed"]
         ctrl_source_joint_target = int(SolverMuJoCo.CtrlSource.JOINT_TARGET)
 
         def _row(key: str, row: int) -> Any:

--- a/newton/tests/assets/mjc_schema_import.usda
+++ b/newton/tests/assets/mjc_schema_import.usda
@@ -1,0 +1,137 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    kilogramsPerUnit = 1
+    metersPerUnit = 1
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def Xform "Articulation" (
+        apiSchemas = ["PhysicsArticulationRootAPI"]
+    )
+    {
+        def Cube "Root" (
+            apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
+        )
+        {
+            double size = 0.2
+        }
+
+        def Cube "Link1" (
+            apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
+        )
+        {
+            double size = 0.2
+        }
+
+        def Cube "Link2" (
+            apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
+        )
+        {
+            double size = 0.2
+        }
+
+        def Cube "Link3" (
+            apiSchemas = ["PhysicsRigidBodyAPI", "PhysicsCollisionAPI"]
+        )
+        {
+            double size = 0.2
+        }
+
+        def PhysicsFixedJoint "RootToWorld"
+        {
+            rel physics:body0 = </World/Articulation/Root>
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def PhysicsRevoluteJoint "Joint1" (
+            apiSchemas = ["MjcJointAPI"]
+        )
+        {
+            uniform double[] mjc:solreflimit = [0.03, 0.8]
+            uniform token physics:axis = "Z"
+            rel physics:body0 = </World/Articulation/Root>
+            rel physics:body1 = </World/Articulation/Link1>
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def PhysicsRevoluteJoint "Joint2" (
+            apiSchemas = ["MjcEqualityJointAPI", "MjcJointAPI"]
+        )
+        {
+            uniform double mjc:coef0 = 0.5
+            uniform double mjc:coef1 = 1.5
+            rel mjc:target = </World/Articulation/Joint1>
+            uniform token physics:axis = "Z"
+            rel physics:body0 = </World/Articulation/Link1>
+            rel physics:body1 = </World/Articulation/Link2>
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def PhysicsRevoluteJoint "Joint3"
+        {
+            uniform token physics:axis = "Z"
+            rel physics:body0 = </World/Articulation/Link2>
+            rel physics:body1 = </World/Articulation/Link3>
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def PhysicsSphericalJoint "Connect" (
+            apiSchemas = ["MjcEqualityConnectAPI"]
+        )
+        {
+            rel physics:body0 = </World/Articulation/Link1>
+            rel physics:body1 = </World/Articulation/Link2>
+            bool physics:excludeFromArticulation = true
+            point3f physics:localPos0 = (0.1, 0.2, 0.3)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def PhysicsFixedJoint "Weld" (
+            apiSchemas = ["MjcEqualityWeldAPI"]
+        )
+        {
+            uniform float mjc:torqueScale = 2.5
+            rel physics:body0 = </World/Articulation/Root>
+            rel physics:body1 = </World/Articulation/Link2>
+            bool physics:excludeFromArticulation = true
+            point3f physics:localPos0 = (0, 0, 0)
+            point3f physics:localPos1 = (0, 0, 0)
+            quatf physics:localRot0 = (1, 0, 0, 0)
+            quatf physics:localRot1 = (1, 0, 0, 0)
+        }
+
+        def MjcActuator "Actuator"
+        {
+            uniform token mjc:biasType = "affine"
+            uniform double[] mjc:biasPrm = [0, -10, -1, 0, 0, 0, 0, 0, 0, 0]
+            uniform token mjc:dynType = "none"
+            uniform token mjc:gainType = "fixed"
+            uniform double[] mjc:gainPrm = [10, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            uniform double[] mjc:gear = [1, 0, 0, 0, 0, 0]
+            rel mjc:target = </World/Articulation/Joint1>
+        }
+    }
+}
+
+def PhysicsScene "PhysicsScene"
+{
+    vector3f physics:gravityDirection = (0, 0, -1)
+    float physics:gravityMagnitude = 9.81
+}

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import builtins
 import functools
 import hashlib
 import math
@@ -5886,6 +5887,52 @@ def Xform "Body" (
 
 
 class TestImportSampleAssetsParsing(unittest.TestCase):
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_add_usd_mjc_schemas_without_mujoco(self):
+        asset_path = os.path.join(os.path.dirname(__file__), "assets", "mjc_schema_import.usda")
+        original_import = builtins.__import__
+        optional_runtime_imports = []
+
+        def track_optional_runtime_imports(name, *args, **kwargs):
+            if name.partition(".")[0] in {"mujoco", "mujoco_warp"}:
+                optional_runtime_imports.append(name)
+            return original_import(name, *args, **kwargs)
+
+        for register_mujoco, convert_equalities in (
+            (False, False),
+            (False, True),
+            (True, False),
+            (True, True),
+        ):
+            with self.subTest(register_mujoco=register_mujoco, convert_equalities=convert_equalities):
+                builder = newton.ModelBuilder()
+                if register_mujoco:
+                    SolverMuJoCo.register_custom_attributes(builder)
+
+                optional_runtime_imports.clear()
+                with mock.patch.object(builtins, "__import__", side_effect=track_optional_runtime_imports):
+                    builder.add_usd(
+                        asset_path,
+                        convert_mjc_equality_constraints=convert_equalities,
+                        schema_resolvers=[usd.SchemaResolverMjc()],
+                    )
+                self.assertEqual(optional_runtime_imports, [])
+
+                model = builder.finalize()
+                self.assertEqual(model.mujoco.equality_constraint_count, 3)
+                self.assertEqual(model.constraint_mimic_count, int(convert_equalities))
+                self.assertEqual(model.custom_frequency_counts.get("mujoco:actuator", 0), int(register_mujoco))
+
+                if register_mujoco:
+                    np.testing.assert_array_equal(model.mujoco.actuator_dyntype.numpy(), [0])
+                    np.testing.assert_array_equal(model.mujoco.actuator_gaintype.numpy(), [0])
+                    np.testing.assert_array_equal(model.mujoco.actuator_biastype.numpy(), [1])
+                    self.assertIn(int(newton.JointTargetMode.POSITION), builder.joint_target_mode)
+                    self.assertEqual(
+                        set(model.mujoco.solreflimit_mode.numpy().tolist()),
+                        {SOLREF_MODE_FORCE_SPACE, SOLREF_MODE_RAW, SOLREF_MODE_MJCF_DEFAULT},
+                    )
+
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_jnt_actgravcomp_parsing(self):
         """Test that jnt_actgravcomp attribute is parsed correctly from USD."""


### PR DESCRIPTION
## Summary

- Limit default MJC equality conversion to equality-specific custom attributes.
- Parse registered `MjcActuator` values through Newton-owned mappings without importing the optional MuJoCo runtime.
- Keep `SolverMuJoCo.TrnType` as the source of truth for transmission values.
- Add a USD regression covering conversion and preservation, explicit registration, all solref modes, and import-attempt detection.

## Validation

- MJC equality import and conversion tests.
- MuJoCo general-actuator tests.
- Strict-warning regression and repository pre-commit checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD imports involving MuJoCo actuator and equality schemas so they no longer require the optional MuJoCo package at runtime.
  * Corrected actuator type handling, including support for slider-crank transmissions and accurate default values.

* **Tests**
  * Added regression coverage for importing MuJoCo-related USD schemas without the optional package.
  * Added a representative USD scene for validating joints, actuators, and articulation behavior.

* **Documentation**
  * Updated the changelog with the USD import fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->