### PR TITLE
Add ViewerGL post-processing callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add three VBD contact examples — `vbd_rigid_rigid_contact`, `vbd_soft_rigid_contact`, and `vbd_soft_rigid_mix_contact` — demonstrating rigid-rigid, soft (particle-rigid), and mixed cloth-bag contacts
 - Add masked rigid-body reset support to `SolverVBD`; particle resets are not yet supported. (#3256)
 - Add viewer layer system to overlay multiple solvers/models in supported rendering viewers; call `ViewerBase.activate(layer_id)` to route subsequent `set_model` / `log_state` / `log_*` calls into a named layer, `ViewerBase.set_layer_visible()` to toggle layers independently, and `ViewerBase.set_layer_transform()` to position layers side-by-side. See `example_basic_multi_solver_overlay.py`
+- Add `ViewerGL.register_post_process()` for ordered OpenGL color-and-depth post-processing before UI rendering and frame capture.
 - Add `ViewerBase.camera_speed` to configure keyboard translation speed for interactive viewers. (#3439)
 - Add SDF contact support for convex-hull shapes with mesh-attached SDFs and opt-in SDF contact generation for box shapes.
 - Add opt-in filtering of static-static, static-kinematic, and kinematic-kinematic contacts during broad-phase collision detection. Set `CollisionPipeline(include_static_kinematic_pairs=False)` to enable filtering; the default preserves existing contact generation. `Model.shape_contact_pairs` remains an unfiltered superset for direct consumers such as `SolverKamino` and hydroelastic SDF setup.

--- a/docs/guide/visualization.rst
+++ b/docs/guide/visualization.rst
@@ -113,6 +113,50 @@ Warp array on the viewer device:
     # Returns a wp.array with shape (height, width, 3), dtype wp.uint8
     frame = viewer.get_frame()
 
+**OpenGL post-processing:**
+
+:meth:`~newton.viewer.ViewerGL.register_post_process` registers an OpenGL callback that runs after
+the scene color and depth have been resolved and before the UI is rendered. Multiple callbacks run
+in registration order, with Newton ping-ponging both color and depth between passes. The final pass
+is used for window presentation and :meth:`~newton.viewer.ViewerGL.get_frame`.
+
+The OpenGL context is current when the callback runs. Newton binds the input framebuffer for reading,
+the output framebuffer for drawing, and ``context.viewport`` in physical framebuffer pixels. A pass
+must restore every other OpenGL state it modifies before returning. A pass that makes no visual change
+must still copy both color and depth:
+
+.. code-block:: python
+
+    from pyglet import gl
+
+    def post_process(context):
+        gl.glBlitFramebuffer(
+            0,
+            0,
+            context.width,
+            context.height,
+            0,
+            0,
+            context.width,
+            context.height,
+            gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT,
+            gl.GL_NEAREST,
+        )
+
+    registration = viewer.register_post_process(post_process)
+
+    # Unregister explicitly, or let viewer.close() do it before destroying
+    # the OpenGL context.
+    registration.close()
+
+Input and output color attachments are single-sample ``GL_RGB8`` textures containing display-encoded
+RGB. Depth attachments use ``GL_DEPTH_COMPONENT32`` and standard non-reversed OpenGL window depth in
+``[0, 1]``. The origin is bottom-left and UI rendering is excluded. Input attachments are read-only,
+output contents are initially undefined, and their identifiers are valid only for the current callback;
+resizing may change them. ``context.camera`` is an immutable snapshot of the camera values and matrices
+used to render the scene. Its field of view is in degrees, clipping distances are in meters, and its
+immutable float32 matrices have shape ``(16,)`` in OpenGL column-major upload order.
+
 **Custom UI panels:**
 
 :meth:`~newton.viewer.ViewerGL.register_ui_callback` adds custom imgui UI elements to the viewer.

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1102,6 +1102,8 @@ class RendererGL:
         self._mouse_motion_callbacks = []
         self._mouse_scroll_callbacks = []
         self._resize_callbacks = []
+        self._close_callbacks = []
+        self._closed = False
 
         # Initialize device and shape lookup
         self._device = device if device is not None else wp.get_device()
@@ -1117,6 +1119,12 @@ class RendererGL:
         self._frame_texture = None
         self._frame_depth_texture = None
         self._frame_fbo = None
+        self._post_process_texture = None
+        self._post_process_depth_texture = None
+        self._post_process_fbo = None
+        self._last_frame_texture = None
+        self._last_frame_depth_texture = None
+        self._last_frame_fbo = None
         self._frame_pbo = None
 
         self._sun_direction = None  # set on first render based on camera up_axis
@@ -1214,7 +1222,7 @@ class RendererGL:
                 # This is a non-fatal error that can be safely ignored
                 pass
 
-    def render(self, camera, objects, lines=None, wireframe_shapes=None, arrows=None):
+    def render(self, camera, objects, lines=None, wireframe_shapes=None, arrows=None, post_process=None):
         gl = RendererGL.gl
         self._make_current()
 
@@ -1307,6 +1315,11 @@ class RendererGL:
                 gl.GL_NEAREST,
             )
 
+        final_target = (self._frame_fbo, self._frame_texture, self._frame_depth_texture)
+        if post_process is not None:
+            final_target = post_process()
+        self._last_frame_fbo, self._last_frame_texture, self._last_frame_depth_texture = final_target
+
         # ------------------------------------------------------------------
         # Draw resolved texture to the screen
         # ------------------------------------------------------------------
@@ -1315,10 +1328,10 @@ class RendererGL:
         gl.glViewport(0, 0, self._screen_width, self._screen_height)
 
         # render frame buffer texture to screen
-        if self._frame_fbo is not None:
+        if self._last_frame_fbo is not None:
             with self._frame_shader:
                 gl.glActiveTexture(gl.GL_TEXTURE0)
-                gl.glBindTexture(gl.GL_TEXTURE_2D, self._frame_texture)
+                gl.glBindTexture(gl.GL_TEXTURE_2D, self._last_frame_texture)
                 self._frame_shader.update(0)
 
                 gl.glBindVertexArray(self._frame_vao)
@@ -1367,14 +1380,36 @@ class RendererGL:
         return self.app.event_loop.has_exit
 
     def close(self):
-        self._make_current()
+        if self._closed:
+            return
+        self._closed = True
+        first_error = None
+
+        def run_cleanup(operation):
+            nonlocal first_error
+            try:
+                operation()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+
+        try:
+            self._make_current()
+        except Exception as error:
+            first_error = error
+        else:
+            callbacks = tuple(reversed(self._close_callbacks))
+            self._close_callbacks.clear()
+            for callback in callbacks:
+                run_cleanup(callback)
 
         if not self.headless:
-            self.app.event_loop.dispatch_event("on_exit")
-            self.app.platform_event_loop.stop()
-
+            run_cleanup(lambda: self.app.event_loop.dispatch_event("on_exit"))
+            run_cleanup(self.app.platform_event_loop.stop)
         RendererGL._fallback_texture = None
-        self.window.close()
+        run_cleanup(self.window.close)
+        if first_error is not None:
+            raise first_error
 
     def _setup_window_callbacks(self):
         """Set up the basic window event handlers."""
@@ -1459,6 +1494,10 @@ class RendererGL:
             callback: Function that takes (width, height) parameters
         """
         self._resize_callbacks.append(callback)
+
+    def register_close(self, callback):
+        """Register a callback that runs before the OpenGL context closes."""
+        self._close_callbacks.append(callback)
 
     def register_update(self, callback):
         """Register a per-frame update callback receiving dt (seconds)."""
@@ -1566,6 +1605,87 @@ class RendererGL:
 
         check_gl_error()
 
+    def _setup_color_depth_target(self, color_texture, depth_texture, framebuffer):
+        gl = RendererGL.gl
+        created_color = color_texture is None
+        created_depth = depth_texture is None
+        created_framebuffer = framebuffer is None
+        try:
+            if created_color:
+                color_texture = gl.GLuint()
+                gl.glGenTextures(1, color_texture)
+            if created_depth:
+                depth_texture = gl.GLuint()
+                gl.glGenTextures(1, depth_texture)
+
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+            gl.glBindBuffer(gl.GL_PIXEL_UNPACK_BUFFER, 0)
+            gl.glBindTexture(gl.GL_TEXTURE_2D, color_texture)
+            gl.glTexImage2D(
+                gl.GL_TEXTURE_2D,
+                0,
+                gl.GL_RGB8,
+                self._screen_width,
+                self._screen_height,
+                0,
+                gl.GL_RGB,
+                gl.GL_UNSIGNED_BYTE,
+                None,
+            )
+            gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
+            gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
+
+            gl.glBindTexture(gl.GL_TEXTURE_2D, depth_texture)
+            gl.glTexImage2D(
+                gl.GL_TEXTURE_2D,
+                0,
+                gl.GL_DEPTH_COMPONENT32,
+                self._screen_width,
+                self._screen_height,
+                0,
+                gl.GL_DEPTH_COMPONENT,
+                gl.GL_FLOAT,
+                None,
+            )
+            gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
+            gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
+            gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+
+            if created_framebuffer:
+                framebuffer = gl.GLuint()
+                gl.glGenFramebuffers(1, framebuffer)
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, framebuffer)
+            gl.glFramebufferTexture2D(gl.GL_FRAMEBUFFER, gl.GL_COLOR_ATTACHMENT0, gl.GL_TEXTURE_2D, color_texture, 0)
+            gl.glFramebufferTexture2D(gl.GL_FRAMEBUFFER, gl.GL_DEPTH_ATTACHMENT, gl.GL_TEXTURE_2D, depth_texture, 0)
+            if gl.glCheckFramebufferStatus(gl.GL_FRAMEBUFFER) != gl.GL_FRAMEBUFFER_COMPLETE:
+                raise RuntimeError("ViewerGL framebuffer is incomplete")
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+            return color_texture, depth_texture, framebuffer
+        except Exception:
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+            gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
+            if created_framebuffer and framebuffer is not None:
+                gl.glDeleteFramebuffers(1, framebuffer)
+            if created_depth and depth_texture is not None:
+                gl.glDeleteTextures(1, depth_texture)
+            if created_color and color_texture is not None:
+                gl.glDeleteTextures(1, color_texture)
+            raise
+
+    def _ensure_post_process_target(self):
+        if self._post_process_fbo is not None:
+            return
+        self._make_current()
+        (
+            self._post_process_texture,
+            self._post_process_depth_texture,
+            self._post_process_fbo,
+        ) = self._setup_color_depth_target(
+            self._post_process_texture,
+            self._post_process_depth_texture,
+            self._post_process_fbo,
+        )
+
     def _setup_frame_buffer(self):
         gl = RendererGL.gl
 
@@ -1578,71 +1698,24 @@ class RendererGL:
             self._frame_msaa_fbo = None
 
         self._make_current()
-
-        if self._frame_texture is None:
-            self._frame_texture = gl.GLuint()
-            gl.glGenTextures(1, self._frame_texture)
-        if self._frame_depth_texture is None:
-            self._frame_depth_texture = gl.GLuint()
-            gl.glGenTextures(1, self._frame_depth_texture)
-
-        # set up RGB texture
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
-        gl.glBindBuffer(gl.GL_PIXEL_UNPACK_BUFFER, 0)
-        gl.glBindTexture(gl.GL_TEXTURE_2D, self._frame_texture)
-        gl.glTexImage2D(
-            gl.GL_TEXTURE_2D,
-            0,
-            gl.GL_RGB,
-            self._screen_width,
-            self._screen_height,
-            0,
-            gl.GL_RGB,
-            gl.GL_UNSIGNED_BYTE,
-            None,
+        self._frame_texture, self._frame_depth_texture, self._frame_fbo = self._setup_color_depth_target(
+            self._frame_texture,
+            self._frame_depth_texture,
+            self._frame_fbo,
         )
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
-
-        # set up depth texture
-        gl.glBindTexture(gl.GL_TEXTURE_2D, self._frame_depth_texture)
-        gl.glTexImage2D(
-            gl.GL_TEXTURE_2D,
-            0,
-            gl.GL_DEPTH_COMPONENT32,
-            self._screen_width,
-            self._screen_height,
-            0,
-            gl.GL_DEPTH_COMPONENT,
-            gl.GL_FLOAT,
-            None,
-        )
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_LINEAR)
-        gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_LINEAR)
-        gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
-
-        # create a framebuffer object (FBO)
-        if self._frame_fbo is None:
-            self._frame_fbo = gl.GLuint()
-            gl.glGenFramebuffers(1, self._frame_fbo)
-            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self._frame_fbo)
-
-            # attach the texture to the FBO as its color attachment
-            gl.glFramebufferTexture2D(
-                gl.GL_FRAMEBUFFER, gl.GL_COLOR_ATTACHMENT0, gl.GL_TEXTURE_2D, self._frame_texture, 0
+        if self._post_process_fbo is not None:
+            (
+                self._post_process_texture,
+                self._post_process_depth_texture,
+                self._post_process_fbo,
+            ) = self._setup_color_depth_target(
+                self._post_process_texture,
+                self._post_process_depth_texture,
+                self._post_process_fbo,
             )
-            # attach the depth texture to the FBO as its depth attachment
-            gl.glFramebufferTexture2D(
-                gl.GL_FRAMEBUFFER, gl.GL_DEPTH_ATTACHMENT, gl.GL_TEXTURE_2D, self._frame_depth_texture, 0
-            )
-
-            if gl.glCheckFramebufferStatus(gl.GL_FRAMEBUFFER) != gl.GL_FRAMEBUFFER_COMPLETE:
-                print("Framebuffer is not complete!", flush=True)
-                gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
-                sys.exit(1)
-
-        # unbind the FBO (switch back to the default framebuffer)
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+        self._last_frame_texture = self._frame_texture
+        self._last_frame_depth_texture = self._frame_depth_texture
+        self._last_frame_fbo = self._frame_fbo
 
         if self._frame_pbo is None:
             self._frame_pbo = gl.GLuint()

--- a/newton/_src/viewer/gl/opengl.py
+++ b/newton/_src/viewer/gl/opengl.py
@@ -1496,7 +1496,11 @@ class RendererGL:
         self._resize_callbacks.append(callback)
 
     def register_close(self, callback):
-        """Register a callback that runs before the OpenGL context closes."""
+        """Register a callback that runs before the OpenGL context closes.
+
+        Args:
+            callback: Function to invoke during renderer shutdown.
+        """
         self._close_callbacks.append(callback)
 
     def register_update(self, callback):

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -248,7 +248,7 @@ class ViewerGL(ViewerBase):
             cleanup: Callable[[], None] | None,
         ):
             self._viewer = weakref.ref(viewer)
-            self._callback = callback
+            self._callback: Callable[[ViewerGL.PostProcessContext], None] | None = callback
             self._cleanup = cleanup
             self._closed = False
 
@@ -264,6 +264,8 @@ class ViewerGL(ViewerBase):
             viewer = self._viewer()
             if viewer is None:
                 self._closed = True
+                self._callback = None
+                self._cleanup = None
                 return
             viewer._close_post_process_registration(self)
 
@@ -491,9 +493,12 @@ class ViewerGL(ViewerBase):
 
         cleanup = registration._cleanup
         registration._cleanup = None
-        if cleanup is not None:
-            self.renderer._make_current()
-            cleanup()
+        try:
+            if cleanup is not None:
+                self.renderer._make_current()
+                cleanup()
+        finally:
+            registration._callback = None
 
     def _close_post_processes(self) -> None:
         if self._post_process_closed:
@@ -574,6 +579,9 @@ class ViewerGL(ViewerBase):
         for registration in tuple(self._post_process_registrations):
             if registration.closed:
                 continue
+            callback = registration._callback
+            if callback is None:
+                continue
             context = self.PostProcessContext(
                 width=width,
                 height=height,
@@ -591,7 +599,7 @@ class ViewerGL(ViewerBase):
             gl.glBindFramebuffer(gl.GL_DRAW_FRAMEBUFFER, output_target[0])
             gl.glDrawBuffer(gl.GL_COLOR_ATTACHMENT0)
             gl.glViewport(*viewport)
-            registration._callback(context)
+            callback(context)
             input_target, output_target = output_target, input_target
 
         return input_target

--- a/newton/_src/viewer/viewer_gl.py
+++ b/newton/_src/viewer/viewer_gl.py
@@ -7,7 +7,9 @@ import collections
 import ctypes
 import re
 import time
+import weakref
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from importlib import metadata
 from typing import Any, Literal
 
@@ -194,6 +196,77 @@ class ViewerGL(ViewerBase):
         - Extensible logging of meshes, lines, points, and arrays for custom visualization.
     """
 
+    @dataclass(frozen=True, slots=True)
+    class CameraSnapshot:
+        """Camera values used to render a post-processed frame.
+
+        Field of view is measured in degrees and clipping distances in meters.
+        Matrices are immutable float32 arrays with shape ``(16,)`` in the
+        column-major order uploaded to OpenGL. ``up_axis`` uses ``0``, ``1``,
+        and ``2`` for the X, Y, and Z axes.
+        """
+
+        position: tuple[float, float, float]
+        right: tuple[float, float, float]
+        up: tuple[float, float, float]
+        forward: tuple[float, float, float]
+        fov_y: float
+        near: float
+        far: float
+        up_axis: int
+        view_matrix: np.ndarray
+        projection_matrix: np.ndarray
+
+    @dataclass(frozen=True, slots=True)
+    class PostProcessContext:
+        """Resolved scene resources supplied to a post-process callback.
+
+        Texture and framebuffer identifiers are valid only for the current
+        callback. Input attachments are read-only and never alias the output
+        attachments. The callback must write both color and depth across the
+        full viewport.
+        """
+
+        width: int
+        height: int
+        viewport: tuple[int, int, int, int]
+        input_framebuffer_id: int
+        input_color_texture_id: int
+        input_depth_texture_id: int
+        output_framebuffer_id: int
+        output_color_texture_id: int
+        output_depth_texture_id: int
+        camera: ViewerGL.CameraSnapshot
+
+    class PostProcessRegistration:
+        """Handle for a callback registered with :meth:`register_post_process`."""
+
+        def __init__(
+            self,
+            viewer: ViewerGL,
+            callback: Callable[[ViewerGL.PostProcessContext], None],
+            cleanup: Callable[[], None] | None,
+        ):
+            self._viewer = weakref.ref(viewer)
+            self._callback = callback
+            self._cleanup = cleanup
+            self._closed = False
+
+        @property
+        def closed(self) -> bool:
+            """Whether the callback has been unregistered."""
+            return self._closed
+
+        def close(self) -> None:
+            """Unregister the callback and run its cleanup once."""
+            if self._closed:
+                return
+            viewer = self._viewer()
+            if viewer is None:
+                self._closed = True
+                return
+            viewer._close_post_process_registration(self)
+
     def __init__(
         self,
         width: int = 1920,
@@ -236,6 +309,8 @@ class ViewerGL(ViewerBase):
         # Initialized below once self.device is available; declared here so
         # close() can safely run if __init__ raises before that point.
         self._image_logger: ImageLogger | None = None
+        self._post_process_registrations: list[ViewerGL.PostProcessRegistration] = []
+        self._post_process_closed = False
 
         super().__init__()
 
@@ -300,6 +375,7 @@ class ViewerGL(ViewerBase):
         self._pbo = None
         self._wp_pbo = None
         self._pbo_host_buffer = None
+        self.renderer.register_close(self._cleanup_gl_resources)
 
     @override
     def _init_extra_layer_state(self, layer):
@@ -367,6 +443,158 @@ class ViewerGL(ViewerBase):
         for name in list(self._array_textures.keys()):
             if owns(name):
                 self._delete_array_texture(name)
+
+    def register_post_process(
+        self,
+        callback: Callable[[ViewerGL.PostProcessContext], None],
+        *,
+        cleanup: Callable[[], None] | None = None,
+    ) -> ViewerGL.PostProcessRegistration:
+        """Register a post-process callback for resolved scene color and depth.
+
+        Callbacks run in registration order after MSAA resolve and before UI
+        rendering. The OpenGL context is current and the callback's output
+        framebuffer and physical-pixel viewport are bound on entry. Callbacks
+        must restore every other OpenGL state they modify before returning.
+
+        Args:
+            callback: Function that writes the context output color and depth.
+            cleanup: Optional function run when the registration or viewer closes.
+
+        Returns:
+            A handle that can unregister the callback.
+
+        Raises:
+            RuntimeError: If the viewer is closing or closed.
+            TypeError: If either callback is not callable.
+        """
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        if cleanup is not None and not callable(cleanup):
+            raise TypeError("cleanup must be callable or None")
+        if self._post_process_closed:
+            raise RuntimeError("Cannot register post-processing on a closed ViewerGL")
+
+        self.renderer._ensure_post_process_target()
+        registration = self.PostProcessRegistration(self, callback, cleanup)
+        self._post_process_registrations.append(registration)
+        return registration
+
+    def _close_post_process_registration(self, registration: ViewerGL.PostProcessRegistration) -> None:
+        if registration._closed:
+            return
+        registration._closed = True
+        try:
+            self._post_process_registrations.remove(registration)
+        except ValueError:
+            pass
+
+        cleanup = registration._cleanup
+        registration._cleanup = None
+        if cleanup is not None:
+            self.renderer._make_current()
+            cleanup()
+
+    def _close_post_processes(self) -> None:
+        if self._post_process_closed:
+            return
+        self._post_process_closed = True
+        first_error = None
+        for registration in reversed(tuple(self._post_process_registrations)):
+            try:
+                registration.close()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+    def _cleanup_gl_resources(self) -> None:
+        first_error = None
+        cleanup_operations = [self._close_post_processes, self._clear_array_textures, self._invalidate_pbo]
+        if self._image_logger is not None:
+            cleanup_operations.append(self._image_logger.clear)
+        for cleanup in cleanup_operations:
+            try:
+                cleanup()
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+        if first_error is not None:
+            raise first_error
+
+    @staticmethod
+    def _gl_id(value) -> int:
+        return int(value.value) if hasattr(value, "value") else int(value)
+
+    def _camera_snapshot(self) -> ViewerGL.CameraSnapshot:
+        view_matrix = np.array(self.renderer._view_matrix, dtype=np.float32, copy=True)
+        projection_matrix = np.array(self.renderer._projection_matrix, dtype=np.float32, copy=True)
+        view_matrix.setflags(write=False)
+        projection_matrix.setflags(write=False)
+
+        def vec3_tuple(value) -> tuple[float, float, float]:
+            return (float(value[0]), float(value[1]), float(value[2]))
+
+        return self.CameraSnapshot(
+            position=vec3_tuple(self.camera.pos),
+            right=vec3_tuple(self.camera.get_right()),
+            up=vec3_tuple(self.camera.get_up()),
+            forward=vec3_tuple(self.camera.get_front()),
+            fov_y=float(self.camera.fov),
+            near=float(self.camera.near),
+            far=float(self.camera.far),
+            up_axis=int(self.camera.up_axis),
+            view_matrix=view_matrix,
+            projection_matrix=projection_matrix,
+        )
+
+    def _render_post_processes(self) -> tuple[int, int, int]:
+        renderer = self.renderer
+        input_target = (
+            self._gl_id(renderer._frame_fbo),
+            self._gl_id(renderer._frame_texture),
+            self._gl_id(renderer._frame_depth_texture),
+        )
+        if not self._post_process_registrations:
+            return input_target
+
+        renderer._ensure_post_process_target()
+        output_target = (
+            self._gl_id(renderer._post_process_fbo),
+            self._gl_id(renderer._post_process_texture),
+            self._gl_id(renderer._post_process_depth_texture),
+        )
+        camera = self._camera_snapshot()
+        width = int(renderer._screen_width)
+        height = int(renderer._screen_height)
+        viewport = (0, 0, width, height)
+        gl = RendererGL.gl
+
+        for registration in tuple(self._post_process_registrations):
+            if registration.closed:
+                continue
+            context = self.PostProcessContext(
+                width=width,
+                height=height,
+                viewport=viewport,
+                input_framebuffer_id=input_target[0],
+                input_color_texture_id=input_target[1],
+                input_depth_texture_id=input_target[2],
+                output_framebuffer_id=output_target[0],
+                output_color_texture_id=output_target[1],
+                output_depth_texture_id=output_target[2],
+                camera=camera,
+            )
+            gl.glBindFramebuffer(gl.GL_READ_FRAMEBUFFER, input_target[0])
+            gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)
+            gl.glBindFramebuffer(gl.GL_DRAW_FRAMEBUFFER, output_target[0])
+            gl.glDrawBuffer(gl.GL_COLOR_ATTACHMENT0)
+            gl.glViewport(*viewport)
+            registration._callback(context)
+            input_target, output_target = output_target, input_target
+
+        return input_target
 
     def register_ui_callback(
         self,
@@ -1729,7 +1957,15 @@ class ViewerGL(ViewerBase):
             return
 
         # Render the scene and present it
-        self.renderer.render(self.camera, self.objects, self.lines, self.wireframe_shapes, self.arrows)
+        post_process = self._render_post_processes if self._post_process_registrations else None
+        self.renderer.render(
+            self.camera,
+            self.objects,
+            self.lines,
+            self.wireframe_shapes,
+            self.arrows,
+            post_process=post_process,
+        )
 
         if self.gui:
             self.gui.render_frame(update_fps=True)
@@ -1781,8 +2017,9 @@ class ViewerGL(ViewerBase):
             gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
 
         # GPU-to-GPU readback into PBO.
-        assert self.renderer._frame_fbo is not None
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self.renderer._frame_fbo)
+        assert self.renderer._last_frame_fbo is not None
+        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self.renderer._last_frame_fbo)
+        gl.glReadBuffer(gl.GL_COLOR_ATTACHMENT0)
         gl.glBindBuffer(gl.GL_PIXEL_PACK_BUFFER, self._pbo)
 
         if render_ui and self.gui:
