### PR TITLE
Temporary: Calibrate FastKitchenG1 scaling

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -136,6 +136,13 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Install benchmark system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+              libgl1-mesa-dev libglu1-mesa-dev
+          sudo apt-get clean
+
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
@@ -156,26 +163,54 @@ jobs:
       - name: Check disk space
         run: df -h
 
-      - name: Run Tests
-        env:
-          PYTHONFAULTHANDLER: "1"
-          # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
-          COVERAGE_CORE: "sysmon"
-        run: uv run --extra dev --extra torch-cu13 -m newton.tests --strict-warnings --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
+      - name: Install benchmark environment
+        run: uv sync --extra dev --extra sim
+
+      - name: Calibrate FastKitchenG1
+        shell: bash
+        run: |
+          set +e
+          stdbuf -oL nvidia-smi dmon -s pucvmet -d 1 &
+          dmon_pid=$!
+          trap 'kill "$dmon_pid" 2>/dev/null || true' EXIT
+
+          status=0
+          for world_count in 256 384; do
+            echo "::group::FastKitchenG1 world_count=${world_count}"
+            /usr/bin/time -v env \
+              KITCHEN_WORLD_COUNT="${world_count}" \
+              PYTHONPATH="asv/benchmarks/simulation:asv/benchmarks" \
+              .venv/bin/python -c '
+          import os
+          from bench_mujoco import FastKitchenG1
+          from newton.utils import run_benchmark
+
+          FastKitchenG1.params = [[int(os.environ["KITCHEN_WORLD_COUNT"])]]
+          run_benchmark(FastKitchenG1)
+          '
+            run_status=$?
+            echo "CALIBRATION world_count=${world_count} exit_code=${run_status}"
+            echo "::endgroup::"
+            if [[ ${run_status} -ne 0 ]]; then
+              status=${run_status}
+              break
+            fi
+          done
+          exit "${status}"
 
       - name: Check disk space (post-test)
         if: always()
         run: df -h
 
       - name: Test Summary
-        if: ${{ !cancelled() }}
+        if: ${{ false }}
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
 
       - name: Upload coverage artifact
