### PR TITLE
Respect USD schema default applicability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix MJCF, URDF, and USD imports rendering collision-only bodies as visuals when the asset authors visual geometry elsewhere. (#3291)
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
 - Fix builder merging (`ModelBuilder.add_builder()`, `add_world()`, `replicate()`) offsetting negative reference sentinels in custom attribute values stored as NumPy or Warp integer scalars.
+- Fix USD schema mapping defaults applying to prims that do not carry the corresponding solver schema, and preserve resolver/source provenance for importer decisions.
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.

--- a/docs/concepts/usd_parsing.rst
+++ b/docs/concepts/usd_parsing.rst
@@ -470,7 +470,11 @@ The attribute resolution process follows a three-layer fallback hierarchy to det
 
 1. **Authored Values**: Resolvers are queried in priority order; the first resolver that finds an authored value on the prim returns it and remaining resolvers are not consulted.
 2. **Importer Defaults**: If no authored value is found, Newton's importer uses a property-specific fallback (e.g. ``builder.default_joint_cfg.armature`` for joint armature). This takes precedence over schema-level defaults.
-3. **Approximated Schema Defaults**: If neither an authored value nor an importer default is available, Newton falls back to a hardcoded approximation of each solver's schema default, defined in Newton's resolver mapping. These approximations will be replaced by actual USD schema defaults in a future release.
+3. **Applicable Schema Defaults**: If neither an authored value nor an importer default is
+   available, Newton uses the first mapping default whose corresponding API schema applies to
+   the prim (or whose typed prim matches). A configured resolver does not inject its defaults
+   into unrelated prims. Resolver results retain whether the winner was authored, an importer
+   default, or a schema default so importer-specific semantics can use the same resolution path.
 
 **Configuring Resolver Priority:**
 

--- a/newton/_src/usd/schema_resolver.py
+++ b/newton/_src/usd/schema_resolver.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import Enum, IntEnum
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from . import utils as usd
@@ -81,6 +81,13 @@ class SchemaResolver:
     # namespaces are never read as deformable attributes.
     deformable_attr_namespaces: ClassVar[list[str]] = []
 
+    # Applied API schemas and typed prim names that make this resolver's mapping defaults
+    # applicable. Resolvers that leave both maps empty retain the legacy always-applicable
+    # behavior, which keeps third-party resolver subclasses backward compatible.
+    _applicable_api_schemas: ClassVar[dict[PrimType, tuple[str, ...]]] = {}
+    _applicable_api_schemas_by_key: ClassVar[dict[PrimType, dict[str, tuple[str, ...]]]] = {}
+    _applicable_prim_type_names: ClassVar[dict[PrimType, tuple[str, ...]]] = {}
+
     def __init__(self) -> None:
         # Precompute the full set of USD attribute names referenced by this resolver's mapping.
         names: set[str] = set()
@@ -122,6 +129,29 @@ class SchemaResolver:
             if v is not None:
                 return spec.usd_value_transformer(v) if spec.usd_value_transformer is not None else v
         return None
+
+    def _is_applicable(self, prim: Usd.Prim, prim_type: PrimType, key: str) -> bool:
+        """Return whether this resolver's schema default applies to a prim and key."""
+        api_names = self._applicable_api_schemas_by_key.get(prim_type, {}).get(
+            key, self._applicable_api_schemas.get(prim_type, ())
+        )
+        prim_type_names = self._applicable_prim_type_names.get(prim_type, ())
+        if not api_names and not prim_type_names:
+            return (
+                not self._applicable_api_schemas
+                and not self._applicable_api_schemas_by_key
+                and not self._applicable_prim_type_names
+            )
+        if prim is None:
+            return False
+        try:
+            applied = {str(name).split(":", 1)[0] for name in prim.GetAppliedSchemas()}
+            if any(name in applied or usd.has_applied_api_schema(prim, name) for name in api_names):
+                return True
+            type_name = str(prim.GetTypeName())
+            return any(type_name.startswith(name) for name in prim_type_names)
+        except (AttributeError, RuntimeError):
+            return False
 
     def collect_prim_attrs(self, prim: Usd.Prim) -> dict[str, Any]:
         """Collect all resolver-relevant attributes for a prim.
@@ -194,6 +224,22 @@ class SchemaResolverManager:
     Manager for resolving multiple USD schemas in a priority order.
     """
 
+    class Source(Enum):
+        """Origin of a resolved value."""
+
+        AUTHORED = "authored"
+        IMPORTER_DEFAULT = "importer_default"
+        SCHEMA_DEFAULT = "schema_default"
+        UNRESOLVED = "unresolved"
+
+    @dataclass(frozen=True)
+    class Resolution:
+        """Resolved value together with its schema and source provenance."""
+
+        value: Any
+        resolver: SchemaResolver | None
+        source: SchemaResolverManager.Source
+
     def __init__(self, resolvers: Sequence[SchemaResolver]):
         """
         Initialize resolver manager with resolver instances in priority order.
@@ -221,11 +267,11 @@ class SchemaResolverManager:
         self, prim: Usd.Prim, prim_type: PrimType, key: str, default: Any = None, verbose: bool = False
     ) -> Any:
         """
-        Resolve value using schema priority, with layered fallbacks:
+        Resolve a value using schema priority, with layered fallbacks:
 
         1) First authored value found in resolver order (highest priority first)
         2) If none authored, use the provided 'default' argument if not None
