### PR TITLE
Fix XPBD elastic multiplier persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix MJCF, URDF, and USD imports rendering collision-only bodies as visuals when the asset authors visual geometry elsewhere. (#3291)
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
 - Fix builder merging (`ModelBuilder.add_builder()`, `add_world()`, `replicate()`) offsetting negative reference sentinels in custom attribute values stored as NumPy or Warp integer scalars.
+- Fix `SolverXPBD` spring, bending, and tetrahedral compliance becoming artificially rigid as nonlinear iteration counts increase.
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -321,10 +321,12 @@ def solve_springs(
     spring_stiffness: wp.array[float],
     spring_damping: wp.array[float],
     dt: float,
-    lambdas: wp.array[float],
+    lambda_in: wp.array[float],
+    lambda_out: wp.array[float],
     delta: wp.array[wp.vec3],
 ):
     tid = wp.tid()
+    lambda_out[tid] = lambda_in[tid]
 
     i = spring_indices[tid * 2 + 0]
     j = spring_indices[tid * 2 + 1]
@@ -366,12 +368,13 @@ def solve_springs(
     gamma = kd / (ke * dt)
 
     grad_c_dot_v = dt * wp.dot(grad_c_xi, vij)  # Note: dt because from the paper we want x_i - x^n, not v...
-    dlambda = -1.0 * (c + alpha * lambdas[tid] + gamma * grad_c_dot_v) / ((1.0 + gamma) * denom + alpha)
+    lambda_prev = lambda_in[tid]
+    dlambda = -1.0 * (c + alpha * lambda_prev + gamma * grad_c_dot_v) / ((1.0 + gamma) * denom + alpha)
 
     dxi = wi * dlambda * grad_c_xi
     dxj = wj * dlambda * grad_c_xj
 
-    lambdas[tid] = lambdas[tid] + dlambda
+    lambda_out[tid] = lambda_prev + dlambda
 
     wp.atomic_add(delta, i, dxi)
     wp.atomic_add(delta, j, dxj)
@@ -386,10 +389,12 @@ def bending_constraint(
     rest: wp.array[float],
     bending_properties: wp.array2d[float],
     dt: float,
-    lambdas: wp.array[float],
+    lambda_in: wp.array[float],
+    lambda_out: wp.array[float],
     delta: wp.array[wp.vec3],
 ):
     tid = wp.tid()
+    lambda_out[tid] = lambda_in[tid]
     eps = 1.0e-6
 
     ke = bending_properties[tid, 0]
@@ -463,14 +468,15 @@ def bending_constraint(
 
     grad_dot_v = dt * (wp.dot(grad_x1, v1) + wp.dot(grad_x2, v2) + wp.dot(grad_x3, v3) + wp.dot(grad_x4, v4))
 
-    dlambda = -1.0 * (c + alpha * lambdas[tid] + gamma * grad_dot_v) / ((1.0 + gamma) * denominator + alpha)
+    lambda_prev = lambda_in[tid]
+    dlambda = -1.0 * (c + alpha * lambda_prev + gamma * grad_dot_v) / ((1.0 + gamma) * denominator + alpha)
 
     delta0 = w1 * dlambda * grad_x1
     delta1 = w2 * dlambda * grad_x2
     delta2 = w3 * dlambda * grad_x3
     delta3 = w4 * dlambda * grad_x4
 
-    lambdas[tid] = lambdas[tid] + dlambda
+    lambda_out[tid] = lambda_prev + dlambda
 
     wp.atomic_add(delta, i, delta0)
     wp.atomic_add(delta, j, delta1)
@@ -489,7 +495,8 @@ def solve_tetrahedra(
     materials: wp.array2d[float],
     dt: float,
     relaxation: float,
-    lambdas: wp.array[float],
+    lambda_in: wp.array[float],
+    lambda_out: wp.array[float],
     delta: wp.array[wp.vec3],
 ):
     # Tetrahedral XPBD constraint solve.
@@ -526,6 +533,8 @@ def solve_tetrahedra(
     # They persist across nonlinear iterations within the time step so finite
     # compliance does not harden as the iteration count increases.
     tid = wp.tid()
+    lambda_out[tid * 2] = lambda_in[tid * 2]
+    lambda_out[tid * 2 + 1] = lambda_in[tid * 2 + 1]
 
     i = indices[tid, 0]
     j = indices[tid, 1]
@@ -615,9 +624,10 @@ def solve_tetrahedra(
                 gamma = k_damp / (stiffness * dt)
                 grad_dot_v = dt * (wp.dot(grad0, v0) + wp.dot(grad1, v1) + wp.dot(grad2, v2) + wp.dot(grad3, v3))
             lambda_index = tid * num_terms + term
-            dlambda = -1.0 * (C + alpha * lambdas[lambda_index] + gamma * grad_dot_v) / ((1.0 + gamma) * w + alpha)
+            lambda_prev = lambda_in[lambda_index]
+            dlambda = -1.0 * (C + alpha * lambda_prev + gamma * grad_dot_v) / ((1.0 + gamma) * w + alpha)
             dlambda *= relaxation
-            lambdas[lambda_index] = lambdas[lambda_index] + dlambda
+            lambda_out[lambda_index] = lambda_prev + dlambda
 
             wp.atomic_add(delta, i, w0 * dlambda * grad0)
             wp.atomic_add(delta, j, w1 * dlambda * grad1)

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -489,6 +489,7 @@ def solve_tetrahedra(
     materials: wp.array2d[float],
     dt: float,
     relaxation: float,
+    lambdas: wp.array[float],
     delta: wp.array[wp.vec3],
 ):
     # Tetrahedral XPBD constraint solve.
@@ -521,8 +522,9 @@ def solve_tetrahedra(
     #     dlambda = -(C + gamma * dt * grad(C).dot(v))
     #               / ((1 + gamma) * sum_i(w_i |grad_i C|^2) + alpha)
     #
-    # The solver does not persist lambdas for this constraint, so each iteration
-    # computes a local multiplier and accumulates relaxed position corrections.
+    # Each tetrahedron stores one accumulated multiplier per scalar constraint.
+    # They persist across nonlinear iterations within the time step so finite
+    # compliance does not harden as the iteration count increases.
     tid = wp.tid()
 
     i = indices[tid, 0]
@@ -592,37 +594,35 @@ def solve_tetrahedra(
             compliance = inv_rest_volume / k_lambda
             stiffness = k_lambda
 
-        if C != 0.0:
-            dP = dC * inv_QT
-            grad1 = wp.vec3(dP[0][0], dP[1][0], dP[2][0])
-            grad2 = wp.vec3(dP[0][1], dP[1][1], dP[2][1])
-            grad3 = wp.vec3(dP[0][2], dP[1][2], dP[2][2])
-            grad0 = -grad1 - grad2 - grad3
+        dP = dC * inv_QT
+        grad1 = wp.vec3(dP[0][0], dP[1][0], dP[2][0])
+        grad2 = wp.vec3(dP[0][1], dP[1][1], dP[2][1])
+        grad3 = wp.vec3(dP[0][2], dP[1][2], dP[2][2])
+        grad0 = -grad1 - grad2 - grad3
 
-            w = (
-                wp.dot(grad0, grad0) * w0
-                + wp.dot(grad1, grad1) * w1
-                + wp.dot(grad2, grad2) * w2
-                + wp.dot(grad3, grad3) * w3
-            )
+        w = (
+            wp.dot(grad0, grad0) * w0
+            + wp.dot(grad1, grad1) * w1
+            + wp.dot(grad2, grad2) * w2
+            + wp.dot(grad3, grad3) * w3
+        )
 
-            if w > 0.0:
-                alpha = compliance / dt / dt
-                gamma = float(0.0)
-                grad_dot_v = float(0.0)
-                if k_damp > 0.0 and stiffness > 0.0:
-                    gamma = k_damp / (stiffness * dt)
-                    grad_dot_v = dt * (wp.dot(grad0, v0) + wp.dot(grad1, v1) + wp.dot(grad2, v2) + wp.dot(grad3, v3))
-                dlambda = -1.0 * (C + gamma * grad_dot_v) / ((1.0 + gamma) * w + alpha)
+        if w > 0.0:
+            alpha = compliance / dt / dt
+            gamma = float(0.0)
+            grad_dot_v = float(0.0)
+            if k_damp > 0.0 and stiffness > 0.0:
+                gamma = k_damp / (stiffness * dt)
+                grad_dot_v = dt * (wp.dot(grad0, v0) + wp.dot(grad1, v1) + wp.dot(grad2, v2) + wp.dot(grad3, v3))
+            lambda_index = tid * num_terms + term
+            dlambda = -1.0 * (C + alpha * lambdas[lambda_index] + gamma * grad_dot_v) / ((1.0 + gamma) * w + alpha)
+            dlambda *= relaxation
+            lambdas[lambda_index] = lambdas[lambda_index] + dlambda
 
-                wp.atomic_add(delta, i, w0 * dlambda * grad0 * relaxation)
-                wp.atomic_add(delta, j, w1 * dlambda * grad1 * relaxation)
-                wp.atomic_add(delta, k, w2 * dlambda * grad2 * relaxation)
-                wp.atomic_add(delta, l, w3 * dlambda * grad3 * relaxation)
-                # wp.atomic_add(particle.num_corr, id0, 1)
-                # wp.atomic_add(particle.num_corr, id1, 1)
-                # wp.atomic_add(particle.num_corr, id2, 1)
-                # wp.atomic_add(particle.num_corr, id3, 1)
+            wp.atomic_add(delta, i, w0 * dlambda * grad0)
+            wp.atomic_add(delta, j, w1 * dlambda * grad1)
+            wp.atomic_add(delta, k, w2 * dlambda * grad2)
+            wp.atomic_add(delta, l, w3 * dlambda * grad3)
 
     # C_Spherical
     # r_s = wp.sqrt(wp.dot(f1, f1) + wp.dot(f2, f2) + wp.dot(f3, f3))

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -459,10 +459,15 @@ class SolverXPBD(SolverBase, CouplingInterface):
 
             spring_constraint_lambdas = None
             if model.spring_count:
-                spring_constraint_lambdas = wp.empty_like(model.spring_rest_length)
+                spring_constraint_lambdas = wp.zeros_like(model.spring_rest_length)
             edge_constraint_lambdas = None
             if model.edge_count:
-                edge_constraint_lambdas = wp.empty_like(model.edge_rest_angle)
+                edge_constraint_lambdas = wp.zeros_like(model.edge_rest_angle)
+            tet_constraint_lambdas = None
+            if model.tet_count:
+                tet_constraint_lambdas = wp.zeros(
+                    model.tet_count * 2, dtype=float, device=model.device, requires_grad=requires_grad
+                )
 
             for i in range(self.iterations):
                 with wp.ScopedTimer(f"iteration_{i}", False):
@@ -540,7 +545,6 @@ class SolverXPBD(SolverBase, CouplingInterface):
 
                         # distance constraints
                         if model.spring_count:
-                            spring_constraint_lambdas.zero_()
                             wp.launch(
                                 kernel=solve_springs,
                                 dim=model.spring_count,
@@ -561,7 +565,6 @@ class SolverXPBD(SolverBase, CouplingInterface):
 
                         # bending constraints
                         if model.edge_count:
-                            edge_constraint_lambdas.zero_()
                             wp.launch(
                                 kernel=bending_constraint,
                                 dim=model.edge_count,
@@ -594,6 +597,7 @@ class SolverXPBD(SolverBase, CouplingInterface):
                                     model.tet_materials,
                                     dt,
                                     self.soft_body_relaxation,
+                                    tet_constraint_lambdas,
                                 ],
                                 outputs=[particle_deltas],
                                 device=model.device,

--- a/newton/_src/solvers/xpbd/solver_xpbd.py
+++ b/newton/_src/solvers/xpbd/solver_xpbd.py
@@ -458,16 +458,22 @@ class SolverXPBD(SolverBase, CouplingInterface):
                     state_in.body_f = body_f_prev
 
             spring_constraint_lambdas = None
+            spring_constraint_lambdas_next = None
             if model.spring_count:
-                spring_constraint_lambdas = wp.zeros_like(model.spring_rest_length)
+                spring_constraint_lambdas = wp.zeros_like(model.spring_rest_length, requires_grad=requires_grad)
+                spring_constraint_lambdas_next = wp.zeros_like(model.spring_rest_length, requires_grad=requires_grad)
             edge_constraint_lambdas = None
+            edge_constraint_lambdas_next = None
             if model.edge_count:
-                edge_constraint_lambdas = wp.zeros_like(model.edge_rest_angle)
+                edge_constraint_lambdas = wp.zeros_like(model.edge_rest_angle, requires_grad=requires_grad)
+                edge_constraint_lambdas_next = wp.zeros_like(model.edge_rest_angle, requires_grad=requires_grad)
             tet_constraint_lambdas = None
+            tet_constraint_lambdas_next = None
             if model.tet_count:
                 tet_constraint_lambdas = wp.zeros(
                     model.tet_count * 2, dtype=float, device=model.device, requires_grad=requires_grad
                 )
+                tet_constraint_lambdas_next = wp.zeros_like(tet_constraint_lambdas, requires_grad=requires_grad)
 
             for i in range(self.iterations):
                 with wp.ScopedTimer(f"iteration_{i}", False):
@@ -559,9 +565,17 @@ class SolverXPBD(SolverBase, CouplingInterface):
                                     dt,
                                     spring_constraint_lambdas,
                                 ],
-                                outputs=[particle_deltas],
+                                outputs=[spring_constraint_lambdas_next, particle_deltas],
                                 device=model.device,
                             )
+                            previous_lambdas = spring_constraint_lambdas
+                            spring_constraint_lambdas = spring_constraint_lambdas_next
+                            if requires_grad and i + 1 < self.iterations:
+                                spring_constraint_lambdas_next = wp.zeros_like(
+                                    spring_constraint_lambdas, requires_grad=True
+                                )
+                            else:
+                                spring_constraint_lambdas_next = previous_lambdas
 
                         # bending constraints
                         if model.edge_count:
@@ -578,9 +592,17 @@ class SolverXPBD(SolverBase, CouplingInterface):
                                     dt,
                                     edge_constraint_lambdas,
                                 ],
-                                outputs=[particle_deltas],
+                                outputs=[edge_constraint_lambdas_next, particle_deltas],
                                 device=model.device,
                             )
+                            previous_lambdas = edge_constraint_lambdas
+                            edge_constraint_lambdas = edge_constraint_lambdas_next
+                            if requires_grad and i + 1 < self.iterations:
+                                edge_constraint_lambdas_next = wp.zeros_like(
+                                    edge_constraint_lambdas, requires_grad=True
+                                )
+                            else:
+                                edge_constraint_lambdas_next = previous_lambdas
 
                         # tetrahedral FEM
                         if model.tet_count:
@@ -599,9 +621,15 @@ class SolverXPBD(SolverBase, CouplingInterface):
                                     self.soft_body_relaxation,
                                     tet_constraint_lambdas,
                                 ],
-                                outputs=[particle_deltas],
+                                outputs=[tet_constraint_lambdas_next, particle_deltas],
                                 device=model.device,
                             )
+                            previous_lambdas = tet_constraint_lambdas
+                            tet_constraint_lambdas = tet_constraint_lambdas_next
+                            if requires_grad and i + 1 < self.iterations:
+                                tet_constraint_lambdas_next = wp.zeros_like(tet_constraint_lambdas, requires_grad=True)
+                            else:
+                                tet_constraint_lambdas_next = previous_lambdas
 
                         particle_q, particle_qd = self._apply_particle_deltas(
                             model, state_in, state_out, particle_deltas, dt

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -189,12 +189,44 @@ def test_elastic_spring_compliance_is_iteration_independent(test, device):
     one_iteration = solve(iterations=1)
     eight_iterations = solve(iterations=8)
 
+    for value in (one_iteration, eight_iterations):
+        test.assertGreater(value, 1.0)
+        test.assertLess(value, 2.0)
     test.assertAlmostEqual(
         eight_iterations,
         one_iteration,
         places=5,
         msg="More nonlinear iterations must not make a compliant spring artificially rigid.",
     )
+
+
+def test_elastic_spring_multiplier_autodiff(test, device):
+    """Verify multi-iteration multiplier accumulation preserves reverse-mode history."""
+    builder = newton.ModelBuilder()
+    builder.add_particle(pos=(0.0, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=0.0, radius=0.0)
+    builder.add_particle(pos=(1.0, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=1.0, radius=0.0)
+    builder.add_spring(0, 1, ke=10.0, kd=0.0, control=0.0)
+
+    model = builder.finalize(device=device, requires_grad=True)
+    model.set_gravity((0.0, 0.0, 0.0))
+    state_in = model.state(requires_grad=True)
+    state_out = model.state(requires_grad=True)
+    state_in.particle_q.assign([(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)])
+    solver = newton.solvers.SolverXPBD(model, iterations=4)
+
+    verify_array_access = wp.config.verify_autograd_array_access
+    wp.config.verify_autograd_array_access = True
+    try:
+        with wp.Tape() as tape:
+            solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+        output_grad = wp.array([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)], dtype=wp.vec3, device=device)
+        tape.backward(grads={state_out.particle_q: output_grad})
+    finally:
+        wp.config.verify_autograd_array_access = verify_array_access
+
+    gradient = float(model.spring_stiffness.grad.numpy()[0])
+    test.assertTrue(np.isfinite(gradient))
+    test.assertAlmostEqual(gradient, -1.0 / 121.0, places=5)
 
 
 def test_elastic_bending_compliance_is_iteration_independent(test, device):
@@ -224,6 +256,9 @@ def test_elastic_bending_compliance_is_iteration_independent(test, device):
     four_iterations = solve(iterations=4)
     sixteen_iterations = solve(iterations=16)
 
+    for value in (four_iterations, sixteen_iterations):
+        test.assertGreater(value, 0.0)
+        test.assertLess(value, 1.0)
     test.assertAlmostEqual(
         sixteen_iterations,
         four_iterations,
@@ -259,6 +294,9 @@ def test_elastic_tet_compliance_is_iteration_independent(test, device):
     four_iterations = solve(iterations=4)
     sixteen_iterations = solve(iterations=16)
 
+    for value in (four_iterations, sixteen_iterations):
+        test.assertGreater(value, 1.0)
+        test.assertLess(value, 2.0)
     test.assertAlmostEqual(
         sixteen_iterations,
         four_iterations,
@@ -1689,6 +1727,14 @@ add_function_test(
     TestSolverXPBD,
     "test_elastic_spring_compliance_is_iteration_independent",
     test_elastic_spring_compliance_is_iteration_independent,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_elastic_spring_multiplier_autodiff",
+    test_elastic_spring_multiplier_autodiff,
     devices=devices,
     check_output=False,
 )

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -167,6 +167,106 @@ def test_optional_control_and_contacts(test, device):
     test.assertLess(float(state_out.particle_q.numpy()[0, 1]), 1.0)
 
 
+def test_elastic_spring_compliance_is_iteration_independent(test, device):
+    """Verify nonlinear iterations preserve finite spring compliance."""
+
+    def solve(iterations: int) -> float:
+        builder = newton.ModelBuilder()
+        builder.add_particle(pos=(0.0, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=0.0, radius=0.0)
+        builder.add_particle(pos=(1.0, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=1.0, radius=0.0)
+        builder.add_spring(0, 1, ke=10.0, kd=0.0, control=0.0)
+
+        model = builder.finalize(device=device)
+        model.set_gravity((0.0, 0.0, 0.0))
+        state_in = model.state()
+        state_out = model.state()
+        state_in.particle_q.assign([(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)])
+
+        solver = newton.solvers.SolverXPBD(model, iterations=iterations)
+        solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+        return float(state_out.particle_q.numpy()[1, 0])
+
+    one_iteration = solve(iterations=1)
+    eight_iterations = solve(iterations=8)
+
+    test.assertAlmostEqual(
+        eight_iterations,
+        one_iteration,
+        places=5,
+        msg="More nonlinear iterations must not make a compliant spring artificially rigid.",
+    )
+
+
+def test_elastic_bending_compliance_is_iteration_independent(test, device):
+    """Verify converged bending constraints preserve finite compliance."""
+
+    def solve(iterations: int) -> float:
+        builder = newton.ModelBuilder()
+        for position, mass in (
+            ((0.0, 1.0, 0.0), 0.0),
+            ((0.0, -1.0, 0.0), 1.0),
+            ((0.0, 0.0, 0.0), 0.0),
+            ((1.0, 0.0, 0.0), 0.0),
+        ):
+            builder.add_particle(pos=wp.vec3(*position), vel=wp.vec3(0.0), mass=mass, radius=0.0)
+        builder.add_edge(0, 1, 2, 3, edge_ke=10.0, edge_kd=0.0)
+
+        model = builder.finalize(device=device)
+        model.set_gravity((0.0, 0.0, 0.0))
+        state_in = model.state()
+        state_out = model.state()
+        state_in.particle_q.assign([(0.0, 1.0, 0.0), (0.0, -1.0, 1.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)])
+
+        solver = newton.solvers.SolverXPBD(model, iterations=iterations)
+        solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+        return float(state_out.particle_q.numpy()[1, 2])
+
+    four_iterations = solve(iterations=4)
+    sixteen_iterations = solve(iterations=16)
+
+    test.assertAlmostEqual(
+        sixteen_iterations,
+        four_iterations,
+        places=5,
+        msg="Converged nonlinear iterations must not make a compliant bending edge artificially rigid.",
+    )
+
+
+def test_elastic_tet_compliance_is_iteration_independent(test, device):
+    """Verify converged tetrahedral constraints preserve finite compliance."""
+
+    def solve(iterations: int) -> float:
+        builder = newton.ModelBuilder()
+        for position, mass in (
+            ((0.0, 0.0, 0.0), 0.0),
+            ((1.0, 0.0, 0.0), 0.0),
+            ((0.0, 1.0, 0.0), 0.0),
+            ((0.0, 0.0, 1.0), 1.0),
+        ):
+            builder.add_particle(pos=position, vel=(0.0, 0.0, 0.0), mass=mass, radius=0.0)
+        builder.add_tetrahedron(0, 1, 2, 3, k_mu=10.0, k_lambda=10.0, k_damp=0.0)
+
+        model = builder.finalize(device=device)
+        model.set_gravity((0.0, 0.0, 0.0))
+        state_in = model.state()
+        state_out = model.state()
+        state_in.particle_q.assign([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 2.0)])
+
+        solver = newton.solvers.SolverXPBD(model, iterations=iterations, soft_body_relaxation=1.0)
+        solver.step(state_in, state_out, control=None, contacts=None, dt=0.1)
+        return float(state_out.particle_q.numpy()[3, 2])
+
+    four_iterations = solve(iterations=4)
+    sixteen_iterations = solve(iterations=16)
+
+    test.assertAlmostEqual(
+        sixteen_iterations,
+        four_iterations,
+        places=5,
+        msg="Converged nonlinear iterations must not make a compliant tetrahedron artificially rigid.",
+    )
+
+
 def test_particle_particle_friction_with_relative_motion(test, device):
     """
     Test that friction DOES affect particles with different tangential velocities.
@@ -1581,6 +1681,30 @@ add_function_test(
     TestSolverXPBD,
     "test_optional_control_and_contacts",
     test_optional_control_and_contacts,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_elastic_spring_compliance_is_iteration_independent",
+    test_elastic_spring_compliance_is_iteration_independent,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_elastic_bending_compliance_is_iteration_independent",
+    test_elastic_bending_compliance_is_iteration_independent,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_elastic_tet_compliance_is_iteration_independent",
+    test_elastic_tet_compliance_is_iteration_independent,
     devices=devices,
     check_output=False,
 )


### PR DESCRIPTION
## Description

Preserve accumulated XPBD Lagrange multipliers across nonlinear iterations for springs, bending edges, and both tetrahedral material constraints. Tetrahedral relaxation now scales the multiplier and position update together. Differentiable solves write each iteration to fresh multiplier storage so reverse-mode history is preserved.

This keeps finite material compliance stable as iteration counts increase.

Closes #2933.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_solver_xpbd
uvx pre-commit run -a
```

32 focused tests pass on CPU, including spring, bending, and tetrahedron iteration-independence regressions plus multi-iteration reverse-mode coverage.

## Bug fix

**Steps to reproduce:**

1. Build a finite-stiffness spring, bending edge, or tetrahedron.
2. Start it away from its rest configuration.
3. Compare one step with converged low and high nonlinear iteration counts.
4. On main, the higher count drives the elastic constraint toward a hard constraint.

**Minimal reproduction:**

```python
import newton

builder = newton.ModelBuilder()
builder.add_particle((0.0, 0.0, 0.0), mass=0.0)
builder.add_particle((1.0, 0.0, 0.0), mass=1.0)
builder.add_spring(0, 1, ke=10.0, kd=0.0)
model = builder.finalize()
solver = newton.solvers.SolverXPBD(model, iterations=8)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XPBD spring, bending, and tetrahedral constraints becoming artificially rigid when nonlinear iteration counts increase.
  * Improved compliance consistency across varying iteration counts for more stable, repeatable simulations.

* **Tests**
  * Added regression tests covering iteration-independent compliance for elastic spring, elastic bending, and elastic tetrahedral constraints.
  * Added a regression test to ensure spring constraint multiplier behavior remains correct under reverse-mode autodiff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
