### PR TITLE
Document solver determinism

### DIFF
--- a/docs/solvers/index.rst
+++ b/docs/solvers/index.rst
@@ -60,6 +60,41 @@ fits the application. :class:`~newton.solvers.SolverMuJoCo` and
 bodies, particles, or differentiable simulation, use the feature matrix below
 to narrow the choice, then follow the linked API documentation.
 
+Determinism
+-----------
+
+By default, solvers inherit Warp's current determinism mode. The following
+solvers also accept ``deterministic=wp.DeterministicMode.RUN_TO_RUN`` to opt
+into deterministic execution for their atomic-emitting kernel modules:
+
+- :class:`~newton.solvers.SolverFeatherstone`
+- :class:`~newton.solvers.SolverMuJoCo`
+- :class:`~newton.solvers.SolverSemiImplicit`
+- :class:`~newton.solvers.SolverVBD`
+- :class:`~newton.solvers.SolverXPBD`
+
+For example:
+
+.. code-block:: python
+
+    import warp as wp
+    import newton
+
+    solver = newton.solvers.SolverXPBD(
+        model,
+        deterministic=wp.DeterministicMode.RUN_TO_RUN,
+    )
+
+:class:`~newton.solvers.SolverImplicitMPM`,
+:class:`~newton.solvers.SolverKamino`, and
+:class:`~newton.solvers.SolverStyle3D` do not currently provide a solver
+``deterministic`` option.
+
+This setting applies to the solver's kernels only; it does not guarantee that
+an entire simulation is deterministic. For example, simulations using
+Newton-generated contacts should also configure deterministic contact ordering
+as described in the :doc:`collisions guide </concepts/collisions>`.
+
 .. _Supported Features:
 
 Supported Features


### PR DESCRIPTION
# Document solver determinism

## Summary

Document solver-level determinism in the solver overview. The new section lists the five solvers that accept a `deterministic` mode, identifies the three built-in solvers that do not, and explains that deterministic contact ordering must be configured separately for Newton-generated contacts.

Fixes #3561

## Changes

- Add a determinism section to the solver documentation with a `SolverXPBD` example.
- State the scope and current support boundary of the `deterministic` option.

## Testing

- `sandbox-run "python -m pip install '.[docs,sim]' && python -m sphinx -j auto -W -D nbsphinx_execute=never -b html docs docs/_build/html"` — passed.
- `git diff --check` — passed.
- `sandbox-run "python -m pip install pre-commit && pre-commit run -a"` — could not run because the sandbox image lacks the required `git` executable.
- The full notebook-executing Sphinx build could not run because a tutorial downloads assets through GitPython and the sandbox image lacks the required `git` executable.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on solver determinism behavior and configuration.
  * Documented which Newton solvers support forcing run-to-run deterministic execution.
  * Included a Python example and clarified limitations around achieving fully deterministic simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->