-        if: ${{ !cancelled() }}
+        if: ${{ false }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-gpu
@@ -224,7 +259,7 @@ jobs:
   codecov-upload:
     name: Upload coverage to Codecov
     needs: gpu-unit-tests
-    if: ${{ !cancelled() && needs.gpu-unit-tests.result != 'skipped' }}
+    if: ${{ false }}
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token; contents access is
     # only used to build Codecov's source network for coverage path mapping.

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -136,13 +136,6 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
-      - name: Install benchmark system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
-              libgl1-mesa-dev libglu1-mesa-dev
-          sudo apt-get clean
-
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
@@ -163,54 +156,26 @@ jobs:
       - name: Check disk space
         run: df -h
 
-      - name: Install benchmark environment
-        run: uv sync --extra dev --extra sim
-
-      - name: Calibrate FastKitchenG1
-        shell: bash
-        run: |
-          set +e
-          stdbuf -oL nvidia-smi dmon -s pucvmet -d 1 &
-          dmon_pid=$!
-          trap 'kill "$dmon_pid" 2>/dev/null || true' EXIT
-
-          status=0
-          for world_count in 256 384; do
-            echo "::group::FastKitchenG1 world_count=${world_count}"
-            /usr/bin/time -v env \
-              KITCHEN_WORLD_COUNT="${world_count}" \
-              PYTHONPATH="asv/benchmarks/simulation:asv/benchmarks" \
-              .venv/bin/python -c '
-          import os
-          from bench_mujoco import FastKitchenG1
-          from newton.utils import run_benchmark
-
-          FastKitchenG1.params = [[int(os.environ["KITCHEN_WORLD_COUNT"])]]
-          run_benchmark(FastKitchenG1)
-          '
-            run_status=$?
-            echo "CALIBRATION world_count=${world_count} exit_code=${run_status}"
-            echo "::endgroup::"
-            if [[ ${run_status} -ne 0 ]]; then
-              status=${run_status}
-              break
-            fi
-          done
-          exit "${status}"
+      - name: Run Tests
+        env:
+          PYTHONFAULTHANDLER: "1"
+          # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
+          COVERAGE_CORE: "sysmon"
+        run: uv run --extra dev --extra torch-cu13 -m newton.tests --strict-warnings --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
       - name: Check disk space (post-test)
         if: always()
         run: df -h
 
       - name: Test Summary
-        if: ${{ false }}
+        if: ${{ !cancelled() }}
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
 
       - name: Upload coverage artifact
-        if: ${{ false }}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-gpu
@@ -259,7 +224,7 @@ jobs:
   codecov-upload:
     name: Upload coverage to Codecov
     needs: gpu-unit-tests
-    if: ${{ false }}
+    if: ${{ !cancelled() && needs.gpu-unit-tests.result != 'skipped' }}
     runs-on: ubuntu-latest
     # Same-run artifact downloads use the runtime token; contents access is
     # only used to build Codecov's source network for coverage path mapping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.
+- Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `forward_depth_image` output support to `SensorTiledCamera.update()` and `SensorTiledCamera.utils.create_forward_depth_image_output()` for native forward-depth rendering without post-processing `depth_image`.
+- Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, and timestep metrics to the ASV robot-learning benchmarks.
 
 ### Changed
 

--- a/asv/benchmarks/benchmark_kamino.py
+++ b/asv/benchmarks/benchmark_kamino.py
@@ -12,6 +12,11 @@ wp.config.log_level = wp.LOG_WARNING
 
 import newton
 
+if __package__:
+    from .benchmark_metrics import validate_simulation_state
+else:
+    from benchmark_metrics import validate_simulation_state
+
 _NUM_ACTIONS = 12
 _OBS_DIM = 94
 _MIN_STANDING_HEIGHT = 0.20
@@ -435,37 +440,23 @@ class DRLegsBenchmarkWorkload:
         self.sim_time += self.frame_dt
 
     def test_final(self):
-        state_values = {}
-        for name in ("joint_q", "body_q", "body_qd"):
-            values = getattr(self.state_0, name).numpy()
-            if not np.isfinite(values).all():
-                raise RuntimeError(f"Simulation produced non-finite values in state.{name}")
-            state_values[name] = values
-
-        body_count = self.model.body_count // self.world_count
-        body_qd = state_values["body_qd"].reshape(self.world_count, body_count, 6)
-        max_linear_speed = np.linalg.norm(body_qd[:, :, :3], axis=-1).max()
-        max_angular_speed = np.linalg.norm(body_qd[:, :, 3:], axis=-1).max()
-        if max_linear_speed > _MAX_BODY_LINEAR_SPEED:
-            raise RuntimeError(
-                f"Maximum body linear speed is {max_linear_speed:.3f} m/s, exceeding {_MAX_BODY_LINEAR_SPEED:.1f} m/s"
-            )
-        if max_angular_speed > _MAX_BODY_ANGULAR_SPEED:
-            raise RuntimeError(
-                f"Maximum body angular speed is {max_angular_speed:.3f} rad/s, "
-                f"exceeding {_MAX_BODY_ANGULAR_SPEED:.1f} rad/s"
-            )
+        validate_simulation_state(
+            self.state_0,
+            max_linear_speed=_MAX_BODY_LINEAR_SPEED,
+            max_angular_speed=_MAX_BODY_ANGULAR_SPEED,
+        )
 
         if self.policy_controller is None:
             return
 
+        body_count = self.model.body_count // self.world_count
         body_labels = [label.rsplit("/", 1)[-1] for label in self.model.body_label[:body_count]]
         try:
             pelvis_index = body_labels.index("pelvis")
         except ValueError as e:
             raise RuntimeError("DR Legs model has no pelvis root body") from e
 
-        body_q = state_values["body_q"].reshape(self.world_count, body_count, 7)[:, pelvis_index]
+        body_q = self.state_0.body_q.numpy().reshape(self.world_count, body_count, 7)[:, pelvis_index]
         body_com = self.model.body_com.numpy().reshape(self.world_count, body_count, 3)[:, pelvis_index]
         quat_vector = body_q[:, 3:6]
         twice_cross = 2.0 * np.cross(quat_vector, body_com)

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -71,7 +71,7 @@ class _SimulationMetricTracks:
     track_sim_substeps.unit = "simulation-steps/frame"
 
 
-class _UnparameterizedSimulationMetricTracks:
+class _SimulationMetricTracksUnparameterized:
     """ASV track methods backed by one cached simulation configuration."""
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
@@ -264,7 +264,7 @@ def collect_simulation_metrics(
     )
 
 
-def collect_synchronized_simulation_metrics(
+def collect_simulation_metrics_synchronized(
     create_workload: Callable[[], Any],
     world_count: int,
     num_frames: int,

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -199,8 +199,7 @@ def validate_simulation_state(
     max_measured_angular_speed = np.linalg.norm(body_qd[:, 3:], axis=-1).max()
     if max_measured_linear_speed > max_linear_speed:
         raise RuntimeError(
-            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, "
-            f"exceeding {max_linear_speed:.1f} m/s"
+            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, exceeding {max_linear_speed:.1f} m/s"
         )
     if max_measured_angular_speed > max_angular_speed:
         raise RuntimeError(

--- a/asv/benchmarks/benchmark_metrics.py
+++ b/asv/benchmarks/benchmark_metrics.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import warp as wp
+from asv_runner.benchmarks.mark import skip_benchmark_if
+
+
+@dataclass(frozen=True)
+class SimulationMetrics:
+    """Metrics collected from one simulation benchmark configuration."""
+
+    mean_world_step_time_ms: float
+    world_steps_per_second: float
+    real_time_factor: float
+    p95_frame_time_ms: float
+    gpu_memory_mib: float
+    sim_dt: float
+    sim_substeps: int
+
+
+class _SimulationMetricTracks:
+    """ASV track methods backed by cached simulation metrics."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulate(self, metrics, world_count):
+        return metrics[world_count].mean_world_step_time_ms
+
+    track_simulate.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics, world_count):
+        return metrics[world_count].world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics, world_count):
+        return metrics[world_count].real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics, world_count):
+        return metrics[world_count].p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics, world_count):
+        return metrics[world_count].gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics, world_count):
+        return metrics[world_count].sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics, world_count):
+        return metrics[world_count].sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"
+
+
+class _UnparameterizedSimulationMetricTracks:
+    """ASV track methods backed by one cached simulation configuration."""
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_mean_world_step_time(self, metrics):
+        return metrics.mean_world_step_time_ms
+
+    track_mean_world_step_time.unit = "ms/world-step"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_simulation_steps_per_second(self, metrics):
+        return metrics.world_steps_per_second
+
+    track_simulation_steps_per_second.unit = "world-steps/s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_real_time_factor(self, metrics):
+        return metrics.real_time_factor
+
+    track_real_time_factor.unit = "x"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_p95_step_time(self, metrics):
+        return metrics.p95_frame_time_ms
+
+    track_p95_step_time.unit = "ms/frame"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_steady_state_gpu_memory(self, metrics):
+        return metrics.gpu_memory_mib
+
+    track_steady_state_gpu_memory.unit = "MiB"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_dt(self, metrics):
+        return metrics.sim_dt
+
+    track_sim_dt.unit = "s"
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def track_sim_substeps(self, metrics):
+        return metrics.sim_substeps
+
+    track_sim_substeps.unit = "simulation-steps/frame"
+
+
+def _percentile(values: Sequence[float], percentile: float) -> float:
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * percentile / 100.0
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return ordered[lower]
+    fraction = rank - lower
+    return ordered[lower] + fraction * (ordered[upper] - ordered[lower])
+
+
+def compute_simulation_metrics(
+    frame_times: Sequence[float],
+    sim_dt: float,
+    sim_substeps: int,
+    world_count: int,
+    gpu_memory_bytes: int,
+    experience_frame_times: Sequence[float] | None = None,
+) -> SimulationMetrics:
+    """Compute comparable simulation metrics from synchronized frame times."""
+    if not frame_times or any(not math.isfinite(value) or value <= 0.0 for value in frame_times):
+        raise ValueError("frame_times must contain positive finite values")
+    if experience_frame_times is None:
+        experience_frame_times = frame_times
+    if len(experience_frame_times) != len(frame_times) or any(
+        not math.isfinite(value) or value <= 0.0 for value in experience_frame_times
+    ):
+        raise ValueError("experience_frame_times must contain one positive finite value per frame")
+    if not math.isfinite(sim_dt) or sim_dt <= 0.0:
+        raise ValueError("sim_dt must be positive and finite")
+    if sim_substeps <= 0 or world_count <= 0:
+        raise ValueError("sim_substeps and world_count must be positive")
+    if gpu_memory_bytes < 0:
+        raise ValueError("gpu_memory_bytes must be non-negative")
+
+    total_time = sum(frame_times)
+    experience_total_time = sum(experience_frame_times)
+    world_steps = len(frame_times) * sim_substeps * world_count
+    return SimulationMetrics(
+        mean_world_step_time_ms=total_time * 1000.0 / world_steps,
+        world_steps_per_second=world_steps / experience_total_time,
+        real_time_factor=world_steps * sim_dt / experience_total_time,
+        p95_frame_time_ms=_percentile(experience_frame_times, 95.0) * 1000.0,
+        gpu_memory_mib=gpu_memory_bytes / 1024**2,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+    )
+
+
+def compute_gpu_memory_usage(device: Any, free_memory_before: int) -> int:
+    """Compute the change in total device memory usage from a free-memory baseline."""
+    used_memory = free_memory_before - device.free_memory
+    if used_memory < 0:
+        raise RuntimeError("GPU free memory increased after workload initialization")
+    return used_memory
+
+
+def validate_simulation_state(
+    state: Any,
+    max_linear_speed: float,
+    max_angular_speed: float,
+    quaternion_tolerance: float = 1.0e-3,
+):
+    """Validate finite rigid-body state, normalized rotations, and bounded speeds."""
+    state_values = {}
+    for name in ("joint_q", "joint_qd", "body_q", "body_qd"):
+        values = getattr(state, name).numpy()
+        if not np.isfinite(values).all():
+            raise RuntimeError(f"Simulation produced non-finite values in state.{name}")
+        state_values[name] = values
+
+    body_q = state_values["body_q"].reshape(-1, 7)
+    quaternion_norms = np.linalg.norm(body_q[:, 3:7], axis=-1)
+    if not np.allclose(quaternion_norms, 1.0, atol=quaternion_tolerance, rtol=0.0):
+        max_error = np.abs(quaternion_norms - 1.0).max()
+        raise RuntimeError(f"Maximum body quaternion norm error is {max_error:.3g}")
+
+    body_qd = state_values["body_qd"].reshape(-1, 6)
+    max_measured_linear_speed = np.linalg.norm(body_qd[:, :3], axis=-1).max()
+    max_measured_angular_speed = np.linalg.norm(body_qd[:, 3:], axis=-1).max()
+    if max_measured_linear_speed > max_linear_speed:
+        raise RuntimeError(
+            f"Maximum body linear speed is {max_measured_linear_speed:.3f} m/s, "
+            f"exceeding {max_linear_speed:.1f} m/s"
+        )
+    if max_measured_angular_speed > max_angular_speed:
+        raise RuntimeError(
+            f"Maximum body angular speed is {max_measured_angular_speed:.3f} rad/s, "
+            f"exceeding {max_angular_speed:.1f} rad/s"
+        )
+
+
+def validate_simulation_workload(workload: Any, max_linear_speed: float, max_angular_speed: float):
+    """Run generic state validation followed by a workload's specialized checks."""
+    validate_simulation_state(
+        workload.state_0,
+        max_linear_speed=max_linear_speed,
+        max_angular_speed=max_angular_speed,
+    )
+    workload.test_final()
+
+
+def collect_simulation_metrics(
+    create_workload: Callable[[], Any],
+    world_count: int,
+    num_frames: int,
+    samples: int,
+    memory_usage_bytes: Callable[[Any], int],
+    validate: Callable[[Any], None] | None = None,
+    timer: Callable[[], float] = time.perf_counter,
+) -> SimulationMetrics:
+    """Collect internal physics timing and complete synchronized step timing."""
+    frame_times = []
+    experience_frame_times = []
+    gpu_memory_bytes = None
+    sim_dt = None
+    sim_substeps = None
+
+    for sample_index in range(samples):
+        workload = create_workload()
+        if sim_dt is None:
+            sim_dt = workload.sim_dt
+            sim_substeps = workload.sim_substeps
+        elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
+            raise ValueError("simulation parameters changed between samples")
+
+        for _ in range(num_frames):
+            start_time = workload.benchmark_time
+            experience_start_time = timer()
+            workload.step()
+            frame_times.append(workload.benchmark_time - start_time)
+            experience_frame_times.append(timer() - experience_start_time)
+
+        if sample_index == 0:
+            gpu_memory_bytes = memory_usage_bytes(workload)
+        if validate is not None:
+            validate(workload)
+
+    return compute_simulation_metrics(
+        frame_times=frame_times,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+        world_count=world_count,
+        gpu_memory_bytes=gpu_memory_bytes,
+        experience_frame_times=experience_frame_times,
+    )
+
+
+def collect_synchronized_simulation_metrics(
+    create_workload: Callable[[], Any],
+    world_count: int,
+    num_frames: int,
+    samples: int,
+    synchronize: Callable[[], None],
+    memory_usage_bytes: Callable[[Any], int],
+    validate: Callable[[Any], None] | None = None,
+    timer: Callable[[], float] = time.perf_counter,
+) -> SimulationMetrics:
+    """Collect metrics for workloads without an internal synchronized timer."""
+    frame_times = []
+    gpu_memory_bytes = None
+    sim_dt = None
+    sim_substeps = None
+
+    for sample_index in range(samples):
+        workload = create_workload()
+        if sim_dt is None:
+            sim_dt = workload.sim_dt
+            sim_substeps = workload.sim_substeps
+        elif workload.sim_dt != sim_dt or workload.sim_substeps != sim_substeps:
+            raise ValueError("simulation parameters changed between samples")
+
+        synchronize()
+        for _ in range(num_frames):
+            start_time = timer()
+            workload.step()
+            synchronize()
+            frame_times.append(timer() - start_time)
+
+        if sample_index == 0:
+            gpu_memory_bytes = memory_usage_bytes(workload)
+        if validate is not None:
+            validate(workload)
+
+    return compute_simulation_metrics(
+        frame_times=frame_times,
+        sim_dt=sim_dt,
+        sim_substeps=sim_substeps,
+        world_count=world_count,
+        gpu_memory_bytes=gpu_memory_bytes,
+    )

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -490,7 +490,7 @@ class Example:
 
         wp.synchronize_device()
         start_time = time.perf_counter()
-        if self.use_cuda_graph:
+        if self.use_cuda_graph and self.graph is not None:
             wp.capture_launch(self.graph)
         else:
             self.simulate()

--- a/asv/benchmarks/benchmark_mujoco.py
+++ b/asv/benchmarks/benchmark_mujoco.py
@@ -23,7 +23,14 @@ import newton.utils
 from newton.sensors import SensorContact
 from newton.utils import EventTracer
 
+if __package__:
+    from .benchmark_metrics import validate_simulation_state
+else:
+    from benchmark_metrics import validate_simulation_state
+
 _NEW_LAYOUT_AVAILABLE = hasattr(newton, "use_coord_layout_targets")
+_MAX_BODY_LINEAR_SPEED = 100.0
+_MAX_BODY_ANGULAR_SPEED = 500.0
 
 
 def _target_q(owner):
@@ -482,16 +489,23 @@ class Example:
             self.apply_waypoint_control()
 
         wp.synchronize_device()
-        start_time = time.time()
+        start_time = time.perf_counter()
         if self.use_cuda_graph:
             wp.capture_launch(self.graph)
         else:
             self.simulate()
         wp.synchronize_device()
-        end_time = time.time()
+        end_time = time.perf_counter()
 
         self.benchmark_time += end_time - start_time
         self.sim_time += self.frame_dt
+
+    def test_final(self):
+        validate_simulation_state(
+            self.state_0,
+            max_linear_speed=_MAX_BODY_LINEAR_SPEED,
+            max_angular_speed=_MAX_BODY_ANGULAR_SPEED,
+        )
 
     def render(self):
         if self.renderer is None:

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -24,6 +24,10 @@ import newton
 import newton.examples
 from newton.examples.robot.example_robot_anymal_c_walk import Example
 
+_NUM_FRAMES = 50
+_MIN_BASE_HEIGHT = 0.4
+_MIN_FORWARD_PROGRESS = 0.25
+
 
 def _create_example(num_frames):
     if hasattr(newton.examples, "default_args"):
@@ -33,12 +37,27 @@ def _create_example(num_frames):
     return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
 
 
+def _validate_workload(workload):
+    validate_simulation_state(
+        workload.state_0,
+        max_linear_speed=10.0,
+        max_angular_speed=50.0,
+    )
+    root_position = workload.state_0.joint_q.numpy()[:3]
+    if root_position[2] < _MIN_BASE_HEIGHT:
+        raise RuntimeError(f"ANYmal base height is too low after {_NUM_FRAMES} frames: {root_position[2]:.3f} m")
+    if root_position[1] < _MIN_FORWARD_PROGRESS:
+        raise RuntimeError(
+            f"ANYmal made insufficient forward progress after {_NUM_FRAMES} frames: {root_position[1]:.3f} m"
+        )
+
+
 class FastExampleAnymalPretrained:
     repeat = 3
     number = 1
 
     def setup(self):
-        self.num_frames = 50
+        self.num_frames = _NUM_FRAMES
         self.example = _create_example(self.num_frames)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
@@ -49,7 +68,7 @@ class FastExampleAnymalPretrained:
 
 
 class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
-    num_frames = 50
+    num_frames = _NUM_FRAMES
     samples = 3
     world_count = 1
 
@@ -64,11 +83,7 @@ class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks)
             samples=self.samples,
             synchronize=wp.synchronize_device,
             memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
-            validate=lambda workload: validate_simulation_state(
-                workload.state_0,
-                max_linear_speed=10.0,
-                max_angular_speed=50.0,
-            ),
+            validate=_validate_workload,
         )
 
 

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -14,8 +14,8 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_metrics import (
-    _UnparameterizedSimulationMetricTracks,
-    collect_synchronized_simulation_metrics,
+    _SimulationMetricTracksUnparameterized,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     validate_simulation_state,
 )
@@ -67,7 +67,7 @@ class FastExampleAnymalPretrained:
         wp.synchronize_device()
 
 
-class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
+class FastMetricsExampleAnymalPretrained(_SimulationMetricTracksUnparameterized):
     num_frames = _NUM_FRAMES
     samples = 3
     world_count = 1
@@ -76,7 +76,7 @@ class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks)
         wp.synchronize_device()
         device = wp.get_device()
         free_memory_before = device.free_memory
-        return collect_synchronized_simulation_metrics(
+        return collect_simulation_metrics_synchronized(
             create_workload=lambda: _create_example(self.num_frames),
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_anymal.py
+++ b/asv/benchmarks/simulation/bench_anymal.py
@@ -1,15 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from benchmark_metrics import (
+    _UnparameterizedSimulationMetricTracks,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    validate_simulation_state,
+)
+
 import newton
 import newton.examples
 from newton.examples.robot.example_robot_anymal_c_walk import Example
+
+
+def _create_example(num_frames):
+    if hasattr(newton.examples, "default_args"):
+        args = newton.examples.default_args()
+    else:
+        args = None
+    return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
 
 
 class FastExampleAnymalPretrained:
@@ -18,17 +39,37 @@ class FastExampleAnymalPretrained:
 
     def setup(self):
         self.num_frames = 50
-        if hasattr(newton.examples, "default_args"):
-            args = newton.examples.default_args()
-        else:
-            args = None
-        self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), args)
+        self.example = _create_example(self.num_frames)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_simulate(self):
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+class FastMetricsExampleAnymalPretrained(_UnparameterizedSimulationMetricTracks):
+    num_frames = 50
+    samples = 3
+    world_count = 1
+
+    def setup_cache(self):
+        wp.synchronize_device()
+        device = wp.get_device()
+        free_memory_before = device.free_memory
+        return collect_synchronized_simulation_metrics(
+            create_workload=lambda: _create_example(self.num_frames),
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            synchronize=wp.synchronize_device,
+            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+            validate=lambda workload: validate_simulation_state(
+                workload.state_0,
+                max_linear_speed=10.0,
+                max_angular_speed=50.0,
+            ),
+        )
 
 
 if __name__ == "__main__":
@@ -38,6 +79,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastExampleAnymalPretrained": FastExampleAnymalPretrained,
+        "FastMetricsExampleAnymalPretrained": FastMetricsExampleAnymalPretrained,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -15,6 +15,41 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_kamino import DRLegsBenchmarkWorkload
+from benchmark_metrics import (
+    _SimulationMetricTracks,
+    _UnparameterizedSimulationMetricTracks,
+    collect_simulation_metrics,
+    compute_gpu_memory_usage,
+)
+
+
+def _collect_dr_legs_metrics(robot, world_count, num_frames, samples, use_policy):
+    wp.synchronize_device()
+    device = wp.get_device()
+    free_memory_before = device.free_memory
+    builder = DRLegsBenchmarkWorkload.create_model_builder(robot, world_count)
+
+    def create_workload():
+        workload = DRLegsBenchmarkWorkload(
+            robot=robot,
+            world_count=world_count,
+            use_cuda_graph=True,
+            use_policy=use_policy,
+            builder=builder,
+        )
+        if workload.graph is None or workload.reset_graph is None:
+            raise RuntimeError("KPI benchmark requires CUDA graph capture (is the CUDA mempool allocator enabled?)")
+        wp.synchronize_device()
+        return workload
+
+    return collect_simulation_metrics(
+        create_workload=create_workload,
+        world_count=world_count,
+        num_frames=num_frames,
+        samples=samples,
+        memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+        validate=lambda workload: workload.test_final(),
+    )
 
 
 class _FastBenchmark:
@@ -58,7 +93,7 @@ class _FastBenchmark:
         wp.synchronize_device()
 
 
-class _KpiBenchmark:
+class _KpiBenchmark(_SimulationMetricTracks):
     """Utility base class for Kamino KPI benchmarks."""
 
     param_names: ClassVar[list[str]] = ["world_count"]
@@ -68,35 +103,17 @@ class _KpiBenchmark:
     samples = None
     use_policy = True
 
-    def setup(self, world_count):
-        if not hasattr(self, "_builder") or self._builder is None:
-            self._builder = {}
-        if world_count not in self._builder:
-            self._builder[world_count] = DRLegsBenchmarkWorkload.create_model_builder(self.robot, world_count)
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulate(self, world_count):
-        total_time = 0.0
-        for _iter in range(self.samples):
-            workload = DRLegsBenchmarkWorkload(
+    def _collect_metrics(self):
+        metrics = {}
+        for world_count in self.params[0]:
+            metrics[world_count] = _collect_dr_legs_metrics(
                 robot=self.robot,
                 world_count=world_count,
-                use_cuda_graph=True,
+                num_frames=self.num_frames,
+                samples=self.samples,
                 use_policy=self.use_policy,
-                builder=self._builder[world_count],
             )
-            if workload.graph is None or workload.reset_graph is None:
-                raise RuntimeError("KPI benchmark requires CUDA graph capture (is the CUDA mempool allocator enabled?)")
-
-            wp.synchronize_device()
-            for _ in range(self.num_frames):
-                workload.step()
-            total_time += workload.benchmark_time
-            workload.test_final()
-
-        return total_time * 1000 / (self.num_frames * workload.sim_substeps * world_count * self.samples)
-
-    track_simulate.unit = "ms/world-step"
+        return metrics
 
 
 class FastDRLegs(_FastBenchmark):
@@ -106,11 +123,30 @@ class FastDRLegs(_FastBenchmark):
     world_count = 32
 
 
+class FastMetricsDRLegs(_UnparameterizedSimulationMetricTracks):
+    num_frames = 25
+    robot = "dr_legs"
+    samples = 2
+    world_count = 32
+
+    def setup_cache(self):
+        return _collect_dr_legs_metrics(
+            robot=self.robot,
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            use_policy=False,
+        )
+
+
 class KpiDRLegs(_KpiBenchmark):
     params: ClassVar[list[list[int]]] = [[4096]]
     num_frames = 25
     robot = "dr_legs"
     samples = 2
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 if __name__ == "__main__":
@@ -120,6 +156,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastDRLegs": FastDRLegs,
+        "FastMetricsDRLegs": FastMetricsDRLegs,
         "KpiDRLegs": KpiDRLegs,
     }
 

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -148,6 +148,8 @@ class KpiDRLegs(_KpiBenchmark):
     def setup_cache(self):
         return self._collect_metrics()
 
+    setup_cache.timeout = 1200
+
 
 if __name__ == "__main__":
     import argparse

--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -17,13 +17,13 @@ sys.path.append(parent_dir)
 from benchmark_kamino import DRLegsBenchmarkWorkload
 from benchmark_metrics import (
     _SimulationMetricTracks,
-    _UnparameterizedSimulationMetricTracks,
+    _SimulationMetricTracksUnparameterized,
     collect_simulation_metrics,
     compute_gpu_memory_usage,
 )
 
 
-def _collect_dr_legs_metrics(robot, world_count, num_frames, samples, use_policy):
+def _collect_metrics_dr_legs(robot, world_count, num_frames, samples, use_policy):
     wp.synchronize_device()
     device = wp.get_device()
     free_memory_before = device.free_memory
@@ -106,7 +106,7 @@ class _KpiBenchmark(_SimulationMetricTracks):
     def _collect_metrics(self):
         metrics = {}
         for world_count in self.params[0]:
-            metrics[world_count] = _collect_dr_legs_metrics(
+            metrics[world_count] = _collect_metrics_dr_legs(
                 robot=self.robot,
                 world_count=world_count,
                 num_frames=self.num_frames,
@@ -123,14 +123,14 @@ class FastDRLegs(_FastBenchmark):
     world_count = 32
 
 
-class FastMetricsDRLegs(_UnparameterizedSimulationMetricTracks):
+class FastMetricsDRLegs(_SimulationMetricTracksUnparameterized):
     num_frames = 25
     robot = "dr_legs"
     samples = 2
     world_count = 32
 
     def setup_cache(self):
-        return _collect_dr_legs_metrics(
+        return _collect_metrics_dr_legs(
             robot=self.robot,
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -14,12 +14,17 @@ from asv_runner.benchmarks.mark import skip_benchmark_if
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
+from benchmark_metrics import (
+    _SimulationMetricTracks,
+    collect_simulation_metrics,
+    compute_gpu_memory_usage,
+)
 from benchmark_mujoco import Example
 
 from newton.utils import EventTracer
 
 
-class _KpiBenchmark:
+class _KpiBenchmark(_SimulationMetricTracks):
     """Utility base class for KPI benchmarks."""
 
     param_names = ["world_count"]
@@ -31,39 +36,40 @@ class _KpiBenchmark:
     random_init = None
     environment = "None"
 
-    def setup(self, world_count):
-        if not hasattr(self, "builder") or self.builder is None:
-            self.builder = {}
-        if world_count not in self.builder:
-            self.builder[world_count] = Example.create_model_builder(
-                self.robot, world_count, randomize=self.random_init, seed=123
-            )
-
-    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
-    def track_simulate(self, world_count):
-        total_time = 0.0
-        for _iter in range(self.samples):
-            example = Example(
-                stage_path=None,
-                robot=self.robot,
-                randomize=self.random_init,
-                headless=True,
-                actuation="random",
-                use_cuda_graph=True,
-                builder=self.builder[world_count],
-                ls_iteration=self.ls_iteration,
-                environment=self.environment,
-            )
-
+    def _collect_metrics(self):
+        metrics = {}
+        for world_count in self.params[0]:
             wp.synchronize_device()
-            for _ in range(self.num_frames):
-                example.step()
-            wp.synchronize_device()
-            total_time += example.benchmark_time
+            device = wp.get_device()
+            free_memory_before = device.free_memory
+            builder = Example.create_model_builder(self.robot, world_count, randomize=self.random_init, seed=123)
 
-        return total_time * 1000 / (self.num_frames * example.sim_substeps * world_count * self.samples)
+            def create_workload(builder=builder):
+                example = Example(
+                    stage_path=None,
+                    robot=self.robot,
+                    randomize=self.random_init,
+                    headless=True,
+                    actuation="random",
+                    use_cuda_graph=True,
+                    builder=builder,
+                    ls_iteration=self.ls_iteration,
+                    environment=self.environment,
+                )
+                wp.synchronize_device()
+                return example
 
-    track_simulate.unit = "ms/world-step"
+            metrics[world_count] = collect_simulation_metrics(
+                create_workload=create_workload,
+                world_count=world_count,
+                num_frames=self.num_frames,
+                samples=self.samples,
+                memory_usage_bytes=lambda workload, device=device, free_memory_before=free_memory_before: (
+                    compute_gpu_memory_usage(device, free_memory_before)
+                ),
+                validate=lambda workload: workload.test_final(),
+            )
+        return metrics
 
 
 class _NewtonOverheadBenchmark:
@@ -124,6 +130,9 @@ class FastCartpole(_KpiBenchmark):
     random_init = True
     environment = "None"
 
+    def setup_cache(self):
+        return self._collect_metrics()
+
 
 class FastG1(_KpiBenchmark):
     params = [[8192]]
@@ -134,6 +143,9 @@ class FastG1(_KpiBenchmark):
     ls_iteration = 10
     random_init = True
     environment = "None"
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 class FastNewtonOverheadG1(_NewtonOverheadBenchmark):
@@ -155,6 +167,9 @@ class FastHumanoid(_KpiBenchmark):
     random_init = True
     environment = "None"
 
+    def setup_cache(self):
+        return self._collect_metrics()
+
 
 class FastNewtonOverheadHumanoid(_NewtonOverheadBenchmark):
     params = [[8192]]
@@ -175,6 +190,9 @@ class FastAllegro(_KpiBenchmark):
     random_init = False
     environment = "None"
 
+    def setup_cache(self):
+        return self._collect_metrics()
+
 
 class FastKitchenG1(_KpiBenchmark):
     params = [[512]]
@@ -185,6 +203,9 @@ class FastKitchenG1(_KpiBenchmark):
     ls_iteration = 10
     random_init = True
     environment = "kitchen"
+
+    def setup_cache(self):
+        return self._collect_metrics()
 
 
 if __name__ == "__main__":

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -42,7 +42,13 @@ class _KpiBenchmark(_SimulationMetricTracks):
             wp.synchronize_device()
             device = wp.get_device()
             free_memory_before = device.free_memory
-            builder = Example.create_model_builder(self.robot, world_count, randomize=self.random_init, seed=123)
+            builder = Example.create_model_builder(
+                self.robot,
+                world_count,
+                environment=self.environment,
+                randomize=self.random_init,
+                seed=123,
+            )
 
             def create_workload(builder=builder):
                 example = Example(
@@ -199,6 +205,7 @@ class FastKitchenG1(_KpiBenchmark):
     num_frames = 50
     robot = "g1"
     timeout = 900
+    version = "2"  # The pre-v2 series accidentally omitted the kitchen environment.
     samples = 2
     ls_iteration = 10
     random_init = True

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import os
 import sys
 
@@ -214,6 +215,43 @@ class FastKitchenG1(_KpiBenchmark):
 
     def setup_cache(self):
         return self._collect_metrics()
+
+
+class _CalibrationKitchenG1(_KpiBenchmark):
+    """Temporary isolated calibration for replicated kitchen memory scaling."""
+
+    class _Metrics(dict):
+        def __init__(self, simulation_metrics, host_peak_rss_mib):
+            super().__init__(simulation_metrics)
+            self.host_peak_rss_mib = host_peak_rss_mib
+
+    num_frames = 50
+    robot = "g1"
+    timeout = 900
+    samples = 2
+    ls_iteration = 10
+    random_init = True
+    environment = "kitchen"
+
+    def setup_cache(self):
+        resource = importlib.import_module("resource")
+        simulation_metrics = self._collect_metrics()
+        host_peak_rss_mib = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+        return self._Metrics(simulation_metrics, host_peak_rss_mib)
+
+    def track_host_peak_rss(self, metrics, world_count):
+        return metrics.host_peak_rss_mib
+
+    track_host_peak_rss.unit = "MiB"
+
+
+# Separate classes make ASV release all process memory between world counts.
+class FastCalibrationKitchenG1Worlds256(_CalibrationKitchenG1):
+    params = [[256]]
+
+
+class FastCalibrationKitchenG1Worlds384(_CalibrationKitchenG1):
+    params = [[384]]
 
 
 if __name__ == "__main__":

--- a/asv/benchmarks/simulation/bench_mujoco.py
+++ b/asv/benchmarks/simulation/bench_mujoco.py
@@ -201,7 +201,8 @@ class FastAllegro(_KpiBenchmark):
 
 
 class FastKitchenG1(_KpiBenchmark):
-    params = [[512]]
+    # Leave headroom for replicated kitchen construction on 64 GiB CI runners.
+    params = [[128]]
     num_frames = 50
     robot = "g1"
     timeout = 900

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -14,8 +14,8 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
 
 from benchmark_metrics import (
-    _UnparameterizedSimulationMetricTracks,
-    collect_synchronized_simulation_metrics,
+    _SimulationMetricTracksUnparameterized,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     validate_simulation_workload,
 )
@@ -48,7 +48,7 @@ class FastExampleQuadrupedXPBD:
         wp.synchronize_device()
 
 
-class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
+class FastMetricsExampleQuadrupedXPBD(_SimulationMetricTracksUnparameterized):
     num_frames = 1000
     samples = 1
     world_count = 200
@@ -57,7 +57,7 @@ class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
         wp.synchronize_device()
         device = wp.get_device()
         free_memory_before = device.free_memory
-        return collect_synchronized_simulation_metrics(
+        return collect_simulation_metrics_synchronized(
             create_workload=lambda: _create_example(self.num_frames, self.world_count),
             world_count=self.world_count,
             num_frames=self.num_frames,

--- a/asv/benchmarks/simulation/bench_quadruped_xpbd.py
+++ b/asv/benchmarks/simulation/bench_quadruped_xpbd.py
@@ -1,15 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import warp as wp
 from asv_runner.benchmarks.mark import skip_benchmark_if
 
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+from benchmark_metrics import (
+    _UnparameterizedSimulationMetricTracks,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    validate_simulation_workload,
+)
+
 import newton
 import newton.examples
 from newton.examples.basic.example_basic_urdf import Example
+
+
+def _create_example(num_frames, world_count):
+    if hasattr(newton.examples, "default_args") and hasattr(Example, "create_parser"):
+        args = newton.examples.default_args(Example.create_parser())
+        args.world_count = world_count
+        return Example(newton.viewer.ViewerNull(num_frames=num_frames), args)
+    return Example(newton.viewer.ViewerNull(num_frames=num_frames), world_count)
 
 
 class FastExampleQuadrupedXPBD:
@@ -18,18 +39,37 @@ class FastExampleQuadrupedXPBD:
 
     def setup(self):
         self.num_frames = 1000
-        if hasattr(newton.examples, "default_args") and hasattr(Example, "create_parser"):
-            args = newton.examples.default_args(Example.create_parser())
-            args.world_count = 200
-            self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), args)
-        else:
-            self.example = Example(newton.viewer.ViewerNull(num_frames=self.num_frames), 200)
+        self.example = _create_example(self.num_frames, world_count=200)
 
     @skip_benchmark_if(wp.get_cuda_device_count() == 0)
     def time_simulate(self):
         for _ in range(self.num_frames):
             self.example.step()
         wp.synchronize_device()
+
+
+class FastMetricsExampleQuadrupedXPBD(_UnparameterizedSimulationMetricTracks):
+    num_frames = 1000
+    samples = 1
+    world_count = 200
+
+    def setup_cache(self):
+        wp.synchronize_device()
+        device = wp.get_device()
+        free_memory_before = device.free_memory
+        return collect_synchronized_simulation_metrics(
+            create_workload=lambda: _create_example(self.num_frames, self.world_count),
+            world_count=self.world_count,
+            num_frames=self.num_frames,
+            samples=self.samples,
+            synchronize=wp.synchronize_device,
+            memory_usage_bytes=lambda workload: compute_gpu_memory_usage(device, free_memory_before),
+            validate=lambda workload: validate_simulation_workload(
+                workload,
+                max_linear_speed=0.3,
+                max_angular_speed=0.3,
+            ),
+        )
 
 
 if __name__ == "__main__":
@@ -39,6 +79,7 @@ if __name__ == "__main__":
 
     benchmark_list = {
         "FastExampleQuadrupedXPBD": FastExampleQuadrupedXPBD,
+        "FastMetricsExampleQuadrupedXPBD": FastMetricsExampleQuadrupedXPBD,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/docs/guide/development.rst
+++ b/docs/guide/development.rst
@@ -799,6 +799,42 @@ benchmark code from the ``asv/benchmarks`` directory against the code state of t
 the benchmark definitions themselves are not checked out from different branches—only the code being
 benchmarked is.
 
+Simulation benchmark metrics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The nightly robot and policy simulation benchmarks publish several metrics from one cached benchmark run. This
+includes the batched MuJoCo and Kamino KPI workloads, the non-policy DR Legs workload, the pretrained Anymal
+workload, and the XPBD quadruped workload. Companion ``FastMetrics*`` classes reuse the exact factories, scenes,
+solvers, and frame counts of existing aggregate benchmarks. Rendering, IK, inverse dynamics, CPU-backend
+regression, material/contact microbenchmarks, and startup benchmarks are not experience-collection workloads and
+are outside this metric set.
+
+Let ``F`` be the number of measured frames across all samples, ``S`` the number of physics substeps per frame,
+``W`` the world count, ``dt`` the physics timestep in seconds, ``T`` the synchronized complete-step wall time in
+seconds, and ``T_physics`` the workload's synchronized internal physics time. The reported metrics are:
+
+* mean world-step time: ``1000 * T_physics / (F * S * W)`` in ``ms/world-step`` for workloads with an internal
+  timer and ``1000 * T / (F * S * W)`` otherwise;
+* simulation throughput: ``F * S * W / T`` in ``world-steps/s``;
+* real-time factor: ``F * S * W * dt / T``;
+* p95 step time: the 95th percentile of synchronized complete-step times in ``ms/frame``; and
+* steady-state GPU memory in ``MiB``.
+
+The existing KPI mean world-step series keeps its ``track_simulate`` name and definition, and existing
+``time_simulate`` aggregate series remain unchanged. ``world_count`` remains an ASV parameter where applicable,
+while ``sim_dt`` and ``sim_substeps`` are also recorded as tracked values so dashboard results retain the
+configuration needed to interpret throughput and real-time factor. The existing KPI mean series continues to use
+each workload's internal physics timer. Throughput, real-time factor, and p95 metrics time and synchronize the
+complete ``step()`` operation, including any policy or control work it performs.
+
+GPU memory is the decrease in ``Device.free_memory`` between a baseline immediately before model construction
+and a measurement after initialization, CUDA graph capture, and the first complete measured sample, while that
+sample's workload is still live. This device-level delta includes allocations from Warp, PyTorch, solver support,
+and CUDA graphs. Because the measurement is device-wide, runners must provide exclusive GPU access during the
+measurement interval. The remaining samples do not affect this measurement. A benchmark fails instead of
+publishing metrics if its final simulation state is invalid, has non-normalized body rotations, or exceeds the
+workload's body-speed bounds.
+
 Benchmarks can also be run against a range of commits using the ``commit1..commit2`` syntax.
 This is useful for comparing performance across several recent changes:
 

--- a/newton/_src/utils/benchmark.py
+++ b/newton/_src/utils/benchmark.py
@@ -175,13 +175,20 @@ def run_benchmark(benchmark_cls, number=1, print_results=True):
     else:
         combinations = [()]
 
+    cache = None
+    has_cache = hasattr(benchmark_cls, "setup_cache")
+    if has_cache:
+        cache = benchmark_cls().setup_cache()
+        has_cache = cache is not None
+
     results = {}
     # For each parameter combination:
     for params in combinations:
+        call_params = (cache, *params) if has_cache else params
         # Create a fresh benchmark instance.
         instance = benchmark_cls()
         if hasattr(instance, "setup"):
-            instance.setup(*params)
+            instance.setup(*call_params)
         # Iterate over all attributes to find benchmark methods.
         for attr in dir(instance):
             if attr.startswith("time_") or attr.startswith("track_"):
@@ -190,24 +197,24 @@ def run_benchmark(benchmark_cls, number=1, print_results=True):
                 samples = []
                 if attr.startswith("time_"):
                     # Warmup run (not measured).
-                    method(*params)
+                    method(*call_params)
                     wp.synchronize()
                     # Run timing benchmarks multiple times and measure elapsed time.
                     for _ in range(number):
                         start = time.perf_counter()
-                        method(*params)
+                        method(*call_params)
                         t = time.perf_counter() - start
                         samples.append(t)
                 elif attr.startswith("track_"):
                     # Run tracking benchmarks multiple times and record returned values.
                     for _ in range(number):
-                        val = method(*params)
+                        val = method(*call_params)
                         samples.append(val)
                 # Compute the average result.
                 avg = sum(samples) / len(samples)
                 results[(attr, params)] = avg
         if hasattr(instance, "teardown"):
-            instance.teardown(*params)
+            instance.teardown(*call_params)
 
     if print_results:
         print("\n=== Benchmark Results ===")

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from benchmark_metrics import (  # noqa: E402
+    collect_simulation_metrics,
+    collect_synchronized_simulation_metrics,
+    compute_gpu_memory_usage,
+    compute_simulation_metrics,
+    validate_simulation_state,
+    validate_simulation_workload,
+)
+
+from newton.utils import run_benchmark
+
+
+class TestBenchmarkMetrics(unittest.TestCase):
+    def test_compute_simulation_metrics(self):
+        metrics = compute_simulation_metrics(
+            frame_times=[0.1, 0.2, 0.3, 0.4],
+            sim_dt=0.002,
+            sim_substeps=5,
+            world_count=10,
+            gpu_memory_bytes=10 * 1024**2,
+        )
+
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 5.0)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 200.0)
+        self.assertAlmostEqual(metrics.real_time_factor, 0.4)
+        self.assertAlmostEqual(metrics.p95_frame_time_ms, 385.0)
+        self.assertAlmostEqual(metrics.gpu_memory_mib, 10.0)
+        self.assertEqual(metrics.sim_dt, 0.002)
+        self.assertEqual(metrics.sim_substeps, 5)
+
+    def test_collect_simulation_metrics(self):
+        workloads = []
+        events = []
+        timer_values = iter((0.0, 0.02, 0.02, 0.06, 0.06, 0.08, 0.08, 0.12))
+
+        class FakeWorkload:
+            sim_dt = 0.01
+            sim_substeps = 2
+
+            def __init__(self):
+                self.benchmark_time = 0.0
+                self.step_count = 0
+
+            def step(self):
+                self.benchmark_time += (0.01, 0.02)[self.step_count]
+                self.step_count += 1
+
+        def create_workload():
+            workload = FakeWorkload()
+            workloads.append(workload)
+            return workload
+
+        def memory_usage_bytes(workload):
+            self.assertIs(workload, workloads[0])
+            self.assertEqual(workload.step_count, 2)
+            events.append(("memory", workload))
+            return 8 * 1024**2
+
+        def validate(workload):
+            events.append(("validate", workload))
+
+        metrics = collect_simulation_metrics(
+            create_workload=create_workload,
+            world_count=4,
+            num_frames=2,
+            samples=2,
+            memory_usage_bytes=memory_usage_bytes,
+            validate=validate,
+            timer=lambda: next(timer_values),
+        )
+
+        self.assertEqual(len(workloads), 2)
+        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0]), ("validate", workloads[1])])
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 32 / 0.12)
+        self.assertAlmostEqual(metrics.real_time_factor, 32 * 0.01 / 0.12)
+        self.assertAlmostEqual(metrics.p95_frame_time_ms, 40.0)
+        self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
+
+    def test_collect_synchronized_simulation_metrics(self):
+        workloads = []
+        events = []
+        sync_calls = []
+        timer_values = iter((0.0, 0.01, 0.01, 0.03))
+
+        class FakeWorkload:
+            sim_dt = 0.01
+            sim_substeps = 2
+
+            def __init__(self):
+                self.step_count = 0
+
+            def step(self):
+                self.step_count += 1
+
+        def create_workload():
+            workload = FakeWorkload()
+            workloads.append(workload)
+            return workload
+
+        def memory_usage_bytes(workload):
+            events.append(("memory", workload))
+            return 8 * 1024**2
+
+        def validate(workload):
+            events.append(("validate", workload))
+
+        metrics = collect_synchronized_simulation_metrics(
+            create_workload=create_workload,
+            world_count=4,
+            num_frames=2,
+            samples=1,
+            synchronize=lambda: sync_calls.append(None),
+            timer=lambda: next(timer_values),
+            memory_usage_bytes=memory_usage_bytes,
+            validate=validate,
+        )
+
+        self.assertEqual(len(sync_calls), 3)
+        self.assertEqual(events, [("memory", workloads[0]), ("validate", workloads[0])])
+        self.assertAlmostEqual(metrics.mean_world_step_time_ms, 1.875)
+        self.assertAlmostEqual(metrics.world_steps_per_second, 16 / 0.03)
+        self.assertAlmostEqual(metrics.real_time_factor, 16 * 0.01 / 0.03)
+
+    def test_compute_gpu_memory_usage(self):
+        class FakeDevice:
+            free_memory = 700
+
+        self.assertEqual(compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000), 300)
+
+        FakeDevice.free_memory = 1100
+        with self.assertRaisesRegex(RuntimeError, "increased"):
+            compute_gpu_memory_usage(FakeDevice(), free_memory_before=1000)
+
+    def test_validate_simulation_state(self):
+        class FakeArray:
+            def __init__(self, values):
+                self.values = np.asarray(values, dtype=np.float32)
+
+            def numpy(self):
+                return self.values
+
+        class FakeState:
+            joint_q = FakeArray([0.0])
+            joint_qd = FakeArray([0.0])
+            body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+            body_qd = FakeArray([[1.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+
+        validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.body_qd = FakeArray([[11.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        with self.assertRaisesRegex(RuntimeError, "linear speed"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.body_qd = FakeArray([[1.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        FakeState.body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0]])
+        with self.assertRaisesRegex(RuntimeError, "quaternion"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        specialized_checks = []
+        FakeState.body_q = FakeArray([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
+        FakeState.joint_qd = FakeArray([np.nan])
+        with self.assertRaisesRegex(RuntimeError, "state.joint_qd"):
+            validate_simulation_state(FakeState(), max_linear_speed=10.0, max_angular_speed=10.0)
+
+        FakeState.joint_qd = FakeArray([0.0])
+
+        class FakeWorkload:
+            state_0 = FakeState()
+
+            def test_final(self):
+                specialized_checks.append(self)
+
+        workload = FakeWorkload()
+        validate_simulation_workload(workload, max_linear_speed=10.0, max_angular_speed=10.0)
+        self.assertEqual(specialized_checks, [workload])
+
+    def test_run_benchmark_with_setup_cache(self):
+        class CachedBenchmark:
+            params = [[2, 3]]
+            setup_cache_calls = 0
+
+            def setup_cache(self):
+                type(self).setup_cache_calls += 1
+                return 10
+
+            def track_value(self, cache, value):
+                return cache + value
+
+        results = run_benchmark(CachedBenchmark, print_results=False)
+
+        self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
+        self.assertEqual(results[("track_value", (2,))], 12)
+        self.assertEqual(results[("track_value", (3,))], 13)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(BENCHMARK_DIR))
 
 from benchmark_metrics import (  # noqa: E402
     collect_simulation_metrics,
-    collect_synchronized_simulation_metrics,
+    collect_simulation_metrics_synchronized,
     compute_gpu_memory_usage,
     compute_simulation_metrics,
     validate_simulation_state,
@@ -90,7 +90,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics.p95_frame_time_ms, 40.0)
         self.assertAlmostEqual(metrics.gpu_memory_mib, 8.0)
 
-    def test_collect_synchronized_simulation_metrics(self):
+    def test_collect_simulation_metrics_synchronized(self):
         workloads = []
         events = []
         sync_calls = []
@@ -118,7 +118,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
         def validate(workload):
             events.append(("validate", workload))
 
-        metrics = collect_synchronized_simulation_metrics(
+        metrics = collect_simulation_metrics_synchronized(
             create_workload=create_workload,
             world_count=4,
             num_frames=2,
@@ -189,20 +189,39 @@ class TestBenchmarkMetrics(unittest.TestCase):
         self.assertEqual(specialized_checks, [workload])
 
     def test_run_benchmark_with_setup_cache(self):
+        cache_events = []
+
         class CachedBenchmark:
             params: ClassVar = [[2, 3]]
             setup_cache_calls = 0
+            cache_value: ClassVar = {"base": 10}
 
             def setup_cache(self):
                 type(self).setup_cache_calls += 1
-                return 10
+                return self.cache_value
+
+            def setup(self, cache, value):
+                cache_events.append(("setup", cache, value))
+
+            def time_value(self, cache, value):
+                cache_events.append(("time", cache, value))
 
             def track_value(self, cache, value):
-                return cache + value
+                cache_events.append(("track", cache, value))
+                return cache["base"] + value
+
+            def teardown(self, cache, value):
+                cache_events.append(("teardown", cache, value))
 
         results = run_benchmark(CachedBenchmark, print_results=False)
 
         self.assertEqual(CachedBenchmark.setup_cache_calls, 1)
+        self.assertTrue(all(cache is CachedBenchmark.cache_value for _, cache, _ in cache_events))
+        self.assertEqual([event for event, _, _ in cache_events].count("setup"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("time"), 4)
+        self.assertEqual([event for event, _, _ in cache_events].count("track"), 2)
+        self.assertEqual([event for event, _, _ in cache_events].count("teardown"), 2)
+        self.assertEqual({value for _, _, value in cache_events}, {2, 3})
         self.assertEqual(results[("track_value", (2,))], 12)
         self.assertEqual(results[("track_value", (3,))], 13)
 

--- a/newton/tests/test_benchmark_metrics.py
+++ b/newton/tests/test_benchmark_metrics.py
@@ -4,8 +4,11 @@
 import sys
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 import numpy as np
+
+from newton.utils import run_benchmark
 
 BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
@@ -18,8 +21,6 @@ from benchmark_metrics import (  # noqa: E402
     validate_simulation_state,
     validate_simulation_workload,
 )
-
-from newton.utils import run_benchmark
 
 
 class TestBenchmarkMetrics(unittest.TestCase):
@@ -189,7 +190,7 @@ class TestBenchmarkMetrics(unittest.TestCase):
 
     def test_run_benchmark_with_setup_cache(self):
         class CachedBenchmark:
-            params = [[2, 3]]
+            params: ClassVar = [[2, 3]]
             setup_cache_calls = 0
 
             def setup_cache(self):

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -5,35 +5,47 @@ import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 import numpy as np
+import warp as wp
 
 BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
 sys.path.insert(0, str(BENCHMARK_DIR))
 
-from simulation import bench_anymal, bench_kamino, bench_mujoco  # noqa: E402
+_WARP_CONFIG_FIELDS = ("enable_backward", "log_level")
+_WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS = {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS}
 
-
-class _FakeArray:
-    def __init__(self, values):
-        self.values = np.asarray(values, dtype=np.float32)
-
-    def numpy(self):
-        return self.values
-
-
-def _make_anymal_workload(root_y, root_z):
-    state = SimpleNamespace(
-        joint_q=_FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
-        joint_qd=_FakeArray([0.0] * 6),
-        body_q=_FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
-        body_qd=_FakeArray([[0.0] * 6]),
-    )
-    return SimpleNamespace(state_0=state)
+try:
+    from simulation import bench_anymal, bench_kamino, bench_mujoco
+finally:
+    for _name, _value in _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS.items():
+        setattr(wp.config, _name, _value)
 
 
 class TestSimulationBenchmarks(unittest.TestCase):
+    class _FakeArray:
+        def __init__(self, values):
+            self.values = np.asarray(values, dtype=np.float32)
+
+        def numpy(self):
+            return self.values
+
+    def _make_anymal_workload(self, root_y, root_z):
+        state = SimpleNamespace(
+            joint_q=self._FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
+            joint_qd=self._FakeArray([0.0] * 6),
+            body_q=self._FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
+            body_qd=self._FakeArray([[0.0] * 6]),
+        )
+        return SimpleNamespace(state_0=state)
+
+    def test_benchmark_imports_preserve_warp_config(self):
+        self.assertEqual(
+            {name: getattr(wp.config, name) for name in _WARP_CONFIG_FIELDS},
+            _WARP_CONFIG_BEFORE_BENCHMARK_IMPORTS,
+        )
+
     def test_fast_kitchen_g1_builds_kitchen_environment(self):
         class FakeDevice:
             free_memory = 1024
@@ -56,25 +68,47 @@ class TestSimulationBenchmarks(unittest.TestCase):
 
         create_model_builder.assert_called_once_with(
             "g1",
-            512,
+            128,
             environment="kitchen",
             randomize=True,
             seed=123,
         )
-        self.assertEqual(metrics, {512: sentinel.metrics})
+        self.assertEqual(metrics, {128: sentinel.metrics})
         self.assertEqual(bench_mujoco.FastKitchenG1.version, "2")
+
+    def test_mujoco_step_falls_back_when_cuda_graph_is_unavailable(self):
+        example = bench_mujoco.Example.__new__(bench_mujoco.Example)
+        example.actuation = "None"
+        example.use_cuda_graph = True
+        example.graph = None
+        example.simulate = Mock()
+        example.benchmark_time = 0.0
+        example.sim_time = 0.0
+        example.frame_dt = 0.01
+
+        with (
+            patch("benchmark_mujoco.time.perf_counter", side_effect=(1.0, 1.25)),
+            patch.object(bench_mujoco.wp, "synchronize_device"),
+            patch.object(bench_mujoco.wp, "capture_launch") as capture_launch,
+        ):
+            example.step()
+
+        example.simulate.assert_called_once_with()
+        capture_launch.assert_not_called()
+        self.assertEqual(example.benchmark_time, 0.25)
+        self.assertEqual(example.sim_time, 0.01)
 
     def test_kpi_dr_legs_has_setup_cache_timeout(self):
         self.assertEqual(bench_kamino.KpiDRLegs.setup_cache.timeout, 1200)
 
     def test_anymal_short_horizon_validation(self):
-        bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.530))
+        bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.530))
 
         with self.assertRaisesRegex(RuntimeError, "forward progress"):
-            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.0, root_z=0.530))
+            bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.0, root_z=0.530))
 
         with self.assertRaisesRegex(RuntimeError, "base height"):
-            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.200))
+            bench_anymal._validate_workload(self._make_anymal_workload(root_y=0.719, root_z=0.200))
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, sentinel
+
+import numpy as np
+
+BENCHMARK_DIR = Path(__file__).parents[2] / "asv" / "benchmarks"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+from simulation import bench_anymal, bench_kamino, bench_mujoco  # noqa: E402
+
+
+class _FakeArray:
+    def __init__(self, values):
+        self.values = np.asarray(values, dtype=np.float32)
+
+    def numpy(self):
+        return self.values
+
+
+def _make_anymal_workload(root_y, root_z):
+    state = SimpleNamespace(
+        joint_q=_FakeArray([0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]),
+        joint_qd=_FakeArray([0.0] * 6),
+        body_q=_FakeArray([[0.0, root_y, root_z, 0.0, 0.0, 0.0, 1.0]]),
+        body_qd=_FakeArray([[0.0] * 6]),
+    )
+    return SimpleNamespace(state_0=state)
+
+
+class TestSimulationBenchmarks(unittest.TestCase):
+    def test_fast_kitchen_g1_builds_kitchen_environment(self):
+        class FakeDevice:
+            free_memory = 1024
+
+        with (
+            patch.object(bench_mujoco.wp, "synchronize_device"),
+            patch.object(bench_mujoco.wp, "get_device", return_value=FakeDevice()),
+            patch.object(
+                bench_mujoco.Example,
+                "create_model_builder",
+                return_value=sentinel.builder,
+            ) as create_model_builder,
+            patch.object(
+                bench_mujoco,
+                "collect_simulation_metrics",
+                return_value=sentinel.metrics,
+            ),
+        ):
+            metrics = bench_mujoco.FastKitchenG1()._collect_metrics()
+
+        create_model_builder.assert_called_once_with(
+            "g1",
+            512,
+            environment="kitchen",
+            randomize=True,
+            seed=123,
+        )
+        self.assertEqual(metrics, {512: sentinel.metrics})
+        self.assertEqual(bench_mujoco.FastKitchenG1.version, "2")
+
+    def test_kpi_dr_legs_has_setup_cache_timeout(self):
+        self.assertEqual(bench_kamino.KpiDRLegs.setup_cache.timeout, 1200)
+
+    def test_anymal_short_horizon_validation(self):
+        bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.530))
+
+        with self.assertRaisesRegex(RuntimeError, "forward progress"):
+            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.0, root_z=0.530))
+
+        with self.assertRaisesRegex(RuntimeError, "base height"):
+            bench_anymal._validate_workload(_make_anymal_workload(root_y=0.719, root_z=0.200))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Temporary calibration only — **do not merge**.

