### PR TITLE
Surface additional simulation benchmark metrics

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -137,12 +137,13 @@ jobs:
 
       - name: Run Benchmarks
         run: |
+          # ASV assumes smaller values are better, so compare only metrics with that direction.
           uvx --with virtualenv asv continuous \
             --launch-method spawn \
             --interleave-rounds \
             --append-samples \
             --no-only-changed \
-            -e -b Fast \
+            -e -b '^(?!.*track_(simulation_steps_per_second|real_time_factor)).*Fast' \
             ${{ inputs.base_ref }} \
             ${{ inputs.ref }}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
+- Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix masked PID state reset to execute on the integral-state device. (#3447)
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Add opt-in `body_frame_origin="com"` to `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()` for COM-centered cable capsule body frames.
 - Add `sign_method` argument to `Mesh.build_sdf` and `SDF.create_from_mesh` support for a `"normal"` (angle-weighted pseudo-normal) sign strategy, for selecting the inside/outside sign of the baked SDF (`"auto"`, `"parity"`, `"winding"`, or `"normal"`).
 - Add `forward_depth_image` output support to `SensorTiledCamera.update()` and `SensorTiledCamera.utils.create_forward_depth_image_output()` for native forward-depth rendering without post-processing `depth_image`.
-- Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, and timestep metrics to the ASV robot-learning benchmarks.
+- Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, timestep, and MuJoCo solver-iteration metrics to the ASV robot-learning benchmarks.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add opt-in `body_frame_origin="com"` to `ModelBuilder.add_rod()` and `ModelBuilder.add_rod_graph()` for COM-centered cable capsule body frames.
 - Add `sign_method` argument to `Mesh.build_sdf` and `SDF.create_from_mesh` support for a `"normal"` (angle-weighted pseudo-normal) sign strategy, for selecting the inside/outside sign of the baked SDF (`"auto"`, `"parity"`, `"winding"`, or `"normal"`).
 - Add `forward_depth_image` output support to `SensorTiledCamera.update()` and `SensorTiledCamera.utils.create_forward_depth_image_output()` for native forward-depth rendering without post-processing `depth_image`.
+- Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, and timestep metrics to the ASV robot-learning benchmarks.
 
 ### Changed
 

--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -12,6 +12,11 @@ wp.config.log_level = wp.LOG_WARNING
 
 import newton
 
+if __package__:
+    from .benchmark_metrics import validate_simulation_state
+else:
+    from benchmark_metrics import validate_simulation_state
+
 _NUM_ACTIONS = 12
 _OBS_DIM = 94
 _MIN_STANDING_HEIGHT = 0.20
@@ -435,37 +440,23 @@ class DRLegsBenchmarkWorkload:
         self.sim_time += self.frame_dt
 
     def test_final(self):
-        state_values = {}
-        for name in ("joint_q", "body_q", "body_qd"):
-            values = getattr(self.state_0, name).numpy()
-            if not np.isfinite(values).all():
-                raise RuntimeError(f"Simulation produced non-finite values in state.{name}")
-            state_values[name] = values
-
-        body_count = self.model.body_count // self.world_count
-        body_qd = state_values["body_qd"].reshape(self.world_count, body_count, 6)
-        max_linear_speed = np.linalg.norm(body_qd[:, :, :3], axis=-1).max()
-        max_angular_speed = np.linalg.norm(body_qd[:, :, 3:], axis=-1).max()
-        if max_linear_speed > _MAX_BODY_LINEAR_SPEED:
-            raise RuntimeError(
-                f"Maximum body linear speed is {max_linear_speed:.3f} m/s, exceeding {_MAX_BODY_LINEAR_SPEED:.1f} m/s"
-            )
-        if max_angular_speed > _MAX_BODY_ANGULAR_SPEED:
-            raise RuntimeError(
-                f"Maximum body angular speed is {max_angular_speed:.3f} rad/s, "
-                f"exceeding {_MAX_BODY_ANGULAR_SPEED:.1f} rad/s"
-            )
+        validate_simulation_state(
+            self.state_0,
+            max_linear_speed=_MAX_BODY_LINEAR_SPEED,
+            max_angular_speed=_MAX_BODY_ANGULAR_SPEED,
+        )
 
         if self.policy_controller is None:
             return
 
+        body_count = self.model.body_count // self.world_count
         body_labels = [label.rsplit("/", 1)[-1] for label in self.model.body_label[:body_count]]
         try:
             pelvis_index = body_labels.index("pelvis")
         except ValueError as e:
             raise RuntimeError("DR Legs model has no pelvis root body") from e
 
-        body_q = state_values["body_q"].reshape(self.world_count, body_count, 7)[:, pelvis_index]
+        body_q = self.state_0.body_q.numpy().reshape(self.world_count, body_count, 7)[:, pelvis_index]
         body_com = self.model.body_com.numpy().reshape(self.world_count, body_count, 3)[:, pelvis_index]
         quat_vector = body_q[:, 3:6]
         twice_cross = 2.0 * np.cross(quat_vector, body_com)

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -23,6 +23,8 @@ class SimulationMetrics:
     gpu_memory_mib: float
     sim_dt: float
     sim_substeps: int
+    solver_niter_mean: float | None = None
+    solver_niter_max: float | None = None
 
 
 class _SimulationMetricTracks:
@@ -117,17 +119,6 @@ class _SimulationMetricTracksUnparameterized:
     track_sim_substeps.unit = "simulation-steps/frame"
 
 
-def _percentile(values: Sequence[float], percentile: float) -> float:
-    ordered = sorted(values)
-    rank = (len(ordered) - 1) * percentile / 100.0
-    lower = math.floor(rank)
-    upper = math.ceil(rank)
-    if lower == upper:
-        return ordered[lower]
-    fraction = rank - lower
-    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
-
-
 def compute_simulation_metrics(
     frame_times: Sequence[float],
     sim_dt: float,
@@ -159,19 +150,11 @@ def compute_simulation_metrics(
         mean_world_step_time_ms=total_time * 1000.0 / world_steps,
         world_steps_per_second=world_steps / experience_total_time,
         real_time_factor=world_steps * sim_dt / experience_total_time,
-        p95_frame_time_ms=_percentile(experience_frame_times, 95.0) * 1000.0,
+        p95_frame_time_ms=float(np.percentile(experience_frame_times, 95.0)) * 1000.0,
         gpu_memory_mib=gpu_memory_bytes / 1024**2,
         sim_dt=sim_dt,
         sim_substeps=sim_substeps,
     )
-
-
-def compute_gpu_memory_usage(device: Any, free_memory_before: int) -> int:
-    """Compute the change in total device memory usage from a free-memory baseline."""
-    used_memory = free_memory_before - device.free_memory
-    if used_memory < 0:
-        raise RuntimeError("GPU free memory increased after workload initialization")
-    return used_memory
 
 
 def validate_simulation_state(
@@ -208,31 +191,25 @@ def validate_simulation_state(
         )
 
 
-def validate_simulation_workload(workload: Any, max_linear_speed: float, max_angular_speed: float):
-    """Run generic state validation followed by a workload's specialized checks."""
-    validate_simulation_state(
-        workload.state_0,
-        max_linear_speed=max_linear_speed,
-        max_angular_speed=max_angular_speed,
-    )
-    workload.test_final()
-
-
 def collect_simulation_metrics(
     create_workload: Callable[[], Any],
     world_count: int,
     num_frames: int,
     samples: int,
-    memory_usage_bytes: Callable[[Any], int],
+    synchronize: Callable[[], None] | None = None,
     validate: Callable[[Any], None] | None = None,
     timer: Callable[[], float] = time.perf_counter,
 ) -> SimulationMetrics:
-    """Collect internal physics timing and complete synchronized step timing."""
+    """Collect simulation metrics using internal or synchronized wall timing."""
     frame_times = []
     experience_frame_times = []
     gpu_memory_bytes = None
     sim_dt = None
     sim_substeps = None
+
+    wp.synchronize_device()
+    device = wp.get_device()
+    free_memory_before = device.free_memory
 
     for sample_index in range(samples):
         workload = create_workload()
@@ -242,15 +219,27 @@ def collect_simulation_metrics(
         elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
             raise ValueError("simulation parameters changed between samples")
 
+        if synchronize is not None:
+            synchronize()
         for _ in range(num_frames):
-            start_time = workload.benchmark_time
             experience_start_time = timer()
+            benchmark_start_time = workload.benchmark_time if synchronize is None else None
             workload.step()
-            frame_times.append(workload.benchmark_time - start_time)
-            experience_frame_times.append(timer() - experience_start_time)
+            if synchronize is not None:
+                synchronize()
+            experience_frame_time = timer() - experience_start_time
+            experience_frame_times.append(experience_frame_time)
+            frame_times.append(
+                experience_frame_time
+                if benchmark_start_time is None
+                else workload.benchmark_time - benchmark_start_time
+            )
 
         if sample_index == 0:
-            gpu_memory_bytes = memory_usage_bytes(workload)
+            wp.synchronize_device()
+            gpu_memory_bytes = free_memory_before - device.free_memory
+            if gpu_memory_bytes < 0:
+                raise RuntimeError("GPU free memory increased after workload initialization")
         if validate is not None:
             validate(workload)
 
@@ -261,49 +250,4 @@ def collect_simulation_metrics(
         world_count=world_count,
         gpu_memory_bytes=gpu_memory_bytes,
         experience_frame_times=experience_frame_times,
-    )
-
-
-def collect_simulation_metrics_synchronized(
-    create_workload: Callable[[], Any],
-    world_count: int,
-    num_frames: int,
-    samples: int,
-    synchronize: Callable[[], None],
-    memory_usage_bytes: Callable[[Any], int],
-    validate: Callable[[Any], None] | None = None,
-    timer: Callable[[], float] = time.perf_counter,
-) -> SimulationMetrics:
-    """Collect metrics for workloads without an internal synchronized timer."""
-    frame_times = []
-    gpu_memory_bytes = None
-    sim_dt = None
-    sim_substeps = None
-
-    for sample_index in range(samples):
-        workload = create_workload()
-        if sim_dt is None:
-            sim_dt = workload.sim_dt
-            sim_substeps = workload.sim_substeps
-        elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
-            raise ValueError("simulation parameters changed between samples")
-
-        synchronize()
-        for _ in range(num_frames):
-            start_time = timer()
-            workload.step()
-            synchronize()
-            frame_times.append(timer() - start_time)
-
-        if sample_index == 0:
-            gpu_memory_bytes = memory_usage_bytes(workload)
-        if validate is not None:
-            validate(workload)
-
-    return compute_simulation_metrics(
-        frame_times=frame_times,
-        sim_dt=sim_dt,
-        sim_substeps=sim_substeps,
-        world_count=world_count,
-        gpu_memory_bytes=gpu_memory_bytes,
     )

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -71,7 +71,7 @@ class _SimulationMetricTracks:
     track_sim_substeps.unit = "simulation-steps/frame"
 
 
-class _UnparameterizedSimulationMetricTracks:
+class _SimulationMetricTracksUnparameterized:
     """ASV track methods backed by one cached simulation configuration."""
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
@@ -264,7 +264,7 @@ def collect_simulation_metrics(
     )
 
 
-def collect_synchronized_simulation_metrics(
+def collect_simulation_metrics_synchronized(
     create_workload: Callable[[], Any],
     world_count: int,
     num_frames: int,

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -199,8 +199,7 @@ def validate_simulation_state(
     max_measured_angular_speed = np.linalg.norm(body_qd[:, 3:], axis=-1).max()
     if max_measured_linear_speed > max_linear_speed:
         raise RuntimeError(
-            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, "
-            f"exceeding {max_linear_speed:.1f} m/s"
+            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, exceeding {max_linear_speed:.1f} m/s"
         )
     if max_measured_angular_speed > max_angular_speed:
         raise RuntimeError(

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import warp as wp
+from asv_runner.benchmarks.mark import skip_benchmark_if
+
+
+@dataclass(frozen=True)
+class SimulationMetrics:
+    """Metrics collected from one simulation benchmark configuration."""
+
+    mean_world_step_time_ms: float
+    world_steps_per_second: float
+    real_time_factor: float
+    p95_frame_time_ms: float
+    gpu_memory_mib: float
+    sim_dt: float
+    sim_substeps: int
+
+
+class _SimulationMetricTracks:
+    """ASV track methods backed by cached simulation metrics."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulate(self, metrics, world_count):
+        return metrics[world_count].mean_world_step_time_ms
+
+    track_simulate.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics, world_count):
+        return metrics[world_count].world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics, world_count):
+        return metrics[world_count].real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics, world_count):
+        return metrics[world_count].p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics, world_count):
+        return metrics[world_count].gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics, world_count):
+        return metrics[world_count].sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics, world_count):
+        return metrics[world_count].sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"
+
+
+class _UnparameterizedSimulationMetricTracks:
+    """ASV track methods backed by one cached simulation configuration."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_mean_world_step_time(self, metrics):
+        return metrics.mean_world_step_time_ms
+
+    track_mean_world_step_time.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics):
+        return metrics.world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics):
+        return metrics.real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics):
+        return metrics.p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics):
+        return metrics.gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics):
+        return metrics.sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics):
+        return metrics.sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * percentile / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def compute_simulation_metrics(
+    frame_times: Sequence[float],
+    sim_dt: float,
+    sim_substeps: int,
+    world_count: int,
+    gpu_memory_bytes: int,
+    experience_frame_times: Sequence[float] | None = None,
+) -> SimulationMetrics:
+    """Compute comparable simulation metrics from synchronized frame times."""
+    if not frame_times or any(not math.isfinite(value) or value <= 0.0 for value in frame_times):
+        raise ValueError("frame_times must contain positive finite values")
+    if experience_frame_times is None:
+        experience_frame_times = frame_times
+    if len(experience_frame_times) != len(frame_times) or any(
+        not math.isfinite(value) or value <= 0.0 for value in experience_frame_times
+    ):
+        raise ValueError("experience_frame_times must contain one positive finite value per frame")
+    if not math.isfinite(sim_dt) or sim_dt <= 0.0:
+        raise ValueError("sim_dt must be positive and finite")
+    if sim_substeps <= 0 or world_count <= 0:
+        raise ValueError("sim_substeps and world_count must be positive")
+    if gpu_memory_bytes < 0:
+        raise ValueError("gpu_memory_bytes must be non-negative")
+
+    total_time = sum(frame_times)
+    experience_total_time = sum(experience_frame_times)
+    world_steps = len(frame_times) * sim_substeps * world_count
+    return SimulationMetrics(
+        mean_world_step_time_ms=total_time * 1000.0 / world_steps,
+        world_steps_per_second=world_steps / experience_total_time,
+        real_time_factor=world_steps * sim_dt / experience_total_time,
+        p95_frame_time_ms=_percentile(experience_frame_times, 95.0) * 1000.0,
+        gpu_memory_mib=gpu_memory_bytes / 1024**2,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+    )
+
+
+def compute_gpu_memory_usage(device: Any, free_memory_before: int) -> int:
+    """Compute the change in total device memory usage from a free-memory baseline."""
+    used_memory = free_memory_before - device.free_memory
+    if used_memory < 0:
+        raise RuntimeError("GPU free memory increased after workload initialization")
+    return used_memory
+
+
+def validate_simulation_state(
+    state: Any,
+    max_linear_speed: float,
+    max_angular_speed: float,
+    quaternion_tolerance: float = 1.0e-3,
+):
+    """Validate finite rigid-body state, normalized rotations, and bounded speeds."""
+    state_values = {}
+    for name in ("joint_q", "joint_qd", "body_q", "body_qd"):
+        values = getattr(state, name).numpy()
+        if not np.isfinite(values).all():
+            raise RuntimeError(f"Simulation produced non-finite values in state.{name}")
+        state_values[name] = values
+
+    body_q = state_values["body_q"].reshape(-1, 7)
+    quaternion_norms = np.linalg.norm(body_q[:, 3:7], axis=-1)
+    if not np.allclose(quaternion_norms, 1.0, atol=quaternion_tolerance, rtol=0.0):
+        max_error = np.abs(quaternion_norms - 1.0).max()
+        raise RuntimeError(f"Maximum body quaternion norm error is {max_error:.3g}")
+
+    body_qd = state_values["body_qd"].reshape(-1, 6)
+    max_measured_linear_speed = np.linalg.norm(body_qd[:, :3], axis=-1).max()
+    max_measured_angular_speed = np.linalg.norm(body_qd[:, 3:], axis=-1).max()
+    if max_measured_linear_speed > max_linear_speed:
+        raise RuntimeError(
+            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, "
+            f"exceeding {max_linear_speed:.1f} m/s"
+        )
+    if max_measured_angular_speed > max_angular_speed:
+        raise RuntimeError(
+            f"Maximum body angular speed is {max_measured_angular_speed:.3f} rad/s, "
+            f"exceeding {max_angular_speed:.1f} rad/s"
+        )
+
+
+def validate_simulation_workload(workload: Any, max_linear_speed: float, max_angular_speed: float):
+    """Run generic state validation followed by a workload's specialized checks."""
+    validate_simulation_state(
+        workload.state_0,
+        max_linear_speed=max_linear_speed,
+        max_angular_speed=max_angular_speed,
+    )
+    workload.test_final()
+
+
+def collect_simulation_metrics(
+    create_workload: Callable[[], Any],
+    world_count: int,
+    num_frames: int,
+    samples: int,
+    memory_usage_bytes: Callable[[Any], int],
+    validate: Callable[[Any], None] | None = None,
+    timer: Callable[[], float] = time.perf_counter,
+) -> SimulationMetrics:
+    """Collect internal physics timing and complete synchronized step timing."""
+    frame_times = []
+    experience_frame_times = []
+    gpu_memory_bytes = None
+    sim_dt = None
+    sim_substeps = None
+
+    for sample_index in range(samples):
+        workload = create_workload()
+        if sim_dt is None:
+            sim_dt = workload.sim_dt
+            sim_substeps = workload.sim_substeps
+        elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
+            raise ValueError("simulation parameters changed between samples")
+
+        for _ in range(num_frames):
+            start_time = workload.benchmark_time
+            experience_start_time = timer()
+            workload.step()
+            frame_times.append(workload.benchmark_time - start_time)
+            experience_frame_times.append(timer() - experience_start_time)
+
+        if sample_index == 0:
+            gpu_memory_bytes = memory_usage_bytes(workload)
+        if validate is not None:
+            validate(workload)
+
+    return compute_simulation_metrics(
+        frame_times=frame_times,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+        world_count=world_count,
+        gpu_memory_bytes=gpu_memory_bytes,
+        experience_frame_times=experience_frame_times,
+    )
+
+
+def collect_synchronized_simulation_metrics(
+    create_workload: Callable[[], Any],
+    world_count: int,
+    num_frames: int,
+    samples: int,
+    synchronize: Callable[[], None],
+    memory_usage_bytes: Callable[[Any], int],
+    validate: Callable[[Any], None] | None = None,
+    timer: Callable[[], float] = time.perf_counter,
+) -> SimulationMetrics:
+    """Collect metrics for workloads without an internal synchronized timer."""
+    frame_times = []
+    gpu_memory_bytes = None
+    sim_dt = None
+    sim_substeps = None
+
+    for sample_index in range(samples):
+        workload = create_workload()
+        if sim_dt is None:
+            sim_dt = workload.sim_dt
+            sim_substeps = workload.sim_substeps
+        elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
+            raise ValueError("simulation parameters changed between samples")
+
+        synchronize()
+        for _ in range(num_frames):
+            start_time = timer()
+            workload.step()
+            synchronize()
+            frame_times.append(timer() - start_time)
+
+        if sample_index == 0:
+            gpu_memory_bytes = memory_usage_bytes(workload)
+        if validate is not None:
+            validate(workload)
+
+    return compute_simulation_metrics(
+        frame_times=frame_times,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+        world_count=world_count,
+        gpu_memory_bytes=gpu_memory_bytes,
+    )

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -493,7 +493,7 @@ class Example:
 
         wp.synchronize_device()
         start_time = time.perf_counter()
-        if self.use_cuda_graph:
+        if self.use_cuda_graph and self.graph is not None:
             wp.capture_launch(self.graph)
         else:
             self.simulate()

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -23,7 +23,14 @@ import newton.utils
 from newton.sensors import SensorContact
 from newton.utils import EventTracer
 
+if __package__:
+    from .benchmark_metrics import validate_simulation_state
+else:
+    from benchmark_metrics import validate_simulation_state
+
 _NEW_LAYOUT_AVAILABLE = hasattr(newton, "use_coord_layout_targets")
+_MAX_BODY_LINEAR_SPEED = 100.0
+_MAX_BODY_ANGULAR_SPEED = 500.0
 
 
 def _target_q(owner):
@@ -485,16 +492,23 @@ class Example:
             self.apply_waypoint_control()
 
         wp.synchronize_device()
-        start_time = time.time()
+        start_time = time.perf_counter()
         if self.use_cuda_graph:
             wp.capture_launch(self.graph)
         else:
             self.simulate()
         wp.synchronize_device()
-        end_time = time.time()
+        end_time = time.perf_counter()
 
         self.benchmark_time += end_time - start_time
         self.sim_time += self.frame_dt
+
+    def test_final(self):
+        validate_simulation_state(
+            self.state_0,
+            max_linear_speed=_MAX_BODY_LINEAR_SPEED,
+            max_angular_speed=_MAX_BODY_ANGULAR_SPEED,
+        )
 
     def render(self):
         if self.renderer is None:

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -24,6 +24,10 @@ import newton
 import newton.examples
 from newton.examples.robot.example_robot_anymal_c_walk import Example
 
+_NUM_FRAMES = 50
+_MIN_BASE_HEIGHT = 0.4
+_MIN_FORWARD_PROGRESS = 0.25
+
 
 def _create_example(num_frames):
     if hasattr(newton.examples, "default_args"):
@@ -33,12 +37,27 @@ def _create_example(num_frames):
     return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
 
 
+def _validate_workload(workload):
+    validate_simulation_state(
+        workload.state_0,
+        max_linear_speed=10.0,
+        max_angular_speed=50.0,
+    )
+    root_position = workload.state_0.joint_q.numpy()[:3]
+    if root_position[2] < _MIN_BASE_HEIGHT:
+        raise RuntimeError(f"ANYmal base height is too low after {_NUM_FRAMES} frames: {root_position[2]:.3f} m")
+    if root_position[1] < _MIN_FORWARD_PROGRESS:
+        raise RuntimeError(
+            f"ANYmal made insufficient forward progress after {_NUM_FRAMES} frames: {root_position[1]:.3f} m"
+        )
+
+
 class FastExampleAnymalPretrained:
     repeat = 3
     number = 1
 
     def setup(self):
-        self.num_frames = 50
+        self.num_frames = _NUM_FRAMES
         self.example = _create_example(self.num_frames)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
@@ -49,7 +68,7 @@ class FastExampleAnymalPretrained:
 
 
 class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
-    num_frames = 50
+    num_frames = _NUM_FRAMES
     samples = 3
     world_count = 1
 
@@ -64,11 +83,7 @@ class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks)
             samples=self.samples,
             synchronize=wp.synchronize_device,
             memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
-            validate=lambda workload: validate_simulation_state(
-                workload.state_0,
-                max_linear_speed=10.0,
-                max_angular_speed=50.0,
-            ),
+            validate=_validate_workload,
         )
 
 

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -14,8 +14,8 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_metrics import (
-    _UnparameterizedSimulationMetricTracks,
-    collect_synchronized_simulation_metrics,
+    _SimulationMetricTracksUnparameterized,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     validate_simulation_state,
 )
