### PR TITLE
Fix spurious Kamino floating-base reset warning

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -966,20 +966,18 @@ def convert_joints(
     joint_dof_type_np = joint_dof_type.numpy()
 
     # Assign base bodies based on articulation roots (if articulations are present)
-    world_has_non_free_root = np.zeros((model.world_count,), dtype=bool)
+    world_has_non_floating_root = np.zeros((model.world_count,), dtype=bool)
     if model.articulation_count > 0:
         articulation_start_np = model.articulation_start.numpy()
         articulation_world_np = model.articulation_world.numpy()
-        # For each articulation, assign its base body and joint to the corresponding world,
-        # if the base joint is a unary free joint.
-        # NOTE: We only assign the first free-rooted articulation found in each world
+        # NOTE: We only assign the first articulation rooted by a unary free joint in each world
         for aid in range(model.articulation_count):
             wid = articulation_world_np[aid]
             base_joint = articulation_start_np[aid]
             base_body = joint_child_np[base_joint]
             if base_body_idx_np[wid] == -1 and base_joint_idx_np[wid] == -1:
-                if joint_dof_type_np[base_joint] != JointDoFType.FREE:
-                    world_has_non_free_root[wid] = True
+                if joint_dof_type_np[base_joint] != JointDoFType.FREE or joint_parent_np[base_joint] != -1:
+                    world_has_non_floating_root[wid] = True
                     continue
                 base_body_idx_np[wid] = base_body
                 base_joint_idx_np[wid] = base_joint
@@ -1005,10 +1003,11 @@ def convert_joints(
                 continue
             base_body_idx_np[wid] = body_world_start_np[wid]
 
-    # Only warn for worlds where a skipped non-free root left the world without a base
-    if np.any(world_has_non_free_root & (base_body_idx_np == -1)):
+    # Only warn for worlds where a skipped root left the world without a base
+    if np.any(world_has_non_floating_root & (base_body_idx_np == -1)):
         msg.warning(
-            "Model has articulations with a non-free joint as root, disabling floating base resets for those worlds."
+            "Model has articulations whose root is not a free joint attached to the world, "
+            "disabling floating base resets for those worlds."
         )
 
     # Update size object

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -966,27 +966,23 @@ def convert_joints(
     joint_dof_type_np = joint_dof_type.numpy()
 
     # Assign base bodies based on articulation roots (if articulations are present)
+    world_has_non_free_root = np.zeros((model.world_count,), dtype=bool)
     if model.articulation_count > 0:
         articulation_start_np = model.articulation_start.numpy()
         articulation_world_np = model.articulation_world.numpy()
         # For each articulation, assign its base body and joint to the corresponding world,
         # if the base joint is a unary free joint.
-        # NOTE: We only assign the first articulation found in each world
-        has_non_free_root = False
+        # NOTE: We only assign the first free-rooted articulation found in each world
         for aid in range(model.articulation_count):
             wid = articulation_world_np[aid]
             base_joint = articulation_start_np[aid]
             base_body = joint_child_np[base_joint]
             if base_body_idx_np[wid] == -1 and base_joint_idx_np[wid] == -1:
                 if joint_dof_type_np[base_joint] != JointDoFType.FREE:
-                    has_non_free_root = True
+                    world_has_non_free_root[wid] = True
                     continue
                 base_body_idx_np[wid] = base_body
                 base_joint_idx_np[wid] = base_joint
-        if has_non_free_root:
-            msg.warning(
-                "Model has articulations with a non-free joint as root, disabling floating base resets for those worlds."
-            )
 
     # For worlds without articulations, look for a unary free joint, or use the first body
     for wid in range(model.world_count):
@@ -1008,6 +1004,12 @@ def convert_joints(
                 msg.warning(f"Zero bodies in world {wid}, no base body assigned.")
                 continue
             base_body_idx_np[wid] = body_world_start_np[wid]
+
+    # Only warn for worlds where a skipped non-free root left the world without a base
+    if np.any(world_has_non_free_root & (base_body_idx_np == -1)):
+        msg.warning(
+            "Model has articulations with a non-free joint as root, disabling floating base resets for those worlds."
+        )
 
     # Update size object
     model_size.sum_of_num_joints = int(num_joints_np.sum())

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -470,6 +470,40 @@ class TestModelConversions(unittest.TestCase):
         ]
         test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino, excluded=excluded)
 
+    def test_05_model_conversions_base_assignment_non_free_root(self):
+        """
+        Test per-world base assignment when articulations have non-free root joints.
+
+        A free-rooted articulation following a fixed-rooted one still provides the
+        world's floating base without warning; a world whose only articulation is
+        fixed-rooted gets no base and warns that floating base resets are disabled.
+        """
+
+        def build_model(with_free_articulation: bool) -> Model:
+            builder: ModelBuilder = ModelBuilder()
+            SolverKamino.register_custom_attributes(builder)
+            body_fixed = builder.add_link()
+            builder.add_shape_box(body_fixed)
+            joint_fixed = builder.add_joint_fixed(parent=-1, child=body_fixed)
+            builder.add_articulation([joint_fixed])
+            if with_free_articulation:
+                body_free = builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 2.0), wp.quat_identity()))
+                builder.add_shape_box(body_free)
+                joint_free = builder.add_joint_free(child=body_free)
+                builder.add_articulation([joint_free])
+            return builder.finalize(device=self.default_device)
+
+        with self.assertNoLogs(level="WARNING"):
+            model_kamino = ModelKamino.from_newton(build_model(with_free_articulation=True))
+        self.assertEqual(model_kamino.info.base_body_index.numpy().tolist(), [1])
+        self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [1])
+
+        with self.assertLogs(level="WARNING") as logs:
+            model_kamino = ModelKamino.from_newton(build_model(with_free_articulation=False))
+        self.assertTrue(any("non-free joint as root" in message for message in logs.output))
+        self.assertEqual(model_kamino.info.base_body_index.numpy().tolist(), [-1])
+        self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [-1])
+
     def test_10_model_conversions_arbitrary_axis(self):
         """
         Test that Newton→Kamino conversion succeeds for a revolute joint

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -470,39 +470,42 @@ class TestModelConversions(unittest.TestCase):
         ]
         test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino, excluded=excluded)
 
-    def test_05_model_conversions_base_assignment_non_free_root(self):
+    def test_05_model_conversions_base_assignment_non_floating_root(self):
         """
