### PR TITLE
Only emit collision filters between colliding shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.
+- Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -6335,6 +6335,8 @@ class ModelBuilder:
         if cfg.has_shape_collision:
             # no contacts between shapes of the same body
             for same_body_shape in self.body_shapes[body]:
+                if not self.shape_flags[same_body_shape] & ShapeFlags.COLLIDE_SHAPES:
+                    continue
                 self.add_shape_collision_filter_pair(same_body_shape, shape)
         self.body_shapes[body].append(shape)
         self.shape_label.append(label or f"shape_{shape}")
@@ -6384,11 +6386,15 @@ class ModelBuilder:
                 if not self.joint_collision_filter_parent[joint_idx]:
                     continue
                 for parent_shape in self.body_shapes[parent_body]:
+                    if not self.shape_flags[parent_shape] & ShapeFlags.COLLIDE_SHAPES:
+                        continue
                     self.add_shape_collision_filter_pair(parent_shape, shape)
             for child_body, joint_idx in self.joint_children.get(body, ()):
                 if not self.joint_collision_filter_parent[joint_idx]:
                     continue
                 for child_shape in self.body_shapes[child_body]:
+                    if not self.shape_flags[child_shape] & ShapeFlags.COLLIDE_SHAPES:
+                        continue
                     self.add_shape_collision_filter_pair(shape, child_shape)
 
         if not is_static and cfg.density > 0.0 and body >= 0 and not self.body_lock_inertia[body]:
@@ -8043,7 +8049,11 @@ class ModelBuilder:
                             # Already filtered by add_joint_cable(collision_filter_parent=True).
                             continue
                         for si in self.body_shapes.get(bi, []):
+                            if not self.shape_flags[si] & ShapeFlags.COLLIDE_SHAPES:
+                                continue
                             for sj in self.body_shapes.get(bj, []):
