### PR TITLE
Honor MJCF geom inertia selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@
 - Fix `ModelBuilder.add_mjcf()` ignoring positive explicit mass on mesh geoms. (#3595)
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
-- Fix `ModelBuilder.add_mjcf()` to honor compiler `inertiafromgeom` and `inertiagrouprange`, and keep inferred mass independent of `parse_visuals`. (#3593)
+- Fix `ModelBuilder.add_mjcf()` to honor compiler `inertiafromgeom` and `inertiagrouprange`, and keep inferred mass independent of `parse_visuals`. (#3596)
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.
 - Fix `cloth_franka` example rendering particles at simulation scale (cm) instead of viewer scale (m)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Fix `ModelBuilder.add_mjcf()` ignoring positive explicit mass on mesh geoms. (#3595)
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
+- Fix `ModelBuilder.add_mjcf()` to honor compiler `inertiafromgeom` and `inertiagrouprange`, and keep inferred mass independent of `parse_visuals`. (#3593)
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.
 - Fix `cloth_franka` example rendering particles at simulation scale (cm) instead of viewer scale (m)

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -411,6 +411,15 @@ def parse_mjcf(
         texture_dir = "."
         fitaabb = False
 
+    inertia_from_geom = compiler_attribs.get("inertiafromgeom", "auto").lower()
+    if inertia_from_geom not in {"auto", "false", "true"}:
+        raise ValueError(
+            f"MJCF compiler inertiafromgeom must be 'auto', 'false', or 'true'; got {inertia_from_geom!r}."
+        )
+    inertia_group_range = tuple(int(value) for value in compiler_attribs.get("inertiagrouprange", "0 5").split())
+    if len(inertia_group_range) != 2:
+        raise ValueError("MJCF compiler inertiagrouprange must contain exactly 2 integers.")
+
     # Parse MJCF compiler and option tags for ONCE and WORLD frequency custom attributes
     # WORLD frequency attributes use index 0 here; they get remapped during add_world()
     # Use findall for <option> to handle multiple elements after include expansion
@@ -687,8 +696,19 @@ def parse_mjcf(
         return wp.quat_identity()
 
     def parse_shapes(
-        defaults, body_name, link, geoms, density, visible=True, just_visual=False, incoming_xform=None, label_prefix=""
+        defaults,
+        body_name,
+        link,
+        geoms,
+        density,
+        visible=True,
+        just_visual=False,
+        incoming_xform=None,
+        label_prefix="",
+        contribute_inertia=True,
+        target_builder=None,
     ):
+        shape_builder = builder if target_builder is None else target_builder
         shapes = []
         for geo_count, geom in enumerate(geoms):
             geom_class = geom.attrib.get("class")
@@ -734,6 +754,11 @@ def parse_mjcf(
                 # Set density to 0 to skip density-based mass contribution
                 # We'll add the explicit mass to the body separately
                 geom_density = 0.0
+
+            geom_group = int(geom_attrib.get("group", 0))
+            if not contribute_inertia or not (inertia_group_range[0] <= geom_group <= inertia_group_range[1]):
+                geom_density = 0.0
+                geom_mass_explicit = None
 
             shape_cfg = builder.default_shape_cfg.copy()
             shape_cfg.is_visible = visible
@@ -796,8 +821,12 @@ def parse_mjcf(
             if "gap" in geom_attrib:
                 shape_cfg.gap = mj_gap
 
-            custom_attributes = parse_custom_attributes(geom_attrib, builder_custom_attr_shape, parsing_mode="mjcf")
-            if has_solref_mode:
+            custom_attributes = (
+                parse_custom_attributes(geom_attrib, builder_custom_attr_shape, parsing_mode="mjcf")
+                if shape_builder is builder
+                else {}
+            )
+            if has_solref_mode and shape_builder is builder:
                 # Authored solref → RAW (forwarded verbatim); unauthored →
                 # MJCF_DEFAULT (force-space scaling is strictly opt-in for
                 # shapes — no auto-promote, unlike joint limits). See
@@ -946,7 +975,7 @@ def parse_mjcf(
                             tf = tf * wp.transform(center_offset, fit_rot)
 
             if geom_type == "sphere":
-                s = builder.add_shape_sphere(
+                s = shape_builder.add_shape_sphere(
                     xform=tf,
                     radius=geom_size[0],
                     **shape_kwargs,
@@ -954,7 +983,7 @@ def parse_mjcf(
                 shapes.append(s)
 
             elif geom_type == "box":
-                s = builder.add_shape_box(
+                s = shape_builder.add_shape_box(
                     xform=tf,
                     hx=geom_size[0],
                     hy=geom_size[1],
@@ -1018,7 +1047,7 @@ def parse_mjcf(
                     if explicit_mesh_density is not None:
                         mesh_cfg.density = explicit_mesh_density
                     mesh_shape_kwargs["cfg"] = mesh_cfg
-                    s = builder.add_shape_mesh(
+                    s = shape_builder.add_shape_mesh(
                         xform=tf,
                         mesh=m_mesh,
                         **mesh_shape_kwargs,
@@ -1064,7 +1093,7 @@ def parse_mjcf(
                     geom_height = geom_size[1]
 
                 if geom_type == "cylinder":
-                    s = builder.add_shape_cylinder(
+                    s = shape_builder.add_shape_cylinder(
                         xform=tf,
                         radius=geom_radius,
                         half_height=geom_height,
@@ -1072,7 +1101,7 @@ def parse_mjcf(
                     )
                     shapes.append(s)
                 else:
-                    s = builder.add_shape_capsule(
+                    s = shape_builder.add_shape_capsule(
                         xform=tf,
                         radius=geom_radius,
                         half_height=geom_height,
@@ -1117,7 +1146,7 @@ def parse_mjcf(
 
                 # Heightfields are always static — don't pass body from shape_kwargs
                 hfield_kwargs = {k: v for k, v in shape_kwargs.items() if k != "body"}
-                s = builder.add_shape_heightfield(
+                s = shape_builder.add_shape_heightfield(
                     xform=tf,
                     heightfield=heightfield,
                     **hfield_kwargs,
@@ -1128,7 +1157,7 @@ def parse_mjcf(
                 # Use xform directly - plane has local normal (0,0,1) and passes through origin
                 # The transform tf positions and orients the plane in world space
                 # MuJoCo planes are always infinite for collision; pass 0 extents.
-                s = builder.add_shape_plane(
+                s = shape_builder.add_shape_plane(
                     xform=tf,
                     width=0.0,
                     length=0.0,
@@ -1137,7 +1166,7 @@ def parse_mjcf(
                 shapes.append(s)
 
             elif geom_type == "ellipsoid":
-                s = builder.add_shape_ellipsoid(
+                s = shape_builder.add_shape_ellipsoid(
                     xform=tf,
                     rx=geom_size[0],
                     ry=geom_size[1],
@@ -1203,11 +1232,39 @@ def parse_mjcf(
                     )
 
                 # Add explicit mass and computed inertia to body (skip if inertia is locked by <inertial>)
-                if inertia_computed and not builder.body_lock_inertia[link]:
+                if inertia_computed and not shape_builder.body_lock_inertia[link]:
                     com_body = wp.transform_point(tf, com)
-                    builder._update_body_mass(link, geom_mass_explicit, inertia_tensor, com_body, tf.q)
+                    shape_builder._update_body_mass(link, geom_mass_explicit, inertia_tensor, com_body, tf.q)
 
         return shapes
+
+    def accumulate_inertia_from_unloaded_geoms(defaults, body_name, link, geoms, incoming_xform=None, label_prefix=""):
+        """Accumulate selected geom inertia without retaining visual shapes."""
+        if link < 0 or not geoms:
+            return
+        inertia_builder = ModelBuilder()
+        inertia_link = inertia_builder.add_link()
+        parse_shapes(
+            defaults,
+            body_name,
+            inertia_link,
+            geoms,
+            density=default_shape_density,
+            just_visual=True,
+            visible=False,
+            incoming_xform=incoming_xform,
+            label_prefix=label_prefix,
+            target_builder=inertia_builder,
+        )
+        mass = inertia_builder.body_mass[inertia_link]
+        if mass > 0.0:
+            builder._update_body_mass(
+                link,
+                mass,
+                inertia_builder.body_inertia[inertia_link],
+                inertia_builder.body_com[inertia_link],
+                wp.quat_identity(),
+            )
 
     def _parse_sites_impl(defaults, body_name, link, sites, incoming_xform=None, label_prefix=""):
         """Parse site elements from MJCF."""
@@ -1303,6 +1360,7 @@ def parse_mjcf(
         link: int,
         incoming_xform: wp.transform | None = None,
         label_prefix: str = "",
+        infer_inertia_from_geoms: bool = False,
     ) -> list:
         """Process geoms for a body, partitioning into visuals and colliders.
 
@@ -1316,6 +1374,7 @@ def parse_mjcf(
             link: The body index.
             incoming_xform: Optional transform to apply to geoms.
             label_prefix: Hierarchical label prefix for shape labels.
+            infer_inertia_from_geoms: Whether selected geoms contribute body inertia.
 
         Returns:
             List of visual shape indices (if parse_visuals is True).
@@ -1371,7 +1430,10 @@ def parse_mjcf(
 
         visual_shape_indices = []
 
+        unloaded_geoms = []
         if parse_visuals_as_colliders:
+            loaded_geom_ids = {id(geom) for geom in visuals}
+            unloaded_geoms = [geom for geom in colliders if id(geom) not in loaded_geom_ids]
             colliders = visuals
         elif parse_visuals:
             s = parse_shapes(
@@ -1384,8 +1446,22 @@ def parse_mjcf(
                 visible=not hide_visuals,
                 incoming_xform=incoming_xform,
                 label_prefix=label_prefix,
+                contribute_inertia=infer_inertia_from_geoms,
             )
             visual_shape_indices.extend(s)
+        else:
+            loaded_geom_ids = {id(geom) for geom in colliders}
+            unloaded_geoms = [geom for geom in visuals if id(geom) not in loaded_geom_ids]
+
+        if infer_inertia_from_geoms:
+            accumulate_inertia_from_unloaded_geoms(
+                defaults,
+                body_name,
+                link,
+                unloaded_geoms,
+                incoming_xform=incoming_xform,
+                label_prefix=label_prefix,
+            )
 
         colliders.extend(required_colliders)
 
@@ -1404,6 +1480,7 @@ def parse_mjcf(
             visible=show_colliders,
             incoming_xform=incoming_xform,
             label_prefix=label_prefix,
+            contribute_inertia=infer_inertia_from_geoms,
         )
         collider_shapes.extend(collider_shape_indices)
 
@@ -1418,6 +1495,7 @@ def parse_mjcf(
         body_relative_xform: wp.transform | None = None,
         label_prefix: str = "",
         track_root_boundaries: bool = False,
+        infer_inertia_from_geoms: bool = False,
     ):
         """Process frame elements, composing transforms with children.
 
@@ -1433,6 +1511,7 @@ def parse_mjcf(
                 (appropriate for static geoms at worldbody level).
             label_prefix: Hierarchical label prefix for child entity labels.
             track_root_boundaries: If True, record root body boundaries for articulation splitting.
+            infer_inertia_from_geoms: Whether frame geoms contribute to the parent body's inertia.
         """
         # Stack entries: (frame, world_xform, body_relative_xform, frame_defaults, frame_childclass)
         # For worldbody frames, body_relative equals world (static geoms use world coords)
@@ -1479,6 +1558,7 @@ def parse_mjcf(
                     parent_body,
                     incoming_xform=composed_body_rel,
                     label_prefix=label_prefix,
+                    infer_inertia_from_geoms=infer_inertia_from_geoms,
                 )
                 visual_shapes.extend(frame_visual_shapes)
 
@@ -1540,6 +1620,10 @@ def parse_mjcf(
         body_attrib = merge_attrib(defaults.get("body", {}), body.attrib)
         body_name = body_attrib.get("name", f"body_{builder.body_count}")
         body_name = sanitize_name(body_name)
+        has_inertial_definition = body.find("inertial") is not None
+        infer_body_inertia_from_geoms = ignore_inertial_definitions or inertia_from_geom == "true"
+        if inertia_from_geom == "auto" and not has_inertial_definition:
+            infer_body_inertia_from_geoms = True
         # Build XPath-style hierarchical label path for this body
         body_label_path = f"{parent_label_path}/{body_name}" if parent_label_path else body_name
         body_pos = parse_vec(body_attrib, "pos", (0.0, 0.0, 0.0))
@@ -1927,7 +2011,14 @@ def parse_mjcf(
         # add shapes (using shared helper for visual/collider partitioning)
 
         geoms = body.findall("geom")
-        body_visual_shapes = _process_body_geoms(geoms, defaults, body_name, link, label_prefix=body_label_path)
+        body_visual_shapes = _process_body_geoms(
+            geoms,
+            defaults,
+            body_name,
+            link,
+            label_prefix=body_label_path,
+            infer_inertia_from_geoms=infer_body_inertia_from_geoms,
+        )
         visual_shapes.extend(body_visual_shapes)
 
         # Parse sites (non-colliding reference points)
@@ -1943,7 +2034,7 @@ def parse_mjcf(
                 )
 
         m = builder.body_mass[link]
-        if not ignore_inertial_definitions and body.find("inertial") is not None:
+        if not infer_body_inertia_from_geoms and not ignore_inertial_definitions and has_inertial_definition:
             inertial = body.find("inertial")
             if "inertial" in defaults:
                 inertial_attrib = merge_attrib(defaults["inertial"], inertial.attrib)
@@ -2038,6 +2129,7 @@ def parse_mjcf(
             world_xform=world_xform,
             body_relative_xform=wp.transform_identity(),  # Geoms/sites need body-relative coords
             label_prefix=body_label_path,
+            infer_inertia_from_geoms=infer_body_inertia_from_geoms,
         )
 
     def parse_equality_constraints(equality):

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1621,6 +1621,10 @@ def parse_mjcf(
         body_name = body_attrib.get("name", f"body_{builder.body_count}")
         body_name = sanitize_name(body_name)
         has_inertial_definition = body.find("inertial") is not None
+        if inertia_from_geom == "false" and not ignore_inertial_definitions and not has_inertial_definition:
+            raise ValueError(
+                f"MJCF body '{body_name}' requires an <inertial> element when compiler inertiafromgeom=\"false\"."
+            )
         infer_body_inertia_from_geoms = ignore_inertial_definitions or inertia_from_geom == "true"
         if inertia_from_geom == "auto" and not has_inertial_definition:
             infer_body_inertia_from_geoms = True

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -751,8 +751,6 @@ def parse_mjcf(
             # Skip density-based mass contribution and compute inertia directly from mass.
             if "mass" in geom_attrib:
                 geom_mass_explicit = parse_float(geom_attrib, "mass", 0.0)
-                # Set density to 0 to skip density-based mass contribution
-                # We'll add the explicit mass to the body separately
                 geom_density = 0.0
 
             geom_group = int(geom_attrib.get("group", 0))
@@ -1239,7 +1237,7 @@ def parse_mjcf(
         return shapes
 
     def accumulate_inertia_from_unloaded_geoms(defaults, body_name, link, geoms, incoming_xform=None, label_prefix=""):
-        """Accumulate selected geom inertia without retaining visual shapes."""
+        """Accumulate inertia from geoms not loaded as shapes, via a scratch builder."""
         if link < 0 or not geoms:
             return
         inertia_builder = ModelBuilder()
@@ -1257,7 +1255,7 @@ def parse_mjcf(
             target_builder=inertia_builder,
         )
         mass = inertia_builder.body_mass[inertia_link]
-        if mass > 0.0:
+        if mass > 0.0 and not builder.body_lock_inertia[link]:
             builder._update_body_mass(
                 link,
                 mass,
@@ -1621,7 +1619,13 @@ def parse_mjcf(
         body_name = body_attrib.get("name", f"body_{builder.body_count}")
         body_name = sanitize_name(body_name)
         has_inertial_definition = body.find("inertial") is not None
-        if inertia_from_geom == "false" and not ignore_inertial_definitions and not has_inertial_definition:
+        has_joint_definition = body.find("joint") is not None or body.find("freejoint") is not None
+        if (
+            inertia_from_geom == "false"
+            and not ignore_inertial_definitions
+            and has_joint_definition
+            and not has_inertial_definition
+        ):
             raise ValueError(
                 f"MJCF body '{body_name}' requires an <inertial> element when compiler inertiafromgeom=\"false\"."
             )
@@ -2037,7 +2041,6 @@ def parse_mjcf(
                     label_prefix=body_label_path,
                 )
 
-        m = builder.body_mass[link]
         if not infer_body_inertia_from_geoms and not ignore_inertial_definitions and has_inertial_definition:
             inertial = body.find("inertial")
             if "inertial" in defaults:

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2917,7 +2917,7 @@ f 4 5 8
 
                 self.assertAlmostEqual(builder.body_mass[0], expected_mass, places=6)
 
-        missing_inertial_mjcf = """<?xml version="1.0" ?>
+        mjcf_missing_inertial = """<?xml version="1.0" ?>
 <mujoco>
   <compiler inertiafromgeom="false"/>
   <worldbody>
@@ -2928,7 +2928,7 @@ f 4 5 8
   </worldbody>
 </mujoco>"""
         with self.assertRaisesRegex(ValueError, "requires an <inertial> element"):
-            newton.ModelBuilder().add_mjcf(missing_inertial_mjcf)
+            newton.ModelBuilder().add_mjcf(mjcf_missing_inertial)
 
     def test_inertial_locks_body_against_frame_geom_mass(self):
         """Regression: explicit <inertial> must lock body mass/COM against later frame geoms.

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2898,8 +2898,12 @@ f 4 5 8
 
     def test_compiler_inertiafromgeom_modes(self):
         """Test compiler control over geom inference when inertial data exists."""
-        expected_masses = {"auto": 1.0, "false": 1.0, "true": 2.0}
-        for mode, expected_mass in expected_masses.items():
+        expected_properties = {
+            "auto": (1.0, [0.1, 0.2, 0.3], [0.01, 0.02, 0.03]),
+            "false": (1.0, [0.1, 0.2, 0.3], [0.01, 0.02, 0.03]),
+            "true": (2.0, [-0.2, 0.4, 0.1], [0.008, 0.008, 0.008]),
+        }
+        for mode, (expected_mass, expected_com, expected_inertia) in expected_properties.items():
             with self.subTest(mode=mode):
                 mjcf = f"""<?xml version="1.0" ?>
 <mujoco>
@@ -2907,8 +2911,8 @@ f 4 5 8
   <worldbody>
     <body name="test">
       <freejoint/>
-      <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
-      <geom type="sphere" size="0.1" mass="2"/>
+      <inertial pos="0.1 0.2 0.3" mass="1" diaginertia="0.01 0.02 0.03"/>
+      <geom type="sphere" size="0.1" pos="-0.2 0.4 0.1" mass="2"/>
     </body>
   </worldbody>
 </mujoco>"""
@@ -2916,6 +2920,12 @@ f 4 5 8
                 builder.add_mjcf(mjcf)
 
                 self.assertAlmostEqual(builder.body_mass[0], expected_mass, places=6)
+                np.testing.assert_allclose(builder.body_com[0], expected_com, atol=1e-7)
+                np.testing.assert_allclose(
+                    np.array(builder.body_inertia[0]).reshape(3, 3),
+                    np.diag(expected_inertia),
+                    atol=1e-7,
+                )
 
         mjcf_missing_inertial = """<?xml version="1.0" ?>
 <mujoco>

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2917,6 +2917,19 @@ f 4 5 8
 
                 self.assertAlmostEqual(builder.body_mass[0], expected_mass, places=6)
 
+        missing_inertial_mjcf = """<?xml version="1.0" ?>
+<mujoco>
+  <compiler inertiafromgeom="false"/>
+  <worldbody>
+    <body name="missing_inertial">
+      <freejoint/>
+      <geom type="sphere" size="0.1" mass="2"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        with self.assertRaisesRegex(ValueError, "requires an <inertial> element"):
+            newton.ModelBuilder().add_mjcf(missing_inertial_mjcf)
+
     def test_inertial_locks_body_against_frame_geom_mass(self):
         """Regression: explicit <inertial> must lock body mass/COM against later frame geoms.
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2849,6 +2849,74 @@ f 4 5 8
             msg="Visual geom with explicit mass should contribute non-zero inertia",
         )
 
+    def test_visual_geom_mass_without_parsing_visuals(self):
+        """Test that skipping visual shapes does not change inferred body mass."""
+        mjcf = """<?xml version="1.0" ?>
+<mujoco>
+  <worldbody>
+    <body name="test">
+      <freejoint/>
+      <geom name="visual" class="visual" type="sphere" size="0.1"
+            contype="0" conaffinity="0" group="2" mass="0.012"/>
+      <geom name="collision" class="collision" type="box" size="0.1 0.1 0.1"
+            group="3" mass="0"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        for parse_visuals, expected_shape_count in ((False, 1), (True, 2)):
+            with self.subTest(parse_visuals=parse_visuals):
+                builder = newton.ModelBuilder()
+                builder.add_mjcf(mjcf, parse_visuals=parse_visuals)
+
+                self.assertEqual(builder.shape_count, expected_shape_count)
+                self.assertAlmostEqual(builder.body_mass[0], 0.012, places=7)
+                self.assertGreater(float(np.trace(np.array(builder.body_inertia[0]).reshape(3, 3))), 0.0)
+
+    def test_compiler_inertiagrouprange(self):
+        """Test that only geom groups in the compiler range contribute inertia."""
+        mjcf = """<?xml version="1.0" ?>
+<mujoco>
+  <compiler inertiagrouprange="0 2"/>
+  <worldbody>
+    <body name="test">
+      <freejoint/>
+      <geom type="sphere" size="0.1" group="2" mass="0.5"/>
+      <geom type="box" size="0.1 0.1 0.1" group="3" mass="8"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+
+        self.assertAlmostEqual(builder.body_mass[0], 0.5, places=6)
+        np.testing.assert_allclose(
+            np.array(builder.body_inertia[0]).reshape(3, 3),
+            np.diag([0.002, 0.002, 0.002]),
+            atol=1e-7,
+            rtol=1e-6,
+        )
+
+    def test_compiler_inertiafromgeom_modes(self):
+        """Test compiler control over geom inference when inertial data exists."""
+        expected_masses = {"auto": 1.0, "false": 1.0, "true": 2.0}
+        for mode, expected_mass in expected_masses.items():
+            with self.subTest(mode=mode):
+                mjcf = f"""<?xml version="1.0" ?>
+<mujoco>
+  <compiler inertiafromgeom="{mode}"/>
+  <worldbody>
+    <body name="test">
+      <freejoint/>
+      <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+      <geom type="sphere" size="0.1" mass="2"/>
+    </body>
+  </worldbody>
+</mujoco>"""
+                builder = newton.ModelBuilder()
+                builder.add_mjcf(mjcf)
+
+                self.assertAlmostEqual(builder.body_mass[0], expected_mass, places=6)
+
     def test_inertial_locks_body_against_frame_geom_mass(self):
         """Regression: explicit <inertial> must lock body mass/COM against later frame geoms.
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -2849,28 +2849,67 @@ f 4 5 8
             msg="Visual geom with explicit mass should contribute non-zero inertia",
         )
 
-    def test_visual_geom_mass_without_parsing_visuals(self):
-        """Test that skipping visual shapes does not change inferred body mass."""
-        mjcf = """<?xml version="1.0" ?>
+    def test_geom_inertia_independent_of_visual_loading(self):
+        """Preserve combined geom mass properties across visual-loading modes."""
+        cases = {
+            "explicit mass": ('mass="1.25"', 'mass="2.75"'),
+            "density": ("", 'density="600"'),
+        }
+        import_modes = {
+            "visuals": ({"parse_visuals": True}, 2),
+            "no visuals": ({"parse_visuals": False}, 1),
+            "visuals as colliders": ({"parse_visuals_as_colliders": True}, 1),
+        }
+        visual_com = np.array([0.4, -0.2, 0.15])
+        collider_com = np.array([-0.3, 0.25, -0.1])
+
+        for case_name, (visual_mass_attrib, collider_mass_attrib) in cases.items():
+            mjcf = f"""<?xml version="1.0" ?>
 <mujoco>
+  <default>
+    <default class="visual">
+      <geom contype="0" conaffinity="0" group="2"/>
+    </default>
+    <default class="collision">
+      <geom group="3"/>
+    </default>
+  </default>
   <worldbody>
     <body name="test">
       <freejoint/>
-      <geom name="visual" class="visual" type="sphere" size="0.1"
-            contype="0" conaffinity="0" group="2" mass="0.012"/>
-      <geom name="collision" class="collision" type="box" size="0.1 0.1 0.1"
-            group="3" mass="0"/>
+      <geom name="visual" class="visual" type="box" size="0.12 0.07 0.03"
+            pos="0.4 -0.2 0.15" quat="0.9238795 0 0 0.3826834" {visual_mass_attrib}/>
+      <geom name="collision" class="collision" type="cylinder" size="0.08 0.2"
+            pos="-0.3 0.25 -0.1" euler="20 0 0" {collider_mass_attrib}/>
     </body>
   </worldbody>
 </mujoco>"""
-        for parse_visuals, expected_shape_count in ((False, 1), (True, 2)):
-            with self.subTest(parse_visuals=parse_visuals):
-                builder = newton.ModelBuilder()
-                builder.add_mjcf(mjcf, parse_visuals=parse_visuals)
+            properties = {}
+            for mode_name, (options, expected_shape_count) in import_modes.items():
+                with self.subTest(case=case_name, mode=mode_name):
+                    builder = newton.ModelBuilder()
+                    builder.add_mjcf(mjcf, **options)
 
-                self.assertEqual(builder.shape_count, expected_shape_count)
-                self.assertAlmostEqual(builder.body_mass[0], 0.012, places=7)
-                self.assertGreater(float(np.trace(np.array(builder.body_inertia[0]).reshape(3, 3))), 0.0)
+                    self.assertEqual(builder.shape_count, expected_shape_count)
+                    properties[mode_name] = (
+                        builder.body_mass[0],
+                        np.array(builder.body_com[0]),
+                        np.array(builder.body_inertia[0]).reshape(3, 3),
+                    )
+
+            reference_mass, reference_com, reference_inertia = properties["visuals"]
+            self.assertFalse(np.allclose(reference_com, visual_com))
+            self.assertFalse(np.allclose(reference_com, collider_com))
+            self.assertGreater(
+                np.max(np.abs(reference_inertia - np.diag(np.diag(reference_inertia)))),
+                1e-4,
+            )
+            for mode_name in ("no visuals", "visuals as colliders"):
+                with self.subTest(case=case_name, mode=mode_name):
+                    mass, com, inertia = properties[mode_name]
+                    self.assertAlmostEqual(mass, reference_mass, places=6)
+                    np.testing.assert_allclose(com, reference_com, atol=1e-7, rtol=1e-6)
+                    np.testing.assert_allclose(inertia, reference_inertia, atol=1e-7, rtol=1e-6)
 
     def test_compiler_inertiagrouprange(self):
         """Test that only geom groups in the compiler range contribute inertia."""
@@ -2897,7 +2936,7 @@ f 4 5 8
         )
 
     def test_compiler_inertiafromgeom_modes(self):
-        """Test compiler control over geom inference when inertial data exists."""
+        """Test inertiafromgeom modes with and without an inertial element."""
         expected_properties = {
             "auto": (1.0, [0.1, 0.2, 0.3], [0.01, 0.02, 0.03]),
             "false": (1.0, [0.1, 0.2, 0.3], [0.01, 0.02, 0.03]),
@@ -2939,6 +2978,31 @@ f 4 5 8
 </mujoco>"""
         with self.assertRaisesRegex(ValueError, "requires an <inertial> element"):
             newton.ModelBuilder().add_mjcf(mjcf_missing_inertial)
+
+        mjcf_fixed_missing_inertial = """<?xml version="1.0" ?>
+<mujoco>
+  <compiler inertiafromgeom="false"/>
+  <worldbody>
+    <body name="fixed_root">
+      <geom type="sphere" size="0.1"/>
+    </body>
+    <body name="moving_parent">
+      <joint type="hinge"/>
+      <inertial pos="0 0 0" mass="1" diaginertia="0.01 0.01 0.01"/>
+      <body name="fixed_child">
+        <geom type="sphere" size="0.1"/>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf_fixed_missing_inertial)
+        fixed_body_indices = [
+            index for index, label in enumerate(builder.body_label) if label.endswith(("fixed_root", "fixed_child"))
+        ]
+        self.assertEqual(len(fixed_body_indices), 2)
+        for body_index in fixed_body_indices:
+            self.assertEqual(builder.body_mass[body_index], 0.0)
 
     def test_inertial_locks_body_against_frame_geom_mass(self):
         """Regression: explicit <inertial> must lock body mass/COM against later frame geoms.


### PR DESCRIPTION
## Description

Newton's MJCF importer did not follow MuJoCo's compiler rules for choosing body inertia.

This change adds support for:

- `inertiafromgeom="auto"`, `"true"`, and `"false"`
- `inertiagrouprange`
- inertia from visual geoms even when `parse_visuals=False`

Loaded shapes still use the normal mass path. Visual geoms that are intentionally not loaded are evaluated in a temporary builder, so they affect body mass and inertia without appearing in the model.

Closes #3593.

## Checklist

- [x] New or existing tests cover the change.
- [x] Existing documentation remains accurate.
- [x] The changelog includes the user-facing fix.

## Test plan

- `uv run --extra dev -m newton.tests -k test_visual_geom_mass_without_parsing_visuals`
- `uv run --extra dev -m newton.tests -k test_compiler_inertiagrouprange`
- `uv run --extra dev -m newton.tests -k test_compiler_inertiafromgeom_modes`
- `uv run --extra dev -m newton.tests -p test_import_mjcf.py` (234 tests)
- `uvx pre-commit run -a`

## Bug fix

Before this change, `parse_visuals=False` could change body mass, excluded geom groups still contributed inertia, and `inertiafromgeom="true"` did not override explicit inertial data. These cases now follow MuJoCo's compiler semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MJCF importer’s inertia/mass inference to properly honor `<compiler inertiafromgeom>` modes and `<compiler inertiagrouprange>` filtering.
  * Ensures inferred body mass/inertia remains consistent regardless of whether visuals are parsed as shapes.
  * Correctly applies explicit `mass` for small mesh geoms without spurious warnings.
  * Enforces expected behavior when inference is disallowed but `<inertial>` data is missing.
* **Tests**
  * Added regression tests for mesh explicit-mass handling and compiler-driven inertia/mass semantics.
* **Documentation**
  * Refreshed the unreleased changelog notes describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->