### PR TITLE
Adds `controllers` module and `ControllerJointImpendance` implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)
+- Add `newton.controllers` module with `Controller` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control.
 - Add list-of-pattern and explicit-index selectors to `ArticulationView`.
 - Add `newton[onnx]` for ONNX policy inference through Warp-NN; `ControllerNeuralMLP`, `ControllerNeuralLSTM`, and RL policy examples can run exported `.onnx` policies without requiring PyTorch for ONNX execution.
 - Add three VBD contact examples — `vbd_rigid_rigid_contact`, `vbd_soft_rigid_contact`, and `vbd_soft_rigid_mix_contact` — demonstrating rigid-rigid, soft (particle-rigid), and mixed cloth-bag contacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Add contact examples for Newton's cradle, a balance bird, and a domino spiral
 - Document geometry-pair contact behavior and clarify that MuJoCo Warp currently produces a single contact for cylinder--box pairs even with MultiCCD enabled.
 - Add `ViewerUSD(points_as_spheres=...)` to render `log_points` particles as a `UsdGeom.PointInstancer` of sphere prototypes; enabled by default (opt out with `points_as_spheres=False` for flat `UsdGeom.Points` splats)
-- Add `newton.controllers` module with `Controller` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control.
+- Add experimental `newton.controllers` module with `ControllerBase` base class, `ControllerJointImpedance`, and `ControllerJointImpedanceModelFree` for GPU-accelerated, vectorized joint-space impedance control.
 - Add list-of-pattern and explicit-index selectors to `ArticulationView`.
 - Add `newton[onnx]` for ONNX policy inference through Warp-NN; `ControllerNeuralMLP`, `ControllerNeuralLSTM`, and RL policy examples can run exported `.onnx` policies without requiring PyTorch for ONNX execution.
 - Add three VBD contact examples — `vbd_rigid_rigid_contact`, `vbd_soft_rigid_contact`, and `vbd_soft_rigid_mix_contact` — demonstrating rigid-rigid, soft (particle-rigid), and mixed cloth-bag contacts

--- a/docs/api/_toctree.rst
+++ b/docs/api/_toctree.rst
@@ -8,6 +8,7 @@
 
    api/newton
    api/newton_actuators
+   api/newton_controllers
    api/newton_geometry
    api/newton_ik
    api/newton_math

--- a/docs/api/newton.rst
+++ b/docs/api/newton.rst
@@ -10,6 +10,7 @@ newton
 .. rubric:: Submodules
 
 - :doc:`newton.actuators <newton_actuators>`
+- :doc:`newton.controllers <newton_controllers>`
 - :doc:`newton.geometry <newton_geometry>`
 - :doc:`newton.ik <newton_ik>`
 - :doc:`newton.math <newton_math>`

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -1,0 +1,31 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+.. SPDX-License-Identifier: CC-BY-4.0
+
+newton.controllers
+==================
+
+GPU-accelerated, vectorized control laws for Newton physics simulations.
+
+This module provides standalone controllers that compute joint torques or
+other actuation signals from simulation state. Each controller is a concrete
+subclass of :class:`Controller` and operates on flat 1D arrays matching the
+layout of :class:`~newton.State` fields, making them composable with any
+Newton solver.
+
+.. experimental::
+
+    The controllers API may change without prior notice. Feedback is welcome —
+    please file issues or discussion threads.
+
+.. py:module:: newton.controllers
+.. currentmodule:: newton.controllers
+
+.. rubric:: Classes
+
+.. autosummary::
+   :toctree: _generated
+   :nosignatures:
+
+   Controller
+   ControllerJointImpedance
+   ControllerJointImpedanceModelFree

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -4,13 +4,11 @@
 newton.controllers
 ==================
 
-GPU-accelerated, vectorized control laws for Newton physics simulations.
+GPU-accelerated, vectorized control laws.
 
-This module provides standalone controllers that compute joint torques or
-other actuation signals from simulation state. Each controller is a concrete
-subclass of :class:`ControllerBase` and operates on flat 1D arrays matching the
-layout of :class:`~newton.State` fields, making them composable with any
-Newton solver.
+This module provides standalone controllers which compute output torques, positions
+or velocities for the robot to track. Each controller is a concrete
+subclass of :class:`ControllerBase` and operates on flat 1D arrays.
 
 .. experimental::
 

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -12,9 +12,6 @@ subclass of :class:`ControllerBase` and operates on flat 1D arrays.
 
 .. experimental::
 
-    The controllers API may change without prior notice. Feedback is welcome —
-    please file issues or discussion threads.
-
 .. py:module:: newton.controllers
 .. currentmodule:: newton.controllers
 

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -6,7 +6,7 @@ newton.controllers
 
 GPU-accelerated, vectorized control laws.
 
-This module provides standalone controllers which compute control signals
+This module provides standalone controllers that compute signals
 for the robot to track. Each controller is a concrete
 subclass of :class:`ControllerBase`.
 

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -6,9 +6,9 @@ newton.controllers
 
 GPU-accelerated, vectorized control laws.
 
-This module provides standalone controllers which compute output torques, positions
-or velocities for the robot to track. Each controller is a concrete
-subclass of :class:`ControllerBase` and operates on flat 1D arrays.
+This module provides standalone controllers which compute control signals
+for the robot to track. Each controller is a concrete
+subclass of :class:`ControllerBase`.
 
 .. experimental::
 

--- a/docs/api/newton_controllers.rst
+++ b/docs/api/newton_controllers.rst
@@ -8,7 +8,7 @@ GPU-accelerated, vectorized control laws for Newton physics simulations.
 
 This module provides standalone controllers that compute joint torques or
 other actuation signals from simulation state. Each controller is a concrete
-subclass of :class:`Controller` and operates on flat 1D arrays matching the
+subclass of :class:`ControllerBase` and operates on flat 1D arrays matching the
 layout of :class:`~newton.State` fields, making them composable with any
 Newton solver.
 
@@ -26,6 +26,6 @@ Newton solver.
    :toctree: _generated
    :nosignatures:
 
-   Controller
+   ControllerBase
    ControllerJointImpedance
    ControllerJointImpedanceModelFree

