### PR TITLE
Add conveyor belt example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   - Import `PhysicsElementCollisionFilter` prims for cable, rigid-body, and collider element groups. Group counts pair elements in order; a count of `0` or an empty counts array selects all elements. Unsupported cloth/volume element sources warn and are skipped.
   - Add `newton.usd.DEFORMABLE_LEGACY_NAMESPACES` for explicitly retaining legacy deformable material namespace compatibility during migration.
 - Add scalar value-based OpenCV, F-theta, and Kannala-Brandt fisheye camera ray helpers to `SensorTiledCamera.utils`, plus pinhole aperture/focal-length parameters, `compute_camera_transforms_usd()`, `compute_camera_rays_usd_pinhole()`, and optional preallocated ray output writes. (#3026)
+- Add the `conveyor_force` example with constant and pivot velocity fields that apply Coulomb-limited tangential body forces from reported rigid-contact forces across `SolverXPBD`, `SolverVBD`, and `SolverMuJoCo`.
 - Add `cloth_stiff_material_hanging` and `cloth_stiff_material_stretch` examples regression-guarding the new Neo-Hookean triangle material (stability under gravity at extreme stiffness, and bulk area-preservation across a Poisson-ratio sweep)
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats). (#2990)
 - Add `ViewerBase.camera_speed` to configure keyboard translation speed for interactive viewers. (#3478)

--- a/newton/examples/basic/conveyor_force_model.py
+++ b/newton/examples/basic/conveyor_force_model.py
@@ -1,0 +1,618 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Force-based conveyor model for Newton.
+
+A conveyor belt is modeled as a *static* shape with an attached velocity field
+that defines the desired surface velocity at every point. No geometry moves;
+instead, after each solver step the model:
+
+1. reads the per-contact points, normals, and normal forces reported by the solver,
+2. keeps only the contacts between a registered belt and a resting body,
+3. evaluates the belt's velocity field at each contact point to get a target velocity,
+4. computes the tangential force that drives the contact-point velocity toward that
+   target, clamped by a Coulomb friction limit (``friction * normal_force``), and
+5. accumulates the resulting force and torque per body into ``State.body_f``.
+
+Each contact uses the velocity field of its belt. Contact contributions use a per-body
+``1 / contact_count`` mass-splitting factor.
+"""
+
+import warp as wp
+
+import newton
+
+# Velocity field types: a constant world-space velocity, or a rotation about a pivot.
+VELOCITY_FIELD_TYPE_CONSTANT = 0
+VELOCITY_FIELD_TYPE_PIVOT = 1
+
+
+# ---------------------------------------------------------------------------
+# Friction force model: target velocity -> Coulomb-clamped tangential force/torque
+# ---------------------------------------------------------------------------
+@wp.struct
+class Vec3Pair:
+    v0: wp.vec3
+    v1: wp.vec3
+
+
+@wp.func
+def compute_basis_vectors(dir: wp.vec3) -> Vec3Pair:
+    """Two unit vectors orthogonal to ``dir`` and to each other. ``dir`` must be normalized."""
+    basis = Vec3Pair()
+    if wp.abs(dir[1]) <= 0.9999:
+        basis.v0 = wp.normalize(wp.vec3(dir[2], 0.0, -dir[0]))
+        basis.v1 = wp.vec3(
+            dir[1] * basis.v0[2],
+            (dir[2] * basis.v0[0]) - (dir[0] * basis.v0[2]),
+            -dir[1] * basis.v0[0],
+        )
+    else:
+        basis.v0 = wp.vec3(1.0, 0.0, 0.0)
+        basis.v1 = wp.normalize(wp.vec3(0.0, dir[2], -dir[1]))
+    return basis
+
+
+@wp.func
+def compute_axis_impulse(
+    constraint_axis: wp.vec3,
+    relative_velocity: wp.vec3,
+    response_linear: wp.float32,
+    inv_inertia_world: wp.mat33,
+    center_of_mass_to_point: wp.vec3,
+    mass_splitting_scale: wp.float32,
+) -> wp.float32:
+    """Impulse along ``constraint_axis`` to null the relative velocity along it."""
+    delta_cross_axis = wp.cross(center_of_mass_to_point, constraint_axis)
+    response_angular = wp.dot(delta_cross_axis, wp.mul(inv_inertia_world, delta_cross_axis))
+    response = response_linear + response_angular
+    if response <= 0.0:
+        return 0.0
+    vel_multiplier = (1.0 / response) * mass_splitting_scale
+    rel_vel_proj = wp.dot(constraint_axis, relative_velocity)
+    return rel_vel_proj * vel_multiplier
+
+
+@wp.func
+def compute_point_impulse(
+    normal: wp.vec3,
+    normal_impulse: wp.float32,
+    current_vel: wp.vec3,
+    target_vel: wp.vec3,
+    response_linear: wp.float32,
+    inv_inertia_world: wp.mat33,
+    center_of_mass_to_point: wp.vec3,
+    friction_coefficient: wp.float32,
+    mass_splitting_scale: wp.float32,
+) -> wp.vec3:
+    """Coulomb-clamped tangential impulse driving the contact-point velocity toward ``target_vel``."""
+    rel_vel = target_vel - current_vel
+    basis = compute_basis_vectors(normal)
+
+    i0 = compute_axis_impulse(
+        basis.v0, rel_vel, response_linear, inv_inertia_world, center_of_mass_to_point, mass_splitting_scale
+    )
+    i1 = compute_axis_impulse(
+        basis.v1, rel_vel, response_linear, inv_inertia_world, center_of_mass_to_point, mass_splitting_scale
+    )
+
+    friction_impulse_max = normal_impulse * friction_coefficient
+    zero_err_magn = wp.sqrt((i0 * i0) + (i1 * i1))
+    impulse_magn = wp.min(friction_impulse_max, zero_err_magn)
+    if zero_err_magn > 0.0:
+        ratio = impulse_magn / zero_err_magn
+    else:
+        ratio = 0.0
+    return (basis.v0 * (i0 * ratio)) + (basis.v1 * (i1 * ratio))
+
+
+@wp.func
+def compute_point_force(
+    dt: wp.float32,
+    inverse_dt: wp.float32,
+    com_world: wp.vec3,
+    body_inverse_mass: wp.float32,
+    body_inverse_inertia_world: wp.mat33,
+    body_linear_velocity: wp.vec3,
+    body_angular_velocity: wp.vec3,
+    contact_position: wp.vec3,
+    contact_normal: wp.vec3,
+    contact_force: wp.float32,
+    mass_splitting_scale: wp.float32,
+    target_vel: wp.vec3,
+    friction_coefficient: wp.float32,
+) -> wp.spatial_vector:
+    """Friction-limited (force, torque about COM) for one contact point, world frame."""
+    contact_impulse = contact_force * dt
+    center_of_mass_to_point = contact_position - com_world
+    current_point_vel = body_linear_velocity + wp.cross(body_angular_velocity, center_of_mass_to_point)
+
+    tangential_impulse = compute_point_impulse(
+        contact_normal,
+        contact_impulse,
+        current_point_vel,
+        target_vel,
+        body_inverse_mass,
+        body_inverse_inertia_world,
+        center_of_mass_to_point,
+        friction_coefficient,
+        mass_splitting_scale,
+    )
+
+    force = tangential_impulse * inverse_dt
+    torque = wp.cross(center_of_mass_to_point, force)
+    return wp.spatial_vector(force, torque)
+
+
+# ---------------------------------------------------------------------------
+# Newton coupling kernels
+# ---------------------------------------------------------------------------
+@wp.struct
+class BeltContact:
+    valid: wp.int32
+    body: wp.int32
+    conv: wp.int32
+    point: wp.vec3
+    normal: wp.vec3  # points from belt toward the body
+    normal_force: wp.float32
+
+
+@wp.func
+def identify_belt_contact(
+    i: int,
+    rigid_contact_count: wp.array[wp.int32],
+    rigid_contact_shape0: wp.array[wp.int32],
+    rigid_contact_shape1: wp.array[wp.int32],
+    rigid_contact_normal: wp.array[wp.vec3],
+    rigid_contact_point0: wp.array[wp.vec3],
+    rigid_contact_point1: wp.array[wp.vec3],
+    contact_force_vec: wp.array[wp.vec3],
+    shape_body: wp.array[wp.int32],
+    shape_conveyor: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    conv_surface_normal: wp.array[wp.vec3],
+    conv_threshold: wp.array[wp.float32],
+) -> BeltContact:
+    """Decide whether contact ``i`` is a belt/body contact and extract its inputs for the force model."""
+    out = BeltContact()
+    out.valid = 0
+    if i >= rigid_contact_count[0]:
+        return out
+
+    shape0 = rigid_contact_shape0[i]
+    shape1 = rigid_contact_shape1[i]
+    if shape0 < 0 or shape1 < 0:
+        return out
+
+    conv0 = shape_conveyor[shape0]
+    conv1 = shape_conveyor[shape1]
+
+    # Exactly one side must be a belt; the other must be a dynamic body.
+    normal = rigid_contact_normal[i]  # shape0 -> shape1
+    if conv0 >= 0 and conv1 < 0:
+        conv = conv0
+        body = shape_body[shape1]
+        body_point_local = rigid_contact_point1[i]
+        normal_toward_body = normal
+    elif conv1 >= 0 and conv0 < 0:
+        conv = conv1
+        body = shape_body[shape0]
+        body_point_local = rigid_contact_point0[i]
+        normal_toward_body = -normal
+    else:
+        return out
+
+    if body < 0:
+        return out
+
+    # Reject contacts whose normal is not aligned with the belt surface normal.
+    acceptance = wp.dot(normal_toward_body, conv_surface_normal[conv])
+    if acceptance < conv_threshold[conv]:
+        return out
+
+    # Normal-force magnitude from the reported per-contact force vector.
+    nforce = wp.abs(wp.dot(contact_force_vec[i], normal))
+    if nforce <= 0.0:
+        return out
+
+    out.valid = 1
+    out.body = body
+    out.conv = conv
+    out.point = wp.transform_point(body_q[body], body_point_local)
+    out.normal = normal_toward_body
+    out.normal_force = nforce
+    return out
+
+
+@wp.kernel
+def count_belt_contacts(
+    rigid_contact_count: wp.array[wp.int32],
+    rigid_contact_shape0: wp.array[wp.int32],
+    rigid_contact_shape1: wp.array[wp.int32],
+    rigid_contact_normal: wp.array[wp.vec3],
+    rigid_contact_point0: wp.array[wp.vec3],
+    rigid_contact_point1: wp.array[wp.vec3],
+    contact_force_vec: wp.array[wp.vec3],
+    shape_body: wp.array[wp.int32],
+    shape_conveyor: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    conv_surface_normal: wp.array[wp.vec3],
+    conv_threshold: wp.array[wp.float32],
+    # output
+    body_contact_count: wp.array[wp.int32],
+):
+    i = wp.tid()
+    c = identify_belt_contact(
+        i,
+        rigid_contact_count,
+        rigid_contact_shape0,
+        rigid_contact_shape1,
+        rigid_contact_normal,
+        rigid_contact_point0,
+        rigid_contact_point1,
+        contact_force_vec,
+        shape_body,
+        shape_conveyor,
+        body_q,
+        conv_surface_normal,
+        conv_threshold,
+    )
+    if c.valid == 1:
+        wp.atomic_add(body_contact_count, c.body, 1)
+
+
+@wp.kernel
+def accumulate_conveyor_forces(
+    dt: wp.float32,
+    rigid_contact_count: wp.array[wp.int32],
+    rigid_contact_shape0: wp.array[wp.int32],
+    rigid_contact_shape1: wp.array[wp.int32],
+    rigid_contact_normal: wp.array[wp.vec3],
+    rigid_contact_point0: wp.array[wp.vec3],
+    rigid_contact_point1: wp.array[wp.vec3],
+    contact_force_vec: wp.array[wp.vec3],
+    shape_body: wp.array[wp.int32],
+    shape_conveyor: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    body_qd: wp.array[wp.spatial_vector],
+    body_com: wp.array[wp.vec3],
+    body_inv_mass: wp.array[wp.float32],
+    body_inv_inertia: wp.array[wp.mat33],
+    body_contact_count: wp.array[wp.int32],
+    conv_field_type: wp.array[wp.int32],
+    conv_const_vel: wp.array[wp.vec3],
+    conv_pivot_point: wp.array[wp.vec3],
+    conv_pivot_angvel: wp.array[wp.vec3],
+    conv_surface_normal: wp.array[wp.vec3],
+    conv_threshold: wp.array[wp.float32],
+    conv_friction: wp.array[wp.float32],
+    global_velocity_scale: wp.array[wp.float32],
+    # output
+    conveyor_body_f: wp.array[wp.spatial_vector],
+):
+    i = wp.tid()
+    c = identify_belt_contact(
+        i,
+        rigid_contact_count,
+        rigid_contact_shape0,
+        rigid_contact_shape1,
+        rigid_contact_normal,
+        rigid_contact_point0,
+        rigid_contact_point1,
+        contact_force_vec,
+        shape_body,
+        shape_conveyor,
+        body_q,
+        conv_surface_normal,
+        conv_threshold,
+    )
+    if c.valid == 0:
+        return
+
+    count = body_contact_count[c.body]
+    if count <= 0:
+        return
+    mass_splitting_scale = 1.0 / float(count)
+
+    # Target surface velocity from the belt's velocity field, evaluated at the contact point.
+    conv = c.conv
+    if conv_field_type[conv] == VELOCITY_FIELD_TYPE_CONSTANT:
+        target_vel = conv_const_vel[conv]
+    else:
+        delta = c.point - conv_pivot_point[conv]
+        target_vel = wp.cross(conv_pivot_angvel[conv], delta)
+    target_vel = target_vel * global_velocity_scale[0]
+
+    # World-space body quantities.
+    q = body_q[c.body]
+    com_world = wp.transform_point(q, body_com[c.body])
+    r = wp.quat_to_matrix(wp.transform_get_rotation(q))
+    inv_inertia_world = r * body_inv_inertia[c.body] * wp.transpose(r)
+    qd = body_qd[c.body]
+    lin_vel = wp.spatial_top(qd)
+    ang_vel = wp.spatial_bottom(qd)
+
+    ft = compute_point_force(
+        dt,
+        1.0 / dt,
+        com_world,
+        body_inv_mass[c.body],
+        inv_inertia_world,
+        lin_vel,
+        ang_vel,
+        c.point,
+        c.normal,
+        c.normal_force,
+        mass_splitting_scale,
+        target_vel,
+        conv_friction[conv],
+    )
+
+    wp.atomic_add(conveyor_body_f, c.body, ft)
+
+
+@wp.kernel
+def add_spatial(dst: wp.array[wp.spatial_vector], src: wp.array[wp.spatial_vector]):
+    i = wp.tid()
+    dst[i] = dst[i] + src[i]
+
+
+@wp.kernel
+def extract_linear(spatial_force: wp.array[wp.spatial_vector], out_vec: wp.array[wp.vec3]):
+    """Copy the linear part of a per-contact spatial wrench into a plain force vector."""
+    i = wp.tid()
+    out_vec[i] = wp.spatial_top(spatial_force[i])
+
+
+class ConveyorForceModel:
+    """Force-based conveyor driver for a Newton :class:`~newton.Model`.
+
+    Register belts (a static shape + a velocity field) with :meth:`add_constant_belt` or
+    :meth:`add_pivot_belt`, call :meth:`finalize`, then drive it each substep::
+
+        conveyor.apply(state_0)  # add the conveyor wrench from the last step
+        conveyor.snapshot_prev(state_0)
+        collision_pipeline.collide(state_0, contacts)
+        solver.step(state_0, state_1, control, contacts, dt)
+        conveyor.update(solver, contacts, state_1, dt)  # read forces, recompute wrench
+    """
+
+    def __init__(self, model: newton.Model, solver_type: str = "xpbd"):
+        if solver_type not in {"xpbd", "vbd", "mujoco"}:
+            raise ValueError(f"Unsupported solver type: {solver_type!r}")
+
+        self.model = model
+        self.solver_type = solver_type
+        self.device = model.device
+        self._field_type: list[int] = []
+        self._const_vel: list[wp.vec3] = []
+        self._pivot_point: list[wp.vec3] = []
+        self._pivot_angvel: list[wp.vec3] = []
+        self._surface_normal: list[wp.vec3] = []
+        self._threshold: list[float] = []
+        self._friction: list[float] = []
+        self._shape_conveyor = [-1] * model.shape_count
+        self._finalized = False
+
+    def _add_belt(
+        self, shape_index, field_type, const_vel, pivot_point, pivot_angvel, surface_normal, friction, threshold
+    ):
+        if self._finalized:
+            raise RuntimeError("Cannot register belts after finalize().")
+        if shape_index < 0 or shape_index >= self.model.shape_count:
+            raise IndexError(f"Belt shape index {shape_index} is out of range.")
+        if self._shape_conveyor[shape_index] >= 0:
+            raise ValueError(f"Shape {shape_index} is already registered as a belt.")
+        if int(self.model.shape_body.numpy()[shape_index]) >= 0:
+            raise ValueError("Conveyor belts must be static shapes.")
+        if wp.length(surface_normal) == 0.0:
+            raise ValueError("surface_normal must be nonzero.")
+        if friction < 0.0:
+            raise ValueError("friction must be nonnegative.")
+        if threshold < -1.0 or threshold > 1.0:
+            raise ValueError("threshold must be in [-1, 1].")
+
+        conv = len(self._field_type)
+        self._shape_conveyor[shape_index] = conv
+        self._field_type.append(field_type)
+        self._const_vel.append(const_vel)
+        self._pivot_point.append(pivot_point)
+        self._pivot_angvel.append(pivot_angvel)
+        self._surface_normal.append(wp.normalize(surface_normal))
+        self._friction.append(friction)
+        self._threshold.append(threshold)
+        return conv
+
+    def add_constant_belt(
+        self,
+        shape_index: int,
+        velocity: wp.vec3,
+        surface_normal: wp.vec3 | None = None,
+        friction: float = 0.5,
+        threshold: float = 0.9,
+    ) -> int:
+        """Register a belt with a constant world-space surface velocity.
+
+        Args:
+            shape_index: Index of the static belt shape.
+            velocity: Target surface velocity [m/s].
+            surface_normal: Belt-facing unit normal in world space. If ``None``, uses +Z.
+            friction: Coulomb friction coefficient used by the force model.
+            threshold: Minimum dot product between the contact and belt normals.
+
+        Returns:
+            Index of the registered belt.
+        """
+        if surface_normal is None:
+            surface_normal = wp.vec3(0.0, 0.0, 1.0)
+        return self._add_belt(
+            shape_index,
+            VELOCITY_FIELD_TYPE_CONSTANT,
+            velocity,
+            wp.vec3(),
+            wp.vec3(),
+            surface_normal,
+            friction,
+            threshold,
+        )
+
+    def add_pivot_belt(
+        self,
+        shape_index: int,
+        pivot_point: wp.vec3,
+        angular_velocity: wp.vec3,
+        surface_normal: wp.vec3 | None = None,
+        friction: float = 0.5,
+        threshold: float = 0.9,
+    ) -> int:
+        """Register a belt with a pivoting world-space surface velocity.
+
+        Args:
+            shape_index: Index of the static belt shape.
+            pivot_point: World-space center of rotation [m].
+            angular_velocity: World-space angular velocity [rad/s].
+            surface_normal: Belt-facing unit normal in world space. If ``None``, uses +Z.
+            friction: Coulomb friction coefficient used by the force model.
+            threshold: Minimum dot product between the contact and belt normals.
+
+        Returns:
+            Index of the registered belt.
+        """
+        if surface_normal is None:
+            surface_normal = wp.vec3(0.0, 0.0, 1.0)
+        return self._add_belt(
+            shape_index,
+            VELOCITY_FIELD_TYPE_PIVOT,
+            wp.vec3(),
+            pivot_point,
+            angular_velocity,
+            surface_normal,
+            friction,
+            threshold,
+        )
+
+    def finalize(self, contacts) -> None:
+        """Allocate device buffers. Call once after registering all belts.
+
+        Args:
+            contacts: The :class:`~newton.Contacts` the step loop will populate; used to size the
+                per-contact force buffer.
+        """
+        if self._finalized:
+            raise RuntimeError("ConveyorForceModel is already finalized.")
+        if not self._field_type:
+            raise RuntimeError("Register at least one belt before finalize().")
+        if contacts.rigid_contact_max <= 0:
+            raise ValueError("Contacts must have nonzero rigid-contact capacity.")
+        if self.solver_type == "vbd":
+            force_buffer = contacts.rigid_contact_force
+        else:
+            force_buffer = contacts.force
+        if force_buffer is None:
+            raise ValueError("Call model.request_contact_attributes('force') before creating Contacts.")
+
+        d = self.device
+        self.conv_field_type = wp.array(self._field_type, dtype=wp.int32, device=d)
+        self.conv_const_vel = wp.array(self._const_vel, dtype=wp.vec3, device=d)
+        self.conv_pivot_point = wp.array(self._pivot_point, dtype=wp.vec3, device=d)
+        self.conv_pivot_angvel = wp.array(self._pivot_angvel, dtype=wp.vec3, device=d)
+        self.conv_surface_normal = wp.array(self._surface_normal, dtype=wp.vec3, device=d)
+        self.conv_threshold = wp.array(self._threshold, dtype=wp.float32, device=d)
+        self.conv_friction = wp.array(self._friction, dtype=wp.float32, device=d)
+        self.shape_conveyor = wp.array(self._shape_conveyor, dtype=wp.int32, device=d)
+        self.global_velocity_scale = wp.array([1.0], dtype=wp.float32, device=d)
+
+        self.body_contact_count = wp.zeros(self.model.body_count, dtype=wp.int32, device=d)
+        self.conveyor_body_f = wp.zeros(self.model.body_count, dtype=wp.spatial_vector, device=d)
+        self.contact_force_vec = wp.zeros(contacts.rigid_contact_max, dtype=wp.vec3, device=d)
+        self.body_q_prev = wp.zeros(self.model.body_count, dtype=wp.transform, device=d)
+        self._finalized = True
+
+    def set_speed_scale(self, scale: float) -> None:
+        """Set a global multiplier on all belt target velocities (e.g. a start-up ramp)."""
+        self.global_velocity_scale.fill_(scale)
+
+    def apply(self, state: newton.State) -> None:
+        """Add the conveyor wrench computed by the previous :meth:`update` into ``state.body_f``."""
+        wp.launch(
+            add_spatial,
+            dim=self.model.body_count,
+            inputs=[state.body_f, self.conveyor_body_f],
+            device=self.device,
+        )
+
+    def snapshot_prev(self, state: newton.State) -> None:
+        """Store the pre-step body poses used for contact-force reporting."""
+        wp.copy(self.body_q_prev, state.body_q)
+
+    def _report_contact_forces(self, solver, contacts, state_post, dt: float) -> None:
+        if self.solver_type == "vbd":
+            solver.collect_rigid_contact_forces(state_post.body_q, self.body_q_prev, contacts, dt)
+            wp.copy(self.contact_force_vec, contacts.rigid_contact_force)
+        else:
+            solver.update_contacts(contacts)
+            wp.launch(
+                extract_linear,
+                dim=contacts.rigid_contact_max,
+                inputs=[contacts.force, self.contact_force_vec],
+                device=self.device,
+            )
+
+    def update(self, solver, contacts, state_post: newton.State, dt: float) -> None:
+        """Read the solver's per-contact forces and recompute the per-body conveyor wrench."""
+        self._report_contact_forces(solver, contacts, state_post, dt)
+        self.conveyor_body_f.zero_()
+        self.body_contact_count.zero_()
+        wp.launch(
+            count_belt_contacts,
+            dim=contacts.rigid_contact_max,
+            inputs=[
+                contacts.rigid_contact_count,
+                contacts.rigid_contact_shape0,
+                contacts.rigid_contact_shape1,
+                contacts.rigid_contact_normal,
+                contacts.rigid_contact_point0,
+                contacts.rigid_contact_point1,
+                self.contact_force_vec,
+                self.model.shape_body,
+                self.shape_conveyor,
+                state_post.body_q,
+                self.conv_surface_normal,
+                self.conv_threshold,
+            ],
+            outputs=[self.body_contact_count],
+            device=self.device,
+        )
+        wp.launch(
+            accumulate_conveyor_forces,
+            dim=contacts.rigid_contact_max,
+            inputs=[
+                dt,
+                contacts.rigid_contact_count,
+                contacts.rigid_contact_shape0,
+                contacts.rigid_contact_shape1,
+                contacts.rigid_contact_normal,
+                contacts.rigid_contact_point0,
+                contacts.rigid_contact_point1,
+                self.contact_force_vec,
+                self.model.shape_body,
+                self.shape_conveyor,
+                state_post.body_q,
+                state_post.body_qd,
+                self.model.body_com,
+                self.model.body_inv_mass,
+                self.model.body_inv_inertia,
+                self.body_contact_count,
+                self.conv_field_type,
+                self.conv_const_vel,
+                self.conv_pivot_point,
+                self.conv_pivot_angvel,
+                self.conv_surface_normal,
+                self.conv_threshold,
+                self.conv_friction,
+                self.global_velocity_scale,
+            ],
+            outputs=[self.conveyor_body_f],
+            device=self.device,
+        )

--- a/newton/examples/basic/example_conveyor_force.py
+++ b/newton/examples/basic/example_conveyor_force.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# Example Conveyor Force
+#
+# Static annular conveyor with a pivot velocity field. Per-contact normal
+# forces determine Coulomb-limited tangential forces applied to the boxes.
+# A central hub and segmented outer wall bound the conveyor path.
+#
+# Command: uv run -m newton.examples conveyor_force
+#
+###########################################################################
+
+import math
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.examples
+from newton.examples.basic.conveyor_force_model import ConveyorForceModel
+
+BELT_TOP_Z = 0.5
+BELT_HALF_Z = 0.1
+HUB_RADIUS = 1.6  # central wall: boxes cannot go inside this
+WALL_RADIUS = 3.2  # outer wall: boxes cannot go past this
+BELT_RADIUS = 3.5  # belt disk covers the whole ring band
+RING_RADIUS = 0.5 * (HUB_RADIUS + WALL_RADIUS)  # box centerline
+BELT_SPEED = 2.0  # surface speed at the ring centerline [m/s]
+BOX_HALF = 0.2
+WALL_SEGMENTS = 24
+WALL_HALF_HEIGHT = 0.35
+NUM_BOXES = 10
+SPEED_RAMP_DURATION = 0.6  # [s]
+CONTACT_FRICTION = 2.0e-5
+
+
+def _look_at(eye, target):
+    """Return (pos, pitch_deg, yaw_deg) for a Z-up camera at ``eye`` looking at ``target``."""
+    d = np.asarray(target, dtype=np.float64) - np.asarray(eye, dtype=np.float64)
+    d /= np.linalg.norm(d)
+    pitch = np.degrees(np.arcsin(d[2]))
+    yaw = np.degrees(np.arctan2(d[1], d[0]))
+    return wp.vec3(*eye), float(pitch), float(yaw)
+
+
+class Example:
+    def __init__(self, viewer, args=None):
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_time = 0.0
+        self.sim_substeps = 8
+        self.sim_dt = self.frame_dt / self.sim_substeps
+
+        self.viewer = viewer
+        belt_speed = float(getattr(args, "belt_speed", BELT_SPEED)) if args is not None else BELT_SPEED
+        self.solver_type = getattr(args, "solver", "xpbd") if args is not None else "xpbd"
+
+        builder = newton.ModelBuilder()
+        builder.add_ground_plane()
+
+        wall_cfg = newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, ke=1.0e5, kd=0.0)
+
+        # Static cylinder representing the annular belt surface.
+        belt_cfg = newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, ke=1.0e5, kd=0.0)
+        self.belt_shape = builder.add_shape_cylinder(
+            body=-1,
+            radius=BELT_RADIUS,
+            half_height=BELT_HALF_Z,
+            xform=wp.transform(p=wp.vec3(0.0, 0.0, BELT_TOP_Z - BELT_HALF_Z), q=wp.quat_identity()),
+            cfg=belt_cfg,
+            color=(0.09, 0.09, 0.09),
+            label="conveyor_belt",
+        )
+
+        # Inner cylindrical boundary.
+        builder.add_shape_cylinder(
+            body=-1,
+            radius=HUB_RADIUS,
+            half_height=WALL_HALF_HEIGHT,
+            xform=wp.transform(p=wp.vec3(0.0, 0.0, BELT_TOP_Z + WALL_HALF_HEIGHT), q=wp.quat_identity()),
+            cfg=wall_cfg,
+            color=(0.55, 0.57, 0.6),
+            label="hub",
+        )
+
+        # Outer polygonal boundary.
+        wall_center_r = WALL_RADIUS + 0.1
+        seg_tangential = math.pi * wall_center_r / WALL_SEGMENTS * 1.15
+        for k in range(WALL_SEGMENTS):
+            ang = 2.0 * math.pi * k / WALL_SEGMENTS
+            builder.add_shape_box(
+                body=-1,
+                hx=0.1,
+                hy=seg_tangential,
+                hz=WALL_HALF_HEIGHT,
+                xform=wp.transform(
+                    p=wp.vec3(
+                        wall_center_r * math.cos(ang), wall_center_r * math.sin(ang), BELT_TOP_Z + WALL_HALF_HEIGHT
+                    ),
+                    q=wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), ang),
+                ),
+                cfg=wall_cfg,
+                color=(0.55, 0.57, 0.6),
+                label=f"wall_{k}",
+            )
+
+        # Dynamic boxes distributed around the ring centerline.
+        self.box_bodies = []
+        box_colors = [(0.85, 0.3, 0.2), (0.2, 0.7, 0.3), (0.9, 0.75, 0.2)]
+        spawn_z = BELT_TOP_Z + BOX_HALF + 0.01
+        for i in range(NUM_BOXES):
+            ang = 2.0 * math.pi * i / NUM_BOXES
+            box = builder.add_link(
+                xform=wp.transform(
+                    p=wp.vec3(RING_RADIUS * math.cos(ang), RING_RADIUS * math.sin(ang), spawn_z),
+                    q=wp.quat_identity(),
+                ),
+                mass=1.0,
+                label=f"box_{i}",
+            )
+            builder.add_shape_box(
+                box,
+                hx=BOX_HALF,
+                hy=BOX_HALF,
+                hz=BOX_HALF,
+                cfg=newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, restitution=0.0),
+                color=box_colors[i % len(box_colors)],
+            )
+            builder.add_articulation([builder.add_joint_free(box)], label=f"box_{i}")
+            self.box_bodies.append(box)
+
+        builder.color()
+        self.model = builder.finalize()
+
+        # Allocate the reported per-contact force attribute.
+        self.model.request_contact_attributes("force")
+
+        if self.solver_type == "mujoco":
+            # MuJoCo configuration for Newton-generated contacts.
+            self.solver = newton.solvers.SolverMuJoCo(
+                self.model,
+                cone="elliptic",
+                use_mujoco_contacts=False,
+                njmax=1500,
+                nconmax=750,
+            )
+        elif self.solver_type == "vbd":
+            self.solver = newton.solvers.SolverVBD(self.model, iterations=5, rigid_body_contact_buffer_size=1024)
+        else:
+            self.solver = newton.solvers.SolverXPBD(self.model)
+
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+        self.control = self.model.control()
+        self.collision_pipeline = newton.CollisionPipeline(self.model, broad_phase="explicit")
+        self.contacts = self.collision_pipeline.contacts()
+
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
+
+        # Pivot velocity field centered on the ring's +Z axis.
+        self.conveyor = ConveyorForceModel(self.model, solver_type=self.solver_type)
+        omega = belt_speed / RING_RADIUS
+        self.conveyor.add_pivot_belt(
+            self.belt_shape,
+            pivot_point=wp.vec3(0.0, 0.0, BELT_TOP_Z),
+            angular_velocity=wp.vec3(0.0, 0.0, omega),
+            surface_normal=wp.vec3(0.0, 0.0, 1.0),
+            friction=0.6,
+        )
+        self.conveyor.finalize(self.contacts)
+
+        self.viewer.set_model(self.model)
+        pos, pitch, yaw = _look_at(eye=(6.5, -6.5, 6.0), target=(0.0, 0.0, BELT_TOP_Z))
+        self.viewer.set_camera(pos, pitch, yaw)
+
+    def simulate(self):
+        for _ in range(self.sim_substeps):
+            self.state_0.clear_forces()
+            self.viewer.apply_forces(self.state_0)
+            self.conveyor.apply(self.state_0)
+
+            self.conveyor.snapshot_prev(self.state_0)
+            self.collision_pipeline.collide(self.state_0, self.contacts)
+            self.solver.step(self.state_0, self.state_1, self.control, self.contacts, self.sim_dt)
+            self.conveyor.update(self.solver, self.contacts, self.state_1, self.sim_dt)
+
+            self.state_0, self.state_1 = self.state_1, self.state_0
+
+    def step(self):
+        # Linear speed ramp over the initial interval.
+        self.conveyor.set_speed_scale(min(1.0, self.sim_time / SPEED_RAMP_DURATION))
+        self.simulate()
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        self.viewer.begin_frame(self.sim_time)
+        self.viewer.log_state(self.state_0)
+        self.viewer.log_contacts(self.contacts, self.state_0)
+        self.viewer.end_frame()
+
+    def test_final(self):
+        body_q = self.state_0.body_q.numpy()
+        for box in self.box_bodies:
+            p = body_q[box][:3]
+            assert np.all(np.isfinite(p)), f"box {box} pose is non-finite"
+            r = float(math.hypot(p[0], p[1]))
+            # Box stays within the ring band and on the belt surface.
+            assert HUB_RADIUS - 0.3 < r < WALL_RADIUS + 0.3, f"box {box} left the ring band: r={r:.3f}"
+            assert abs(float(p[2]) - (BELT_TOP_Z + BOX_HALF)) < 0.15, f"box {box} left the belt surface: z={p[2]:.4f}"
+
+
+if __name__ == "__main__":
+    parser = newton.examples.create_parser()
+    parser.add_argument("--belt-speed", type=float, default=BELT_SPEED, help="Ring surface speed at the centerline [m/s].")
+    parser.add_argument(
+        "--solver", type=str, choices=["xpbd", "vbd", "mujoco"], default="xpbd", help="Solver backend to use."
+    )
+    viewer, args = newton.examples.init(parser)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/tests/test_conveyor_force.py
+++ b/newton/tests/test_conveyor_force.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness-matrix tests for the force-based conveyor model.
+
+Exercises :class:`newton.examples.basic.conveyor_force_model.ConveyorForceModel`
+across solver backends with quantitative (not just validity) checks: zero speed
+(no drift), constant/reversed speed (direction and convergence), rotated belt,
+curved (pivot) velocity field, contact loss, and long-running stability.
+"""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.examples.basic.conveyor_force_model import ConveyorForceModel
+from newton.tests.unittest_utils import add_function_test, get_test_devices
+
+BELT_HALF_X = 1.5
+BELT_HALF_Y = 6.0
+BELT_HALF_Z = 0.1
+BELT_TOP_Z = 0.5
+BOX_HALF = 0.2
+CONTACT_FRICTION = 2.0e-5
+
+
+def _make_solver(solver_name, model):
+    if solver_name == "vbd":
+        return newton.solvers.SolverVBD(model, iterations=5, rigid_body_contact_buffer_size=512)
+    if solver_name == "mujoco":
+        # MuJoCo configuration for Newton-generated contacts.
+        return newton.solvers.SolverMuJoCo(
+            model, cone="elliptic", use_mujoco_contacts=False, njmax=200, nconmax=100
+        )
+    return newton.solvers.SolverXPBD(model)
+
+
+def run_conveyor(
+    device,
+    solver_name,
+    *,
+    velocity=None,
+    pivot_point=None,
+    angular_velocity=None,
+    box_xy=(0.0, 0.0),
+    box_mass=1.0,
+    belt_half_x=BELT_HALF_X,
+    belt_half_y=BELT_HALF_Y,
+    belt_rotation=None,
+    frames=120,
+    substeps=8,
+    fps=60,
+    collect_diagnostics=False,
+):
+    """Build a single-box-on-flat-belt scene, run it, and return the box position history.
+
+    Returns an array of shape ``(frames + 1, 3)`` of the box world position per frame
+    (index 0 is the initial pose).
+    """
+    builder = newton.ModelBuilder()
+    builder.add_ground_plane()
+
+    belt_cfg = newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, ke=1.0e5, kd=0.0)
+    if belt_rotation is None:
+        belt_rotation = wp.quat_identity()
+    belt_shape = builder.add_shape_box(
+        body=-1,
+        hx=belt_half_x,
+        hy=belt_half_y,
+        hz=BELT_HALF_Z,
+        xform=wp.transform(p=wp.vec3(0.0, 0.0, BELT_TOP_Z - BELT_HALF_Z), q=belt_rotation),
+        cfg=belt_cfg,
+    )
+
+    box_body = builder.add_link(
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + BOX_HALF + 0.01), q=wp.quat_identity()),
+        mass=box_mass,
+        label="box",
+    )
+    builder.add_shape_box(
+        box_body,
+        hx=BOX_HALF,
+        hy=BOX_HALF,
+        hz=BOX_HALF,
+        cfg=newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, restitution=0.0),
+    )
+    builder.add_articulation([builder.add_joint_free(box_body)], label="box")
+    builder.color()
+
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = _make_solver(solver_name, model)
+    state_0, state_1 = model.state(), model.state()
+    control = model.control()
+    collision_pipeline = newton.CollisionPipeline(model)
+    contacts = collision_pipeline.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    conveyor = ConveyorForceModel(model, solver_type=solver_name)
+    if pivot_point is not None:
+        conveyor.add_pivot_belt(belt_shape, pivot_point=pivot_point, angular_velocity=angular_velocity)
+    else:
+        conveyor.add_constant_belt(belt_shape, velocity=velocity if velocity is not None else wp.vec3(0.0, 0.0, 0.0))
+    conveyor.finalize(contacts)
+
+    sim_dt = 1.0 / fps / substeps
+    positions = np.zeros((frames + 1, 3), dtype=np.float32)
+    positions[0] = state_0.body_q.numpy()[box_body][:3]
+    if collect_diagnostics:
+        sample_count = frames * substeps
+        belt_contact_counts = np.zeros(sample_count, dtype=np.int32)
+        conveyor_force_norms = np.zeros(sample_count, dtype=np.float32)
+        sample = 0
+
+    for f in range(frames):
+        for _ in range(substeps):
+            state_0.clear_forces()
+            conveyor.apply(state_0)
+            conveyor.snapshot_prev(state_0)
+            collision_pipeline.collide(state_0, contacts)
+            solver.step(state_0, state_1, control, contacts, sim_dt)
+            conveyor.update(solver, contacts, state_1, sim_dt)
+            if collect_diagnostics:
+                belt_contact_counts[sample] = conveyor.body_contact_count.numpy()[box_body]
+                conveyor_force_norms[sample] = np.linalg.norm(conveyor.conveyor_body_f.numpy()[box_body][:3])
+                sample += 1
+            state_0, state_1 = state_1, state_0
+        positions[f + 1] = state_0.body_q.numpy()[box_body][:3]
+
+    if collect_diagnostics:
+        count = int(contacts.rigid_contact_count.numpy()[0])
+        diagnostics = {
+            "belt_contact_counts": belt_contact_counts,
+            "conveyor_force_norms": conveyor_force_norms,
+            "contact_forces": conveyor.contact_force_vec.numpy()[:count],
+            "contact_normals": contacts.rigid_contact_normal.numpy()[:count],
+            "contact_points0": contacts.rigid_contact_point0.numpy()[:count],
+            "contact_points1": contacts.rigid_contact_point1.numpy()[:count],
+            "contact_shape0": contacts.rigid_contact_shape0.numpy()[:count],
+            "contact_shape1": contacts.rigid_contact_shape1.numpy()[:count],
+            "belt_shape": belt_shape,
+            "conveyor_force": conveyor.conveyor_body_f.numpy()[box_body][:3],
+        }
+        return positions, 1.0 / fps, diagnostics
+
+    return positions, 1.0 / fps
+
+
+def _final_velocity(positions, frame_dt, n=30):
+    """Average velocity over the last ``n`` frames."""
+    seg = positions[-n - 1 :]
+    return (seg[-1] - seg[0]) / (n * frame_dt)
+
+
+def _yaw_deg(quat):
+    """Yaw angle [deg] about +Z from an (x, y, z, w) quaternion."""
+    x, y, z, w = quat
+    return np.degrees(np.arctan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z)))
+
+
+def run_multi_belt(device, solver_name, belts, box_xy, *, box_half=(0.45, 0.2, 0.2), frames=150, substeps=8, fps=60):
+    """Run a box over multiple static belts.
+
+    ``belts`` is a list of ``(center_xyz, half_xyz, velocity)`` tuples. Returns
+    ``(positions, quats, frame_dt)`` where positions is ``(frames + 1, 3)`` and quats is
+    ``(frames + 1, 4)`` (x, y, z, w) of the box per frame.
+    """
+    builder = newton.ModelBuilder()
+    builder.add_ground_plane()
+    belt_cfg = newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, ke=1.0e5, kd=0.0)
+
+    belt_shapes = []
+    for center, half, _vel in belts:
+        s = builder.add_shape_box(
+            body=-1,
+            hx=half[0],
+            hy=half[1],
+            hz=half[2],
+            xform=wp.transform(p=wp.vec3(*center), q=wp.quat_identity()),
+            cfg=belt_cfg,
+        )
+        belt_shapes.append(s)
+
+    box_body = builder.add_link(
+        xform=wp.transform(p=wp.vec3(box_xy[0], box_xy[1], BELT_TOP_Z + box_half[2] + 0.01), q=wp.quat_identity()),
+        mass=1.0,
+        label="box",
+    )
+    builder.add_shape_box(
+        box_body,
+        hx=box_half[0],
+        hy=box_half[1],
+        hz=box_half[2],
+        cfg=newton.ModelBuilder.ShapeConfig(mu=CONTACT_FRICTION, restitution=0.0),
+    )
+    builder.add_articulation([builder.add_joint_free(box_body)], label="box")
+    builder.color()
+
+    model = builder.finalize(device=device)
+    model.request_contact_attributes("force")
+
+    solver = _make_solver(solver_name, model)
+    state_0, state_1 = model.state(), model.state()
+    control = model.control()
+    collision_pipeline = newton.CollisionPipeline(model)
+    contacts = collision_pipeline.contacts()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    conveyor = ConveyorForceModel(model, solver_type=solver_name)
+    for shape, (_center, _half, vel) in zip(belt_shapes, belts, strict=True):
+        conveyor.add_constant_belt(shape, velocity=wp.vec3(*vel))
+    conveyor.finalize(contacts)
+
+    sim_dt = 1.0 / fps / substeps
+    positions = np.zeros((frames + 1, 3), dtype=np.float32)
+    quats = np.zeros((frames + 1, 4), dtype=np.float32)
+    q0 = state_0.body_q.numpy()[box_body]
+    positions[0], quats[0] = q0[:3], q0[3:7]
+
+    for f in range(frames):
+        for _ in range(substeps):
+            state_0.clear_forces()
+            conveyor.apply(state_0)
+            conveyor.snapshot_prev(state_0)
+            collision_pipeline.collide(state_0, contacts)
+            solver.step(state_0, state_1, control, contacts, sim_dt)
+            conveyor.update(solver, contacts, state_1, sim_dt)
+            state_0, state_1 = state_1, state_0
+        q = state_0.body_q.numpy()[box_body]
+        positions[f + 1], quats[f + 1] = q[:3], q[3:7]
+
+    return positions, quats, 1.0 / fps
+
+
+def test_zero_speed_no_drift(test, device, solver_name):
+    positions, _ = run_conveyor(device, solver_name, velocity=wp.vec3(0.0, 0.0, 0.0), frames=90)
+    disp = positions[-1] - positions[0]
+    test.assertLess(abs(float(disp[0])), 0.05, "unexpected X drift at zero belt speed")
+    test.assertLess(abs(float(disp[1])), 0.05, "unexpected Y drift at zero belt speed")
+    test.assertTrue(np.all(np.isfinite(positions)))
+
+
+def test_constant_speed_forward(test, device, solver_name):
+    speed = 2.0
+    positions, frame_dt = run_conveyor(device, solver_name, velocity=wp.vec3(0.0, speed, 0.0), frames=150)
+    vy = float(_final_velocity(positions, frame_dt)[1])
+    # Converges toward the target speed (with some slip), in the +Y direction.
+    test.assertGreater(vy, 0.7 * speed, f"box did not converge toward belt speed: vy={vy:.3f}")
+    test.assertLess(vy, 1.1 * speed, f"box overshot belt speed: vy={vy:.3f}")
+    # Negligible lateral drift.
+    test.assertLess(abs(float(positions[-1][0])), 0.1)
+
+
+def test_reversed_speed(test, device, solver_name):
+    speed = 2.0
+    positions, frame_dt = run_conveyor(device, solver_name, velocity=wp.vec3(0.0, -speed, 0.0), frames=150)
+    vy = float(_final_velocity(positions, frame_dt)[1])
+    test.assertLess(vy, -0.7 * speed, f"box not transported in -Y: vy={vy:.3f}")
+
+
+def test_rotated_belt_direction(test, device, solver_name):
+    # Rotate the long belt axis from +Y to +X and drive it in world-space +X.
+    speed = 2.0
+    positions, frame_dt = run_conveyor(
+        device,
+        solver_name,
+        velocity=wp.vec3(speed, 0.0, 0.0),
+        belt_rotation=wp.quat_from_axis_angle(wp.vec3(0.0, 0.0, 1.0), 0.5 * np.pi),
+        frames=90,
+    )
+    vel = _final_velocity(positions, frame_dt)
+    test.assertGreater(float(vel[0]), 0.7 * speed, "box not transported along +X")
+    test.assertLess(abs(float(vel[1])), 0.3, "unexpected Y motion for an X-driven belt")
+
+
+def test_curved_velocity_field(test, device, solver_name):
+    # Pivot field about the +Z axis at the origin: a box at +Y should be driven toward -X
+    # (tangent = omega x r, omega=+Z, r=+Y -> -X).
+    positions, frame_dt = run_conveyor(
+        device,
+        solver_name,
+        pivot_point=wp.vec3(0.0, 0.0, BELT_TOP_Z),
+        angular_velocity=wp.vec3(0.0, 0.0, 1.0),
+        box_xy=(0.0, 2.0),
+        frames=60,
+    )
+    vel = _final_velocity(positions, frame_dt, n=20)
+    test.assertLess(float(vel[0]), -0.2, f"pivot field did not drive box toward -X: vx={vel[0]:.3f}")
+    test.assertTrue(np.all(np.isfinite(positions)))
+
+
+def test_contact_loss_no_force(test, device, solver_name):
+    # Drive a box off a short belt and verify that the previously computed wrench is cleared.
+    positions, _, diagnostics = run_conveyor(
+        device,
+        solver_name,
+        velocity=wp.vec3(0.0, 3.0, 0.0),
+        belt_half_y=1.0,
+        frames=120,
+        collect_diagnostics=True,
+    )
+    test.assertGreater(int(np.max(diagnostics["belt_contact_counts"])), 0, "box never contacted the belt")
+    test.assertTrue(np.all(diagnostics["belt_contact_counts"][-16:] == 0), "belt contact did not end")
+    test.assertTrue(np.all(diagnostics["conveyor_force_norms"][-16:] < 1.0e-6), "stale conveyor force remained")
+    test.assertTrue(np.all(np.isfinite(positions)))
+
+
+def test_long_running_stability(test, device, solver_name):
+    positions, _ = run_conveyor(device, solver_name, velocity=wp.vec3(0.0, 0.5, 0.0), frames=400)
+    test.assertTrue(np.all(np.isfinite(positions)), "state became non-finite over a long run")
+    # Box stays on the belt band (height near belt top + box half extent).
+    test.assertLess(abs(float(positions[-1][2] - (BELT_TOP_Z + BOX_HALF))), 0.15)
+
+
+def test_multi_belt_handoff(test, device, solver_name):
+    # Two belts meet along Y, both driving +Y. The box spans both surfaces during handoff.
+    belts = [
+        ((0.0, -2.0, BELT_TOP_Z - BELT_HALF_Z), (1.0, 2.0, BELT_HALF_Z), (0.0, 2.0, 0.0)),
+        ((0.0, 2.0, BELT_TOP_Z - BELT_HALF_Z), (1.0, 2.0, BELT_HALF_Z), (0.0, 2.0, 0.0)),
+    ]
+    positions, _quats, _dt = run_multi_belt(device, solver_name, belts, box_xy=(0.0, -3.0), frames=150)
+    test.assertTrue(np.all(np.isfinite(positions)))
+    # Crossed the seam (started at y=-3) and kept going into positive Y.
+    test.assertGreater(float(positions[-1][1]), 0.0, "box did not hand off across the belt seam")
+
+
+def test_multi_belt_not_doubled(test, device, solver_name):
+    # A box spanning two coplanar belts running at the SAME speed must converge to that speed,
+    # not a multiple of it (behavior must not be biased by the contact count).
+    speed = 2.0
+    belts = [
+        ((-0.5, 0.0, BELT_TOP_Z - BELT_HALF_Z), (0.5, 4.0, BELT_HALF_Z), (0.0, speed, 0.0)),
+        ((0.5, 0.0, BELT_TOP_Z - BELT_HALF_Z), (0.5, 4.0, BELT_HALF_Z), (0.0, speed, 0.0)),
+    ]
+    positions, _quats, frame_dt = run_multi_belt(device, solver_name, belts, box_xy=(0.0, -2.0), frames=150)
+    vy = float(_final_velocity(positions, frame_dt)[1])
+    test.assertGreater(vy, 0.7 * speed, f"box did not converge toward belt speed: vy={vy:.3f}")
+    test.assertLess(vy, 1.2 * speed, f"contact count doubled the effective speed: vy={vy:.3f}")
+
+
+def test_differential_belts_rotate(test, device, solver_name):
+    # A box straddling two side-by-side belts running at different speeds must turn (yaw),
+    # matching the expected differential-drive behavior.
+    belts = [
+        ((-0.5, 0.0, BELT_TOP_Z - BELT_HALF_Z), (0.5, 4.0, BELT_HALF_Z), (0.0, 1.0, 0.0)),
+        ((0.5, 0.0, BELT_TOP_Z - BELT_HALF_Z), (0.5, 4.0, BELT_HALF_Z), (0.0, 3.0, 0.0)),
+    ]
+    positions, quats, _dt = run_multi_belt(device, solver_name, belts, box_xy=(0.0, 0.0), frames=120)
+    test.assertTrue(np.all(np.isfinite(positions)))
+    yaw = abs(float(_yaw_deg(quats[-1])))
+    test.assertGreater(yaw, 10.0, f"differential belts did not induce turning: yaw={yaw:.1f} deg")
+
+
+def test_load_invariance(test, device, solver_name):
+    speed = 2.0
+    velocities = []
+    for mass in (1.0, 5.0):
+        positions, frame_dt = run_conveyor(
+            device, solver_name, velocity=wp.vec3(0.0, speed, 0.0), box_mass=mass, frames=120
+        )
+        velocities.append(float(_final_velocity(positions, frame_dt)[1]))
+    test.assertGreater(min(velocities), 0.7 * speed)
+    test.assertLess(abs(velocities[0] - velocities[1]), 0.2, f"transport depends on load: {velocities}")
+
+
+def test_timestep_stability(test, device, solver_name):
+    trajectories = []
+    for substeps in (4, 8):
+        positions, frame_dt = run_conveyor(
+            device, solver_name, velocity=wp.vec3(0.0, 2.0, 0.0), frames=120, substeps=substeps
+        )
+        trajectories.append((float(positions[-1][1]), float(_final_velocity(positions, frame_dt)[1])))
+    test.assertLess(abs(trajectories[0][0] - trajectories[1][0]), 0.15, f"timestep changed travel: {trajectories}")
+    test.assertLess(abs(trajectories[0][1] - trajectories[1][1]), 0.1, f"timestep changed speed: {trajectories}")
+
+
+def test_contact_data_consistency(test, device, solver_name):
+    _, _, diagnostics = run_conveyor(
+        device,
+        solver_name,
+        velocity=wp.vec3(0.0, 1.0, 0.0),
+        frames=90,
+        collect_diagnostics=True,
+    )
+    test.assertTrue(np.all(diagnostics["belt_contact_counts"][-16:] > 0), "contact data was unavailable")
+
+    forces = diagnostics["contact_forces"]
+    normals = diagnostics["contact_normals"]
+    test.assertGreater(len(forces), 0)
+    test.assertTrue(np.all(np.isfinite(forces)))
+    test.assertTrue(np.all(np.isfinite(normals)))
+    test.assertTrue(np.all(np.isfinite(diagnostics["contact_points0"])))
+    test.assertTrue(np.all(np.isfinite(diagnostics["contact_points1"])))
+    np.testing.assert_allclose(np.linalg.norm(normals, axis=1), 1.0, atol=1.0e-4)
+
+    belt_mask = (diagnostics["contact_shape0"] == diagnostics["belt_shape"]) | (
+        diagnostics["contact_shape1"] == diagnostics["belt_shape"]
+    )
+    normal_force = np.abs(np.einsum("ij,ij->i", forces[belt_mask], normals[belt_mask])).sum()
+    test.assertGreater(float(normal_force), 0.0)
+    # The externally applied tangential force must remain within the summed Coulomb limit.
+    conveyor_force = float(np.linalg.norm(diagnostics["conveyor_force"]))
+    test.assertLessEqual(conveyor_force, 0.5 * float(normal_force) + 1.0e-4)
+
+
+def test_backend_parity(test, device, solver_name):
+    # The same force model must transport a box consistently across all three solvers.
+    # (solver_name is unused; this case drives XPBD, VBD, and MuJoCo itself.)
+    ys = {}
+    for name in ("xpbd", "vbd", "mujoco"):
+        positions, _ = run_conveyor(device, name, velocity=wp.vec3(0.0, 2.0, 0.0), frames=120)
+        ys[name] = float(positions[-1][1])
+    test.assertTrue(all(np.isfinite(v) for v in ys.values()), f"non-finite result: {ys}")
+    spread = max(ys.values()) - min(ys.values())
+    test.assertLess(spread, 0.6, f"backends disagree on transport distance: {ys}")
+
+
+class TestConveyorForce(unittest.TestCase):
+    pass
+
+
+_devices = get_test_devices()
+_cases = [
+    ("zero_speed_no_drift", test_zero_speed_no_drift),
+    ("constant_speed_forward", test_constant_speed_forward),
+    ("reversed_speed", test_reversed_speed),
+    ("rotated_belt_direction", test_rotated_belt_direction),
+    ("curved_velocity_field", test_curved_velocity_field),
+    ("contact_loss_no_force", test_contact_loss_no_force),
+    ("long_running_stability", test_long_running_stability),
+    ("multi_belt_handoff", test_multi_belt_handoff),
+    ("multi_belt_not_doubled", test_multi_belt_not_doubled),
+    ("differential_belts_rotate", test_differential_belts_rotate),
+    ("load_invariance", test_load_invariance),
+    ("timestep_stability", test_timestep_stability),
+    ("contact_data_consistency", test_contact_data_consistency),
+]
+
+for _device in _devices:
+    # MuJoCo and VBD rigid-contact support target CUDA.
+    if _device.is_cpu:
+        continue
+    for _solver_name in ("xpbd", "vbd", "mujoco"):
+        for _case_name, _case_fn in _cases:
+            add_function_test(
+                TestConveyorForce,
+                f"test_{_case_name}_{_solver_name}",
+                _case_fn,
+                devices=[_device],
+                solver_name=_solver_name,
+            )
+    add_function_test(
+        TestConveyorForce,
+        "test_backend_parity",
+        test_backend_parity,
+        devices=[_device],
+        solver_name="mujoco",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -386,6 +386,13 @@ add_basic_example_test(
     allow_output_regexes=[(_WARP_SDF_CONSTANT_CONVERSION_WARNING_RE, "stderr")],
 )
 add_basic_example_test(
+    name="basic.example_conveyor_force",
+    devices=test_devices,
+    use_viewer=True,
+    test_options={"num-frames": 100},
+    allow_output_regexes=[(_WARP_SDF_CONSTANT_CONVERSION_WARNING_RE, "stderr")],
+)
+add_basic_example_test(
     name="basic.example_basic_dzhanibekov",
     devices=test_devices,
     use_viewer=True,


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a conveyor-force physics model supporting constant-speed and pivot-based moving belts.
  * Added a runnable conveyor belt example with configurable belt speed and solver selection.
  * Supports Coulomb-limited tangential forces across XPBD, VBD, and MuJoCo solvers.

* **Tests**
  * Added comprehensive coverage for belt motion, contact handling, stability, multi-belt behavior, and solver consistency.

* **Documentation**
  * Added release notes for version 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->