### PR TITLE
Prepare Newton 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Newton was initiated by [Disney Research](https://www.disneyresearch.com/), [Goo
 - **OS:** Linux (x86-64, aarch64), Windows (x86-64), or macOS (CPU only)
 - **GPU:** NVIDIA GPU (Maxwell or newer), driver 545 or newer (CUDA 12). No local CUDA Toolkit installation required. macOS runs on CPU.
 
-For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/latest/guide/compatibility.html).
+For detailed system requirements, see the [installation guide](https://newton-physics.github.io/newton/1.4.0/guide/installation.html). For tested configurations and Newton's versioning and deprecation policies, see the [compatibility guide](https://newton-physics.github.io/newton/1.4.0/guide/compatibility.html).
 
 ## Quickstart
 
@@ -29,7 +29,7 @@ pip install "newton[examples]"
 python -m newton.examples
 ```
 
-To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/latest/guide/installation.html).
+To install from source with [uv](https://docs.astral.sh/uv/), see the [installation guide](https://newton-physics.github.io/newton/1.4.0/guide/installation.html).
 
 ## Examples
 
@@ -880,11 +880,11 @@ python -m newton.examples basic_viewer --viewer gl --num-frames 500 --device cpu
 
 ## Contributing and Development
 
-See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/latest/guide/development.html) for instructions on how to contribute to Newton.
+See the [contribution guidelines](https://github.com/newton-physics/newton-governance/blob/main/CONTRIBUTING.md) and the [development guide](https://newton-physics.github.io/newton/1.4.0/guide/development.html) for instructions on how to contribute to Newton.
 
 ## Support and Community Discussion
 
-For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/latest/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
+For questions, please consult the [Newton documentation](https://newton-physics.github.io/newton/1.4.0/guide/overview.html) first before creating [a discussion in the main repository](https://github.com/newton-physics/newton/discussions).
 
 ## Code of Conduct
 

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -73,6 +73,6 @@ newton
    * - ``MAXVAL``
      - ``10000000000.0``
    * - ``__version__``
-     - ``1.4.0rc2``
+     - ``1.4.0``
    * - ``use_coord_layout_targets``
      - ``False``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "newton"
-version = "1.4.0rc2"
+version = "1.4.0"
 license = "Apache-2.0"
 license-files = ["LICENSE.md", "newton/licenses/**/*.txt"]
 authors = [{ name = "Newton Developers", email = "developers@newton-physics.org" }]

--- a/uv.lock
+++ b/uv.lock
@@ -3691,7 +3691,7 @@ wheels = [
 
 [[package]]
 name = "newton"
-version = "1.4.0rc2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "warp-lang" },


### PR DESCRIPTION
## Description

Prepare the final Newton 1.4.0 release after maintainer go/no-go approval:

- Set the project version to `1.4.0`.
- Regenerate the public API metadata and `uv.lock`.
- Pin README documentation links to the versioned `/1.4.0/` site.

The `1.4.0` changelog section is already finalized and dated 2026-07-16. All dependency requirements are stable releases, and the refreshed lockfile contains no pre-release versions.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run docs/generate_api.py
uv lock
uvx pre-commit run -a
uv run --extra dev -m newton.tests -k test_generate_api
uv build --out-dir /tmp/newton-1.4.0-ga-dist-20260716
```

Results: API generation and lockfile refresh completed; pre-commit passed; all three focused tests passed; source distribution and wheel built successfully with version `1.4.0` in their metadata.