@@ -67,7 +67,7 @@ class FastExampleAnymalPretrained:
         wp.synchronize_device()
 
 
-class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
+class FastMetricsExampleAnymalPretrained(_SimulationMetricTracksUnparameterized):
     num_frames = _NUM_FRAMES
     samples = 3
     world_count = 1
@@ -76,7 +76,7 @@ class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks)
         wp.synchronize_device()
         device = wp.get_device()
         free_memory_before = device.free_memory
-        return collect_synchronized_simulation_metrics(
+        return collect_simulation_metrics_synchronized(
             create_workload=lambda: _create_example(self.num_frames),
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -1,15 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from benchmark_metrics import (
+    _UnparameterizedSimulationMetricTracks,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    validate_simulation_state,
+)
+
 import newton
 import newton.examples
 from newton.examples.robot.example_robot_anymal_c_walk import Example
+
+
+def _create_example(num_frames):
+    if hasattr(newton.examples, "default_args"):
+        args = newton.examples.default_args()
+    else:
+        args = None
+    return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
 
 
 class FastExampleAnymalPretrained:
@@ -18,17 +39,37 @@ class FastExampleAnymalPretrained:
 
     def setup(self):
         self.num_frames = 50
-        if hasattr(newton.examples, "default_args"):
-            args = newton.examples.default_args()
-        else:
-            args = None
-        self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), args)
+        self.example = _create_example(self.num_frames)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_simulate(self):
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
+    num_frames = 50
+    samples = 3
+    world_count = 1
+
+    def setup_cache(self):
+        wp.synchronize_device()
+        device = wp.get_device()
+        free_memory_before = device.free_memory
+        return collect_synchronized_simulation_metrics(
+            create_workload=lambda: _create_example(self.num_frames),
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            synchronize=wp.synchronize_device,
+            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+            validate=lambda workload: validate_simulation_state(
+                workload.state_0,
+                max_linear_speed=10.0,
+                max_angular_speed=50.0,
+            ),
+        )
 
 
 if __name__ == "__main__":
@@ -38,6 +79,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastExampleAnymalPretrained": FastExampleAnymalPretrained,
+        "FastMetricsExampleAnymalPretrained": FastMetricsExampleAnymalPretrained,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -19,16 +19,16 @@ from benchmark_metrics import (
     validate_simulation_state,
 )
 
