### PR TITLE
Restore Codecov coverage processing

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -226,8 +226,10 @@ jobs:
     needs: gpu-unit-tests
     if: ${{ !cancelled() && needs.gpu-unit-tests.result != 'skipped' }}
     runs-on: ubuntu-latest
-    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
-    permissions: {}
+    # Same-run artifact downloads use the runtime token; contents access is
+    # only used to build Codecov's source network for coverage path mapping.
+    permissions:
+      contents: read
     steps:
       # *.blob.core.windows.net is intentionally broad: GitHub artifact storage
       # uses rotating productionresultssaN hosts and harden-runner only supports
@@ -239,11 +241,20 @@ jobs:
           allowed-endpoints: >
             *.blob.core.windows.net:443
             cli.codecov.io:443
+            github.com:443
             ingest.codecov.io:443
             keybase.io:443
             o26192.ingest.us.sentry.io:443
             results-receiver.actions.githubusercontent.com:443
             storage.googleapis.com:443
+      - name: Checkout source for coverage path mapping
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github
+            newton
       - name: Download coverage artifact
         id: download-coverage
         continue-on-error: true
@@ -258,6 +269,7 @@ jobs:
           env_vars: AWS_INSTANCE_TYPE
           files: ./coverage.xml
           flags: unittests
+          plugins: noop
           override_commit: ${{ inputs.ref || github.sha }}
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,10 @@ jobs:
             macos-latest,
           ]
     runs-on: ubuntu-latest
-    # Same-run artifact downloads use the runtime token, not GITHUB_TOKEN.
-    permissions: {}
+    # Same-run artifact downloads use the runtime token; contents access is
+    # only used to build Codecov's source network for coverage path mapping.
+    permissions:
+      contents: read
     env:
       OS: ${{ matrix.os }}
     steps:
@@ -200,11 +202,20 @@ jobs:
           allowed-endpoints: >
             *.blob.core.windows.net:443
             cli.codecov.io:443
+            github.com:443
             ingest.codecov.io:443
             keybase.io:443
             o26192.ingest.us.sentry.io:443
             results-receiver.actions.githubusercontent.com:443
             storage.googleapis.com:443
+      - name: Checkout source for coverage path mapping
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            .github
+            newton
       - name: Download test results artifact
         id: download-test-results
         continue-on-error: true
@@ -221,6 +232,7 @@ jobs:
         if: ${{ steps.download-test-results.outcome == 'success' }}
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad  # v5.5.3
         with:
+          disable_search: true
           files: ./rspec.xml
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -232,4 +244,5 @@ jobs:
           env_vars: OS
           files: ./coverage.xml
           flags: unittests
+          plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

The Codecov isolation work moved uploads out of test jobs so jobs
executing repository or PR code no longer receive `CODECOV_TOKEN`.
However, the isolated upload jobs had no repository checkout. Codecov
accepted the artifacts but could not construct the source network used
for path mapping, leaving coverage reports unprocessed.

This PR gives the CI and GPU upload jobs a minimal sparse checkout of
`.github` and `newton` at the exact tested ref. The checkout has
read-only repository access and does not persist credentials, so the
Codecov token remains isolated from jobs that execute tested code.

It also:

- Sets `override_commit` for GPU uploads so `pull_request_target` runs
  are attributed to the tested PR head rather than the base commit.
- Sets `disable_search: true` so only the explicitly named XML reports
  are uploaded.
- Uses `plugins: noop` for coverage uploads because the report path is
  explicit and no Codecov preparation plugin is needed.
- Allows the upload jobs to reach GitHub for the sparse checkout.

This change fixes future uploads. It does not modify historical Codecov
data.

## Checklist

- [x] New or existing tests cover these changes
- [x] Documentation is up to date; no user-facing documentation changes
      are required
- [x] `CHANGELOG.md` is unchanged because this is a CI-only fix

## Test plan

- `uvx --from actionlint-py actionlint .github/workflows/ci.yml .github/workflows/aws_gpu_tests.yml`
- `uvx pre-commit run -a`
- `git diff --check`
- Ran the complete CI workflow on the fork at commit
  `cd6170b8340daad9fb2b52a521e1facfe686b060`:
  https://github.com/shi-eric/newton/actions/runs/29511859561
- All four platform-specific Codecov upload jobs passed.
- Logs confirmed that test-result uploads selected only `rspec.xml`.
- Logs confirmed that coverage uploads selected only `coverage.xml` and
  invoked the Codecov CLI with `--plugin noop`.
- Logs confirmed that the checkout and uploads used the tested commit.

The fork cannot exercise Newton's upstream-only
`pull_request_target` GPU wrapper or its Codecov integration. The
upstream PR checks will therefore provide the final end-to-end
validation of GPU commit attribution and Codecov processing.

## Bug fix

**Steps to reproduce:**

1. Run the isolated Codecov upload jobs without checking out the tested
   source tree.
2. Observe that the Codecov action accepts and queues the uploaded
   artifacts.
3. Inspect the corresponding Codecov commit and observe that coverage
   processing does not complete because the source network required for
   path mapping is unavailable.

**Minimal reproduction:**

The existing isolated upload jobs on `upstream/main` reproduce the
issue: they download the XML artifacts and invoke Codecov without a
repository checkout. No application-level reproduction is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated test coverage reporting and source path mapping.
  - Updated continuous integration workflows to use more secure, limited repository access.
  - Expanded support for coverage uploads and test result processing in hardened build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->