### PR TITLE
Fix explicit mass on MJCF mesh geoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix masked PID state reset to execute on the integral-state device. (#3447)
-- Fix `ModelBuilder.add_mjcf()` ignoring positive explicit mass on mesh geoms. (#3592)
+- Fix `ModelBuilder.add_mjcf()` ignoring positive explicit mass on mesh geoms. (#3595)
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix masked PID state reset to execute on the integral-state device. (#3447)
+- Fix `ModelBuilder.add_mjcf()` ignoring positive explicit mass on mesh geoms. (#3592)
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -725,6 +725,7 @@ def parse_mjcf(
 
             geom_density = parse_float(geom_attrib, "density", density)
             geom_mass_explicit = None
+            explicit_mass_handled = False
 
             # MuJoCo: explicit mass attribute (from <geom mass="..."> or class defaults).
             # Skip density-based mass contribution and compute inertia directly from mass.
@@ -987,6 +988,12 @@ def parse_mjcf(
                     override_color=material_color,
                     override_texture=texture,
                 )
+                explicit_mesh_density = None
+                if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0:
+                    unit_density_mass = sum(float(m_mesh.mass) for m_mesh in m_meshes)
+                    if unit_density_mass > 1.0e-6:
+                        explicit_mesh_density = geom_mass_explicit / unit_density_mass
+                        explicit_mass_handled = True
                 for m_mesh in m_meshes:
                     if m_mesh.texture is not None and m_mesh.uvs is None:
                         if verbose:
@@ -998,6 +1005,8 @@ def parse_mjcf(
                     mesh_cfg.sdf_max_resolution = None
                     mesh_cfg.sdf_target_voxel_size = None
                     mesh_cfg.sdf_narrow_band_range = (-0.1, 0.1)
+                    if explicit_mesh_density is not None:
+                        mesh_cfg.density = explicit_mesh_density
                     mesh_shape_kwargs["cfg"] = mesh_cfg
                     s = builder.add_shape_mesh(
                         xform=tf,
@@ -1133,7 +1142,7 @@ def parse_mjcf(
 
             # Handle explicit mass: compute inertia using existing functions, add to body.
             # Visual geoms can still contribute authored mass when parse_visuals=True.
-            if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0:
+            if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0 and not explicit_mass_handled:
                 from ..geometry.inertia import (  # noqa: PLC0415
                     compute_inertia_box_from_mass,
                     compute_inertia_capsule,

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -15,7 +15,7 @@ import warp as wp
 
 from ..core import quat_between_axes
 from ..core.types import Axis, AxisType, Sequence, Transform, vec10
-from ..geometry import Mesh, ShapeFlags
+from ..geometry import GeoType, Mesh, ShapeFlags, compute_inertia_shape
 from ..geometry.types import Heightfield
 from ..geometry.utils import compute_aabb, compute_inertia_box_mesh
 from ..sim import JointTargetMode, JointType, ModelBuilder
@@ -990,7 +990,17 @@ def parse_mjcf(
                 )
                 explicit_mesh_density = None
                 if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0:
-                    unit_density_mass = sum(float(m_mesh.mass) for m_mesh in m_meshes)
+                    unit_density_mass = sum(
+                        compute_inertia_shape(
+                            GeoType.MESH,
+                            wp.vec3(1.0),
+                            m_mesh,
+                            density=1.0,
+                            is_solid=shape_cfg.is_solid,
+                            thickness=shape_cfg.margin,
+                        )[0]
+                        for m_mesh in m_meshes
+                    )
                     if unit_density_mass > 0.0:
                         explicit_mesh_density = geom_mass_explicit / unit_density_mass
                         explicit_mass_handled = True

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -991,7 +991,7 @@ def parse_mjcf(
                 explicit_mesh_density = None
                 if geom_mass_explicit is not None and geom_mass_explicit > 0.0 and link >= 0:
                     unit_density_mass = sum(float(m_mesh.mass) for m_mesh in m_meshes)
-                    if unit_density_mass > 1.0e-6:
+                    if unit_density_mass > 0.0:
                         explicit_mesh_density = geom_mass_explicit / unit_density_mass
                         explicit_mass_handled = True
                 for m_mesh in m_meshes:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -1511,12 +1511,12 @@ class TestImportMjcfGeometry(unittest.TestCase):
         # Body 6: mass="0" should also have zero inertia
         self.assertAlmostEqual(np.trace(body_inertia[6]), 0.0, places=6, msg="Body 6 (mass=0) should have zero inertia")
 
-    def test_explicit_mesh_geom_mass(self):
-        """Test that a positive mass on a mesh geom sets body mass and inertia."""
+    def test_explicit_small_mesh_geom_mass(self):
+        """Test that a positive mass on a small mesh geom sets body mass and inertia."""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="explicit_mesh_mass_test">
     <asset>
-        <mesh name="box_mesh" file="box.obj"/>
+        <mesh name="box_mesh" file="box.obj" scale="0.005 0.005 0.005"/>
     </asset>
     <worldbody>
         <body name="body">
@@ -1565,8 +1565,8 @@ f 4 5 8
         np.testing.assert_allclose(builder.body_com[0], np.zeros(3), atol=1e-7)
         np.testing.assert_allclose(
             np.array(builder.body_inertia[0]).reshape(3, 3),
-            np.diag([0.002, 0.002, 0.002]),
-            atol=1e-7,
+            np.diag([5.0e-8, 5.0e-8, 5.0e-8]),
+            atol=1e-11,
             rtol=1e-6,
         )
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -1512,7 +1512,7 @@ class TestImportMjcfGeometry(unittest.TestCase):
         self.assertAlmostEqual(np.trace(body_inertia[6]), 0.0, places=6, msg="Body 6 (mass=0) should have zero inertia")
 
     def test_explicit_small_mesh_geom_mass(self):
-        """Test that a positive mass on a small mesh geom sets body mass and inertia."""
+        """Test that a positive mass on a solid or hollow mesh sets body mass and inertia."""
         mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
 <mujoco model="explicit_mesh_mass_test">
     <asset>
@@ -1555,20 +1555,27 @@ f 4 5 8
             with open(mjcf_path, "w") as f:
                 f.write(mjcf_content)
 
-            builder = newton.ModelBuilder()
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                builder.add_mjcf(mjcf_path)
+            for name, is_solid, margin in (("solid", True, 0.0), ("hollow", False, 0.001)):
+                with self.subTest(name=name):
+                    builder = newton.ModelBuilder()
+                    builder.default_shape_cfg.is_solid = is_solid
+                    builder.default_shape_cfg.margin = margin
+                    with warnings.catch_warnings(record=True) as caught:
+                        warnings.simplefilter("always")
+                        builder.add_mjcf(mjcf_path)
 
-        self.assertFalse(any("explicit mass" in str(w.message) for w in caught))
-        self.assertAlmostEqual(builder.body_mass[0], 0.012, places=7)
-        np.testing.assert_allclose(builder.body_com[0], np.zeros(3), atol=1e-7)
-        np.testing.assert_allclose(
-            np.array(builder.body_inertia[0]).reshape(3, 3),
-            np.diag([5.0e-8, 5.0e-8, 5.0e-8]),
-            atol=1e-11,
-            rtol=1e-6,
-        )
+                    self.assertFalse(any("explicit mass" in str(w.message) for w in caught))
+                    self.assertAlmostEqual(builder.body_mass[0], 0.012, places=7)
+                    np.testing.assert_allclose(builder.body_com[0], np.zeros(3), atol=1e-7)
+                    inertia = np.array(builder.body_inertia[0]).reshape(3, 3)
+                    self.assertGreater(np.trace(inertia), 0.0)
+                    if is_solid:
+                        np.testing.assert_allclose(
+                            inertia,
+                            np.diag([5.0e-8, 5.0e-8, 5.0e-8]),
+                            atol=1e-11,
+                            rtol=1e-6,
+                        )
 
     def test_zero_mass_mesh_geom_no_warning(self):
         """Regression test: mass='0' on mesh geoms must not emit a warning.

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -1511,6 +1511,65 @@ class TestImportMjcfGeometry(unittest.TestCase):
         # Body 6: mass="0" should also have zero inertia
         self.assertAlmostEqual(np.trace(body_inertia[6]), 0.0, places=6, msg="Body 6 (mass=0) should have zero inertia")
 
+    def test_explicit_mesh_geom_mass(self):
+        """Test that a positive mass on a mesh geom sets body mass and inertia."""
+        mjcf_content = """<?xml version="1.0" encoding="utf-8"?>
+<mujoco model="explicit_mesh_mass_test">
+    <asset>
+        <mesh name="box_mesh" file="box.obj"/>
+    </asset>
+    <worldbody>
+        <body name="body">
+            <freejoint/>
+            <geom type="mesh" mesh="box_mesh" mass="0.012" density="5000"/>
+        </body>
+    </worldbody>
+</mujoco>
+"""
+        mesh_content = """v -0.5 -0.5 -0.5
+v 0.5 -0.5 -0.5
+v 0.5 0.5 -0.5
+v -0.5 0.5 -0.5
+v -0.5 -0.5 0.5
+v 0.5 -0.5 0.5
+v 0.5 0.5 0.5
+v -0.5 0.5 0.5
+f 1 3 2
+f 1 4 3
+f 5 6 7
+f 5 7 8
+f 1 2 6
+f 1 6 5
+f 2 3 7
+f 2 7 6
+f 3 4 8
+f 3 8 7
+f 4 1 5
+f 4 5 8
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mjcf_path = os.path.join(tmpdir, "test.xml")
+            mesh_path = os.path.join(tmpdir, "box.obj")
+            with open(mesh_path, "w") as f:
+                f.write(mesh_content)
+            with open(mjcf_path, "w") as f:
+                f.write(mjcf_content)
+
+            builder = newton.ModelBuilder()
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                builder.add_mjcf(mjcf_path)
+
+        self.assertFalse(any("explicit mass" in str(w.message) for w in caught))
+        self.assertAlmostEqual(builder.body_mass[0], 0.012, places=7)
+        np.testing.assert_allclose(builder.body_com[0], np.zeros(3), atol=1e-7)
+        np.testing.assert_allclose(
+            np.array(builder.body_inertia[0]).reshape(3, 3),
+            np.diag([0.002, 0.002, 0.002]),
+            atol=1e-7,
+            rtol=1e-6,
+        )
+
     def test_zero_mass_mesh_geom_no_warning(self):
         """Regression test: mass='0' on mesh geoms must not emit a warning.
 


### PR DESCRIPTION
## Description

Positive `mass` values on MJCF mesh geoms were ignored. Newton warned that the value was unsupported and left the body without the requested mass.

This change uses the loaded meshes' unit-density mass properties. It chooses a density that makes all submeshes add up to the exact authored mass. The existing shape code then combines mass, center of mass, and inertia normally.

The regression uses the `0.012` kg value from the converter report and also checks COM, inertia, and warnings.

Closes #3592.

## Checklist

- [x] New or existing tests cover the change.
- [x] Existing documentation remains accurate.
- [x] The changelog includes the user-facing fix.

## Test plan

- `uv run --extra dev -m newton.tests -k test_explicit_mesh_geom_mass`
- `uv run --extra dev -m newton.tests -p test_import_mjcf.py` (232 tests)
- `uvx pre-commit run -a`

## Bug fix

Before this change, a mesh geom with `mass="0.012"` imported with zero mass. It now imports as `0.012` kg with matching mesh inertia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed MJCF importing so explicitly authored **positive `mass`** on mesh geoms is no longer ignored, with correct handling of derived mesh density.
  - Prevented spurious “explicit mass” warnings and ensured imported **body mass**, **center of mass**, and **inertia** align with the authored values.
- **Tests**
  - Added a regression test covering explicit positive mass on small mesh geoms (including both `solid` and `hollow` cases), validating warnings and resulting mass properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->