### PR TITLE
[Kamino] notify shape property updates

### DIFF
--- a/asv/benchmarks/simulation/bench_kamino.py
+++ b/asv/benchmarks/simulation/bench_kamino.py
@@ -8,6 +8,8 @@ from typing import ClassVar
 import warp as wp
 from asv_runner.benchmarks.mark import SkipNotImplemented, skip_benchmark_if
 
+import newton
+
 wp.config.enable_backward = False
 wp.config.log_level = wp.LOG_WARNING
 
@@ -113,6 +115,69 @@ class KpiDRLegs(_KpiBenchmark):
     samples = 2
 
 
+class NotifyDRLegs:
+    """Benchmark Kamino model notifications for 2048 DR Legs worlds."""
+
+    number = 10
+    repeat = 7
+    rounds = 1
+    timeout = 3600
+    world_count = 2048
+
+    def setup(self):
+        builder = DRLegsBenchmarkWorkload.create_model_builder("dr_legs", self.world_count)
+        model = builder.finalize(skip_validation_joints=True)
+        self._solver = newton.solvers.SolverKamino(model)
+        for flag in (
+            newton.ModelFlags.MODEL_PROPERTIES,
+            newton.ModelFlags.BODY_PROPERTIES,
+            newton.ModelFlags.BODY_INERTIAL_PROPERTIES,
+            newton.ModelFlags.SHAPE_PROPERTIES,
+            newton.ModelFlags.JOINT_PROPERTIES,
+            newton.ModelFlags.JOINT_DOF_PROPERTIES,
+            newton.ModelFlags.ACTUATOR_PROPERTIES,
+            newton.ModelFlags.ALL,
+        ):
+            self._solver.notify_model_changed(flag)
+        wp.synchronize_device()
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_actuator_properties(self):
+        self._notify(newton.ModelFlags.ACTUATOR_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_all(self):
+        self._notify(newton.ModelFlags.ALL)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_body_inertial_properties(self):
+        self._notify(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_body_properties(self):
+        self._notify(newton.ModelFlags.BODY_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_joint_dof_properties(self):
+        self._notify(newton.ModelFlags.JOINT_DOF_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_joint_properties(self):
+        self._notify(newton.ModelFlags.JOINT_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_model_properties(self):
+        self._notify(newton.ModelFlags.MODEL_PROPERTIES)
+
+    @skip_benchmark_if(wp.get_cuda_device_count() == 0)
+    def time_notify_shape_properties(self):
+        self._notify(newton.ModelFlags.SHAPE_PROPERTIES)
+
+    def _notify(self, flag):
+        self._solver.notify_model_changed(flag)
+        wp.synchronize_device()
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -121,6 +186,7 @@ if __name__ == "__main__":
     benchmark_list = {
         "FastDRLegs": FastDRLegs,
         "KpiDRLegs": KpiDRLegs,
+        "NotifyDRLegs": NotifyDRLegs,
     }
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -13,6 +13,7 @@ from .core.bodies import (
 )
 from .core.control import ControlKamino
 from .core.conversions import (
+    compute_material_first_shape,
     convert_model_joint_actuation,
     convert_model_joint_transforms,
     convert_model_materials,
@@ -45,6 +46,7 @@ __all__ = [
     "ModelKamino",
     "SolverKaminoImpl",
     "StateKamino",
+    "compute_material_first_shape",
     "convert_base_origin_to_com",
     "convert_body_com_to_origin",
     "convert_body_origin_to_com",

--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -12,7 +12,12 @@ from .core.bodies import (
     convert_geom_offset_origin_to_com,
 )
 from .core.control import ControlKamino
-from .core.conversions import convert_model_joint_transforms, convert_model_materials
+from .core.conversions import (
+    convert_model_joint_actuation,
+    convert_model_joint_transforms,
+    convert_model_materials,
+    validate_model_joint_updates,
+)
 from .core.gravity import convert_model_gravity
 from .core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType
 from .core.model import ModelKamino
@@ -47,7 +52,9 @@ __all__ = [
     "convert_contacts_newton_to_kamino",
     "convert_geom_offset_origin_to_com",
     "convert_model_gravity",
+    "convert_model_joint_actuation",
     "convert_model_joint_transforms",
     "convert_model_materials",
     "msg",
+    "validate_model_joint_updates",
 ]

--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -12,7 +12,7 @@ from .core.bodies import (
     convert_geom_offset_origin_to_com,
 )
 from .core.control import ControlKamino
-from .core.conversions import convert_model_joint_transforms
+from .core.conversions import convert_model_joint_transforms, convert_model_materials
 from .core.gravity import convert_model_gravity
 from .core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType
 from .core.model import ModelKamino
@@ -48,5 +48,6 @@ __all__ = [
     "convert_geom_offset_origin_to_com",
     "convert_model_gravity",
     "convert_model_joint_transforms",
+    "convert_model_materials",
     "msg",
 ]

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -813,8 +813,8 @@ def validate_model_joint_updates(
     violation of that type was found.
 
     Args:
-        model: The Newton model to validate.
-        joints: The JointsModel to validate.
+        model: The Newton model containing the updated joints to validate.
+        joints: The current Kamino joint model, before applying the updates.
         built_limit_finite: The built finite limit state for each DoF.
         violations: The array to store the violations.
         check_dof: Whether to check the DoF updates.
@@ -937,8 +937,7 @@ def compute_material_first_shape(
         the shape count as a sentinel.
     """
     shape_count = geom_material.shape[0]
-    first_shape = wp.empty(num_materials, dtype=wp.int32, device=geom_material.device)
-    first_shape.fill_(shape_count)
+    first_shape = wp.full(num_materials, shape_count, dtype=wp.int32, device=geom_material.device)
     if shape_count > 0:
         wp.launch(
             kernel=material_first_shape_kernel,

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -40,6 +40,7 @@ __all__ = [
     "convert_geometries",
     "convert_joints",
     "convert_model_joint_transforms",
+    "convert_model_materials",
     "convert_rigid_bodies",
     "convert_target_coords_to_target_dofs",
     "convert_target_dofs_to_target_coords",
@@ -652,6 +653,50 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
         ],
         device=model.device,
     )
+
+
+def convert_model_materials(model: Model, model_kamino: ModelKamino) -> None:
+    """Update Kamino's material properties in place from Newton shape materials.
+
+    Recomputes per-material friction and restitution from
+    ``model.shape_material_mu`` and ``model.shape_material_restitution`` while
+    preserving the material arrays referenced by Kamino's collision detector.
+
+    Args:
+        model: Newton model containing the updated shape materials.
+        model_kamino: Kamino model whose material tables are updated.
+
+    Raises:
+        RuntimeError: If shapes assigned to the same material ID have different
+            material properties and would require splitting that material.
+    """
+    shape_friction = model.shape_material_mu.numpy()
+    shape_restitution = model.shape_material_restitution.numpy()
+    geom_material = model_kamino.geoms.material.numpy()
+    materials = model_kamino.materials
+
+    updated_friction = materials.static_friction.numpy()
+    updated_restitution = materials.restitution.numpy()
+    material_written = np.zeros(materials.num_materials, dtype=bool)
+    for shape, material_id in enumerate(geom_material):
+        if material_written[material_id]:
+            if (
+                updated_friction[material_id] != shape_friction[shape]
+                or updated_restitution[material_id] != shape_restitution[shape]
+            ):
+                raise RuntimeError(
+                    f"Multiple shapes assigned to contact material {material_id} attempted to update it with "
+                    "different friction or restitution values; recreate SolverKamino to split the material."
+                )
+            continue
+
+        updated_friction[material_id] = shape_friction[shape]
+        updated_restitution[material_id] = shape_restitution[shape]
+        material_written[material_id] = True
+
+    materials.restitution.assign(updated_restitution)
+    materials.static_friction.assign(updated_friction)
+    materials.dynamic_friction.assign(updated_friction)
 
 
 def convert_rigid_bodies(

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -18,9 +18,11 @@ from .bodies import (
     convert_body_origin_to_com,
     convert_geom_offset_origin_to_com,
 )
-from .builder import JointActuationType
 from .geometry import GeometriesModel
 from .joints import (
+    JOINT_QMAX,
+    JOINT_QMIN,
+    JointActuationType,
     JointDoFType,
     JointsModel,
 )
@@ -39,17 +41,48 @@ if TYPE_CHECKING:
 __all__ = [
     "convert_geometries",
     "convert_joints",
+    "convert_model_joint_actuation",
     "convert_model_joint_transforms",
     "convert_model_materials",
     "convert_rigid_bodies",
     "convert_target_coords_to_target_dofs",
     "convert_target_dofs_to_target_coords",
+    "validate_model_joint_updates",
 ]
 
 
 ###
 # Kernels
 ###
+
+
+@wp.func
+def joint_actuation_type_from_dofs(
+    dof_start: int,
+    dof_end: int,
+    target_mode: wp.array[wp.int32],
+) -> int:
+    """Aggregate Newton's per-DoF target modes into a Kamino joint actuation type."""
+    joint_target_mode = int(0)
+    for dof in range(dof_start, dof_end):
+        joint_target_mode = max(joint_target_mode, target_mode[dof])
+    return JointActuationType.from_newton_wp(joint_target_mode)
+
+
+@wp.func
+def joint_requires_dynamic_constraints(
+    dof_start: int,
+    dof_end: int,
+    armature: wp.array[wp.float32],
+    damping: wp.array[wp.float32],
+    target_ke: wp.array[wp.float32],
+    target_kd: wp.array[wp.float32],
+) -> bool:
+    """Return whether any DoF makes a joint dynamic."""
+    dynamic = bool(False)
+    for dof in range(dof_start, dof_end):
+        dynamic = dynamic or (armature[dof] > 0.0 or damping[dof] > 0.0 or target_ke[dof] > 0.0 or target_kd[dof] > 0.0)
+    return dynamic
 
 
 @wp.kernel
@@ -89,6 +122,126 @@ def world_max_contacts_kernel(
     if max_contacts_per_pair >= 0:
         num_contacts = min(num_contacts, max_contacts_per_pair)
     wp.atomic_add(world_max_contacts, world_id, num_contacts)
+
+
+@wp.kernel
+def material_first_shape_kernel(
+    geom_material: wp.array[wp.int32],
+    first_shape: wp.array[wp.int32],
+):
+    shape = wp.tid()
+    material = geom_material[shape]
+    if material >= 0:
+        wp.atomic_min(first_shape, material, shape)
+
+
+@wp.kernel
+def validate_material_update_kernel(
+    shape_friction: wp.array[wp.float32],
+    shape_restitution: wp.array[wp.float32],
+    geom_material: wp.array[wp.int32],
+    first_shape: wp.array[wp.int32],
+    conflict_material: wp.array[wp.int32],
+):
+    shape = wp.tid()
+    material = geom_material[shape]
+    if material < 0:
+        return
+    representative = first_shape[material]
+    if (
+        shape_friction[shape] != shape_friction[representative]
+        or shape_restitution[shape] != shape_restitution[representative]
+    ):
+        wp.atomic_min(conflict_material, 0, material)
+
+
+@wp.kernel
+def update_materials_kernel(
+    shape_friction: wp.array[wp.float32],
+    shape_restitution: wp.array[wp.float32],
+    first_shape: wp.array[wp.int32],
+    shape_count: int,
+    restitution: wp.array[wp.float32],
+    static_friction: wp.array[wp.float32],
+    dynamic_friction: wp.array[wp.float32],
+    pair_restitution: wp.array[wp.float32],
+    pair_static_friction: wp.array[wp.float32],
+    pair_dynamic_friction: wp.array[wp.float32],
+):
+    material = wp.tid()
+    shape = first_shape[material]
+    if shape < shape_count:
+        friction = shape_friction[shape]
+        restitution[material] = shape_restitution[shape]
+        static_friction[material] = friction
+        dynamic_friction[material] = friction
+        if material == 0:
+            pair_restitution[0] = shape_restitution[shape]
+            pair_static_friction[0] = friction
+            pair_dynamic_friction[0] = friction
+
+
+@wp.kernel
+def validate_joint_updates_kernel(
+    joint_qd_start: wp.array[wp.int32],
+    joint_armature: wp.array[wp.float32],
+    joint_damping: wp.array[wp.float32],
+    joint_target_ke: wp.array[wp.float32],
+    joint_target_kd: wp.array[wp.float32],
+    joint_target_mode: wp.array[wp.int32],
+    joint_limit_lower: wp.array[wp.float32],
+    joint_limit_upper: wp.array[wp.float32],
+    built_limit_finite: wp.array[wp.int32],
+    num_dynamic_cts: wp.array[wp.int32],
+    act_type: wp.array[wp.int32],
+    joint_count: int,
+    dof_count: int,
+    check_dynamic: int,
+    check_limits: int,
+    check_actuation: int,
+    violations: wp.array[wp.int32],
+):
+    tid = wp.tid()
+
+    if tid < joint_count and (check_dynamic != 0 or check_actuation != 0):
+        dof_start = joint_qd_start[tid]
+        dof_end = joint_qd_start[tid + 1]
+
+        if check_dynamic != 0 and joint_requires_dynamic_constraints(
+            dof_start,
+            dof_end,
+            joint_armature,
+            joint_damping,
+            joint_target_ke,
+            joint_target_kd,
+        ) != (num_dynamic_cts[tid] > 0):
+            wp.atomic_min(violations, 0, tid)
+
+        if check_actuation != 0:
+            current_actuation = joint_actuation_type_from_dofs(dof_start, dof_end, joint_target_mode)
+            if current_actuation < 0:
+                wp.atomic_min(violations, 3, tid)
+            elif (current_actuation == JointActuationType.PASSIVE) != (act_type[tid] == JointActuationType.PASSIVE):
+                wp.atomic_min(violations, 2, tid)
+
+    if tid < dof_count and check_limits != 0:
+        current_finite = joint_limit_lower[tid] > JOINT_QMIN or joint_limit_upper[tid] < JOINT_QMAX
+        if current_finite != (built_limit_finite[tid] != 0):
+            wp.atomic_min(violations, 1, tid)
+
+
+@wp.kernel
+def update_joint_actuation_kernel(
+    joint_qd_start: wp.array[wp.int32],
+    joint_target_mode: wp.array[wp.int32],
+    act_type: wp.array[wp.int32],
+):
+    joint = wp.tid()
+    act_type[joint] = joint_actuation_type_from_dofs(
+        joint_qd_start[joint],
+        joint_qd_start[joint + 1],
+        joint_target_mode,
+    )
 
 
 @wp.kernel
@@ -183,21 +336,19 @@ def joint_conversion_kernel(
     joint_num_dofs[joint_id] = ndofs_j
 
     # Determine Kamino actuation mode for joint
-    joint_dofs_target_mode_j = int(0)
-    for dof_id in range(ndofs_j):
-        joint_dofs_target_mode_j = max(joint_dofs_target_mode_j, model_joint_target_mode[dofs_start_j + dof_id])
-    act_type_j = JointActuationType.from_newton_wp(joint_dofs_target_mode_j)
+    act_type_j = joint_actuation_type_from_dofs(dofs_start_j, dofs_start_j + ndofs_j, model_joint_target_mode)
     assert act_type_j >= 0, "Joint actuation type must be valid"
     joint_act_type[joint_id] = act_type_j
 
-    is_dynamic_j = bool(False)
     # Infer if the joint requires dynamic constraints
-    for dof_id in range(ndofs_j):
-        a_j = model_joint_armature[dofs_start_j + dof_id]
-        b_j = model_joint_damping[dofs_start_j + dof_id]
-        ke_j = model_joint_target_ke[dofs_start_j + dof_id]
-        kd_j = model_joint_target_kd[dofs_start_j + dof_id]
-        is_dynamic_j = is_dynamic_j or (a_j > 0.0) or (b_j > 0.0) or (ke_j > 0.0) or (kd_j > 0.0)
+    is_dynamic_j = joint_requires_dynamic_constraints(
+        dofs_start_j,
+        dofs_start_j + ndofs_j,
+        model_joint_armature,
+        model_joint_damping,
+        model_joint_target_ke,
+        model_joint_target_kd,
+    )
 
     # Set joint dimensions
     joint_num_kinematic_cts[joint_id] = ncts_j
@@ -616,6 +767,65 @@ def compute_required_contact_capacity(
     return int(np.sum(world_max_contacts)), world_max_contacts.astype(int).tolist()
 
 
+def validate_model_joint_updates(
+    model: Model,
+    joints: JointsModel,
+    built_limit_finite: wp.array[wp.int32],
+    violations: wp.array[wp.int32],
+    check_dof: bool,
+    check_actuation: bool,
+) -> np.ndarray:
+    """Validate that runtime joint edits preserve Kamino's structural layout."""
+    dim = max(model.joint_count, model.joint_dof_count)
+    violations.fill_(dim)
+    if dim > 0:
+        wp.launch(
+            kernel=validate_joint_updates_kernel,
+            dim=dim,
+            inputs=[
+                # Inputs:
+                model.joint_qd_start,
+                model.joint_armature,
+                model.joint_damping,
+                model.joint_target_ke,
+                model.joint_target_kd,
+                model.joint_target_mode,
+                model.joint_limit_lower,
+                model.joint_limit_upper,
+                built_limit_finite,
+                joints.num_dynamic_cts,
+                joints.act_type,
+                model.joint_count,
+                model.joint_dof_count,
+                int(check_dof),
+                int(check_dof),
+                int(check_actuation),
+                # Outputs:
+                violations,
+            ],
+            device=model.device,
+        )
+    return violations.numpy()
+
+
+def convert_model_joint_actuation(model: Model, joints: JointsModel) -> None:
+    """Update Kamino's per-joint actuation types from Newton target modes."""
+    if model.joint_count == 0:
+        return
+    wp.launch(
+        kernel=update_joint_actuation_kernel,
+        dim=model.joint_count,
+        inputs=[
+            # Inputs:
+            model.joint_qd_start,
+            model.joint_target_mode,
+            # Outputs:
+            joints.act_type,
+        ],
+        device=model.device,
+    )
+
+
 def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     """
     Converts the joint model parameterization of Newton's to Kamino's format.
@@ -655,7 +865,12 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     )
 
 
-def convert_model_materials(model: Model, model_kamino: ModelKamino) -> None:
+def convert_model_materials(
+    model: Model,
+    model_kamino: ModelKamino,
+    first_shape: wp.array[wp.int32],
+    conflict: wp.array[wp.int32],
+) -> None:
     """Update Kamino's material properties in place from Newton shape materials.
 
     Recomputes per-material friction and restitution from
@@ -665,38 +880,68 @@ def convert_model_materials(model: Model, model_kamino: ModelKamino) -> None:
     Args:
         model: Newton model containing the updated shape materials.
         model_kamino: Kamino model whose material tables are updated.
+        first_shape: Per-material scratch array for selecting representative shapes.
+        conflict: Scratch scalar for reporting conflicting material updates.
 
     Raises:
         RuntimeError: If shapes assigned to the same material ID have different
             material properties and would require splitting that material.
     """
-    shape_friction = model.shape_material_mu.numpy()
-    shape_restitution = model.shape_material_restitution.numpy()
-    geom_material = model_kamino.geoms.material.numpy()
     materials = model_kamino.materials
+    first_shape.fill_(model.shape_count)
+    conflict.fill_(materials.num_materials)
+    wp.launch(
+        kernel=material_first_shape_kernel,
+        dim=model.shape_count,
+        inputs=[
+            # Inputs:
+            model_kamino.geoms.material,
+            # Outputs:
+            first_shape,
+        ],
+        device=model.device,
+    )
+    wp.launch(
+        kernel=validate_material_update_kernel,
+        dim=model.shape_count,
+        inputs=[
+            # Inputs:
+            model.shape_material_mu,
+            model.shape_material_restitution,
+            model_kamino.geoms.material,
+            first_shape,
+            # Outputs:
+            conflict,
+        ],
+        device=model.device,
+    )
 
-    updated_friction = materials.static_friction.numpy()
-    updated_restitution = materials.restitution.numpy()
-    material_written = np.zeros(materials.num_materials, dtype=bool)
-    for shape, material_id in enumerate(geom_material):
-        if material_written[material_id]:
-            if (
-                updated_friction[material_id] != shape_friction[shape]
-                or updated_restitution[material_id] != shape_restitution[shape]
-            ):
-                raise RuntimeError(
-                    f"Multiple shapes assigned to contact material {material_id} attempted to update it with "
-                    "different friction or restitution values; recreate SolverKamino to split the material."
-                )
-            continue
+    conflict_material = int(conflict.numpy()[0])
+    if conflict_material < materials.num_materials:
+        raise RuntimeError(
+            f"Multiple shapes assigned to contact material {conflict_material} attempted to update it with "
+            "different friction or restitution values; recreate SolverKamino to split the material."
+        )
 
-        updated_friction[material_id] = shape_friction[shape]
-        updated_restitution[material_id] = shape_restitution[shape]
-        material_written[material_id] = True
-
-    materials.restitution.assign(updated_restitution)
-    materials.static_friction.assign(updated_friction)
-    materials.dynamic_friction.assign(updated_friction)
+    wp.launch(
+        kernel=update_materials_kernel,
+        dim=materials.num_materials,
+        inputs=[
+            # Inputs:
+            model.shape_material_mu,
+            model.shape_material_restitution,
+            first_shape,
+            model.shape_count,
+            # Outputs:
+            materials.restitution,
+            materials.static_friction,
+            materials.dynamic_friction,
+            model_kamino.material_pairs.restitution,
+            model_kamino.material_pairs.static_friction,
+            model_kamino.material_pairs.dynamic_friction,
+        ],
+        device=model.device,
+    )
 
 
 def convert_rigid_bodies(

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -126,9 +126,12 @@ def world_max_contacts_kernel(
 
 @wp.kernel
 def material_first_shape_kernel(
+    # Inputs:
     geom_material: wp.array[wp.int32],
+    # Outputs:
     first_shape: wp.array[wp.int32],
 ):
+    """Record the first shape index associated with each material."""
     shape = wp.tid()
     material = geom_material[shape]
     if material >= 0:
@@ -143,6 +146,7 @@ def validate_material_update_kernel(
     first_shape: wp.array[wp.int32],
     conflict_material: wp.array[wp.int32],
 ):
+    """Find the first material whose shapes have conflicting properties."""
     shape = wp.tid()
     material = geom_material[shape]
     if material < 0:
@@ -157,10 +161,12 @@ def validate_material_update_kernel(
 
 @wp.kernel
 def update_materials_kernel(
+    # Inputs:
     shape_friction: wp.array[wp.float32],
     shape_restitution: wp.array[wp.float32],
     first_shape: wp.array[wp.int32],
     shape_count: int,
+    # Outputs:
     restitution: wp.array[wp.float32],
     static_friction: wp.array[wp.float32],
     dynamic_friction: wp.array[wp.float32],
@@ -168,6 +174,10 @@ def update_materials_kernel(
     pair_static_friction: wp.array[wp.float32],
     pair_dynamic_friction: wp.array[wp.float32],
 ):
+    """Update Kamino material properties from cached representative shapes.
+
+    The material-zero properties are also copied to the default material pair.
+    """
     material = wp.tid()
     shape = first_shape[material]
     if shape < shape_count:
@@ -182,32 +192,28 @@ def update_materials_kernel(
 
 
 @wp.kernel
-def validate_joint_updates_kernel(
+def validate_joint_dof_updates_kernel(
+    # Inputs:
     joint_qd_start: wp.array[wp.int32],
     joint_armature: wp.array[wp.float32],
     joint_damping: wp.array[wp.float32],
     joint_target_ke: wp.array[wp.float32],
     joint_target_kd: wp.array[wp.float32],
-    joint_target_mode: wp.array[wp.int32],
+    num_dynamic_cts: wp.array[wp.int32],
     joint_limit_lower: wp.array[wp.float32],
     joint_limit_upper: wp.array[wp.float32],
     built_limit_finite: wp.array[wp.int32],
-    num_dynamic_cts: wp.array[wp.int32],
-    act_type: wp.array[wp.int32],
     joint_count: int,
     dof_count: int,
-    check_dynamic: int,
-    check_limits: int,
-    check_actuation: int,
+    # Outputs:
     violations: wp.array[wp.int32],
 ):
+    """Find the first structural change to joint degree-of-freedom properties."""
     tid = wp.tid()
-
-    if tid < joint_count and (check_dynamic != 0 or check_actuation != 0):
+    if tid < joint_count:
         dof_start = joint_qd_start[tid]
         dof_end = joint_qd_start[tid + 1]
-
-        if check_dynamic != 0 and joint_requires_dynamic_constraints(
+        if joint_requires_dynamic_constraints(
             dof_start,
             dof_end,
             joint_armature,
@@ -217,25 +223,43 @@ def validate_joint_updates_kernel(
         ) != (num_dynamic_cts[tid] > 0):
             wp.atomic_min(violations, 0, tid)
 
-        if check_actuation != 0:
-            current_actuation = joint_actuation_type_from_dofs(dof_start, dof_end, joint_target_mode)
-            if current_actuation < 0:
-                wp.atomic_min(violations, 3, tid)
-            elif (current_actuation == JointActuationType.PASSIVE) != (act_type[tid] == JointActuationType.PASSIVE):
-                wp.atomic_min(violations, 2, tid)
-
-    if tid < dof_count and check_limits != 0:
+    if tid < dof_count:
         current_finite = joint_limit_lower[tid] > JOINT_QMIN or joint_limit_upper[tid] < JOINT_QMAX
         if current_finite != (built_limit_finite[tid] != 0):
             wp.atomic_min(violations, 1, tid)
 
 
 @wp.kernel
-def update_joint_actuation_kernel(
+def validate_joint_actuation_updates_kernel(
+    # Inputs:
     joint_qd_start: wp.array[wp.int32],
     joint_target_mode: wp.array[wp.int32],
     act_type: wp.array[wp.int32],
+    # Outputs:
+    violations: wp.array[wp.int32],
 ):
+    """Find the first joint with an invalid or structurally changed actuation type."""
+    joint = wp.tid()
+    current_actuation = joint_actuation_type_from_dofs(
+        joint_qd_start[joint],
+        joint_qd_start[joint + 1],
+        joint_target_mode,
+    )
+    if current_actuation < 0:
+        wp.atomic_min(violations, 3, joint)
+    elif (current_actuation == JointActuationType.PASSIVE) != (act_type[joint] == JointActuationType.PASSIVE):
+        wp.atomic_min(violations, 2, joint)
+
+
+@wp.kernel
+def update_joint_actuation_kernel(
+    # Inputs:
+    joint_qd_start: wp.array[wp.int32],
+    joint_target_mode: wp.array[wp.int32],
+    # Outputs:
+    act_type: wp.array[wp.int32],
+):
+    """Update each joint's Kamino actuation type from its target modes."""
     joint = wp.tid()
     act_type[joint] = joint_actuation_type_from_dofs(
         joint_qd_start[joint],
@@ -772,15 +796,38 @@ def validate_model_joint_updates(
     joints: JointsModel,
     built_limit_finite: wp.array[wp.int32],
     violations: wp.array[wp.int32],
+    *,
     check_dof: bool,
     check_actuation: bool,
-) -> np.ndarray:
-    """Validate that runtime joint edits preserve Kamino's structural layout."""
+) -> int:
+    """Validate that runtime joint edits preserve Kamino's structural layout.
+
+    ``violations`` is a four-entry array containing the first index for each
+    violation type:
+       0: a joint whose dynamic-constraint topology changed
+       1: a DoF whose finite-limit state changed
+       2: a joint whose passive/actuated partition changed
+       3: a joint with an unsupported combination of target modes
+
+    An entry equal to the maximum of the joint and DoF counts indicates that no
+    violation of that type was found.
+
+    Args:
+        model: The Newton model to validate.
+        joints: The JointsModel to validate.
+        built_limit_finite: The built finite limit state for each DoF.
+        violations: The array to store the violations.
+        check_dof: Whether to check the DoF updates.
+        check_actuation: Whether to check the actuation updates.
+
+    Returns:
+        The sentinel value indicating no violations.
+    """
     dim = max(model.joint_count, model.joint_dof_count)
     violations.fill_(dim)
-    if dim > 0:
+    if check_dof and dim > 0:
         wp.launch(
-            kernel=validate_joint_updates_kernel,
+            kernel=validate_joint_dof_updates_kernel,
             dim=dim,
             inputs=[
                 # Inputs:
@@ -789,23 +836,33 @@ def validate_model_joint_updates(
                 model.joint_damping,
                 model.joint_target_ke,
                 model.joint_target_kd,
-                model.joint_target_mode,
+                joints.num_dynamic_cts,
                 model.joint_limit_lower,
                 model.joint_limit_upper,
                 built_limit_finite,
-                joints.num_dynamic_cts,
-                joints.act_type,
                 model.joint_count,
                 model.joint_dof_count,
-                int(check_dof),
-                int(check_dof),
-                int(check_actuation),
                 # Outputs:
                 violations,
             ],
             device=model.device,
         )
-    return violations.numpy()
+    if check_actuation and model.joint_count > 0:
+        wp.launch(
+            kernel=validate_joint_actuation_updates_kernel,
+            dim=model.joint_count,
+            inputs=[
+                # Inputs:
+                model.joint_qd_start,
+                model.joint_target_mode,
+                joints.act_type,
+                # Outputs:
+                violations,
+            ],
+            device=model.device,
+        )
+
+    return dim
 
 
 def convert_model_joint_actuation(model: Model, joints: JointsModel) -> None:
@@ -865,6 +922,38 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     )
 
 
+def compute_material_first_shape(
+    geom_material: wp.array[wp.int32],
+    num_materials: int,
+) -> wp.array[wp.int32]:
+    """Compute the first shape associated with each fixed material ID.
+
+    Args:
+        geom_material: Material ID for each shape.
+        num_materials: Number of registered materials.
+
+    Returns:
+        Per-material shape indices. Materials without an associated shape use
+        the shape count as a sentinel.
+    """
+    shape_count = geom_material.shape[0]
+    first_shape = wp.empty(num_materials, dtype=wp.int32, device=geom_material.device)
+    first_shape.fill_(shape_count)
+    if shape_count > 0:
+        wp.launch(
+            kernel=material_first_shape_kernel,
+            dim=shape_count,
+            inputs=[
+                # Inputs:
+                geom_material,
+                # Outputs:
+                first_shape,
+            ],
+            device=geom_material.device,
+        )
+    return first_shape
+
+
 def convert_model_materials(
     model: Model,
     model_kamino: ModelKamino,
@@ -880,7 +969,7 @@ def convert_model_materials(
     Args:
         model: Newton model containing the updated shape materials.
         model_kamino: Kamino model whose material tables are updated.
-        first_shape: Per-material scratch array for selecting representative shapes.
+        first_shape: Cached first shape associated with each fixed material ID.
         conflict: Scratch scalar for reporting conflicting material updates.
 
     Raises:
@@ -888,19 +977,9 @@ def convert_model_materials(
             material properties and would require splitting that material.
     """
     materials = model_kamino.materials
-    first_shape.fill_(model.shape_count)
     conflict.fill_(materials.num_materials)
-    wp.launch(
-        kernel=material_first_shape_kernel,
-        dim=model.shape_count,
-        inputs=[
-            # Inputs:
-            model_kamino.geoms.material,
-            # Outputs:
-            first_shape,
-        ],
-        device=model.device,
-    )
+
+    # Check each shape against the cached representative for its material.
     wp.launch(
         kernel=validate_material_update_kernel,
         dim=model.shape_count,
@@ -923,6 +1002,7 @@ def convert_model_materials(
             "different friction or restitution values; recreate SolverKamino to split the material."
         )
 
+    # Once conflicts have been ruled out, update the material properties in place.
     wp.launch(
         kernel=update_materials_kernel,
         dim=materials.num_materials,

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -48,7 +48,7 @@ The default gravitational acceleration in m/s^2.
 Equal to Earth's standard gravity of approximately 9.8067 m/s^2.
 """
 
-GRAVITY_DIREC_DEFAULT = [0.0, 0.0, -1.0]
+GRAVITY_DIREC_DEFAULT = wp.constant(wp.vec3f(wp.float32(0.0), wp.float32(0.0), wp.float32(-1.0)))
 """The default direction of gravity defined as -Z."""
 
 
@@ -195,7 +195,7 @@ def _convert_model_gravity_kernel(
     world = wp.tid()
     gravity_vector = gravity[world]
     acceleration = wp.length(gravity_vector)
-    direction = wp.vec3f(0.0, 0.0, -1.0)
+    direction = GRAVITY_DIREC_DEFAULT
     enabled = 0.0
     if acceleration > 0.0:
         direction = gravity_vector / acceleration

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import numpy as np
 import warp as wp
 
 from .....core.types import override
@@ -187,7 +186,24 @@ class GravityModel:
 ###
 
 
-# TODO: Re-implement using kernels
+@wp.kernel
+def _convert_model_gravity_kernel(
+    gravity: wp.array[wp.vec3f],
+    g_dir_acc: wp.array[wp.vec4f],
+    vector: wp.array[wp.vec4f],
+):
+    world = wp.tid()
+    gravity_vector = gravity[world]
+    acceleration = wp.length(gravity_vector)
+    direction = wp.vec3f(0.0, 0.0, -1.0)
+    enabled = 0.0
+    if acceleration > 0.0:
+        direction = gravity_vector / acceleration
+        enabled = 1.0
+    g_dir_acc[world] = wp.vec4f(direction[0], direction[1], direction[2], acceleration)
+    vector[world] = wp.vec4f(gravity_vector[0], gravity_vector[1], gravity_vector[2], enabled)
+
+
 def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = None) -> GravityModel:
     """
     Converts the gravity representation from the Newton model to the Kamino format.
@@ -199,49 +215,31 @@ def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = No
             If the arrays within `gravity_out` are not already allocated
             with the appropriate shapes, this function will allocate them.
     """
-    # Capture the necessary properties from source model
-    gravity_np = model_in.gravity.numpy().copy()
-
-    # Allocate data for the conversion
-    g_dir_acc_np = np.zeros((model_in.world_count, 4), dtype=np.float32)
-    vector_np = np.zeros((model_in.world_count, 4), dtype=np.float32)
-
-    # Convert each world's gravity vector into direction
-    # and acceleration, and pack into the output arrays
-    for w in range(model_in.world_count):
-        g_vec = gravity_np[w, :]
-        accel = float(np.linalg.norm(g_vec))
-        if accel > 0.0:
-            direction = g_vec / accel
-        else:
-            direction = np.array([0.0, 0.0, -1.0])
-        g_dir_acc_np[w, :3] = direction
-        g_dir_acc_np[w, 3] = accel
-        vector_np[w, :3] = g_vec
-        vector_np[w, 3] = 1.0 if accel > 0.0 else 0.0
-
-    # If the output gravity model is not provided, create a new one with allocated arrays;
     if gravity_out is None:
         with wp.ScopedDevice(model_in.device):
             gravity_out = GravityModel(
-                g_dir_acc=wp.array(g_dir_acc_np, dtype=wp.vec4f),
-                vector=wp.array(vector_np, dtype=wp.vec4f),
+                g_dir_acc=wp.empty(model_in.world_count, dtype=wp.vec4f),
+                vector=wp.empty(model_in.world_count, dtype=wp.vec4f),
             )
-
-    # Otherwise, ensure the provided model has allocated arrays of the
-    # correct shape and type, and copy the converted data into them.
     else:
-        # Ensure that the output GravityModel has allocated arrays of the correct shape and type
         if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.g_dir_acc` array does not have matching shape. Allocating a new array.")
-            gravity_out.g_dir_acc = wp.array(g_dir_acc_np, dtype=wp.vec4f, device=model_in.device)
-        else:
-            gravity_out.g_dir_acc.assign(g_dir_acc_np)
+            gravity_out.g_dir_acc = wp.empty(model_in.world_count, dtype=wp.vec4f, device=model_in.device)
         if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count,):
             msg.warning("Output `GravityModel.vector` array does not have matching shape. Allocating a new array.")
-            gravity_out.vector = wp.array(vector_np, dtype=wp.vec4f, device=model_in.device)
-        else:
-            gravity_out.vector.assign(vector_np)
+            gravity_out.vector = wp.empty(model_in.world_count, dtype=wp.vec4f, device=model_in.device)
 
-    # Return the output gravity model
+    wp.launch(
+        kernel=_convert_model_gravity_kernel,
+        dim=model_in.world_count,
+        inputs=[
+            # Inputs:
+            model_in.gravity,
+            # Outputs:
+            gravity_out.g_dir_acc,
+            gravity_out.vector,
+        ],
+        device=model_in.device,
+    )
+
     return gravity_out

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -896,10 +896,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._update_geom_offsets()
 
         if flags & ModelFlags.SHAPE_PROPERTIES:
-            pass  # TODO: contact materials.
-
-        if flags & ModelFlags.JOINT_DOF_PROPERTIES:
-            pass
+            self._update_materials()
 
         if flags & (ModelFlags.CONSTRAINT_PROPERTIES | ModelFlags.TENDON_PROPERTIES):
             # Kamino does not support equality/mimic constraints or tendons, so we ignore these flags.
@@ -1246,3 +1243,7 @@ class SolverKamino(SolverBase, CouplingInterface):
     def _update_joint_transforms(self):
         """Re-derive Kamino joint anchors and axes from Newton's joint transforms."""
         self._kamino.convert_model_joint_transforms(self.model, self._model_kamino.joints)
+
+    def _update_materials(self) -> None:
+        """Refresh Kamino contact-material tables from Newton shape materials."""
+        self._kamino.convert_model_materials(self.model, self._model_kamino)

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -19,7 +19,6 @@ from ...core.types import override
 from ...sim import (
     Contacts,
     Control,
-    JointTargetMode,
     JointType,
     Model,
     ModelBuilder,
@@ -620,7 +619,21 @@ class SolverKamino(SolverBase, CouplingInterface):
         # Store for which joints the limits are finite. This is used to validate that finiteness of limits is not changed at runtime.
         q_min = self._model_kamino.joints.q_j_min.numpy()
         q_max = self._model_kamino.joints.q_j_max.numpy()
-        self._built_limit_finite = (q_min > self._kamino.JOINT_QMIN) | (q_max < self._kamino.JOINT_QMAX)
+        built_limit_finite_np = (q_min > self._kamino.JOINT_QMIN) | (q_max < self._kamino.JOINT_QMAX)
+        self._built_limit_finite = wp.array(
+            built_limit_finite_np.astype(np.int32),
+            dtype=wp.int32,
+            device=model.device,
+        )
+
+        # Scratch array for notify validation
+        self._notify_violations = wp.empty(4, dtype=wp.int32, device=model.device)
+
+        # Scratch arrays for material update validation
+        self._material_update_first_shape = wp.empty(
+            self._model_kamino.materials.num_materials, dtype=wp.int32, device=model.device
+        )
+        self._material_update_conflict = wp.empty(1, dtype=wp.int32, device=model.device)
 
         # Create a collision detector if enabled in the config, otherwise
         # set to `None` to disable internal collision detection in Kamino
@@ -1126,40 +1139,27 @@ class SolverKamino(SolverBase, CouplingInterface):
         Raises:
             RuntimeError: If the solver must be recreated to apply the edit.
         """
-        if flags & ModelFlags.JOINT_DOF_PROPERTIES:
-            self._check_dynamic_constraint_topology()
-            self._check_limit_capacity()
-        if flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES):
-            self._check_actuation_types()
+        check_dof = bool(flags & ModelFlags.JOINT_DOF_PROPERTIES)
+        check_actuation = bool(flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES))
+        if not check_dof and not check_actuation:
+            return
 
-    def _reduce_dof_maximum_by_joint(self, values: np.ndarray) -> np.ndarray:
-        """Reduce per-DoF values to per-joint maxima, including zero-DoF joints."""
-        starts = self.model.joint_qd_start.numpy()
-        nonempty = np.diff(starts) > 0
-        maxima = np.zeros(self.model.joint_count, dtype=values.dtype)
-        if np.any(nonempty):
-            maxima[nonempty] = np.maximum.reduceat(values, starts[:-1][nonempty])
-        return maxima
+        dim = max(self.model.joint_count, self.model.joint_dof_count)
+        if dim == 0:
+            return
 
-    def _check_dynamic_constraint_topology(self) -> None:
-        """Check that each joint retains its as-built dynamic status.
-
-        Kamino marks a joint dynamic when any of its DoFs has positive armature,
-        damping, target stiffness, or target damping. A dynamic joint receives
-        one dynamic constraint per DoF, so preserving this status also preserves
-        its constraint count.
-        """
-        dof_dynamic = (
-            (self.model.joint_armature.numpy() > 0.0)
-            | (self.model.joint_damping.numpy() > 0.0)
-            | (self.model.joint_target_ke.numpy() > 0.0)
-            | (self.model.joint_target_kd.numpy() > 0.0)
+        sentinel = dim
+        dynamic_joint, limit_dof, actuation_joint, invalid_joint = self._kamino.validate_model_joint_updates(
+            model=self.model,
+            joints=self._model_kamino.joints,
+            built_limit_finite=self._built_limit_finite,
+            violations=self._notify_violations,
+            check_dof=check_dof,
+            check_actuation=check_actuation,
         )
-        current_dynamic = self._reduce_dof_maximum_by_joint(dof_dynamic)
-        built_dynamic = self._model_kamino.joints.num_dynamic_cts.numpy() > 0
-        changed = np.flatnonzero(current_dynamic != built_dynamic)
-        if changed.size > 0:
-            joint = int(changed[0])  # report only first violation
+
+        if dynamic_joint != sentinel:
+            joint = int(dynamic_joint)
             raise RuntimeError(
                 f"Changing dynamic constraint topology for joint {joint} "
                 f"({self.model.joint_label[joint]!r}) is not supported; recreate SolverKamino to apply the change. "
@@ -1167,57 +1167,27 @@ class SolverKamino(SolverBase, CouplingInterface):
                 "The opposite is also true: if the values are updated to zero, while they were non-zero when creating the solver, the dynamic constraint topology also changes."
             )
 
-    def _check_actuation_types(self) -> None:
-        """Check that each joint remains in its as-built actuation partition.
+        if limit_dof != sentinel:
+            dof = int(limit_dof)
+            raise RuntimeError(
+                f"Changing the existence of a joint limit for DoF {dof} "
+                f"is not supported; recreate SolverKamino to apply the change."
+            )
 
-        The comparison follows Kamino's per-joint aggregation so individual DoF
-        changes are allowed when the joint remains actuated or remains passive.
-        """
-        current_actuation = self._get_joint_actuation()
-        built_actuation = self._model_kamino.joints.act_type.numpy()
-        current_passive = current_actuation == self._kamino.JointActuationType.PASSIVE
-        built_passive = built_actuation == self._kamino.JointActuationType.PASSIVE
-        changed = np.flatnonzero(current_passive != built_passive)
-        if changed.size > 0:
-            joint = int(changed[0])  # report only first violation
+        if invalid_joint != sentinel:
+            joint = int(invalid_joint)
+            raise ValueError(f"Unsupported joint target mode for joint {joint}")
+
+        if actuation_joint != sentinel:
+            joint = int(actuation_joint)
             raise RuntimeError(
                 f"Changing the actuation partition for joint {joint} "
                 f"({self.model.joint_label[joint]!r}) is not supported; recreate SolverKamino to apply the change."
             )
 
-    def _get_joint_actuation(self) -> np.ndarray:
-        """Compute Kamino's per-joint actuation types.
-
-        Newton stores one target mode per DoF. Kamino takes the maximum target
-        mode over all DoFs of a joint, then maps that value to a
-        ``JointActuationType``. Zero-DoF joints retain the reduction's default
-        target mode, ``JointTargetMode.NONE``.
-        """
-        target_modes = self._reduce_dof_maximum_by_joint(self.model.joint_target_mode.numpy())
-        return np.array(
-            [
-                int(self._kamino.JointActuationType.from_newton(JointTargetMode(int(target_mode))))
-                for target_mode in target_modes
-            ],
-            dtype=np.int32,
-        )
-
     def _update_actuation_types(self) -> None:
         """Refresh actuation modes without changing the passive/actuated layout."""
-        self._model_kamino.joints.act_type.assign(self._get_joint_actuation())
-
-    def _check_limit_capacity(self) -> None:
-        """Check that each DoF retains its as-built finite-limit status."""
-        current_finite = (self.model.joint_limit_lower.numpy() > self._kamino.JOINT_QMIN) | (
-            self.model.joint_limit_upper.numpy() < self._kamino.JOINT_QMAX
-        )
-        changed = np.flatnonzero(current_finite != self._built_limit_finite)
-        if changed.size > 0:
-            dof = int(changed[0])  # report only first violation
-            raise RuntimeError(
-                f"Changing the existence of a joint limit for DoF {dof} "
-                f"is not supported; recreate SolverKamino to apply the change."
-            )
+        self._kamino.convert_model_joint_actuation(self.model, self._model_kamino.joints)
 
     def _update_gravity(self):
         """Update Kamino's :class:`GravityModel` from Newton's ``model.gravity``."""
@@ -1246,4 +1216,9 @@ class SolverKamino(SolverBase, CouplingInterface):
 
     def _update_materials(self) -> None:
         """Refresh Kamino contact-material tables from Newton shape materials."""
-        self._kamino.convert_model_materials(self.model, self._model_kamino)
+        self._kamino.convert_model_materials(
+            self.model,
+            self._model_kamino,
+            self._material_update_first_shape,
+            self._material_update_conflict,
+        )

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -629,10 +629,12 @@ class SolverKamino(SolverBase, CouplingInterface):
         # Scratch array for notify validation
         self._notify_violations = wp.empty(4, dtype=wp.int32, device=model.device)
 
-        # Scratch arrays for material update validation
-        self._material_update_first_shape = wp.empty(
-            self._model_kamino.materials.num_materials, dtype=wp.int32, device=model.device
+        # Cache one representative shape per material.
+        self._material_first_shape = self._kamino.compute_material_first_shape(
+            self._model_kamino.geoms.material,
+            self._model_kamino.materials.num_materials,
         )
+        # Scratch scalar for material update validation
         self._material_update_conflict = wp.empty(1, dtype=wp.int32, device=model.device)
 
         # Create a collision detector if enabled in the config, otherwise
@@ -1144,19 +1146,15 @@ class SolverKamino(SolverBase, CouplingInterface):
         if not check_dof and not check_actuation:
             return
 
-        dim = max(self.model.joint_count, self.model.joint_dof_count)
-        if dim == 0:
-            return
-
-        sentinel = dim
-        dynamic_joint, limit_dof, actuation_joint, invalid_joint = self._kamino.validate_model_joint_updates(
-            model=self.model,
-            joints=self._model_kamino.joints,
-            built_limit_finite=self._built_limit_finite,
-            violations=self._notify_violations,
+        sentinel = self._kamino.validate_model_joint_updates(
+            self.model,
+            self._model_kamino.joints,
+            self._built_limit_finite,
+            self._notify_violations,
             check_dof=check_dof,
             check_actuation=check_actuation,
         )
+        dynamic_joint, limit_dof, actuation_joint, invalid_joint = self._notify_violations.numpy()
 
         if dynamic_joint != sentinel:
             joint = int(dynamic_joint)
@@ -1174,16 +1172,16 @@ class SolverKamino(SolverBase, CouplingInterface):
                 f"is not supported; recreate SolverKamino to apply the change."
             )
 
-        if invalid_joint != sentinel:
-            joint = int(invalid_joint)
-            raise ValueError(f"Unsupported joint target mode for joint {joint}")
-
         if actuation_joint != sentinel:
             joint = int(actuation_joint)
             raise RuntimeError(
                 f"Changing the actuation partition for joint {joint} "
                 f"({self.model.joint_label[joint]!r}) is not supported; recreate SolverKamino to apply the change."
             )
+
+        if invalid_joint != sentinel:
+            joint = int(invalid_joint)
+            raise ValueError(f"Unsupported joint target mode for joint {joint}")
 
     def _update_actuation_types(self) -> None:
         """Refresh actuation modes without changing the passive/actuated layout."""
@@ -1215,10 +1213,10 @@ class SolverKamino(SolverBase, CouplingInterface):
         self._kamino.convert_model_joint_transforms(self.model, self._model_kamino.joints)
 
     def _update_materials(self) -> None:
-        """Refresh Kamino contact-material tables from Newton shape materials."""
+        """Refresh Kamino contact-material tables using cached representative shapes."""
         self._kamino.convert_model_materials(
             self.model,
             self._model_kamino,
-            self._material_update_first_shape,
+            self._material_first_shape,
             self._material_update_conflict,
         )

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -12,6 +12,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.solvers.kamino._src.core.materials import DEFAULT_FRICTION, DEFAULT_RESTITUTION
 from newton._src.solvers.kamino.solver_kamino import SolverKamino
 from newton._src.solvers.kamino.tests import setup_tests, test_context
 
@@ -22,6 +23,7 @@ def _build_revolute(
     limited: bool = False,
     actuator_mode: newton.JointTargetMode = newton.JointTargetMode.NONE,
     body_com: wp.vec3f | None = None,
+    shape_materials: tuple[tuple[float, float], ...] | None = None,
 ) -> newton.Model:
     """Build a tiny world-to-body revolute model for notify tests."""
     builder = newton.ModelBuilder()
@@ -36,7 +38,22 @@ def _build_revolute(
         com=body_com,
         lock_inertia=True,
     )
-    builder.add_shape_box(label="box", body=bid, hx=0.1, hy=0.1, hz=0.1)
+    if shape_materials is None:
+        builder.add_shape_box(label="box", body=bid, hx=0.1, hy=0.1, hz=0.1)
+    else:
+        for shape, (mu, restitution) in enumerate(shape_materials):
+            builder.add_shape_box(
+                label=f"box_{shape}",
+                body=bid,
+                xform=wp.transformf(
+                    wp.vec3f(0.3 * shape, 0.0, 0.0),
+                    wp.quat_identity(dtype=wp.float32),
+                ),
+                hx=0.1,
+                hy=0.1,
+                hz=0.1,
+                cfg=newton.ModelBuilder.ShapeConfig(mu=mu, restitution=restitution),
+            )
 
     jid = builder.add_joint_revolute(
         label="world_to_link",
@@ -294,6 +311,73 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         # Reset goes through a body pose -> com pose -> body pose conversion. Check that the conversion is correct.
         solver.reset(state)
         np.testing.assert_allclose(state.body_q.numpy(), model.body_q.numpy(), atol=1e-6)
+
+    def test_material_value_update_propagates(self):
+        """Two shapes sharing one material can update it together and keep sharing it."""
+        model = _build_revolute(shape_materials=((0.2, 0.1), (0.2, 0.1)))
+        solver = SolverKamino(model)
+        materials = solver._model_kamino.materials
+        material_pairs = solver._model_kamino.material_pairs
+        arrays = (
+            materials.restitution,
+            materials.static_friction,
+            materials.dynamic_friction,
+            material_pairs.restitution,
+            material_pairs.static_friction,
+            material_pairs.dynamic_friction,
+        )
+        pointers = tuple(array.ptr for array in arrays)
+        pair_values = tuple(array.numpy().copy() for array in arrays[3:])
+
+        model.shape_material_mu.assign(np.array([0.4, 0.4], dtype=np.float32))
+        model.shape_material_restitution.assign(np.array([0.3, 0.3], dtype=np.float32))
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        self.assertEqual(tuple(array.ptr for array in arrays), pointers)
+        np.testing.assert_allclose(materials.static_friction.numpy(), [DEFAULT_FRICTION, 0.4])
+        np.testing.assert_allclose(materials.dynamic_friction.numpy(), [DEFAULT_FRICTION, 0.4])
+        np.testing.assert_allclose(materials.restitution.numpy(), [DEFAULT_RESTITUTION, 0.3])
+        for actual, expected in zip(arrays[3:], pair_values, strict=True):
+            np.testing.assert_array_equal(actual.numpy(), expected)
+
+    def test_material_ids_can_converge_to_same_values(self):
+        """Distinct material IDs remain valid when their coefficients become equal."""
+        model = _build_revolute(shape_materials=((0.2, 0.1), (0.6, 0.5)))
+        solver = SolverKamino(model)
+        materials = solver._model_kamino.materials
+        geoms = solver._model_kamino.geoms
+        material_mapping = geoms.material.numpy().copy()
+
+        model.shape_material_mu.assign(np.array([0.4, 0.4], dtype=np.float32))
+        model.shape_material_restitution.assign(np.array([0.3, 0.3], dtype=np.float32))
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        np.testing.assert_array_equal(geoms.material.numpy(), material_mapping)
+        np.testing.assert_allclose(materials.static_friction.numpy(), [DEFAULT_FRICTION, 0.4, 0.4])
+        np.testing.assert_allclose(materials.dynamic_friction.numpy(), [DEFAULT_FRICTION, 0.4, 0.4])
+        np.testing.assert_allclose(materials.restitution.numpy(), [DEFAULT_RESTITUTION, 0.3, 0.3])
+
+    def test_material_structural_change_raises(self):
+        """Two shapes sharing one material cannot update it to different values."""
+        model = _build_revolute(shape_materials=((0.2, 0.1), (0.2, 0.1)))
+        solver = SolverKamino(model)
+        materials = solver._model_kamino.materials
+        before = (
+            materials.restitution.numpy().copy(),
+            materials.static_friction.numpy().copy(),
+            materials.dynamic_friction.numpy().copy(),
+        )
+        model.shape_material_mu.assign(np.array([0.2, 0.4], dtype=np.float32))
+
+        with self.assertRaisesRegex(RuntimeError, "recreate"):
+            solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        for actual, expected in zip(
+            (materials.restitution, materials.static_friction, materials.dynamic_friction),
+            before,
+            strict=True,
+        ):
+            np.testing.assert_array_equal(actual.numpy(), expected)
 
     def test_dynamic_constraint_toggle_raises(self):
         """Adding or removing a joint's dynamic constraints requires solver recreation."""

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -12,6 +12,7 @@ import numpy as np
 import warp as wp
 
 import newton
+from newton._src.solvers.kamino._src.core.gravity import GRAVITY_DIREC_DEFAULT
 from newton._src.solvers.kamino._src.core.materials import DEFAULT_FRICTION, DEFAULT_RESTITUTION
 from newton._src.solvers.kamino.solver_kamino import SolverKamino
 from newton._src.solvers.kamino.tests import setup_tests, test_context
@@ -220,7 +221,8 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
         solver.notify_model_changed(newton.ModelFlags.MODEL_PROPERTIES)
 
-        np.testing.assert_array_equal(solver._model_kamino.gravity.g_dir_acc.numpy(), [[0.0, 0.0, -1.0, 0.0]])
+        expected_g_dir_acc = np.append(np.asarray(GRAVITY_DIREC_DEFAULT), 0.0)[None, :]
+        np.testing.assert_array_equal(solver._model_kamino.gravity.g_dir_acc.numpy(), expected_g_dir_acc)
         np.testing.assert_array_equal(solver._model_kamino.gravity.vector.numpy(), [[0.0, 0.0, 0.0, 0.0]])
 
     def test_joint_transform_update(self):

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -24,6 +24,7 @@ def _build_revolute(
     actuator_mode: newton.JointTargetMode = newton.JointTargetMode.NONE,
     body_com: wp.vec3f | None = None,
     shape_materials: tuple[tuple[float, float], ...] | None = None,
+    has_shape_collision: bool = True,
 ) -> newton.Model:
     """Build a tiny world-to-body revolute model for notify tests."""
     builder = newton.ModelBuilder()
@@ -39,7 +40,14 @@ def _build_revolute(
         lock_inertia=True,
     )
     if shape_materials is None:
-        builder.add_shape_box(label="box", body=bid, hx=0.1, hy=0.1, hz=0.1)
+        builder.add_shape_box(
+            label="box",
+            body=bid,
+            hx=0.1,
+            hy=0.1,
+            hz=0.1,
+            cfg=newton.ModelBuilder.ShapeConfig(has_shape_collision=has_shape_collision),
+        )
     else:
         for shape, (mu, restitution) in enumerate(shape_materials):
             builder.add_shape_box(
@@ -52,7 +60,11 @@ def _build_revolute(
                 hx=0.1,
                 hy=0.1,
                 hz=0.1,
-                cfg=newton.ModelBuilder.ShapeConfig(mu=mu, restitution=restitution),
+                cfg=newton.ModelBuilder.ShapeConfig(
+                    mu=mu,
+                    restitution=restitution,
+                    has_shape_collision=has_shape_collision,
+                ),
             )
 
     jid = builder.add_joint_revolute(
@@ -389,7 +401,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
     def test_shape_without_material_is_ignored(self):
         """Shapes without a Kamino material mapping do not modify material tables."""
-        model = _build_revolute(shape_materials=((0.2, 0.1),))
+        model = _build_revolute(shape_materials=((0.2, 0.1),), has_shape_collision=False)
         solver = SolverKamino(model)
         materials = solver._model_kamino.materials
         before = (
@@ -397,9 +409,8 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
             materials.static_friction.numpy().copy(),
             materials.dynamic_friction.numpy().copy(),
         )
-        # Non-collidable shapes use -1 to indicate that they need no contact material;
-        # material updates must skip this sentinel instead of treating it as an array index.
-        solver._model_kamino.geoms.material.fill_(-1)
+        # Non-collidable shapes use -1 to indicate that they need no contact material.
+        np.testing.assert_array_equal(solver._model_kamino.geoms.material.numpy(), [-1])
         model.shape_material_mu.assign([0.7])
         model.shape_material_restitution.assign([0.8])
 

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -200,6 +200,17 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         np.testing.assert_allclose(solver._model_kamino.gravity.g_dir_acc.numpy(), expected_g_dir_acc, atol=1e-6)
         np.testing.assert_allclose(solver._model_kamino.gravity.vector.numpy(), expected_vector, atol=1e-6)
 
+    def test_zero_gravity_update(self):
+        """Zero gravity uses Kamino's fallback direction and disables gravity."""
+        model = _build_revolute(limited=True)
+        solver = SolverKamino(model)
+        model.gravity.zero_()
+
+        solver.notify_model_changed(newton.ModelFlags.MODEL_PROPERTIES)
+
+        np.testing.assert_array_equal(solver._model_kamino.gravity.g_dir_acc.numpy(), [[0.0, 0.0, -1.0, 0.0]])
+        np.testing.assert_array_equal(solver._model_kamino.gravity.vector.numpy(), [[0.0, 0.0, 0.0, 0.0]])
+
     def test_joint_transform_update(self):
         """Joint-property notifications recompute Kamino's parent and child frames."""
         model = _build_revolute(limited=True)
@@ -340,6 +351,25 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         for actual, expected in zip(arrays[3:], pair_values, strict=True):
             np.testing.assert_array_equal(actual.numpy(), expected)
 
+    def test_default_material_update_propagates_to_default_pair(self):
+        """Updating material zero keeps its explicit self-pair synchronized."""
+        model = _build_revolute(shape_materials=((DEFAULT_FRICTION, DEFAULT_RESTITUTION),))
+        solver = SolverKamino(model)
+        materials = solver._model_kamino.materials
+        material_pairs = solver._model_kamino.material_pairs
+        np.testing.assert_array_equal(solver._model_kamino.geoms.material.numpy(), [0])
+
+        model.shape_material_mu.assign([0.4])
+        model.shape_material_restitution.assign([0.3])
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        np.testing.assert_allclose(materials.static_friction.numpy(), [0.4])
+        np.testing.assert_allclose(materials.dynamic_friction.numpy(), [0.4])
+        np.testing.assert_allclose(materials.restitution.numpy(), [0.3])
+        np.testing.assert_allclose(material_pairs.static_friction.numpy(), [0.4])
+        np.testing.assert_allclose(material_pairs.dynamic_friction.numpy(), [0.4])
+        np.testing.assert_allclose(material_pairs.restitution.numpy(), [0.3])
+
     def test_material_ids_can_converge_to_same_values(self):
         """Distinct material IDs remain valid when their coefficients become equal."""
         model = _build_revolute(shape_materials=((0.2, 0.1), (0.6, 0.5)))
@@ -356,6 +386,31 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         np.testing.assert_allclose(materials.static_friction.numpy(), [DEFAULT_FRICTION, 0.4, 0.4])
         np.testing.assert_allclose(materials.dynamic_friction.numpy(), [DEFAULT_FRICTION, 0.4, 0.4])
         np.testing.assert_allclose(materials.restitution.numpy(), [DEFAULT_RESTITUTION, 0.3, 0.3])
+
+    def test_shape_without_material_is_ignored(self):
+        """Shapes without a Kamino material mapping do not modify material tables."""
+        model = _build_revolute(shape_materials=((0.2, 0.1),))
+        solver = SolverKamino(model)
+        materials = solver._model_kamino.materials
+        before = (
+            materials.restitution.numpy().copy(),
+            materials.static_friction.numpy().copy(),
+            materials.dynamic_friction.numpy().copy(),
+        )
+        # Non-collidable shapes use -1 to indicate that they need no contact material;
+        # material updates must skip this sentinel instead of treating it as an array index.
+        solver._model_kamino.geoms.material.fill_(-1)
+        model.shape_material_mu.assign([0.7])
+        model.shape_material_restitution.assign([0.8])
+
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        for actual, expected in zip(
+            (materials.restitution, materials.static_friction, materials.dynamic_friction),
+            before,
+            strict=True,
+        ):
+            np.testing.assert_array_equal(actual.numpy(), expected)
 
     def test_material_structural_change_raises(self):
         """Two shapes sharing one material cannot update it to different values."""
@@ -470,6 +525,18 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
                     expected = solver._kamino.JointActuationType.from_newton(changed_mode)
                     self.assertEqual(solver._model_kamino.joints.act_type.numpy()[0], expected)
+
+    def test_invalid_actuation_mode_raises_before_update(self):
+        """Invalid target modes do not mutate Kamino's actuation table."""
+        model = _build_revolute(actuator_mode=newton.JointTargetMode.POSITION)
+        solver = SolverKamino(model)
+        before = solver._model_kamino.joints.act_type.numpy().copy()
+        model.joint_target_mode.assign([99])
+
+        with self.assertRaisesRegex(ValueError, "Unsupported joint target mode"):
+            solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+
+        np.testing.assert_array_equal(solver._model_kamino.joints.act_type.numpy(), before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description



- Adds the Kamino solver notify implementation for shape property changes and maps the updates to Kamino's internal material model. The update is performed in warp. 

  The approach for updating the shape properties is to keep the shape -> material assignment constant and only update the material values. This means that we need to check that two shapes assigned to the same material agree on what the new values should be.
  
- Other model update functionality is ported to warp as well. Now that this is in Warp we can re-use some helper functions between the model build and model update.
- A benchmark for the solver notify performance is added for 2048 DrLegs. Porting the implementation from numpy to warp resulting in a ~500x speed-up:

| Notify flag | Before (ms) | After (ms) | Speedup |
|---|---:|---:|---:|
| `ACTUATOR_PROPERTIES` | 82.053 | 0.080 | 1025.7× |
| `JOINT_DOF_PROPERTIES` | 81.509 | 0.069 | 1181.3× |
| `SHAPE_PROPERTIES` | 15.300 | 0.095 | 161.1× |
| `MODEL_PROPERTIES` | 3.885 | 0.016 | 242.8× |
| `BODY_INERTIAL_PROPERTIES` | 0.056 | 0.052 | 1.1× |
| `BODY_PROPERTIES` | 0.018 | 0.018 | 1.0× |
| `JOINT_PROPERTIES` | 0.041 | 0.035 | 1.2× |
| `ALL` | 102.246 | 0.207 | 493.9× |

Resolves vastsoun#104

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader runtime model updates for Kamino: joint actuation-type refresh and contact-material table updates now respond to relevant actuator/joint/shape/material edits.
  * Added runtime validation for unsupported joint edits and incompatible material changes, with clearer errors and no unintended mutations.
  * Expanded conversion utilities for advanced integrations.
* **Performance**
  * Gravity conversion moved to device-accelerated kernels.
  * Added an ASV benchmark to measure notify-model-changed update costs.
* **Testing**
  * Expanded notify propagation tests (including materials/shapes), zero-gravity updates, and invalid actuation-mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->