### PR TITLE
Load solver backends lazily to speed up `import newton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Compile tiled camera render kernels with CUDA fast math by default for faster rendering; set `SensorTiledCamera.render_config.enable_fast_math = False` for bit-exact, IEEE-precise output.
 - Optimize raycast/raytrace queries by restructuring ray-shape intersection into local-space primitives and compile specialized depth/shadow variants that skip unused surface-normal work (mesh shadows also use any-hit queries).
 - Improve `SolverKamino` GPU simulation and kernel compilation performance.
+- Load solver backends lazily on first access to speed up `import newton`; access solver classes through `newton.solvers` as before, and import solver modules explicitly if module-level side effects are required.
 - Speed up `ModelBuilder.replicate()` for large world counts by merging all copies in one pass; it no longer calls `add_world()` or `add_builder()` per copy, so `ModelBuilder` subclass overrides of those methods are not invoked during replication.
 
 ### Deprecated

--- a/newton/_src/solvers/__init__.py
+++ b/newton/_src/solvers/__init__.py
@@ -5,6 +5,7 @@ import importlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from . import style3d
     from .featherstone import SolverFeatherstone
     from .flags import SolverNotifyFlags
     from .implicit_mpm import SolverImplicitMPM
@@ -27,32 +28,36 @@ __all__ = [
     "SolverStyle3D",
     "SolverVBD",
     "SolverXPBD",
+    "style3d",
 ]
 
-# Maps each public symbol to the submodule that defines it. Symbols are
+# Maps each public symbol to the module that provides it and the attribute to
+# fetch from that module (None returns the module itself). Symbols are
 # resolved on first attribute access (PEP 562) so that importing Newton does
 # not pay the import cost of every solver backend.
-_LAZY_IMPORTS = {
-    "SolverBase": ".solver",
-    "SolverFeatherstone": ".featherstone",
-    "SolverImplicitMPM": ".implicit_mpm",
-    "SolverKamino": ".kamino",
-    "SolverMuJoCo": ".mujoco",
-    "SolverNotifyFlags": ".flags",
-    "SolverSemiImplicit": ".semi_implicit",
-    "SolverStyle3D": ".style3d.solver_style3d",
-    "SolverVBD": ".vbd",
-    "SolverXPBD": ".xpbd",
+_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    "SolverBase": (".solver", "SolverBase"),
+    "SolverFeatherstone": (".featherstone", "SolverFeatherstone"),
+    "SolverImplicitMPM": (".implicit_mpm", "SolverImplicitMPM"),
+    "SolverKamino": (".kamino", "SolverKamino"),
+    "SolverMuJoCo": (".mujoco", "SolverMuJoCo"),
+    "SolverNotifyFlags": (".flags", "SolverNotifyFlags"),
+    "SolverSemiImplicit": (".semi_implicit", "SolverSemiImplicit"),
+    "SolverStyle3D": (".style3d.solver_style3d", "SolverStyle3D"),
+    "SolverVBD": (".vbd", "SolverVBD"),
+    "SolverXPBD": (".xpbd", "SolverXPBD"),
+    "style3d": (".style3d", None),
 }
 
 
 def __getattr__(name: str):
     try:
-        module_name = _LAZY_IMPORTS[name]
+        module_name, attr_name = _LAZY_IMPORTS[name]
     except KeyError:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
 
-    value = getattr(importlib.import_module(module_name, __name__), name)
+    module = importlib.import_module(module_name, __name__)
+    value = module if attr_name is None else getattr(module, attr_name)
     globals()[name] = value
     return value
 

--- a/newton/_src/solvers/__init__.py
+++ b/newton/_src/solvers/__init__.py
@@ -1,16 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-from .featherstone import SolverFeatherstone
-from .flags import SolverNotifyFlags
-from .implicit_mpm import SolverImplicitMPM
-from .kamino import SolverKamino
-from .mujoco import SolverMuJoCo
-from .semi_implicit import SolverSemiImplicit
-from .solver import SolverBase
-from .style3d.solver_style3d import SolverStyle3D
-from .vbd import SolverVBD
-from .xpbd import SolverXPBD
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .featherstone import SolverFeatherstone
+    from .flags import SolverNotifyFlags
+    from .implicit_mpm import SolverImplicitMPM
+    from .kamino import SolverKamino
+    from .mujoco import SolverMuJoCo
+    from .semi_implicit import SolverSemiImplicit
+    from .solver import SolverBase
+    from .style3d.solver_style3d import SolverStyle3D
+    from .vbd import SolverVBD
+    from .xpbd import SolverXPBD
 
 __all__ = [
     "SolverBase",
@@ -24,3 +28,34 @@ __all__ = [
     "SolverVBD",
     "SolverXPBD",
 ]
+
+# Maps each public symbol to the submodule that defines it. Symbols are
+# resolved on first attribute access (PEP 562) so that importing Newton does
+# not pay the import cost of every solver backend.
+_LAZY_IMPORTS = {
+    "SolverBase": ".solver",
+    "SolverFeatherstone": ".featherstone",
+    "SolverImplicitMPM": ".implicit_mpm",
+    "SolverKamino": ".kamino",
+    "SolverMuJoCo": ".mujoco",
+    "SolverNotifyFlags": ".flags",
+    "SolverSemiImplicit": ".semi_implicit",
+    "SolverStyle3D": ".style3d.solver_style3d",
+    "SolverVBD": ".vbd",
+    "SolverXPBD": ".xpbd",
+}
+
+
+def __getattr__(name: str):
+    try:
+        module_name = _LAZY_IMPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    value = getattr(importlib.import_module(module_name, __name__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_IMPORTS))

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -19,71 +19,40 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
 
-from ._src.solvers import coupled as _coupled
+from ._src import solvers as _solvers
 
 if TYPE_CHECKING:
-    from ._src.solvers import (
-        SolverBase,
-        SolverFeatherstone,
-        SolverImplicitMPM,
-        SolverKamino,
-        SolverMuJoCo,
-        SolverNotifyFlags,
-        SolverSemiImplicit,
-        SolverStyle3D,
-        SolverVBD,
-        SolverXPBD,
-        style3d,
-    )
+    from ._src.solvers import *  # noqa: F403
 
-__all__ = [
-    "SolverBase",
-    "SolverFeatherstone",
-    "SolverImplicitMPM",
-    "SolverKamino",
-    "SolverMuJoCo",
-    "SolverNotifyFlags",
-    "SolverSemiImplicit",
-    "SolverStyle3D",
-    "SolverVBD",
-    "SolverXPBD",
-    "experimental",
-    "style3d",
-]
-
-# Maps each public symbol to the module that provides it and the attribute to
-# fetch from that module (None returns the module itself). Symbols are
-# resolved on first attribute access (PEP 562) so that ``import newton`` does
-# not pay the import cost of every solver backend.
-_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
-    "SolverBase": ("._src.solvers", "SolverBase"),
-    "SolverFeatherstone": ("._src.solvers", "SolverFeatherstone"),
-    "SolverImplicitMPM": ("._src.solvers", "SolverImplicitMPM"),
-    "SolverKamino": ("._src.solvers", "SolverKamino"),
-    "SolverMuJoCo": ("._src.solvers", "SolverMuJoCo"),
-    "SolverNotifyFlags": ("._src.solvers", "SolverNotifyFlags"),
-    "SolverSemiImplicit": ("._src.solvers", "SolverSemiImplicit"),
-    "SolverStyle3D": ("._src.solvers", "SolverStyle3D"),
-    "SolverVBD": ("._src.solvers", "SolverVBD"),
-    "SolverXPBD": ("._src.solvers", "SolverXPBD"),
-    "style3d": ("._src.solvers.style3d", None),
-}
+__all__ = [*_solvers.__all__, "experimental"]  # noqa: PLE0604
 
 
 def __getattr__(name: str):
-    try:
-        module_name, attr_name = _LAZY_IMPORTS[name]
-    except KeyError:
+    if name not in __all__:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
 
-    module = importlib.import_module(module_name, __package__)
-    value = module if attr_name is None else getattr(module, attr_name)
+    value = getattr(_solvers, name)
     globals()[name] = value
     return value
 
 
 def __dir__() -> list[str]:
-    return sorted(set(globals()) | set(_LAZY_IMPORTS))
+    return sorted(set(globals()) | set(__all__))
+
+
+class _LazyCoupledModule(ModuleType):
+    def _load(self) -> ModuleType:
+        module = importlib.import_module("._src.solvers.coupled", __package__)
+        experimental.coupled = module
+        sys.modules[self.__name__] = module
+        return module
+
+    def __getattr__(self, name: str):
+        module = self._load()
+        return getattr(module, name)
+
+    def __dir__(self) -> list[str]:
+        return dir(self._load())
 
 
 experimental = ModuleType(f"{__name__}.experimental")
@@ -93,7 +62,7 @@ experimental.__doc__ = """Experimental solver namespaces.
 """
 experimental.__all__ = ["coupled"]
 experimental.__path__ = []
-experimental.coupled = _coupled
+experimental.coupled = _LazyCoupledModule(f"{__name__}.experimental.coupled")
 
 sys.modules[f"{__name__}.experimental"] = experimental
-sys.modules[f"{__name__}.experimental.coupled"] = _coupled
+sys.modules[f"{__name__}.experimental.coupled"] = experimental.coupled

--- a/newton/solvers.py
+++ b/newton/solvers.py
@@ -14,38 +14,27 @@ Installed-wheel users can use the stable hosted guide at
 https://newton-physics.github.io/newton/stable/solvers/index.html.
 """
 
-# solver types
+import importlib
 import sys
 from types import ModuleType
+from typing import TYPE_CHECKING
 
-from ._src.solvers import (
-    SolverBase,
-    SolverFeatherstone,
-    SolverImplicitMPM,
-    SolverKamino,
-    SolverMuJoCo,
-    SolverSemiImplicit,
-    SolverStyle3D,
-    SolverVBD,
-    SolverXPBD,
-    style3d,
-)
 from ._src.solvers import coupled as _coupled
 
-# solver flags
-from ._src.solvers.flags import SolverNotifyFlags
-
-experimental = ModuleType(f"{__name__}.experimental")
-experimental.__doc__ = """Experimental solver namespaces.
-
-.. experimental::
-"""
-experimental.__all__ = ["coupled"]
-experimental.__path__ = []
-experimental.coupled = _coupled
-
-sys.modules[f"{__name__}.experimental"] = experimental
-sys.modules[f"{__name__}.experimental.coupled"] = _coupled
+if TYPE_CHECKING:
+    from ._src.solvers import (
+        SolverBase,
+        SolverFeatherstone,
+        SolverImplicitMPM,
+        SolverKamino,
+        SolverMuJoCo,
+        SolverNotifyFlags,
+        SolverSemiImplicit,
+        SolverStyle3D,
+        SolverVBD,
+        SolverXPBD,
+        style3d,
+    )
 
 __all__ = [
     "SolverBase",
@@ -61,3 +50,50 @@ __all__ = [
     "experimental",
     "style3d",
 ]
+
+# Maps each public symbol to the module that provides it and the attribute to
+# fetch from that module (None returns the module itself). Symbols are
+# resolved on first attribute access (PEP 562) so that ``import newton`` does
+# not pay the import cost of every solver backend.
+_LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
+    "SolverBase": ("._src.solvers", "SolverBase"),
+    "SolverFeatherstone": ("._src.solvers", "SolverFeatherstone"),
+    "SolverImplicitMPM": ("._src.solvers", "SolverImplicitMPM"),
+    "SolverKamino": ("._src.solvers", "SolverKamino"),
+    "SolverMuJoCo": ("._src.solvers", "SolverMuJoCo"),
+    "SolverNotifyFlags": ("._src.solvers", "SolverNotifyFlags"),
+    "SolverSemiImplicit": ("._src.solvers", "SolverSemiImplicit"),
+    "SolverStyle3D": ("._src.solvers", "SolverStyle3D"),
+    "SolverVBD": ("._src.solvers", "SolverVBD"),
+    "SolverXPBD": ("._src.solvers", "SolverXPBD"),
+    "style3d": ("._src.solvers.style3d", None),
+}
+
+
+def __getattr__(name: str):
+    try:
+        module_name, attr_name = _LAZY_IMPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    module = importlib.import_module(module_name, __package__)
+    value = module if attr_name is None else getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_LAZY_IMPORTS))
+
+
+experimental = ModuleType(f"{__name__}.experimental")
+experimental.__doc__ = """Experimental solver namespaces.
+
+.. experimental::
+"""
+experimental.__all__ = ["coupled"]
+experimental.__path__ = []
+experimental.coupled = _coupled
+
+sys.modules[f"{__name__}.experimental"] = experimental
+sys.modules[f"{__name__}.experimental.coupled"] = _coupled

--- a/newton/tests/test_lazy_imports.py
+++ b/newton/tests/test_lazy_imports.py
@@ -6,12 +6,14 @@ import sys
 import unittest
 
 import newton
+from newton._src import solvers as internal_solvers
 
 
 class TestLazySolverImports(unittest.TestCase):
     def test_import_newton_does_not_import_solvers(self):
         """Verify that importing newton does not import any solver backend module."""
         backends = (
+            "coupled",
             "featherstone",
             "implicit_mpm",
             "kamino",
@@ -29,6 +31,10 @@ class TestLazySolverImports(unittest.TestCase):
         )
         result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
         self.assertEqual(result.stdout.strip(), "", f"solver modules imported eagerly: {result.stdout.strip()}")
+
+    def test_public_exports_match_internal_exports(self):
+        """Expose the internal solver surface through the public module."""
+        self.assertEqual(set(newton.solvers.__all__), set(internal_solvers.__all__) | {"experimental"})
 
     def test_lazy_attributes_resolve(self):
         """Verify that every public solver symbol resolves to the implementation object."""

--- a/newton/tests/test_lazy_imports.py
+++ b/newton/tests/test_lazy_imports.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+import unittest
+
+import newton
+
+
+class TestLazySolverImports(unittest.TestCase):
+    def test_import_newton_does_not_import_solvers(self):
+        """Verify that importing newton does not import any solver backend module."""
+        backends = (
+            "featherstone",
+            "implicit_mpm",
+            "kamino",
+            "mujoco",
+            "semi_implicit",
+            "style3d",
+            "vbd",
+            "xpbd",
+        )
+        code = (
+            "import sys; import newton; "
+            f"prefixes = tuple(f'newton._src.solvers.{{name}}' for name in {backends!r}); "
+            "loaded = [m for m in sys.modules if m.startswith(prefixes)]; "
+            "print(','.join(loaded))"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        self.assertEqual(result.stdout.strip(), "", f"solver modules imported eagerly: {result.stdout.strip()}")
+
+    def test_lazy_attributes_resolve(self):
+        """Verify that every public solver symbol resolves to the implementation object."""
+        for name in newton.solvers.__all__:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(newton.solvers, name))
+                self.assertIn(name, dir(newton.solvers))
+        self.assertTrue(issubclass(newton.solvers.SolverSemiImplicit, newton.solvers.SolverBase))
+        with self.assertRaises(AttributeError):
+            _ = newton.solvers.SolverNonexistent
+
+    def test_experimental_coupled_import(self):
+        """Verify that the experimental coupled-solver package imports lazily in a fresh interpreter."""
+        code = (
+            "from newton.solvers.experimental.coupled import SolverCoupled, SolverCoupledProxy; "
+            "import newton.solvers.experimental.coupled as coupled; "
+            "assert coupled.SolverCoupled is SolverCoupled; "
+            "print('ok')"
+        )
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+        self.assertEqual(result.stdout.strip(), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

`import newton` currently takes ~1.35 s, and about 60% of that is spent eagerly importing every solver backend: `newton/__init__.py` imports `newton.solvers`, which imports all solver packages. A user who only needs one solver (e.g. IsaacLab with `SolverMuJoCo`, whose own import cost is ~28 ms) still pays for all of them. Most of the cost is Warp kernel module creation at import time, plus `warp.fem` / `warp.optim` pulled in by `SolverImplicitMPM`.

This PR makes the solver backends load lazily. `newton/solvers.py` and `newton/_src/solvers/__init__.py` now resolve their public symbols on first attribute access via a module-level `__getattr__` ([PEP 562](https://peps.python.org/pep-0562/)), following the pattern already used in `newton/geometry.py`. Each solver is imported the first time it is actually referenced.

With this change, `import newton` drops from **~1.35 s to ~0.58 s** (warm cache, Python 3.12, Linux), and importing a single solver no longer imports the others.

Nothing changes for users:

- All symbols are still reachable exactly as before (`newton.solvers.SolverMuJoCo`, `from newton.solvers import SolverXPBD`, `newton.solvers.style3d.add_cloth_mesh`, ...), appear in `dir(newton.solvers)`, and are listed in `__all__`.
- The same imports are re-exported under `TYPE_CHECKING`, so IDEs and static type checkers resolve them as before.
- The experimental `newton.solvers.experimental.coupled` namespace keeps its eager registration, so `from newton.solvers.experimental.coupled import SolverCoupled` continues to work unchanged. (Deferring this one too is possible with an import-system hook, but it only costs ~55 ms and is left as a follow-up to keep this change simple.)

The one behavioral difference: code that relies on a solver *module* being loaded as a side effect of `import newton` (without ever referencing the solver) must import that module explicitly. A note was added to the changelog.

Closes #3600

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- New `newton/tests/test_lazy_imports.py` verifies that a fresh `import newton` loads no solver backend module, that every `newton.solvers.__all__` symbol resolves and appears in `dir()`, and that the experimental coupled namespace imports in a fresh interpreter.
- Existing suites exercised locally on GPU:

```
uv run --extra dev -m newton.tests -k test_lazy_imports
uv run --extra dev -m newton.tests -k test_api
uv run --extra dev -m newton.tests -k test_generate_api
uv run --extra dev -m newton.tests -k test_coupled_solver
uv run --extra dev -m newton.tests -k test_admm_coupled_solver
uv run --extra dev -m newton.tests -k test_solver_style3d
uv run --extra dev -m newton.tests -k test_custom_solver
```

- Import-time measurements (median of 5 fresh interpreters, warm cache):

| | before | after |
|---|---:|---:|
| `import newton` | ~1350 ms | ~575 ms |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster `newton` imports by lazily loading solver backends only on first access.

* **Changed**
  * Solver symbols are now resolved dynamically while keeping the same public access via `newton.solvers`.
  * Solver names are improved for discovery (e.g., `dir()`), and non-exported symbols raise `AttributeError`.
  * `newton.solvers.experimental.coupled` is now lazily loaded on demand.

* **Tests**
  * Expanded coverage to verify public-surface consistency and lazy-import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->