-        3) If no default provided, use the first non-None mapping default from resolvers in priority order
+        3) If no default is provided, use the first mapping default whose schema applies to the prim
         4) If no mapping default found, return None
 
         Args:
@@ -237,46 +283,48 @@ class SchemaResolverManager:
         Returns:
             Resolved value according to the precedence above.
         """
-        value, _ = self.get_value_with_resolver(prim, prim_type, key, default, verbose)
-        return value
+        return self.resolve(prim, prim_type, key, default, verbose).value
 
-    def get_value_with_resolver(
+    def resolve(
         self, prim: Usd.Prim, prim_type: PrimType, key: str, default: Any = None, verbose: bool = False
-    ) -> tuple[Any, SchemaResolver | None]:
-        """Resolve a value and return the resolver that supplied an authored value."""
-        # 1) Authored value by schema priority
-        for r in self.resolvers:
-            val = r.get_value(prim, prim_type, key)
-            if val is None:
+    ) -> Resolution:
+        """Resolve a value and preserve its winning resolver and source."""
+        for resolver in self.resolvers:
+            value = resolver.get_value(prim, prim_type, key)
+            if value is None:
                 continue
-            self._collect_on_first_use(r, prim)
-            return val, r
+            self._collect_on_first_use(resolver, prim)
+            return self.Resolution(value, resolver, self.Source.AUTHORED)
 
-        # 2) Caller-provided default, if any
         if default is not None:
-            return default, None
+            return self.Resolution(default, None, self.Source.IMPORTER_DEFAULT)
 
-        # 3) Resolver mapping defaults in priority order
         for resolver in self.resolvers:
             spec = resolver.mapping.get(prim_type, {}).get(key) if hasattr(resolver, "mapping") else None
-            if spec is not None:
-                d = getattr(spec, "default", None)
-                if d is not None:
-                    transformer = getattr(spec, "usd_value_transformer", None)
-                    return (transformer(d) if transformer is not None else d), None
+            if spec is None or spec.default is None or not resolver._is_applicable(prim, prim_type, key):
+                continue
+            transformer = spec.usd_value_transformer
+            value = transformer(spec.default) if transformer is not None else spec.default
+            if value is not None:
+                return self.Resolution(value, resolver, self.Source.SCHEMA_DEFAULT)
 
-        # Nothing found
         try:
             prim_path = str(prim.GetPath()) if prim is not None else "<None>"
         except (AttributeError, RuntimeError):
             prim_path = "<invalid>"
         if verbose:
-            error_message = (
+            print(
                 f"Error: Cannot resolve value for '{prim_type.name.lower()}:{key}' on prim '{prim_path}'; "
-                + "no authored value, no explicit default, and no solver mapping default."
+                "no authored value, no explicit default, and no applicable schema mapping default."
             )
-            print(error_message)
-        return None, None
+        return self.Resolution(None, None, self.Source.UNRESOLVED)
+
+    def get_value_with_resolver(
+        self, prim: Usd.Prim, prim_type: PrimType, key: str, default: Any = None, verbose: bool = False
+    ) -> tuple[Any, SchemaResolver | None]:
+        """Resolve a value and return the resolver that supplied it, if any."""
+        resolution = self.resolve(prim, prim_type, key, default, verbose)
+        return resolution.value, resolution.resolver
 
     def deformable_compat_namespaces(self) -> list[str]:
         """Deformable vendor attribute namespaces declared by the active resolvers.

--- a/newton/_src/usd/schema_resolver.py
+++ b/newton/_src/usd/schema_resolver.py
@@ -130,7 +130,14 @@ class SchemaResolver:
                 return spec.usd_value_transformer(v) if spec.usd_value_transformer is not None else v
         return None
 
-    def _is_applicable(self, prim: Usd.Prim, prim_type: PrimType, key: str) -> bool:
+    def _is_applicable(
+        self,
+        prim: Usd.Prim,
+        prim_type: PrimType,
+        key: str,
+        applied_schemas: frozenset[str],
+        prim_type_name: str,
+    ) -> bool:
         """Return whether this resolver's schema default applies to a prim and key."""
         api_names = self._applicable_api_schemas_by_key.get(prim_type, {}).get(
             key, self._applicable_api_schemas.get(prim_type, ())
@@ -144,14 +151,9 @@ class SchemaResolver:
             )
         if prim is None:
             return False