Measure the corrected FastKitchenG1 workload at 256 and 384 worlds on the upstream `g7e.2xlarge` runner. The two sizes use separate ASV benchmark classes so process memory is released between measurements. Each reports host peak RSS alongside the existing throughput, timing, and GPU-memory metrics.

This draft exists only because repository rules prevent collaborators from creating a temporary upstream branch for manual workflow dispatch. It will be closed and its branch deleted after the logs are captured. Related to #3566.

## Checklist

- [x] ASV discovery covers the temporary benchmark classes
- [x] Documentation is not applicable to this temporary calibration
- [x] `CHANGELOG.md` is not applicable because this will not be merged

## Test plan

- `uvx --with virtualenv asv check`
- `uvx pre-commit run -a`
- Pull Request - AWS GPU Benchmarks on `g7e.2xlarge`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added simulation benchmark metrics for throughput, real-time factor, frame times, and GPU memory usage.
  - Added metrics coverage for Anymal, quadruped, DR Legs, MuJoCo, and kitchen simulations.
  - Added host-memory scaling measurements for kitchen simulations.
  - Added benchmark result caching to improve repeatability and reduce setup overhead.

- **Bug Fixes**
  - Improved simulation-state validation and CUDA graph fallback behavior.
  - Corrected kitchen benchmark environment and metrics reporting.

- **Documentation**
  - Documented simulation benchmark metrics and validation criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->