-import newton
-import newton.examples
-from newton.examples.robot.example_robot_anymal_c_walk import Example
-
 _NUM_FRAMES = 50
 _MIN_BASE_HEIGHT = 0.4
 _MIN_FORWARD_PROGRESS = 0.25
 
 
 def _create_example(num_frames):
+    import newton  # noqa: PLC0415
+    import newton.examples  # noqa: PLC0415
+    from newton.examples.robot.example_robot_anymal_c_walk import Example  # noqa: PLC0415
+
     if hasattr(newton.examples, "default_args"):
         args = newton.examples.default_args()
     else:

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -15,8 +15,7 @@ sys.path.append(parent_dir)
 
 from benchmark_metrics import (
     _SimulationMetricTracksUnparameterized,
-    collect_simulation_metrics_synchronized,
-    compute_gpu_memory_usage,
+    collect_simulation_metrics,
     validate_simulation_state,
 )
 
@@ -73,16 +72,14 @@ class FastMetricsExampleAnymalPretrained(_SimulationMetricTracksUnparameterized)
     world_count = 1
 
     def setup_cache(self):
-        wp.synchronize_device()
-        device = wp.get_device()
-        free_memory_before = device.free_memory
-        return collect_simulation_metrics_synchronized(
+        if wp.get_cuda_device_count() == 0:
+            return None
+        return collect_simulation_metrics(
             create_workload=lambda: _create_example(self.num_frames),
             world_count=self.world_count,
             num_frames=self.num_frames,
             samples=self.samples,
             synchronize=wp.synchronize_device,
-            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
             validate=_validate_workload,
         )
 

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -8,15 +8,12 @@ from typing import ClassVar
 import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
-import newton
-
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
-from benchmark_kamino import DRLegsBenchmarkWorkload
 from benchmark_metrics import (
     _SimulationMetricTracks,
     _SimulationMetricTracksUnparameterized,
@@ -27,6 +24,8 @@ from benchmark_metrics import (
 def _collect_metrics_dr_legs(robot, world_count, num_frames, samples, use_policy):
     if wp.get_cuda_device_count() == 0:
         return None
+
+    from benchmark_kamino import DRLegsBenchmarkWorkload  # noqa: PLC0415
 
     builder = DRLegsBenchmarkWorkload.create_model_builder(robot, world_count)
 
@@ -63,6 +62,8 @@ class _FastBenchmark:
     world_count = None
 
     def setup(self):
+        from benchmark_kamino import DRLegsBenchmarkWorkload  # noqa: PLC0415
+
         if not hasattr(self, "_builder") or self._builder is None:
             self._builder = DRLegsBenchmarkWorkload.create_model_builder(self.robot, self.world_count)
 
@@ -164,53 +165,58 @@ class NotifyDRLegs:
     world_count = 2048
 
     def setup(self):
+        from benchmark_kamino import DRLegsBenchmarkWorkload  # noqa: PLC0415
+
+        import newton  # noqa: PLC0415
+
         builder = DRLegsBenchmarkWorkload.create_model_builder("dr_legs", self.world_count)
         model = builder.finalize(skip_validation_joints=True)
         self._solver = newton.solvers.SolverKamino(model)
+        self._model_flags = newton.ModelFlags
         for flag in (
-            newton.ModelFlags.MODEL_PROPERTIES,
-            newton.ModelFlags.BODY_PROPERTIES,
-            newton.ModelFlags.BODY_INERTIAL_PROPERTIES,
-            newton.ModelFlags.SHAPE_PROPERTIES,
-            newton.ModelFlags.JOINT_PROPERTIES,
-            newton.ModelFlags.JOINT_DOF_PROPERTIES,
-            newton.ModelFlags.ACTUATOR_PROPERTIES,
-            newton.ModelFlags.ALL,
+            self._model_flags.MODEL_PROPERTIES,
+            self._model_flags.BODY_PROPERTIES,
+            self._model_flags.BODY_INERTIAL_PROPERTIES,
+            self._model_flags.SHAPE_PROPERTIES,
+            self._model_flags.JOINT_PROPERTIES,
+            self._model_flags.JOINT_DOF_PROPERTIES,
+            self._model_flags.ACTUATOR_PROPERTIES,
+            self._model_flags.ALL,
         ):
             self._solver.notify_model_changed(flag)
         wp.synchronize_device()
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_actuator_properties(self):
-        self._notify(newton.ModelFlags.ACTUATOR_PROPERTIES)
+        self._notify(self._model_flags.ACTUATOR_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_all(self):
-        self._notify(newton.ModelFlags.ALL)
+        self._notify(self._model_flags.ALL)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_body_inertial_properties(self):
-        self._notify(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+        self._notify(self._model_flags.BODY_INERTIAL_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_body_properties(self):
-        self._notify(newton.ModelFlags.BODY_PROPERTIES)
+        self._notify(self._model_flags.BODY_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_joint_dof_properties(self):
-        self._notify(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+        self._notify(self._model_flags.JOINT_DOF_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_joint_properties(self):
-        self._notify(newton.ModelFlags.JOINT_PROPERTIES)
+        self._notify(self._model_flags.JOINT_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_model_properties(self):
-        self._notify(newton.ModelFlags.MODEL_PROPERTIES)
+        self._notify(self._model_flags.MODEL_PROPERTIES)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_notify_shape_properties(self):
-        self._notify(newton.ModelFlags.SHAPE_PROPERTIES)
+        self._notify(self._model_flags.SHAPE_PROPERTIES)
 
     def _notify(self, flag):
         self._solver.notify_model_changed(flag)

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -21,14 +21,13 @@ from benchmark_metrics import (
     _SimulationMetricTracks,
     _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
-    compute_gpu_memory_usage,
 )
 
 
 def _collect_metrics_dr_legs(robot, world_count, num_frames, samples, use_policy):
-    wp.synchronize_device()
-    device = wp.get_device()
-    free_memory_before = device.free_memory
+    if wp.get_cuda_device_count() == 0:
+        return None
+
     builder = DRLegsBenchmarkWorkload.create_model_builder(robot, world_count)
 
     def create_workload():
@@ -49,7 +48,6 @@ def _collect_metrics_dr_legs(robot, world_count, num_frames, samples, use_policy
         world_count=world_count,
         num_frames=num_frames,
         samples=samples,
-        memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
         validate=lambda workload: workload.test_final(),
     )
 
@@ -106,6 +104,9 @@ class _KpiBenchmark(_SimulationMetricTracks):
     use_policy = True
 
     def _collect_metrics(self):
+        if wp.get_cuda_device_count() == 0:
+            return None
+
         metrics = {}
         for world_count in self.params[0]:
             metrics[world_count] = _collect_metrics_dr_legs(

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -17,6 +17,41 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_kamino import DRLegsBenchmarkWorkload
+from benchmark_metrics import (
+    _SimulationMetricTracks,
+    _UnparameterizedSimulationMetricTracks,
+    collect_simulation_metrics,
+    compute_gpu_memory_usage,
+)
+
+
+def _collect_dr_legs_metrics(robot, world_count, num_frames, samples, use_policy):
+    wp.synchronize_device()
+    device = wp.get_device()
+    free_memory_before = device.free_memory
+    builder = DRLegsBenchmarkWorkload.create_model_builder(robot, world_count)
+
+    def create_workload():
+        workload = DRLegsBenchmarkWorkload(
+            robot=robot,
+            world_count=world_count,
+            use_cuda_graph=True,
+            use_policy=use_policy,
+            builder=builder,
+        )
+        if workload.graph is None or workload.reset_graph is None:
+            raise RuntimeError("KPI benchmark requires CUDA graph capture (is the CUDA mempool allocator enabled?)")
+        wp.synchronize_device()
+        return workload
+
+    return collect_simulation_metrics(
+        create_workload=create_workload,
+        world_count=world_count,
+        num_frames=num_frames,
+        samples=samples,
+        memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+        validate=lambda workload: workload.test_final(),
+    )
 
 
 class _FastBenchmark:
@@ -60,7 +95,7 @@ class _FastBenchmark:
         wp.synchronize_device()
 
 
-class _KpiBenchmark:
+class _KpiBenchmark(_SimulationMetricTracks):
     """Utility base class for Kamino KPI benchmarks."""
 
     param_names: ClassVar[list[str]] = ["world_count"]
@@ -70,35 +105,17 @@ class _KpiBenchmark:
     samples = None
     use_policy = True
 
-    def setup(self, world_count):
-        if not hasattr(self, "_builder") or self._builder is None:
-            self._builder = {}
-        if world_count not in self._builder:
-            self._builder[world_count] = DRLegsBenchmarkWorkload.create_model_builder(self.robot, world_count)
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulate(self, world_count):
-        total_time = 0.0
-        for _iter in range(self.samples):
-            workload = DRLegsBenchmarkWorkload(
+    def _collect_metrics(self):
+        metrics = {}
+        for world_count in self.params[0]:
+            metrics[world_count] = _collect_dr_legs_metrics(
                 robot=self.robot,
                 world_count=world_count,
-                use_cuda_graph=True,
+                num_frames=self.num_frames,
+                samples=self.samples,
                 use_policy=self.use_policy,
-                builder=self._builder[world_count],
             )
-            if workload.graph is None or workload.reset_graph is None:
-                raise RuntimeError("KPI benchmark requires CUDA graph capture (is the CUDA mempool allocator enabled?)")
-
-            wp.synchronize_device()
-            for _ in range(self.num_frames):
-                workload.step()
-            total_time += workload.benchmark_time
-            workload.test_final()
-
-        return total_time * 1000 / (self.num_frames * workload.sim_substeps * world_count * self.samples)
-
-    track_simulate.unit = "ms/world-step"
+        return metrics
 
 
 class FastDRLegs(_FastBenchmark):
@@ -108,11 +125,30 @@ class FastDRLegs(_FastBenchmark):
     world_count = 32
 
 
+class FastMetricsDRLegs(_UnparameterizedSimulationMetricTracks):
+    num_frames = 25
+    robot = "dr_legs"
+    samples = 2
+    world_count = 32
+
+    def setup_cache(self):
+        return _collect_dr_legs_metrics(
+            robot=self.robot,
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            use_policy=False,
+        )
+
+
 class KpiDRLegs(_KpiBenchmark):
     params: ClassVar[list[list[int]]] = [[4096]]
     num_frames = 25
     robot = "dr_legs"
     samples = 2
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 class NotifyDRLegs:
@@ -185,6 +221,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastDRLegs": FastDRLegs,
+        "FastMetricsDRLegs": FastMetricsDRLegs,
         "KpiDRLegs": KpiDRLegs,
         "NotifyDRLegs": NotifyDRLegs,
     }

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -150,6 +150,8 @@ class KpiDRLegs(_KpiBenchmark):
     def setup_cache(self):
         return self._collect_metrics()
 
+    setup_cache.timeout = 1200
+
 
 class NotifyDRLegs:
     """Benchmark Kamino model notifications for 2048 DR Legs worlds."""

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -19,13 +19,13 @@ sys.path.append(parent_dir)
 from benchmark_kamino import DRLegsBenchmarkWorkload
 from benchmark_metrics import (
     _SimulationMetricTracks,
-    _UnparameterizedSimulationMetricTracks,
+    _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
     compute_gpu_memory_usage,
 )
 
 
-def _collect_dr_legs_metrics(robot, world_count, num_frames, samples, use_policy):
+def _collect_metrics_dr_legs(robot, world_count, num_frames, samples, use_policy):
     wp.synchronize_device()
     device = wp.get_device()
     free_memory_before = device.free_memory
@@ -108,7 +108,7 @@ class _KpiBenchmark(_SimulationMetricTracks):
     def _collect_metrics(self):
         metrics = {}
         for world_count in self.params[0]:
-            metrics[world_count] = _collect_dr_legs_metrics(
+            metrics[world_count] = _collect_metrics_dr_legs(
                 robot=self.robot,
                 world_count=world_count,
                 num_frames=self.num_frames,
@@ -125,14 +125,14 @@ class FastDRLegs(_FastBenchmark):
     world_count = 32
 
 
-class FastMetricsDRLegs(_UnparameterizedSimulationMetricTracks):
+class FastMetricsDRLegs(_SimulationMetricTracksUnparameterized):
     num_frames = 25
     robot = "dr_legs"
     samples = 2
     world_count = 32
 
     def setup_cache(self):
-        return _collect_dr_legs_metrics(
+        return _collect_metrics_dr_legs(
             robot=self.robot,
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -16,12 +16,17 @@ from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
+from benchmark_metrics import (
+    _SimulationMetricTracks,
+    collect_simulation_metrics,
+    compute_gpu_memory_usage,
+)
 from benchmark_mujoco import Example
 
 from newton.utils import EventTracer
 
 
-class _KpiBenchmark:
+class _KpiBenchmark(_SimulationMetricTracks):
     """Utility base class for KPI benchmarks."""
 
     param_names = ["world_count"]
@@ -33,39 +38,40 @@ class _KpiBenchmark:
     random_init = None
     environment = "None"
 
-    def setup(self, world_count):
-        if not hasattr(self, "builder") or self.builder is None:
-            self.builder = {}
-        if world_count not in self.builder:
-            self.builder[world_count] = Example.create_model_builder(
-                self.robot, world_count, randomize=self.random_init, seed=123
-            )
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulate(self, world_count):
-        total_time = 0.0
-        for _iter in range(self.samples):
-            example = Example(
-                stage_path=None,
-                robot=self.robot,
-                randomize=self.random_init,
-                headless=True,
-                actuation="random",
-                use_cuda_graph=True,
-                builder=self.builder[world_count],
-                ls_iteration=self.ls_iteration,
-                environment=self.environment,
-            )
-
+    def _collect_metrics(self):
+        metrics = {}
+        for world_count in self.params[0]:
             wp.synchronize_device()
-            for _ in range(self.num_frames):
-                example.step()
-            wp.synchronize_device()
-            total_time += example.benchmark_time
+            device = wp.get_device()
+            free_memory_before = device.free_memory
+            builder = Example.create_model_builder(self.robot, world_count, randomize=self.random_init, seed=123)
 
-        return total_time * 1000 / (self.num_frames * example.sim_substeps * world_count * self.samples)
+            def create_workload(builder=builder):
+                example = Example(
+                    stage_path=None,
+                    robot=self.robot,
+                    randomize=self.random_init,
+                    headless=True,
+                    actuation="random",
+                    use_cuda_graph=True,
+                    builder=builder,
+                    ls_iteration=self.ls_iteration,
+                    environment=self.environment,
+                )
+                wp.synchronize_device()
+                return example
 
-    track_simulate.unit = "ms/world-step"
+            metrics[world_count] = collect_simulation_metrics(
+                create_workload=create_workload,
+                world_count=world_count,
+                num_frames=self.num_frames,
+                samples=self.samples,
+                memory_usage_bytes=lambda workload, device=device, free_memory_before=free_memory_before: (
+                    compute_gpu_memory_usage(device, free_memory_before)
+                ),
+                validate=lambda workload: workload.test_final(),
+            )
+        return metrics
 
 
 class _RealtimePhysicsBenchmark:
@@ -204,6 +210,9 @@ class FastCartpole(_KpiBenchmark):
     random_init = True
     environment = "None"
 
+    def setup_cache(self):
+        return self._collect_metrics()
+
 
 class FastG1(_KpiBenchmark):
     params = [[8192]]
@@ -214,6 +223,9 @@ class FastG1(_KpiBenchmark):
     ls_iteration = 10
     random_init = True
     environment = "None"
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 class FastNewtonOverheadG1(_NewtonOverheadBenchmark):
@@ -234,6 +246,9 @@ class FastHumanoid(_KpiBenchmark):
     ls_iteration = 15
     random_init = True
     environment = "None"
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 class RealtimeHumanoidPhysics(_RealtimePhysicsBenchmark):
@@ -261,6 +276,9 @@ class FastAllegro(_KpiBenchmark):
     random_init = False
     environment = "None"
 
+    def setup_cache(self):
+        return self._collect_metrics()
+
 
 class FastKitchenG1(_KpiBenchmark):
     params = [[512]]
@@ -271,6 +289,9 @@ class FastKitchenG1(_KpiBenchmark):
     ls_iteration = 10
     random_init = True
     environment = "kitchen"
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 if __name__ == "__main__":

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -23,9 +23,6 @@ from benchmark_metrics import (
     _SimulationMetricTracks,
     collect_simulation_metrics,
 )
-from benchmark_mujoco import Example
-
-from newton.utils import EventTracer
 
 
 class _SimulationMetricTracksMuJoCo(_SimulationMetricTracks):
@@ -58,6 +55,8 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
     expected_bodies_per_world = None
 
     def _create_workload(self, builder, world_count):
+        from benchmark_mujoco import Example  # noqa: PLC0415
+
         workload = Example(
             stage_path=None,
             robot=self.robot,
@@ -93,6 +92,8 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
     def _collect_metrics(self):
         if wp.get_cuda_device_count() == 0:
             return None
+
+        from benchmark_mujoco import Example  # noqa: PLC0415
 
         metrics = {}
         for world_count in self.params[0]:
@@ -143,6 +144,9 @@ class _RealtimePhysicsBenchmark:
     def setup(self):
         if wp.get_cuda_device_count() == 0:
             raise SkipNotImplemented
+
+        from benchmark_mujoco import Example  # noqa: PLC0415
+
         with wp.ScopedDevice("cuda:0"):
             if not wp.is_mempool_enabled(wp.get_device()):
                 raise SkipNotImplemented
@@ -218,6 +222,8 @@ class _NewtonOverheadBenchmark:
     random_init = None
 
     def setup(self, world_count):
+        from benchmark_mujoco import Example  # noqa: PLC0415
+
         if not hasattr(self, "builder") or self.builder is None:
             self.builder = {}
         if world_count not in self.builder:
@@ -227,6 +233,10 @@ class _NewtonOverheadBenchmark:
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def track_simulate(self, world_count):
+        from benchmark_mujoco import Example  # noqa: PLC0415
+
+        from newton.utils import EventTracer  # noqa: PLC0415
+
         trace = {}
         with EventTracer(enabled=True) as tracer:
             for _iter in range(self.samples):

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -287,7 +287,8 @@ class FastAllegro(_KpiBenchmark):
 
 
 class FastKitchenG1(_KpiBenchmark):
-    params = [[512]]
+    # Leave headroom for replicated kitchen construction on 64 GiB CI runners.
+    params = [[128]]
     num_frames = 50
     robot = "g1"
     timeout = 900

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -5,7 +5,10 @@ import math
 import os
 import sys
 import time
+from dataclasses import replace
+from functools import partial
 
+import numpy as np
 import warp as wp
 
 wp.config.enable_backward = False
@@ -19,14 +22,29 @@ sys.path.append(parent_dir)
 from benchmark_metrics import (
     _SimulationMetricTracks,
     collect_simulation_metrics,
-    compute_gpu_memory_usage,
 )
 from benchmark_mujoco import Example
 
 from newton.utils import EventTracer
 
 
-class _KpiBenchmark(_SimulationMetricTracks):
+class _SimulationMetricTracksMuJoCo(_SimulationMetricTracks):
+    """MuJoCo-specific tracked metrics."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_solver_niter_mean(self, metrics, world_count):
+        return metrics[world_count].solver_niter_mean
+
+    track_solver_niter_mean.unit = "iterations"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_solver_niter_max(self, metrics, world_count):
+        return metrics[world_count].solver_niter_max
+
+    track_solver_niter_max.unit = "iterations"
+
+
+class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
     """Utility base class for KPI benchmarks."""
 
     param_names = ["world_count"]
@@ -37,13 +55,46 @@ class _KpiBenchmark(_SimulationMetricTracks):
     ls_iteration = None
     random_init = None
     environment = "None"
+    expected_bodies_per_world = None
+
+    def _create_workload(self, builder):
+        workload = Example(
+            stage_path=None,
+            robot=self.robot,
+            randomize=self.random_init,
+            headless=True,
+            actuation="random",
+            use_cuda_graph=True,
+            builder=builder,
+            ls_iteration=self.ls_iteration,
+            environment=self.environment,
+        )
+        if workload.graph is None:
+            raise RuntimeError("KPI benchmark requires CUDA graph capture (is the CUDA mempool allocator enabled?)")
+        wp.synchronize_device()
+        return workload
+
+    def _validate_workload(self, workload):
+        workload.test_final()
+        if self.expected_bodies_per_world is None:
+            return
+        expected_body_count = self.expected_bodies_per_world * workload.world_count
+        if workload.model.body_count != expected_body_count:
+            raise RuntimeError(
+                f"Expected {self.expected_bodies_per_world} bodies per world for {self.environment}, "
+                f"got {workload.model.body_count / workload.world_count:g}"
+            )
+
+    def _validate_metrics_workload(self, workload, solver_niter_samples):
+        self._validate_workload(workload)
+        solver_niter_samples.append(workload.solver.mjw_data.solver_niter.numpy())
 
     def _collect_metrics(self):
+        if wp.get_cuda_device_count() == 0:
+            return None
+
         metrics = {}
         for world_count in self.params[0]:
-            wp.synchronize_device()
-            device = wp.get_device()
-            free_memory_before = device.free_memory
             builder = Example.create_model_builder(
                 self.robot,
                 world_count,
@@ -51,31 +102,23 @@ class _KpiBenchmark(_SimulationMetricTracks):
                 randomize=self.random_init,
                 seed=123,
             )
+            solver_niter_samples = []
 
             def create_workload(builder=builder):
-                example = Example(
-                    stage_path=None,
-                    robot=self.robot,
-                    randomize=self.random_init,
-                    headless=True,
-                    actuation="random",
-                    use_cuda_graph=True,
-                    builder=builder,
-                    ls_iteration=self.ls_iteration,
-                    environment=self.environment,
-                )
-                wp.synchronize_device()
-                return example
+                return self._create_workload(builder)
 
-            metrics[world_count] = collect_simulation_metrics(
+            world_metrics = collect_simulation_metrics(
                 create_workload=create_workload,
                 world_count=world_count,
                 num_frames=self.num_frames,
                 samples=self.samples,
-                memory_usage_bytes=lambda workload, device=device, free_memory_before=free_memory_before: (
-                    compute_gpu_memory_usage(device, free_memory_before)
-                ),
-                validate=lambda workload: workload.test_final(),
+                validate=partial(self._validate_metrics_workload, solver_niter_samples=solver_niter_samples),
+            )
+            solver_niter = np.concatenate([np.asarray(values).reshape(-1) for values in solver_niter_samples])
+            metrics[world_count] = replace(
+                world_metrics,
+                solver_niter_mean=float(np.mean(solver_niter)),
+                solver_niter_max=float(np.max(solver_niter)),
             )
         return metrics
 
@@ -297,6 +340,7 @@ class FastKitchenG1(_KpiBenchmark):
     ls_iteration = 10
     random_init = True
     environment = "kitchen"
+    expected_bodies_per_world = 111
 
     def setup_cache(self):
         return self._collect_metrics()

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -44,7 +44,13 @@ class _KpiBenchmark(_SimulationMetricTracks):
             wp.synchronize_device()
             device = wp.get_device()
             free_memory_before = device.free_memory
-            builder = Example.create_model_builder(self.robot, world_count, randomize=self.random_init, seed=123)
+            builder = Example.create_model_builder(
+                self.robot,
+                world_count,
+                environment=self.environment,
+                randomize=self.random_init,
+                seed=123,
+            )
 
             def create_workload(builder=builder):
                 example = Example(
@@ -285,6 +291,7 @@ class FastKitchenG1(_KpiBenchmark):
     num_frames = 50
     robot = "g1"
     timeout = 900
+    version = "2"  # The pre-v2 series accidentally omitted the kitchen environment.
     samples = 2
     ls_iteration = 10
     random_init = True

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -57,7 +57,7 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
     environment = "None"
     expected_bodies_per_world = None
 
-    def _create_workload(self, builder):
+    def _create_workload(self, builder, world_count):
         workload = Example(
             stage_path=None,
             robot=self.robot,
@@ -66,6 +66,7 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
             actuation="random",
             use_cuda_graph=True,
             builder=builder,
+            world_count=world_count,
             ls_iteration=self.ls_iteration,
             environment=self.environment,
         )
@@ -74,19 +75,19 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
         wp.synchronize_device()
         return workload
 
-    def _validate_workload(self, workload):
+    def _validate_workload(self, workload, world_count):
         workload.test_final()
         if self.expected_bodies_per_world is None:
             return
-        expected_body_count = self.expected_bodies_per_world * workload.world_count
+        expected_body_count = self.expected_bodies_per_world * world_count
         if workload.model.body_count != expected_body_count:
             raise RuntimeError(
                 f"Expected {self.expected_bodies_per_world} bodies per world for {self.environment}, "
-                f"got {workload.model.body_count / workload.world_count:g}"
+                f"got {workload.model.body_count / world_count:g}"
             )
 
-    def _validate_metrics_workload(self, workload, solver_niter_samples):
-        self._validate_workload(workload)
+    def _validate_metrics_workload(self, workload, world_count, solver_niter_samples):
+        self._validate_workload(workload, world_count)
         solver_niter_samples.append(workload.solver.mjw_data.solver_niter.numpy())
 
     def _collect_metrics(self):
@@ -104,15 +105,19 @@ class _KpiBenchmark(_SimulationMetricTracksMuJoCo):
             )
             solver_niter_samples = []
 
-            def create_workload(builder=builder):
-                return self._create_workload(builder)
+            def create_workload(builder=builder, world_count=world_count):
+                return self._create_workload(builder, world_count)
 
             world_metrics = collect_simulation_metrics(
                 create_workload=create_workload,
                 world_count=world_count,
                 num_frames=self.num_frames,
                 samples=self.samples,
-                validate=partial(self._validate_metrics_workload, solver_niter_samples=solver_niter_samples),
+                validate=partial(
+                    self._validate_metrics_workload,
+                    world_count=world_count,
+                    solver_niter_samples=solver_niter_samples,
+                ),
             )
             solver_niter = np.concatenate([np.asarray(values).reshape(-1) for values in solver_niter_samples])
             metrics[world_count] = replace(
@@ -330,8 +335,8 @@ class FastAllegro(_KpiBenchmark):
 
 
 class FastKitchenG1(_KpiBenchmark):
-    # Leave headroom for replicated kitchen construction on 64 GiB CI runners.
-    params = [[128]]
+    # #3574 bounds replicated filter pairs to colliding shapes so 512 worlds fit on CI hosts.
+    params = [[512]]
     num_frames = 50
     robot = "g1"
     timeout = 900

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -14,8 +14,8 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_metrics import (
-    _UnparameterizedSimulationMetricTracks,
-    collect_synchronized_simulation_metrics,
+    _SimulationMetricTracksUnparameterized,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     validate_simulation_workload,
 )
@@ -48,7 +48,7 @@ class FastExampleQuadrupedXPBD:
         wp.synchronize_device()
 
 
-class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
+class FastMetricsExampleQuadrupedXPBD(_SimulationMetricTracksUnparameterized):
     num_frames = 1000
     samples = 1
     world_count = 200
@@ -57,7 +57,7 @@ class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
         wp.synchronize_device()
         device = wp.get_device()
         free_memory_before = device.free_memory
-        return collect_synchronized_simulation_metrics(
+        return collect_simulation_metrics_synchronized(
             create_workload=lambda: _create_example(self.num_frames, self.world_count),
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -19,12 +19,12 @@ from benchmark_metrics import (
     validate_simulation_state,
 )
 
-import newton
-import newton.examples
-from newton.examples.basic.example_basic_urdf import Example
-
 
 def _create_example(num_frames, world_count):
+    import newton  # noqa: PLC0415
+    import newton.examples  # noqa: PLC0415
+    from newton.examples.basic.example_basic_urdf import Example  # noqa: PLC0415
+
     if hasattr(newton.examples, "default_args") and hasattr(Example, "create_parser"):
         args = newton.examples.default_args(Example.create_parser())
         args.world_count = world_count

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -15,9 +15,8 @@ sys.path.append(parent_dir)
 
 from benchmark_metrics import (
     _SimulationMetricTracksUnparameterized,
-    collect_simulation_metrics_synchronized,
-    compute_gpu_memory_usage,
-    validate_simulation_workload,
+    collect_simulation_metrics,
+    validate_simulation_state,
 )
 
 import newton
@@ -54,21 +53,24 @@ class FastMetricsExampleQuadrupedXPBD(_SimulationMetricTracksUnparameterized):
     world_count = 200
 
     def setup_cache(self):
-        wp.synchronize_device()
-        device = wp.get_device()
-        free_memory_before = device.free_memory
-        return collect_simulation_metrics_synchronized(
+        if wp.get_cuda_device_count() == 0:
+            return None
+
+        def validate_workload(workload):
+            validate_simulation_state(
+                workload.state_0,
+                max_linear_speed=0.3,
+                max_angular_speed=0.3,
+            )
+            workload.test_final()
+
+        return collect_simulation_metrics(
             create_workload=lambda: _create_example(self.num_frames, self.world_count),
             world_count=self.world_count,
             num_frames=self.num_frames,
             samples=self.samples,
             synchronize=wp.synchronize_device,
-            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
-            validate=lambda workload: validate_simulation_workload(
-                workload,
-                max_linear_speed=0.3,
-                max_angular_speed=0.3,
-            ),
+            validate=validate_workload,
         )
 
 

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -1,15 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from benchmark_metrics import (
+    _UnparameterizedSimulationMetricTracks,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    validate_simulation_workload,
+)
+
 import newton
 import newton.examples
 from newton.examples.basic.example_basic_urdf import Example
+
+
+def _create_example(num_frames, world_count):
+    if hasattr(newton.examples, "default_args") and hasattr(Example, "create_parser"):
+        args = newton.examples.default_args(Example.create_parser())
+        args.world_count = world_count
+        return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
+    return Example(newton.viewer.ViewerNull(num_frames=num_frames), world_count)
 
 
 class FastExampleQuadrupedXPBD:
@@ -18,18 +39,37 @@ class FastExampleQuadrupedXPBD:
 
     def setup(self):
         self.num_frames = 1000
-        if hasattr(newton.examples, "default_args") and hasattr(Example, "create_parser"):
-            args = newton.examples.default_args(Example.create_parser())
-            args.world_count = 200
-            self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), args)
-        else:
-            self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), 200)
+        self.example = _create_example(self.num_frames, world_count=200)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_simulate(self):
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
+    num_frames = 1000
+    samples = 1
+    world_count = 200
+
+    def setup_cache(self):
+        wp.synchronize_device()
+        device = wp.get_device()
+        free_memory_before = device.free_memory
+        return collect_synchronized_simulation_metrics(
+            create_workload=lambda: _create_example(self.num_frames, self.world_count),
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            synchronize=wp.synchronize_device,
+            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+            validate=lambda workload: validate_simulation_workload(
+                workload,
+                max_linear_speed=0.3,
+                max_angular_speed=0.3,
+            ),
+        )
 
 
 if __name__ == "__main__":
@@ -39,6 +79,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastExampleQuadrupedXPBD": FastExampleQuadrupedXPBD,
+        "FastMetricsExampleQuadrupedXPBD": FastMetricsExampleQuadrupedXPBD,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -799,6 +799,42 @@ benchmark code from the ``asv/benchmarks`` directory against the code state of t
 the benchmark definitions themselves are not checked out from different branches—only the code being
 benchmarked is.
 
+Simulation benchmark metrics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The nightly robot and policy simulation benchmarks publish several metrics from one cached benchmark run. This
+includes the batched MuJoCo and Kamino KPI workloads, the non-policy DR Legs workload, the pretrained Anymal
+workload, and the XPBD quadruped workload. Companion ``FastMetrics*`` classes reuse the exact factories, scenes,
+solvers, and frame counts of existing aggregate benchmarks. Rendering, IK, inverse dynamics, CPU-backend
+regression, material/contact microbenchmarks, and startup benchmarks are not experience-collection workloads and
+are outside this metric set.
+
+Let ``F`` be the number of measured frames across all samples, ``S`` the number of physics substeps per frame,
+``W`` the world count, ``dt`` the physics timestep in seconds, ``T`` the synchronized complete-step wall time in
+seconds, and ``T_physics`` the workload's synchronized internal physics time. The reported metrics are:
+
+* mean world-step time: ``1000 * T_physics / (F * S * W)`` in ``ms/world-step`` for workloads with an internal
+  timer and ``1000 * T / (F * S * W)`` otherwise;
+* simulation throughput: ``F * S * W / T`` in ``world-steps/s``;
+* real-time factor: ``F * S * W * dt / T``;
+* p95 step time: the 95th percentile of synchronized complete-step times in ``ms/frame``; and
+* steady-state GPU memory in ``MiB``.
+
+The existing KPI mean world-step series keeps its ``track_simulate`` name and definition, and existing
+``time_simulate`` aggregate series remain unchanged. ``world_count`` remains an ASV parameter where applicable,
+while ``sim_dt`` and ``sim_substeps`` are also recorded as tracked values so dashboard results retain the
+configuration needed to interpret throughput and real-time factor. The existing KPI mean series continues to use
+each workload's internal physics timer. Throughput, real-time factor, and p95 metrics time and synchronize the
+complete ``step()`` operation, including any policy or control work it performs.
+
+GPU memory is the decrease in ``Device.free_memory`` between a baseline immediately before model construction
+and a measurement after initialization, CUDA graph capture, and the first complete measured sample, while that
+sample's workload is still live. This device-level delta includes allocations from Warp, PyTorch, solver support,
+and CUDA graphs. Because the measurement is device-wide, runners must provide exclusive GPU access during the
+measurement interval. The remaining samples do not affect this measurement. A benchmark fails instead of
+publishing metrics if its final simulation state is invalid, has non-normalized body rotations, or exceeds the
+workload's body-speed bounds.
+
 Benchmarks can also be run against a range of commits using the ``commit1..commit2`` syntax.
 This is useful for comparing performance across several recent changes:
 

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -818,7 +818,8 @@ seconds, and ``T_physics`` the workload's synchronized internal physics time. Th
 * simulation throughput: ``F * S * W / T`` in ``world-steps/s``;
 * real-time factor: ``F * S * W * dt / T``;
 * p95 step time: the 95th percentile of synchronized complete-step times in ``ms/frame``; and
-* steady-state GPU memory in ``MiB``.
+* steady-state GPU memory in ``MiB``; and
+* mean and maximum MuJoCo solver iteration counts across worlds at the final frame of each measured sample.
 
 The existing KPI mean world-step series keeps its ``track_simulate`` name and definition, and existing
 ``time_simulate`` aggregate series remain unchanged. ``world_count`` remains an ASV parameter where applicable,
@@ -827,13 +828,13 @@ configuration needed to interpret throughput and real-time factor. The existing 
 each workload's internal physics timer. Throughput, real-time factor, and p95 metrics time and synchronize the
 complete ``step()`` operation, including any policy or control work it performs.
 
-GPU memory is the decrease in ``Device.free_memory`` between a baseline immediately before model construction
-and a measurement after initialization, CUDA graph capture, and the first complete measured sample, while that
-sample's workload is still live. This device-level delta includes allocations from Warp, PyTorch, solver support,
-and CUDA graphs. Because the measurement is device-wide, runners must provide exclusive GPU access during the
-measurement interval. The remaining samples do not affect this measurement. A benchmark fails instead of
-publishing metrics if its final simulation state is invalid, has non-normalized body rotations, or exceeds the
-workload's body-speed bounds.
+GPU memory is the decrease in ``Device.free_memory`` between a baseline immediately before the first finalized
+workload is created and a measurement after initialization, CUDA graph capture, and the first complete measured
+sample, while that sample's workload is still live. This device-level delta includes allocations from Warp,
+PyTorch, solver support, and CUDA graphs. Because the measurement is device-wide, runners must provide exclusive
+GPU access during the measurement interval. The remaining samples do not affect this measurement. A benchmark
+fails instead of publishing metrics if its final simulation state is invalid, has non-normalized body rotations,
+or exceeds the workload's body-speed bounds.
 
 Benchmarks can also be run against a range of commits using the ``commit1..commit2`` syntax.
 This is useful for comparing performance across several recent changes:

--- a/newton/_src/utils/benchmark.py
+++ b/newton/_src/utils/benchmark.py
@@ -175,13 +175,20 @@ def run_benchmark(benchmark_cls, number=1, print_results=True):
     else:
         combinations = [()]
 
+    cache = None
+    has_cache = hasattr(benchmark_cls, "setup_cache")
+    if has_cache:
+        cache = benchmark_cls().setup_cache()
+        has_cache = cache is not None
+
     results = {}
     # For each parameter combination:
     for params in combinations:
+        call_params = (cache, *params) if has_cache else params
         # Create a fresh benchmark instance.
         instance = benchmark_cls()
         if hasattr(instance, "setup"):
-            instance.setup(*params)
+            instance.setup(*call_params)
         # Iterate over all attributes to find benchmark methods.
         for attr in dir(instance):
             if attr.startswith("time_") or attr.startswith("track_"):
@@ -190,24 +197,24 @@ def run_benchmark(benchmark_cls, number=1, print_results=True):
                 samples = []
                 if attr.startswith("time_"):
                     # Warmup run (not measured).
-                    method(*params)
+                    method(*call_params)
                     wp.synchronize()
                     # Run timing benchmarks multiple times and measure elapsed time.
                     for _ in range(number):
                         start = time.perf_counter()
-                        method(*params)
+                        method(*call_params)
                         t = time.perf_counter() - start
                         samples.append(t)
                 elif attr.startswith("track_"):
                     # Run tracking benchmarks multiple times and record returned values.
                     for _ in range(number):
-                        val = method(*params)
+                        val = method(*call_params)
                         samples.append(val)
                 # Compute the average result.
                 avg = sum(samples) / len(samples)
                 results[(attr, params)] = avg
         if hasattr(instance, "teardown"):
-            instance.teardown(*params)
+            instance.teardown(*call_params)
 
     if print_results:
         print("\n=== Benchmark Results ===")

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -23,6 +23,7 @@ from benchmark_metrics import (  # noqa: E402
 
 class TestBenchmarkMetrics(unittest.TestCase):
     def test_compute_simulation_metrics(self):
+        """Verify derived simulation metrics and their units."""
         metrics = compute_simulation_metrics(
             frame_times=[0.1, 0.2, 0.3, 0.4],
             sim_dt=0.002,
@@ -40,6 +41,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertEqual(metrics.sim_substeps, 5)
 
     def test_collect_simulation_metrics(self):
+        """Verify internal timing, validation, and memory collection."""
         workloads = []
         events = []
         timer_values = iter((0.0, 0.02, 0.02, 0.06, 0.06, 0.08, 0.08, 0.12))
@@ -98,6 +100,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
     def test_collect_simulation_metrics_with_synchronization(self):
+        """Verify synchronized wall timing drives collected metrics."""
         workloads = []
         events = []
         sync_calls = []
@@ -151,6 +154,8 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
     def test_collect_simulation_metrics_rejects_increased_free_memory(self):
+        """Reject an invalid increase in measured free GPU memory."""
+
         class FakeDevice:
             free_memory_values = iter((1000, 1100))
 
@@ -180,6 +185,8 @@ class TestBenchmarkMetrics(unittest.TestCase):
             )
 
     def test_validate_simulation_state(self):
+        """Validate finite states, unit quaternions, and bounded speeds."""
+
         class FakeArray:
             def __init__(self, values):
                 self.values = np.asarray(values, dtype=np.float32)
@@ -210,6 +217,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
             validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
 
     def test_run_benchmark_with_setup_cache(self):
+        """Pass one setup cache through the full benchmark lifecycle."""
         cache_events = []
 
         class CachedBenchmark:

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from benchmark_metrics import (  # noqa: E402
+    collect_simulation_metrics,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    compute_simulation_metrics,
+    validate_simulation_state,
+    validate_simulation_workload,
+)
+
+from newton.utils import run_benchmark
+
+
+class TestBenchmarkMetrics(unittest.TestCase):
+    def test_compute_simulation_metrics(self):
+        metrics = compute_simulation_metrics(
+            frame_times=[0.1, 0.2, 0.3, 0.4],
+            sim_dt=0.002,
+            sim_substeps=5,
+            world_count=10,
+            gpu_memory_bytes=10 * 1024**2,
+        )
+
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 5.0)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 200.0)
+        self.assertAlmostEqual(metrics.real_time_factor, 0.4)
+        self.assertAlmostEqual(metrics.p95_frame_time_ms, 385.0)
+        self.assertAlmostEqual(metrics.gpu_memory_mib, 10.0)
+        self.assertEqual(metrics.sim_dt, 0.002)
+        self.assertEqual(metrics.sim_substeps, 5)
+
+    def test_collect_simulation_metrics(self):
+        workloads = []
+        events = []
+        timer_values = iter((0.0, 0.02, 0.02, 0.06, 0.06, 0.08, 0.08, 0.12))
+
+        class FakeWorkload:
+            sim_dt = 0.01
+            sim_substeps = 2
+
+            def __init__(self):
+                self.benchmark_time = 0.0
+                self.step_count = 0
+
+            def step(self):
+                self.benchmark_time += (0.01, 0.02)[self.step_count]
+                self.step_count += 1
+
+        def create_workload():
+            workload = FakeWorkload()
+            workloads.append(workload)
+            return workload
+
+        def memory_usage_bytes(workload):
+            self.assertIs(workload, workloads[0])
+            self.assertEqual(workload.step_count, 2)
+            events.append(("memory", workload))
+            return 8 * 1024**2
+
+        def validate(workload):
+            events.append(("validate", workload))
+
+        metrics = collect_simulation_metrics(
+            create_workload=create_workload,
+            world_count=4,
+            num_frames=2,
+            samples=2,
+            memory_usage_bytes=memory_usage_bytes,
+            validate=validate,
+            timer=lambda: next(timer_values),
+        )
+
+        self.assertEqual(len(workloads), 2)
+        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0]), ("validate", workloads[1])])
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 32 / 0.12)
+        self.assertAlmostEqual(metrics.real_time_factor, 32 * 0.01 / 0.12)
+        self.assertAlmostEqual(metrics.p95_frame_time_ms, 40.0)
+        self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
+
+    def test_collect_synchronized_simulation_metrics(self):
+        workloads = []
+        events = []
+        sync_calls = []
+        timer_values = iter((0.0, 0.01, 0.01, 0.03))
+
+        class FakeWorkload:
+            sim_dt = 0.01
+            sim_substeps = 2
+
+            def __init__(self):
+                self.step_count = 0
+
+            def step(self):
+                self.step_count += 1
+
+        def create_workload():
+            workload = FakeWorkload()
+            workloads.append(workload)
+            return workload
+
+        def memory_usage_bytes(workload):
+            events.append(("memory", workload))
+            return 8 * 1024**2
+
+        def validate(workload):
+            events.append(("validate", workload))
+
+        metrics = collect_synchronized_simulation_metrics(
+            create_workload=create_workload,
+            world_count=4,
+            num_frames=2,
+            samples=1,
+            synchronize=lambda: sync_calls.append(None),
+            timer=lambda: next(timer_values),
+            memory_usage_bytes=memory_usage_bytes,
+            validate=validate,
+        )
+
+        self.assertEqual(len(sync_calls), 3)
+        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0])])
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 16 / 0.03)
+        self.assertAlmostEqual(metrics.real_time_factor, 16 * 0.01 / 0.03)
+
+    def test_compute_gpu_memory_usage(self):
+        class FakeDevice:
+            free_memory = 700
+
+        self.assertEqual(compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000), 300)
+
+        FakeDevice.free_memory = 1100
+        with self.assertRaisesRegex(RuntimeError, "increased"):
+            compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000)
+
+    def test_validate_simulation_state(self):
+        class FakeArray:
+            def __init__(self, values):
+                self.values = np.asarray(values, dtype=np.float32)
+
+            def numpy(self):
+                return self.values
+
+        class FakeState:
+            joint_q = FakeArray([0.0])
+            joint_qd = FakeArray([0.0])
+            body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+            body_qd = FakeArray([[1.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+
+        validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.body_qd = FakeArray([[11.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        with self.assertRaisesRegex(RuntimeError, "linear speed"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.body_qd = FakeArray([[1.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        FakeState.body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        with self.assertRaisesRegex(RuntimeError, "quaternion"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        specialized_checks = []
+        FakeState.body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+        FakeState.joint_qd = FakeArray([np.nan])
+        with self.assertRaisesRegex(RuntimeError, "state.joint_qd"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.joint_qd = FakeArray([0.0])
+
+        class FakeWorkload:
+            state_0 = FakeState()
+
+            def test_final(self):
+                specialized_checks.append(self)
+
+        workload = FakeWorkload()
+        validate_simulation_workload(workload, max_linear_speed=10.0, max_angular_speed=10.0)
+        self.assertEqual(specialized_checks, [workload])
+
+    def test_run_benchmark_with_setup_cache(self):
+        class CachedBenchmark:
+            params = [[2, 3]]
+            setup_cache_calls = 0
+
+            def setup_cache(self):
+                type(self).setup_cache_calls += 1
+                return 10
+
+            def track_value(self, cache, value):
+                return cache + value
+
+        results = run_benchmark(CachedBenchmark, print_results=False)
+
+        self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
+        self.assertEqual(results[("track_value", (2,))], 12)
+        self.assertEqual(results[("track_value", (3,))], 13)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(BENCHMARK_DIR))
 
 from benchmark_metrics import (  # noqa: E402
     collect_simulation_metrics,
-    collect_synchronized_simulation_metrics,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     compute_simulation_metrics,
     validate_simulation_state,
@@ -90,7 +90,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics.p95_frame_time_ms, 40.0)
         self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
-    def test_collect_synchronized_simulation_metrics(self):
+    def test_collect_simulation_metrics_synchronized(self):
         workloads = []
         events = []
         sync_calls = []
@@ -118,7 +118,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         def validate(workload):
             events.append(("validate", workload))
 
-        metrics = collect_synchronized_simulation_metrics(
+        metrics = collect_simulation_metrics_synchronized(
             create_workload=create_workload,
             world_count=4,
             num_frames=2,
@@ -189,20 +189,39 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertEqual(specialized_checks, [workload])
 
     def test_run_benchmark_with_setup_cache(self):
+        cache_events = []
+
         class CachedBenchmark:
             params: ClassVar = [[2, 3]]
             setup_cache_calls = 0
+            cache_value: ClassVar = {"base": 10}
 
             def setup_cache(self):
                 type(self).setup_cache_calls += 1
-                return 10
+                return self.cache_value
+
+            def setup(self, cache, value):
+                cache_events.append(("setup", cache, value))
+
+            def time_value(self, cache, value):
+                cache_events.append(("time", cache, value))
 
             def track_value(self, cache, value):
-                return cache + value
+                cache_events.append(("track", cache, value))
+                return cache["base"] + value
+
+            def teardown(self, cache, value):
+                cache_events.append(("teardown", cache, value))
 
         results = run_benchmark(CachedBenchmark, print_results=False)
 
         self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
+        self.assertTrue(all(cache is CachedBenchmark.cache_value for _, cache, _ in cache_events))
+        self.assertEqual([event for event, _, _ in cache_events].count("setup"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("time"), 4)
+        self.assertEqual([event for event, _, _ in cache_events].count("track"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("teardown"), 2)
+        self.assertEqual({value for _, _, value in cache_events}, {2, 3})
         self.assertEqual(results[("track_value", (2,))], 12)
         self.assertEqual(results[("track_value", (3,))], 13)
 

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -5,6 +5,7 @@ import sys
 import unittest
 from pathlib import Path
 from typing import ClassVar
+from unittest.mock import patch
 
 import numpy as np
 
@@ -15,11 +16,8 @@ sys.path.insert(0, str(BENCHMARK_DIR))
 
 from benchmark_metrics import (  # noqa: E402
     collect_simulation_metrics,
-    collect_simulation_metrics_synchronized,
-    compute_gpu_memory_usage,
     compute_simulation_metrics,
     validate_simulation_state,
-    validate_simulation_workload,
 )
 
 
@@ -46,6 +44,17 @@ class TestBenchmarkMetrics(unittest.TestCase):
         events = []
         timer_values = iter((0.0, 0.02, 0.02, 0.06, 0.06, 0.08, 0.08, 0.12))
 
+        class FakeDevice:
+            free_memory_values = iter((20 * 1024**2, 12 * 1024**2))
+
+            @property
+            def free_memory(self):
+                if workloads:
+                    self_test.assertEqual(workloads[0].step_count, 2)
+                return next(self.free_memory_values)
+
+        self_test = self
+
         class FakeWorkload:
             sim_dt = 0.01
             sim_substeps = 2
@@ -63,38 +72,43 @@ class TestBenchmarkMetrics(unittest.TestCase):
             workloads.append(workload)
             return workload
 
-        def memory_usage_bytes(workload):
-            self.assertIs(workload, workloads[0])
-            self.assertEqual(workload.step_count, 2)
-            events.append(("memory", workload))
-            return 8 * 1024**2
-
         def validate(workload):
             events.append(("validate", workload))
 
-        metrics = collect_simulation_metrics(
-            create_workload=create_workload,
-            world_count=4,
-            num_frames=2,
-            samples=2,
-            memory_usage_bytes=memory_usage_bytes,
-            validate=validate,
-            timer=lambda: next(timer_values),
-        )
+        with (
+            patch("benchmark_metrics.wp.get_device", return_value=FakeDevice()),
+            patch("benchmark_metrics.wp.synchronize_device") as synchronize_device,
+        ):
+            metrics = collect_simulation_metrics(
+                create_workload=create_workload,
+                world_count=4,
+                num_frames=2,
+                samples=2,
+                validate=validate,
+                timer=lambda: next(timer_values),
+            )
 
         self.assertEqual(len(workloads), 2)
-        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0]), ("validate", workloads[1])])
+        self.assertEqual(events, [("validate", workloads[0]), ("validate", workloads[1])])
+        self.assertEqual(synchronize_device.call_count, 2)
         self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
         self.assertAlmostEqual(metrics.world_steps_per_second, 32 / 0.12)
         self.assertAlmostEqual(metrics.real_time_factor, 32 * 0.01 / 0.12)
         self.assertAlmostEqual(metrics.p95_frame_time_ms, 40.0)
         self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
-    def test_collect_simulation_metrics_synchronized(self):
+    def test_collect_simulation_metrics_with_synchronization(self):
         workloads = []
         events = []
         sync_calls = []
         timer_values = iter((0.0, 0.01, 0.01, 0.03))
+
+        class FakeDevice:
+            free_memory_values = iter((16 * 1024**2, 8 * 1024**2))
+
+            @property
+            def free_memory(self):
+                return next(self.free_memory_values)
 
         class FakeWorkload:
             sim_dt = 0.01
@@ -111,39 +125,59 @@ class TestBenchmarkMetrics(unittest.TestCase):
             workloads.append(workload)
             return workload
 
-        def memory_usage_bytes(workload):
-            events.append(("memory", workload))
-            return 8 * 1024**2
-
         def validate(workload):
             events.append(("validate", workload))
 
-        metrics = collect_simulation_metrics_synchronized(
-            create_workload=create_workload,
-            world_count=4,
-            num_frames=2,
-            samples=1,
-            synchronize=lambda: sync_calls.append(None),
-            timer=lambda: next(timer_values),
-            memory_usage_bytes=memory_usage_bytes,
-            validate=validate,
-        )
+        with (
+            patch("benchmark_metrics.wp.get_device", return_value=FakeDevice()),
+            patch("benchmark_metrics.wp.synchronize_device") as synchronize_device,
+        ):
+            metrics = collect_simulation_metrics(
+                create_workload=create_workload,
+                world_count=4,
+                num_frames=2,
+                samples=1,
+                synchronize=lambda: sync_calls.append(None),
+                timer=lambda: next(timer_values),
+                validate=validate,
+            )
 
         self.assertEqual(len(sync_calls), 3)
-        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0])])
+        self.assertEqual(events, [("validate", workloads[0])])
+        self.assertEqual(synchronize_device.call_count, 2)
         self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
         self.assertAlmostEqual(metrics.world_steps_per_second, 16 / 0.03)
         self.assertAlmostEqual(metrics.real_time_factor, 16 * 0.01 / 0.03)
+        self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
-    def test_compute_gpu_memory_usage(self):
+    def test_collect_simulation_metrics_rejects_increased_free_memory(self):
         class FakeDevice:
-            free_memory = 700
+            free_memory_values = iter((1000, 1100))
 
-        self.assertEqual(compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000), 300)
+            @property
+            def free_memory(self):
+                return next(self.free_memory_values)
 
-        FakeDevice.free_memory = 1100
-        with self.assertRaisesRegex(RuntimeError, "increased"):
-            compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000)
+        class FakeWorkload:
+            sim_dt = 0.01
+            sim_substeps = 1
+            benchmark_time = 0.0
+
+            def step(self):
+                self.benchmark_time += 0.01
+
+        with (
+            patch("benchmark_metrics.wp.get_device", return_value=FakeDevice()),
+            patch("benchmark_metrics.wp.synchronize_device"),
+            self.assertRaisesRegex(RuntimeError, "increased"),
+        ):
+            collect_simulation_metrics(
+                create_workload=FakeWorkload,
+                world_count=1,
+                num_frames=1,
+                samples=1,
+                timer=iter((0.0, 0.01)).__next__,
+            )
 
     def test_validate_simulation_state(self):
         class FakeArray:
@@ -170,23 +204,10 @@ class TestBenchmarkMetrics(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "quaternion"):
             validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
 
-        specialized_checks = []
         FakeState.body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
         FakeState.joint_qd = FakeArray([np.nan])
         with self.assertRaisesRegex(RuntimeError, "state.joint_qd"):
             validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
-
-        FakeState.joint_qd = FakeArray([0.0])
-
-        class FakeWorkload:
-            state_0 = FakeState()
-
-            def test_final(self):
-                specialized_checks.append(self)
-
-        workload = FakeWorkload()
-        validate_simulation_workload(workload, max_linear_speed=10.0, max_angular_speed=10.0)
-        self.assertEqual(specialized_checks, [workload])
 
     def test_run_benchmark_with_setup_cache(self):
         cache_events = []

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -4,8 +4,11 @@
 import sys
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
+
+from newton.utils import run_benchmark
 
 BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
@@ -18,8 +21,6 @@ from benchmark_metrics import (  # noqa: E402
     validate_simulation_state,
     validate_simulation_workload,
 )
-
-from newton.utils import run_benchmark
 
 
 class TestBenchmarkMetrics(unittest.TestCase):
@@ -189,7 +190,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
 
     def test_run_benchmark_with_setup_cache(self):
         class CachedBenchmark:
-            params = [[2, 3]]
+            params: ClassVar = [[2, 3]]
             setup_cache_calls = 0
 
             def setup_cache(self):

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -16,10 +16,22 @@ sys.path.insert(0, str(BENCHMARK_DIR))
 
 _WARP_CONFIG_FIELDS = ("enable_backward", "log_level")
 _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS = {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS}
+_DEFERRED_WORKLOAD_MODULES = (
+    "benchmark_kamino",
+    "benchmark_mujoco",
+    "newton.examples.basic.example_basic_urdf",
+    "newton.examples.robot.example_robot_anymal_c_walk",
+)
+_DEFERRED_WORKLOAD_MODULES_BEFORE_IMPORT = {name: name in sys.modules for name in _DEFERRED_WORKLOAD_MODULES}
 
 try:
     from benchmark_metrics import SimulationMetrics
     from simulation import bench_anymal, bench_kamino, bench_mujoco, bench_quadruped_xpbd
+
+    _DEFERRED_WORKLOAD_MODULES_AFTER_METRIC_IMPORT = {name: name in sys.modules for name in _DEFERRED_WORKLOAD_MODULES}
+
+    from benchmark_kamino import DRLegsBenchmarkWorkload
+    from benchmark_mujoco import Example as MuJoCoExample
 finally:
     for _name, _value in _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS.items():
         setattr(wp.config, _name, _value)
@@ -43,12 +55,29 @@ class TestSimulationBenchmarks(unittest.TestCase):
         return SimpleNamespace(state_0=state)
 
     def test_benchmark_imports_preserve_warp_config(self):
+        """Preserve Warp global configuration across benchmark imports."""
         self.assertEqual(
             {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS},
             _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS,
         )
 
+    def test_benchmark_modules_defer_workload_imports(self):
+        """Defer workload-only imports until benchmark setup."""
+        for name in _DEFERRED_WORKLOAD_MODULES:
+            if not _DEFERRED_WORKLOAD_MODULES_BEFORE_IMPORT[name]:
+                self.assertFalse(_DEFERRED_WORKLOAD_MODULES_AFTER_METRIC_IMPORT[name], name)
+
+        self.assertFalse(hasattr(bench_anymal, "Example"))
+        self.assertFalse(hasattr(bench_anymal, "newton"))
+        self.assertFalse(hasattr(bench_kamino, "DRLegsBenchmarkWorkload"))
+        self.assertFalse(hasattr(bench_kamino, "newton"))
+        self.assertFalse(hasattr(bench_mujoco, "EventTracer"))
+        self.assertFalse(hasattr(bench_mujoco, "Example"))
+        self.assertFalse(hasattr(bench_quadruped_xpbd, "Example"))
+        self.assertFalse(hasattr(bench_quadruped_xpbd, "newton"))
+
     def test_fast_kitchen_g1_validates_kitchen_body_count(self):
+        """Validate the configured kitchen body count at runtime."""
         benchmark = bench_mujoco.FastKitchenG1()
         world_count = benchmark.params[0][0]
         kitchen_workload = SimpleNamespace(
@@ -66,7 +95,8 @@ class TestSimulationBenchmarks(unittest.TestCase):
             benchmark._validate_workload(incomplete_kitchen_workload, world_count)
 
     def test_mujoco_step_falls_back_when_cuda_graph_is_unavailable(self):
-        example = bench_mujoco.Example.__new__(bench_mujoco.Example)
+        """Fall back to eager MuJoCo stepping without a captured graph."""
+        example = MuJoCoExample.__new__(MuJoCoExample)
         example.actuation = "None"
         example.use_cuda_graph = True
         example.graph = None
@@ -88,14 +118,16 @@ class TestSimulationBenchmarks(unittest.TestCase):
         self.assertEqual(example.sim_time, 0.01)
 
     def test_mujoco_kpi_requires_cuda_graph(self):
+        """Reject KPI workloads that fail CUDA graph capture."""
         benchmark = bench_mujoco.FastCartpole()
         with (
-            patch.object(bench_mujoco, "Example", return_value=SimpleNamespace(graph=None)),
+            patch("benchmark_mujoco.Example", return_value=SimpleNamespace(graph=None)),
             self.assertRaisesRegex(RuntimeError, "requires CUDA graph capture"),
         ):
             benchmark._create_workload(Mock(), world_count=1)
 
     def test_mujoco_metrics_include_solver_iterations(self):
+        """Publish mean and maximum MuJoCo solver iterations."""
         benchmark = bench_mujoco.FastCartpole()
         workloads = []
 
@@ -118,7 +150,7 @@ class TestSimulationBenchmarks(unittest.TestCase):
 
         with (
             patch.object(bench_mujoco.wp, "get_cuda_device_count", return_value=1),
-            patch.object(bench_mujoco.Example, "create_model_builder", return_value=Mock()),
+            patch.object(MuJoCoExample, "create_model_builder", return_value=Mock()),
             patch.object(bench_mujoco, "collect_simulation_metrics", side_effect=collect_metrics),
         ):
             metrics = benchmark._collect_metrics()[8192]
@@ -128,10 +160,11 @@ class TestSimulationBenchmarks(unittest.TestCase):
         self.assertEqual(metrics.solver_niter_max, 5.0)
 
     def test_metric_setup_caches_skip_without_cuda(self):
+        """Skip metric caches without constructing CPU workloads."""
         with (
             patch.object(bench_mujoco.wp, "get_cuda_device_count", return_value=0),
-            patch.object(bench_mujoco.Example, "create_model_builder") as create_mujoco_builder,
-            patch.object(bench_kamino.DRLegsBenchmarkWorkload, "create_model_builder") as create_kamino_builder,
+            patch.object(MuJoCoExample, "create_model_builder") as create_mujoco_builder,
+            patch.object(DRLegsBenchmarkWorkload, "create_model_builder") as create_kamino_builder,
             patch.object(bench_anymal, "_create_example") as create_anymal,
             patch.object(bench_quadruped_xpbd, "_create_example") as create_quadruped,
         ):
@@ -146,10 +179,12 @@ class TestSimulationBenchmarks(unittest.TestCase):
         create_quadruped.assert_not_called()
 
     def test_kpi_dr_legs_setup_cache_timeout_exceeds_default(self):
+        """Give the DR Legs cache longer than ASV's default timeout."""
         config = json.loads((BENCHMARK_DIR.parents[1] / "asv.conf.json").read_text(encoding="utf-8"))
         self.assertGreater(bench_kamino.KpiDRLegs.setup_cache.timeout, config["default_benchmark_timeout"])
 
     def test_anymal_short_horizon_validation(self):
+        """Validate short-horizon ANYmal posture and forward progress."""
         bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.530))
 
         with self.assertRaisesRegex(RuntimeError, "forward progress"):

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -5,35 +5,47 @@ import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 import numpy as np
+import warp as wp
 
 BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
 
-from simulation import bench_anymal, bench_kamino, bench_mujoco  # noqa: E402
+_WARP_CONFIG_FIELDS = ("enable_backward", "log_level")
+_WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS = {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS}
 
-
-class _FakeArray:
-    def __init__(self, values):
-        self.values = np.asarray(values, dtype=np.float32)
-
-    def numpy(self):
-        return self.values
-
-
-def _make_anymal_workload(root_y, root_z):
-    state = SimpleNamespace(
-        joint_q=_FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
-        joint_qd=_FakeArray([0.0] * 6),
-        body_q=_FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
-        body_qd=_FakeArray([[0.0] * 6]),
-    )
-    return SimpleNamespace(state_0=state)
+try:
+    from simulation import bench_anymal, bench_kamino, bench_mujoco
+finally:
+    for _name, _value in _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS.items():
+        setattr(wp.config, _name, _value)
 
 
 class TestSimulationBenchmarks(unittest.TestCase):
+    class _FakeArray:
+        def __init__(self, values):
+            self.values = np.asarray(values, dtype=np.float32)
+
+        def numpy(self):
+            return self.values
+
+    def _make_anymal_workload(self, root_y, root_z):
+        state = SimpleNamespace(
+            joint_q=self._FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
+            joint_qd=self._FakeArray([0.0] * 6),
+            body_q=self._FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
+            body_qd=self._FakeArray([[0.0] * 6]),
+        )
+        return SimpleNamespace(state_0=state)
+
+    def test_benchmark_imports_preserve_warp_config(self):
+        self.assertEqual(
+            {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS},
+            _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS,
+        )
+
     def test_fast_kitchen_g1_builds_kitchen_environment(self):
         class FakeDevice:
             free_memory = 1024
@@ -56,25 +68,47 @@ class TestSimulationBenchmarks(unittest.TestCase):
 
         create_model_builder.assert_called_once_with(
             "g1",
-            512,
+            128,
             environment="kitchen",
             randomize=True,
             seed=123,
         )
-        self.assertEqual(metrics, {512: sentinel.metrics})
+        self.assertEqual(metrics, {128: sentinel.metrics})
         self.assertEqual(bench_mujoco.FastKitchenG1.version, "2")
+
+    def test_mujoco_step_falls_back_when_cuda_graph_is_unavailable(self):
+        example = bench_mujoco.Example.__new__(bench_mujoco.Example)
+        example.actuation = "None"
+        example.use_cuda_graph = True
+        example.graph = None
+        example.simulate = Mock()
+        example.benchmark_time = 0.0
+        example.sim_time = 0.0
+        example.frame_dt = 0.01
+
+        with (
+            patch("benchmark_mujoco.time.perf_counter", side_effect=(1.0, 1.25)),
+            patch.object(bench_mujoco.wp, "synchronize_device"),
+            patch.object(bench_mujoco.wp, "capture_launch") as capture_launch,
+        ):
+            example.step()
+
+        example.simulate.assert_called_once_with()
+        capture_launch.assert_not_called()
+        self.assertEqual(example.benchmark_time, 0.25)
+        self.assertEqual(example.sim_time, 0.01)
 
     def test_kpi_dr_legs_has_setup_cache_timeout(self):
         self.assertEqual(bench_kamino.KpiDRLegs.setup_cache.timeout, 1200)
 
     def test_anymal_short_horizon_validation(self):
-        bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.530))
+        bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.530))
 
         with self.assertRaisesRegex(RuntimeError, "forward progress"):
-            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.0, root_z=0.530))
+            bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.0, root_z=0.530))
 
         with self.assertRaisesRegex(RuntimeError, "base height"):
-            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.200))
+            bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.200))
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -54,18 +54,16 @@ class TestSimulationBenchmarks(unittest.TestCase):
         kitchen_workload = SimpleNamespace(
             model=SimpleNamespace(body_count=benchmark.expected_bodies_per_world * world_count),
             test_final=Mock(),
-            world_count=world_count,
         )
-        benchmark._validate_workload(kitchen_workload)
+        benchmark._validate_workload(kitchen_workload, world_count)
         kitchen_workload.test_final.assert_called_once_with()
 
         incomplete_kitchen_workload = SimpleNamespace(
             model=SimpleNamespace(body_count=(benchmark.expected_bodies_per_world - 1) * world_count),
             test_final=Mock(),
-            world_count=world_count,
         )
         with self.assertRaisesRegex(RuntimeError, "bodies per world for kitchen"):
-            benchmark._validate_workload(incomplete_kitchen_workload)
+            benchmark._validate_workload(incomplete_kitchen_workload, world_count)
 
     def test_mujoco_step_falls_back_when_cuda_graph_is_unavailable(self):
         example = bench_mujoco.Example.__new__(bench_mujoco.Example)
@@ -95,7 +93,7 @@ class TestSimulationBenchmarks(unittest.TestCase):
             patch.object(bench_mujoco, "Example", return_value=SimpleNamespace(graph=None)),
             self.assertRaisesRegex(RuntimeError, "requires CUDA graph capture"),
         ):
-            benchmark._create_workload(Mock())
+            benchmark._create_workload(Mock(), world_count=1)
 
     def test_mujoco_metrics_include_solver_iterations(self):
         benchmark = bench_mujoco.FastCartpole()

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, patch, sentinel
+from unittest.mock import Mock, patch
 
 import numpy as np
 import warp as wp
@@ -17,7 +18,8 @@ _WARP_CONFIG_FIELDS = ("enable_backward", "log_level")
 _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS = {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS}
 
 try:
-    from simulation import bench_anymal, bench_kamino, bench_mujoco
+    from benchmark_metrics import SimulationMetrics
+    from simulation import bench_anymal, bench_kamino, bench_mujoco, bench_quadruped_xpbd
 finally:
     for _name, _value in _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS.items():
         setattr(wp.config, _name, _value)
@@ -46,35 +48,24 @@ class TestSimulationBenchmarks(unittest.TestCase):
             _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS,
         )
 