-        try:
-            applied = {str(name).split(":", 1)[0] for name in prim.GetAppliedSchemas()}
-            if any(name in applied or usd.has_applied_api_schema(prim, name) for name in api_names):
-                return True
-            type_name = str(prim.GetTypeName())
-            return any(type_name.startswith(name) for name in prim_type_names)
-        except (AttributeError, RuntimeError):
-            return False
+        if any(name in applied_schemas for name in api_names):
+            return True
+        return any(prim_type_name.startswith(name) for name in prim_type_names)
 
     def collect_prim_attrs(self, prim: Usd.Prim) -> dict[str, Any]:
         """Collect all resolver-relevant attributes for a prim.
@@ -253,6 +255,25 @@ class SchemaResolverManager:
         # Dictionary to accumulate schema attributes as prims are encountered
         # Pre-initialize maps for each configured resolver
         self._schema_attrs: dict[str, dict[str, dict[str, Any]]] = {r.name: {} for r in self.resolvers}
+        self._prim_applicability_cache: dict[tuple[int, str], tuple[str, frozenset[str], str]] = {}
+
+    def _get_prim_applicability(self, prim: Usd.Prim) -> tuple[frozenset[str], str]:
+        """Return cached applied-schema and typed-prim information."""
+        if prim is None:
+            return frozenset(), ""
+        try:
+            cache_key = (id(prim.GetStage()), str(prim.GetPath()))
+            prim_type_name = str(prim.GetTypeName())
+            schema_signature = str(prim.GetMetadata("apiSchemas"))
+            cached = self._prim_applicability_cache.get(cache_key)
+            if cached is not None and cached[0] == schema_signature and cached[2] == prim_type_name:
+                return cached[1], cached[2]
+            schema_names = (*prim.GetAppliedSchemas(), *usd._get_raw_api_schemas(prim))
+            applied_schemas = frozenset(str(name).split(":", 1)[0] for name in schema_names)
+            self._prim_applicability_cache[cache_key] = (schema_signature, applied_schemas, prim_type_name)
+            return applied_schemas, prim_type_name
+        except (AttributeError, RuntimeError):
+            return frozenset(), ""
 
     def _collect_on_first_use(self, resolver: SchemaResolver, prim: Usd.Prim) -> None:
         """Collect and store attributes for this resolver/prim on first use."""
@@ -299,9 +320,14 @@ class SchemaResolverManager:
         if default is not None:
             return self.Resolution(default, None, self.Source.IMPORTER_DEFAULT)
 
+        applied_schemas, prim_type_name = self._get_prim_applicability(prim)
         for resolver in self.resolvers:
             spec = resolver.mapping.get(prim_type, {}).get(key) if hasattr(resolver, "mapping") else None
-            if spec is None or spec.default is None or not resolver._is_applicable(prim, prim_type, key):
+            if (
+                spec is None
+                or spec.default is None
+                or not resolver._is_applicable(prim, prim_type, key, applied_schemas, prim_type_name)
+            ):
                 continue
             transformer = spec.usd_value_transformer
             value = transformer(spec.default) if transformer is not None else spec.default

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -120,6 +120,48 @@ class SchemaResolverNewton(SchemaResolver):
     """
 
     name: ClassVar[str] = "newton"
