### PR TITLE
Fix DiffSim bear graph capture and test horizon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 - Fix USD import ignoring ancestor material bindings with `strongerThanDescendants` strength when a mesh authors `material:binding` without applying `MaterialBindingAPI`: material resolution now uses UsdShade's canonical `ComputeBoundMaterial` unconditionally, which also adds collection-based binding support. Prims authoring bindings without the applied schema are invalid USD and now surface USD's own warning (once per prim per import) — fix such assets with `usdchecker` or `usd-validation-nvidia`.
 - Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3406)
 - Fix Style3D solver divergence caused by isolated vertices.
-- Fix the `diffsim_bear` example crashing with its default CUDA configuration.
+- Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Fix USD import ignoring ancestor material bindings with `strongerThanDescendants` strength when a mesh authors `material:binding` without applying `MaterialBindingAPI`: material resolution now uses UsdShade's canonical `ComputeBoundMaterial` unconditionally, which also adds collection-based binding support. Prims authoring bindings without the applied schema are invalid USD and now surface USD's own warning (once per prim per import) — fix such assets with `usdchecker` or `usd-validation-nvidia`.
 - Fix `ModelBuilder.add_usd()` to honor `ignore_paths` in the custom-frequency traversal, so prims under ignored subtrees no longer register spurious custom-frequency rows in two-pass import workflows. (#3406)
 - Fix Style3D solver divergence caused by isolated vertices.
+- Fix the `diffsim_bear` example crashing with its default CUDA configuration.
 - Fix USD joint `physics:collisionEnabled` import so joints with two explicit bodies honor authored collision behavior; joints to world continue to allow body/world collisions, and articulation-wide self-collision filtering remains additive.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix `ViewerFile.is_running()` to return `False` after `ViewerFile.close()` so headless recording loops can terminate like interactive viewers. (#3094)

--- a/newton/examples/diffsim/example_diffsim_bear.py
+++ b/newton/examples/diffsim/example_diffsim_bear.py
@@ -205,9 +205,17 @@ class Example:
         self.capture()
 
     def capture(self):
+        self.tape = wp.Tape()
         with wp.ScopedCapture() as capture:
-            self.forward_backward()
-        self.graph = capture.graph
+            with self.tape:
+                for i in range(self.sim_steps):
+                    self.forward(i)
+        self.forward_graph = capture.graph
+
+        # Avoid oversized graph executables for long training rollouts.
+        with wp.ScopedCapture() as capture:
+            self.tape.backward(self.loss)
+        self.backward_graph = capture.graph
 
     def forward_backward(self):
         self.tape = wp.Tape()
@@ -259,8 +267,9 @@ class Example:
         wp.launch(loss_kernel, dim=1, inputs=[self.coms[frame], self.loss], outputs=[])
 
     def step(self):
-        if self.graph:
-            wp.capture_launch(self.graph)
+        if self.forward_graph and self.backward_graph:
+            wp.capture_launch(self.forward_graph)
+            wp.capture_launch(self.backward_graph)
         else:
             self.forward_backward()
 

--- a/newton/examples/diffsim/example_diffsim_bear.py
+++ b/newton/examples/diffsim/example_diffsim_bear.py
@@ -168,6 +168,8 @@ class Example:
         self.collision_pipeline.collide(self.states[0], self.contacts)
 
         # initialize the solver.
+        # Particle-particle contacts do not support correct gradients in SolverSemiImplicit.
+        self.model.particle_grid = None
         self.solver = newton.solvers.SolverSemiImplicit(self.model, enable_tri_contact=False)
 
         # model input

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -801,7 +801,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_bear",
     devices=test_devices,
-    test_options={"usd_required": True, "num-frames": 4 * 60, "sim-steps": 60},  # train_iters * sim_steps
+    test_options={"usd_required": True, "num-frames": 4 * 120, "sim-steps": 120},  # train_iters * sim_steps
     test_options_cpu={"num-frames": 2, "sim-steps": 10},
     use_viewer=True,
 )

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -801,7 +801,7 @@ add_example_test(
     TestDiffSimExamples,
     name="diffsim.example_diffsim_bear",
     devices=test_devices,
-    test_options={"usd_required": True, "num-frames": 4 * 60},  # train_iters * sim_steps
+    test_options={"usd_required": True, "num-frames": 4 * 60, "sim-steps": 60},  # train_iters * sim_steps
     test_options_cpu={"num-frames": 2, "sim-steps": 10},
     use_viewer=True,
 )


### PR DESCRIPTION
## Description

Capture the DiffSim bear forward rollout and backward pass as separate graphs. The default 300-step rollout previously created one oversized graph executable that terminated inside `cudaGraphLaunch()` on affected CUDA systems; enqueuing the two graphs on the same stream preserves their ordering while avoiding that failure.

Disable particle-particle contacts in the example by setting `model.particle_grid = None` before constructing `SolverSemiImplicit`. Since 195454cc the solver rebuilds the particle grid during `step()`, activating particle-particle contacts whose gradients are documented as unsupported; training diverged at the fourth iteration for rollouts of 120 steps or longer.

Run the CUDA example test with four training iterations of 120 simulation steps. The previous registration used the example's 300-step default and completed at most one training iteration instead of the intended four. A 120-step horizon covers the gradient-corruption regression above, which a 60-step rollout cannot: at 60 steps all iterations are numerically identical with and without the opt-out. The existing CPU override continues to use 10 simulation steps.

Closes #3522.

## Checklist

- [x] New or existing tests cover these changes
- [x] No documentation changes are required
- [x] `CHANGELOG.md` has been updated

## Test plan

```console
uv run --extra dev -m newton.tests -p test_examples.py -k example_diffsim_bear_cuda_0 -j 1
uv run --extra dev -m newton.tests -p test_examples.py -k example_diffsim_bear_cpu -j 1
python -m newton.examples.diffsim.example_diffsim_bear --device cuda:0 --test --quiet --viewer null --num-frames 1 --sim-steps 300
python -m newton.examples.diffsim.example_diffsim_bear --device cuda:0 --test --verbose --viewer null --num-frames 1200 --sim-steps 300
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the minimal reproduction from `main`.
2. On affected CUDA systems, observe the combined forward/backward graph terminate with `SIGSEGV` during its first launch.
3. Run the example for four training iterations with a rollout of 120 steps or longer (e.g. `--num-frames 1200 --sim-steps 300`) and observe the loss diverge at the fourth iteration.

**Minimal reproduction:**

```console
python -m newton.examples.diffsim.example_diffsim_bear --device cuda:0 --test --quiet --viewer null --num-frames 1 --sim-steps 300
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `diffsim_bear` example so it no longer crashes with the default CUDA configuration.
  * Improved simulation stability to prevent divergence after several training iterations.
  * Updated the example’s simulation settings for more reliable multi-frame runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->