-    def test_fast_kitchen_g1_builds_kitchen_environment(self):
-        class FakeDevice:
-            free_memory = 1024
-
-        with (
-            patch.object(bench_mujoco.wp, "synchronize_device"),
-            patch.object(bench_mujoco.wp, "get_device", return_value=FakeDevice()),
-            patch.object(
-                bench_mujoco.Example,
-                "create_model_builder",
-                return_value=sentinel.builder,
-            ) as create_model_builder,
-            patch.object(
-                bench_mujoco,
-                "collect_simulation_metrics",
-                return_value=sentinel.metrics,
-            ),
-        ):
-            metrics = bench_mujoco.FastKitchenG1()._collect_metrics()
-
-        create_model_builder.assert_called_once_with(
-            "g1",
-            128,
-            environment="kitchen",
-            randomize=True,
-            seed=123,
+    def test_fast_kitchen_g1_validates_kitchen_body_count(self):
+        benchmark = bench_mujoco.FastKitchenG1()
+        world_count = benchmark.params[0][0]
+        kitchen_workload = SimpleNamespace(
+            model=SimpleNamespace(body_count=benchmark.expected_bodies_per_world * world_count),
+            test_final=Mock(),
+            world_count=world_count,
         )
-        self.assertEqual(metrics, {128: sentinel.metrics})
-        self.assertEqual(bench_mujoco.FastKitchenG1.version, "2")
+        benchmark._validate_workload(kitchen_workload)
+        kitchen_workload.test_final.assert_called_once_with()
+
+        incomplete_kitchen_workload = SimpleNamespace(
+            model=SimpleNamespace(body_count=(benchmark.expected_bodies_per_world - 1) * world_count),
+            test_final=Mock(),
+            world_count=world_count,
+        )
+        with self.assertRaisesRegex(RuntimeError, "bodies per world for kitchen"):
+            benchmark._validate_workload(incomplete_kitchen_workload)
 
     def test_mujoco_step_falls_back_when_cuda_graph_is_unavailable(self):
         example = bench_mujoco.Example.__new__(bench_mujoco.Example)
@@ -98,8 +89,67 @@ class TestSimulationBenchmarks(unittest.TestCase):
         self.assertEqual(example.benchmark_time, 0.25)
         self.assertEqual(example.sim_time, 0.01)
 
-    def test_kpi_dr_legs_has_setup_cache_timeout(self):
-        self.assertEqual(bench_kamino.KpiDRLegs.setup_cache.timeout, 1200)
+    def test_mujoco_kpi_requires_cuda_graph(self):
+        benchmark = bench_mujoco.FastCartpole()
+        with (
+            patch.object(bench_mujoco, "Example", return_value=SimpleNamespace(graph=None)),
+            self.assertRaisesRegex(RuntimeError, "requires CUDA graph capture"),
+        ):
+            benchmark._create_workload(Mock())
+
+    def test_mujoco_metrics_include_solver_iterations(self):
+        benchmark = bench_mujoco.FastCartpole()
+        workloads = []
+
+        class FakeArray:
+            def __init__(self, values):
+                self.values = np.asarray(values)
+
+            def numpy(self):
+                return self.values
+
+        def collect_metrics(**kwargs):
+            for values in ([2, 4], [1, 5]):
+                workload = SimpleNamespace(
+                    solver=SimpleNamespace(mjw_data=SimpleNamespace(solver_niter=FakeArray(values))),
+                    test_final=Mock(),
+                )
+                workloads.append(workload)
+                kwargs["validate"](workload)
+            return SimulationMetrics(1.0, 2.0, 3.0, 4.0, 5.0, 0.01, 2)
+
+        with (
+            patch.object(bench_mujoco.wp, "get_cuda_device_count", return_value=1),
+            patch.object(bench_mujoco.Example, "create_model_builder", return_value=Mock()),
+            patch.object(bench_mujoco, "collect_simulation_metrics", side_effect=collect_metrics),
+        ):
+            metrics = benchmark._collect_metrics()[8192]
+
+        self.assertTrue(all(workload.test_final.call_count == 1 for workload in workloads))
+        self.assertEqual(metrics.solver_niter_mean, 3.0)
+        self.assertEqual(metrics.solver_niter_max, 5.0)
+
+    def test_metric_setup_caches_skip_without_cuda(self):
+        with (
+            patch.object(bench_mujoco.wp, "get_cuda_device_count", return_value=0),
+            patch.object(bench_mujoco.Example, "create_model_builder") as create_mujoco_builder,
+            patch.object(bench_kamino.DRLegsBenchmarkWorkload, "create_model_builder") as create_kamino_builder,
+            patch.object(bench_anymal, "_create_example") as create_anymal,
+            patch.object(bench_quadruped_xpbd, "_create_example") as create_quadruped,
+        ):
+            self.assertIsNone(bench_mujoco.FastCartpole().setup_cache())
+            self.assertIsNone(bench_kamino.KpiDRLegs().setup_cache())
+            self.assertIsNone(bench_anymal.FastMetricsExampleAnymalPretrained().setup_cache())
+            self.assertIsNone(bench_quadruped_xpbd.FastMetricsExampleQuadrupedXPBD().setup_cache())
+
+        create_mujoco_builder.assert_not_called()
+        create_kamino_builder.assert_not_called()
+        create_anymal.assert_not_called()
+        create_quadruped.assert_not_called()
+
+    def test_kpi_dr_legs_setup_cache_timeout_exceeds_default(self):
+        config = json.loads((BENCHMARK_DIR.parents[1] / "asv.conf.json").read_text(encoding="utf-8"))
+        self.assertGreater(bench_kamino.KpiDRLegs.setup_cache.timeout, config["default_benchmark_timeout"])
 
     def test_anymal_short_horizon_validation(self):
         bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.530))

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, sentinel
+
+import numpy as np
+
+BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from simulation import bench_anymal, bench_kamino, bench_mujoco  # noqa: E402
+
+
+class _FakeArray:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=np.float32)
+
+    def numpy(self):
+        return self.values
+
+
+def _make_anymal_workload(root_y, root_z):
+    state = SimpleNamespace(
+        joint_q=_FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
+        joint_qd=_FakeArray([0.0] * 6),
+        body_q=_FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
+        body_qd=_FakeArray([[0.0] * 6]),
+    )
+    return SimpleNamespace(state_0=state)
+
+
+class TestSimulationBenchmarks(unittest.TestCase):
+    def test_fast_kitchen_g1_builds_kitchen_environment(self):
+        class FakeDevice:
+            free_memory = 1024
+
+        with (
+            patch.object(bench_mujoco.wp, "synchronize_device"),
+            patch.object(bench_mujoco.wp, "get_device", return_value=FakeDevice()),
+            patch.object(
+                bench_mujoco.Example,
+                "create_model_builder",
+                return_value=sentinel.builder,
+            ) as create_model_builder,
+            patch.object(
+                bench_mujoco,
+                "collect_simulation_metrics",
+                return_value=sentinel.metrics,
+            ),
+        ):
+            metrics = bench_mujoco.FastKitchenG1()._collect_metrics()
+
+        create_model_builder.assert_called_once_with(
+            "g1",
+            512,
+            environment="kitchen",
+            randomize=True,
+            seed=123,
+        )
+        self.assertEqual(metrics, {512: sentinel.metrics})
+        self.assertEqual(bench_mujoco.FastKitchenG1.version, "2")
+
+    def test_kpi_dr_legs_has_setup_cache_timeout(self):
+        self.assertEqual(bench_kamino.KpiDRLegs.setup_cache.timeout, 1200)
+
+    def test_anymal_short_horizon_validation(self):
+        bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.530))
+
+        with self.assertRaisesRegex(RuntimeError, "forward progress"):
+            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.0, root_z=0.530))
+
+        with self.assertRaisesRegex(RuntimeError, "base height"):
+            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.200))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Closes #3343.