-        Test per-world base assignment when articulations have non-free root joints.
+        Test per-world base assignment when articulation roots are not unary free joints.
 
         A free-rooted articulation following a fixed-rooted one still provides the
-        world's floating base without warning; a world whose only articulation is
-        fixed-rooted gets no base and warns that floating base resets are disabled.
+        world's floating base without warning; a world whose articulations are
+        fixed-rooted or rooted by a free joint with a body parent gets no base and
+        warns that floating base resets are disabled.
         """
 
-        def build_model(with_free_articulation: bool) -> Model:
+        def build_model(free_root: str | None) -> Model:
             builder: ModelBuilder = ModelBuilder()
             SolverKamino.register_custom_attributes(builder)
             body_fixed = builder.add_link()
             builder.add_shape_box(body_fixed)
             joint_fixed = builder.add_joint_fixed(parent=-1, child=body_fixed)
             builder.add_articulation([joint_fixed])
-            if with_free_articulation:
+            if free_root is not None:
                 body_free = builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 2.0), wp.quat_identity()))
                 builder.add_shape_box(body_free)
-                joint_free = builder.add_joint_free(child=body_free)
+                parent = -1 if free_root == "world" else body_fixed
+                joint_free = builder.add_joint_free(child=body_free, parent=parent)
                 builder.add_articulation([joint_free])
             return builder.finalize(device=self.default_device)
 
         with self.assertNoLogs(level="WARNING"):
-            model_kamino = ModelKamino.from_newton(build_model(with_free_articulation=True))
+            model_kamino = ModelKamino.from_newton(build_model(free_root="world"))
         self.assertEqual(model_kamino.info.base_body_index.numpy().tolist(), [1])
         self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [1])
 
-        with self.assertLogs(level="WARNING") as logs:
-            model_kamino = ModelKamino.from_newton(build_model(with_free_articulation=False))
-        self.assertTrue(any("non-free joint as root" in message for message in logs.output))
-        self.assertEqual(model_kamino.info.base_body_index.numpy().tolist(), [-1])
-        self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [-1])
+        for free_root in (None, "body"):
+            with self.assertLogs(level="WARNING") as logs:
+                model_kamino = ModelKamino.from_newton(build_model(free_root=free_root))
+            self.assertTrue(any("not a free joint attached to the world" in message for message in logs.output))
+            self.assertEqual(model_kamino.info.base_body_index.numpy().tolist(), [-1])
+            self.assertEqual(model_kamino.info.base_joint_index.numpy().tolist(), [-1])
 
     def test_10_model_conversions_arbitrary_axis(self):
         """


### PR DESCRIPTION
## Description

The Kamino conversion emits "Model has articulations with a non-free joint as root, disabling floating base resets for those worlds." whenever any articulation has a non-free root joint, even if the world still receives a floating base from another free-rooted articulation — in which case floating-base resets remain fully functional and nothing was disabled. This produces spurious warnings for models that mix fixed-rooted and free-rooted articulations in the same world, including coupled-solver setups where another solver's fixed-base articulation appears in Kamino's view as a proxy (e.g. `multiphysics.example_kamino_mujoco_admm_solver`).

Track skipped non-free roots per world and emit the warning only if such a world ends up without a base body after all assignment fallbacks have run. Worlds whose articulations are all fixed-rooted still warn as before.

Unblocks the stricter example output checks in #3527.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` is not required for this warning-emission fix

## Test plan

```
uv run --extra dev python -m unittest newton._src.solvers.kamino.tests.test_core_model.TestModelConversions.test_05_model_conversions_base_assignment_non_free_root
```

## Bug fix

**Steps to reproduce:**

1. Build a model containing a fixed-rooted articulation followed by a free-rooted articulation in the same world
2. Convert it to a Kamino model
3. Observe the "disabling floating base resets" warning even though the world's base body and joint are assigned from the free-rooted articulation

**Minimal reproduction:**

```python
import newton
from newton.solvers import SolverKamino

builder = newton.ModelBuilder()
SolverKamino.register_custom_attributes(builder)

body_fixed = builder.add_link()
builder.add_shape_box(body_fixed)
builder.add_articulation([builder.add_joint_fixed(parent=-1, child=body_fixed)])

body_free = builder.add_link()
builder.add_shape_box(body_free)
builder.add_articulation([builder.add_joint_free(child=body_free)])

SolverKamino(model=builder.finalize())  # warns, yet base_body_index/base_joint_index are assigned
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved articulated model conversion for multi-world setups, ensuring base body/joint assignments correctly skip incompatible non-free roots.
  * Warning messages are now emitted only for the specific worlds that can’t be assigned a valid base, rather than affecting all worlds.

* **Tests**
  * Added a new model conversion test covering free-root vs fixed/non-floating root articulation scenarios, including expected base index results and warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->