### PR TITLE
Fix CPU-only output test failures

### DIFF
--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -40,9 +40,14 @@ _HAS_ONNX_RUNTIME = importlib.util.find_spec("onnx") is not None and importlib.u
 _PXR_WORK_THREAD_LIMIT_OUTPUT_RE = (
     r"(?s)#+\n#  PXR_WORK_THREAD_LIMIT is overridden to '1'\.  Default is '0'\.  #\n#+\n?"
 )
-_WARP_CUDA_DRIVER_WARNING_RE = (
+_WARP_CUDA_UNAVAILABLE_OUTPUT_RE = (
+    r"(?:"
     r"Warp CUDA warning: Could not find or load the NVIDIA CUDA driver\. "
-    r"GPU execution will not be available\.\n?"
+    r"GPU execution will not be available\."
+    r"|"
+    r"Warp CUDA error 100: no CUDA-capable device is detected "
+    r"\(in function init_cuda_driver, [^\n]*cuda_util\.cpp:\d+\)"
+    r")\n?"
 )
 _MATPLOTLIB_FONT_CACHE_OUTPUT_RE = r"Matplotlib is building the font cache; this may take a moment\.\n?"
 _BASIC_PLOTTING_OUTPUT_RE = (
@@ -262,6 +267,18 @@ def _register_output_regexes(test: NewtonTestCase, regexes: list[_OutputRegexSpe
 
 
 class TestExampleOutputRegexes(unittest.TestCase):
+    def test_warp_cuda_unavailable_output_is_allowed(self):
+        outputs = (
+            "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. GPU execution will not be available.\n",
+            "Warp CUDA error 100: no CUDA-capable device is detected "
+            "(in function init_cuda_driver, /builds/omniverse/warp/warp/native/cuda_util.cpp:319)\n",
+        )
+
+        for output in outputs:
+            with self.subTest(output=output):
+                unmatched_output = re.sub(_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "", output, flags=re.MULTILINE)
+                self.assertEqual(unmatched_output, "")
+
     def test_basic_plotting_output_does_not_consume_trailing_output(self):
         unexpected_output = "unexpected output\n"
         output = (
@@ -283,7 +300,7 @@ test_devices = get_test_devices(mode="basic")
 
 _BASIC_EXAMPLE_ALLOW_OUTPUT_REGEXES = [
     (_PXR_WORK_THREAD_LIMIT_OUTPUT_RE, "stderr"),
-    (_WARP_CUDA_DRIVER_WARNING_RE, "stderr"),
+    (_WARP_CUDA_UNAVAILABLE_OUTPUT_RE, "stderr"),
 ]
 
 

--- a/newton/tests/test_unittest_utils.py
+++ b/newton/tests/test_unittest_utils.py
@@ -167,6 +167,25 @@ class TestNewtonTestCaseOutputContract(unittest.TestCase):
         self.assertIn("subprocess stdout", result.failures[0][1])
         self.assertIn("subprocess stderr", result.failures[0][1])
 
+    def test_caught_subprocess_failure_does_not_report_output_again(self):
+        unittest_utils.wp.init()
+
+        class CatchesFailingSubprocess(NewtonTestCase):
+            def test_output(self):
+                result = subprocess.CompletedProcess(
+                    args=["fake-command"],
+                    returncode=7,
+                    stdout="subprocess stdout\n",
+                    stderr="subprocess stderr\n",
+                )
+
+                with self.assertRaisesRegex(AssertionError, "Failed with return code 7"):
+                    self.assertSubprocessSuccess(result, command=result.args)
+
+        result = self._run_test_case(CatchesFailingSubprocess)
+
+        self.assertTrue(result.wasSuccessful(), result.failures)
+
     def test_synchronized_output_is_captured(self):
         class SynchronizeEmitsOutput(NewtonTestCase):
             def test_output(self):

--- a/newton/tests/unittest_utils.py
+++ b/newton/tests/unittest_utils.py
@@ -427,14 +427,16 @@ class NewtonTestCase(unittest.TestCase):
         output_capture = self._require_output_capture()
         stdout = getattr(result, "stdout", None)
         stderr = getattr(result, "stderr", None)
-        output_capture.record("stdout", stdout)
-        output_capture.record("stderr", stderr)
 
         if result.returncode != 0:
+            # The primary failure already includes both streams, so leave no output for cleanup to report again.
             command_text = _format_command(command)
             self.fail(
                 f"Failed with return code {result.returncode}, command: {command_text}\n\nOutput:\n{stdout}\n{stderr}"
             )
+
+        output_capture.record("stdout", stdout)
+        output_capture.record("stderr", stderr)
 
     def _finish_output_capture(self):
         output_capture = self._output_capture


### PR DESCRIPTION
## Description

Fix CPU-only test failures introduced by the strict stdout/stderr output contract.

CPU example subprocesses can report CUDA unavailability in two ways. Hosted CI runners emit the already-allowed missing-driver warning, while machines with a discoverable CUDA driver but no CUDA-capable device emit error 100. The examples still run successfully on CPU, but the strict output checker rejected the second message and failed every basic CPU example.

Allow both known CUDA-unavailable startup messages for basic examples. Also make failed subprocess reporting single-purpose: a nonzero subprocess includes its command, stdout, and stderr in the primary assertion without recording those streams for strict cleanup to report a second time.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (no documentation changes needed)
- [x] `CHANGELOG.md` has been updated (test-harness-only change; no changelog entry needed)

## Test plan

```bash
CUDA_VISIBLE_DEVICES=-1 uv run --extra dev -m newton.tests \
  -k test_basic.example_basic_pendulum_cpu

uv run --extra dev -m newton.tests -k test_unittest_utils

uv run --extra dev python -m unittest \
  newton.tests.test_unittest_utils.TestNewtonTestCaseOutputContract.test_subprocess_failure_reports_command_and_output \
  newton.tests.test_unittest_utils.TestNewtonTestCaseOutputContract.test_caught_subprocess_failure_does_not_report_output_again \
  newton.tests.test_examples.TestExampleOutputRegexes -v

uvx --python 3.12 pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Run the Newton test suite on a CPU-only machine where the CUDA driver is discoverable but no CUDA-capable device is present.
2. Observe successful basic CPU examples emit `Warp CUDA error 100: no CUDA-capable device is detected` on stderr.
3. Observe the strict output contract fail those examples and the subprocess-contract self-test report two failures instead of one.

**Minimal reproduction:**

```bash
CUDA_VISIBLE_DEVICES=-1 uv run --extra dev -m newton.tests \
  -k test_basic.example_basic_pendulum_cpu
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable CUDA environments by recognizing additional driver and device error messages.
  * Prevented failed subprocess output from being reported redundantly during test failures.

* **Tests**
  * Added coverage for multiple CUDA-unavailable error formats.
  * Added validation that subprocess failure output is reported only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->