@@ -1884,10 +2121,6 @@ class ViewerGL(ViewerBase):
         """
         Close the viewer and clean up resources.
         """
-        self._clear_array_textures()
-        self._invalidate_pbo()
-        if self._image_logger is not None:
-            self._image_logger.clear()
         self.renderer.close()
 
     @property

--- a/newton/tests/test_viewer_get_frame.py
+++ b/newton/tests/test_viewer_get_frame.py
@@ -27,6 +27,7 @@ class _FakeGL:
     GL_STREAM_READ = 0x88E1
     GL_PACK_ALIGNMENT = 0x0D05
     GL_FRAMEBUFFER = 0x8D40
+    GL_COLOR_ATTACHMENT0 = 0x8CE0
     GL_RGB = 0x1907
     GL_UNSIGNED_BYTE = 0x1401
 
@@ -36,6 +37,8 @@ class _FakeGL:
     def __init__(self, pixels: np.ndarray):
         self.pixels = pixels
         self.bound_buffer = 0
+        self.bound_framebuffer = 0
+        self.read_buffer = None
         self.readback_count = 0
 
     def glGenBuffers(self, count, buffers):
@@ -51,10 +54,13 @@ class _FakeGL:
         pass
 
     def glBindFramebuffer(self, target, framebuffer):
