### PR TITLE
Warn for ignored MuJoCo loop-joint properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix MJCF, URDF, and USD imports rendering collision-only bodies as visuals when the asset authors visual geometry elsewhere. (#3291)
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
 - Fix builder merging (`ModelBuilder.add_builder()`, `add_world()`, `replicate()`) offsetting negative reference sentinels in custom attribute values stored as NumPy or Warp integer scalars.
+- Warn when `SolverMuJoCo` converts a loop-closing joint to equality constraints and drops configured joint properties; document that loop-joint state and controls are not synchronized.
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.

--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -74,6 +74,28 @@ Joint types
      - *unsupported*
      - Not forwarded to MuJoCo.
 
+Loop-closing joints
+~~~~~~~~~~~~~~~~~~~
+
+MuJoCo requires a tree topology. :class:`~newton.solvers.SolverMuJoCo`
+therefore converts Newton joints outside an articulation that close a
+kinematic loop into MuJoCo equality constraints: ``WELD`` for a fixed joint,
+two ``CONNECT`` constraints for a revolute joint, or one ``CONNECT`` for a
+ball joint. Equality constraints do not have MuJoCo joint coordinates or
+joint properties. Consequently, limits, drives, damping, passive stiffness,
+armature, friction, effort/velocity limits, and ``joint_enabled`` configured
+on a loop-closing joint are ignored. The solver emits one warning per affected
+loop joint and names the configured properties it cannot represent.
+
+The corresponding entries in :attr:`~newton.State.joint_q` and
+:attr:`~newton.State.joint_qd` remain in Newton's shape-stable arrays, but the
+MuJoCo push/pull path does not read or write them. Setting those entries,
+:attr:`~newton.Control.joint_target_q`,
+:attr:`~newton.Control.joint_target_qd`, or
+:attr:`~newton.Control.joint_f` has no effect on the equality constraint, and
+their values must not be used as measured loop-joint state. Use the relative
+poses and velocities of the connected bodies when loop state is needed.
+
 
 Geometry types
 --------------

--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -83,9 +83,10 @@ kinematic loop into MuJoCo equality constraints: ``WELD`` for a fixed joint,
 two ``CONNECT`` constraints for a revolute joint, or one ``CONNECT`` for a
 ball joint. Equality constraints do not have MuJoCo joint coordinates or
 joint properties. Consequently, limits, drives, damping, passive stiffness,
-armature, friction, effort/velocity limits, and ``joint_enabled`` configured
-on a loop-closing joint are ignored. The solver emits one warning per affected
-loop joint and names the configured properties it cannot represent.
+spring reference, reference position, armature, friction, effort/velocity
+limits, and ``joint_enabled`` configured on a loop-closing joint are ignored.
+The solver emits one warning per affected loop joint and names the configured
+properties it cannot represent.
 
 The corresponding entries in :attr:`~newton.State.joint_q` and
 :attr:`~newton.State.joint_qd` remain in Newton's shape-stable arrays, but the

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -436,6 +436,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
           :attr:`~newton.Model.joint_target_ke`/:attr:`~newton.Model.joint_target_kd`,
           :attr:`~newton.Model.joint_target_mode`, and :attr:`~newton.Control.joint_f` are supported.
         - Equality constraints (CONNECT, WELD, JOINT) and mimic constraints (REVOLUTE and PRISMATIC only) are supported.
+          Loop-closing Newton joints are lowered to equality constraints, so their limits, drives,
+          passive properties, controls, and ``joint_q``/``joint_qd`` entries are not supported.
         - :attr:`~newton.Model.joint_velocity_limit` and :attr:`~newton.Model.joint_enabled`
           are not supported.
 
@@ -5029,6 +5031,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         joint_q_start = model.joint_q_start.numpy()
         joint_armature = model.joint_armature.numpy()
         joint_effort_limit = model.joint_effort_limit.numpy()
+        joint_velocity_limit = model.joint_velocity_limit.numpy()
+        joint_enabled = model.joint_enabled.numpy()
         # Per-DOF actuator arrays
         joint_target_mode = model.joint_target_mode.numpy()
         joint_target_ke = model.joint_target_ke.numpy()
@@ -5258,6 +5262,49 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         joints_loop = np.asarray(
             [joint for joint in joints_unassigned if joint not in standalone_root_set], dtype=np.int32
         )
+
+        def warn_ignored_loop_joint_properties(joint: int) -> None:
+            dof_start = int(joint_qd_start[joint])
+            dof_end = int(joint_qd_start[joint + 1])
+            ignored = []
+
+            if not bool(joint_enabled[joint]):
+                ignored.append("enabled=False")
+            if dof_end > dof_start:
+                dofs = slice(dof_start, dof_end)
+                if np.any(joint_limit_lower[dofs] > -MAXVAL) or np.any(joint_limit_upper[dofs] < MAXVAL):
+                    ignored.append("limits (including limit stiffness/damping)")
+                if (
+                    np.any(joint_target_mode[dofs] != int(JointTargetMode.NONE))
+                    or np.any(joint_target_ke[dofs] != 0.0)
+                    or np.any(joint_target_kd[dofs] != 0.0)
+                ):
+                    ignored.append("drive")
+                if joint_damping is not None and np.any(joint_damping[dofs] != 0.0):
+                    ignored.append("damping")
+                if joint_stiffness is not None and np.any(joint_stiffness[dofs] != 0.0):
+                    ignored.append("passive stiffness")
+                if np.any(joint_armature[dofs] != 0.0):
+                    ignored.append("armature")
+                if np.any(joint_friction[dofs] != 0.0):
+                    ignored.append("friction")
+                if np.any(joint_effort_limit[dofs] != 1.0e6):
+                    ignored.append("effort limit")
+                if np.any(joint_velocity_limit[dofs] != 1.0e6):
+                    ignored.append("velocity limit")
+                if joint_springref is not None and np.any(joint_springref[dofs] != 0.0):
+                    ignored.append("spring reference")
+                if joint_ref is not None and np.any(joint_ref[dofs] != 0.0):
+                    ignored.append("reference position")
+
+            if ignored:
+                label = model.joint_label[joint]
+                warnings.warn(
+                    f"SolverMuJoCo converts loop joint '{label}' to MuJoCo equality constraints, which ignore "
+                    f"these configured joint properties: {', '.join(ignored)}. Loop-joint joint_q and joint_qd "
+                    "entries are also not synchronized, and Control targets/joint_f have no effect.",
+                    stacklevel=2,
+                )
 
         # Every selected body needs exactly one creation path before its shapes and state can be converted.
         instantiated_bodies = articulated_bodies | standalone_root_bodies
@@ -6299,6 +6346,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         for j in joints_loop:
             if int(j) in converted_loop_joint_targets:
                 continue
+
+            warn_ignored_loop_joint_properties(int(j))
 
             j_type = int(joint_type[j])
             parent_name = get_body_name(joint_parent[j])

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -5037,8 +5037,6 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         joint_target_mode = model.joint_target_mode.numpy()
         joint_target_ke = model.joint_target_ke.numpy()
         joint_target_kd = model.joint_target_kd.numpy()
-        # MoJoCo doesn't have velocity limit
-        # joint_velocity_limit = model.joint_velocity_limit.numpy()
         joint_friction = model.joint_friction.numpy()
         joint_world = model.joint_world.numpy()
         body_flags = model.body_flags.numpy()

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -7488,6 +7488,49 @@ class TestMuJoCoArticulationConversion(unittest.TestCase):
         # (only CONNECT entries are tracked) so the mapping should be all -1
         assert np.allclose(solver.mjc_eq_to_newton_jnt.numpy(), np.full_like(solver.mjc_eq_to_newton_jnt.numpy(), -1))
 
+    def test_loop_joint_warns_for_ignored_properties(self):
+        """Configured joint properties report what equality conversion drops."""
+        builder = newton.ModelBuilder()
+        b0 = builder.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        b1 = builder.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        j0 = builder.add_joint_revolute(-1, b0)
+        j1 = builder.add_joint_revolute(b0, b1)
+        builder.add_articulation([j0, j1])
+        builder.add_joint_revolute(
+            b1,
+            b0,
+            label="closing_hinge",
+            limit_lower=-0.5,
+            limit_upper=0.5,
+            target_ke=10.0,
+            target_kd=1.0,
+            damping=0.2,
+            armature=0.3,
+            effort_limit=4.0,
+            velocity_limit=5.0,
+            friction=0.6,
+            enabled=False,
+        )
+        model = builder.finalize()
+
+        with self.assertWarnsRegex(UserWarning, "closing_hinge") as caught:
+            SolverMuJoCo(model, disable_contacts=True)
+
+        message = str(caught.warning)
+        for property_name in (
+            "limits",
+            "drive",
+            "damping",
+            "armature",
+            "effort limit",
+            "velocity limit",
+            "friction",
+            "enabled=False",
+            "joint_q",
+            "joint_qd",
+        ):
+            self.assertIn(property_name, message)
+
     def test_mixed_loop_joints_and_equality_constraints(self):
         """Testing that loop joints and regular equality constraints are converted to equality constraints."""
         builder = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Warn when a Newton loop-closing joint configures behavior that MuJoCo equality constraints cannot represent: enable state, limits, drives, damping, stiffness, armature, friction, effort/velocity limits, or reference state.

The warning also states that `joint_q` and `joint_qd` are not synchronized and controls have no effect. The MuJoCo solver documentation now describes the equality-constraint limitation and recommended modeling choices.

This follows the warning/documentation direction discussed by @adenzler-nvidia and @gyeomannvidia.

Closes #2428.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_mujoco_solver.TestMuJoCoArticulationConversion
uvx pre-commit run -a
```

19 focused tests pass on CPU.

## Bug fix

**Steps to reproduce:**

1. Create a joint that closes an articulation loop.
2. Configure a limit, drive, friction, armature, or state.
3. Construct `SolverMuJoCo`.
4. On main, conversion silently drops those properties.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
# Build an articulation, then add an unassigned closing joint with limits.
model = builder.finalize()
solver = newton.solvers.SolverMuJoCo(model)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MuJoCo solver now emits warnings (one per affected loop joint) when loop-closing joints have configured properties that can’t be preserved after conversion, including `enabled=False`, and drops those properties.
  * Converted loop joints are handled via MuJoCo equality constraints, so their joint coordinates/properties and direct control targets are not applied.
* **Documentation**
  * Added a “Loop-closing joints” section describing how loop joints are converted (WELD/CONNECT) and which properties are ignored, plus guidance for retrieving loop state from connected-body relative poses/velocities.
* **Tests**
  * Added a unit test asserting the warning content includes all ignored property categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->