### PR TITLE
Add NVTX Scope for SensorTiledCamera rendering

### DIFF
--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import warnings
 from typing import Any
 
@@ -18,6 +19,8 @@ from .warp_raytrace import (
     RenderOrder,
     Utils,
 )
+
+PROFILE_ENABLED = os.environ.get("NEWTON_PROFILE", "0") != "0"
 
 _RENDER_CONFIG_DEPRECATION_MSG = (
     "SensorTiledCamera.render_config is deprecated as of Newton 1.4; "
@@ -224,24 +227,27 @@ class SensorTiledCamera:
                 for the render megakernel.
         """
 
-        self.sync_transforms(state)
+        with wp.ScopedTimer(
+            "Newton::SensorTiledCamera::update", active=PROFILE_ENABLED, use_nvtx=True, print=False, synchronize=True
+        ):
+            self.sync_transforms(state)
 
-        self.__render_context.render(
-            self.model,
-            state,
-            camera_transforms=camera_transforms,
-            camera_rays=camera_rays,
-            color_image=color_image,
-            hdr_color_image=hdr_color_image,
-            depth_image=depth_image,
-            forward_depth_image=forward_depth_image,
-            shape_index_image=shape_index_image,
-            normal_image=normal_image,
-            albedo_image=albedo_image,
-            clear_data=clear_data if clear_data is not None else self.default_clear_data,
-            config=render_config if render_config is not None else self.default_render_config,
-            kernel_block_dim=kernel_block_dim,
-        )
+            self.__render_context.render(
+                self.model,
+                state,
+                camera_transforms=camera_transforms,
+                camera_rays=camera_rays,
+                color_image=color_image,
+                hdr_color_image=hdr_color_image,
+                depth_image=depth_image,
+                forward_depth_image=forward_depth_image,
+                shape_index_image=shape_index_image,
+                normal_image=normal_image,
+                albedo_image=albedo_image,
+                clear_data=clear_data if clear_data is not None else self.default_clear_data,
+                config=render_config if render_config is not None else self.default_render_config,
+                kernel_block_dim=kernel_block_dim,
+            )
 
     @property
     def render_config(self) -> RenderConfig:

--- a/newton/_src/sensors/sensor_tiled_camera.py
+++ b/newton/_src/sensors/sensor_tiled_camera.py
@@ -228,7 +228,7 @@ class SensorTiledCamera:
         """
 
         with wp.ScopedTimer(
-            "Newton::SensorTiledCamera::update", active=PROFILE_ENABLED, use_nvtx=True, print=False, synchronize=True
+            "Newton::SensorTiledCamera::update", active=PROFILE_ENABLED, use_nvtx=True, synchronize=True
         ):
             self.sync_transforms(state)
 


### PR DESCRIPTION
## Description

Add an NVTX profiling scope around `SensorTiledCamera.update()` so tiled-camera transform sync and rendering are visible under Newton’s existing `NEWTON_PROFILE` profiling switch.

- Add a module-level `PROFILE_ENABLED` gate using `NEWTON_PROFILE`.
- Wrap tiled-camera update work in `wp.ScopedTimer("Newton::SensorTiledCamera::update", use_nvtx=True)`.
- Leave default rendering behavior unchanged when profiling is disabled.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` update not required for profiling-only instrumentation

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera.TestSensorTiledCamera.test_tiled_render_order_accepts_partial_tiles
```

Also attempted the profiling-enabled path:

```bash
NEWTON_PROFILE=1 uv run --extra dev -m newton.tests -k test_sensor_tiled_camera.TestSensorTiledCamera.test_tiled_render_order_accepts_partial_tiles
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added optional profiling for tiled camera updates when enabled via the `NEWTON_PROFILE` environment variable.
  * When profiling is on, camera synchronization and rendering are measured together using timing markers, with synchronization performed when the profiling scope ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->