### PR TITLE
Remove pip check from ASV install commands

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -17,7 +17,6 @@
   "install_command": [
     "in-dir={env_dir} python -m pip install {wheel_file}[dev] --extra-index-url=https://pypi.nvidia.com/",
     "in-dir={env_dir} python -m pip install {wheel_file}[sim] warp-lang==1.16.0.dev20260716 mujoco==3.10.0 mujoco-warp==3.10.0.2 --extra-index-url=https://pypi.nvidia.com/",
-    "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130",
-    "python -m pip check"
+    "python -m pip install torch==2.10.0+cu130 --index-url https://download.pytorch.org/whl/cu130"
   ]
 }


### PR DESCRIPTION
## Description

Remove the `python -m pip check` step from the ASV `install_command`. It breaks nightly benchmark runs on the aarch64 (Orin/Thor) machines with a false positive: the `nvidia-cusparselt-cu13` 0.8.0 aarch64 wheel (pulled in by `torch==2.10.0+cu130`, which pins it exactly) records an invalid `manylinux2014_sbsa` platform tag in its `WHEEL` metadata, so `pip check` (pip >= 24.2 validates recorded wheel tags against the current platform) reports it as "not supported on this platform" even though the wheel installs and works. The failed install aborts env setup, benchmark discovery never runs, and the automation then crashes on the missing `benchmarks.json`. NVIDIA fixed the metadata in cusparselt 0.9.1, but installing it alongside torch's `==0.8.0` pin would create a genuine version conflict, so drop the check until the pinned torch depends on a fixed wheel.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Verified the root cause by extracting the `WHEEL` metadata from `nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl` (`Tag: py3-none-manylinux2014_sbsa`, vs. a matching `manylinux2014_x86_64` tag in the x86_64 wheel, which is why x86_64 runners pass). Config-only change; the remaining install commands are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency installation process to complete without an additional package validation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->