Surface robot-learning-relevant metrics from the existing ASV simulation workloads:

- simulation world-steps per second and real-time factor using synchronized complete-step timing;
- p95 complete-step latency;
- steady-state GPU memory using the device free-memory delta after warm-up;
- simulation timestep and substep configuration; and
- final-state validation for finite coordinates and velocities, normalized rotations, workload-specific health checks, and bounded body speeds.

The existing KPI mean world-step series remains physics-only and keeps its existing name and unit. Cached ASV setup runs provide all related metrics without rerunning each workload for every tracked value. The development guide documents formulas, timing scope, memory measurement, and the exclusive-GPU requirement.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv --cache-dir C:\work\newton\main\.uv-cache run --frozen --extra dev -m newton.tests -k benchmark_metrics`
- `uvx --cache-dir C:\work\newton\main\.uv-cache --with virtualenv asv check`
- `uvx --cache-dir C:\work\newton\main\.uv-cache pre-commit run -a`
- Ran `FastCartpole` and `FastMetricsExampleQuadrupedXPBD` directly on an RTX 3080 Laptop GPU.
- Ran `simulation.bench_mujoco.FastCartpole.track_real_time_factor` through ASV's real setup-cache subprocess path.

The full 4,096-world `KpiDRLegs` policy setup exceeded the existing 600-second timeout on the RTX 3080 Laptop GPU; its full result remains to be verified on the nightly benchmark hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded standardized simulation benchmark metrics (adds mean/max MuJoCo solver-iteration reporting).
  - Added synchronized metric-collection utilities and new “fast metrics” benchmark variants for quicker precomputed metric tracks.
  - Introduced optional cache lifecycle support during benchmark runs.
- **Bug Fixes**
  - Fixed FastKitchenG1 KPI benchmark metrics by building the full kitchen environment for accurate results.
- **Documentation**
  - Documented the published metrics, formulas, and benchmark failure conditions.
- **Tests**
  - Added coverage for metric aggregation, validation rules, GPU memory checks, CUDA-graph behavior, and cache-aware execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->