### PR TITLE
Require docstrings for test methods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ uv run --extra dev --extra torch-cu12 -m newton.tests                  # with Py
 
 ### Testing guidelines
 
-- Give every test function or method a concise one- or two-line docstring using triple double quotes (`"""..."""`).
+- Give every test function or method a docstring using triple double quotes (`"""..."""`). Start with a concise one-line summary in imperative mood that states what the test verifies. For a particularly complex test, add a body that elaborates on the tested behavior, separated from the summary by a blank line following Google-style docstring conventions.
 - Never call `wp.synchronize()` or `wp.synchronize_device()` right before `.numpy()` on a Warp array. This is redundant as `.numpy()` performs a synchronous device-to-host copy that completes all outstanding work.
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ uv run --extra dev --extra torch-cu12 -m newton.tests                  # with Py
 
 ### Testing guidelines
 
+- Give every test function or method a concise one- or two-line docstring using triple double quotes (`"""..."""`).
 - Never call `wp.synchronize()` or `wp.synchronize_device()` right before `.numpy()` on a Warp array. This is redundant as `.numpy()` performs a synchronous device-to-host copy that completes all outstanding work.
 
 ```bash


### PR DESCRIPTION
## Description

Require every test function or method to have a concise one- or two-line docstring written with triple double quotes. This keeps each test's intended behavior explicit at its definition.

## Checklist

- [x] New or existing tests cover these changes (not applicable: instruction-only change)
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable: no user-facing behavior change)

## Test plan

```text
uvx pre-commit run --files AGENTS.md
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidelines to require each test function or method to include a concise docstring (imperative first line, with optional elaboration separated by a blank line).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->