--- a/newton/__init__.py
+++ b/newton/__init__.py
@@ -121,10 +121,11 @@ __all__ += [
 # ==================================================================================
 # submodule APIs
 # ==================================================================================
-from . import actuators, geometry, ik, math, selection, sensors, solvers, usd, utils, viewer  # noqa: E402
+from . import actuators, controllers, geometry, ik, math, selection, sensors, solvers, usd, utils, viewer  # noqa: E402
 
 __all__ += [
     "actuators",
+    "controllers",
     "geometry",
     "ik",
     "math",

--- a/newton/_src/controllers/__init__.py
+++ b/newton/_src/controllers/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from .controller import Controller
+from .impl import ControllerJointImpedance, ControllerJointImpedanceModelFree
+
+__all__ = [
+    "Controller",
+    "ControllerJointImpedance",
+    "ControllerJointImpedanceModelFree",
+]

--- a/newton/_src/controllers/__init__.py
+++ b/newton/_src/controllers/__init__.py
@@ -1,11 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from .controller import Controller
+from .controller import ControllerBase
 from .impl import ControllerJointImpedance, ControllerJointImpedanceModelFree
 
 __all__ = [
-    "Controller",
+    "ControllerBase",
     "ControllerJointImpedance",
     "ControllerJointImpedanceModelFree",
 ]

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -22,8 +22,9 @@ class Controller(ABC):
 
     Subclasses are responsible for:
 
-    - :meth:`is_graphable`, :meth:`is_stateful`: predicates the user can query
-      to decide CUDA-graph capture and double-buffered state setup.
+    - :meth:`is_graphable`: predicate the user can query to decide CUDA-graph
+      capture. Check ``ctrl.state() is not None`` to determine whether
+      double-buffered state setup is needed.
     - :meth:`state`: allocate a fresh :class:`State`, or return ``None`` for
       stateless laws.
     - :meth:`input`, :meth:`output`: allocate fresh duck-typed containers
@@ -44,12 +45,14 @@ class Controller(ABC):
         """Whether :meth:`compute` is safe to capture in a CUDA graph."""
 
     @abstractmethod
-    def is_stateful(self) -> bool:
-        """Whether this controller maintains internal state between steps."""
-
-    @abstractmethod
     def state(self) -> Controller.State | None:
-        """Allocate a fresh :class:`State`, or ``None`` if stateless."""
+        """Allocate a fresh :class:`State`, or ``None`` if stateless.
+
+        The return value is the canonical indicator of statefulness:
+        ``ctrl.state() is not None`` means the controller maintains state
+        between steps and callers should allocate two buffers for
+        double-buffering.
+        """
 
     @abstractmethod
     def input(self) -> Any:

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Abstract base for Newton controllers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+import warp as wp
+
+
+class Controller(ABC):
+    """Abstract interface for a single Newton control law.
+
+    Every concrete control law (joint impedance, differential IK, …) subclasses
+    :class:`Controller` directly. There is no framework-level composition: users
+    who want to combine multiple control laws call each one's :meth:`compute`
+    in sequence themselves.
+
+    Subclasses are responsible for:
+
+    - :meth:`is_graphable`, :meth:`is_stateful`: predicates the user can query
+      to decide CUDA-graph capture and double-buffered state setup.
+    - :meth:`state`: allocate a fresh :class:`State`, or return ``None`` for
+      stateless laws.
+    - :meth:`input`, :meth:`output`: allocate fresh duck-typed containers
+      holding only the live ports declared at construction. Baked-in arrays
+      (gain ports given a :class:`wp.array` rather than an attr name) are
+      stored on the controller and do **not** appear on the input struct.
+    - :meth:`compute`: read the input struct's live arrays, run kernels, write
+      the output struct's live arrays. Writes are slot-replacing (``=``, not
+      ``+=``); composing laws is the user's job.
+    """
+
+    @dataclass
+    class State:
+        """Pure data container. Subclasses declare their fields."""
+
+    @abstractmethod
+    def is_graphable(self) -> bool:
+        """Whether :meth:`compute` is safe to capture in a CUDA graph."""
+
+    @abstractmethod
+    def is_stateful(self) -> bool:
+        """Whether this controller maintains internal state between steps."""
+
+    @abstractmethod
+    def state(self) -> Controller.State | None:
+        """Allocate a fresh :class:`State`, or ``None`` if stateless."""
+
+    @abstractmethod
+    def input(self) -> Any:
+        """Allocate a fresh input container with one field per input port.
+
+        The returned object has attributes whose names match the ``*_attr``
+        strings passed at construction. Each field is a freshly
+        :func:`wp.zeros`-allocated array of the right dtype and size. The
+        user typically reassigns these fields to point at live data buffers.
+        """
+
+    @abstractmethod
+    def output(self) -> Any:
+        """Allocate a fresh output container with one field per output port."""
+
+    @abstractmethod
+    def compute(
+        self,
+        inputs: Any,
+        outputs: Any,
+        controller_state_now: Controller.State | None,
+        controller_state_next: Controller.State | None,
+        time_step: float | wp.array[wp.float32],
+    ) -> None:
+        """Run one control step.
+
+        Args:
+            inputs: Object whose attributes hold the live read ports.
+                Resolved via ``getattr(inputs, attr_name)``. Any
+                duck-typed object works; :meth:`input` returns a
+                pre-allocated one.
+            outputs: Same contract as ``inputs`` for write ports. The
+                kernel performs slot-replacing writes — slots outside the
+                declared port indices are left untouched.
+            controller_state_now: Current state (``None`` if stateless).
+            controller_state_next: Next-step state to populate (``None``
+                if stateless). Double-buffered against
+                ``controller_state_now``.
+            time_step: Step duration [s]. Either a plain ``float`` or a
+                ``wp.array`` of shape ``(1,)`` dtype ``wp.float32``.
+        """

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -36,23 +36,9 @@ class Controller(ABC):
       ``+=``); composing laws is the user's job.
     """
 
-    @dataclass
-    class State:
-        """Pure data container. Subclasses declare their fields."""
-
     @abstractmethod
     def is_graphable(self) -> bool:
         """Whether :meth:`compute` is safe to capture in a CUDA graph."""
-
-    @abstractmethod
-    def state(self) -> Controller.State | None:
-        """Allocate a fresh :class:`State`, or ``None`` if stateless.
-
-        The return value is the canonical indicator of statefulness:
-        ``ctrl.state() is not None`` means the controller maintains state
-        between steps and callers should allocate two buffers for
-        double-buffering.
-        """
 
     @abstractmethod
     def input(self) -> Any:
@@ -73,9 +59,7 @@ class Controller(ABC):
         self,
         inputs: Any,
         outputs: Any,
-        controller_state_now: Controller.State | None,
-        controller_state_next: Controller.State | None,
-        time_step: float | wp.array[wp.float32],
+        dt: float | wp.array[wp.float32],
     ) -> None:
         """Run one control step.
 
@@ -87,10 +71,6 @@ class Controller(ABC):
             outputs: Same contract as ``inputs`` for write ports. The
                 kernel performs slot-replacing writes — slots outside the
                 declared port indices are left untouched.
-            controller_state_now: Current state (``None`` if stateless).
-            controller_state_next: Next-step state to populate (``None``
-                if stateless). Double-buffered against
-                ``controller_state_now``.
-            time_step: Step duration [s]. Either a plain ``float`` or a
+            dt: Step duration [s]. Either a plain ``float`` or a
                 ``wp.array`` of shape ``(1,)`` dtype ``wp.float32``.
         """

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Any
 
 import warp as wp

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -56,6 +56,7 @@ class Controller(ABC):
     @abstractmethod
     def compute(
         self,
+        *,
         inputs: Any,
         outputs: Any,
         dt: float | wp.array[wp.float32],

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -24,9 +24,8 @@ class ControllerBase(ABC, Generic[InputT, OutputT]):
 
     Subclasses are responsible for:
 
-    - :meth:`is_graphable`: predicate the user can query to decide graph
-      capture. Check ``ctrl.state() is not None`` to determine whether
-      double-buffered state setup is needed.
+    - :meth:`is_graphable`: predicate the user can query to decide whether
+      graph capture is possible.
     - :meth:`input`, :meth:`output`: allocate fresh typed input/output structs.
       Baked-in arrays (gains passed as a ``wp.array`` at construction) are
       stored on the controller and do **not** appear on the input struct.

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -6,29 +6,29 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Generic, TypeVar
 
 import warp as wp
 
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
 
-class Controller(ABC):
+
+class ControllerBase(ABC, Generic[InputT, OutputT]):
     """Abstract interface for a single Newton control law.
 
     Every concrete control law (joint impedance, differential IK, …) subclasses
-    :class:`Controller` directly. There is no framework-level composition: users
+    :class:`ControllerBase` directly. There is no framework-level composition: users
     who want to combine multiple control laws call each one's :meth:`compute`
     in sequence themselves.
 
     Subclasses are responsible for:
 
-    - :meth:`is_graphable`: predicate the user can query to decide CUDA-graph
+    - :meth:`is_graphable`: predicate the user can query to decide graph
       capture. Check ``ctrl.state() is not None`` to determine whether
       double-buffered state setup is needed.
-    - :meth:`state`: allocate a fresh :class:`State`, or return ``None`` for
-      stateless laws.
-    - :meth:`input`, :meth:`output`: allocate fresh duck-typed containers
-      holding only the live ports declared at construction. Baked-in arrays
-      (gain ports given a :class:`wp.array` rather than an attr name) are
+    - :meth:`input`, :meth:`output`: allocate fresh typed input/output structs.
+      Baked-in arrays (gains passed as a ``wp.array`` at construction) are
       stored on the controller and do **not** appear on the input struct.
     - :meth:`compute`: read the input struct's live arrays, run kernels, write
       the output struct's live arrays. Writes are slot-replacing (``=``, not
@@ -40,37 +40,29 @@ class Controller(ABC):
         """Whether :meth:`compute` is safe to capture in a graph."""
 
     @abstractmethod
-    def input(self) -> Any:
-        """Allocate a fresh input container with one field per input port.
+    def input(self) -> InputT:
+        """Allocate a fresh input struct with zero-initialised arrays.
 
-        The returned object has attributes whose names match the ``*_attr``
-        strings passed at construction. Each field is a freshly
-        :func:`wp.zeros`-allocated array of the right dtype and size. The
-        user typically reassigns these fields to point at live data buffers.
+        The user typically reassigns fields to point at live data buffers.
+        Fields for disabled features are ``None``.
         """
 
     @abstractmethod
-    def output(self) -> Any:
-        """Allocate a fresh output container with one field per output port."""
+    def output(self) -> OutputT:
+        """Allocate a fresh output struct."""
 
     @abstractmethod
     def compute(
         self,
         *,
-        inputs: Any,
-        outputs: Any,
+        inputs: InputT,
+        outputs: OutputT,
         dt: float | wp.array[wp.float32],
     ) -> None:
         """Run one control step.
 
         Args:
-            inputs: Object whose attributes hold the live read ports.
-                Resolved via ``getattr(inputs, attr_name)``. Any
-                duck-typed object works; :meth:`input` returns a
-                pre-allocated one.
-            outputs: Same contract as ``inputs`` for write ports. The
-                kernel performs slot-replacing writes — slots outside the
-                declared port indices are left untouched.
-            dt: Step duration [s]. Either a plain ``float`` or a
-                ``wp.array`` of shape ``(1,)`` dtype ``wp.float32``.
+            inputs: Populated input struct (see :meth:`input`).
+            outputs: Output struct to write into (see :meth:`output`).
+            dt: Step duration [s].
         """

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -37,7 +37,7 @@ class Controller(ABC):
 
     @abstractmethod
     def is_graphable(self) -> bool:
-        """Whether :meth:`compute` is safe to capture in a CUDA graph."""
+        """Whether :meth:`compute` is safe to capture in a graph."""
 
     @abstractmethod
     def input(self) -> Any:

--- a/newton/_src/controllers/controller.py
+++ b/newton/_src/controllers/controller.py
@@ -19,7 +19,7 @@ class ControllerBase(ABC, Generic[InputT, OutputT]):
 
     Every concrete control law (joint impedance, differential IK, …) subclasses
     :class:`ControllerBase` directly. There is no framework-level composition: users
-    who want to combine multiple control laws call each one's :meth:`compute`
+    who want to combine multiple control laws call each one's :meth:`step`
     in sequence themselves.
 
     Subclasses are responsible for:
@@ -30,14 +30,14 @@ class ControllerBase(ABC, Generic[InputT, OutputT]):
     - :meth:`input`, :meth:`output`: allocate fresh typed input/output structs.
       Baked-in arrays (gains passed as a ``wp.array`` at construction) are
       stored on the controller and do **not** appear on the input struct.
-    - :meth:`compute`: read the input struct's live arrays, run kernels, write
+    - :meth:`step`: read the input struct's live arrays, run kernels, write
       the output struct's live arrays. Writes are slot-replacing (``=``, not
       ``+=``); composing laws is the user's job.
     """
 
     @abstractmethod
     def is_graphable(self) -> bool:
-        """Whether :meth:`compute` is safe to capture in a graph."""
+        """Whether :meth:`step` is safe to capture in a graph."""
 
     @abstractmethod
     def input(self) -> InputT:
@@ -52,7 +52,7 @@ class ControllerBase(ABC, Generic[InputT, OutputT]):
         """Allocate a fresh output struct."""
 
     @abstractmethod
-    def compute(
+    def step(
         self,
         *,
         inputs: InputT,

--- a/newton/_src/controllers/impl/__init__.py
+++ b/newton/_src/controllers/impl/__init__.py
@@ -1,9 +1,23 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from .joint_impedance import ControllerJointImpedance, ControllerJointImpedanceModelFree
-
+from . import differential_kinematics
+from .controller_ackermann import ControllerAckermann
+from . import joint_impedance
+from .controller_differential_drive import ControllerDifferentialDrive
+from .differential_kinematics import (
+    ControllerDifferentialKinematics,
+    ControllerDifferentialKinematicsModelFree,
+)
+from .joint_impedance import (
+    ControllerJointImpedance,
+    ControllerJointImpedanceModelFree,
+)
 __all__ = [
+    "ControllerAckermann",
+    "ControllerDifferentialDrive",
+    "ControllerDifferentialKinematics",
+    "ControllerDifferentialKinematicsModelFree",
     "ControllerJointImpedance",
     "ControllerJointImpedanceModelFree",
 ]

--- a/newton/_src/controllers/impl/__init__.py
+++ b/newton/_src/controllers/impl/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from .joint_impedance import ControllerJointImpedance, ControllerJointImpedanceModelFree
+
+__all__ = [
+    "ControllerJointImpedance",
+    "ControllerJointImpedanceModelFree",
+]

--- a/newton/_src/controllers/impl/__init__.py
+++ b/newton/_src/controllers/impl/__init__.py
@@ -1,23 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from . import differential_kinematics
-from .controller_ackermann import ControllerAckermann
-from . import joint_impedance
-from .controller_differential_drive import ControllerDifferentialDrive
-from .differential_kinematics import (
-    ControllerDifferentialKinematics,
-    ControllerDifferentialKinematicsModelFree,
-)
-from .joint_impedance import (
-    ControllerJointImpedance,
-    ControllerJointImpedanceModelFree,
-)
+from .joint_impedance import ControllerJointImpedance, ControllerJointImpedanceModelFree
+
 __all__ = [
-    "ControllerAckermann",
-    "ControllerDifferentialDrive",
-    "ControllerDifferentialKinematics",
-    "ControllerDifferentialKinematicsModelFree",
     "ControllerJointImpedance",
     "ControllerJointImpedanceModelFree",
 ]

--- a/newton/_src/controllers/impl/joint_impedance/__init__.py
+++ b/newton/_src/controllers/impl/joint_impedance/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from .model_based import ControllerJointImpedance
+from .model_free import ControllerJointImpedanceModelFree
+
+__all__ = [
+    "ControllerJointImpedance",
+    "ControllerJointImpedanceModelFree",
+]

--- a/newton/_src/controllers/impl/joint_impedance/_common.py
+++ b/newton/_src/controllers/impl/joint_impedance/_common.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Warp kernels for :class:`~newton.controllers.ControllerJointImpedance`."""
+
+import numpy as np
+import warp as wp
+
+
+def _idx_max(idx: wp.array[wp.uint32]) -> int:
+    """Return the minimum flat-array size needed to hold all indices."""
+    return int(np.max(idx.numpy())) + 1
+
+
+@wp.kernel
+def _pd_term_kernel(
+    joint_q: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    joint_qd: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    joint_q_des: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    joint_qd_des: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    stiffness: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    damping: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    out: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+):
+    robot, dof = wp.tid()
+    if dof >= dofs_per_robot[robot]:
+        return
+    out[robot, dof] = stiffness[robot, dof] * (joint_q_des[robot, dof] - joint_q[robot, dof]) + damping[robot, dof] * (
+        joint_qd_des[robot, dof] - joint_qd[robot, dof]
+    )
+
+
+@wp.kernel
+def _add_term_kernel(
+    term: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    tau: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+):
+    robot, dof = wp.tid()
+    if dof >= dofs_per_robot[robot]:
+        return
+    tau[robot, dof] = tau[robot, dof] + term[robot, dof]
+
+
+@wp.kernel
+def _mass_matrix_multiply_kernel(
+    M: wp.array3d[wp.float32],  # (num_robots, max_dofs, max_dofs)
+    vec: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    out: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+):
+    robot, dof = wp.tid()
+    if dof >= dofs_per_robot[robot]:
+        return
+    acc = float(0.0)
+    for col in range(dofs_per_robot[robot]):
+        acc = acc + M[robot, dof, col] * vec[robot, col]
+    out[robot, dof] = acc
+
+
+@wp.kernel
+def _gather_dof_flat_kernel(
+    src: wp.array[wp.float32],  # flat sim array
+    indices: wp.array[wp.uint32],  # (total_dofs,) — concatenated per-robot, no padding
+    dst: wp.array[wp.float32],  # flat output (total_dofs,)
+):
+    flat = wp.tid()
+    dst[flat] = src[indices[flat]]
+
+
+@wp.kernel
+def _gather_dof_kernel(
+    src: wp.array[wp.float32],  # flat sim array
+    dof_indices: wp.array[wp.uint32],  # (total_dofs,) — concatenated per-robot indices
+    dof_offsets: wp.array[wp.int32],  # (num_robots,) — start of each robot in dof_indices
+    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    dst: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+):
+    robot, dof = wp.tid()
+    if dof >= dofs_per_robot[robot]:
+        return
+    dst[robot, dof] = src[dof_indices[dof_offsets[robot] + dof]]
+
+
+@wp.kernel
+def _scatter_dof_kernel(
+    src: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    dof_indices: wp.array[wp.uint32],  # (total_dofs,) — concatenated per-robot indices
+    dof_offsets: wp.array[wp.int32],  # (num_robots,) — start of each robot in dof_indices
+    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    dst: wp.array[wp.float32],  # flat sim output
+):
+    robot, dof = wp.tid()
+    if dof >= dofs_per_robot[robot]:
+        return
+    dst[dof_indices[dof_offsets[robot] + dof]] = src[robot, dof]

--- a/newton/_src/controllers/impl/joint_impedance/_common.py
+++ b/newton/_src/controllers/impl/joint_impedance/_common.py
@@ -14,14 +14,14 @@ def _idx_max(idx: wp.array[wp.uint32]) -> int:
 
 @wp.kernel
 def _pd_term_kernel(
-    joint_q: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    joint_qd: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    joint_q_des: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    joint_qd_des: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    stiffness: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    damping: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
-    out: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    joint_q: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    joint_qd: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    joint_q_des: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    joint_qd_des: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    stiffness: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    damping: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (robot_count,)
+    out: wp.array2d[wp.float32],  # (robot_count, max_dofs)
 ):
     robot, dof = wp.tid()
     if dof >= dofs_per_robot[robot]:
@@ -33,9 +33,9 @@ def _pd_term_kernel(
 
 @wp.kernel
 def _add_term_kernel(
-    term: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
-    tau: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    term: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (robot_count,)
+    tau: wp.array2d[wp.float32],  # (robot_count, max_dofs)
 ):
     robot, dof = wp.tid()
     if dof >= dofs_per_robot[robot]:
@@ -45,10 +45,10 @@ def _add_term_kernel(
 
 @wp.kernel
 def _mass_matrix_multiply_kernel(
-    M: wp.array3d[wp.float32],  # (num_robots, max_dofs, max_dofs)
-    vec: wp.array2d[wp.float32],  # (num_robots, max_dofs)
-    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
-    out: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    M: wp.array3d[wp.float32],  # (robot_count, max_dofs, max_dofs)
+    vec: wp.array2d[wp.float32],  # (robot_count, max_dofs)
+    dofs_per_robot: wp.array[wp.int32],  # (robot_count,)
+    out: wp.array2d[wp.float32],  # (robot_count, max_dofs)
 ):
     robot, dof = wp.tid()
     if dof >= dofs_per_robot[robot]:
@@ -73,9 +73,9 @@ def _gather_dof_flat_kernel(
 def _gather_dof_kernel(
     src: wp.array[wp.float32],  # flat sim array
     dof_indices: wp.array[wp.uint32],  # (total_dofs,) — concatenated per-robot indices
-    dof_offsets: wp.array[wp.int32],  # (num_robots,) — start of each robot in dof_indices
-    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
-    dst: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    dof_offsets: wp.array[wp.int32],  # (robot_count,) — start of each robot in dof_indices
+    dofs_per_robot: wp.array[wp.int32],  # (robot_count,)
+    dst: wp.array2d[wp.float32],  # (robot_count, max_dofs)
 ):
     robot, dof = wp.tid()
     if dof >= dofs_per_robot[robot]:
@@ -85,10 +85,10 @@ def _gather_dof_kernel(
 
 @wp.kernel
 def _scatter_dof_kernel(
-    src: wp.array2d[wp.float32],  # (num_robots, max_dofs)
+    src: wp.array2d[wp.float32],  # (robot_count, max_dofs)
     dof_indices: wp.array[wp.uint32],  # (total_dofs,) — concatenated per-robot indices
-    dof_offsets: wp.array[wp.int32],  # (num_robots,) — start of each robot in dof_indices
-    dofs_per_robot: wp.array[wp.int32],  # (num_robots,)
+    dof_offsets: wp.array[wp.int32],  # (robot_count,) — start of each robot in dof_indices
+    dofs_per_robot: wp.array[wp.int32],  # (robot_count,)
     dst: wp.array[wp.float32],  # flat sim output
 ):
     robot, dof = wp.tid()

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -295,6 +295,7 @@ class ControllerJointImpedance(Controller):
 
     def compute(
         self,
+        *,
         inputs: Any,
         outputs: Any,
         dt: float | wp.array[wp.float32],
@@ -347,4 +348,4 @@ class ControllerJointImpedance(Controller):
         if self._damping_attr is not None:
             setattr(self._mf_input, self._damping_attr, getattr(inputs, self._damping_attr))
 
-        self._model_free.compute(self._mf_input, outputs, dt)
+        self._model_free.compute(inputs=self._mf_input, outputs=outputs, dt=dt)

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""ControllerJointImpedance — joint-space impedance control with
+Newton model-internal dynamics.
+
+Internally calls :func:`newton.eval_fk` and :func:`newton.eval_mass_matrix`
+each step to obtain the mass matrix, then delegates all gather/compute/scatter
+work to an inner :class:`ControllerJointImpedanceModelFree` instance.
+
+Gravity and Coriolis compensation use :func:`newton.eval_inverse_dynamics_passive`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from newton import JointType
+from newton._src.sim.articulation import eval_fk, eval_mass_matrix
+from newton._src.sim.builder import ModelBuilder
+from newton._src.sim.inverse_dynamics import eval_inverse_dynamics_passive
+
+from ...controller import Controller
+from ...utils import _allocate_namespace, _normalize_indices
+from ._common import _gather_dof_flat_kernel, _idx_max
+from .model_free import ControllerJointImpedanceModelFree
+
+
+class ControllerJointImpedance(Controller):
+    """One-step joint-space impedance controller for a batch of robots.
+
+    Has an identical input/output interface to
+    :class:`ControllerJointImpedanceModelFree` — flat 1D sim arrays in,
+    flat 1D torque array out — except that the dynamics terms (mass matrix,
+    gravity force, Coriolis force) are computed internally from the Newton
+    model rather than supplied by the caller.
+
+    Supports heterogeneous robot fleets — robots in the batch may have
+    different DOF counts. The ``model_builder`` articulations define the
+    per-robot topology; the controller pads internal buffers to
+    ``model.max_dofs_per_articulation`` and skips padding slots in all kernels.
+
+    Impedance law (terms enabled at construction):
+
+        τ = [M(q) if use_inertia_decoupling else I] · (q̈_des + Kp·Δq + Kd·Δq̇)
+            + [C(q,q̇)·q̇ if use_coriolis_compensation else 0]
+            + [g(q)      if use_gravity_compensation  else 0]
+
+    Args:
+        model_builder: :class:`~newton.ModelBuilder` with N articulations (one
+            per robot). Articulations may have different DOF counts.
+        default_dof_indices: ``wp.array[uint32]`` of length
+            ``sum(dofs per articulation)`` — concatenated per-robot index
+            arrays mapping controller DOF slots to positions in the flat
+            simulation arrays (robot 0's indices first, then robot 1's, etc.).
+        stiffness: Position-error gain Kp. ``wp.array2d[float32]`` of shape
+            ``(N, max_dofs)`` (baked) or ``str`` (live attr on input struct).
+        damping: Velocity-error gain Kd. Same format as ``stiffness``.
+        use_gravity_compensation: Add gravity generalized forces to τ.
+        use_coriolis_compensation: Add Coriolis generalized forces to τ.
+        use_inertia_decoupling: Premultiply the PD term by M(q).
+        has_qdd_feedforward: Accept a desired-acceleration feedforward
+            ``joint_qdd`` in the input struct.
+        joint_q_attr: Flat sim attr name for current joint positions.
+        joint_q_idx: Optional index array (same length as
+            ``default_dof_indices``) overriding it for the position read.
+        joint_qd_attr: Flat sim attr name for current joint velocities.
+        joint_qd_idx: Optional index array for velocity read.
+        joint_q_des_attr: Flat sim attr name for desired joint positions.
+        joint_q_des_idx: Optional index array for desired position read.
+        joint_qd_des_attr: Flat sim attr name for desired joint velocities.
+        joint_qd_des_idx: Optional index array for desired velocity read.
+        joint_qdd_attr: Flat sim attr name for desired acceleration feedforward
+            (only used when ``has_qdd_feedforward=True``).
+        joint_qdd_idx: Optional index array for feedforward read.
+        joint_f_attr: Flat sim attr name for the torque output.
+        joint_f_idx: Optional index array overriding ``default_dof_indices``
+            for the torque-output write.
+        device: Warp device.
+        requires_grad: Whether internal buffers need gradient support.
+    """
+
+    def __init__(
+        self,
+        model_builder: ModelBuilder,
+        default_dof_indices: wp.array[wp.uint32],
+        stiffness: wp.array2d[wp.float32] | str,
+        damping: wp.array2d[wp.float32] | str,
+        use_gravity_compensation: bool = True,
+        use_coriolis_compensation: bool = True,
+        use_inertia_decoupling: bool = True,
+        has_qdd_feedforward: bool = False,
+        joint_q_attr: str = "joint_q",
+        joint_q_idx: wp.array[wp.uint32] | None = None,
+        joint_qd_attr: str = "joint_qd",
+        joint_qd_idx: wp.array[wp.uint32] | None = None,
+        joint_q_des_attr: str = "joint_q_des",
+        joint_q_des_idx: wp.array[wp.uint32] | None = None,
+        joint_qd_des_attr: str = "joint_qd_des",
+        joint_qd_des_idx: wp.array[wp.uint32] | None = None,
+        joint_qdd_attr: str = "joint_qdd",
+        joint_qdd_idx: wp.array[wp.uint32] | None = None,
+        joint_f_attr: str = "joint_f",
+        joint_f_idx: wp.array[wp.uint32] | None = None,
+        device: Any = None,
+        requires_grad: bool = False,
+    ):
+        if not isinstance(model_builder, ModelBuilder):
+            raise TypeError(f"model_builder must be a newton.ModelBuilder, got {type(model_builder).__name__}.")
+        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
+            raise TypeError("default_dof_indices must be wp.array[uint32].")
+
+        num_robots = model_builder.articulation_count
+        if num_robots < 1:
+            raise ValueError("model_builder has no articulations.")
+
+        scalar_dof_joint_types = {int(JointType.REVOLUTE), int(JointType.PRISMATIC)}
+        unsupported_joints = [
+            (joint_index, JointType(joint_type).name)
+            for joint_index, joint_type in enumerate(model_builder.joint_type)
+            if joint_type not in scalar_dof_joint_types
+        ]
+        if unsupported_joints:
+            raise ValueError(
+                f"ControllerJointImpedance requires 1-DOF joints (Revolute/Prismatic) only; "
+                f"found unsupported joint types: {unsupported_joints}"
+            )
+
+        self._device = device if device is not None else wp.get_device()
+        self._requires_grad = requires_grad
+        self._use_gravity = bool(use_gravity_compensation)
+        self._use_coriolis = bool(use_coriolis_compensation)
+        self._use_inertia = bool(use_inertia_decoupling)
+        self._has_qdd = bool(has_qdd_feedforward)
+        self._needs_fk = self._use_inertia or self._use_gravity or self._use_coriolis
+
+        self._model = model_builder.finalize(device=self._device, requires_grad=requires_grad)
+        self._model_state = self._model.state()
+
+        max_dofs = self._model.max_dofs_per_articulation
+
+        # Derive per-articulation DOF counts from the finalized model.
+        art_start = self._model.articulation_start.numpy()  # first joint per articulation
+        art_end = self._model.articulation_end.numpy()  # one-past-last joint per articulation
+        joint_q_start = self._model.joint_q_start.numpy()  # DOF start per joint (+1 sentinel)
+        dofs_per_robot_np = np.array(
+            [joint_q_start[art_end[i]] - joint_q_start[art_start[i]] for i in range(num_robots)],
+            dtype=np.int32,
+        )
+        dofs_per_robot = wp.array(dofs_per_robot_np, dtype=wp.int32, device=self._device)
+        total_dofs = int(dofs_per_robot_np.sum())
+
+        if int(default_dof_indices.size) != total_dofs:
+            raise ValueError(
+                f"default_dof_indices length {default_dof_indices.size} must equal "
+                f"sum of per-robot DOF counts = {total_dofs}."
+            )
+
+        self._num_robots = num_robots
+        self._max_dofs = max_dofs
+        self._total_dofs = total_dofs
+        self._dofs_per_robot_np = dofs_per_robot_np
+
+        self._q_attr = joint_q_attr
+        self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
+        self._qd_attr = joint_qd_attr
+        self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
+        self._q_des_attr = joint_q_des_attr
+        self._q_des_idx = _normalize_indices(joint_q_des_idx, default_dof_indices, name="joint_q_des")
+        self._qd_des_attr = joint_qd_des_attr
+        self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
+        self._qdd_attr = joint_qdd_attr
+        self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
+        self._f_attr = joint_f_attr
+        self._f_idx = _normalize_indices(joint_f_idx, default_dof_indices, name="joint_f")
+
+        # Validate gain port shapes only (ModelFree will store/copy them).
+        self._stiffness_attr, _ = self._check_gain(stiffness, num_robots, max_dofs, "stiffness")
+        self._damping_attr, _ = self._check_gain(damping, num_robots, max_dofs, "damping")
+
+        self._mass_matrix: wp.array3d[wp.float32] | None = None
+        self._gravity_flat: wp.array[wp.float32] | None = None
+        self._coriolis_flat: wp.array[wp.float32] | None = None
+
+        if self._use_inertia:
+            self._mass_matrix = wp.zeros(
+                (num_robots, max_dofs, max_dofs),
+                dtype=wp.float32,
+                device=self._device,
+                requires_grad=requires_grad,
+            )
+        if self._use_gravity:
+            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device)
+        if self._use_coriolis:
+            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device)
+
+        # Newton fills dynamics in the same DOF order as model.joint_q (robot-stride,
+        # no sim-level remapping needed) — use identity indices.
+        identity_idx = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self._device)
+
+        self._model_free = ControllerJointImpedanceModelFree(
+            num_robots=num_robots,
+            dofs_per_robot=dofs_per_robot,
+            max_dofs=max_dofs,
+            default_dof_indices=default_dof_indices,
+            stiffness=stiffness,
+            damping=damping,
+            use_gravity_compensation=use_gravity_compensation,
+            use_coriolis_compensation=use_coriolis_compensation,
+            use_inertia_decoupling=use_inertia_decoupling,
+            has_qdd_feedforward=has_qdd_feedforward,
+            joint_q_attr=joint_q_attr,
+            joint_q_idx=joint_q_idx,
+            joint_qd_attr=joint_qd_attr,
+            joint_qd_idx=joint_qd_idx,
+            joint_q_des_attr=joint_q_des_attr,
+            joint_q_des_idx=joint_q_des_idx,
+            joint_qd_des_attr=joint_qd_des_attr,
+            joint_qd_des_idx=joint_qd_des_idx,
+            joint_qdd_attr=joint_qdd_attr,
+            joint_qdd_idx=joint_qdd_idx,
+            gravity_force_idx=identity_idx,
+            coriolis_force_idx=identity_idx,
+            joint_f_attr=joint_f_attr,
+            joint_f_idx=joint_f_idx,
+            device=device,
+            requires_grad=requires_grad,
+        )
+
+        self._mf_input = SimpleNamespace()
+        if self._use_inertia:
+            self._mf_input.mass_matrix = self._mass_matrix
+        if self._use_gravity:
+            self._mf_input.gravity_force = self._gravity_flat
+        if self._use_coriolis:
+            self._mf_input.coriolis_force = self._coriolis_flat
+
+        self._input_specs: list[tuple[str, Any, int]] = [
+            (self._q_attr, wp.float32, _idx_max(self._q_idx)),
+            (self._qd_attr, wp.float32, _idx_max(self._qd_idx)),
+            (self._q_des_attr, wp.float32, _idx_max(self._q_des_idx)),
+            (self._qd_des_attr, wp.float32, _idx_max(self._qd_des_idx)),
+        ]
+        if self._has_qdd:
+            self._input_specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
+
+    @staticmethod
+    def _check_gain(
+        value: wp.array2d[wp.float32] | str,
+        num_robots: int,
+        max_dofs: int,
+        name: str,
+    ) -> tuple[str | None, None]:
+        """Validate gain port type/shape without copying (ModelFree does that)."""
+        if isinstance(value, str):
+            return value, None
+        if isinstance(value, wp.array):
+            expected = (num_robots, max_dofs)
+            if tuple(value.shape) != expected:
+                raise ValueError(
+                    f"Port '{name}': baked array shape {tuple(value.shape)} must equal "
+                    f"(num_robots, max_dofs) = {expected}."
+                )
+            if value.dtype != wp.float32:
+                raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
+            return None, None
+        raise TypeError(
+            f"Port '{name}': must be wp.array2d[wp.float32] of shape (num_robots, max_dofs) "
+            f"or str; got {type(value).__name__}."
+        )
+
+    @property
+    def num_robots(self) -> int:
+        return self._num_robots
+
+    @property
+    def max_dofs(self) -> int:
+        return self._max_dofs
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
+
+    def is_stateful(self) -> bool:
+        return False
+
+    def is_graphable(self) -> bool:
+        return True
+
+    def state(self) -> None:
+        return None
+
+    def input(self):
+        """Return a pre-allocated input struct without dynamics fields (computed internally)."""
+        ns = _allocate_namespace(self._input_specs, self._device, self._requires_grad)
+        shape_2d = (self._num_robots, self._max_dofs)
+        if self._stiffness_attr is not None:
+            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+        if self._damping_attr is not None:
+            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+        return ns
+
+    def output(self):
+        """Return a pre-allocated output struct with a flat torque array."""
+        return self._model_free.output()
+
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: None,
+        controller_state_next: None,
+        time_step: float | wp.array[wp.float32],
+    ) -> None:
+        """Run one impedance-control step.
+
+        Args:
+            input_struct: Namespace with flat sim arrays for joint state and
+                desired state. Dynamics terms are computed internally.
+            output_struct: Namespace with a flat sim torque array.
+            controller_state_now: Unused (stateless). Pass ``None``.
+            controller_state_next: Unused. Pass ``None``.
+            time_step: Unused. Accepted for API compatibility.
+        """
+        # Populate the Newton model state for FK/dynamics using a flat gather —
+        # model_state.joint_q is a flat array of length total_dofs (no padding).
+        wp.launch(
+            _gather_dof_flat_kernel,
+            dim=self._total_dofs,
+            inputs=[getattr(input_struct, self._q_attr), self._q_idx],
+            outputs=[self._model_state.joint_q],
+            device=self._device,
+        )
+        wp.launch(
+            _gather_dof_flat_kernel,
+            dim=self._total_dofs,
+            inputs=[getattr(input_struct, self._qd_attr), self._qd_idx],
+            outputs=[self._model_state.joint_qd],
+            device=self._device,
+        )
+
+        if self._needs_fk:
+            eval_fk(self._model, self._model_state.joint_q, self._model_state.joint_qd, self._model_state)
+        if self._use_inertia:
+            eval_mass_matrix(self._model, self._model_state, H=self._mass_matrix)
+        if self._use_gravity or self._use_coriolis:
+            eval_inverse_dynamics_passive(
+                self._model,
+                self._model_state,
+                gravity_force=self._gravity_flat,
+                coriolis_force=self._coriolis_flat,
+            )
+
+        self._mf_input.joint_q = getattr(input_struct, self._q_attr)
+        self._mf_input.joint_qd = getattr(input_struct, self._qd_attr)
+        self._mf_input.joint_q_des = getattr(input_struct, self._q_des_attr)
+        self._mf_input.joint_qd_des = getattr(input_struct, self._qd_des_attr)
+        if self._has_qdd:
+            self._mf_input.joint_qdd = getattr(input_struct, self._qdd_attr)
+        if self._stiffness_attr is not None:
+            setattr(self._mf_input, self._stiffness_attr, getattr(input_struct, self._stiffness_attr))
+        if self._damping_attr is not None:
+            setattr(self._mf_input, self._damping_attr, getattr(input_struct, self._damping_attr))
+
+        self._model_free.compute(self._mf_input, output_struct, None, None, time_step)

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -87,6 +87,7 @@ class ControllerJointImpedance(Controller):
     def __init__(
         self,
         model_builder: ModelBuilder,
+        *,
         default_dof_indices: wp.array[wp.uint32],
         stiffness: wp.array2d[wp.float32] | str,
         damping: wp.array2d[wp.float32] | str,
@@ -176,12 +177,10 @@ class ControllerJointImpedance(Controller):
         self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
         self._qdd_attr = joint_qdd_attr
         self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
-        self._f_attr = joint_f_attr
-        self._f_idx = _normalize_indices(joint_f_idx, default_dof_indices, name="joint_f")
 
         # Validate gain port shapes only (ModelFree will store/copy them).
-        self._stiffness_attr, _ = self._check_gain(stiffness, num_robots, max_dofs, "stiffness")
-        self._damping_attr, _ = self._check_gain(damping, num_robots, max_dofs, "damping")
+        self._stiffness_attr = stiffness if isinstance(stiffness, str) else None
+        self._damping_attr = damping if isinstance(damping, str) else None
 
         self._mass_matrix: wp.array3d[wp.float32] | None = None
         self._gravity_flat: wp.array[wp.float32] | None = None
@@ -195,9 +194,9 @@ class ControllerJointImpedance(Controller):
                 requires_grad=requires_grad,
             )
         if self._use_gravity:
-            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device)
+            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
         if self._use_coriolis:
-            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device)
+            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
 
         # Newton fills dynamics in the same DOF order as model.joint_q (robot-stride,
         # no sim-level remapping needed) — use identity indices.
@@ -250,30 +249,6 @@ class ControllerJointImpedance(Controller):
             self._input_specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
 
     @staticmethod
-    def _check_gain(
-        value: wp.array2d[wp.float32] | str,
-        num_robots: int,
-        max_dofs: int,
-        name: str,
-    ) -> tuple[str | None, None]:
-        """Validate gain port type/shape without copying (ModelFree does that)."""
-        if isinstance(value, str):
-            return value, None
-        if isinstance(value, wp.array):
-            expected = (num_robots, max_dofs)
-            if tuple(value.shape) != expected:
-                raise ValueError(
-                    f"Port '{name}': baked array shape {tuple(value.shape)} must equal "
-                    f"(num_robots, max_dofs) = {expected}."
-                )
-            if value.dtype != wp.float32:
-                raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
-            return None, None
-        raise TypeError(
-            f"Port '{name}': must be wp.array2d[wp.float32] of shape (num_robots, max_dofs) "
-            f"or str; got {type(value).__name__}."
-        )
-
     @property
     def num_robots(self) -> int:
         return self._num_robots
@@ -293,17 +268,14 @@ class ControllerJointImpedance(Controller):
     def is_graphable(self) -> bool:
         return True
 
-    def state(self) -> None:
-        return None
-
     def input(self):
         """Return a pre-allocated input struct without dynamics fields (computed internally)."""
         ns = _allocate_namespace(self._input_specs, self._device, self._requires_grad)
         shape_2d = (self._num_robots, self._max_dofs)
         if self._stiffness_attr is not None:
-            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
         if self._damping_attr is not None:
-            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
         return ns
 
     def output(self):
@@ -312,35 +284,31 @@ class ControllerJointImpedance(Controller):
 
     def compute(
         self,
-        input_struct: Any,
-        output_struct: Any,
-        controller_state_now: None,
-        controller_state_next: None,
-        time_step: float | wp.array[wp.float32],
+        inputs: Any,
+        outputs: Any,
+        dt: float | wp.array[wp.float32],
     ) -> None:
         """Run one impedance-control step.
 
         Args:
-            input_struct: Namespace with flat sim arrays for joint state and
+            inputs: Namespace with flat sim arrays for joint state and
                 desired state. Dynamics terms are computed internally.
-            output_struct: Namespace with a flat sim torque array.
-            controller_state_now: Unused (stateless). Pass ``None``.
-            controller_state_next: Unused. Pass ``None``.
-            time_step: Unused. Accepted for API compatibility.
+            outputs: Namespace with a flat sim torque array.
+            dt: Unused. Accepted for API compatibility.
         """
         # Populate the Newton model state for FK/dynamics using a flat gather —
         # model_state.joint_q is a flat array of length total_dofs (no padding).
         wp.launch(
             _gather_dof_flat_kernel,
             dim=self._total_dofs,
-            inputs=[getattr(input_struct, self._q_attr), self._q_idx],
+            inputs=[getattr(inputs, self._q_attr), self._q_idx],
             outputs=[self._model_state.joint_q],
             device=self._device,
         )
         wp.launch(
             _gather_dof_flat_kernel,
             dim=self._total_dofs,
-            inputs=[getattr(input_struct, self._qd_attr), self._qd_idx],
+            inputs=[getattr(inputs, self._qd_attr), self._qd_idx],
             outputs=[self._model_state.joint_qd],
             device=self._device,
         )
@@ -357,15 +325,15 @@ class ControllerJointImpedance(Controller):
                 coriolis_force=self._coriolis_flat,
             )
 
-        self._mf_input.joint_q = getattr(input_struct, self._q_attr)
-        self._mf_input.joint_qd = getattr(input_struct, self._qd_attr)
-        self._mf_input.joint_q_des = getattr(input_struct, self._q_des_attr)
-        self._mf_input.joint_qd_des = getattr(input_struct, self._qd_des_attr)
+        self._mf_input.joint_q = getattr(inputs, self._q_attr)
+        self._mf_input.joint_qd = getattr(inputs, self._qd_attr)
+        self._mf_input.joint_q_des = getattr(inputs, self._q_des_attr)
+        self._mf_input.joint_qd_des = getattr(inputs, self._qd_des_attr)
         if self._has_qdd:
-            self._mf_input.joint_qdd = getattr(input_struct, self._qdd_attr)
+            self._mf_input.joint_qdd = getattr(inputs, self._qdd_attr)
         if self._stiffness_attr is not None:
-            setattr(self._mf_input, self._stiffness_attr, getattr(input_struct, self._stiffness_attr))
+            setattr(self._mf_input, self._stiffness_attr, getattr(inputs, self._stiffness_attr))
         if self._damping_attr is not None:
-            setattr(self._mf_input, self._damping_attr, getattr(input_struct, self._damping_attr))
+            setattr(self._mf_input, self._damping_attr, getattr(inputs, self._damping_attr))
 
-        self._model_free.compute(self._mf_input, output_struct, None, None, time_step)
+        self._model_free.compute(self._mf_input, outputs, dt)

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -194,9 +194,13 @@ class ControllerJointImpedance(Controller):
                 requires_grad=requires_grad,
             )
         if self._use_gravity:
-            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+            self._gravity_flat = wp.zeros(
+                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
+            )
         if self._use_coriolis:
-            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+            self._coriolis_flat = wp.zeros(
+                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
+            )
 
         # Newton fills dynamics in the same DOF order as model.joint_q (robot-stride,
         # no sim-level remapping needed) — use identity indices.
@@ -248,7 +252,6 @@ class ControllerJointImpedance(Controller):
         if self._has_qdd:
             self._input_specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
 
-    @staticmethod
     @property
     def num_robots(self) -> int:
         return self._num_robots
@@ -273,9 +276,17 @@ class ControllerJointImpedance(Controller):
         ns = _allocate_namespace(self._input_specs, self._device, self._requires_grad)
         shape_2d = (self._num_robots, self._max_dofs)
         if self._stiffness_attr is not None:
-            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
+            setattr(
+                ns,
+                self._stiffness_attr,
+                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
+            )
         if self._damping_attr is not None:
-            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
+            setattr(
+                ns,
+                self._damping_attr,
+                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
+            )
         return ns
 
     def output(self):

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -118,16 +118,17 @@ class ControllerJointImpedance(Controller):
         if num_robots < 1:
             raise ValueError("model_builder has no articulations.")
 
-        scalar_dof_joint_types = {int(JointType.REVOLUTE), int(JointType.PRISMATIC)}
+        # Fixed joints contribute zero DOFs and are invisible to the PD error term.
+        allowed_joint_types = {int(JointType.REVOLUTE), int(JointType.PRISMATIC), int(JointType.FIXED)}
         unsupported_joints = [
             (joint_index, JointType(joint_type).name)
             for joint_index, joint_type in enumerate(model_builder.joint_type)
-            if joint_type not in scalar_dof_joint_types
+            if joint_type not in allowed_joint_types
         ]
         if unsupported_joints:
             raise ValueError(
-                f"ControllerJointImpedance requires 1-DOF joints (Revolute/Prismatic) only; "
-                f"found unsupported joint types: {unsupported_joints}"
+                f"ControllerJointImpedance only supports 1-DOF joints (Revolute/Prismatic) and "
+                f"zero-DOF fixed joints; found unsupported joint types: {unsupported_joints}"
             )
 
         self._device = device if device is not None else wp.get_device()
@@ -288,9 +289,6 @@ class ControllerJointImpedance(Controller):
     @property
     def requires_grad(self) -> bool:
         return self._requires_grad
-
-    def is_stateful(self) -> bool:
-        return False
 
     def is_graphable(self) -> bool:
         return True

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -294,7 +294,7 @@ class ControllerJointImpedance(ControllerBase):
         outputs.joint_f = self._model_free.output().joint_f
         return outputs
 
-    def compute(
+    def step(
         self,
         *,
         inputs: Inputs,
@@ -347,4 +347,4 @@ class ControllerJointImpedance(ControllerBase):
         if self._damping_is_live:
             self._mf_input.damping = inputs.damping
 
-        self._model_free.compute(inputs=self._mf_input, outputs=outputs, dt=dt)
+        self._model_free.step(inputs=self._mf_input, outputs=outputs, dt=dt)

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -13,7 +13,6 @@ Gravity and Coriolis compensation use :func:`newton.eval_inverse_dynamics_passiv
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
@@ -24,13 +23,13 @@ from newton._src.sim.articulation import eval_fk, eval_mass_matrix
 from newton._src.sim.builder import ModelBuilder
 from newton._src.sim.inverse_dynamics import eval_inverse_dynamics_passive
 
-from ...controller import Controller
-from ...utils import _allocate_namespace, _normalize_indices
+from ...controller import ControllerBase
+from ...utils import _normalize_indices
 from ._common import _gather_dof_flat_kernel, _idx_max
 from .model_free import ControllerJointImpedanceModelFree
 
 
-class ControllerJointImpedance(Controller):
+class ControllerJointImpedance(ControllerBase):
     """One-step joint-space impedance controller for a batch of robots.
 
     Has an identical input/output interface to
@@ -44,6 +43,10 @@ class ControllerJointImpedance(Controller):
     per-robot topology; the controller pads internal buffers to
     ``model.max_dofs_per_articulation`` and skips padding slots in all kernels.
 
+    Only 1-DOF joints (Revolute, Prismatic) and zero-DOF Fixed joints are
+    supported. The PD error term ``q_des - q`` is only valid for scalar
+    joint coordinates.
+
     Impedance law (terms enabled at construction):
 
         τ = [M(q) if use_inertia_decoupling else I] · (q̈_des + Kp·Δq + Kd·Δq̇)
@@ -53,59 +56,76 @@ class ControllerJointImpedance(Controller):
     Args:
         builder: :class:`~newton.ModelBuilder` with N articulations (one
             per robot). Articulations may have different DOF counts.
-        default_dof_indices: ``wp.array[uint32]`` of length
-            ``sum(dofs per articulation)`` — concatenated per-robot index
-            arrays mapping controller DOF slots to positions in the flat
-            simulation arrays (robot 0's indices first, then robot 1's, etc.).
-        stiffness: Position-error gain Kp. ``wp.array2d[float32]`` of shape
-            ``(N, max_dofs)`` (baked) or ``str`` (live attr on input struct).
-        damping: Velocity-error gain Kd. Same format as ``stiffness``.
+        default_dof_indices: Concatenated per-robot index arrays of length
+            ``sum(dofs per articulation)`` mapping controller DOF slots to
+            positions in the flat simulation arrays (robot 0's indices first,
+            then robot 1's, etc.).
+        stiffness: Position-error gain Kp [N/m or N·m/rad], shape
+            ``(N, max_dofs)``. Pass a baked array or ``None`` to read from
+            ``inputs.stiffness`` each step.
+        damping: Velocity-error gain Kd [N·s/m or N·m·s/rad]. Same format
+            as ``stiffness``.
         use_gravity_compensation: Add gravity generalized forces to τ.
         use_coriolis_compensation: Add Coriolis generalized forces to τ.
         use_inertia_decoupling: Premultiply the PD term by M(q).
-        has_qdd_feedforward: Accept a desired-acceleration feedforward
-            ``joint_qdd`` in the input struct.
-        joint_q_attr: Flat sim attr name for current joint positions.
+        has_qdd_feedforward: Accept a desired-acceleration feedforward via
+            ``inputs.joint_qdd``.
         joint_q_idx: Optional index array (same length as
             ``default_dof_indices``) overriding it for the position read.
-        joint_qd_attr: Flat sim attr name for current joint velocities.
         joint_qd_idx: Optional index array for velocity read.
-        joint_q_des_attr: Flat sim attr name for desired joint positions.
         joint_q_des_idx: Optional index array for desired position read.
-        joint_qd_des_attr: Flat sim attr name for desired joint velocities.
         joint_qd_des_idx: Optional index array for desired velocity read.
-        joint_qdd_attr: Flat sim attr name for desired acceleration feedforward
-            (only used when ``has_qdd_feedforward=True``).
         joint_qdd_idx: Optional index array for feedforward read.
-        joint_f_attr: Flat sim attr name for the torque output.
         joint_f_idx: Optional index array overriding ``default_dof_indices``
             for the torque-output write.
         device: Warp device.
         requires_grad: Whether internal buffers need gradient support.
     """
 
+    class Inputs:
+        """Input struct returned by :meth:`~ControllerJointImpedance.input`.
+
+        Dynamics fields (mass matrix, gravity, Coriolis) are computed
+        internally and do not appear here.
+        """
+
+        joint_q: wp.array[wp.float32]
+        """Current joint positions [m or rad], flat sim-level array."""
+        joint_qd: wp.array[wp.float32]
+        """Current joint velocities [m/s or rad/s], flat sim-level array."""
+        joint_q_des: wp.array[wp.float32]
+        """Desired joint positions [m or rad], flat sim-level array."""
+        joint_qd_des: wp.array[wp.float32]
+        """Desired joint velocities [m/s or rad/s], flat sim-level array."""
+        joint_qdd: wp.array[wp.float32] | None
+        """Desired acceleration feedforward [m/s² or rad/s²], flat sim-level array. ``None`` unless ``has_qdd_feedforward=True``."""
+        stiffness: wp.array2d[wp.float32] | None
+        """Position-error gain Kp [N/m or N·m/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        damping: wp.array2d[wp.float32] | None
+        """Velocity-error gain Kd [N·s/m or N·m·s/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+
+    class Outputs:
+        """Output struct returned by :meth:`~ControllerJointImpedance.output`."""
+
+        joint_f: wp.array[wp.float32]
+        """Joint torque command [N or N·m], flat sim-level array."""
+
     def __init__(
         self,
         builder: ModelBuilder,
         *,
         default_dof_indices: wp.array[wp.uint32],
-        stiffness: wp.array2d[wp.float32] | str,
-        damping: wp.array2d[wp.float32] | str,
+        stiffness: wp.array2d[wp.float32] | None,
+        damping: wp.array2d[wp.float32] | None,
         use_gravity_compensation: bool = True,
         use_coriolis_compensation: bool = True,
         use_inertia_decoupling: bool = True,
         has_qdd_feedforward: bool = False,
-        joint_q_attr: str = "joint_q",
         joint_q_idx: wp.array[wp.uint32] | None = None,
-        joint_qd_attr: str = "joint_qd",
         joint_qd_idx: wp.array[wp.uint32] | None = None,
-        joint_q_des_attr: str = "joint_q_des",
         joint_q_des_idx: wp.array[wp.uint32] | None = None,
-        joint_qd_des_attr: str = "joint_qd_des",
         joint_qd_des_idx: wp.array[wp.uint32] | None = None,
-        joint_qdd_attr: str = "joint_qdd",
         joint_qdd_idx: wp.array[wp.uint32] | None = None,
-        joint_f_attr: str = "joint_f",
         joint_f_idx: wp.array[wp.uint32] | None = None,
         device: Any = None,
         requires_grad: bool = False,
@@ -139,6 +159,8 @@ class ControllerJointImpedance(Controller):
         self._use_inertia = bool(use_inertia_decoupling)
         self._has_qdd = bool(has_qdd_feedforward)
         self._needs_fk = self._use_inertia or self._use_gravity or self._use_coriolis
+        self._stiffness_is_live = stiffness is None
+        self._damping_is_live = damping is None
 
         self._model = builder.finalize(device=self._device, requires_grad=requires_grad)
         self._model_state = self._model.state()
@@ -146,9 +168,9 @@ class ControllerJointImpedance(Controller):
         max_dofs = self._model.max_dofs_per_articulation
 
         # Derive per-articulation DOF counts from the finalized model.
-        art_start = self._model.articulation_start.numpy()  # first joint per articulation
-        art_end = self._model.articulation_end.numpy()  # one-past-last joint per articulation
-        joint_q_start = self._model.joint_q_start.numpy()  # DOF start per joint (+1 sentinel)
+        art_start = self._model.articulation_start.numpy()
+        art_end = self._model.articulation_end.numpy()
+        joint_q_start = self._model.joint_q_start.numpy()
         dofs_per_robot_np = np.array(
             [joint_q_start[art_end[i]] - joint_q_start[art_start[i]] for i in range(robot_count)],
             dtype=np.int32,
@@ -165,22 +187,12 @@ class ControllerJointImpedance(Controller):
         self._robot_count = robot_count
         self._max_dofs = max_dofs
         self._total_dofs = total_dofs
-        self._dofs_per_robot_np = dofs_per_robot_np
 
-        self._q_attr = joint_q_attr
         self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
-        self._qd_attr = joint_qd_attr
         self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
-        self._q_des_attr = joint_q_des_attr
         self._q_des_idx = _normalize_indices(joint_q_des_idx, default_dof_indices, name="joint_q_des")
-        self._qd_des_attr = joint_qd_des_attr
         self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
-        self._qdd_attr = joint_qdd_attr
         self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
-
-        # Validate gain port shapes only (ModelFree will store/copy them).
-        self._stiffness_attr = stiffness if isinstance(stiffness, str) else None
-        self._damping_attr = damping if isinstance(damping, str) else None
 
         self._mass_matrix: wp.array3d[wp.float32] | None = None
         self._gravity_flat: wp.array[wp.float32] | None = None
@@ -188,22 +200,15 @@ class ControllerJointImpedance(Controller):
 
         if self._use_inertia:
             self._mass_matrix = wp.zeros(
-                ((robot_count, max_dofs, max_dofs)),
-                dtype=wp.float32,
-                device=self._device,
-                requires_grad=requires_grad,
+                (robot_count, max_dofs, max_dofs),
+                dtype=wp.float32, device=self._device, requires_grad=requires_grad,
             )
         if self._use_gravity:
-            self._gravity_flat = wp.zeros(
-                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
-            )
+            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
         if self._use_coriolis:
-            self._coriolis_flat = wp.zeros(
-                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
-            )
+            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
 
-        # Newton fills dynamics in the same DOF order as model.joint_q (robot-stride,
-        # no sim-level remapping needed) — use identity indices.
+        # Newton fills dynamics in the same DOF order as model.joint_q — use identity indices.
         identity_idx = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self._device)
 
         self._model_free = ControllerJointImpedanceModelFree(
@@ -217,40 +222,26 @@ class ControllerJointImpedance(Controller):
             use_coriolis_compensation=use_coriolis_compensation,
             use_inertia_decoupling=use_inertia_decoupling,
             has_qdd_feedforward=has_qdd_feedforward,
-            joint_q_attr=joint_q_attr,
             joint_q_idx=joint_q_idx,
-            joint_qd_attr=joint_qd_attr,
             joint_qd_idx=joint_qd_idx,
-            joint_q_des_attr=joint_q_des_attr,
             joint_q_des_idx=joint_q_des_idx,
-            joint_qd_des_attr=joint_qd_des_attr,
             joint_qd_des_idx=joint_qd_des_idx,
-            joint_qdd_attr=joint_qdd_attr,
             joint_qdd_idx=joint_qdd_idx,
             gravity_force_idx=identity_idx,
             coriolis_force_idx=identity_idx,
-            joint_f_attr=joint_f_attr,
             joint_f_idx=joint_f_idx,
             device=device,
             requires_grad=requires_grad,
         )
 
-        self._mf_input = SimpleNamespace()
+        # Pre-wired dynamics fields forwarded to ModelFree each step.
+        self._mf_input = ControllerJointImpedanceModelFree.Inputs()
         if self._use_inertia:
             self._mf_input.mass_matrix = self._mass_matrix
         if self._use_gravity:
             self._mf_input.gravity_force = self._gravity_flat
         if self._use_coriolis:
             self._mf_input.coriolis_force = self._coriolis_flat
-
-        self._input_specs: list[tuple[str, Any, int]] = [
-            (self._q_attr, wp.float32, _idx_max(self._q_idx)),
-            (self._qd_attr, wp.float32, _idx_max(self._qd_idx)),
-            (self._q_des_attr, wp.float32, _idx_max(self._q_des_idx)),
-            (self._qd_des_attr, wp.float32, _idx_max(self._qd_des_idx)),
-        ]
-        if self._has_qdd:
-            self._input_specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
 
     @property
     def robot_count(self) -> int:
@@ -271,56 +262,52 @@ class ControllerJointImpedance(Controller):
     def is_graphable(self) -> bool:
         return True
 
-    def input(self):
-        """Return a pre-allocated input struct without dynamics fields (computed internally)."""
-        ns = _allocate_namespace(self._input_specs, self._device, self._requires_grad)
+    def input(self) -> Inputs:
+        """Return a pre-allocated :class:`Inputs` without dynamics fields."""
+        d, rg = self._device, self._requires_grad
+        inputs = ControllerJointImpedance.Inputs()
+        inputs.joint_q = wp.zeros(_idx_max(self._q_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qd = wp.zeros(_idx_max(self._qd_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_q_des = wp.zeros(_idx_max(self._q_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qd_des = wp.zeros(_idx_max(self._qd_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qdd = wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
         shape_2d = (self._robot_count, self._max_dofs)
-        if self._stiffness_attr is not None:
-            setattr(
-                ns,
-                self._stiffness_attr,
-                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
-            )
-        if self._damping_attr is not None:
-            setattr(
-                ns,
-                self._damping_attr,
-                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
-            )
-        return ns
+        inputs.stiffness = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_is_live else None
+        inputs.damping = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_is_live else None
+        return inputs
 
-    def output(self):
-        """Return a pre-allocated output struct with a flat torque array."""
-        return self._model_free.output()
+    def output(self) -> Outputs:
+        """Return a pre-allocated :class:`Outputs` with a flat torque array."""
+        outputs = ControllerJointImpedance.Outputs()
+        outputs.joint_f = self._model_free.output().joint_f
+        return outputs
 
     def compute(
         self,
         *,
-        inputs: Any,
-        outputs: Any,
+        inputs: Inputs,
+        outputs: Outputs,
         dt: float | wp.array[wp.float32],
     ) -> None:
         """Run one impedance-control step.
 
         Args:
-            inputs: Namespace with flat sim arrays for joint state and
-                desired state. Dynamics terms are computed internally.
-            outputs: Namespace with a flat sim torque array.
+            inputs: Populated :class:`Inputs` struct. Dynamics terms are
+                computed internally from the Newton model.
+            outputs: :class:`Outputs` struct to write torques into.
             dt: Unused. Accepted for API compatibility.
         """
-        # Populate the Newton model state for FK/dynamics using a flat gather —
-        # model_state.joint_q is a flat array of length total_dofs (no padding).
         wp.launch(
             _gather_dof_flat_kernel,
             dim=self._total_dofs,
-            inputs=[getattr(inputs, self._q_attr), self._q_idx],
+            inputs=[inputs.joint_q, self._q_idx],
             outputs=[self._model_state.joint_q],
             device=self._device,
         )
         wp.launch(
             _gather_dof_flat_kernel,
             dim=self._total_dofs,
-            inputs=[getattr(inputs, self._qd_attr), self._qd_idx],
+            inputs=[inputs.joint_qd, self._qd_idx],
             outputs=[self._model_state.joint_qd],
             device=self._device,
         )
@@ -337,15 +324,15 @@ class ControllerJointImpedance(Controller):
                 coriolis_force=self._coriolis_flat,
             )
 
-        self._mf_input.joint_q = getattr(inputs, self._q_attr)
-        self._mf_input.joint_qd = getattr(inputs, self._qd_attr)
-        self._mf_input.joint_q_des = getattr(inputs, self._q_des_attr)
-        self._mf_input.joint_qd_des = getattr(inputs, self._qd_des_attr)
+        self._mf_input.joint_q = inputs.joint_q
+        self._mf_input.joint_qd = inputs.joint_qd
+        self._mf_input.joint_q_des = inputs.joint_q_des
+        self._mf_input.joint_qd_des = inputs.joint_qd_des
         if self._has_qdd:
-            self._mf_input.joint_qdd = getattr(inputs, self._qdd_attr)
-        if self._stiffness_attr is not None:
-            setattr(self._mf_input, self._stiffness_attr, getattr(inputs, self._stiffness_attr))
-        if self._damping_attr is not None:
-            setattr(self._mf_input, self._damping_attr, getattr(inputs, self._damping_attr))
+            self._mf_input.joint_qdd = inputs.joint_qdd
+        if self._stiffness_is_live:
+            self._mf_input.stiffness = inputs.stiffness
+        if self._damping_is_live:
+            self._mf_input.damping = inputs.damping
 
         self._model_free.compute(inputs=self._mf_input, outputs=outputs, dt=dt)

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -40,7 +40,7 @@ class ControllerJointImpedance(Controller):
     model rather than supplied by the caller.
 
     Supports heterogeneous robot fleets — robots in the batch may have
-    different DOF counts. The ``model_builder`` articulations define the
+    different DOF counts. The ``builder`` articulations define the
     per-robot topology; the controller pads internal buffers to
     ``model.max_dofs_per_articulation`` and skips padding slots in all kernels.
 
@@ -51,7 +51,7 @@ class ControllerJointImpedance(Controller):
             + [g(q)      if use_gravity_compensation  else 0]
 
     Args:
-        model_builder: :class:`~newton.ModelBuilder` with N articulations (one
+        builder: :class:`~newton.ModelBuilder` with N articulations (one
             per robot). Articulations may have different DOF counts.
         default_dof_indices: ``wp.array[uint32]`` of length
             ``sum(dofs per articulation)`` — concatenated per-robot index
@@ -86,7 +86,7 @@ class ControllerJointImpedance(Controller):
 
     def __init__(
         self,
-        model_builder: ModelBuilder,
+        builder: ModelBuilder,
         *,
         default_dof_indices: wp.array[wp.uint32],
         stiffness: wp.array2d[wp.float32] | str,
@@ -110,20 +110,20 @@ class ControllerJointImpedance(Controller):
         device: Any = None,
         requires_grad: bool = False,
     ):
-        if not isinstance(model_builder, ModelBuilder):
-            raise TypeError(f"model_builder must be a newton.ModelBuilder, got {type(model_builder).__name__}.")
+        if not isinstance(builder, ModelBuilder):
+            raise TypeError(f"builder must be a newton.ModelBuilder, got {type(builder).__name__}.")
         if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
             raise TypeError("default_dof_indices must be wp.array[uint32].")
 
-        num_robots = model_builder.articulation_count
-        if num_robots < 1:
-            raise ValueError("model_builder has no articulations.")
+        robot_count = builder.articulation_count
+        if robot_count < 1:
+            raise ValueError("builder has no articulations.")
 
         # Fixed joints contribute zero DOFs and are invisible to the PD error term.
         allowed_joint_types = {int(JointType.REVOLUTE), int(JointType.PRISMATIC), int(JointType.FIXED)}
         unsupported_joints = [
             (joint_index, JointType(joint_type).name)
-            for joint_index, joint_type in enumerate(model_builder.joint_type)
+            for joint_index, joint_type in enumerate(builder.joint_type)
             if joint_type not in allowed_joint_types
         ]
         if unsupported_joints:
@@ -140,7 +140,7 @@ class ControllerJointImpedance(Controller):
         self._has_qdd = bool(has_qdd_feedforward)
         self._needs_fk = self._use_inertia or self._use_gravity or self._use_coriolis
 
-        self._model = model_builder.finalize(device=self._device, requires_grad=requires_grad)
+        self._model = builder.finalize(device=self._device, requires_grad=requires_grad)
         self._model_state = self._model.state()
 
         max_dofs = self._model.max_dofs_per_articulation
@@ -150,7 +150,7 @@ class ControllerJointImpedance(Controller):
         art_end = self._model.articulation_end.numpy()  # one-past-last joint per articulation
         joint_q_start = self._model.joint_q_start.numpy()  # DOF start per joint (+1 sentinel)
         dofs_per_robot_np = np.array(
-            [joint_q_start[art_end[i]] - joint_q_start[art_start[i]] for i in range(num_robots)],
+            [joint_q_start[art_end[i]] - joint_q_start[art_start[i]] for i in range(robot_count)],
             dtype=np.int32,
         )
         dofs_per_robot = wp.array(dofs_per_robot_np, dtype=wp.int32, device=self._device)
@@ -162,7 +162,7 @@ class ControllerJointImpedance(Controller):
                 f"sum of per-robot DOF counts = {total_dofs}."
             )
 
-        self._num_robots = num_robots
+        self._robot_count = robot_count
         self._max_dofs = max_dofs
         self._total_dofs = total_dofs
         self._dofs_per_robot_np = dofs_per_robot_np
@@ -188,7 +188,7 @@ class ControllerJointImpedance(Controller):
 
         if self._use_inertia:
             self._mass_matrix = wp.zeros(
-                (num_robots, max_dofs, max_dofs),
+                ((robot_count, max_dofs, max_dofs)),
                 dtype=wp.float32,
                 device=self._device,
                 requires_grad=requires_grad,
@@ -207,7 +207,7 @@ class ControllerJointImpedance(Controller):
         identity_idx = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self._device)
 
         self._model_free = ControllerJointImpedanceModelFree(
-            num_robots=num_robots,
+            robot_count=robot_count,
             dofs_per_robot=dofs_per_robot,
             max_dofs=max_dofs,
             default_dof_indices=default_dof_indices,
@@ -253,8 +253,8 @@ class ControllerJointImpedance(Controller):
             self._input_specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
 
     @property
-    def num_robots(self) -> int:
-        return self._num_robots
+    def robot_count(self) -> int:
+        return self._robot_count
 
     @property
     def max_dofs(self) -> int:
@@ -274,7 +274,7 @@ class ControllerJointImpedance(Controller):
     def input(self):
         """Return a pre-allocated input struct without dynamics fields (computed internally)."""
         ns = _allocate_namespace(self._input_specs, self._device, self._requires_grad)
-        shape_2d = (self._num_robots, self._max_dofs)
+        shape_2d = (self._robot_count, self._max_dofs)
         if self._stiffness_attr is not None:
             setattr(
                 ns,

--- a/newton/_src/controllers/impl/joint_impedance/model_based.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_based.py
@@ -201,12 +201,18 @@ class ControllerJointImpedance(ControllerBase):
         if self._use_inertia:
             self._mass_matrix = wp.zeros(
                 (robot_count, max_dofs, max_dofs),
-                dtype=wp.float32, device=self._device, requires_grad=requires_grad,
+                dtype=wp.float32,
+                device=self._device,
+                requires_grad=requires_grad,
             )
         if self._use_gravity:
-            self._gravity_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+            self._gravity_flat = wp.zeros(
+                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
+            )
         if self._use_coriolis:
-            self._coriolis_flat = wp.zeros(total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+            self._coriolis_flat = wp.zeros(
+                total_dofs, dtype=wp.float32, device=self._device, requires_grad=requires_grad
+            )
 
         # Newton fills dynamics in the same DOF order as model.joint_q — use identity indices.
         identity_idx = wp.array(np.arange(total_dofs, dtype=np.uint32), device=self._device)
@@ -270,10 +276,16 @@ class ControllerJointImpedance(ControllerBase):
         inputs.joint_qd = wp.zeros(_idx_max(self._qd_idx), dtype=wp.float32, device=d, requires_grad=rg)
         inputs.joint_q_des = wp.zeros(_idx_max(self._q_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
         inputs.joint_qd_des = wp.zeros(_idx_max(self._qd_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
-        inputs.joint_qdd = wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
+        inputs.joint_qdd = (
+            wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
+        )
         shape_2d = (self._robot_count, self._max_dofs)
-        inputs.stiffness = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_is_live else None
-        inputs.damping = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_is_live else None
+        inputs.stiffness = (
+            wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_is_live else None
+        )
+        inputs.damping = (
+            wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_is_live else None
+        )
         return inputs
 
     def output(self) -> Outputs:

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -284,9 +284,17 @@ class ControllerJointImpedanceModelFree(Controller):
         ns = _allocate_namespace(specs, self._device, self._requires_grad)
         shape_2d = (self._num_robots, self._max_dofs)
         if self._stiffness_attr is not None:
-            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
+            setattr(
+                ns,
+                self._stiffness_attr,
+                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
+            )
         if self._damping_attr is not None:
-            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
+            setattr(
+                ns,
+                self._damping_attr,
+                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
+            )
         if self._use_inertia:
             setattr(
                 ns,

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -318,6 +318,7 @@ class ControllerJointImpedanceModelFree(Controller):
 
     def compute(
         self,
+        *,
         inputs: Any,
         outputs: Any,
         dt: float | wp.array[wp.float32],

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -198,6 +198,13 @@ class ControllerJointImpedanceModelFree(Controller):
         self._coriolis_idx = _normalize_indices(coriolis_force_idx, default_dof_indices, name="coriolis_force")
         self._f_idx = _normalize_indices(joint_f_idx, default_dof_indices, name="joint_f")
 
+        f_idx_np = self._f_idx.numpy()
+        if len(f_idx_np) != len(np.unique(f_idx_np)):
+            raise ValueError(
+                "joint_f output indices must be unique — two robots cannot scatter torques "
+                "to the same simulation DOF slot."
+            )
+
         self._stiffness_attr, self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
         self._damping_attr, self._damping_baked = self._normalize_gain(damping, "damping")
 
@@ -255,9 +262,6 @@ class ControllerJointImpedanceModelFree(Controller):
     @property
     def requires_grad(self) -> bool:
         return self._requires_grad
-
-    def is_stateful(self) -> bool:
-        return False
 
     def is_graphable(self) -> bool:
         return True
@@ -324,8 +328,10 @@ class ControllerJointImpedanceModelFree(Controller):
             controller_state_next: Unused. Pass ``None``.
             time_step: Unused. Accepted for API compatibility.
         """
-        stiffness = self._stiffness_baked or getattr(input_struct, self._stiffness_attr)
-        damping = self._damping_baked or getattr(input_struct, self._damping_attr)
+        stiffness = (
+            self._stiffness_baked if self._stiffness_baked is not None else getattr(input_struct, self._stiffness_attr)
+        )
+        damping = self._damping_baked if self._damping_baked is not None else getattr(input_struct, self._damping_attr)
 
         dim2d = (self._num_robots, self._max_dofs)
 

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""ControllerJointImpedanceModelFree — joint-space impedance control with
+caller-supplied dynamics terms.
+
+The controller reads flat 1D sim arrays, gathers the controlled DOFs internally,
+computes a joint torque command, and scatters the result back to a flat 1D
+output array.
+
+The difference from :class:`ControllerJointImpedance` is that this controller
+requires the caller to supply dynamics terms (mass matrix, gravity force, Coriolis
+force) that the model-based controller computes internally.
+
+Impedance law (terms enabled at construction):
+
+    τ = [M(q) if use_inertia_decoupling else I] · (q̈_des + Kp·Δq + Kd·Δq̇)
+        + [C(q,q̇)·q̇ if use_coriolis_compensation else 0]
+        + [g(q)      if use_gravity_compensation  else 0]
+
+where Δq = q_des - q and Δq̇ = q̇_des - q̇.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import warp as wp
+
+from ...controller import Controller
+from ...utils import _allocate_namespace, _normalize_indices
+from ._common import (
+    _add_term_kernel,
+    _gather_dof_kernel,
+    _idx_max,
+    _mass_matrix_multiply_kernel,
+    _pd_term_kernel,
+    _scatter_dof_kernel,
+)
+
+
+class ControllerJointImpedanceModelFree(Controller):
+    """Joint-space impedance controller with caller-supplied dynamics.
+
+    Supports heterogeneous robot fleets — robots in the batch may have
+    different DOF counts. Internal buffers are padded to ``max_dofs``; kernels
+    skip padding slots via a per-robot guard.
+
+    **Input struct fields** (allocate via :meth:`input`):
+
+    - ``joint_q``: flat float32 — current joint positions (sim-sized).
+    - ``joint_qd``: flat float32 — current joint velocities (sim-sized).
+    - ``joint_q_des``: flat float32 — desired joint positions (sim-sized).
+    - ``joint_qd_des``: flat float32 — desired joint velocities (sim-sized).
+    - ``joint_qdd``: flat float32 — desired acceleration feedforward
+      (sim-sized). Only present when ``has_qdd_feedforward=True``.
+    - ``gravity_force``: flat float32 — gravity generalized forces
+      (sim-sized). Only present when ``use_gravity_compensation=True``.
+    - ``coriolis_force``: flat float32 — Coriolis generalized forces
+      (sim-sized). Only present when ``use_coriolis_compensation=True``.
+    - ``mass_matrix``: ``(num_robots, max_dofs, max_dofs)`` float32 —
+      per-robot mass matrices, padded to ``max_dofs``. Only present when
+      ``use_inertia_decoupling=True``.
+    - Live gain fields: present when ``stiffness`` or ``damping`` is a str.
+
+    **Output struct fields** (allocate via :meth:`output`):
+
+    - ``joint_f``: flat float32 — joint torque command (sim-sized).
+
+    Args:
+        num_robots: Number of parallel robots.
+        dofs_per_robot: ``wp.array[int32]`` of length ``num_robots`` giving
+            the DOF count for each robot. All values must be >= 1 and <=
+            ``max_dofs``.
+        max_dofs: Padded buffer width. Must equal
+            ``int(dofs_per_robot.numpy().max())``. Exposed as a separate
+            argument so callers can pass it without a device round-trip.
+        default_dof_indices: ``wp.array[uint32]`` of length
+            ``sum(dofs_per_robot)`` — concatenated per-robot index arrays
+            mapping controller DOF slots to positions in the flat simulation
+            arrays (robot 0's indices first, then robot 1's, etc.).
+        stiffness: Position-error gain Kp. ``wp.array2d[float32]`` of shape
+            ``(num_robots, max_dofs)`` (baked) or ``str`` (live attr on input
+            struct pointing to an array of that shape).
+        damping: Velocity-error gain Kd. Same format as ``stiffness``.
+        use_gravity_compensation: Add gravity generalized forces to τ.
+        use_coriolis_compensation: Add Coriolis generalized forces to τ.
+        use_inertia_decoupling: Premultiply the PD term by M(q).
+        has_qdd_feedforward: Accept a desired-acceleration feedforward
+            ``joint_qdd`` in the input struct.
+        joint_q_attr: Input struct attr name for current joint positions.
+        joint_q_idx: Optional index override; same length/layout as
+            ``default_dof_indices``.
+        joint_qd_attr: Input struct attr name for current joint velocities.
+        joint_qd_idx: Optional index override for current joint velocities.
+        joint_q_des_attr: Input struct attr name for desired positions.
+        joint_q_des_idx: Optional index override for desired positions.
+        joint_qd_des_attr: Input struct attr name for desired velocities.
+        joint_qd_des_idx: Optional index override for desired velocities.
+        joint_qdd_attr: Input struct attr name for desired acceleration
+            feedforward (only used when ``has_qdd_feedforward=True``).
+        joint_qdd_idx: Optional index override for feedforward.
+        gravity_force_attr: Input struct attr name for gravity forces.
+        gravity_force_idx: Optional index override for gravity forces.
+        coriolis_force_attr: Input struct attr name for Coriolis forces.
+        coriolis_force_idx: Optional index override for Coriolis forces.
+        mass_matrix_attr: Input struct attr name for the mass matrix.
+        joint_f_attr: Output struct attr name for the torque command.
+        joint_f_idx: Optional index override for the torque output.
+        device: Warp device.
+        requires_grad: Whether internal buffers need gradient support.
+    """
+
+    def __init__(
+        self,
+        num_robots: int,
+        dofs_per_robot: wp.array[wp.int32],
+        max_dofs: int,
+        default_dof_indices: wp.array[wp.uint32],
+        stiffness: wp.array2d[wp.float32] | str,
+        damping: wp.array2d[wp.float32] | str,
+        use_gravity_compensation: bool = True,
+        use_coriolis_compensation: bool = True,
+        use_inertia_decoupling: bool = True,
+        has_qdd_feedforward: bool = False,
+        joint_q_attr: str = "joint_q",
+        joint_q_idx: wp.array[wp.uint32] | None = None,
+        joint_qd_attr: str = "joint_qd",
+        joint_qd_idx: wp.array[wp.uint32] | None = None,
+        joint_q_des_attr: str = "joint_q_des",
+        joint_q_des_idx: wp.array[wp.uint32] | None = None,
+        joint_qd_des_attr: str = "joint_qd_des",
+        joint_qd_des_idx: wp.array[wp.uint32] | None = None,
+        joint_qdd_attr: str = "joint_qdd",
+        joint_qdd_idx: wp.array[wp.uint32] | None = None,
+        gravity_force_attr: str = "gravity_force",
+        gravity_force_idx: wp.array[wp.uint32] | None = None,
+        coriolis_force_attr: str = "coriolis_force",
+        coriolis_force_idx: wp.array[wp.uint32] | None = None,
+        mass_matrix_attr: str = "mass_matrix",
+        joint_f_attr: str = "joint_f",
+        joint_f_idx: wp.array[wp.uint32] | None = None,
+        device: Any = None,
+        requires_grad: bool = False,
+    ):
+        if num_robots < 1:
+            raise ValueError(f"num_robots must be >= 1, got {num_robots}.")
+        if not isinstance(dofs_per_robot, wp.array) or dofs_per_robot.dtype != wp.int32:
+            raise TypeError("dofs_per_robot must be wp.array[int32].")
+        if int(dofs_per_robot.size) != num_robots:
+            raise ValueError(f"dofs_per_robot length {dofs_per_robot.size} must equal num_robots={num_robots}.")
+        if max_dofs < 1:
+            raise ValueError(f"max_dofs must be >= 1, got {max_dofs}.")
+        if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
+            raise TypeError("default_dof_indices must be wp.array[uint32].")
+
+        dofs_per_robot_np = dofs_per_robot.numpy()
+        total_dofs = int(dofs_per_robot_np.sum())
+        if int(default_dof_indices.size) != total_dofs:
+            raise ValueError(
+                f"default_dof_indices length {default_dof_indices.size} must equal sum(dofs_per_robot) = {total_dofs}."
+            )
+
+        self._num_robots = num_robots
+        self._max_dofs = max_dofs
+        self._total_dofs = total_dofs
+        self._use_gravity = bool(use_gravity_compensation)
+        self._use_coriolis = bool(use_coriolis_compensation)
+        self._use_inertia = bool(use_inertia_decoupling)
+        self._has_qdd = bool(has_qdd_feedforward)
+        self._device = device if device is not None else wp.get_device()
+        self._requires_grad = requires_grad
+
+        self._dofs_per_robot = dofs_per_robot
+        # Cumulative offsets into the flat index / gather arrays (one per robot).
+        offsets_np = np.zeros(num_robots, dtype=np.int32)
+        offsets_np[1:] = np.cumsum(dofs_per_robot_np[:-1])
+        self._dof_offsets = wp.array(offsets_np, dtype=wp.int32, device=self._device)
+
+        self._q_attr = joint_q_attr
+        self._qd_attr = joint_qd_attr
+        self._q_des_attr = joint_q_des_attr
+        self._qd_des_attr = joint_qd_des_attr
+        self._qdd_attr = joint_qdd_attr
+        self._gravity_attr = gravity_force_attr
+        self._coriolis_attr = coriolis_force_attr
+        self._mass_matrix_attr = mass_matrix_attr
+        self._f_attr = joint_f_attr
+
+        self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
+        self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
+        self._q_des_idx = _normalize_indices(joint_q_des_idx, default_dof_indices, name="joint_q_des")
+        self._qd_des_idx = _normalize_indices(joint_qd_des_idx, default_dof_indices, name="joint_qd_des")
+        self._qdd_idx = _normalize_indices(joint_qdd_idx, default_dof_indices, name="joint_qdd")
+        self._gravity_idx = _normalize_indices(gravity_force_idx, default_dof_indices, name="gravity_force")
+        self._coriolis_idx = _normalize_indices(coriolis_force_idx, default_dof_indices, name="coriolis_force")
+        self._f_idx = _normalize_indices(joint_f_idx, default_dof_indices, name="joint_f")
+
+        self._stiffness_attr, self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
+        self._damping_attr, self._damping_baked = self._normalize_gain(damping, "damping")
+
+        def _buf():
+            return wp.zeros((num_robots, max_dofs), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+
+        self._q_2d = _buf()
+        self._qd_2d = _buf()
+        self._q_des_2d = _buf()
+        self._qd_des_2d = _buf()
+        self._qdd_2d: wp.array2d[wp.float32] | None = _buf() if self._has_qdd else None
+        self._grav_2d: wp.array2d[wp.float32] | None = _buf() if self._use_gravity else None
+        self._cor_2d: wp.array2d[wp.float32] | None = _buf() if self._use_coriolis else None
+
+        self._tau_buf = _buf()
+        self._acc_buf: wp.array2d[wp.float32] | None = _buf() if self._use_inertia else None
+
+    def _normalize_gain(
+        self,
+        value: wp.array2d[wp.float32] | str,
+        name: str,
+    ) -> tuple[str | None, wp.array2d[wp.float32] | None]:
+        """Validate and optionally bake a per-robot gain array."""
+        if isinstance(value, str):
+            return value, None
+        if isinstance(value, wp.array):
+            expected = (self._num_robots, self._max_dofs)
+            if tuple(value.shape) != expected:
+                raise ValueError(
+                    f"Port '{name}': baked array shape {tuple(value.shape)} must equal "
+                    f"(num_robots, max_dofs) = {expected}."
+                )
+            if value.dtype != wp.float32:
+                raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
+            baked = wp.zeros(expected, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad)
+            wp.copy(baked, value)
+            return None, baked
+        raise TypeError(
+            f"Port '{name}': must be wp.array2d[wp.float32] of shape (num_robots, max_dofs) "
+            f"or str; got {type(value).__name__}."
+        )
+
+    @property
+    def num_robots(self) -> int:
+        return self._num_robots
+
+    @property
+    def max_dofs(self) -> int:
+        return self._max_dofs
+
+    @property
+    def device(self):
+        return self._device
+
+    @property
+    def requires_grad(self) -> bool:
+        return self._requires_grad
+
+    def is_stateful(self) -> bool:
+        return False
+
+    def is_graphable(self) -> bool:
+        return True
+
+    def state(self) -> None:
+        return None
+
+    def input(self) -> SimpleNamespace:
+        """Return a pre-allocated input struct with zero-initialised flat arrays."""
+        specs = [
+            (self._q_attr, wp.float32, _idx_max(self._q_idx)),
+            (self._qd_attr, wp.float32, _idx_max(self._qd_idx)),
+            (self._q_des_attr, wp.float32, _idx_max(self._q_des_idx)),
+            (self._qd_des_attr, wp.float32, _idx_max(self._qd_des_idx)),
+        ]
+        if self._has_qdd:
+            specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
+        if self._use_gravity:
+            specs.append((self._gravity_attr, wp.float32, _idx_max(self._gravity_idx)))
+        if self._use_coriolis:
+            specs.append((self._coriolis_attr, wp.float32, _idx_max(self._coriolis_idx)))
+        ns = _allocate_namespace(specs, self._device, self._requires_grad)
+        shape_2d = (self._num_robots, self._max_dofs)
+        if self._stiffness_attr is not None:
+            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+        if self._damping_attr is not None:
+            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+        if self._use_inertia:
+            setattr(
+                ns,
+                self._mass_matrix_attr,
+                wp.zeros(
+                    (self._num_robots, self._max_dofs, self._max_dofs),
+                    dtype=wp.float32,
+                    device=self._device,
+                ),
+            )
+        return ns
+
+    def output(self) -> SimpleNamespace:
+        """Return a pre-allocated output struct with a flat torque array."""
+        return _allocate_namespace(
+            [(self._f_attr, wp.float32, _idx_max(self._f_idx))],
+            self._device,
+            self._requires_grad,
+        )
+
+    def compute(
+        self,
+        input_struct: Any,
+        output_struct: Any,
+        controller_state_now: None,
+        controller_state_next: None,
+        time_step: float | wp.array[wp.float32],
+    ) -> None:
+        """Compute one impedance-control step and write joint torques.
+
+        Args:
+            input_struct: Namespace with flat sim arrays as described in the
+                class docstring. Dynamics fields must be populated by the
+                caller before each call.
+            output_struct: Namespace with a flat sim torque array.
+            controller_state_now: Unused (stateless). Pass ``None``.
+            controller_state_next: Unused. Pass ``None``.
+            time_step: Unused. Accepted for API compatibility.
+        """
+        stiffness = self._stiffness_baked or getattr(input_struct, self._stiffness_attr)
+        damping = self._damping_baked or getattr(input_struct, self._damping_attr)
+
+        dim2d = (self._num_robots, self._max_dofs)
+
+        def _gather(src_attr, src_idx, dst_2d):
+            wp.launch(
+                _gather_dof_kernel,
+                dim=dim2d,
+                inputs=[getattr(input_struct, src_attr), src_idx, self._dof_offsets, self._dofs_per_robot],
+                outputs=[dst_2d],
+                device=self._device,
+            )
+
+        _gather(self._q_attr, self._q_idx, self._q_2d)
+        _gather(self._qd_attr, self._qd_idx, self._qd_2d)
+        _gather(self._q_des_attr, self._q_des_idx, self._q_des_2d)
+        _gather(self._qd_des_attr, self._qd_des_idx, self._qd_des_2d)
+        if self._has_qdd:
+            _gather(self._qdd_attr, self._qdd_idx, self._qdd_2d)
+        if self._use_gravity:
+            _gather(self._gravity_attr, self._gravity_idx, self._grav_2d)
+        if self._use_coriolis:
+            _gather(self._coriolis_attr, self._coriolis_idx, self._cor_2d)
+
+        working_buf = self._acc_buf if self._use_inertia else self._tau_buf
+        wp.launch(
+            _pd_term_kernel,
+            dim=dim2d,
+            inputs=[self._q_2d, self._qd_2d, self._q_des_2d, self._qd_des_2d, stiffness, damping, self._dofs_per_robot],
+            outputs=[working_buf],
+            device=self._device,
+        )
+
+        if self._has_qdd:
+            wp.launch(
+                _add_term_kernel,
+                dim=dim2d,
+                inputs=[self._qdd_2d, self._dofs_per_robot],
+                outputs=[working_buf],
+                device=self._device,
+            )
+
+        if self._use_inertia:
+            wp.launch(
+                _mass_matrix_multiply_kernel,
+                dim=dim2d,
+                inputs=[getattr(input_struct, self._mass_matrix_attr), self._acc_buf, self._dofs_per_robot],
+                outputs=[self._tau_buf],
+                device=self._device,
+            )
+
+        if self._use_gravity:
+            wp.launch(
+                _add_term_kernel,
+                dim=dim2d,
+                inputs=[self._grav_2d, self._dofs_per_robot],
+                outputs=[self._tau_buf],
+                device=self._device,
+            )
+        if self._use_coriolis:
+            wp.launch(
+                _add_term_kernel,
+                dim=dim2d,
+                inputs=[self._cor_2d, self._dofs_per_robot],
+                outputs=[self._tau_buf],
+                device=self._device,
+            )
+
+        wp.launch(
+            _scatter_dof_kernel,
+            dim=dim2d,
+            inputs=[self._tau_buf, self._f_idx, self._dof_offsets, self._dofs_per_robot],
+            outputs=[getattr(output_struct, self._f_attr)],
+            device=self._device,
+        )

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -115,6 +115,7 @@ class ControllerJointImpedanceModelFree(Controller):
 
     def __init__(
         self,
+        *,
         num_robots: int,
         dofs_per_robot: wp.array[wp.int32],
         max_dofs: int,
@@ -266,9 +267,6 @@ class ControllerJointImpedanceModelFree(Controller):
     def is_graphable(self) -> bool:
         return True
 
-    def state(self) -> None:
-        return None
-
     def input(self) -> SimpleNamespace:
         """Return a pre-allocated input struct with zero-initialised flat arrays."""
         specs = [
@@ -286,9 +284,9 @@ class ControllerJointImpedanceModelFree(Controller):
         ns = _allocate_namespace(specs, self._device, self._requires_grad)
         shape_2d = (self._num_robots, self._max_dofs)
         if self._stiffness_attr is not None:
-            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+            setattr(ns, self._stiffness_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
         if self._damping_attr is not None:
-            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device))
+            setattr(ns, self._damping_attr, wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad))
         if self._use_inertia:
             setattr(
                 ns,
@@ -297,6 +295,7 @@ class ControllerJointImpedanceModelFree(Controller):
                     (self._num_robots, self._max_dofs, self._max_dofs),
                     dtype=wp.float32,
                     device=self._device,
+                    requires_grad=self._requires_grad,
                 ),
             )
         return ns
@@ -311,27 +310,23 @@ class ControllerJointImpedanceModelFree(Controller):
 
     def compute(
         self,
-        input_struct: Any,
-        output_struct: Any,
-        controller_state_now: None,
-        controller_state_next: None,
-        time_step: float | wp.array[wp.float32],
+        inputs: Any,
+        outputs: Any,
+        dt: float | wp.array[wp.float32],
     ) -> None:
         """Compute one impedance-control step and write joint torques.
 
         Args:
-            input_struct: Namespace with flat sim arrays as described in the
+            inputs: Namespace with flat sim arrays as described in the
                 class docstring. Dynamics fields must be populated by the
                 caller before each call.
-            output_struct: Namespace with a flat sim torque array.
-            controller_state_now: Unused (stateless). Pass ``None``.
-            controller_state_next: Unused. Pass ``None``.
-            time_step: Unused. Accepted for API compatibility.
+            outputs: Namespace with a flat sim torque array.
+            dt: Unused. Accepted for API compatibility.
         """
         stiffness = (
-            self._stiffness_baked if self._stiffness_baked is not None else getattr(input_struct, self._stiffness_attr)
+            self._stiffness_baked if self._stiffness_baked is not None else getattr(inputs, self._stiffness_attr)
         )
-        damping = self._damping_baked if self._damping_baked is not None else getattr(input_struct, self._damping_attr)
+        damping = self._damping_baked if self._damping_baked is not None else getattr(inputs, self._damping_attr)
 
         dim2d = (self._num_robots, self._max_dofs)
 
@@ -339,7 +334,7 @@ class ControllerJointImpedanceModelFree(Controller):
             wp.launch(
                 _gather_dof_kernel,
                 dim=dim2d,
-                inputs=[getattr(input_struct, src_attr), src_idx, self._dof_offsets, self._dofs_per_robot],
+                inputs=[getattr(inputs, src_attr), src_idx, self._dof_offsets, self._dofs_per_robot],
                 outputs=[dst_2d],
                 device=self._device,
             )
@@ -377,7 +372,7 @@ class ControllerJointImpedanceModelFree(Controller):
             wp.launch(
                 _mass_matrix_multiply_kernel,
                 dim=dim2d,
-                inputs=[getattr(input_struct, self._mass_matrix_attr), self._acc_buf, self._dofs_per_robot],
+                inputs=[getattr(inputs, self._mass_matrix_attr), self._acc_buf, self._dofs_per_robot],
                 outputs=[self._tau_buf],
                 device=self._device,
             )
@@ -403,6 +398,6 @@ class ControllerJointImpedanceModelFree(Controller):
             _scatter_dof_kernel,
             dim=dim2d,
             inputs=[self._tau_buf, self._f_idx, self._dof_offsets, self._dofs_per_robot],
-            outputs=[getattr(output_struct, self._f_attr)],
+            outputs=[getattr(outputs, self._f_attr)],
             device=self._device,
         )

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -60,7 +60,7 @@ class ControllerJointImpedanceModelFree(Controller):
       (sim-sized). Only present when ``use_gravity_compensation=True``.
     - ``coriolis_force``: flat float32 — Coriolis generalized forces
       (sim-sized). Only present when ``use_coriolis_compensation=True``.
-    - ``mass_matrix``: ``(num_robots, max_dofs, max_dofs)`` float32 —
+    - ``mass_matrix``: ``(robot_count, max_dofs, max_dofs)`` float32 —
       per-robot mass matrices, padded to ``max_dofs``. Only present when
       ``use_inertia_decoupling=True``.
     - Live gain fields: present when ``stiffness`` or ``damping`` is a str.
@@ -70,8 +70,8 @@ class ControllerJointImpedanceModelFree(Controller):
     - ``joint_f``: flat float32 — joint torque command (sim-sized).
 
     Args:
-        num_robots: Number of parallel robots.
-        dofs_per_robot: ``wp.array[int32]`` of length ``num_robots`` giving
+        robot_count: Number of parallel robots.
+        dofs_per_robot: ``wp.array[int32]`` of length ``robot_count`` giving
             the DOF count for each robot. All values must be >= 1 and <=
             ``max_dofs``.
         max_dofs: Padded buffer width. Must equal
@@ -82,7 +82,7 @@ class ControllerJointImpedanceModelFree(Controller):
             mapping controller DOF slots to positions in the flat simulation
             arrays (robot 0's indices first, then robot 1's, etc.).
         stiffness: Position-error gain Kp. ``wp.array2d[float32]`` of shape
-            ``(num_robots, max_dofs)`` (baked) or ``str`` (live attr on input
+            ``(robot_count, max_dofs)`` (baked) or ``str`` (live attr on input
             struct pointing to an array of that shape).
         damping: Velocity-error gain Kd. Same format as ``stiffness``.
         use_gravity_compensation: Add gravity generalized forces to τ.
@@ -116,7 +116,7 @@ class ControllerJointImpedanceModelFree(Controller):
     def __init__(
         self,
         *,
-        num_robots: int,
+        robot_count: int,
         dofs_per_robot: wp.array[wp.int32],
         max_dofs: int,
         default_dof_indices: wp.array[wp.uint32],
@@ -146,12 +146,12 @@ class ControllerJointImpedanceModelFree(Controller):
         device: Any = None,
         requires_grad: bool = False,
     ):
-        if num_robots < 1:
-            raise ValueError(f"num_robots must be >= 1, got {num_robots}.")
+        if robot_count < 1:
+            raise ValueError(f"robot_count must be >= 1, got {robot_count}.")
         if not isinstance(dofs_per_robot, wp.array) or dofs_per_robot.dtype != wp.int32:
             raise TypeError("dofs_per_robot must be wp.array[int32].")
-        if int(dofs_per_robot.size) != num_robots:
-            raise ValueError(f"dofs_per_robot length {dofs_per_robot.size} must equal num_robots={num_robots}.")
+        if int(dofs_per_robot.size) != robot_count:
+            raise ValueError(f"dofs_per_robot length {dofs_per_robot.size} must equal robot_count={robot_count}.")
         if max_dofs < 1:
             raise ValueError(f"max_dofs must be >= 1, got {max_dofs}.")
         if not isinstance(default_dof_indices, wp.array) or default_dof_indices.dtype != wp.uint32:
@@ -164,7 +164,7 @@ class ControllerJointImpedanceModelFree(Controller):
                 f"default_dof_indices length {default_dof_indices.size} must equal sum(dofs_per_robot) = {total_dofs}."
             )
 
-        self._num_robots = num_robots
+        self._robot_count = robot_count
         self._max_dofs = max_dofs
         self._total_dofs = total_dofs
         self._use_gravity = bool(use_gravity_compensation)
@@ -176,7 +176,7 @@ class ControllerJointImpedanceModelFree(Controller):
 
         self._dofs_per_robot = dofs_per_robot
         # Cumulative offsets into the flat index / gather arrays (one per robot).
-        offsets_np = np.zeros(num_robots, dtype=np.int32)
+        offsets_np = np.zeros(robot_count, dtype=np.int32)
         offsets_np[1:] = np.cumsum(dofs_per_robot_np[:-1])
         self._dof_offsets = wp.array(offsets_np, dtype=wp.int32, device=self._device)
 
@@ -210,7 +210,7 @@ class ControllerJointImpedanceModelFree(Controller):
         self._damping_attr, self._damping_baked = self._normalize_gain(damping, "damping")
 
         def _buf():
-            return wp.zeros((num_robots, max_dofs), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
+            return wp.zeros((robot_count, max_dofs), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
 
         self._q_2d = _buf()
         self._qd_2d = _buf()
@@ -232,11 +232,11 @@ class ControllerJointImpedanceModelFree(Controller):
         if isinstance(value, str):
             return value, None
         if isinstance(value, wp.array):
-            expected = (self._num_robots, self._max_dofs)
+            expected = (self._robot_count, self._max_dofs)
             if tuple(value.shape) != expected:
                 raise ValueError(
                     f"Port '{name}': baked array shape {tuple(value.shape)} must equal "
-                    f"(num_robots, max_dofs) = {expected}."
+                    f"(robot_count, max_dofs) = {expected}."
                 )
             if value.dtype != wp.float32:
                 raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
@@ -244,13 +244,13 @@ class ControllerJointImpedanceModelFree(Controller):
             wp.copy(baked, value)
             return None, baked
         raise TypeError(
-            f"Port '{name}': must be wp.array2d[wp.float32] of shape (num_robots, max_dofs) "
+            f"Port '{name}': must be wp.array2d[wp.float32] of shape (robot_count, max_dofs) "
             f"or str; got {type(value).__name__}."
         )
 
     @property
-    def num_robots(self) -> int:
-        return self._num_robots
+    def robot_count(self) -> int:
+        return self._robot_count
 
     @property
     def max_dofs(self) -> int:
@@ -282,7 +282,7 @@ class ControllerJointImpedanceModelFree(Controller):
         if self._use_coriolis:
             specs.append((self._coriolis_attr, wp.float32, _idx_max(self._coriolis_idx)))
         ns = _allocate_namespace(specs, self._device, self._requires_grad)
-        shape_2d = (self._num_robots, self._max_dofs)
+        shape_2d = (self._robot_count, self._max_dofs)
         if self._stiffness_attr is not None:
             setattr(
                 ns,
@@ -300,7 +300,7 @@ class ControllerJointImpedanceModelFree(Controller):
                 ns,
                 self._mass_matrix_attr,
                 wp.zeros(
-                    (self._num_robots, self._max_dofs, self._max_dofs),
+                    (self._robot_count, self._max_dofs, self._max_dofs),
                     dtype=wp.float32,
                     device=self._device,
                     requires_grad=self._requires_grad,
@@ -337,7 +337,7 @@ class ControllerJointImpedanceModelFree(Controller):
         )
         damping = self._damping_baked if self._damping_baked is not None else getattr(inputs, self._damping_attr)
 
-        dim2d = (self._num_robots, self._max_dofs)
+        dim2d = (self._robot_count, self._max_dofs)
 
         def _gather(src_attr, src_idx, dst_2d):
             wp.launch(

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -262,19 +262,39 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         inputs.joint_qd = wp.zeros(_idx_max(self._qd_idx), dtype=wp.float32, device=d, requires_grad=rg)
         inputs.joint_q_des = wp.zeros(_idx_max(self._q_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
         inputs.joint_qd_des = wp.zeros(_idx_max(self._qd_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
-        inputs.joint_qdd = wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
-        inputs.gravity_force = wp.zeros(_idx_max(self._gravity_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._use_gravity else None
-        inputs.coriolis_force = wp.zeros(_idx_max(self._coriolis_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._use_coriolis else None
+        inputs.joint_qdd = (
+            wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
+        )
+        inputs.gravity_force = (
+            wp.zeros(_idx_max(self._gravity_idx), dtype=wp.float32, device=d, requires_grad=rg)
+            if self._use_gravity
+            else None
+        )
+        inputs.coriolis_force = (
+            wp.zeros(_idx_max(self._coriolis_idx), dtype=wp.float32, device=d, requires_grad=rg)
+            if self._use_coriolis
+            else None
+        )
         shape_2d = (self._robot_count, self._max_dofs)
-        inputs.mass_matrix = wp.zeros((self._robot_count, self._max_dofs, self._max_dofs), dtype=wp.float32, device=d, requires_grad=rg) if self._use_inertia else None
-        inputs.stiffness = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_baked is None else None
-        inputs.damping = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_baked is None else None
+        inputs.mass_matrix = (
+            wp.zeros((self._robot_count, self._max_dofs, self._max_dofs), dtype=wp.float32, device=d, requires_grad=rg)
+            if self._use_inertia
+            else None
+        )
+        inputs.stiffness = (
+            wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_baked is None else None
+        )
+        inputs.damping = (
+            wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_baked is None else None
+        )
         return inputs
 
     def output(self) -> Outputs:
         """Return a pre-allocated :class:`Outputs` with a flat torque array."""
         outputs = ControllerJointImpedanceModelFree.Outputs()
-        outputs.joint_f = wp.zeros(_idx_max(self._f_idx), dtype=wp.float32, device=self._device, requires_grad=self._requires_grad)
+        outputs.joint_f = wp.zeros(
+            _idx_max(self._f_idx), dtype=wp.float32, device=self._device, requires_grad=self._requires_grad
+        )
         return outputs
 
     def compute(

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -23,14 +23,13 @@ where Δq = q_des - q and Δq̇ = q̇_des - q̇.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import warp as wp
 
-from ...controller import Controller
-from ...utils import _allocate_namespace, _normalize_indices
+from ...controller import ControllerBase
+from ...utils import _normalize_indices
 from ._common import (
     _add_term_kernel,
     _gather_dof_kernel,
@@ -41,77 +40,85 @@ from ._common import (
 )
 
 
-class ControllerJointImpedanceModelFree(Controller):
+class ControllerJointImpedanceModelFree(ControllerBase):
     """Joint-space impedance controller with caller-supplied dynamics.
 
     Supports heterogeneous robot fleets — robots in the batch may have
     different DOF counts. Internal buffers are padded to ``max_dofs``; kernels
     skip padding slots via a per-robot guard.
 
-    **Input struct fields** (allocate via :meth:`input`):
-
-    - ``joint_q``: flat float32 — current joint positions (sim-sized).
-    - ``joint_qd``: flat float32 — current joint velocities (sim-sized).
-    - ``joint_q_des``: flat float32 — desired joint positions (sim-sized).
-    - ``joint_qd_des``: flat float32 — desired joint velocities (sim-sized).
-    - ``joint_qdd``: flat float32 — desired acceleration feedforward
-      (sim-sized). Only present when ``has_qdd_feedforward=True``.
-    - ``gravity_force``: flat float32 — gravity generalized forces
-      (sim-sized). Only present when ``use_gravity_compensation=True``.
-    - ``coriolis_force``: flat float32 — Coriolis generalized forces
-      (sim-sized). Only present when ``use_coriolis_compensation=True``.
-    - ``mass_matrix``: ``(robot_count, max_dofs, max_dofs)`` float32 —
-      per-robot mass matrices, padded to ``max_dofs``. Only present when
-      ``use_inertia_decoupling=True``.
-    - Live gain fields: present when ``stiffness`` or ``damping`` is a str.
-
-    **Output struct fields** (allocate via :meth:`output`):
-
-    - ``joint_f``: flat float32 — joint torque command (sim-sized).
+    Allocate input and output structs via :meth:`input` and :meth:`output`.
+    All field names on those structs are fixed — see :class:`Inputs` and
+    :class:`Outputs` for the typed schema. Fields for disabled features
+    (e.g. ``gravity_force`` when ``use_gravity_compensation=False``) are
+    allocated as ``None`` and must not be written.
 
     Args:
         robot_count: Number of parallel robots.
-        dofs_per_robot: ``wp.array[int32]`` of length ``robot_count`` giving
-            the DOF count for each robot. All values must be >= 1 and <=
-            ``max_dofs``.
-        max_dofs: Padded buffer width. Must equal
-            ``int(dofs_per_robot.numpy().max())``. Exposed as a separate
-            argument so callers can pass it without a device round-trip.
-        default_dof_indices: ``wp.array[uint32]`` of length
-            ``sum(dofs_per_robot)`` — concatenated per-robot index arrays
-            mapping controller DOF slots to positions in the flat simulation
-            arrays (robot 0's indices first, then robot 1's, etc.).
-        stiffness: Position-error gain Kp. ``wp.array2d[float32]`` of shape
-            ``(robot_count, max_dofs)`` (baked) or ``str`` (live attr on input
-            struct pointing to an array of that shape).
-        damping: Velocity-error gain Kd. Same format as ``stiffness``.
+        dofs_per_robot: DOF count for each robot, length ``robot_count``.
+        max_dofs: Padded buffer width — must equal
+            ``int(dofs_per_robot.numpy().max())``. Passed explicitly to avoid
+            a device round-trip.
+        default_dof_indices: Concatenated per-robot index arrays of length
+            ``sum(dofs_per_robot)`` mapping controller DOF slots to positions
+            in the flat simulation arrays (robot 0's indices first, then
+            robot 1's, etc.).
+        stiffness: Position-error gain Kp [N/m or N·m/rad], shape
+            ``(robot_count, max_dofs)``. Pass a baked array or ``None`` to
+            read from ``inputs.stiffness`` each step.
+        damping: Velocity-error gain Kd [N·s/m or N·m·s/rad]. Same format
+            as ``stiffness``.
         use_gravity_compensation: Add gravity generalized forces to τ.
         use_coriolis_compensation: Add Coriolis generalized forces to τ.
         use_inertia_decoupling: Premultiply the PD term by M(q).
-        has_qdd_feedforward: Accept a desired-acceleration feedforward
-            ``joint_qdd`` in the input struct.
-        joint_q_attr: Input struct attr name for current joint positions.
-        joint_q_idx: Optional index override; same length/layout as
-            ``default_dof_indices``.
-        joint_qd_attr: Input struct attr name for current joint velocities.
-        joint_qd_idx: Optional index override for current joint velocities.
-        joint_q_des_attr: Input struct attr name for desired positions.
-        joint_q_des_idx: Optional index override for desired positions.
-        joint_qd_des_attr: Input struct attr name for desired velocities.
-        joint_qd_des_idx: Optional index override for desired velocities.
-        joint_qdd_attr: Input struct attr name for desired acceleration
-            feedforward (only used when ``has_qdd_feedforward=True``).
-        joint_qdd_idx: Optional index override for feedforward.
-        gravity_force_attr: Input struct attr name for gravity forces.
-        gravity_force_idx: Optional index override for gravity forces.
-        coriolis_force_attr: Input struct attr name for Coriolis forces.
-        coriolis_force_idx: Optional index override for Coriolis forces.
-        mass_matrix_attr: Input struct attr name for the mass matrix.
-        joint_f_attr: Output struct attr name for the torque command.
+        has_qdd_feedforward: Accept a desired-acceleration feedforward via
+            ``inputs.joint_qdd``.
+        joint_q_idx: Optional index override for ``inputs.joint_q``; same
+            length/layout as ``default_dof_indices``.
+        joint_qd_idx: Optional index override for ``inputs.joint_qd``.
+        joint_q_des_idx: Optional index override for ``inputs.joint_q_des``.
+        joint_qd_des_idx: Optional index override for ``inputs.joint_qd_des``.
+        joint_qdd_idx: Optional index override for ``inputs.joint_qdd``.
+        gravity_force_idx: Optional index override for ``inputs.gravity_force``.
+        coriolis_force_idx: Optional index override for ``inputs.coriolis_force``.
         joint_f_idx: Optional index override for the torque output.
         device: Warp device.
         requires_grad: Whether internal buffers need gradient support.
     """
+
+    class Inputs:
+        """Input struct returned by :meth:`~ControllerJointImpedanceModelFree.input`.
+
+        All four kinematic fields are always allocated. Optional fields are
+        ``None`` when the corresponding feature is disabled at construction.
+        """
+
+        joint_q: wp.array[wp.float32]
+        """Current joint positions [m or rad], flat sim-level array."""
+        joint_qd: wp.array[wp.float32]
+        """Current joint velocities [m/s or rad/s], flat sim-level array."""
+        joint_q_des: wp.array[wp.float32]
+        """Desired joint positions [m or rad], flat sim-level array."""
+        joint_qd_des: wp.array[wp.float32]
+        """Desired joint velocities [m/s or rad/s], flat sim-level array."""
+        joint_qdd: wp.array[wp.float32] | None
+        """Desired acceleration feedforward [m/s² or rad/s²], flat sim-level array. ``None`` unless ``has_qdd_feedforward=True``."""
+        gravity_force: wp.array[wp.float32] | None
+        """Gravity generalized forces [N or N·m], flat sim-level array. ``None`` unless ``use_gravity_compensation=True``."""
+        coriolis_force: wp.array[wp.float32] | None
+        """Coriolis generalized forces [N or N·m], flat sim-level array. ``None`` unless ``use_coriolis_compensation=True``."""
+        mass_matrix: wp.array3d[wp.float32] | None
+        """Per-robot generalized mass matrices [kg or kg·m²], shape ``(robot_count, max_dofs, max_dofs)``. ``None`` unless ``use_inertia_decoupling=True``."""
+        stiffness: wp.array2d[wp.float32] | None
+        """Position-error gain Kp [N/m or N·m/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+        damping: wp.array2d[wp.float32] | None
+        """Velocity-error gain Kd [N·s/m or N·m·s/rad], shape ``(robot_count, max_dofs)``. ``None`` when gains are baked at construction."""
+
+    class Outputs:
+        """Output struct returned by :meth:`~ControllerJointImpedanceModelFree.output`."""
+
+        joint_f: wp.array[wp.float32]
+        """Joint torque command [N or N·m], flat sim-level array."""
 
     def __init__(
         self,
@@ -120,28 +127,19 @@ class ControllerJointImpedanceModelFree(Controller):
         dofs_per_robot: wp.array[wp.int32],
         max_dofs: int,
         default_dof_indices: wp.array[wp.uint32],
-        stiffness: wp.array2d[wp.float32] | str,
-        damping: wp.array2d[wp.float32] | str,
+        stiffness: wp.array2d[wp.float32] | None,
+        damping: wp.array2d[wp.float32] | None,
         use_gravity_compensation: bool = True,
         use_coriolis_compensation: bool = True,
         use_inertia_decoupling: bool = True,
         has_qdd_feedforward: bool = False,
-        joint_q_attr: str = "joint_q",
         joint_q_idx: wp.array[wp.uint32] | None = None,
-        joint_qd_attr: str = "joint_qd",
         joint_qd_idx: wp.array[wp.uint32] | None = None,
-        joint_q_des_attr: str = "joint_q_des",
         joint_q_des_idx: wp.array[wp.uint32] | None = None,
-        joint_qd_des_attr: str = "joint_qd_des",
         joint_qd_des_idx: wp.array[wp.uint32] | None = None,
-        joint_qdd_attr: str = "joint_qdd",
         joint_qdd_idx: wp.array[wp.uint32] | None = None,
-        gravity_force_attr: str = "gravity_force",
         gravity_force_idx: wp.array[wp.uint32] | None = None,
-        coriolis_force_attr: str = "coriolis_force",
         coriolis_force_idx: wp.array[wp.uint32] | None = None,
-        mass_matrix_attr: str = "mass_matrix",
-        joint_f_attr: str = "joint_f",
         joint_f_idx: wp.array[wp.uint32] | None = None,
         device: Any = None,
         requires_grad: bool = False,
@@ -175,20 +173,9 @@ class ControllerJointImpedanceModelFree(Controller):
         self._requires_grad = requires_grad
 
         self._dofs_per_robot = dofs_per_robot
-        # Cumulative offsets into the flat index / gather arrays (one per robot).
         offsets_np = np.zeros(robot_count, dtype=np.int32)
         offsets_np[1:] = np.cumsum(dofs_per_robot_np[:-1])
         self._dof_offsets = wp.array(offsets_np, dtype=wp.int32, device=self._device)
-
-        self._q_attr = joint_q_attr
-        self._qd_attr = joint_qd_attr
-        self._q_des_attr = joint_q_des_attr
-        self._qd_des_attr = joint_qd_des_attr
-        self._qdd_attr = joint_qdd_attr
-        self._gravity_attr = gravity_force_attr
-        self._coriolis_attr = coriolis_force_attr
-        self._mass_matrix_attr = mass_matrix_attr
-        self._f_attr = joint_f_attr
 
         self._q_idx = _normalize_indices(joint_q_idx, default_dof_indices, name="joint_q")
         self._qd_idx = _normalize_indices(joint_qd_idx, default_dof_indices, name="joint_qd")
@@ -206,8 +193,8 @@ class ControllerJointImpedanceModelFree(Controller):
                 "to the same simulation DOF slot."
             )
 
-        self._stiffness_attr, self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
-        self._damping_attr, self._damping_baked = self._normalize_gain(damping, "damping")
+        self._stiffness_baked = self._normalize_gain(stiffness, "stiffness")
+        self._damping_baked = self._normalize_gain(damping, "damping")
 
         def _buf():
             return wp.zeros((robot_count, max_dofs), dtype=wp.float32, device=self._device, requires_grad=requires_grad)
@@ -225,12 +212,12 @@ class ControllerJointImpedanceModelFree(Controller):
 
     def _normalize_gain(
         self,
-        value: wp.array2d[wp.float32] | str,
+        value: wp.array2d[wp.float32] | None,
         name: str,
-    ) -> tuple[str | None, wp.array2d[wp.float32] | None]:
-        """Validate and optionally bake a per-robot gain array."""
-        if isinstance(value, str):
-            return value, None
+    ) -> wp.array2d[wp.float32] | None:
+        """Validate and copy a baked gain array, or return ``None`` for live gains."""
+        if value is None:
+            return None
         if isinstance(value, wp.array):
             expected = (self._robot_count, self._max_dofs)
             if tuple(value.shape) != expected:
@@ -242,10 +229,10 @@ class ControllerJointImpedanceModelFree(Controller):
                 raise TypeError(f"Port '{name}': baked array dtype must be wp.float32, got {value.dtype}.")
             baked = wp.zeros(expected, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad)
             wp.copy(baked, value)
-            return None, baked
+            return baked
         raise TypeError(
             f"Port '{name}': must be wp.array2d[wp.float32] of shape (robot_count, max_dofs) "
-            f"or str; got {type(value).__name__}."
+            f"or None; got {type(value).__name__}."
         )
 
     @property
@@ -267,97 +254,68 @@ class ControllerJointImpedanceModelFree(Controller):
     def is_graphable(self) -> bool:
         return True
 
-    def input(self) -> SimpleNamespace:
-        """Return a pre-allocated input struct with zero-initialised flat arrays."""
-        specs = [
-            (self._q_attr, wp.float32, _idx_max(self._q_idx)),
-            (self._qd_attr, wp.float32, _idx_max(self._qd_idx)),
-            (self._q_des_attr, wp.float32, _idx_max(self._q_des_idx)),
-            (self._qd_des_attr, wp.float32, _idx_max(self._qd_des_idx)),
-        ]
-        if self._has_qdd:
-            specs.append((self._qdd_attr, wp.float32, _idx_max(self._qdd_idx)))
-        if self._use_gravity:
-            specs.append((self._gravity_attr, wp.float32, _idx_max(self._gravity_idx)))
-        if self._use_coriolis:
-            specs.append((self._coriolis_attr, wp.float32, _idx_max(self._coriolis_idx)))
-        ns = _allocate_namespace(specs, self._device, self._requires_grad)
+    def input(self) -> Inputs:
+        """Return a pre-allocated :class:`Inputs` with zero-initialised arrays."""
+        d, rg = self._device, self._requires_grad
+        inputs = ControllerJointImpedanceModelFree.Inputs()
+        inputs.joint_q = wp.zeros(_idx_max(self._q_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qd = wp.zeros(_idx_max(self._qd_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_q_des = wp.zeros(_idx_max(self._q_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qd_des = wp.zeros(_idx_max(self._qd_des_idx), dtype=wp.float32, device=d, requires_grad=rg)
+        inputs.joint_qdd = wp.zeros(_idx_max(self._qdd_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._has_qdd else None
+        inputs.gravity_force = wp.zeros(_idx_max(self._gravity_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._use_gravity else None
+        inputs.coriolis_force = wp.zeros(_idx_max(self._coriolis_idx), dtype=wp.float32, device=d, requires_grad=rg) if self._use_coriolis else None
         shape_2d = (self._robot_count, self._max_dofs)
-        if self._stiffness_attr is not None:
-            setattr(
-                ns,
-                self._stiffness_attr,
-                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
-            )
-        if self._damping_attr is not None:
-            setattr(
-                ns,
-                self._damping_attr,
-                wp.zeros(shape_2d, dtype=wp.float32, device=self._device, requires_grad=self._requires_grad),
-            )
-        if self._use_inertia:
-            setattr(
-                ns,
-                self._mass_matrix_attr,
-                wp.zeros(
-                    (self._robot_count, self._max_dofs, self._max_dofs),
-                    dtype=wp.float32,
-                    device=self._device,
-                    requires_grad=self._requires_grad,
-                ),
-            )
-        return ns
+        inputs.mass_matrix = wp.zeros((self._robot_count, self._max_dofs, self._max_dofs), dtype=wp.float32, device=d, requires_grad=rg) if self._use_inertia else None
+        inputs.stiffness = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._stiffness_baked is None else None
+        inputs.damping = wp.zeros(shape_2d, dtype=wp.float32, device=d, requires_grad=rg) if self._damping_baked is None else None
+        return inputs
 
-    def output(self) -> SimpleNamespace:
-        """Return a pre-allocated output struct with a flat torque array."""
-        return _allocate_namespace(
-            [(self._f_attr, wp.float32, _idx_max(self._f_idx))],
-            self._device,
-            self._requires_grad,
-        )
+    def output(self) -> Outputs:
+        """Return a pre-allocated :class:`Outputs` with a flat torque array."""
+        outputs = ControllerJointImpedanceModelFree.Outputs()
+        outputs.joint_f = wp.zeros(_idx_max(self._f_idx), dtype=wp.float32, device=self._device, requires_grad=self._requires_grad)
+        return outputs
 
     def compute(
         self,
         *,
-        inputs: Any,
-        outputs: Any,
+        inputs: Inputs,
+        outputs: Outputs,
         dt: float | wp.array[wp.float32],
     ) -> None:
         """Compute one impedance-control step and write joint torques.
 
         Args:
-            inputs: Namespace with flat sim arrays as described in the
-                class docstring. Dynamics fields must be populated by the
-                caller before each call.
-            outputs: Namespace with a flat sim torque array.
+            inputs: Populated :class:`Inputs` struct. Dynamics fields must be
+                filled by the caller before each call.
+            outputs: :class:`Outputs` struct to write torques into.
             dt: Unused. Accepted for API compatibility.
         """
-        stiffness = (
-            self._stiffness_baked if self._stiffness_baked is not None else getattr(inputs, self._stiffness_attr)
-        )
-        damping = self._damping_baked if self._damping_baked is not None else getattr(inputs, self._damping_attr)
+        stiffness = self._stiffness_baked if self._stiffness_baked is not None else inputs.stiffness
+        damping = self._damping_baked if self._damping_baked is not None else inputs.damping
 
         dim2d = (self._robot_count, self._max_dofs)
 
-        def _gather(src_attr, src_idx, dst_2d):
+        def _gather(src, src_idx, dst_2d):
             wp.launch(
                 _gather_dof_kernel,
                 dim=dim2d,
-                inputs=[getattr(inputs, src_attr), src_idx, self._dof_offsets, self._dofs_per_robot],
+                inputs=[src, src_idx, self._dof_offsets, self._dofs_per_robot],
                 outputs=[dst_2d],
                 device=self._device,
             )
 
-        _gather(self._q_attr, self._q_idx, self._q_2d)
-        _gather(self._qd_attr, self._qd_idx, self._qd_2d)
-        _gather(self._q_des_attr, self._q_des_idx, self._q_des_2d)
-        _gather(self._qd_des_attr, self._qd_des_idx, self._qd_des_2d)
+        _gather(inputs.joint_q, self._q_idx, self._q_2d)
+        _gather(inputs.joint_qd, self._qd_idx, self._qd_2d)
+        _gather(inputs.joint_q_des, self._q_des_idx, self._q_des_2d)
+        _gather(inputs.joint_qd_des, self._qd_des_idx, self._qd_des_2d)
         if self._has_qdd:
-            _gather(self._qdd_attr, self._qdd_idx, self._qdd_2d)
+            _gather(inputs.joint_qdd, self._qdd_idx, self._qdd_2d)
         if self._use_gravity:
-            _gather(self._gravity_attr, self._gravity_idx, self._grav_2d)
+            _gather(inputs.gravity_force, self._gravity_idx, self._grav_2d)
         if self._use_coriolis:
-            _gather(self._coriolis_attr, self._coriolis_idx, self._cor_2d)
+            _gather(inputs.coriolis_force, self._coriolis_idx, self._cor_2d)
 
         working_buf = self._acc_buf if self._use_inertia else self._tau_buf
         wp.launch(
@@ -381,7 +339,7 @@ class ControllerJointImpedanceModelFree(Controller):
             wp.launch(
                 _mass_matrix_multiply_kernel,
                 dim=dim2d,
-                inputs=[getattr(inputs, self._mass_matrix_attr), self._acc_buf, self._dofs_per_robot],
+                inputs=[inputs.mass_matrix, self._acc_buf, self._dofs_per_robot],
                 outputs=[self._tau_buf],
                 device=self._device,
             )
@@ -407,6 +365,6 @@ class ControllerJointImpedanceModelFree(Controller):
             _scatter_dof_kernel,
             dim=dim2d,
             inputs=[self._tau_buf, self._f_idx, self._dof_offsets, self._dofs_per_robot],
-            outputs=[getattr(outputs, self._f_attr)],
+            outputs=[outputs.joint_f],
             device=self._device,
         )

--- a/newton/_src/controllers/impl/joint_impedance/model_free.py
+++ b/newton/_src/controllers/impl/joint_impedance/model_free.py
@@ -297,7 +297,7 @@ class ControllerJointImpedanceModelFree(ControllerBase):
         )
         return outputs
 
-    def compute(
+    def step(
         self,
         *,
         inputs: Inputs,

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -32,37 +32,6 @@ def _normalize_indices(
     return idx
 
 
-def _normalize_parameter_port(
-    value: Any,
-    expected_size: int,
-    dtype: Any,
-    device: Any,
-    requires_grad: bool,
-    *,
-    name: str,
-) -> tuple[str | None, wp.array[Any] | None]:
-    """Normalize a parameter-type port.
-
-    - ``str``: live — at step time the controller resolves
-      ``getattr(input, value)`` and reads that array.
-    - ``wp.array``: baked — the controller stores a copy of the supplied
-      array and reads from it each step.
-
-    Returns ``(attr_name, baked_array)`` — exactly one is non-``None``.
-    """
-    if isinstance(value, str):
-        return value, None
-    if isinstance(value, wp.array):
-        if value.size != expected_size:
-            raise ValueError(f"Port '{name}': baked array length {value.size} must equal {expected_size}.")
-        if value.dtype != dtype:
-            raise TypeError(f"Port '{name}': baked array dtype {value.dtype} must equal {dtype}.")
-        baked = wp.zeros(expected_size, dtype=dtype, device=device, requires_grad=requires_grad)
-        wp.copy(baked, value)
-        return None, baked
-    raise TypeError(f"Port '{name}': must be wp.array[{dtype}] or str (attr name); got {type(value).__name__}.")
-
-
 def _allocate_namespace(
     specs: list[tuple[str, Any, int]],
     device: Any,

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal helpers for :mod:`newton.controllers`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import warp as wp
+
+
+def _normalize_indices(
+    idx: Any,
+    default_idx: wp.array[wp.uint32],
+    *,
+    name: str,
+) -> wp.array[wp.uint32]:
+    """Return ``idx`` after validation, or ``default_idx`` if ``idx`` is ``None``."""
+    if idx is None:
+        return default_idx
+
+    if (not isinstance(idx, wp.array)) or (idx.dtype != wp.uint32):
+        raise TypeError(f"Port '{name}': idx must be wp.array[uint32] or None, got {type(idx).__name__}.")
+
+    if idx.size != default_idx.size:
+        raise TypeError(
+            f"Port '{name}': indices must be the same size as default_dof_indices: {idx.size} != {default_idx.size}."
+        )
+
+    return idx
+
+
+def _normalize_parameter_port(
+    value: Any,
+    expected_size: int,
+    dtype: Any,
+    device: Any,
+    requires_grad: bool,
+    *,
+    name: str,
+) -> tuple[str | None, wp.array[Any] | None]:
+    """Normalize a parameter-type port.
+
+    - ``str``: live — at step time the controller resolves
+      ``getattr(input, value)`` and reads that array.
+    - ``wp.array``: baked — the controller stores a copy of the supplied
+      array and reads from it each step.
+
+    Returns ``(attr_name, baked_array)`` — exactly one is non-``None``.
+    """
+    if isinstance(value, str):
+        return value, None
+    if isinstance(value, wp.array):
+        if value.size != expected_size:
+            raise ValueError(f"Port '{name}': baked array length {value.size} must equal {expected_size}.")
+        if value.dtype != dtype:
+            raise TypeError(f"Port '{name}': baked array dtype {value.dtype} must equal {dtype}.")
+        baked = wp.zeros(expected_size, dtype=dtype, device=device, requires_grad=requires_grad)
+        wp.copy(baked, value)
+        return None, baked
+    raise TypeError(f"Port '{name}': must be wp.array[{dtype}] or str (attr name); got {type(value).__name__}.")
+
+
+def _allocate_namespace(
+    specs: list[tuple[str, Any, int]],
+    device: Any,
+    requires_grad: bool,
+) -> SimpleNamespace:
+    """Build a :class:`SimpleNamespace` with one zero-allocated ``wp.array`` per spec.
+
+    Duplicate attr names take the larger size (smaller views are a prefix of the larger).
+    """
+    merged: dict[str, tuple[Any, int]] = {}
+    for attr, dtype, size in specs:
+        if attr in merged:
+            prev_dtype, prev_size = merged[attr]
+            if prev_dtype != dtype:
+                raise TypeError(f"Field '{attr}': two ports declared incompatible dtypes ({prev_dtype} vs {dtype}).")
+            merged[attr] = (dtype, max(prev_size, size))
+        else:
+            merged[attr] = (dtype, size)
+    return SimpleNamespace(
+        **{
+            attr: wp.zeros(size, dtype=dtype, device=device, requires_grad=requires_grad)
+            for attr, (dtype, size) in merged.items()
+        }
+    )

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from typing import Any
 
 import warp as wp
@@ -30,29 +29,3 @@ def _normalize_indices(
         )
 
     return idx
-
-
-def _allocate_namespace(
-    specs: list[tuple[str, Any, int]],
-    device: Any,
-    requires_grad: bool,
-) -> SimpleNamespace:
-    """Build a :class:`SimpleNamespace` with one zero-allocated ``wp.array`` per spec.
-
-    Duplicate attr names take the larger size (smaller views are a prefix of the larger).
-    """
-    merged: dict[str, tuple[Any, int]] = {}
-    for attr, dtype, size in specs:
-        if attr in merged:
-            prev_dtype, prev_size = merged[attr]
-            if prev_dtype != dtype:
-                raise TypeError(f"Field '{attr}': two ports declared incompatible dtypes ({prev_dtype} vs {dtype}).")
-            merged[attr] = (dtype, max(prev_size, size))
-        else:
-            merged[attr] = (dtype, size)
-    return SimpleNamespace(
-        **{
-            attr: wp.zeros(size, dtype=dtype, device=device, requires_grad=requires_grad)
-            for attr, (dtype, size) in merged.items()
-        }
-    )

--- a/newton/_src/controllers/utils.py
+++ b/newton/_src/controllers/utils.py
@@ -24,7 +24,7 @@ def _normalize_indices(
         raise TypeError(f"Port '{name}': idx must be wp.array[uint32] or None, got {type(idx).__name__}.")
 
     if idx.size != default_idx.size:
-        raise TypeError(
+        raise ValueError(
             f"Port '{name}': indices must be the same size as default_dof_indices: {idx.size} != {default_idx.size}."
         )
 

--- a/newton/controllers.py
+++ b/newton/controllers.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPU-accelerated, vectorized control laws for Newton physics simulations.
+
+This module provides standalone controllers that compute joint torques or
+other actuation signals from simulation state. Each controller is a concrete
+subclass of :class:`Controller` and operates on flat 1D arrays matching the
+layout of :class:`~newton.State` fields, making them composable with any
+Newton solver.
+
+.. experimental::
+
+    The controllers API may change without prior notice. Feedback is welcome —
+    please file issues or discussion threads.
+"""
+
+from ._src.controllers import (
+    Controller,
+    ControllerJointImpedance,
+    ControllerJointImpedanceModelFree,
+)
+
+__all__ = [
+    "Controller",
+    "ControllerJointImpedance",
+    "ControllerJointImpedanceModelFree",
+]

--- a/newton/controllers.py
+++ b/newton/controllers.py
@@ -10,9 +10,6 @@ layout of :class:`~newton.State` fields, making them composable with any
 Newton solver.
 
 .. experimental::
-
-    The controllers API may change without prior notice. Feedback is welcome —
-    please file issues or discussion threads.
 """
 
 from ._src.controllers import (

--- a/newton/controllers.py
+++ b/newton/controllers.py
@@ -1,13 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""GPU-accelerated, vectorized control laws for Newton physics simulations.
+"""GPU-accelerated, vectorized control laws.
 
-This module provides standalone controllers that compute joint torques or
-other actuation signals from simulation state. Each controller is a concrete
-subclass of :class:`ControllerBase` and operates on flat 1D arrays matching the
-layout of :class:`~newton.State` fields, making them composable with any
-Newton solver.
+This module provides standalone controllers that compute signals
+for the robot to track. Each controller is a concrete
+subclass of :class:`ControllerBase`.
 
 .. experimental::
 """

--- a/newton/controllers.py
+++ b/newton/controllers.py
@@ -5,7 +5,7 @@
 
 This module provides standalone controllers that compute joint torques or
 other actuation signals from simulation state. Each controller is a concrete
-subclass of :class:`Controller` and operates on flat 1D arrays matching the
+subclass of :class:`ControllerBase` and operates on flat 1D arrays matching the
 layout of :class:`~newton.State` fields, making them composable with any
 Newton solver.
 
@@ -16,13 +16,13 @@ Newton solver.
 """
 
 from ._src.controllers import (
-    Controller,
+    ControllerBase,
     ControllerJointImpedance,
     ControllerJointImpedanceModelFree,
 )
 
 __all__ = [
-    "Controller",
+    "ControllerBase",
     "ControllerJointImpedance",
     "ControllerJointImpedanceModelFree",
 ]

--- a/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
+++ b/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################################################
+# Example Controllers — Heterogeneous Joint Impedance
+#
+# Demonstrates ControllerJointImpedance on a mixed fleet:
+#   Robot A — 3-DOF revolute chain (triple pendulum), left side
+#   Robot B — 1-DOF revolute pendulum, right side
+#
+# Robot A tracks a sinusoidal target with staggered joint phases.
+# Robot B holds upright at q=0.
+# Both robots use model-based impedance (gravity compensation + inertia
+# decoupling computed internally from their respective Newton models).
+#
+# The two robots have different DOF counts, exercising the heterogeneous
+# gather/scatter and per-robot kernel guard paths.
+#
+# Command: python -m newton.examples controller_joint_impedance_heterogeneous
+###########################################################################
+
+import math
+
+import numpy as np
+import warp as wp
+
+import newton
+import newton.examples
+import newton.solvers
+from newton import JointTargetMode
+from newton.controllers import ControllerJointImpedance
+
+# ---------------------------------------------------------------------------
+# Robot geometry
+# ---------------------------------------------------------------------------
+
+LINK_LEN_A = 0.25  # length of each link in robot A [m]
+LINK_LEN_B = 0.45  # length of robot B's single link [m]
+DOFS_A = 3
+DOFS_B = 1
+MAX_DOFS = max(DOFS_A, DOFS_B)  # = 3
+TOTAL_DOFS = DOFS_A + DOFS_B  # = 4
+
+# Gains — shape (2, MAX_DOFS); robot B's columns 1 and 2 are padding (unused)
+KP = np.array([[200.0, 200.0, 200.0], [200.0, 0.0, 0.0]], dtype=np.float32)
+KD = np.array([[20.0, 20.0, 20.0], [20.0, 0.0, 0.0]], dtype=np.float32)
+
+# Sinusoidal target for robot A: each joint offset by π/3
+TARGET_AMP = 0.4  # [rad]
+TARGET_FREQ = 0.4  # [Hz]
+PHASE_A = [0.0, math.pi / 3, 2 * math.pi / 3]
+
+# Continuous rotation for robot B
+ROT_SPEED_B = 1.5  # [rad/s]
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_revolute_chain(builder, n_links, link_len, x_offset, label):
+    """Add an n-link revolute pendulum chain to builder.
+
+    Joints rotate about the Z axis. The first joint is anchored at
+    (x_offset, 0, 0). Each link hangs downward along -Y.
+    """
+    joints = []
+    prev_body = -1
+    for i in range(n_links):
+        body = builder.add_link()
+
+        # Pivot location: world origin for first link, bottom of previous link otherwise.
+        if i == 0:
+            parent_xform = wp.transform(wp.vec3(x_offset, 0.0, 0.0), wp.quat_identity())
+        else:
+            parent_xform = wp.transform(wp.vec3(0.0, -link_len, 0.0), wp.quat_identity())
+
+        j = builder.add_joint_revolute(
+            parent=prev_body,
+            child=body,
+            axis=wp.vec3(0.0, 0.0, 1.0),
+            parent_xform=parent_xform,
+            child_xform=wp.transform_identity(),
+        )
+        joints.append(j)
+
+        # Thin box as the link rod, centred at half the link length below the pivot
+        builder.add_shape_box(
+            body=body,
+            xform=wp.transform(wp.vec3(0.0, -link_len * 0.5, 0.0), wp.quat_identity()),
+            hx=0.02,
+            hy=link_len * 0.5,
+            hz=0.02,
+        )
+
+        prev_body = body
+
+    builder.add_articulation(joints, label=label)
+    return joints
+
+
+# ---------------------------------------------------------------------------
+# Example
+# ---------------------------------------------------------------------------
+
+
+class Example:
+    @staticmethod
+    def create_parser():
+        return newton.examples.create_parser()
+
+    def __init__(self, viewer, args):
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_substeps = 4
+        self.sim_dt = self.frame_dt / self.sim_substeps
+        self.sim_time = 0.0
+        self.viewer = viewer
+        self.device = wp.get_device()
+
+        # ---- Controller model ------------------------------------------------
+        # Both articulations in one builder so ControllerJointImpedance can
+        # derive per-robot DOF counts and run FK/dynamics for both.
+        ctrl_builder = newton.ModelBuilder()
+        _add_revolute_chain(ctrl_builder, DOFS_A, LINK_LEN_A, x_offset=-0.5, label="robot_a")
+        _add_revolute_chain(ctrl_builder, DOFS_B, LINK_LEN_B, x_offset=+0.5, label="robot_b")
+        # ctrl_builder is passed to ControllerJointImpedance; it finalizes it internally.
+
+        # ---- Physics scene ---------------------------------------------------
+        # Identical topology to ctrl_builder, with effort-control mode.
+        scene = newton.ModelBuilder()
+        _add_revolute_chain(scene, DOFS_A, LINK_LEN_A, x_offset=-0.5, label="robot_a")
+        _add_revolute_chain(scene, DOFS_B, LINK_LEN_B, x_offset=+0.5, label="robot_b")
+        scene.add_ground_plane()
+
+        for i in range(TOTAL_DOFS):
+            scene.joint_target_ke[i] = 0.0
+            scene.joint_target_kd[i] = 0.0
+            scene.joint_target_mode[i] = int(JointTargetMode.EFFORT)
+
+        self.model = scene.finalize()
+        self.state_0 = self.model.state()
+        self.state_1 = self.model.state()
+        self.control = self.model.control()
+        newton.eval_fk(self.model, self.model.joint_q, self.model.joint_qd, self.state_0)
+
+        self.solver = newton.solvers.SolverMuJoCo(self.model, disable_contacts=True)
+
+        # ---- Impedance controller --------------------------------------------
+        # default_dof_indices: identity — robot A occupies DOFs 0..2, robot B DOF 3.
+        default_idx = wp.array(np.arange(TOTAL_DOFS, dtype=np.uint32), device=self.device)
+
+        self.controller = ControllerJointImpedance(
+            model_builder=ctrl_builder,
+            default_dof_indices=default_idx,
+            stiffness=wp.array(KP, dtype=wp.float32, device=self.device),
+            damping=wp.array(KD, dtype=wp.float32, device=self.device),
+            use_gravity_compensation=True,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=True,
+            device=self.device,
+        )
+
+        self._input = self.controller.input()
+        self._output = self.controller.output()
+        # Wire torque output directly into the sim control buffer.
+        self._output.joint_f = self.control.joint_f
+
+        # Bind live sim arrays before capture so the graph records the correct
+        # buffer addresses. state_0 holds the current frame result after
+        # sim_substeps (even number), so these pointers remain valid each replay.
+        self._input.joint_q = self.state_0.joint_q
+        self._input.joint_qd = self.state_0.joint_qd
+
+        self._graph = None
+        if self.controller.is_graphable() and self.device.is_cuda:
+            with wp.ScopedCapture() as capture:
+                self._gpu_step()
+            self._graph = capture.graph
+
+        self.viewer.set_model(self.model)
+
+    def _gpu_step(self):
+        """Pure GPU work: controller compute + physics substeps. Safe to graph-capture."""
+        self.controller.compute(self._input, self._output, None, None, self.sim_dt)
+
+        for _ in range(self.sim_substeps):
+            self.state_0.clear_forces()
+            self.solver.step(self.state_0, self.state_1, self.control, None, self.sim_dt)
+            self.state_0, self.state_1 = self.state_1, self.state_0
+
+    def step(self):
+        # Update targets on the CPU — cannot be graph-captured.
+        q_des = np.zeros(TOTAL_DOFS, dtype=np.float32)
+        for k, phase in enumerate(PHASE_A):
+            q_des[k] = TARGET_AMP * math.sin(2 * math.pi * TARGET_FREQ * self.sim_time + phase)
+        q_des[3] = ROT_SPEED_B * self.sim_time  # robot B rotates continuously
+        self._input.joint_q_des.assign(q_des)
+
+        if self._graph:
+            wp.capture_launch(self._graph)
+        else:
+            self._gpu_step()
+
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        self.viewer.begin_frame(self.sim_time)
+        self.viewer.log_state(self.state_0)
+        self.viewer.end_frame()
+
+    def test_final(self):
+        """Verify that both robots are tracking their targets with finite joint positions."""
+        joint_q = self.state_0.joint_q.numpy()
+        assert np.all(np.isfinite(joint_q)), f"joint_q has NaN/Inf: {joint_q}"
+
+        # Robot B (DOF index 3) should be tracking its rotating target.
+        expected_b = ROT_SPEED_B * self.sim_time
+        np.testing.assert_allclose(
+            joint_q[3],
+            expected_b,
+            atol=0.3,
+            err_msg=f"Robot B not tracking target: q={joint_q[3]:.3f}, expected={expected_b:.3f}",
+        )
+
+        # Robot A (DOF indices 0..2) should be within the sinusoidal amplitude range.
+        assert np.all(np.abs(joint_q[:3]) <= TARGET_AMP + 0.3), f"Robot A joints out of expected range: {joint_q[:3]}"
+
+
+if __name__ == "__main__":
+    parser = Example.create_parser()
+    viewer, args = newton.examples.init(parser)
+    newton.examples.run(Example(viewer, args), args)

--- a/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
+++ b/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
@@ -183,7 +183,7 @@ class Example:
 
     def _gpu_step(self):
         """Pure GPU work: controller compute + physics substeps. Safe to graph-capture."""
-        self.controller.compute(self._input, self._output, self.sim_dt)
+        self.controller.compute(inputs=self._input, outputs=self._output, dt=self.sim_dt)
 
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()

--- a/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
+++ b/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
@@ -183,7 +183,7 @@ class Example:
 
     def _gpu_step(self):
         """Pure GPU work: controller compute + physics substeps. Safe to graph-capture."""
-        self.controller.compute(self._input, self._output, None, None, self.sim_dt)
+        self.controller.compute(self._input, self._output, self.sim_dt)
 
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()

--- a/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
+++ b/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
@@ -152,7 +152,7 @@ class Example:
         default_idx = wp.array(np.arange(TOTAL_DOFS, dtype=np.uint32), device=self.device)
 
         self.controller = ControllerJointImpedance(
-            model_builder=ctrl_builder,
+            builder=ctrl_builder,
             default_dof_indices=default_idx,
             stiffness=wp.array(KP, dtype=wp.float32, device=self.device),
             damping=wp.array(KD, dtype=wp.float32, device=self.device),

--- a/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
+++ b/newton/examples/controllers/example_controller_joint_impedance_heterogeneous.py
@@ -182,8 +182,8 @@ class Example:
         self.viewer.set_model(self.model)
 
     def _gpu_step(self):
-        """Pure GPU work: controller compute + physics substeps. Safe to graph-capture."""
-        self.controller.compute(inputs=self._input, outputs=self._output, dt=self.sim_dt)
+        """Pure GPU work: controller step + physics substeps. Safe to graph-capture."""
+        self.controller.step(inputs=self._input, outputs=self._output, dt=self.sim_dt)
 
         for _ in range(self.sim_substeps):
             self.state_0.clear_forces()

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -1,0 +1,613 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ControllerJointImpedance and ControllerJointImpedanceModelFree."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+import newton
+from newton.controllers import ControllerJointImpedance, ControllerJointImpedanceModelFree
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iota(n, device):
+    """Return a wp.array[uint32] of [0, 1, …, n-1]."""
+    return wp.array(np.arange(n, dtype=np.uint32), device=device)
+
+
+def _dofs_arr(dofs_list, device):
+    """Return a wp.array[int32] from a list of per-robot DOF counts."""
+    return wp.array(np.array(dofs_list, dtype=np.int32), device=device)
+
+
+def _gains(num_robots, max_dofs, value, device):
+    """Return a (num_robots, max_dofs) float32 gain array filled with value."""
+    return wp.full((num_robots, max_dofs), value, dtype=wp.float32, device=device)
+
+
+def _flat(data, device):
+    """Return a flat float32 Warp array from any array-like."""
+    return wp.array(np.array(data, dtype=np.float32).flatten(), dtype=wp.float32, device=device)
+
+
+def _build_single_prismatic():
+    """Build a one-robot, one-DOF prismatic-joint ModelBuilder."""
+    builder = newton.ModelBuilder()
+    link = builder.add_link()
+    j = builder.add_joint_prismatic(
+        parent=-1,
+        child=link,
+        axis=wp.vec3(1.0, 0.0, 0.0),
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([j], label="robot")
+    return builder
+
+
+def _build_two_robot_mixed():
+    """Build a ModelBuilder with robot 0 (2 revolute DOFs) and robot 1 (1 prismatic DOF)."""
+    builder = newton.ModelBuilder()
+    # Robot 0: 2-DOF revolute chain
+    l0a = builder.add_link()
+    l0b = builder.add_link()
+    j0a = builder.add_joint_revolute(
+        parent=-1,
+        child=l0a,
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    j0b = builder.add_joint_revolute(
+        parent=l0a,
+        child=l0b,
+        axis=wp.vec3(0.0, 0.0, 1.0),
+        parent_xform=wp.transform(p=wp.vec3(1.0, 0.0, 0.0)),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([j0a, j0b], label="robot0")
+    # Robot 1: 1-DOF prismatic
+    l1 = builder.add_link()
+    j1 = builder.add_joint_prismatic(
+        parent=-1,
+        child=l1,
+        axis=wp.vec3(1.0, 0.0, 0.0),
+        parent_xform=wp.transform_identity(),
+        child_xform=wp.transform_identity(),
+    )
+    builder.add_articulation([j1], label="robot1")
+    return builder
+
+
+def _make_mf(
+    *,
+    num_robots,
+    dofs_list,
+    kp,
+    kd,
+    device,
+    use_gravity=False,
+    use_coriolis=False,
+    use_inertia=False,
+    has_qdd=False,
+):
+    """Construct a ControllerJointImpedanceModelFree with identity indices."""
+    max_dofs = max(dofs_list)
+    total_dofs = sum(dofs_list)
+    return ControllerJointImpedanceModelFree(
+        num_robots=num_robots,
+        dofs_per_robot=_dofs_arr(dofs_list, device),
+        max_dofs=max_dofs,
+        default_dof_indices=_iota(total_dofs, device),
+        stiffness=_gains(num_robots, max_dofs, kp, device),
+        damping=_gains(num_robots, max_dofs, kd, device),
+        use_gravity_compensation=use_gravity,
+        use_coriolis_compensation=use_coriolis,
+        use_inertia_decoupling=use_inertia,
+        has_qdd_feedforward=has_qdd,
+        device=device,
+    )
+
+
+def _run_mf(ctrl, *, q, qd, q_des, qd_des, device, **extras):
+    """Run one compute step on a ModelFree controller and return the torque array."""
+    ins = ctrl.input()
+    ins.joint_q = _flat(q, device)
+    ins.joint_qd = _flat(qd, device)
+    ins.joint_q_des = _flat(q_des, device)
+    ins.joint_qd_des = _flat(qd_des, device)
+    for k, v in extras.items():
+        setattr(ins, k, v)
+    outs = ctrl.output()
+    ctrl.compute(ins, outs, None, None, 0.01)
+    return outs.joint_f.numpy()
+
+
+# ---------------------------------------------------------------------------
+# ControllerJointImpedanceModelFree — homogeneous
+# ---------------------------------------------------------------------------
+
+
+class TestControllerJointImpedanceModelFree(unittest.TestCase):
+    def test_zero_error_gives_zero_torque(self):
+        """Verify that zero position and velocity error produces zero torque."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=10.0, kd=1.0, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.1, 0.2, 0.3], qd=[0.0, 0.0, 0.0], q_des=[0.1, 0.2, 0.3], qd_des=[0.0, 0.0, 0.0], device=device
+        )
+        np.testing.assert_allclose(tau, np.zeros(3, dtype=np.float32), atol=1e-5)
+
+    def test_position_error_produces_stiffness_torque(self):
+        """Verify τ = Kp * (q_des - q) when Kd=0."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=5.0, kd=0.0, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[1.0, 0.0, 0.0], qd_des=[0.0, 0.0, 0.0], device=device
+        )
+        np.testing.assert_allclose(tau, [5.0, 0.0, 0.0], atol=1e-5)
+
+    def test_velocity_error_produces_damping_torque(self):
+        """Verify τ = Kd * (qd_des - qd) when Kp=0."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=0.0, kd=2.0, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[0.0, 0.0, 0.0], qd_des=[0.0, 1.0, 0.0], device=device
+        )
+        np.testing.assert_allclose(tau, [0.0, 2.0, 0.0], atol=1e-5)
+
+    def test_multiple_robots_independent(self):
+        """Verify that torques for each robot depend only on that robot's error."""
+        device = wp.get_device()
+        num_robots, num_dofs = 3, 2
+        ctrl = _make_mf(num_robots=num_robots, dofs_list=[num_dofs] * num_robots, kp=1.0, kd=0.0, device=device)
+        q_des = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
+        q = np.zeros((num_robots, num_dofs), dtype=np.float32)
+        tau = _run_mf(ctrl, q=q, qd=q * 0, q_des=q_des, qd_des=q * 0, device=device)
+        np.testing.assert_allclose(tau, q_des.flatten(), atol=1e-5)
+
+    def test_inertia_decoupling_scales_by_mass_matrix(self):
+        """Verify τ = M @ (Kp * Δq) when use_inertia_decoupling=True."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device, use_inertia=True)
+        M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 2.0, dtype=wp.float32, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[1.0, 1.0], qd_des=[0.0, 0.0], device=device, mass_matrix=M
+        )
+        np.testing.assert_allclose(tau, [2.0, 2.0], atol=1e-5)
+
+    def test_gravity_compensation_adds_to_tau(self):
+        """Verify gravity_force is added to τ when use_gravity_compensation=True."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_gravity=True)
+        grav = wp.array([3.0, 4.0], dtype=wp.float32, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, gravity_force=grav
+        )
+        np.testing.assert_allclose(tau, [3.0, 4.0], atol=1e-5)
+
+    def test_coriolis_compensation_adds_to_tau(self):
+        """Verify coriolis_force is added to τ when use_coriolis_compensation=True."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_coriolis=True)
+        cor = wp.array([1.0, -1.0], dtype=wp.float32, device=device)
+        tau = _run_mf(
+            ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, coriolis_force=cor
+        )
+        np.testing.assert_allclose(tau, [1.0, -1.0], atol=1e-5)
+
+    def test_qdd_feedforward_adds_before_inertia(self):
+        """Verify qdd feedforward is included inside M @ (PD + qdd) when use_inertia=True."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_inertia=True, has_qdd=True)
+        M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 3.0, dtype=wp.float32, device=device)
+        qdd = wp.array([1.0, 0.0], dtype=wp.float32, device=device)
+        tau = _run_mf(
+            ctrl,
+            q=[0.0, 0.0],
+            qd=[0.0, 0.0],
+            q_des=[0.0, 0.0],
+            qd_des=[0.0, 0.0],
+            device=device,
+            mass_matrix=M,
+            joint_qdd=qdd,
+        )
+        np.testing.assert_allclose(tau, [3.0, 0.0], atol=1e-5)
+
+    def test_live_stiffness_port(self):
+        """Verify stiffness supplied via a live input attribute is applied correctly."""
+        device = wp.get_device()
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=1,
+            dofs_per_robot=_dofs_arr([2], device),
+            max_dofs=2,
+            default_dof_indices=_iota(2, device),
+            stiffness="kp",
+            damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(2, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(2, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array([2.0, 0.0], dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(2, dtype=wp.float32, device=device)
+        ins.kp = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
+
+    def test_is_not_stateful(self):
+        """Verify the controller reports is_stateful() == False."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        self.assertFalse(ctrl.is_stateful())
+
+    def test_is_graphable(self):
+        """Verify the controller reports is_graphable() == True."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        self.assertTrue(ctrl.is_graphable())
+
+    def test_input_struct_has_required_fields(self):
+        """Verify input() returns a namespace with all declared port fields present."""
+        device = wp.get_device()
+        ctrl = _make_mf(
+            num_robots=1,
+            dofs_list=[3],
+            kp=1.0,
+            kd=0.0,
+            device=device,
+            use_gravity=True,
+            use_coriolis=True,
+            use_inertia=True,
+            has_qdd=True,
+        )
+        ins = ctrl.input()
+        for field in (
+            "joint_q",
+            "joint_qd",
+            "joint_q_des",
+            "joint_qd_des",
+            "joint_qdd",
+            "mass_matrix",
+            "gravity_force",
+            "coriolis_force",
+        ):
+            self.assertTrue(hasattr(ins, field), f"Missing field: {field}")
+
+    def test_output_struct_has_joint_f(self):
+        """Verify output() returns a flat array of size sum(dofs_per_robot)."""
+        device = wp.get_device()
+        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        outs = ctrl.output()
+        self.assertTrue(hasattr(outs, "joint_f"))
+        self.assertEqual(outs.joint_f.shape, (2,))
+
+    def test_custom_output_attr_name(self):
+        """Verify joint_f_attr renames the output field on the output struct."""
+        device = wp.get_device()
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=1,
+            dofs_per_robot=_dofs_arr([2], device),
+            max_dofs=2,
+            default_dof_indices=_iota(2, device),
+            stiffness=wp.ones((1, 2), dtype=wp.float32, device=device),
+            damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
+            joint_f_attr="tau_cmd",
+            device=device,
+        )
+        outs = ctrl.output()
+        self.assertTrue(hasattr(outs, "tau_cmd"))
+        self.assertFalse(hasattr(outs, "joint_f"))
+
+    def test_partial_sim_indices(self):
+        """Verify gather/scatter correctly selects a controller-DOF subset from a larger sim array."""
+        device = wp.get_device()
+        indices = wp.array([1, 3], dtype=wp.uint32, device=device)
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=1,
+            dofs_per_robot=_dofs_arr([2], device),
+            max_dofs=2,
+            default_dof_indices=indices,
+            stiffness=wp.ones((1, 2), dtype=wp.float32, device=device),
+            damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(4, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(4, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array([0.0, 5.0, 0.0, 3.0], dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        result = outs.joint_f.numpy()
+        self.assertAlmostEqual(result[0], 0.0, places=5)
+        self.assertAlmostEqual(result[1], 5.0, places=5)
+        self.assertAlmostEqual(result[2], 0.0, places=5)
+        self.assertAlmostEqual(result[3], 3.0, places=5)
+
+
+# ---------------------------------------------------------------------------
+# ControllerJointImpedanceModelFree — heterogeneous
+# ---------------------------------------------------------------------------
+
+
+class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
+    def test_heterogeneous_pd_torques(self):
+        """Verify PD torques are correct for each robot with different DOF counts."""
+        device = wp.get_device()
+        # Robot 0: 2 DOFs, Kp=5; Robot 1: 1 DOF, Kp=5
+        # Errors: robot0=[1,0], robot1=[2]  →  tau: robot0=[5,0], robot1=[10]
+        dofs_list = [2, 1]
+        max_dofs = 2
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=2,
+            dofs_per_robot=_dofs_arr(dofs_list, device),
+            max_dofs=max_dofs,
+            default_dof_indices=_iota(3, device),  # 2 + 1 = 3 total DOFs
+            stiffness=_gains(2, max_dofs, 5.0, device),
+            damping=_gains(2, max_dofs, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        tau = outs.joint_f.numpy()
+        np.testing.assert_allclose(tau, [5.0, 0.0, 10.0], atol=1e-5)
+
+    def test_heterogeneous_independence(self):
+        """Verify robot 0's torques are zero when only robot 1 has a position error."""
+        device = wp.get_device()
+        dofs_list = [2, 1]
+        max_dofs = 2
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=2,
+            dofs_per_robot=_dofs_arr(dofs_list, device),
+            max_dofs=max_dofs,
+            default_dof_indices=_iota(3, device),
+            stiffness=_gains(2, max_dofs, 1.0, device),
+            damping=_gains(2, max_dofs, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array([0.0, 0.0, 3.0], dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        tau = outs.joint_f.numpy()
+        # Only robot 1's slot (index 2) should be nonzero
+        np.testing.assert_allclose(tau[:2], [0.0, 0.0], atol=1e-5)
+        self.assertAlmostEqual(tau[2], 3.0, places=5)
+
+    def test_heterogeneous_padding_not_scattered(self):
+        """Verify that padded slots never write to the output array."""
+        device = wp.get_device()
+        # Robot 0 has 3 DOFs, robot 1 has 1 DOF (max_dofs=3, padded slots: robot1 dofs 1,2)
+        dofs_list = [3, 1]
+        max_dofs = 3
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=2,
+            dofs_per_robot=_dofs_arr(dofs_list, device),
+            max_dofs=max_dofs,
+            default_dof_indices=_iota(4, device),
+            stiffness=_gains(2, max_dofs, 1.0, device),
+            damping=_gains(2, max_dofs, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        # Large desired values everywhere; only 4 real outputs should be written
+        ins.joint_q = wp.zeros(4, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(4, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.full(4, 99.0, dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        tau = outs.joint_f.numpy()
+        # Exactly 4 real DOFs: all should equal 99
+        self.assertEqual(tau.shape[0], 4)
+        np.testing.assert_allclose(tau, [99.0, 99.0, 99.0, 99.0], atol=1e-5)
+
+    def test_heterogeneous_inertia_decoupling(self):
+        """Verify M @ acc is computed per-robot with heterogeneous DOF counts."""
+        device = wp.get_device()
+        # Robot 0: 2 DOFs, M=2*I; Robot 1: 1 DOF, M=[[3]]
+        # Errors: robot0=[1,1], robot1=[1] →  acc=[1,1] and [1]
+        # tau: robot0 = 2*I @ [1,1] = [2,2], robot1 = [[3]] @ [1] = [3]
+        dofs_list = [2, 1]
+        max_dofs = 2
+        ctrl = ControllerJointImpedanceModelFree(
+            num_robots=2,
+            dofs_per_robot=_dofs_arr(dofs_list, device),
+            max_dofs=max_dofs,
+            default_dof_indices=_iota(3, device),
+            stiffness=_gains(2, max_dofs, 1.0, device),
+            damping=_gains(2, max_dofs, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=True,
+            device=device,
+        )
+        # Mass matrices padded to (2, 2, 2); robot1's second row/col is unused
+        M_np = np.zeros((2, 2, 2), dtype=np.float32)
+        M_np[0] = np.eye(2) * 2.0
+        M_np[1, 0, 0] = 3.0
+        M = wp.array(M_np, dtype=wp.float32, device=device)
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.ones(3, dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.mass_matrix = M
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        tau = outs.joint_f.numpy()
+        np.testing.assert_allclose(tau, [2.0, 2.0, 3.0], atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# ControllerJointImpedance (model-based)
+# ---------------------------------------------------------------------------
+
+
+class TestControllerJointImpedance(unittest.TestCase):
+    def _make_ctrl(self, device, *, kp=10.0, kd=1.0, use_inertia=False):
+        """Build a ControllerJointImpedance for a single prismatic robot."""
+        builder = _build_single_prismatic()
+        return ControllerJointImpedance(
+            model_builder=builder,
+            default_dof_indices=_iota(1, device),
+            stiffness=_gains(1, 1, kp, device),
+            damping=_gains(1, 1, kd, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=use_inertia,
+            device=device,
+        )
+
+    def _run(self, ctrl, *, q_sim, qd_sim, q_des_sim, qd_des_sim, device):
+        """Run one compute step and return the torque array."""
+        ins = ctrl.input()
+        ins.joint_q = wp.array(np.array(q_sim, dtype=np.float32), dtype=wp.float32, device=device)
+        ins.joint_qd = wp.array(np.array(qd_sim, dtype=np.float32), dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array(np.array(q_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.array(np.array(qd_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        return outs.joint_f.numpy()
+
+    def test_zero_error_gives_zero_torque(self):
+        """Verify zero position and velocity error produces zero torque."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device)
+        tau = self._run(ctrl, q_sim=[0.5], qd_sim=[0.0], q_des_sim=[0.5], qd_des_sim=[0.0], device=device)
+        np.testing.assert_allclose(tau, [0.0], atol=1e-4)
+
+    def test_position_error_produces_stiffness_torque(self):
+        """Verify τ = Kp * (q_des - q) for a simple prismatic robot."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device, kp=5.0, kd=0.0)
+        tau = self._run(ctrl, q_sim=[0.0], qd_sim=[0.0], q_des_sim=[1.0], qd_des_sim=[0.0], device=device)
+        np.testing.assert_allclose(tau, [5.0], atol=1e-4)
+
+    def test_damping_term(self):
+        """Verify τ = Kd * (qd_des - qd) when Kp=0."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device, kp=0.0, kd=3.0)
+        tau = self._run(ctrl, q_sim=[0.0], qd_sim=[0.0], q_des_sim=[0.0], qd_des_sim=[2.0], device=device)
+        np.testing.assert_allclose(tau, [6.0], atol=1e-4)
+
+    def test_is_stateful_false(self):
+        """Verify is_stateful() returns False."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device)
+        self.assertFalse(ctrl.is_stateful())
+
+    def test_is_graphable_true(self):
+        """Verify is_graphable() returns True."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device)
+        self.assertTrue(ctrl.is_graphable())
+
+    def test_non_scalar_joint_type_raises(self):
+        """Verify that a model containing a non-1-DOF joint type raises ValueError."""
+        device = wp.get_device()
+        builder = newton.ModelBuilder()
+        link = builder.add_link()
+        j = builder.add_joint_ball(
+            parent=-1,
+            child=link,
+            parent_xform=wp.transform_identity(),
+            child_xform=wp.transform_identity(),
+        )
+        builder.add_articulation([j], label="ball_robot")
+        with self.assertRaises(ValueError):
+            ControllerJointImpedance(
+                model_builder=builder,
+                default_dof_indices=_iota(3, device),  # ball joint has 3 DOFs
+                stiffness=_gains(1, 3, 1.0, device),
+                damping=_gains(1, 3, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                device=device,
+            )
+
+    def test_wrong_index_length_raises(self):
+        """Verify that a mismatched default_dof_indices length raises ValueError."""
+        device = wp.get_device()
+        builder = _build_single_prismatic()
+        with self.assertRaises(ValueError):
+            ControllerJointImpedance(
+                model_builder=builder,
+                default_dof_indices=_iota(5, device),
+                stiffness=_gains(1, 1, 1.0, device),
+                damping=_gains(1, 1, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                device=device,
+            )
+
+    def test_input_output_struct_shapes(self):
+        """Verify input/output struct arrays have the expected flat shapes."""
+        device = wp.get_device()
+        ctrl = self._make_ctrl(device)
+        ins = ctrl.input()
+        outs = ctrl.output()
+        self.assertEqual(ins.joint_q.shape, (1,))
+        self.assertEqual(outs.joint_f.shape, (1,))
+
+    def test_heterogeneous_model(self):
+        """Verify model-based controller works with a heterogeneous two-robot fleet."""
+        device = wp.get_device()
+        builder = _build_two_robot_mixed()  # robot0: 2 DOFs, robot1: 1 DOF
+        max_dofs = 2
+        ctrl = ControllerJointImpedance(
+            model_builder=builder,
+            default_dof_indices=_iota(3, device),  # 2 + 1 total DOFs
+            stiffness=_gains(2, max_dofs, 4.0, device),
+            damping=_gains(2, max_dofs, 0.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            use_inertia_decoupling=False,
+            device=device,
+        )
+        ins = ctrl.input()
+        ins.joint_q = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_qd = wp.zeros(3, dtype=wp.float32, device=device)
+        ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
+        ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
+        outs = ctrl.output()
+        ctrl.compute(ins, outs, None, None, 0.01)
+        tau = outs.joint_f.numpy()
+        # robot0 DOF0: 4*1=4, robot0 DOF1: 4*0=0, robot1 DOF0: 4*2=8
+        np.testing.assert_allclose(tau, [4.0, 0.0, 8.0], atol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -245,11 +245,11 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ctrl.compute(ins, outs, None, None, 0.01)
         np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
 
-    def test_is_not_stateful(self):
-        """Verify the controller reports is_stateful() == False."""
+    def test_is_stateless(self):
+        """Verify state() returns None (controller is stateless)."""
         device = wp.get_device()
         ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
-        self.assertFalse(ctrl.is_stateful())
+        self.assertIsNone(ctrl.state())
 
     def test_is_graphable(self):
         """Verify the controller reports is_graphable() == True."""
@@ -337,6 +337,25 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         self.assertAlmostEqual(result[1], 5.0, places=5)
         self.assertAlmostEqual(result[2], 0.0, places=5)
         self.assertAlmostEqual(result[3], 3.0, places=5)
+
+    def test_duplicate_output_indices_raises(self):
+        """Verify that overlapping scatter indices raise ValueError at construction."""
+        device = wp.get_device()
+        # Two robots, both claiming DOF slot 0 as their output — undefined scatter behaviour.
+        duplicate_indices = wp.array([0, 0], dtype=wp.uint32, device=device)
+        with self.assertRaises(ValueError):
+            ControllerJointImpedanceModelFree(
+                num_robots=2,
+                dofs_per_robot=_dofs_arr([1, 1], device),
+                max_dofs=1,
+                default_dof_indices=duplicate_indices,
+                stiffness=_gains(2, 1, 1.0, device),
+                damping=_gains(2, 1, 0.0, device),
+                use_gravity_compensation=False,
+                use_coriolis_compensation=False,
+                use_inertia_decoupling=False,
+                device=device,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -523,11 +542,11 @@ class TestControllerJointImpedance(unittest.TestCase):
         tau = self._run(ctrl, q_sim=[0.0], qd_sim=[0.0], q_des_sim=[0.0], qd_des_sim=[2.0], device=device)
         np.testing.assert_allclose(tau, [6.0], atol=1e-4)
 
-    def test_is_stateful_false(self):
-        """Verify is_stateful() returns False."""
+    def test_is_stateless(self):
+        """Verify state() returns None (controller is stateless)."""
         device = wp.get_device()
         ctrl = self._make_ctrl(device)
-        self.assertFalse(ctrl.is_stateful())
+        self.assertIsNone(ctrl.state())
 
     def test_is_graphable_true(self):
         """Verify is_graphable() returns True."""
@@ -535,8 +554,8 @@ class TestControllerJointImpedance(unittest.TestCase):
         ctrl = self._make_ctrl(device)
         self.assertTrue(ctrl.is_graphable())
 
-    def test_non_scalar_joint_type_raises(self):
-        """Verify that a model containing a non-1-DOF joint type raises ValueError."""
+    def test_ball_joint_raises(self):
+        """Verify that a multi-DOF ball joint raises ValueError."""
         device = wp.get_device()
         builder = newton.ModelBuilder()
         link = builder.add_link()
@@ -550,13 +569,45 @@ class TestControllerJointImpedance(unittest.TestCase):
         with self.assertRaises(ValueError):
             ControllerJointImpedance(
                 model_builder=builder,
-                default_dof_indices=_iota(3, device),  # ball joint has 3 DOFs
+                default_dof_indices=_iota(3, device),
                 stiffness=_gains(1, 3, 1.0, device),
                 damping=_gains(1, 3, 0.0, device),
                 use_gravity_compensation=False,
                 use_coriolis_compensation=False,
                 device=device,
             )
+
+    def test_fixed_joint_allowed(self):
+        """Verify that fixed joints (zero DOF) are accepted alongside revolute/prismatic joints."""
+        device = wp.get_device()
+        builder = newton.ModelBuilder()
+        base = builder.add_link()
+        arm = builder.add_link()
+        j_fixed = builder.add_joint_fixed(
+            parent=-1,
+            child=base,
+            parent_xform=wp.transform_identity(),
+            child_xform=wp.transform_identity(),
+        )
+        j_rev = builder.add_joint_revolute(
+            parent=base,
+            child=arm,
+            axis=wp.vec3(0.0, 0.0, 1.0),
+            parent_xform=wp.transform_identity(),
+            child_xform=wp.transform_identity(),
+        )
+        builder.add_articulation([j_fixed, j_rev], label="robot")
+        # Should not raise — fixed joint is zero-DOF and irrelevant to the PD term.
+        ctrl = ControllerJointImpedance(
+            model_builder=builder,
+            default_dof_indices=_iota(1, device),
+            stiffness=_gains(1, 1, 10.0, device),
+            damping=_gains(1, 1, 1.0, device),
+            use_gravity_compensation=False,
+            use_coriolis_compensation=False,
+            device=device,
+        )
+        self.assertIsNotNone(ctrl)
 
     def test_wrong_index_length_raises(self):
         """Verify that a mismatched default_dof_indices length raises ValueError."""

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -125,7 +125,7 @@ def _run_mf(ctrl, *, q, qd, q_des, qd_des, device, **extras):
     for k, v in extras.items():
         setattr(ins, k, v)
     outs = ctrl.output()
-    ctrl.compute(ins, outs, None, None, 0.01)
+    ctrl.compute(ins, outs, 0.01)
     return outs.joint_f.numpy()
 
 
@@ -242,14 +242,8 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(2, dtype=wp.float32, device=device)
         ins.kp = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
-
-    def test_is_stateless(self):
-        """Verify state() returns None (controller is stateless)."""
-        device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
-        self.assertIsNone(ctrl.state())
 
     def test_is_graphable(self):
         """Verify the controller reports is_graphable() == True."""
@@ -257,7 +251,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
         self.assertTrue(ctrl.is_graphable())
 
-    def test_input_struct_has_required_fields(self):
+    def test_inputs_has_required_fields(self):
         """Verify input() returns a namespace with all declared port fields present."""
         device = wp.get_device()
         ctrl = _make_mf(
@@ -284,7 +278,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ):
             self.assertTrue(hasattr(ins, field), f"Missing field: {field}")
 
-    def test_output_struct_has_joint_f(self):
+    def test_outputs_has_joint_f(self):
         """Verify output() returns a flat array of size sum(dofs_per_robot)."""
         device = wp.get_device()
         ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
@@ -331,7 +325,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 5.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         result = outs.joint_f.numpy()
         self.assertAlmostEqual(result[0], 0.0, places=5)
         self.assertAlmostEqual(result[1], 5.0, places=5)
@@ -389,7 +383,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [5.0, 0.0, 10.0], atol=1e-5)
 
@@ -416,7 +410,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         tau = outs.joint_f.numpy()
         # Only robot 1's slot (index 2) should be nonzero
         np.testing.assert_allclose(tau[:2], [0.0, 0.0], atol=1e-5)
@@ -447,7 +441,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.full(4, 99.0, dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         tau = outs.joint_f.numpy()
         # Exactly 4 real DOFs: all should equal 99
         self.assertEqual(tau.shape[0], 4)
@@ -485,7 +479,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         ins.mass_matrix = M
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [2.0, 2.0, 3.0], atol=1e-5)
 
@@ -518,7 +512,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         ins.joint_q_des = wp.array(np.array(q_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.array(np.array(qd_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         return outs.joint_f.numpy()
 
     def test_zero_error_gives_zero_torque(self):
@@ -541,12 +535,6 @@ class TestControllerJointImpedance(unittest.TestCase):
         ctrl = self._make_ctrl(device, kp=0.0, kd=3.0)
         tau = self._run(ctrl, q_sim=[0.0], qd_sim=[0.0], q_des_sim=[0.0], qd_des_sim=[2.0], device=device)
         np.testing.assert_allclose(tau, [6.0], atol=1e-4)
-
-    def test_is_stateless(self):
-        """Verify state() returns None (controller is stateless)."""
-        device = wp.get_device()
-        ctrl = self._make_ctrl(device)
-        self.assertIsNone(ctrl.state())
 
     def test_is_graphable_true(self):
         """Verify is_graphable() returns True."""
@@ -624,7 +612,7 @@ class TestControllerJointImpedance(unittest.TestCase):
                 device=device,
             )
 
-    def test_input_output_struct_shapes(self):
+    def test_input_outputs_shapes(self):
         """Verify input/output struct arrays have the expected flat shapes."""
         device = wp.get_device()
         ctrl = self._make_ctrl(device)
@@ -654,7 +642,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, None, None, 0.01)
+        ctrl.compute(ins, outs, 0.01)
         tau = outs.joint_f.numpy()
         # robot0 DOF0: 4*1=4, robot0 DOF1: 4*0=0, robot1 DOF0: 4*2=8
         np.testing.assert_allclose(tau, [4.0, 0.0, 8.0], atol=1e-4)

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -125,7 +125,7 @@ def _run_mf(ctrl, *, q, qd, q_des, qd_des, device, **extras):
     for k, v in extras.items():
         setattr(ins, k, v)
     outs = ctrl.output()
-    ctrl.compute(ins, outs, 0.01)
+    ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
     return outs.joint_f.numpy()
 
 
@@ -242,7 +242,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(2, dtype=wp.float32, device=device)
         ins.kp = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
 
     def test_is_graphable(self):
@@ -325,7 +325,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 5.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         result = outs.joint_f.numpy()
         self.assertAlmostEqual(result[0], 0.0, places=5)
         self.assertAlmostEqual(result[1], 5.0, places=5)
@@ -383,7 +383,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [5.0, 0.0, 10.0], atol=1e-5)
 
@@ -410,7 +410,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # Only robot 1's slot (index 2) should be nonzero
         np.testing.assert_allclose(tau[:2], [0.0, 0.0], atol=1e-5)
@@ -441,7 +441,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.full(4, 99.0, dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # Exactly 4 real DOFs: all should equal 99
         self.assertEqual(tau.shape[0], 4)
@@ -479,7 +479,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         ins.mass_matrix = M
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [2.0, 2.0, 3.0], atol=1e-5)
 
@@ -512,7 +512,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         ins.joint_q_des = wp.array(np.array(q_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.array(np.array(qd_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         return outs.joint_f.numpy()
 
     def test_zero_error_gives_zero_torque(self):
@@ -642,7 +642,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(ins, outs, 0.01)
+        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # robot0 DOF0: 4*1=4, robot0 DOF1: 4*0=0, robot1 DOF0: 4*2=8
         np.testing.assert_allclose(tau, [4.0, 0.0, 8.0], atol=1e-4)

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -116,7 +116,7 @@ def _make_mf(
 
 
 def _run_mf(ctrl, *, q, qd, q_des, qd_des, device, **extras):
-    """Run one compute step on a ModelFree controller and return the torque array."""
+    """Run one step on a ModelFree controller and return the torque array."""
     ins = ctrl.input()
     ins.joint_q = _flat(q, device)
     ins.joint_qd = _flat(qd, device)
@@ -125,7 +125,7 @@ def _run_mf(ctrl, *, q, qd, q_des, qd_des, device, **extras):
     for k, v in extras.items():
         setattr(ins, k, v)
     outs = ctrl.output()
-    ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+    ctrl.step(inputs=ins, outputs=outs, dt=0.01)
     return outs.joint_f.numpy()
 
 
@@ -242,7 +242,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(2, dtype=wp.float32, device=device)
         ins.stiffness = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
 
     def test_is_graphable(self):
@@ -323,7 +323,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 5.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         result = outs.joint_f.numpy()
         self.assertAlmostEqual(result[0], 0.0, places=5)
         self.assertAlmostEqual(result[1], 5.0, places=5)
@@ -381,7 +381,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [5.0, 0.0, 10.0], atol=1e-5)
 
@@ -408,7 +408,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.array([0.0, 0.0, 3.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # Only robot 1's slot (index 2) should be nonzero
         np.testing.assert_allclose(tau[:2], [0.0, 0.0], atol=1e-5)
@@ -439,7 +439,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_q_des = wp.full(4, 99.0, dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(4, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # Exactly 4 real DOFs: all should equal 99
         self.assertEqual(tau.shape[0], 4)
@@ -477,7 +477,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         ins.mass_matrix = M
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         np.testing.assert_allclose(tau, [2.0, 2.0, 3.0], atol=1e-5)
 
@@ -503,14 +503,14 @@ class TestControllerJointImpedance(unittest.TestCase):
         )
 
     def _run(self, ctrl, *, q_sim, qd_sim, q_des_sim, qd_des_sim, device):
-        """Run one compute step and return the torque array."""
+        """Run one step and return the torque array."""
         ins = ctrl.input()
         ins.joint_q = wp.array(np.array(q_sim, dtype=np.float32), dtype=wp.float32, device=device)
         ins.joint_qd = wp.array(np.array(qd_sim, dtype=np.float32), dtype=wp.float32, device=device)
         ins.joint_q_des = wp.array(np.array(q_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.array(np.array(qd_des_sim, dtype=np.float32), dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         return outs.joint_f.numpy()
 
     def test_zero_error_gives_zero_torque(self):
@@ -640,7 +640,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         ins.joint_q_des = wp.array([1.0, 0.0, 2.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(3, dtype=wp.float32, device=device)
         outs = ctrl.output()
-        ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
+        ctrl.step(inputs=ins, outputs=outs, dt=0.01)
         tau = outs.joint_f.numpy()
         # robot0 DOF0: 4*1=4, robot0 DOF1: 4*0=0, robot1 DOF0: 4*2=8
         np.testing.assert_allclose(tau, [4.0, 0.0, 8.0], atol=1e-4)

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -221,14 +221,14 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         np.testing.assert_allclose(tau, [3.0, 0.0], atol=1e-5)
 
     def test_live_stiffness_port(self):
-        """Verify stiffness supplied via a live input attribute is applied correctly."""
+        """Verify stiffness supplied via inputs.stiffness each step is applied correctly."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
             robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
             max_dofs=2,
             default_dof_indices=_iota(2, device),
-            stiffness="kp",
+            stiffness=None,
             damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
             use_gravity_compensation=False,
             use_coriolis_compensation=False,
@@ -240,7 +240,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         ins.joint_qd = wp.zeros(2, dtype=wp.float32, device=device)
         ins.joint_q_des = wp.array([2.0, 0.0], dtype=wp.float32, device=device)
         ins.joint_qd_des = wp.zeros(2, dtype=wp.float32, device=device)
-        ins.kp = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
+        ins.stiffness = wp.array([[3.0, 3.0]], dtype=wp.float32, device=device)
         outs = ctrl.output()
         ctrl.compute(inputs=ins, outputs=outs, dt=0.01)
         np.testing.assert_allclose(outs.joint_f.numpy(), [6.0, 0.0], atol=1e-5)
@@ -286,8 +286,8 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         self.assertTrue(hasattr(outs, "joint_f"))
         self.assertEqual(outs.joint_f.shape, (2,))
 
-    def test_custom_output_attr_name(self):
-        """Verify joint_f_attr renames the output field on the output struct."""
+    def test_output_has_joint_f(self):
+        """Verify output() always returns a struct with joint_f."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
             robot_count=1,
@@ -296,12 +296,10 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
             default_dof_indices=_iota(2, device),
             stiffness=wp.ones((1, 2), dtype=wp.float32, device=device),
             damping=wp.zeros((1, 2), dtype=wp.float32, device=device),
-            joint_f_attr="tau_cmd",
             device=device,
         )
         outs = ctrl.output()
-        self.assertTrue(hasattr(outs, "tau_cmd"))
-        self.assertFalse(hasattr(outs, "joint_f"))
+        self.assertTrue(hasattr(outs, "joint_f"))
 
     def test_partial_sim_indices(self):
         """Verify gather/scatter correctly selects a controller-DOF subset from a larger sim array."""

--- a/newton/tests/test_controllers_joint_impedance.py
+++ b/newton/tests/test_controllers_joint_impedance.py
@@ -26,9 +26,9 @@ def _dofs_arr(dofs_list, device):
     return wp.array(np.array(dofs_list, dtype=np.int32), device=device)
 
 
-def _gains(num_robots, max_dofs, value, device):
-    """Return a (num_robots, max_dofs) float32 gain array filled with value."""
-    return wp.full((num_robots, max_dofs), value, dtype=wp.float32, device=device)
+def _gains(robot_count, max_dofs, value, device):
+    """Return a (robot_count, max_dofs) float32 gain array filled with value."""
+    return wp.full((robot_count, max_dofs), value, dtype=wp.float32, device=device)
 
 
 def _flat(data, device):
@@ -87,7 +87,7 @@ def _build_two_robot_mixed():
 
 def _make_mf(
     *,
-    num_robots,
+    robot_count,
     dofs_list,
     kp,
     kd,
@@ -101,12 +101,12 @@ def _make_mf(
     max_dofs = max(dofs_list)
     total_dofs = sum(dofs_list)
     return ControllerJointImpedanceModelFree(
-        num_robots=num_robots,
+        robot_count=robot_count,
         dofs_per_robot=_dofs_arr(dofs_list, device),
         max_dofs=max_dofs,
         default_dof_indices=_iota(total_dofs, device),
-        stiffness=_gains(num_robots, max_dofs, kp, device),
-        damping=_gains(num_robots, max_dofs, kd, device),
+        stiffness=_gains(robot_count, max_dofs, kp, device),
+        damping=_gains(robot_count, max_dofs, kd, device),
         use_gravity_compensation=use_gravity,
         use_coriolis_compensation=use_coriolis,
         use_inertia_decoupling=use_inertia,
@@ -138,7 +138,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_zero_error_gives_zero_torque(self):
         """Verify that zero position and velocity error produces zero torque."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=10.0, kd=1.0, device=device)
+        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=10.0, kd=1.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.1, 0.2, 0.3], qd=[0.0, 0.0, 0.0], q_des=[0.1, 0.2, 0.3], qd_des=[0.0, 0.0, 0.0], device=device
         )
@@ -147,7 +147,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_position_error_produces_stiffness_torque(self):
         """Verify τ = Kp * (q_des - q) when Kd=0."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=5.0, kd=0.0, device=device)
+        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=5.0, kd=0.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[1.0, 0.0, 0.0], qd_des=[0.0, 0.0, 0.0], device=device
         )
@@ -156,7 +156,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_velocity_error_produces_damping_torque(self):
         """Verify τ = Kd * (qd_des - qd) when Kp=0."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[3], kp=0.0, kd=2.0, device=device)
+        ctrl = _make_mf(robot_count=1, dofs_list=[3], kp=0.0, kd=2.0, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0, 0.0], qd=[0.0, 0.0, 0.0], q_des=[0.0, 0.0, 0.0], qd_des=[0.0, 1.0, 0.0], device=device
         )
@@ -165,17 +165,17 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_multiple_robots_independent(self):
         """Verify that torques for each robot depend only on that robot's error."""
         device = wp.get_device()
-        num_robots, num_dofs = 3, 2
-        ctrl = _make_mf(num_robots=num_robots, dofs_list=[num_dofs] * num_robots, kp=1.0, kd=0.0, device=device)
+        robot_count, num_dofs = 3, 2
+        ctrl = _make_mf(robot_count=robot_count, dofs_list=[num_dofs] * robot_count, kp=1.0, kd=0.0, device=device)
         q_des = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
-        q = np.zeros((num_robots, num_dofs), dtype=np.float32)
+        q = np.zeros((robot_count, num_dofs), dtype=np.float32)
         tau = _run_mf(ctrl, q=q, qd=q * 0, q_des=q_des, qd_des=q * 0, device=device)
         np.testing.assert_allclose(tau, q_des.flatten(), atol=1e-5)
 
     def test_inertia_decoupling_scales_by_mass_matrix(self):
         """Verify τ = M @ (Kp * Δq) when use_inertia_decoupling=True."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device, use_inertia=True)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device, use_inertia=True)
         M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 2.0, dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[1.0, 1.0], qd_des=[0.0, 0.0], device=device, mass_matrix=M
@@ -185,7 +185,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_gravity_compensation_adds_to_tau(self):
         """Verify gravity_force is added to τ when use_gravity_compensation=True."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_gravity=True)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_gravity=True)
         grav = wp.array([3.0, 4.0], dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, gravity_force=grav
@@ -195,7 +195,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_coriolis_compensation_adds_to_tau(self):
         """Verify coriolis_force is added to τ when use_coriolis_compensation=True."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_coriolis=True)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_coriolis=True)
         cor = wp.array([1.0, -1.0], dtype=wp.float32, device=device)
         tau = _run_mf(
             ctrl, q=[0.0, 0.0], qd=[0.0, 0.0], q_des=[0.0, 0.0], qd_des=[0.0, 0.0], device=device, coriolis_force=cor
@@ -205,7 +205,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_qdd_feedforward_adds_before_inertia(self):
         """Verify qdd feedforward is included inside M @ (PD + qdd) when use_inertia=True."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_inertia=True, has_qdd=True)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=0.0, kd=0.0, device=device, use_inertia=True, has_qdd=True)
         M = wp.array(np.eye(2, dtype=np.float32).reshape(1, 2, 2) * 3.0, dtype=wp.float32, device=device)
         qdd = wp.array([1.0, 0.0], dtype=wp.float32, device=device)
         tau = _run_mf(
@@ -224,7 +224,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         """Verify stiffness supplied via a live input attribute is applied correctly."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=1,
+            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
             max_dofs=2,
             default_dof_indices=_iota(2, device),
@@ -248,14 +248,14 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_is_graphable(self):
         """Verify the controller reports is_graphable() == True."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
         self.assertTrue(ctrl.is_graphable())
 
     def test_inputs_has_required_fields(self):
         """Verify input() returns a namespace with all declared port fields present."""
         device = wp.get_device()
         ctrl = _make_mf(
-            num_robots=1,
+            robot_count=1,
             dofs_list=[3],
             kp=1.0,
             kd=0.0,
@@ -281,7 +281,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
     def test_outputs_has_joint_f(self):
         """Verify output() returns a flat array of size sum(dofs_per_robot)."""
         device = wp.get_device()
-        ctrl = _make_mf(num_robots=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
+        ctrl = _make_mf(robot_count=1, dofs_list=[2], kp=1.0, kd=0.0, device=device)
         outs = ctrl.output()
         self.assertTrue(hasattr(outs, "joint_f"))
         self.assertEqual(outs.joint_f.shape, (2,))
@@ -290,7 +290,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         """Verify joint_f_attr renames the output field on the output struct."""
         device = wp.get_device()
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=1,
+            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
             max_dofs=2,
             default_dof_indices=_iota(2, device),
@@ -308,7 +308,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         device = wp.get_device()
         indices = wp.array([1, 3], dtype=wp.uint32, device=device)
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=1,
+            robot_count=1,
             dofs_per_robot=_dofs_arr([2], device),
             max_dofs=2,
             default_dof_indices=indices,
@@ -339,7 +339,7 @@ class TestControllerJointImpedanceModelFree(unittest.TestCase):
         duplicate_indices = wp.array([0, 0], dtype=wp.uint32, device=device)
         with self.assertRaises(ValueError):
             ControllerJointImpedanceModelFree(
-                num_robots=2,
+                robot_count=2,
                 dofs_per_robot=_dofs_arr([1, 1], device),
                 max_dofs=1,
                 default_dof_indices=duplicate_indices,
@@ -366,7 +366,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=2,
+            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
             max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),  # 2 + 1 = 3 total DOFs
@@ -393,7 +393,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=2,
+            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
             max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),
@@ -423,7 +423,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [3, 1]
         max_dofs = 3
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=2,
+            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
             max_dofs=max_dofs,
             default_dof_indices=_iota(4, device),
@@ -456,7 +456,7 @@ class TestControllerJointImpedanceModelFreeHeterogeneous(unittest.TestCase):
         dofs_list = [2, 1]
         max_dofs = 2
         ctrl = ControllerJointImpedanceModelFree(
-            num_robots=2,
+            robot_count=2,
             dofs_per_robot=_dofs_arr(dofs_list, device),
             max_dofs=max_dofs,
             default_dof_indices=_iota(3, device),
@@ -494,7 +494,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         """Build a ControllerJointImpedance for a single prismatic robot."""
         builder = _build_single_prismatic()
         return ControllerJointImpedance(
-            model_builder=builder,
+            builder=builder,
             default_dof_indices=_iota(1, device),
             stiffness=_gains(1, 1, kp, device),
             damping=_gains(1, 1, kd, device),
@@ -556,7 +556,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         builder.add_articulation([j], label="ball_robot")
         with self.assertRaises(ValueError):
             ControllerJointImpedance(
-                model_builder=builder,
+                builder=builder,
                 default_dof_indices=_iota(3, device),
                 stiffness=_gains(1, 3, 1.0, device),
                 damping=_gains(1, 3, 0.0, device),
@@ -587,7 +587,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         builder.add_articulation([j_fixed, j_rev], label="robot")
         # Should not raise — fixed joint is zero-DOF and irrelevant to the PD term.
         ctrl = ControllerJointImpedance(
-            model_builder=builder,
+            builder=builder,
             default_dof_indices=_iota(1, device),
             stiffness=_gains(1, 1, 10.0, device),
             damping=_gains(1, 1, 1.0, device),
@@ -603,7 +603,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         builder = _build_single_prismatic()
         with self.assertRaises(ValueError):
             ControllerJointImpedance(
-                model_builder=builder,
+                builder=builder,
                 default_dof_indices=_iota(5, device),
                 stiffness=_gains(1, 1, 1.0, device),
                 damping=_gains(1, 1, 0.0, device),
@@ -627,7 +627,7 @@ class TestControllerJointImpedance(unittest.TestCase):
         builder = _build_two_robot_mixed()  # robot0: 2 DOFs, robot1: 1 DOF
         max_dofs = 2
         ctrl = ControllerJointImpedance(
-            model_builder=builder,
+            builder=builder,
             default_dof_indices=_iota(3, device),  # 2 + 1 total DOFs
             stiffness=_gains(2, max_dofs, 4.0, device),
             damping=_gains(2, max_dofs, 0.0, device),

--- a/newton/tests/test_examples.py
+++ b/newton/tests/test_examples.py
@@ -1255,5 +1255,18 @@ add_example_test(
 )
 
 
+class TestControllersExamples(unittest.TestCase):
+    pass
+
+
+add_example_test(
+    TestControllersExamples,
+    name="controllers.example_controller_joint_impedance_heterogeneous",
+    devices=cuda_test_devices,
+    test_options={"num-frames": 120},
+    use_viewer=True,
+)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

<!-- What does this PR change and why?
     Reference any issues closed by this PR with "Closes #1234". -->

Related issue: #3548 

This PR adds the base `Controller` API, and the `ControllerJointImpedance` (both newton model-based and model-free) as a concrete controller implementation.

Follow-up PRs will add more derived `Controller` classes, as per the referenced issue.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

```
uv run --extra dev -m newton.tests -k test_controllers
```

## New feature / API change

```python
import newton
import numpy as np
import warp as wp
from newton.controllers import ControllerJointImpedance

# -- setup --
device = wp.get_device()
robot_count = 512
num_dofs = 7  # e.g. Franka panda

# ControllerJointImpedance takes a separate ModelBuilder (the "controller model")
# distinct from the physics sim model. Both describe the same robot topology.
# Robots may have different DOF counts; only Revolute, Prismatic, and Fixed
# joints are supported.
controller_model = newton.ModelBuilder()
for _ in range(robot_count):
    # ... add_link / add_joint_revolute / add_articulation per robot ...
    pass

# gains: (robot_count, num_dofs) — per-robot, padded to max_dofs for heterogeneous fleets
stiffness = wp.full((robot_count, num_dofs), 100.0, dtype=wp.float32, device=device)
damping   = wp.full((robot_count, num_dofs),  10.0, dtype=wp.float32, device=device)

# identity indices: controller DOFs map 1:1 to the sim's flat joint arrays
dof_indices = wp.array(np.arange(robot_count * num_dofs, dtype=np.uint32), device=device)

ctrl = ControllerJointImpedance(
    controller_model,
    default_dof_indices=dof_indices,
    stiffness=stiffness,
    damping=damping,
    use_gravity_compensation=True,
    use_coriolis_compensation=True,
    use_inertia_decoupling=True,
    device=device,
)

# allocate i/o structs once; reuse each step
inputs = ctrl.input()
outputs = ctrl.output()

# -- sim loop --
model, state = ...  # newton model + sim state

for _ in range(1000):
    # point input fields at live sim arrays (no copy — just rebind the references)
    inputs.joint_q = state.joint_q
    inputs.joint_qd = state.joint_qd
    inputs.joint_q_des = desired_q    # wp.array[wp.float32], shape (robot_count * num_dofs,)
    inputs.joint_qd_des = desired_qd

    ctrl.compute(inputs=inputs, outputs=outputs, dt=dt)

    # write torques into sim control
    state.joint_act = outputs.joint_f

    solver.step(model, state, control, dt)
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new `newton.controllers` public API with a `Controller` base class and GPU-accelerated joint impedance controllers (model-based and model-free).
  * Supports stiffness/damping, optional gravity/Coriolis compensation, inertia decoupling, optional acceleration feedforward, and heterogeneous multi-DOF mappings.
* **Documentation**
  * Added Sphinx API docs for the new controllers and a heterogeneous joint impedance example.
* **Bug Fixes / Changes**
  * Updated the controller step interface to run exactly one compute step using provided inputs/outputs and a `dt` parameter.
* **Tests**
  * Added unit tests for both controllers and an example integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->