### PR TITLE
Update PADMM test tolerances

### DIFF
--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -180,8 +180,10 @@ def check_padmm_solution(
         test.assertLessEqual(r_p, solver.config[w].primal_tolerance)
         test.assertLessEqual(r_d, solver.config[w].dual_tolerance)
         test.assertLessEqual(r_c, solver.config[w].compl_tolerance)
-        test.assertLessEqual(error_dual_abs_l2, solver.config[w].dual_tolerance)
-        test.assertLessEqual(error_dual_abs_inf, solver.config[w].dual_tolerance)
+        # Using expanded tolerance for true dual error due to potential numerical inaccuracies
+        # between in-solver residual and true residual.
+        test.assertLessEqual(error_dual_abs_l2, solver.config[w].dual_tolerance * 4.0)
+        test.assertLessEqual(error_dual_abs_inf, solver.config[w].dual_tolerance * 4.0)
 
 
 def save_solver_info(solver: PADMMSolver, path: str | None = None, verbose: bool = False):


### PR DESCRIPTION
## Description

#3564 has lead to some test failures on some of our developer machines, which later turned out to always have failed for other developers. This seems to point to a test tolerance being set too tight, with test success being dependent on the specific hardware and compiler. The additional register availability introduced by disabling grid-stride loops in #3564 turned out to be sufficient to introduce some numerical divergence, leading to earlier PADMM convergence, but a slightly larger error in some test metrics.

This PR updates the tolerances for some of checks in the PADMM tests.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
python -m unittest "newton/_src/solvers/kamino/tests/test_solvers_padmm.py"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Relaxed validation thresholds for PADMM dual residual checks to accommodate expected numerical differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->