-        pass
+        self.bound_framebuffer = int(framebuffer)
 
     def glReadPixels(self, x, y, width, height, pixel_format, pixel_type, data):
         pass
+
+    def glReadBuffer(self, buffer):
+        self.read_buffer = buffer
 
     def glGetBufferSubData(self, target, offset, size, data):
         if self.bound_buffer == 0:
@@ -128,7 +134,7 @@ class TestViewerGLGetFrame(unittest.TestCase):
         viewer.renderer = SimpleNamespace(
             _screen_width=2,
             _screen_height=2,
-            _frame_fbo=3,
+            _last_frame_fbo=7,
         )
         viewer.gui = None
         viewer._pbo = None
@@ -157,6 +163,8 @@ class TestViewerGLGetFrame(unittest.TestCase):
         )
         self.assertEqual(frame.device, wp.get_device("cpu"))
         self.assertEqual(fake_gl.readback_count, 1)
+        self.assertEqual(fake_gl.bound_framebuffer, 0)
+        self.assertEqual(fake_gl.read_buffer, fake_gl.GL_COLOR_ATTACHMENT0)
 
 
 if __name__ == "__main__":

--- a/newton/tests/test_viewer_image_logger_class.py
+++ b/newton/tests/test_viewer_image_logger_class.py
@@ -385,6 +385,7 @@ class TestViewerGLInitialization(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 self.window = _FakeWindow()
                 self.closed = False
+                self.close_callbacks = []
 
             def set_title(self, title):
                 self.title = title
@@ -410,7 +411,12 @@ class TestViewerGLInitialization(unittest.TestCase):
             def register_resize(self, callback):
                 pass
 
+            def register_close(self, callback):
+                self.close_callbacks.append(callback)
+
             def close(self):
+                for callback in reversed(self.close_callbacks):
+                    callback()
                 self.closed = True
 
         class _FakeImageLogger:

--- a/newton/tests/test_viewer_post_process.py
+++ b/newton/tests/test_viewer_post_process.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from typing import get_type_hints
+from types import SimpleNamespace
+from unittest import mock
+
+import numpy as np
+
+from newton._src.viewer.gl.opengl import RendererGL
+from newton._src.viewer.viewer_gl import ViewerGL
+
+
+class _FakeGL:
+    GL_READ_FRAMEBUFFER = 0x8CA8
+    GL_DRAW_FRAMEBUFFER = 0x8CA9
+    GL_COLOR_ATTACHMENT0 = 0x8CE0
+
+    def __init__(self):
+        self.calls = []
+
+    def glBindFramebuffer(self, target, framebuffer):
+        self.calls.append(("bind_framebuffer", target, int(framebuffer)))
+
+    def glReadBuffer(self, buffer):
+        self.calls.append(("read_buffer", buffer))
+
+    def glDrawBuffer(self, buffer):
+        self.calls.append(("draw_buffer", buffer))
+
+    def glViewport(self, x, y, width, height):
+        self.calls.append(("viewport", x, y, width, height))
+
+
+class _FakeRenderer:
+    def __init__(self):
+        self._screen_width = 640
+        self._screen_height = 360
+        self._frame_fbo = 1
+        self._frame_texture = 2
+        self._frame_depth_texture = 3
+        self._post_process_fbo = 4
+        self._post_process_texture = 5
+        self._post_process_depth_texture = 6
+        self._view_matrix = np.arange(16, dtype=np.float32)
+        self._projection_matrix = np.arange(16, 32, dtype=np.float32)
+        self.ensure_count = 0
+        self.make_current_count = 0
+
+    def _ensure_post_process_target(self):
+        self.ensure_count += 1
+
+    def _make_current(self):
+        self.make_current_count += 1
+
+
+def _make_viewer():
+    viewer = ViewerGL.__new__(ViewerGL)
+    viewer.renderer = _FakeRenderer()
+    viewer.camera = SimpleNamespace(
+        pos=(1.0, 2.0, 3.0),
+        get_right=lambda: (1.0, 0.0, 0.0),
+        get_up=lambda: (0.0, 1.0, 0.0),
+        get_front=lambda: (0.0, 0.0, -1.0),
+        fov=55.0,
+        near=0.05,
+        far=500.0,
+        up_axis=2,
+    )
+    viewer._post_process_registrations = []
+    viewer._post_process_closed = False
+    return viewer
+
+
+class TestViewerGLPostProcessRegistration(unittest.TestCase):
+    def test_registration_close_is_idempotent_and_reentrant(self):
+        viewer = _make_viewer()
+        cleanup_count = 0
+        registration = None
+
+        def cleanup():
+            nonlocal cleanup_count
+            cleanup_count += 1
+            registration.close()
+
+        registration = viewer.register_post_process(lambda context: None, cleanup=cleanup)
+        self.assertFalse(registration.closed)
+
+        registration.close()
+        registration.close()
+
+        self.assertTrue(registration.closed)
+        self.assertEqual(cleanup_count, 1)
+        self.assertEqual(viewer._post_process_registrations, [])
+        self.assertEqual(viewer.renderer.make_current_count, 1)
+
+    def test_viewer_cleanup_closes_registrations_in_reverse_order(self):
+        viewer = _make_viewer()
+        events = []
+        registrations = [
+            viewer.register_post_process(lambda context: None, cleanup=lambda name=name: events.append(name))
+            for name in ("a", "b", "c")
+        ]
+
+        viewer._close_post_processes()
+        viewer._close_post_processes()
+
+        self.assertEqual(events, ["c", "b", "a"])
+        self.assertTrue(all(registration.closed for registration in registrations))
+        self.assertEqual(viewer._post_process_registrations, [])
+
+    def test_rejects_invalid_callbacks(self):
+        viewer = _make_viewer()
+
+        with self.assertRaises(TypeError):
+            viewer.register_post_process(None)
+        with self.assertRaises(TypeError):
+            viewer.register_post_process(lambda context: None, cleanup=object())
+
+    def test_public_annotations_resolve_at_runtime(self):
+        context_hints = get_type_hints(ViewerGL.PostProcessContext)
+        registration_hints = get_type_hints(ViewerGL.register_post_process)
+
+        self.assertIs(context_hints["camera"], ViewerGL.CameraSnapshot)
+        self.assertIs(registration_hints["return"], ViewerGL.PostProcessRegistration)
+
+
+class TestViewerGLPostProcessDispatch(unittest.TestCase):
+    def test_callbacks_receive_color_depth_ping_pong_and_camera_snapshot(self):
+        viewer = _make_viewer()
+        fake_gl = _FakeGL()
+        contexts = []
+
+        for _ in range(3):
+            viewer.register_post_process(contexts.append)
+
+        with mock.patch.object(RendererGL, "gl", fake_gl):
+            final_target = viewer._render_post_processes()
+
+        self.assertEqual(final_target, (4, 5, 6))
+        self.assertEqual(
+            [
+                (
+                    context.input_framebuffer_id,
+                    context.input_color_texture_id,
+                    context.input_depth_texture_id,
+                    context.output_framebuffer_id,
+                    context.output_color_texture_id,
+                    context.output_depth_texture_id,
+                )
+                for context in contexts
+            ],
+            [
+                (1, 2, 3, 4, 5, 6),
+                (4, 5, 6, 1, 2, 3),
+                (1, 2, 3, 4, 5, 6),
+            ],
+        )
+
+        for context in contexts:
+            self.assertEqual(context.viewport, (0, 0, 640, 360))
+            self.assertEqual(context.width, 640)
+            self.assertEqual(context.height, 360)
+            self.assertEqual(context.camera.position, (1.0, 2.0, 3.0))
+            self.assertEqual(context.camera.forward, (0.0, 0.0, -1.0))
+            self.assertEqual(context.camera.fov_y, 55.0)
+            with self.assertRaises(ValueError):
+                context.camera.view_matrix[0] = 0.0
+            with self.assertRaises(ValueError):
+                context.camera.projection_matrix[0] = 0.0
+        self.assertIs(contexts[0].camera, contexts[1].camera)
+        self.assertIs(contexts[1].camera, contexts[2].camera)
+
+        self.assertEqual(
+            [call for call in fake_gl.calls if call[0] == "viewport"],
+            [("viewport", 0, 0, 640, 360)] * 3,
+        )
+
+    def test_closed_callback_is_skipped_without_consuming_a_target(self):
+        viewer = _make_viewer()
+        fake_gl = _FakeGL()
+        events = []
+        registration_b = None
+
+        def callback_a(context):
+            events.append(("a", context.input_framebuffer_id, context.output_framebuffer_id))
+            registration_b.close()
+
+        def callback_b(context):
+            events.append(("b", context.input_framebuffer_id, context.output_framebuffer_id))
+
+        def callback_c(context):
+            events.append(("c", context.input_framebuffer_id, context.output_framebuffer_id))
+
+        viewer.register_post_process(callback_a)
+        registration_b = viewer.register_post_process(callback_b)
+        viewer.register_post_process(callback_c)
+
+        with mock.patch.object(RendererGL, "gl", fake_gl):
+            final_target = viewer._render_post_processes()
+
+        self.assertEqual(events, [("a", 1, 4), ("c", 4, 1)])
+        self.assertEqual(final_target, (1, 2, 3))
+
+    def test_callback_exception_stops_dispatch(self):
+        viewer = _make_viewer()
+        fake_gl = _FakeGL()
+        events = []
+
+        viewer.register_post_process(lambda context: events.append("a"))
+
+        def fail(context):
+            events.append("b")
+            raise RuntimeError("callback failed")
+
+        viewer.register_post_process(fail)
+        viewer.register_post_process(lambda context: events.append("c"))
+
+        with mock.patch.object(RendererGL, "gl", fake_gl), self.assertRaisesRegex(RuntimeError, "callback failed"):
+            viewer._render_post_processes()
+
+        self.assertEqual(events, ["a", "b"])
+
+
+class TestRendererGLPostProcessLifecycle(unittest.TestCase):
+    def test_close_runs_all_callbacks_before_window_close_and_is_idempotent(self):
+        renderer = RendererGL.__new__(RendererGL)
+        renderer._closed = False
+        renderer._close_callbacks = []
+        renderer.headless = True
+        events = []
+        renderer._make_current = lambda: events.append("current")
+        renderer.window = SimpleNamespace(close=lambda: events.append("window"))
+
+        renderer.register_close(lambda: events.append("a"))
+
+        def cleanup_b():
+            events.append("b")
+            raise RuntimeError("cleanup failed")
+
+        renderer.register_close(cleanup_b)
+
+        with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+            renderer.close()
+        renderer.close()
+
+        self.assertEqual(events, ["current", "b", "a", "window"])
+
+    def test_close_still_closes_window_when_event_shutdown_fails(self):
+        renderer = RendererGL.__new__(RendererGL)
+        renderer._closed = False
+        renderer._close_callbacks = []
+        renderer.headless = False
+        events = []
+        renderer._make_current = lambda: events.append("current")
+
+        def fail_on_exit(event):
+            events.append(event)
+            raise RuntimeError("event shutdown failed")
+
+        renderer.app = SimpleNamespace(
+            event_loop=SimpleNamespace(dispatch_event=fail_on_exit),
+            platform_event_loop=SimpleNamespace(stop=lambda: events.append("stop")),
+        )
+        renderer.window = SimpleNamespace(close=lambda: events.append("window"))
+
+        with self.assertRaisesRegex(RuntimeError, "event shutdown failed"):
+            renderer.close()
+
+        self.assertEqual(events, ["current", "on_exit", "stop", "window"])
+
+    def test_resize_rebuilds_all_existing_frame_targets(self):
+        renderer = RendererGL.__new__(RendererGL)
+        renderer.window = SimpleNamespace(get_framebuffer_size=lambda: (800, 450))
+        renderer._setup_frame_buffer = mock.Mock()
+
+        renderer.resize(10, 20)
+
+        self.assertEqual((renderer._screen_width, renderer._screen_height), (800, 450))
+        renderer._setup_frame_buffer.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/newton/tests/test_viewer_post_process.py
+++ b/newton/tests/test_viewer_post_process.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
-from typing import get_type_hints
 from types import SimpleNamespace
+from typing import get_type_hints
 from unittest import mock
 
 import numpy as np

--- a/newton/tests/test_viewer_post_process.py
+++ b/newton/tests/test_viewer_post_process.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import unittest
+import weakref
 from types import SimpleNamespace
 from typing import get_type_hints
 from unittest import mock
@@ -10,6 +12,10 @@ import numpy as np
 
 from newton._src.viewer.gl.opengl import RendererGL
 from newton._src.viewer.viewer_gl import ViewerGL
+
+
+class _CapturedResource:
+    pass
 
 
 class _FakeGL:
@@ -94,6 +100,56 @@ class TestViewerGLPostProcessRegistration(unittest.TestCase):
         self.assertEqual(cleanup_count, 1)
         self.assertEqual(viewer._post_process_registrations, [])
         self.assertEqual(viewer.renderer.make_current_count, 1)
+
+    def test_registration_close_releases_callback_captures(self):
+        viewer = _make_viewer()
+        resource = _CapturedResource()
+        resource_ref = weakref.ref(resource)
+
+        def callback(context, captured=resource):
+            pass
+
+        registration = viewer.register_post_process(callback)
+        del callback
+        del resource
+        self.assertIsNotNone(resource_ref())
+
+        registration.close()
+        gc.collect()
+
+        self.assertIsNone(resource_ref())
+        self.assertIsNone(registration._callback)
+
+    def test_close_without_viewer_releases_callback_and_cleanup(self):
+        viewer = _make_viewer()
+        registration = viewer.register_post_process(lambda context: None, cleanup=lambda: None)
+        viewer_ref = weakref.ref(viewer)
+        del viewer
+        gc.collect()
+        self.assertIsNone(viewer_ref())
+
+        registration.close()
+
+        self.assertTrue(registration.closed)
+        self.assertIsNone(registration._callback)
+        self.assertIsNone(registration._cleanup)
+
+    def test_cleanup_failure_still_releases_callback(self):
+        viewer = _make_viewer()
+
+        def cleanup():
+            raise RuntimeError("cleanup failed")
+
+        registration = viewer.register_post_process(lambda context: None, cleanup=cleanup)
+
+        with self.assertRaisesRegex(RuntimeError, "cleanup failed"):
+            registration.close()
+
+        self.assertTrue(registration.closed)
+        self.assertIsNone(registration._callback)
+        self.assertIsNone(registration._cleanup)
+        self.assertEqual(viewer._post_process_registrations, [])
+        registration.close()
 
     def test_viewer_cleanup_closes_registrations_in_reverse_order(self):
         viewer = _make_viewer()

--- a/newton/tests/test_viewer_post_process_gl.py
+++ b/newton/tests/test_viewer_post_process_gl.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import ctypes
+import unittest
+
+import numpy as np
+import warp as wp
+
+from newton._src.viewer.viewer_gl import ViewerGL
+
+
+class TestViewerGLPostProcessGL(unittest.TestCase):
+    def test_headless_color_depth_ping_pong_and_frame_capture(self):
+        try:
+            viewer = ViewerGL(width=32, height=24, headless=True)
+        except Exception as error:
+            self.skipTest(f"ViewerGL not available: {error}")
+            return
+
+        cleanup_events = []
+        try:
+            from pyglet import gl
+
+            viewer.device = wp.get_device("cpu")
+            sampled_depth = []
+
+            def clear_output(red: float, green: float, blue: float, depth: float) -> None:
+                gl.glDisable(gl.GL_SCISSOR_TEST)
+                gl.glColorMask(gl.GL_TRUE, gl.GL_TRUE, gl.GL_TRUE, gl.GL_TRUE)
+                gl.glDepthMask(gl.GL_TRUE)
+                gl.glClearColor(red, green, blue, 1.0)
+                gl.glClearDepth(depth)
+                gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT)
+
+            def pass_a(context):
+                clear_output(1.0, 0.0, 0.0, 0.25)
+
+            viewer.register_post_process(pass_a, cleanup=lambda: cleanup_events.append("a"))
+            viewer.begin_frame(0.0)
+            viewer.end_frame()
+            frame = viewer.get_frame().numpy()
+            expected = np.broadcast_to(np.array([255, 0, 0], dtype=np.uint8), frame.shape)
+            np.testing.assert_allclose(frame, expected, atol=1)
+
+            def pass_b(context):
+                depth = (gl.GLfloat * 1)()
+                gl.glReadPixels(0, 0, 1, 1, gl.GL_DEPTH_COMPONENT, gl.GL_FLOAT, ctypes.byref(depth))
+                sampled_depth.append(float(depth[0]))
+                clear_output(0.0, 1.0, 0.0, 0.75)
+
+            viewer.register_post_process(pass_b, cleanup=lambda: cleanup_events.append("b"))
+            viewer.begin_frame(1.0)
+            viewer.end_frame()
+            frame = viewer.get_frame().numpy()
+
+            self.assertAlmostEqual(sampled_depth[0], 0.25, places=4)
+            expected = np.broadcast_to(np.array([0, 255, 0], dtype=np.uint8), frame.shape)
+            np.testing.assert_allclose(frame, expected, atol=1)
+        finally:
+            viewer.close()
+        self.assertEqual(cleanup_events, ["b", "a"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Add an OpenGL post-processing extension point to `ViewerGL` for custom renderers that need access to the resolved scene color and depth buffers.

Post-process callbacks run after scene rendering and MSAA resolve, but before UI rendering and presentation.

- Execute callbacks in stable registration order
- Ping-pong color and depth attachments between multiple passes
- Expose input/output framebuffer and texture IDs
- Provide the physical viewport and an immutable camera snapshot
- Use the final pass for both window presentation and `get_frame()`
- Reallocate post-process targets on framebuffer resize
- Run registration cleanup before the OpenGL context is destroyed
- Keep registrations and cleanup handles idempotent and context-safe

The API defines the color, depth, viewport, GL state, callback ordering, and resource-lifetime contracts required by external renderers such as particle splatting and screen-space fluid rendering.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```shell
uv run --extra dev -m newton.tests -p "test_viewer*.py"
uvx pre-commit run -a
uv run --extra docs --extra sim sphinx-build -j auto -W -b html docs docs/_build/html
```

All 199 Viewer tests pass, including a real headless OpenGL test that verifies color/depth ping-pong and final-frame capture.

Also verified CUDA/OpenGL integration manually with `newton-fluid`'s `ParticleSplatRenderer`; the custom adapter remained active, completed without a runtime failure, and produced a captured RGB frame.

## New feature / API change

```python
import newton
from pyglet import gl

viewer = newton.viewer.ViewerGL()


def post_process(context):
    # Newton has already bound the input framebuffer for reading and the
    # output framebuffer for drawing.
    gl.glBlitFramebuffer(
        0,
        0,
        context.width,
        context.height,
        0,
        0,
        context.width,
        context.height,
        gl.GL_COLOR_BUFFER_BIT | gl.GL_DEPTH_BUFFER_BIT,
        gl.GL_NEAREST,
    )


registration = viewer.register_post_process(post_process)

# Unregister explicitly, or let viewer.close() clean it up before the
# OpenGL context is destroyed.
registration.close()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `ViewerGL.register_post_process` for ordered OpenGL post-processing passes before UI rendering and frame capture.
  - Post-process callbacks can swap color+depth targets across multiple passes.
  - Added `RendererGL.render(..., post_process=...)` plus a `register_close` hook to support reliable shutdown.
- **Documentation**
  - Expanded the OpenGL viewer guide with execution timing, required framebuffer/state conventions, and a full example (including cleanup/unregistration).
- **Tests**
  - Added unit and headless tests covering registration idempotency, dispatch order, depth/color correctness, and close/resize lifecycle behavior.
- **Bug Fixes**
  - Improved frame readback to use the most recently post-processed output reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->