+                                if not self.shape_flags[sj] & ShapeFlags.COLLIDE_SHAPES:
+                                    continue
                                 self.add_shape_collision_filter_pair(int(si), int(sj))
 
         return edge_bodies, all_joints

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -3017,13 +3017,13 @@ def parse_mjcf(
 
     end_shape_count = len(builder.shape_type)
 
-    for i in range(start_shape_count, end_shape_count):
-        for j in visual_shapes:
-            builder.add_shape_collision_filter_pair(i, j)
-
     if not enable_self_collisions:
-        for i in range(start_shape_count, end_shape_count):
-            for j in range(i + 1, end_shape_count):
+        # The broad phase only ever tests colliding shapes, so visual-only shapes need no filter pairs.
+        colliding_shapes = [
+            i for i in range(start_shape_count, end_shape_count) if builder.shape_flags[i] & ShapeFlags.COLLIDE_SHAPES
+        ]
+        for a, i in enumerate(colliding_shapes):
+            for j in colliding_shapes[a + 1 :]:
                 builder.add_shape_collision_filter_pair(i, j)
 
     # Create articulations from collected joints

--- a/newton/_src/utils/import_urdf.py
+++ b/newton/_src/utils/import_urdf.py
@@ -16,7 +16,7 @@ import warp as wp
 
 from ..core import Axis, AxisType, quat_between_axes
 from ..core.types import Transform
-from ..geometry import Mesh
+from ..geometry import Mesh, ShapeFlags
 from ..sim import ModelBuilder
 from ..sim.enums import JointTargetMode
 from ..sim.model import Model
@@ -627,7 +627,6 @@ def parse_urdf(
 
     # maps from link name -> link index
     link_index: dict[str, int] = {}
-    visual_shapes: list[int] = []
     start_shape_count = len(builder.shape_type)
     model_has_visual_shapes = any(len(urdf_link.findall("visual")) > 0 for urdf_link in urdf_links)
 
@@ -649,8 +648,7 @@ def parse_urdf(
         if parse_visuals_as_colliders:
             colliders = visuals
         else:
-            s = parse_shapes(link, visuals, density=0.0, just_visual=True, visible=not hide_visuals)
-            visual_shapes.extend(s)
+            parse_shapes(link, visuals, density=0.0, just_visual=True, visible=not hide_visuals)
 
         show_colliders = should_show_collider(
             force_show_colliders,
@@ -896,13 +894,13 @@ def parse_urdf(
         custom_attributes=articulation_custom_attrs,
     )
 
-    for i in range(start_shape_count, end_shape_count):
-        for j in visual_shapes:
-            builder.add_shape_collision_filter_pair(i, j)
-
     if not enable_self_collisions:
-        for i in range(start_shape_count, end_shape_count):
-            for j in range(i + 1, end_shape_count):
+        # The broad phase only ever tests colliding shapes, so visual-only shapes need no filter pairs.
+        colliding_shapes = [
+            i for i in range(start_shape_count, end_shape_count) if builder.shape_flags[i] & ShapeFlags.COLLIDE_SHAPES
+        ]
+        for a, i in enumerate(colliding_shapes):
+            for j in colliding_shapes[a + 1 :]:
                 builder.add_shape_collision_filter_pair(i, j)
 
     if collapse_fixed_joints:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -5859,6 +5859,32 @@ class TestImportMjcfComposition(unittest.TestCase):
         joint_articulation = model.joint_articulation.numpy()
         self.assertEqual(joint_articulation[0], joint_articulation[initial_joint_count])
 
+    def test_self_collision_filter_pairs_reference_only_colliding_shapes(self):
+        mjcf = """
+        <mujoco>
+          <worldbody>
+            <body name="b1">
+              <joint type="hinge" axis="0 0 1"/>
+              <geom type="sphere" size="0.1"/>
+              <geom type="sphere" size="0.1" contype="0" conaffinity="0"/>
+              <body name="b2">
+                <joint type="hinge" axis="0 0 1"/>
+                <geom type="sphere" size="0.1"/>
+              </body>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf, enable_self_collisions=False)
+
+        colliding = {i for i in range(builder.shape_count) if builder.shape_flags[i] & newton.ShapeFlags.COLLIDE_SHAPES}
+        self.assertEqual(len(colliding), 2)
+        filter_pairs = set(builder.shape_collision_filter_pairs)
+        self.assertIn(tuple(sorted(colliding)), filter_pairs)
+        for pair in filter_pairs:
+            self.assertLessEqual(set(pair), colliding)
+
     def test_exclude_tag(self):
         """Test that <exclude> tags properly filter collisions between specified body pairs."""
         builder = newton.ModelBuilder()

--- a/newton/tests/test_import_urdf.py
+++ b/newton/tests/test_import_urdf.py
@@ -631,6 +631,35 @@ class TestImportUrdfBasic(unittest.TestCase):
                 else:
                     self.assertIn(filter_pair, builder.shape_collision_filter_pairs)
 
+    def test_self_collision_filter_pairs_reference_only_colliding_shapes(self):
+        urdf = """<?xml version="1.0"?>
+        <robot name="visual_filter_test">
+          <link name="link1">
+            <collision><geometry><sphere radius="0.1"/></geometry></collision>
+            <visual><geometry><sphere radius="0.1"/></geometry></visual>
+          </link>
+          <link name="link2">
+            <collision><geometry><sphere radius="0.1"/></geometry></collision>
+            <visual><geometry><sphere radius="0.1"/></geometry></visual>
+          </link>
+          <joint name="j1" type="revolute">
+            <parent link="link1"/>
+            <child link="link2"/>
+            <axis xyz="0 0 1"/>
+            <limit lower="-1" upper="1" effort="10" velocity="1"/>
+          </joint>
+        </robot>
+        """
+        builder = newton.ModelBuilder()
+        builder.add_urdf(urdf, enable_self_collisions=False)
+
+        colliding = {i for i in range(builder.shape_count) if builder.shape_flags[i] & newton.ShapeFlags.COLLIDE_SHAPES}
+        self.assertEqual(len(colliding), 2)
+        filter_pairs = set(builder.shape_collision_filter_pairs)
+        self.assertIn(tuple(sorted(colliding)), filter_pairs)
+        for pair in filter_pairs:
+            self.assertLessEqual(set(pair), colliding)
+
     def test_revolute_joint_urdf(self):
         # Test a simple revolute joint with axis and limits
         builder = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Importers with `enable_self_collisions=False` and the `ModelBuilder` same-body, parent-child, and cable filter paths emit collision filter pairs over all shapes, including visual-only shapes the broad phase never tests. Every consumer already restricts itself to shapes with `ShapeFlags.COLLIDE_SHAPES` before consulting the filters (`find_shape_contact_pairs`, the SolverMuJoCo exclude generation, and `add_joint`'s own filter emission), so these pairs are unreachable.

They are not free, however: the kitchen benchmark environment generates 5.0M filter pairs per world, 93% of which reference non-colliding shapes, and expanding them across 512 replicated worlds during `finalize()` exhausts the 64 GiB benchmark runner (see the `FastKitchenG1` discussion on #3566). This PR restricts filter pair generation to colliding shapes, matching the existing `add_joint` guard; the kitchen world drops to 338K pairs (15x). The URDF importer's now write-only `visual_shapes` accumulator is removed along the way. A small residual of non-colliding pairs comes from the USD import path, which is not touched here.

This is safe with respect to later flag changes: `ShapeFlags.COLLIDE_SHAPES` is only ever cleared after shape creation, never enabled.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- New tests `test_import_mjcf.TestImportMjcfComposition.test_self_collision_filter_pairs_reference_only_colliding_shapes` and `test_import_urdf.TestImportUrdfBasic.test_self_collision_filter_pairs_reference_only_colliding_shapes` assert that self-collision filtering covers exactly the colliding shapes.
- `uv run --extra dev -m newton.tests -k test_import_mjcf -k test_import_urdf -k test_cable -k test_collision_pipeline -k test_builder_replicate -k test_environment_group_collision`

## Bug fix

**Steps to reproduce:**

1. Import an asset containing visual-only geometry with `enable_self_collisions=False`.
2. Inspect `builder.shape_collision_filter_pairs`: it contains pairs referencing shapes without `ShapeFlags.COLLIDE_SHAPES`, which no consumer can ever match. At scale (e.g. `ModelBuilder.replicate` of the kitchen environment at 512 worlds), materializing these pairs in `finalize()` runs out of host memory.

**Minimal reproduction:**

```python
import newton

MJCF = """<mujoco><worldbody><body><joint type="hinge"/>
<geom type="sphere" size="0.1"/>
<geom type="sphere" size="0.1" contype="0" conaffinity="0"/>
</body></worldbody></mujoco>"""

builder = newton.ModelBuilder()
builder.add_mjcf(MJCF, enable_self_collisions=False)
# Includes pairs referencing the visual-only geom:
print(builder.shape_collision_filter_pairs)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced excessive memory usage when importing MJCF and URDF models with many visual-only shapes and disabled self-collisions.
  * Improved collision filtering so visual-only shapes are excluded from collision filter pair generation.
  * Ensured collision filtering consistently respects shapes configured to participate in collisions.

* **Tests**
  * Added regression coverage for MJCF and URDF self-collision filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->