+    _applicable_api_schemas: ClassVar[dict[PrimType, tuple[str, ...]]] = {
+        PrimType.SCENE: ("NewtonSceneAPI",),
+        PrimType.JOINT: ("NewtonJointAPI",),
+        PrimType.ARTICULATION: ("NewtonArticulationRootAPI",),
+        PrimType.MATERIAL: ("NewtonMaterialAPI",),
+    }
+    _applicable_api_schemas_by_key: ClassVar[dict[PrimType, dict[str, tuple[str, ...]]]] = {
+        PrimType.JOINT: dict.fromkeys(
+            (
+                "angular_position",
+                "linear_position",
+                "rotX_position",
+                "rotY_position",
+                "rotZ_position",
+                "angular_velocity",
+                "linear_velocity",
+                "rotX_velocity",
+                "rotY_velocity",
+                "rotZ_velocity",
+            ),
+            (),
+        ),
+        PrimType.SHAPE: {
+            "max_hull_vertices": ("NewtonMeshCollisionAPI",),
+            "margin": ("NewtonCollisionAPI",),
+            "gap": ("NewtonCollisionAPI",),
+            "ke": ("NewtonCollisionAPI",),
+            "kd": ("NewtonCollisionAPI",),
+            "kf": ("NewtonCollisionAPI",),
+            "ka": ("NewtonCollisionAPI",),
+            "sdf_max_resolution": ("NewtonSDFCollisionAPI",),
+            "sdf_narrow_band_inner": ("NewtonSDFCollisionAPI",),
+            "sdf_narrow_band_outer": ("NewtonSDFCollisionAPI",),
+            "sdf_target_voxel_size": ("NewtonSDFCollisionAPI",),
+            "sdf_texture_format": ("NewtonSDFCollisionAPI",),
+            "sdf_padding": ("NewtonSDFCollisionAPI",),
+            "hydroelastic_enabled": ("NewtonSDFCollisionAPI",),
+            "kh": ("NewtonSDFCollisionAPI",),
+            "mass_model": ("NewtonMassAPI",),
+            "shell_thickness": ("NewtonMassAPI",),
+        },
+    }
     mapping: ClassVar[dict[PrimType, dict[str, SchemaAttribute]]] = {
         PrimType.SCENE: {
             "max_solver_iterations": SchemaAttribute("newton:maxSolverIterations", -1),
@@ -269,15 +311,15 @@ class SchemaResolverNewton(SchemaResolver):
             ),
             # SDF configuration — from NewtonSDFCollisionAPI. `-inf` is the
             # "unset" sentinel (same convention as gap / shell_thickness above).
-            "sdf_max_resolution": SchemaAttribute("newton:sdfMaxResolution", float("-inf")),
+            "sdf_max_resolution": SchemaAttribute("newton:sdfMaxResolution", 64),
             "sdf_narrow_band_inner": SchemaAttribute("newton:sdfNarrowBandInner", float("-inf")),
             "sdf_narrow_band_outer": SchemaAttribute("newton:sdfNarrowBandOuter", float("-inf")),
             "sdf_target_voxel_size": SchemaAttribute("newton:sdfTargetVoxelSize", float("-inf")),
-            "sdf_texture_format": SchemaAttribute("newton:sdfTextureFormat", None),
+            "sdf_texture_format": SchemaAttribute("newton:sdfTextureFormat", "uint16"),
             "sdf_padding": SchemaAttribute("newton:sdfPadding", float("-inf")),
             # Hydroelastic contacts — folded into NewtonSDFCollisionAPI
-            "hydroelastic_enabled": SchemaAttribute("newton:hydroelasticEnabled", None),
-            "kh": SchemaAttribute("newton:hydroelasticStiffness", float("-inf")),
+            "hydroelastic_enabled": SchemaAttribute("newton:hydroelasticEnabled", False),
+            "kh": SchemaAttribute("newton:hydroelasticStiffness", 1.0e10),
             # Mass model
             "mass_model": SchemaAttribute("newton:massModel", "solid"),
             "shell_thickness": SchemaAttribute("newton:shellThickness", float("-inf")),
@@ -308,6 +350,59 @@ class SchemaResolverPhysx(SchemaResolver):
     """
 
     name: ClassVar[str] = "physx"
+    _applicable_api_schemas: ClassVar[dict[PrimType, tuple[str, ...]]] = {
+        PrimType.SCENE: ("PhysxSceneAPI",),
+        PrimType.BODY: ("PhysxRigidBodyAPI",),
+        PrimType.MATERIAL: ("PhysxMaterialAPI",),
+        PrimType.ARTICULATION: ("PhysxArticulationAPI",),
+    }
+    _applicable_api_schemas_by_key: ClassVar[dict[PrimType, dict[str, tuple[str, ...]]]] = {
+        PrimType.JOINT: {
+            "armature": ("PhysxJointAPI",),
+            "velocity_limit": ("PhysxJointAPI",),
+            **dict.fromkeys(
+                (
+                    "limit_transX_ke",
+                    "limit_transY_ke",
+                    "limit_transZ_ke",
+                    "limit_transX_kd",
+                    "limit_transY_kd",
+                    "limit_transZ_kd",
+                    "limit_linear_ke",
+                    "limit_angular_ke",
+                    "limit_rotX_ke",
+                    "limit_rotY_ke",
+                    "limit_rotZ_ke",
+                    "limit_linear_kd",
+                    "limit_angular_kd",
+                    "limit_rotX_kd",
+                    "limit_rotY_kd",
+                    "limit_rotZ_kd",
+                ),
+                ("PhysxLimitAPI",),
+            ),
+            **dict.fromkeys(
+                (
+                    "angular_position",
+                    "linear_position",
+                    "rotX_position",
+                    "rotY_position",
+                    "rotZ_position",
+                    "angular_velocity",
+                    "linear_velocity",
+                    "rotX_velocity",
+                    "rotY_velocity",
+                    "rotZ_velocity",
+                ),
+                ("PhysicsJointStateAPI",),
+            ),
+        },
+        PrimType.SHAPE: {
+            "max_hull_vertices": ("PhysxConvexHullCollisionAPI",),
+            "margin": ("PhysxCollisionAPI",),
+            "gap": ("PhysxCollisionAPI",),
+        },
+    }
     # Deformable material/geometry vendor namespaces (AOUSD proposal). The public
     # schema authors under ``physics:``; these carry the same parameters in existing
     # content. Kept separate from extra_attr_namespaces so they are only consulted
@@ -484,6 +579,15 @@ class SchemaResolverMjc(SchemaResolver):
     """Schema resolver for MuJoCo USD attributes."""
 
     name: ClassVar[str] = "mjc"
+    _applicable_api_schemas: ClassVar[dict[PrimType, tuple[str, ...]]] = {
+        PrimType.SCENE: ("MjcSceneAPI",),
+        PrimType.JOINT: ("MjcJointAPI",),
+        PrimType.SHAPE: ("MjcGeomAPI", "MjcCollisionAPI"),
+        PrimType.MATERIAL: ("MjcMaterialAPI",),
+    }
+    _applicable_prim_type_names: ClassVar[dict[PrimType, tuple[str, ...]]] = {
+        PrimType.ACTUATOR: ("MjcActuator",),
+    }
 
     mapping: ClassVar[dict[PrimType, dict[str, SchemaAttribute]]] = {
         PrimType.SCENE: {

--- a/newton/_src/usd/schemas.py
+++ b/newton/_src/usd/schemas.py
@@ -310,7 +310,8 @@ class SchemaResolverNewton(SchemaResolver):
                 usd_value_getter=_newton_legacy_contact_attr("newton:contact_ka", "newton:contactAdhesion"),
             ),
             # SDF configuration — from NewtonSDFCollisionAPI. `-inf` is the
-            # "unset" sentinel (same convention as gap / shell_thickness above).
+            # unset sentinel for narrow-band, voxel-size, and padding fields;
+            # the other fields use concrete schema defaults.
             "sdf_max_resolution": SchemaAttribute("newton:sdfMaxResolution", 64),
             "sdf_narrow_band_inner": SchemaAttribute("newton:sdfNarrowBandInner", float("-inf")),
             "sdf_narrow_band_outer": SchemaAttribute("newton:sdfNarrowBandOuter", float("-inf")),

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -628,50 +628,20 @@ def parse_usd(
     def _should_write_solreflimit_mode() -> bool:
         return mjc_resolver is not None and solreflimit_mode_key in builder.custom_attributes
 
-    # Keep source tracking local until schema applicability and provenance are modeled globally (#3307).
-    def _get_mjc_joint_limit_default(prim: Usd.Prim, key: str) -> float | None:
-        if mjc_resolver is None or not _has_api_schema(prim, "MjcJointAPI"):
-            return None
-        spec = mjc_resolver.mapping.get(PrimType.JOINT, {}).get(key)
-        if spec is None or spec.default is None:
-            return None
-        if spec.usd_value_transformer is not None:
-            return spec.usd_value_transformer(spec.default)
-        return spec.default
-
     def _resolve_joint_limit_gain(
         prim: Usd.Prim, key: str, builder_default: float
     ) -> tuple[float, Literal["force", "mjc_authored", "mjc_default"]]:
         """Resolve a limit gain and report the semantics of its source."""
-        for resolver in R.resolvers:
-            spec = resolver.mapping.get(PrimType.JOINT, {}).get(key)
-            if spec is None:
-                continue
-
-            if resolver.name == "mjc":
-                raw_value = usd.get_attribute(prim, spec.name)
-                if raw_value is None:
-                    continue
-                R._collect_on_first_use(resolver, prim)
-                authored_value = (
-                    spec.usd_value_transformer(raw_value) if spec.usd_value_transformer is not None else raw_value
-                )
-                if authored_value is not None:
-                    return authored_value, "mjc_authored"
-                mjc_default = _get_mjc_joint_limit_default(prim, key)
-                if mjc_default is not None:
-                    return mjc_default, "mjc_authored"
-                return builder_default, "mjc_authored"
-
-            authored_value = resolver.get_value(prim, PrimType.JOINT, key)
-            if authored_value is not None:
-                R._collect_on_first_use(resolver, prim)
-                return authored_value, "force"
-
-        if mjc_resolver is not None:
-            mjc_default = _get_mjc_joint_limit_default(prim, key)
-            if mjc_default is not None:
-                return mjc_default, "mjc_default"
+        resolution = R.resolve(prim, PrimType.JOINT, key)
+        if resolution.source == SchemaResolverManager.Source.AUTHORED:
+            source = "mjc_authored" if resolution.resolver and resolution.resolver.name == "mjc" else "force"
+            return resolution.value, source
+        if (
+            resolution.source == SchemaResolverManager.Source.SCHEMA_DEFAULT
+            and resolution.resolver
+            and resolution.resolver.name == "mjc"
+        ):
+            return resolution.value, "mjc_default"
         return builder_default, "force"
 
     def _joint_limit_solref_mode(ke_source: str, kd_source: str) -> int:
@@ -3308,9 +3278,10 @@ def parse_usd(
                 # Resolve target_voxel_size first because it overrides
                 # sdf_max_resolution and the two are mutually exclusive in
                 # ShapeConfig.validate().
-                sdf_target_voxel_size = R.get_value(
+                sdf_target_voxel_size_resolution = R.resolve(
                     prim, prim_type=PrimType.SHAPE, key="sdf_target_voxel_size", verbose=verbose
                 )
+                sdf_target_voxel_size = sdf_target_voxel_size_resolution.value
                 if sdf_target_voxel_size == float("-inf"):
                     sdf_target_voxel_size = None
                 elif sdf_target_voxel_size is not None and sdf_target_voxel_size <= 0:
@@ -3323,9 +3294,10 @@ def parse_usd(
                 if sdf_target_voxel_size is None:
                     sdf_target_voxel_size = builder.default_shape_cfg.sdf_target_voxel_size
 
-                sdf_max_resolution = R.get_value(
+                sdf_max_resolution_resolution = R.resolve(
                     prim, prim_type=PrimType.SHAPE, key="sdf_max_resolution", verbose=verbose
                 )
+                sdf_max_resolution = sdf_max_resolution_resolution.value
                 if sdf_max_resolution == float("-inf"):
                     sdf_max_resolution = None
                 elif sdf_max_resolution is not None and sdf_max_resolution <= 0:
@@ -3343,17 +3315,17 @@ def parse_usd(
                     )
                     sdf_max_resolution = None
                 if sdf_target_voxel_size is not None and sdf_max_resolution is not None:
-                    warnings.warn(
-                        f"{prim.GetPath()}: both newton:sdfTargetVoxelSize and newton:sdfMaxResolution "
-                        f"are set; sdfTargetVoxelSize takes precedence.",
-                        stacklevel=2,
-                    )
+                    if sdf_max_resolution_resolution.source != SchemaResolverManager.Source.SCHEMA_DEFAULT:
+                        warnings.warn(
+                            f"{prim.GetPath()}: both newton:sdfTargetVoxelSize and newton:sdfMaxResolution "
+                            f"are set; sdfTargetVoxelSize takes precedence.",
+                            stacklevel=2,
+                        )
                     sdf_max_resolution = None
                 if sdf_max_resolution is None:
-                    # When the API is applied but neither attribute is authored,
-                    # fall back to the schema default (64). When target voxel
-                    # size already drives the resolution, leave max_resolution
-                    # unset so the two don't conflict in ShapeConfig.validate().
+                    # Invalid authored values fall back to the applicable schema
+                    # default. A target voxel size suppresses max resolution so
+                    # the mutually exclusive ShapeConfig fields remain valid.
                     if has_sdf_api and sdf_target_voxel_size is None:
                         sdf_max_resolution = 64
                     else:
@@ -3400,10 +3372,12 @@ def parse_usd(
                     )
                     sdf_padding = None
 
-                hydroelastic_enabled = R.get_value(
+                hydroelastic_enabled_resolution = R.resolve(
                     prim, prim_type=PrimType.SHAPE, key="hydroelastic_enabled", verbose=verbose
                 )
-                kh = R.get_value(prim, prim_type=PrimType.SHAPE, key="kh", verbose=verbose)
+                hydroelastic_enabled = hydroelastic_enabled_resolution.value
+                kh_resolution = R.resolve(prim, prim_type=PrimType.SHAPE, key="kh", verbose=verbose)
+                kh = kh_resolution.value
                 if kh == float("-inf"):
                     kh = None
                 elif kh is not None and kh <= 0:
@@ -3413,17 +3387,12 @@ def parse_usd(
                         stacklevel=2,
                     )
                     kh = None
-                if hydroelastic_enabled is True:
-                    is_hydroelastic = True
-                elif hydroelastic_enabled is False:
-                    is_hydroelastic = False
-                elif has_sdf_api:
-                    # API applied but hydroelasticEnabled unauthored -> schema default False, not builder default.
-                    is_hydroelastic = False
-                else:
+                if hydroelastic_enabled_resolution.source == SchemaResolverManager.Source.UNRESOLVED:
                     is_hydroelastic = builder.default_shape_cfg.is_hydroelastic
+                else:
+                    is_hydroelastic = bool(hydroelastic_enabled)
                 if kh is None:
-                    kh = builder.default_shape_cfg.kh
+                    kh = 1.0e10 if has_sdf_api else builder.default_shape_cfg.kh
 
                 # Hydroelastic meshes need an SDF source. For primitives, a texture
                 # SDF is generated from a synthesized watertight mesh at finalize(),

--- a/newton/tests/test_schema_resolver.py
+++ b/newton/tests/test_schema_resolver.py
@@ -703,10 +703,10 @@ class TestSchemaResolver(unittest.TestCase):
 
     def test_layered_fallback_behavior(self):
         """
-        Test three-layer attribute resolution fallback mechanism.
+        Test layered attribute resolution fallback mechanism.
 
         Uses ant_mixed.usda to test the complete fallback hierarchy: authored USD values →
-        explicit default parameters → solver mapping defaults. Validates each layer works
+        explicit default parameters → applicable schema defaults. Validates each layer works
         correctly by testing scenarios with authored PhysX values, explicit defaults,
         and solver-specific mapping defaults across different plugin priority orders.
         """
@@ -741,19 +741,19 @@ class TestSchemaResolver(unittest.TestCase):
         val2 = resolver_newton_only.get_value(joint_with_physx_armature, PrimType.JOINT, "armature", default=0.99)
         self.assertAlmostEqual(val2, 0.99, places=6)
 
-        # Test 3: No authored value, no explicit default, use Newton mapping default
+        # Test 3: Newton's schema is not applied, so its mapping default does not leak in
         val3 = resolver_newton_only.get_value(joint_with_physx_armature, PrimType.JOINT, "armature", default=None)
-        self.assertAlmostEqual(val3, 0.0, places=6)
+        self.assertIsNone(val3)
 
-        # Test 3b: Use SchemaResolverMjc only - should return SchemaResolverMjc armature default (0.0)
+        # Test 3b: MuJoCo's schema is not applied either
         resolver_mjc_only = SchemaResolverManager([SchemaResolverMjc()])
         val3b = resolver_mjc_only.get_value(joint_with_physx_armature, PrimType.JOINT, "armature", default=None)
-        self.assertAlmostEqual(val3b, 0.0, places=6)
+        self.assertIsNone(val3b)
 
-        # Test 4: Test priority order - PhysX first should use PhysX mapping default when no authored value
+        # Test 4: Resolver order cannot inject a PhysX default on a Newton-only scene
         resolver_physx_first = SchemaResolverManager([SchemaResolverPhysx(), SchemaResolverNewton()])
         val4 = resolver_physx_first.get_value(scene_prim, PrimType.SCENE, "max_solver_iterations", default=None)
-        self.assertAlmostEqual(val4, 255, places=6)
+        self.assertEqual(val4, -1)
 
         # Test same attribute with Newton first priority
         resolver_newton_first = SchemaResolverManager([SchemaResolverNewton(), SchemaResolverPhysx()])
@@ -1424,23 +1424,23 @@ class TestSchemaResolver(unittest.TestCase):
 
         resolver = SchemaResolverManager([SchemaResolverPhysx(), SchemaResolverNewton()])
 
-        # PhysX only restOffset (no contactOffset) -> getter returns None -> default -inf
+        # PhysX only restOffset (no contactOffset) -> no complete authored value or applicable default
         collider_b.CreateAttribute("physxCollision:restOffset", Sdf.ValueTypeNames.Float).Set(0.01)
         gap = resolver.get_value(collider_b, PrimType.SHAPE, "gap")
-        self.assertEqual(gap, float("-inf"))
+        self.assertIsNone(gap)
 
         # PhysX both -> 0.04 - 0.01 = 0.03
         collider_b.CreateAttribute("physxCollision:contactOffset", Sdf.ValueTypeNames.Float).Set(0.04)
         gap = resolver.get_value(collider_b, PrimType.SHAPE, "gap")
         self.assertAlmostEqual(gap, 0.03)
 
-        # --- Collider C: PhysX -inf values ---
+        # --- Collider C: unusable PhysX -inf values do not activate another schema ---
         collider_c = UsdGeom.Cube.Define(stage, "/xform/collider_c").GetPrim()
         UsdPhysics.CollisionAPI.Apply(collider_c)
         collider_c.CreateAttribute("physxCollision:restOffset", Sdf.ValueTypeNames.Float).Set(float("-inf"))
         collider_c.CreateAttribute("physxCollision:contactOffset", Sdf.ValueTypeNames.Float).Set(0.05)
         gap = resolver.get_value(collider_c, PrimType.SHAPE, "gap")
-        self.assertEqual(gap, float("-inf"))
+        self.assertIsNone(gap)
 
         # --- Mjc ---
         resolver = SchemaResolverManager([SchemaResolverMjc(), SchemaResolverNewton()])
@@ -1556,9 +1556,9 @@ class TestSchemaResolver(unittest.TestCase):
         # Create resolver
         resolver = SchemaResolverManager([SchemaResolverPhysx(), SchemaResolverNewton()])
 
-        # there is no authored max_hull_vertices in the asset, so it should be the physx default (64)
+        # Only Newton's collision schemas are applied, so its default wins even with PhysX first
         max_hull_vertices = resolver.get_value(collider, PrimType.SHAPE, "max_hull_vertices")
-        self.assertEqual(max_hull_vertices, 64)
+        self.assertEqual(max_hull_vertices, -1)
 
         # an explicit newton value should be used
         collider.GetAttribute("newton:maxHullVertices").Set(32)
@@ -1645,10 +1645,10 @@ class TestSchemaResolver(unittest.TestCase):
         collider = UsdGeom.Sphere.Define(stage, "/xform/collider").GetPrim()
         UsdPhysics.CollisionAPI.Apply(collider)
 
-        # No authored value → default "solid"
+        # No NewtonMassAPI or authored value means there is no applicable schema default
         resolver = SchemaResolverManager([SchemaResolverNewton()])
         mass_model = resolver.get_value(collider, PrimType.SHAPE, "mass_model")
-        self.assertEqual(mass_model, "solid")
+        self.assertIsNone(mass_model)
 
         # newton:massModel authored
         collider.CreateAttribute("newton:massModel", Sdf.ValueTypeNames.Token).Set("shell")
@@ -1830,6 +1830,7 @@ class TestSchemaResolver(unittest.TestCase):
 
         stage = Usd.Stage.CreateInMemory()
         joint = UsdPhysics.RevoluteJoint.Define(stage, "/joint").GetPrim()
+        joint.AddAppliedSchema("NewtonJointAPI")
 
         # --- Mapping defaults when nothing is authored ---
         resolver_n = SchemaResolverManager([N])
@@ -1841,6 +1842,7 @@ class TestSchemaResolver(unittest.TestCase):
         self.assertIsNone(resolver_n.get_value(joint, PrimType.JOINT, "limit_ke", default=None))
         self.assertIsNone(resolver_n.get_value(joint, PrimType.JOINT, "limit_kd", default=None))
         self.assertEqual(resolver_n.get_value(joint, PrimType.JOINT, "velocity_limit", default=None), float("inf"))
+        self.assertIsNone(resolver_n.get_value(joint, PrimType.JOINT, "angular_position", default=None))
 
         # --- All 6 Newton attrs authored ---
         joint.CreateAttribute("newton:armature", Sdf.ValueTypeNames.Float).Set(0.1)
@@ -1995,6 +1997,56 @@ class TestSchemaResolver(unittest.TestCase):
             val = resolver_p.get_value(joint, PrimType.JOINT, "angular_position")
         self.assertAlmostEqual(val, 0.7)
         self.assertEqual(len([x for x in w if issubclass(x.category, DeprecationWarning)]), 0)
+
+    def test_resolution_provenance_and_schema_applicability(self):
+        """Schema defaults require their API while authored and importer sources remain explicit."""
+        stage = Usd.Stage.CreateInMemory()
+        joint = UsdPhysics.RevoluteJoint.Define(stage, "/joint").GetPrim()
+        mjc = SchemaResolverMjc()
+        resolver = SchemaResolverManager([mjc])
+
+        unresolved = resolver.resolve(joint, PrimType.JOINT, "limit_linear_ke")
+        self.assertEqual(unresolved.source, SchemaResolverManager.Source.UNRESOLVED)
+        self.assertIsNone(unresolved.value)
+        self.assertIsNone(unresolved.resolver)
+
+        importer_default = resolver.resolve(joint, PrimType.JOINT, "limit_linear_ke", default=123.0)
+        self.assertEqual(importer_default.source, SchemaResolverManager.Source.IMPORTER_DEFAULT)
+        self.assertEqual(importer_default.value, 123.0)
+        self.assertIsNone(importer_default.resolver)
+
+        joint.SetMetadata("apiSchemas", Sdf.TokenListOp.Create(prependedItems=["MjcJointAPI"]))
+        schema_default = resolver.resolve(joint, PrimType.JOINT, "limit_linear_ke")
+        self.assertEqual(schema_default.source, SchemaResolverManager.Source.SCHEMA_DEFAULT)
+        self.assertEqual(schema_default.value, 2500.0)
+        self.assertIs(schema_default.resolver, mjc)
+
+        joint.CreateAttribute("mjc:solreflimit", Sdf.ValueTypeNames.Double2).Set((0.1, 1.0))
+        authored = resolver.resolve(joint, PrimType.JOINT, "limit_linear_ke")
+        self.assertEqual(authored.source, SchemaResolverManager.Source.AUTHORED)
+        self.assertAlmostEqual(authored.value, 100.0)
+        self.assertIs(authored.resolver, mjc)
+
+        collider = UsdGeom.Mesh.Define(stage, "/collider").GetPrim()
+        collider.ApplyAPI("NewtonCollisionAPI")
+        newton_resolver = SchemaResolverManager([SchemaResolverNewton()])
+        self.assertEqual(
+            newton_resolver.resolve(collider, PrimType.SHAPE, "gap").source,
+            SchemaResolverManager.Source.SCHEMA_DEFAULT,
+        )
+        self.assertEqual(
+            newton_resolver.resolve(collider, PrimType.SHAPE, "mass_model").source,
+            SchemaResolverManager.Source.UNRESOLVED,
+        )
+        collider.ApplyAPI("NewtonMassAPI")
+        self.assertEqual(newton_resolver.get_value(collider, PrimType.SHAPE, "mass_model"), "solid")
+
+        collider.ApplyAPI("NewtonSDFCollisionAPI")
+        sdf_resolution = newton_resolver.resolve(collider, PrimType.SHAPE, "sdf_max_resolution")
+        self.assertEqual(sdf_resolution.source, SchemaResolverManager.Source.SCHEMA_DEFAULT)
+        self.assertEqual(sdf_resolution.value, 64)
+        self.assertFalse(newton_resolver.get_value(collider, PrimType.SHAPE, "hydroelastic_enabled"))
+        self.assertEqual(newton_resolver.get_value(collider, PrimType.SHAPE, "kh"), 1.0e10)
 
     def test_newton_joint_limit_attrs_deprecated(self):
         """Legacy per-DOF newton limit attrs emit DeprecationWarning pointing to schema attrs."""


### PR DESCRIPTION
## Description

Give USD resolution a single result carrying the value, winning resolver, and source: authored, importer default, applicable schema default, or unresolved.

Built-in resolvers now declare applicability per prim type and, where necessary, per key. Mapping defaults therefore cannot leak from a configured solver schema onto unrelated prims. MuJoCo joint-limit semantics plus Newton SDF and hydroelastic defaults use the shared provenance-aware path.

Third-party resolver subclasses that do not declare applicability keep their legacy always-applicable behavior.

Closes #3307.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_schema_resolver
uv run --extra dev -m newton.tests -k test_sdf_usd
uvx pre-commit run -a
```

The resolver suite passes 34 tests. The SDF suite passes 10 CPU-capable tests and skips 14 CUDA-only tests on this machine.

## Bug fix

**Steps to reproduce:**

1. Configure Newton, PhysX, and MuJoCo schema resolvers.
2. Import a prim that does not apply the first resolver schema.
3. Observe the first configured resolver injecting its hardcoded mapping default on main.

**Minimal reproduction:**

```python
import newton
from newton.usd import SchemaResolverNewton

builder = newton.ModelBuilder()
builder.add_usd(stage, schema_resolvers=[SchemaResolverNewton()])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected USD schema defaults so they apply only when the corresponding API/schema is applicable to the prim.
  - Improved USD importer resolution for joint limits/gains, SDF targets, and hydroelastic parameters, with corrected precedence and mutual exclusivity handling.
  - Preserved resolution provenance so importer behavior follows the correct authored, caller default, or schema-default source.
  - Refined handling for unresolved and invalid attribute values (including hydroelastic `enabled`/`kh` defaults).

- **Documentation**
  - Updated USD “Resolution Hierarchy” guidance to match the new applicable-schema-default behavior and provenance outcomes.

- **Tests**
  - Expanded schema-resolver and provenance coverage for applicability-gated defaults and layered fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->