### PR TITLE
[Kamino] Propagate model changes to the Kamino FK solver

### DIFF
--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -56,15 +56,19 @@ DEFAULT_LIMIT_V7F = vec7f(FLOAT32_MAX)
 
 
 @wp.func
-def correct_rotational_coord(
-    q_j_in: wp.float32, q_j_ref: wp.float32 = 0.0, q_j_limit: wp.float32 = FLOAT32_MAX
-) -> wp.float32:
+def correct_rotational_coord(q_j_in: wp.float32, q_j_ref: wp.float32 = 0.0) -> wp.float32:
     """
     Corrects a rotational joint coordinate to be as close as possible to a reference coordinate.
     """
-    q_j_in += wp.round((q_j_ref - q_j_in) / wp.tau) * wp.tau  # Note: wp.tau is 2 * pi
-    q_j_in = wp.mod(q_j_in, q_j_limit)
-    return q_j_in
+    return q_j_in + wp.round((q_j_ref - q_j_in) / wp.tau) * wp.tau  # Note: wp.tau is 2 * pi
+
+
+@wp.func
+def correct_rotational_coord_with_limit(
+    q_j_in: wp.float32, q_j_ref: wp.float32 = 0.0, q_j_limit: wp.float32 = FLOAT32_MAX
+) -> wp.float32:
+    """Corrects a rotational coordinate relative to a reference and wraps it within a limit."""
+    return wp.mod(correct_rotational_coord(q_j_in, q_j_ref), q_j_limit)
 
 
 @wp.func
@@ -91,7 +95,7 @@ def correct_joint_coord_free(q_j_in: vec7f, q_j_ref: vec7f, q_j_limit: vec7f = D
 @wp.func
 def correct_joint_coord_revolute(q_j_in: vec1f, q_j_ref: vec1f, q_j_limit: vec1f = DEFAULT_LIMIT_V1F) -> vec1f:
     """Corrects the rotational joint coordinate."""
-    q_j_in[0] = correct_rotational_coord(q_j_in[0], q_j_ref[0], q_j_limit[0])
+    q_j_in[0] = correct_rotational_coord_with_limit(q_j_in[0], q_j_ref[0], q_j_limit[0])
     return q_j_in
 
 
@@ -106,7 +110,7 @@ def correct_joint_coord_cylindrical(
     q_j_in: wp.vec2f, q_j_ref: wp.vec2f, q_j_limit: wp.vec2f = DEFAULT_LIMIT_V2F
 ) -> wp.vec2f:
     """Corrects only the rotational joint coordinate."""
-    q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
+    q_j_in[1] = correct_rotational_coord_with_limit(q_j_in[1], q_j_ref[1], q_j_limit[1])
     return q_j_in
 
 
@@ -115,8 +119,8 @@ def correct_joint_coord_universal(
     q_j_in: wp.vec2f, q_j_ref: wp.vec2f, q_j_limit: wp.vec2f = DEFAULT_LIMIT_V2F
 ) -> wp.vec2f:
     """Corrects each of the two rotational joint coordinates individually."""
-    q_j_in[0] = correct_rotational_coord(q_j_in[0], q_j_ref[0], q_j_limit[0])
-    q_j_in[1] = correct_rotational_coord(q_j_in[1], q_j_ref[1], q_j_limit[1])
+    q_j_in[0] = correct_rotational_coord_with_limit(q_j_in[0], q_j_ref[0], q_j_limit[0])
+    q_j_in[1] = correct_rotational_coord_with_limit(q_j_in[1], q_j_ref[1], q_j_limit[1])
     return q_j_in
 
 

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -15,9 +15,10 @@ from ..core.state import StateKamino
 from ..kinematics.joints import (
     compute_joint_pose_and_relative_motion,
     convert_angular_vel_to_universal_joint_intermediary_frame,
+    correct_quat_vector_coord,
+    correct_rotational_coord,
     get_joint_coords_mapping_function,
 )
-from ..solvers.fk.kernels import _correct_joint_angle, _correct_joint_quaternion
 
 ###
 # Module interface
@@ -59,25 +60,25 @@ def make_correct_joint_coords(dof_type: JointDoFType):
             pass  # No correction needed
 
         elif wp.static(dof_type == JointDoFType.CYLINDRICAL):  # Correct angle up to +/- 2 pi
-            coords[1] = _correct_joint_angle(coords[1], coords_ref[1])
+            coords[1] = correct_rotational_coord(coords[1], coords_ref[1])
 
         elif wp.static(dof_type == JointDoFType.FREE):  # Correct quaternion up to sign
             quat = wp.vec4f(coords[3], coords[4], coords[5], coords[6])
             quat_ref = wp.vec4f(coords_ref[3], coords_ref[4], coords_ref[5], coords_ref[6])
-            quat_corrected = _correct_joint_quaternion(quat, quat_ref)
+            quat_corrected = correct_quat_vector_coord(quat, quat_ref)
             for i in range(4):
                 coords[3 + i] = quat_corrected[i]
 
         elif wp.static(dof_type == JointDoFType.REVOLUTE):  # Correct angle up to +/- 2 pi
-            coords[0] = _correct_joint_angle(coords[0], coords_ref[0])
+            coords[0] = correct_rotational_coord(coords[0], coords_ref[0])
 
         elif wp.static(dof_type == JointDoFType.SPHERICAL):  # Correct quaternion up to sign
             quat_ref = wp.vec4f(coords_ref[0], coords_ref[1], coords_ref[2], coords_ref[3])
-            coords = _correct_joint_quaternion(coords, quat_ref)
+            coords = correct_quat_vector_coord(coords, quat_ref)
 
         elif wp.static(dof_type == JointDoFType.UNIVERSAL):  # Correct angles up to +/- 2 pi
-            coords[0] = _correct_joint_angle(coords[0], coords_ref[0])
-            coords[1] = _correct_joint_angle(coords[1], coords_ref[1])
+            coords[0] = correct_rotational_coord(coords[0], coords_ref[0])
+            coords[1] = correct_rotational_coord(coords[1], coords_ref[1])
 
         return coords
 

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -702,7 +702,13 @@ class SolverKaminoImpl(SolverBase):
 
     @override
     def notify_model_changed(self, flags: ModelFlags | int) -> None:
-        pass  # TODO: Migrate implementation when we fully integrate with Newton
+        if self._solver_fk is not None:
+            self._solver_fk.notify_model_changed(flags)
+
+    def validate_model_changed(self, flags: ModelFlags | int) -> None:
+        """Validate solver-specific structural invariants before model updates."""
+        if self._solver_fk is not None:
+            self._solver_fk.validate_model_changed(flags)
 
     @override
     def update_contacts(self, contacts: Contacts, state: State | None = None) -> None:

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -31,6 +31,9 @@ from .types import FKJointDoFType
 __all__ = [
     "_add_regularizer_to_diagonal",
     "_apply_line_search_step",
+    "_compute_base_q_default",
+    "_compute_fk_axis_joint_frames",
+    "_compute_fk_joint_frames",
     "_correct_actuator_coords",
     "_correct_universal_constraint_velocities",
     "_eval_actuator_coords",
@@ -51,6 +54,7 @@ __all__ = [
     "_newton_check",
     "_reset_state",
     "_reset_state_base_q",
+    "_resolve_fk_actuation_types",
     "_update_cg_tolerance_kernel",
     "create_1d_tile_based_kernels",
     "create_2d_tile_based_kernels",
@@ -59,6 +63,7 @@ __all__ = [
     "create_eval_joint_constraints_sparse_jacobian_kernel",
     "create_eval_min_num_iterations_kernel",
     "read_quat_from_array",
+    "validate_fk_actuation_updates",
 ]
 
 
@@ -94,9 +99,150 @@ def read_quat_from_array(array: wp.array[wp.float32], offset: int, normalize: bo
     return q
 
 
+@wp.func
+def _resolve_fk_actuation_type(act_type: wp.int32, fk_act_flag: wp.int32) -> wp.int32:
+    """Apply an optional FK actuation override to a model actuation type."""
+    if fk_act_flag == 0:
+        return JointActuationType.PASSIVE
+    if fk_act_flag == 1:
+        return JointActuationType.FORCE
+    return act_type
+
+
 ###
 # Kernels
 ###
+
+
+@wp.kernel
+def _resolve_fk_actuation_types(
+    # Inputs
+    model_act_type: wp.array[wp.int32],
+    model_fk_act_flag: wp.array[wp.int32],
+    # Outputs
+    fk_act_type: wp.array[wp.int32],
+):
+    """Resolve effective FK actuation types for the main model joints."""
+    joint = wp.tid()
+    flag = wp.int32(-1)
+    if model_fk_act_flag:
+        flag = model_fk_act_flag[joint]
+    fk_act_type[joint] = _resolve_fk_actuation_type(model_act_type[joint], flag)
+
+
+@wp.kernel
+def validate_fk_actuation_updates(
+    # Inputs
+    model_act_type: wp.array[wp.int32],
+    model_fk_act_flag: wp.array[wp.int32],
+    built_fk_actuated: wp.array[wp.int32],
+    # Outputs
+    violations: wp.array[wp.int32],
+):
+    """Find invalid FK overrides and changes to the effective actuation partition."""
+    joint = wp.tid()
+    flag = wp.int32(-1)
+    if model_fk_act_flag:
+        flag = model_fk_act_flag[joint]
+        if flag < -1 or flag > 1:
+            wp.atomic_min(violations, 1, joint)
+            return
+
+    act_type = _resolve_fk_actuation_type(model_act_type[joint], flag)
+    if (act_type != JointActuationType.PASSIVE) != (built_fk_actuated[joint] != 0):
+        wp.atomic_min(violations, 0, joint)
+
+
+@wp.kernel
+def _compute_fk_joint_frames(
+    # Inputs
+    source_joint: wp.array[wp.int32],
+    model_B_r_Bj: wp.array[wp.vec3f],
+    model_F_r_Fj: wp.array[wp.vec3f],
+    model_X_Bj: wp.array[wp.mat33f],
+    model_X_Fj: wp.array[wp.mat33f],
+    # Outputs
+    fk_B_r_Bj: wp.array[wp.vec3f],
+    fk_F_r_Fj: wp.array[wp.vec3f],
+    fk_X_Bj: wp.array[wp.mat33f],
+    fk_X_Fj: wp.array[wp.mat33f],
+):
+    """Compute FK joint frames from the current model data."""
+    fk_joint = wp.tid()
+    model_joint = source_joint[fk_joint]
+    if model_joint >= 0:
+        fk_B_r_Bj[fk_joint] = model_B_r_Bj[model_joint]
+        fk_F_r_Fj[fk_joint] = model_F_r_Fj[model_joint]
+        fk_X_Bj[fk_joint] = model_X_Bj[model_joint]
+        fk_X_Fj[fk_joint] = model_X_Fj[model_joint]
+    else:
+        fk_B_r_Bj[fk_joint] = wp.vec3f(0.0)
+        fk_F_r_Fj[fk_joint] = wp.vec3f(0.0)
+        identity = wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+        fk_X_Bj[fk_joint] = identity
+        fk_X_Fj[fk_joint] = identity
+
+
+@wp.kernel
+def _compute_fk_axis_joint_frames(
+    # Inputs
+    axis_fk_joint: wp.array[wp.int32],
+    axis_body: wp.array[wp.int32],
+    axis_joint_0: wp.array[wp.int32],
+    axis_joint_1: wp.array[wp.int32],
+    model_joint_bid_B: wp.array[wp.int32],
+    model_joint_B_r_Bj: wp.array[wp.vec3f],
+    model_joint_F_r_Fj: wp.array[wp.vec3f],
+    model_body_q_0: wp.array[wp.transformf],
+    # Outputs
+    fk_X_Bj: wp.array[wp.mat33f],
+    fk_X_Fj: wp.array[wp.mat33f],
+):
+    """Compute synthetic axis-joint frames from the model data."""
+    axis_joint = wp.tid()
+    fk_joint = axis_fk_joint[axis_joint]
+    body = axis_body[axis_joint]
+    joint_0 = axis_joint_0[axis_joint]
+    joint_1 = axis_joint_1[axis_joint]
+    body_q = model_body_q_0[body]
+
+    local_0 = model_joint_F_r_Fj[joint_0]
+    if model_joint_bid_B[joint_0] == body:
+        local_0 = model_joint_B_r_Bj[joint_0]
+    local_1 = model_joint_F_r_Fj[joint_1]
+    if model_joint_bid_B[joint_1] == body:
+        local_1 = model_joint_B_r_Bj[joint_1]
+
+    pos_0 = wp.transform_point(body_q, local_0)
+    pos_1 = wp.transform_point(body_q, local_1)
+    a_x = wp.normalize(pos_1 - pos_0)
+    if wp.abs(a_x[2]) < 0.99:
+        a_y = wp.normalize(wp.cross(wp.vec3f(0.0, 0.0, 1.0), a_x))
+    else:
+        a_y = wp.normalize(wp.cross(wp.vec3f(0.0, 1.0, 0.0), a_x))
+    a_z = wp.normalize(wp.cross(a_x, a_y))
+    X_Bj = wp.matrix_from_cols(a_x, a_y, a_z)
+    fk_X_Bj[fk_joint] = X_Bj
+    fk_X_Fj[fk_joint] = wp.quat_to_matrix(wp.transform_get_rotation(body_q)) * X_Bj
+
+
+@wp.kernel
+def _compute_base_q_default(
+    # Inputs
+    model_base_joint: wp.array[wp.int32],
+    model_base_body: wp.array[wp.int32],
+    model_body_q_0: wp.array[wp.transformf],
+    # Outputs
+    base_q_default: wp.array[wp.transformf],
+):
+    """Compute the default FK base pose from the model data."""
+    world = wp.tid()
+    if model_base_joint[world] >= 0:
+        base_q_default[world] = wp.transform_identity()
+    else:
+        body = model_base_body[world]
+        if body >= 0:
+            base_q_default[world] = model_body_q_0[body]
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -182,9 +182,8 @@ def _compute_fk_joint_frames(
     else:
         fk_B_r_Bj[fk_joint] = wp.vec3f(0.0)
         fk_F_r_Fj[fk_joint] = wp.vec3f(0.0)
-        identity = wp.mat33f(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
-        fk_X_Bj[fk_joint] = identity
-        fk_X_Fj[fk_joint] = identity
+        fk_X_Bj[fk_joint] = wp.identity(n=3, dtype=wp.float32)
+        fk_X_Fj[fk_joint] = wp.identity(n=3, dtype=wp.float32)
 
 
 @wp.kernel

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -20,7 +20,11 @@ from ...core.math import (
     unit_quat_conj_apply_jacobian,
     unit_quat_conj_to_rotation_matrix,
 )
-from ...kinematics.joints import get_joint_coords_mapping_function
+from ...kinematics.joints import (
+    correct_quat_vector_coord,
+    correct_rotational_coord,
+    get_joint_coords_mapping_function,
+)
 from ...linalg.sparse_matrix import BlockDType
 from .types import FKJointDoFType
 
@@ -31,7 +35,6 @@ from .types import FKJointDoFType
 __all__ = [
     "_add_regularizer_to_diagonal",
     "_apply_line_search_step",
-    "_compute_base_q_default",
     "_compute_fk_axis_joint_frames",
     "_compute_fk_joint_frames",
     "_correct_actuator_coords",
@@ -139,7 +142,11 @@ def validate_fk_actuation_updates(
     # Outputs
     violations: wp.array[wp.int32],
 ):
-    """Find invalid FK overrides and changes to the effective actuation partition."""
+    """Find invalid overrides and changes to the set of joints actuated for FK.
+
+    ``built_fk_actuated`` is indexed by model joint: 0 is passive, 1 is
+    actuated, and -1 skips validation for a joint replaced by FK.
+    """
     joint = wp.tid()
     flag = wp.int32(-1)
     if model_fk_act_flag:
@@ -175,11 +182,14 @@ def _compute_fk_joint_frames(
     fk_joint = wp.tid()
     model_joint = source_joint[fk_joint]
     if model_joint >= 0:
+        # Preserve frames for joints copied from the model.
         fk_B_r_Bj[fk_joint] = model_B_r_Bj[model_joint]
         fk_F_r_Fj[fk_joint] = model_F_r_Fj[model_joint]
         fk_X_Bj[fk_joint] = model_X_Bj[model_joint]
         fk_X_Fj[fk_joint] = model_X_Fj[model_joint]
     else:
+        # FK-added base and axis joints start at identity; axis orientations are
+        # overwritten by _compute_fk_axis_joint_frames.
         fk_B_r_Bj[fk_joint] = wp.vec3f(0.0)
         fk_F_r_Fj[fk_joint] = wp.vec3f(0.0)
         fk_X_Bj[fk_joint] = wp.identity(n=3, dtype=wp.float32)
@@ -209,6 +219,7 @@ def _compute_fk_axis_joint_frames(
     joint_1 = axis_joint_1[axis_joint]
     body_q = model_body_q_0[body]
 
+    # Locate both spherical-joint anchors in the tie-rod body frame.
     local_0 = model_joint_F_r_Fj[joint_0]
     if model_joint_bid_B[joint_0] == body:
         local_0 = model_joint_B_r_Bj[joint_0]
@@ -216,6 +227,8 @@ def _compute_fk_axis_joint_frames(
     if model_joint_bid_B[joint_1] == body:
         local_1 = model_joint_B_r_Bj[joint_1]
 
+    # Evaluate the anchors in the initial pose and align the joint X axis with
+    # the line that connects them.
     pos_0 = wp.transform_point(body_q, local_0)
     pos_1 = wp.transform_point(body_q, local_1)
     a_x = wp.normalize(pos_1 - pos_0)
@@ -226,26 +239,8 @@ def _compute_fk_axis_joint_frames(
     a_z = wp.normalize(wp.cross(a_x, a_y))
     X_Bj = wp.matrix_from_cols(a_x, a_y, a_z)
     fk_X_Bj[fk_joint] = X_Bj
+    # Match the follower frame to the base frame in the initial pose.
     fk_X_Fj[fk_joint] = wp.quat_to_matrix(wp.transform_get_rotation(body_q)) * X_Bj
-
-
-@wp.kernel
-def _compute_base_q_default(
-    # Inputs
-    model_base_joint: wp.array[wp.int32],
-    model_base_body: wp.array[wp.int32],
-    model_body_q_0: wp.array[wp.transformf],
-    # Outputs
-    base_q_default: wp.array[wp.transformf],
-):
-    """Compute the default FK base pose from the model data."""
-    world = wp.tid()
-    if model_base_joint[world] >= 0:
-        base_q_default[world] = wp.transform_identity()
-    else:
-        body = model_base_body[world]
-        if body >= 0:
-            base_q_default[world] = model_body_q_0[body]
 
 
 @wp.kernel
@@ -508,20 +503,6 @@ def _eval_actuator_coords(
     _joint_transform_to_coords(dof_type, pos_rel, q_rel, coord_id, actuators_q)
 
 
-@wp.func
-def _correct_joint_angle(angle: wp.float32, angle_ref: wp.float32) -> wp.float32:
-    """Function adding multiples of 2 pi to an angle, so that it is the closest to a reference."""
-    return angle + wp.round((angle_ref - angle) / wp.tau) * wp.tau  # Note: wp.tau is 2 * pi
-
-
-@wp.func
-def _correct_joint_quaternion(quat: wp.vec4f, quat_ref: wp.vec4f) -> wp.vec4f:
-    """Function flipping the sign of a quaternion if needed, so it is the closest to a reference."""
-    if wp.length_sq(quat + quat_ref) < wp.length_sq(quat - quat_ref):
-        return -quat
-    return quat
-
-
 @wp.kernel
 def _correct_actuator_coords(
     # Inputs
@@ -561,7 +542,7 @@ def _correct_actuator_coords(
     elif dof_type == FKJointDoFType.CYLINDRICAL:  # Correct angle up to +/- 2 pi
         angle = actuators_q[coord_id + 1]
         angle_ref = actuators_q_ref[coord_id + 1]
-        actuators_q[coord_id + 1] = _correct_joint_angle(angle, angle_ref)
+        actuators_q[coord_id + 1] = correct_rotational_coord(angle, angle_ref)
     elif dof_type == FKJointDoFType.FREE:  # Correct quaternion up to sign
         quat = wp.vec4f(
             actuators_q[coord_id + 3], actuators_q[coord_id + 4], actuators_q[coord_id + 5], actuators_q[coord_id + 6]
@@ -572,13 +553,13 @@ def _correct_actuator_coords(
             actuators_q_ref[coord_id + 5],
             actuators_q_ref[coord_id + 6],
         )
-        quat_corrected = _correct_joint_quaternion(quat, quat_ref)
+        quat_corrected = correct_quat_vector_coord(quat, quat_ref)
         for i in range(4):
             actuators_q[coord_id + 3 + i] = quat_corrected[i]
     elif dof_type == FKJointDoFType.REVOLUTE:  # Correct angle up to +/- 2 pi
         angle = actuators_q[coord_id]
         angle_ref = actuators_q_ref[coord_id]
-        actuators_q[coord_id] = _correct_joint_angle(angle, angle_ref)
+        actuators_q[coord_id] = correct_rotational_coord(angle, angle_ref)
     elif dof_type == FKJointDoFType.SPHERICAL:  # Correct quaternion up to sign
         quat = wp.vec4f(
             actuators_q[coord_id], actuators_q[coord_id + 1], actuators_q[coord_id + 2], actuators_q[coord_id + 3]
@@ -589,16 +570,16 @@ def _correct_actuator_coords(
             actuators_q_ref[coord_id + 2],
             actuators_q_ref[coord_id + 3],
         )
-        quat_corrected = _correct_joint_quaternion(quat, quat_ref)
+        quat_corrected = correct_quat_vector_coord(quat, quat_ref)
         for i in range(4):
             actuators_q[coord_id + i] = quat_corrected[i]
     elif dof_type == FKJointDoFType.UNIVERSAL:  # Correct angles up to +/- 2 pi
         angle = actuators_q[coord_id]
         angle_ref = actuators_q_ref[coord_id]
-        actuators_q[coord_id] = _correct_joint_angle(angle, angle_ref)
+        actuators_q[coord_id] = correct_rotational_coord(angle, angle_ref)
         angle = actuators_q[coord_id + 1]
         angle_ref = actuators_q_ref[coord_id + 1]
-        actuators_q[coord_id + 1] = _correct_joint_angle(angle, angle_ref)
+        actuators_q[coord_id + 1] = correct_rotational_coord(angle, angle_ref)
     else:
         assert False, "Unexpected actuator dof type"  # noqa: B011
 

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -148,8 +148,12 @@ def validate_fk_actuation_updates(
             wp.atomic_min(violations, 1, joint)
             return
 
+    built_actuated = built_fk_actuated[joint]
+    if built_actuated < 0:
+        return
+
     act_type = _resolve_fk_actuation_type(model_act_type[joint], flag)
-    if (act_type != JointActuationType.PASSIVE) != (built_fk_actuated[joint] != 0):
+    if (act_type != JointActuationType.PASSIVE) != (built_actuated != 0):
         wp.atomic_min(violations, 0, joint)
 
 

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -14,6 +14,7 @@ import sys
 import numpy as np
 import warp as wp
 
+from ......sim import ModelFlags
 from ....config import ForwardKinematicsSolverConfig
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.model import ModelKamino
@@ -32,6 +33,9 @@ from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_cl
 from .kernels import (
     _add_regularizer_to_diagonal,
     _apply_line_search_step,
+    _compute_base_q_default,
+    _compute_fk_axis_joint_frames,
+    _compute_fk_joint_frames,
     _correct_actuator_coords,
     _correct_universal_constraint_velocities,
     _eval_actuator_coords,
@@ -52,6 +56,7 @@ from .kernels import (
     _newton_check,
     _reset_state,
     _reset_state_base_q,
+    _resolve_fk_actuation_types,
     _update_cg_tolerance_kernel,
     create_1d_tile_based_kernels,
     create_2d_tile_based_kernels,
@@ -59,6 +64,7 @@ from .kernels import (
     create_eval_joint_constraints_kernel,
     create_eval_joint_constraints_sparse_jacobian_kernel,
     create_eval_min_num_iterations_kernel,
+    validate_fk_actuation_updates,
 )
 from .types import FKJointDoFType, ForwardKinematicsPreconditionerType, ForwardKinematicsStatus
 
@@ -183,13 +189,34 @@ class ForwardKinematicsSolver:
         first_joint_id_prev = np.concatenate(([0], num_joints_prev.cumsum()))  # Index of first joint per world
 
         # Resolve custom actuation types
-        joints_act_type_prev = self.model.joints.act_type.numpy().copy()
         if self.model.joints.fk_act_flag is not None:
-            joints_fk_act_flag = self.model.joints.fk_act_flag.numpy()
-            mapping = np.array([-1, JointActuationType.PASSIVE, JointActuationType.FORCE])
-            joints_fk_act_type = mapping[joints_fk_act_flag + 1]  # Map 0/1 flags to enum constants
-            overwrite_mask = joints_fk_act_flag != -1
-            joints_act_type_prev[overwrite_mask] = joints_fk_act_type[overwrite_mask]
+            fk_act_flag = self.model.joints.fk_act_flag.numpy()
+            invalid = np.flatnonzero((fk_act_flag < -1) | (fk_act_flag > 1))
+            if invalid.size > 0:
+                joint = int(invalid[0])
+                raise ValueError(f"Invalid FK actuation flag for joint {joint}: expected -1, 0, or 1")
+        resolved_act_type = wp.empty(
+            shape=self.model.size.sum_of_num_joints,
+            dtype=wp.int32,
+            device=self.device,
+        )
+        if self.model.size.sum_of_num_joints > 0:
+            wp.launch(
+                _resolve_fk_actuation_types,
+                dim=self.model.size.sum_of_num_joints,
+                inputs=[
+                    self.model.joints.act_type,
+                    self.model.joints.fk_act_flag,
+                    resolved_act_type,
+                ],
+                device=self.device,
+            )
+        joints_act_type_prev = resolved_act_type.numpy()
+        self._built_fk_actuated = to_warp_int32_array(
+            (joints_act_type_prev != JointActuationType.PASSIVE).astype(np.int32),
+            device=self.device,
+        )
+        self._fk_actuation_violations = wp.empty(2, dtype=wp.int32, device=self.device)
 
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
         if self.model.joints.fk_act_flag is None:
@@ -214,28 +241,23 @@ class ForwardKinematicsSolver:
         joints_dof_type_prev = self.model.joints.dof_type.numpy().copy()
         joints_bid_B_prev = self.model.joints.bid_B.numpy().copy()
         joints_bid_F_prev = self.model.joints.bid_F.numpy().copy()
-        joints_B_r_Bj_prev = self.model.joints.B_r_Bj.numpy().copy()
-        joints_F_r_Fj_prev = self.model.joints.F_r_Fj.numpy().copy()
-        joints_X_Bj_prev = self.model.joints.X_Bj.numpy().copy()
-        joints_X_Fj_prev = self.model.joints.X_Fj.numpy().copy()
         joints_num_coords_prev = self.model.joints.num_coords.numpy().copy()
         joints_num_dofs_prev = self.model.joints.num_dofs.numpy().copy()
         joints_dof_type = []
         joints_act_type = []
         joints_bid_B = []
         joints_bid_F = []
-        joints_B_r_Bj = []
-        joints_F_r_Fj = []
-        joints_X_Bj = []
-        joints_X_Fj = []
         joints_num_actuated_coords = []  # Number of actuated coordinates per joint (0 for passive joints)
         joints_num_actuated_dofs = []  # Number of actuated dofs per joint (0 for passive joints)
+        joints_source_id = []  # Source joint in the main model, or -1 for synthetic joints
+        fk_axis_joint = []  # FK index of each synthetic axis joint
+        fk_axis_body = []  # Body defining each synthetic axis joint
+        fk_axis_source_joint_0 = []  # First source joint defining each synthetic axis joint
+        fk_axis_source_joint_1 = []  # Second source joint defining each synthetic axis joint
         num_joints = np.zeros(self.num_worlds, dtype=np.int32)  # Number of joints per world
         self.num_joints_tot = 0  # Number of joints for all worlds
         actuated_coords_map = []  # Map of new actuated coordinates to these in the model or to the base coordinates
         actuated_dofs_map = []  # Map of new actuated dofs to these in the model or to the base dofs
-        base_q_default = np.zeros(7 * self.num_worlds, dtype=np.float32)  # Default base pose
-        bodies_q_0 = self.model.bodies.q_i_0.numpy()
         base_joint_ids = self.num_worlds * [-1]  # Base joint id per world
         base_joint_ids_input = self.model.info.base_joint_index.numpy().tolist()
         base_body_ids_input = self.model.info.base_body_index.numpy().tolist()
@@ -254,10 +276,7 @@ class ForwardKinematicsSolver:
                 joints_act_type.append(joints_act_type_prev[jt_id_prev])
                 joints_bid_B.append(joints_bid_B_prev[jt_id_prev])
                 joints_bid_F.append(joints_bid_F_prev[jt_id_prev])
-                joints_B_r_Bj.append(joints_B_r_Bj_prev[jt_id_prev])
-                joints_F_r_Fj.append(joints_F_r_Fj_prev[jt_id_prev])
-                joints_X_Bj.append(joints_X_Bj_prev[jt_id_prev])
-                joints_X_Fj.append(joints_X_Fj_prev[jt_id_prev])
+                joints_source_id.append(jt_id_prev)
                 if joints_act_type[-1] != JointActuationType.PASSIVE:
                     num_coords_jt = joints_num_coords_prev[jt_id_prev]
                     joints_num_actuated_coords.append(num_coords_jt)
@@ -299,50 +318,13 @@ class ForwardKinematicsSolver:
                     joints_act_type.append(JointActuationType.PASSIVE)
                     joints_bid_B.append(-1)
                     joints_bid_F.append(rb_id_tot)
-                    joints_B_r_Bj.append(np.zeros(dtype=np.float32, shape=3))
-                    joints_F_r_Fj.append(np.zeros(dtype=np.float32, shape=3))
+                    joints_source_id.append(-1)
+                    fk_axis_joint.append(len(joints_dof_type) - 1)
+                    fk_axis_body.append(rb_id_tot)
+                    fk_axis_source_joint_0.append(spherical_joints_per_body[rb_id][0])
+                    fk_axis_source_joint_1.append(spherical_joints_per_body[rb_id][1])
                     joints_num_actuated_coords.append(0)
                     joints_num_actuated_dofs.append(0)
-
-                    # Compute position of both spherical joints on initial pose
-                    def eval_joint_pos_init(jt_id_prev):
-                        bid_B = joints_bid_B_prev[jt_id_prev]
-                        bid_F = joints_bid_F_prev[jt_id_prev]
-                        if bid_B == rb_id_tot:  # Body is the joint's base  # noqa: B023
-                            q_B = bodies_q_0[bid_B]
-                            B_r_B = joints_B_r_Bj_prev[jt_id_prev]
-                            return q_B[:3] + np.array(wp.quat_rotate(wp.quat(q_B[3:]), wp.vec3f(B_r_B)))
-                        else:  # Body is the joint's follower
-                            assert bid_F == rb_id_tot  # noqa: B023
-                            q_F = bodies_q_0[bid_F]
-                            F_r_F = joints_F_r_Fj_prev[jt_id_prev]
-                            return q_F[:3] + np.array(wp.quat_rotate(wp.quat(q_F[3:]), wp.vec3f(F_r_F)))
-
-                    pos_0 = eval_joint_pos_init(spherical_joints_per_body[rb_id][0])
-                    pos_1 = eval_joint_pos_init(spherical_joints_per_body[rb_id][1])
-
-                    # Joint frame on base = in world coordinates
-                    # Set X axis that connects both spherical joints (= tie rod axis)
-                    a_x = pos_1 - pos_0
-                    a_x /= np.linalg.norm(a_x)
-                    if np.abs(a_x[2]) < 0.99:
-                        a_y = np.cross(np.array([0.0, 0.0, 1.0]), a_x)
-                    else:
-                        a_y = np.cross(np.array([0.0, 1.0, 0.0]), a_x)
-                    a_y /= np.linalg.norm(a_y)
-                    a_z = np.cross(a_x, a_y)
-                    a_z /= np.linalg.norm(a_z)
-                    axis_X_j = np.stack((a_x, a_y, a_z), axis=1)
-                    joints_X_Bj.append(axis_X_j)
-
-                    # Joint frame on follower: set so that matches with frame on base on initial pose
-                    q_F_0 = bodies_q_0[rb_id_tot][3:]
-                    if np.max(np.abs(q_F_0 - np.array([0.0, 0.0, 0.0, 1.0]))) > 1e-8:
-                        R_F_0_wp = wp.quat_to_matrix(wp.quatf(q_F_0))
-                        R_F_0 = np.reshape(np.array(R_F_0_wp), shape=(3, 3))
-                        joints_X_Fj.append(R_F_0 @ axis_X_j)
-                    else:
-                        joints_X_Fj.append(axis_X_j)
 
             # Add joint for base joint / base body
             if base_joint_id >= 0:  # Replace base joint with an actuated free joint
@@ -350,22 +332,10 @@ class ForwardKinematicsSolver:
                 joints_act_type.append(JointActuationType.FORCE)
                 joints_bid_B.append(-1)
                 joints_bid_F.append(joints_bid_F_prev[base_joint_id])
-                joints_B_r_Bj.append(joints_B_r_Bj_prev[base_joint_id])
-                joints_F_r_Fj.append(joints_F_r_Fj_prev[base_joint_id])
-                joints_X_Bj.append(joints_X_Bj_prev[base_joint_id])
-                joints_X_Fj.append(joints_X_Fj_prev[base_joint_id])
+                joints_source_id.append(base_joint_id)
                 joints_num_actuated_coords.append(7)
                 coord_offset = -7 * wd_id - 1  # We encode offsets in base_q negatively with i -> -i - 1
                 actuated_coords_map.extend(range(coord_offset, coord_offset - 7, -1))
-                base_q_default[7 * wd_id : 7 * wd_id + 7] = [
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    0.0,
-                    1.0,
-                ]  # Default to zero of free joint
                 joints_num_actuated_dofs.append(6)
                 dof_offset = -6 * wd_id - 1  # We encode offsets in base_u negatively with i -> -i - 1
                 actuated_dofs_map.extend(range(dof_offset, dof_offset - 6, -1))
@@ -376,17 +346,13 @@ class ForwardKinematicsSolver:
                 joints_act_type.append(JointActuationType.FORCE)
                 joints_bid_B.append(-1)
                 joints_bid_F.append(base_body_id)
-                joints_B_r_Bj.append(np.zeros(3, dtype=np.float32))
-                joints_F_r_Fj.append(np.zeros(3, dtype=np.float32))
-                joints_X_Bj.append(np.eye(3, 3, dtype=np.float32))
-                joints_X_Fj.append(np.eye(3, 3, dtype=np.float32))
+                joints_source_id.append(-1)
                 joints_num_actuated_coords.append(7)
                 # Note: we rely on the initial body orientations being identity
                 # Only then will the corresponding joint coordinates be interpretable as
                 # specifying the absolute base position and orientation
                 coord_offset = -7 * wd_id - 1  # We encode offsets in base_q negatively with i -> -i - 1
                 actuated_coords_map.extend(range(coord_offset, coord_offset - 7, -1))
-                base_q_default[7 * wd_id : 7 * wd_id + 7] = bodies_q_0[base_body_id]  # Default to initial body pose
                 joints_num_actuated_dofs.append(6)
                 dof_offset = -6 * wd_id - 1  # We encode offsets in base_u negatively with i -> -i - 1
                 actuated_dofs_map.extend(range(dof_offset, dof_offset - 6, -1))
@@ -578,15 +544,26 @@ class ForwardKinematicsSolver:
             self.joints_act_type = to_warp_int32_array(joints_act_type)
             self.joints_bid_B = to_warp_int32_array(joints_bid_B)
             self.joints_bid_F = to_warp_int32_array(joints_bid_F)
-            self.joints_B_r_Bj = wp.from_numpy(joints_B_r_Bj, dtype=wp.vec3f)
-            self.joints_F_r_Fj = wp.from_numpy(joints_F_r_Fj, dtype=wp.vec3f)
-            self.joints_X_Bj = wp.from_numpy(joints_X_Bj, dtype=wp.mat33f)
-            self.joints_X_Fj = wp.from_numpy(joints_X_Fj, dtype=wp.mat33f)
+            self.joints_B_r_Bj = wp.empty(self.num_joints_tot, dtype=wp.vec3f)
+            self.joints_F_r_Fj = wp.empty(self.num_joints_tot, dtype=wp.vec3f)
+            self.joints_X_Bj = wp.empty(self.num_joints_tot, dtype=wp.mat33f)
+            self.joints_X_Fj = wp.empty(self.num_joints_tot, dtype=wp.mat33f)
+            self.joints_source_id = to_warp_int32_array(joints_source_id)
+            self.fk_axis_joint = to_warp_int32_array(fk_axis_joint)
+            self.fk_axis_body = to_warp_int32_array(fk_axis_body)
+            self.fk_axis_source_joint_0 = to_warp_int32_array(fk_axis_source_joint_0)
+            self.fk_axis_source_joint_1 = to_warp_int32_array(fk_axis_source_joint_1)
+            self.num_axis_joints = len(fk_axis_joint)
             self.base_joint_id = to_warp_int32_array(base_joint_ids)
 
             # Default base state
-            self.base_q_default = wp.from_numpy(base_q_default, dtype=wp.transformf)
+            self.base_q_default = wp.zeros(shape=self.num_worlds, dtype=wp.transformf)
             self.base_u_default = wp.zeros(shape=(self.num_worlds,), dtype=wp.spatial_vectorf)
+
+            # Initialize mutable model-derived values through the same path used by runtime notifications.
+            self._update_joint_frames()
+            self._update_axis_joint_frames()
+            self._update_base_q_default()
 
             # Line search
             self.max_line_search_iterations = wp.array(dtype=wp.int32, shape=(1,))  # Max iterations
@@ -930,6 +907,120 @@ class ForwardKinematicsSolver:
                 rtol=self.cg_rtol,
                 maxiter=self.cg_max_iter,
             )
+
+    def validate_model_changed(self, flags: ModelFlags | int) -> None:
+        """Validate FK structural invariants before model values are updated.
+
+        Args:
+            flags: Bitmask indicating which model properties changed.
+
+        Raises:
+            RuntimeError: If the effective FK actuation partition changed.
+            ValueError: If an FK actuation override is invalid.
+        """
+        if not flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES):
+            return
+        joint_count = self.model.size.sum_of_num_joints
+        if joint_count == 0:
+            return
+
+        self._fk_actuation_violations.fill_(joint_count)
+        wp.launch(
+            validate_fk_actuation_updates,
+            dim=joint_count,
+            inputs=[
+                self.model.joints.act_type,
+                self.model.joints.fk_act_flag,
+                self._built_fk_actuated,
+                self._fk_actuation_violations,
+            ],
+            device=self.device,
+        )
+        changed_joint, invalid_joint = self._fk_actuation_violations.numpy()
+        if invalid_joint != joint_count:
+            raise ValueError(f"Invalid FK actuation flag for joint {int(invalid_joint)}: expected -1, 0, or 1")
+        if changed_joint != joint_count:
+            raise RuntimeError(
+                f"Changing the FK actuation partition for joint {int(changed_joint)} is not supported; "
+                "recreate SolverKamino to apply the change."
+            )
+
+    def notify_model_changed(self, flags: ModelFlags | int) -> None:
+        """Refresh FK-owned values after an in-place model update.
+
+        Structural changes must be rejected by the owning solver before this
+        method is called. Updates here preserve allocations and pointers.
+
+        Args:
+            flags: Bitmask indicating which model properties changed.
+        """
+        if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
+            self._update_joint_frames()
+
+        if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
+            self._update_axis_joint_frames()
+
+        if flags & (ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
+            self._update_base_q_default()
+
+    def _update_joint_frames(self) -> None:
+        """Compute FK joint frames from the current Kamino model."""
+        if self.num_joints_tot == 0:
+            return
+        wp.launch(
+            _compute_fk_joint_frames,
+            dim=self.num_joints_tot,
+            inputs=[
+                self.joints_source_id,
+                self.model.joints.B_r_Bj,
+                self.model.joints.F_r_Fj,
+                self.model.joints.X_Bj,
+                self.model.joints.X_Fj,
+                self.joints_B_r_Bj,
+                self.joints_F_r_Fj,
+                self.joints_X_Bj,
+                self.joints_X_Fj,
+            ],
+            device=self.device,
+        )
+
+    def _update_axis_joint_frames(self) -> None:
+        """Compute synthetic axis-joint frames from the current model."""
+        if self.num_axis_joints == 0:
+            return
+        wp.launch(
+            _compute_fk_axis_joint_frames,
+            dim=self.num_axis_joints,
+            inputs=[
+                self.fk_axis_joint,
+                self.fk_axis_body,
+                self.fk_axis_source_joint_0,
+                self.fk_axis_source_joint_1,
+                self.model.joints.bid_B,
+                self.model.joints.B_r_Bj,
+                self.model.joints.F_r_Fj,
+                self.model.bodies.q_i_0,
+                self.joints_X_Bj,
+                self.joints_X_Fj,
+            ],
+            device=self.device,
+        )
+
+    def _update_base_q_default(self) -> None:
+        """Compute default FK base poses from the current reference pose."""
+        if self.num_worlds == 0:
+            return
+        wp.launch(
+            _compute_base_q_default,
+            dim=self.num_worlds,
+            inputs=[
+                self.model.info.base_joint_index,
+                self.model.info.base_body_index,
+                self.model.bodies.q_i_0,
+                self.base_q_default,
+            ],
+            device=self.device,
+        )
 
     ###
     # Internal evaluators (graph-capturable functions working on pre-allocated data)

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -212,11 +212,7 @@ class ForwardKinematicsSolver:
                 device=self.device,
             )
         joints_act_type_prev = resolved_act_type.numpy()
-        self._built_fk_actuated = to_warp_int32_array(
-            (joints_act_type_prev != JointActuationType.PASSIVE).astype(np.int32),
-            device=self.device,
-        )
-        self._fk_actuation_violations = wp.empty(2, dtype=wp.int32, device=self.device)
+        built_fk_actuated = (joints_act_type_prev != JointActuationType.PASSIVE).astype(np.int32)
 
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
         if self.model.joints.fk_act_flag is None:
@@ -261,6 +257,12 @@ class ForwardKinematicsSolver:
         base_joint_ids = self.num_worlds * [-1]  # Base joint id per world
         base_joint_ids_input = self.model.info.base_joint_index.numpy().tolist()
         base_body_ids_input = self.model.info.base_body_index.numpy().tolist()
+        for base_joint_id in base_joint_ids_input:
+            if base_joint_id >= 0:
+                # FK always replaces an explicit base joint with an actuated free joint.
+                built_fk_actuated[base_joint_id] = -1
+        self._built_fk_actuated = to_warp_int32_array(built_fk_actuated, device=self.device)
+        self._fk_actuation_violations = wp.empty(2, dtype=wp.int32, device=self.device)
         for wd_id in range(self.num_worlds):
             # Retrieve base joint id
             base_joint_id = base_joint_ids_input[wd_id]

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -19,6 +19,7 @@ from ....config import ForwardKinematicsSolverConfig
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.model import ModelKamino
 from ...core.types import assign_to_warp_int32_array, to_warp_int32_array, vec7f
+from ...kinematics.resets import get_base_q_from_joint_q_and_body_q
 from ...linalg.blas import (
     block_sparse_ATA_blockwise_3_4_inv_diagonal_2d,
     block_sparse_ATA_inv_diagonal_2d,
@@ -33,7 +34,6 @@ from ...utils.world_equivalence import DiscreteSignature, compute_equivalence_cl
 from .kernels import (
     _add_regularizer_to_diagonal,
     _apply_line_search_step,
-    _compute_base_q_default,
     _compute_fk_axis_joint_frames,
     _compute_fk_joint_frames,
     _correct_actuator_coords,
@@ -212,6 +212,8 @@ class ForwardKinematicsSolver:
                 device=self.device,
             )
         joints_act_type_prev = resolved_act_type.numpy()
+        # Indexed by model joint: 0 is passive, 1 is actuated, and -1 skips
+        # validation for an explicit base joint that FK replaces.
         built_fk_actuated = (joints_act_type_prev != JointActuationType.PASSIVE).astype(np.int32)
 
         # Retrieve / compute dimensions - Actuated coordinates/dofs (main model)
@@ -231,6 +233,8 @@ class ForwardKinematicsSolver:
         classes = compute_fk_equivalence_classes(self.model)
         num_classes = len(classes)
 
+        # Resolve discrete joint data (e.g. types and indices) first, then
+        # copy or compute continuous joint data (e.g. frames).
         # Create a copy of the model's joints with added joints as needed:
         # - actuated free joints to reset the base position/orientation
         # - axis joints to factor out superfluous DoFs at tie rods
@@ -261,8 +265,6 @@ class ForwardKinematicsSolver:
             if base_joint_id >= 0:
                 # FK always replaces an explicit base joint with an actuated free joint.
                 built_fk_actuated[base_joint_id] = -1
-        self._built_fk_actuated = to_warp_int32_array(built_fk_actuated, device=self.device)
-        self._fk_actuation_violations = wp.empty(2, dtype=wp.int32, device=self.device)
         for wd_id in range(self.num_worlds):
             # Retrieve base joint id
             base_joint_id = base_joint_ids_input[wd_id]
@@ -350,9 +352,6 @@ class ForwardKinematicsSolver:
                 joints_bid_F.append(base_body_id)
                 joints_source_id.append(-1)
                 joints_num_actuated_coords.append(7)
-                # Note: we rely on the initial body orientations being identity
-                # Only then will the corresponding joint coordinates be interpretable as
-                # specifying the absolute base position and orientation
                 coord_offset = -7 * wd_id - 1  # We encode offsets in base_q negatively with i -> -i - 1
                 actuated_coords_map.extend(range(coord_offset, coord_offset - 7, -1))
                 joints_num_actuated_dofs.append(6)
@@ -541,6 +540,10 @@ class ForwardKinematicsSolver:
             self.num_constraints = to_warp_int32_array(num_constraints)
             self.constraint_full_to_red_map = to_warp_int32_array(constraint_full_to_red_map)
 
+            # Helper data for model updates validation
+            self._built_fk_actuated = to_warp_int32_array(built_fk_actuated)
+            self._fk_actuation_violations = wp.empty(2, dtype=wp.int32)
+
             # Modified joints
             self.joints_dof_type = to_warp_int32_array(joints_dof_type)
             self.joints_act_type = to_warp_int32_array(joints_act_type)
@@ -561,11 +564,6 @@ class ForwardKinematicsSolver:
             # Default base state
             self.base_q_default = wp.zeros(shape=self.num_worlds, dtype=wp.transformf)
             self.base_u_default = wp.zeros(shape=(self.num_worlds,), dtype=wp.spatial_vectorf)
-
-            # Initialize mutable model-derived values through the same path used by runtime notifications.
-            self._update_joint_frames()
-            self._update_axis_joint_frames()
-            self._update_base_q_default()
 
             # Line search
             self.max_line_search_iterations = wp.array(dtype=wp.int32, shape=(1,))  # Max iterations
@@ -910,6 +908,11 @@ class ForwardKinematicsSolver:
                 maxiter=self.cg_max_iter,
             )
 
+        # Initialize continuous joint data (e.g. joint frames)
+        self._update_joint_frames()
+        self._update_axis_joint_frames()
+        self._update_base_q_default()
+
     def validate_model_changed(self, flags: ModelFlags | int) -> None:
         """Validate FK structural invariants before model values are updated.
 
@@ -917,7 +920,7 @@ class ForwardKinematicsSolver:
             flags: Bitmask indicating which model properties changed.
 
         Raises:
-            RuntimeError: If the effective FK actuation partition changed.
+            RuntimeError: If the effective set of joints that are actuated for FK changed.
             ValueError: If an FK actuation override is invalid.
         """
         if not flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES):
@@ -943,7 +946,7 @@ class ForwardKinematicsSolver:
             raise ValueError(f"Invalid FK actuation flag for joint {int(invalid_joint)}: expected -1, 0, or 1")
         if changed_joint != joint_count:
             raise RuntimeError(
-                f"Changing the FK actuation partition for joint {int(changed_joint)} is not supported; "
+                f"Changing the actuated vs passive status of joint {int(changed_joint)} for FK is not supported; "
                 "recreate SolverKamino to apply the change."
             )
 
@@ -962,7 +965,7 @@ class ForwardKinematicsSolver:
         if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
             self._update_axis_joint_frames()
 
-        if flags & (ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
+        if flags & (ModelFlags.JOINT_PROPERTIES | ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
             self._update_base_q_default()
 
     def _update_joint_frames(self) -> None:
@@ -1012,16 +1015,12 @@ class ForwardKinematicsSolver:
         """Compute default FK base poses from the current reference pose."""
         if self.num_worlds == 0:
             return
-        wp.launch(
-            _compute_base_q_default,
-            dim=self.num_worlds,
-            inputs=[
-                self.model.info.base_joint_index,
-                self.model.info.base_body_index,
-                self.model.bodies.q_i_0,
-                self.base_q_default,
-            ],
-            device=self.device,
+        get_base_q_from_joint_q_and_body_q(
+            model=self.model,
+            joint_q=self.model.joints.q_j_0,
+            body_q=self.model.bodies.q_i_0,
+            base_q=self.base_q_default,
+            world_mask=self.all_worlds_mask,
         )
 
     ###

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -890,6 +890,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             flags: Bitmask of :class:`~newton.ModelFlags` or custom ``int`` bits indicating which properties changed.
         """
         self._validate_structural_invariants(flags)
+        self._solver_kamino.validate_model_changed(flags)
 
         if flags & (ModelFlags.JOINT_DOF_PROPERTIES | ModelFlags.ACTUATOR_PROPERTIES):
             # The documentation is unclear about which flag should trigger this update, so we update on both flags.
@@ -918,6 +919,8 @@ class SolverKamino(SolverBase, CouplingInterface):
             # When using a coupled solver environment, these flags are meant for one of the other solvers.
             # No warning is emitted for compatibility with such an environment.
             pass
+
+        self._solver_kamino.notify_model_changed(flags)
 
         handled = (
             ModelFlags.MODEL_PROPERTIES

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -26,10 +26,12 @@ def _build_revolute(
     body_com: wp.vec3f | None = None,
     shape_materials: tuple[tuple[float, float], ...] | None = None,
     has_shape_collision: bool = True,
+    fk_actuation_flag: int | None = None,
 ) -> newton.Model:
     """Build a tiny world-to-body revolute model for notify tests."""
     builder = newton.ModelBuilder()
-    SolverKamino.register_custom_attributes(builder)
+    fk_actuation_flags = None if fk_actuation_flag is None else {0: fk_actuation_flag}
+    SolverKamino.register_custom_attributes(builder, fk_actuation_flags=fk_actuation_flags)
 
     builder.begin_world()
     bid = builder.add_link(
@@ -85,6 +87,23 @@ def _build_revolute(
     builder.add_articulation([jid])
     builder.end_world()
 
+    return builder.finalize()
+
+
+def _build_free_body() -> newton.Model:
+    """Build one free body so FK creates a synthetic base joint."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder)
+    builder.begin_world()
+    bid = builder.add_link(
+        label="base",
+        mass=1.0,
+        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        xform=wp.transformf(wp.vec3f(0.0, 0.0, 1.0), wp.quat_identity(dtype=wp.float32)),
+        lock_inertia=True,
+    )
+    builder.add_shape_box(body=bid, hx=0.1, hy=0.1, hz=0.1)
+    builder.end_world()
     return builder.finalize()
 
 
@@ -538,6 +557,131 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
                     expected = solver._kamino.JointActuationType.from_newton(changed_mode)
                     self.assertEqual(solver._model_kamino.joints.act_type.numpy()[0], expected)
+
+    def test_fk_joint_frame_changes_propagate(self):
+        """Joint and CoM notifications propagate to FK-owned frames."""
+        model = _build_revolute(actuator_mode=newton.JointTargetMode.POSITION)
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+        )
+        fk = solver._solver_kamino.solver_fk
+
+        model.joint_X_p.assign(
+            [wp.transformf(wp.vec3f(0.2, -0.1, 0.3), wp.quat_from_axis_angle(wp.vec3f(0.0, 0.0, 1.0), 0.4))]
+        )
+        model.joint_X_c.assign(
+            [wp.transformf(wp.vec3f(-0.4, 0.5, 0.6), wp.quat_from_axis_angle(wp.vec3f(1.0, 0.0, 0.0), -0.35))]
+        )
+        solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES)
+
+        model.body_com.assign([wp.vec3f(0.1, -0.2, 0.15)])
+        solver.notify_model_changed(newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+
+        fk_joint = int(np.flatnonzero(fk.joints_source_id.numpy() == 0)[0])
+        joints = solver._model_kamino.joints
+        for fk_values, model_values in (
+            (fk.joints_B_r_Bj, joints.B_r_Bj),
+            (fk.joints_F_r_Fj, joints.F_r_Fj),
+            (fk.joints_X_Bj, joints.X_Bj),
+            (fk.joints_X_Fj, joints.X_Fj),
+        ):
+            np.testing.assert_allclose(fk_values.numpy()[fk_joint], model_values.numpy()[0], atol=1e-6)
+
+    def test_fk_base_pose_changes_propagate(self):
+        """Body-pose notifications propagate to the default synthetic FK base pose."""
+        model = _build_free_body()
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+        )
+        fk = solver._solver_kamino.solver_fk
+        new_pose = wp.transformf(
+            wp.vec3f(0.3, -0.4, 1.5),
+            wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.25),
+        )
+        model.body_q.assign([new_pose])
+
+        solver.notify_model_changed(newton.ModelFlags.BODY_PROPERTIES)
+
+        np.testing.assert_allclose(
+            fk.base_q_default.numpy()[0],
+            solver._model_kamino.bodies.q_i_0.numpy()[0],
+            atol=1e-6,
+        )
+
+    def test_fk_actuation_partition_change_raises(self):
+        """Runtime FK override edits cannot change the FK buffer layout."""
+        model = _build_revolute(
+            actuator_mode=newton.JointTargetMode.POSITION,
+            fk_actuation_flag=1,
+        )
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+        )
+        model.fk_actuation_flag.assign([0])
+
+        with self.assertRaisesRegex(RuntimeError, "FK actuation partition.*recreate"):
+            solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+
+    def test_equivalent_fk_actuation_override_change_is_allowed(self):
+        """Raw FK override changes are allowed when effective actuation is unchanged."""
+        model = _build_revolute(
+            actuator_mode=newton.JointTargetMode.POSITION,
+            fk_actuation_flag=1,
+        )
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+        )
+        fk = solver._solver_kamino.solver_fk
+        model.fk_actuation_flag.assign([-1])
+
+        solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+
+        fk_joint = int(np.flatnonzero(fk.joints_source_id.numpy() == 0)[0])
+        self.assertNotEqual(
+            fk.joints_act_type.numpy()[fk_joint],
+            solver._kamino.JointActuationType.PASSIVE,
+        )
+
+    def test_invalid_fk_actuation_override_raises(self):
+        """Runtime FK overrides accept only the documented -1, 0, and 1 values."""
+        model = _build_revolute(
+            actuator_mode=newton.JointTargetMode.POSITION,
+            fk_actuation_flag=1,
+        )
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+        )
+        model.fk_actuation_flag.assign([2])
+
+        with self.assertRaisesRegex(ValueError, "Invalid FK actuation flag"):
+            solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+
+    def test_fk_reset_matches_fresh_solver_after_joint_update(self):
+        """An FK reset after notify matches a solver built from the updated model."""
+        model = _build_revolute(actuator_mode=newton.JointTargetMode.POSITION)
+        config = SolverKamino.Config(use_fk_solver=True, use_collision_detector=False)
+        solver = SolverKamino(model, config)
+        model.joint_X_c.assign(
+            [wp.transformf(wp.vec3f(0.2, 0.1, -0.15), wp.quat_from_axis_angle(wp.vec3f(1.0, 0.0, 0.0), 0.2))]
+        )
+        solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES)
+        reference = SolverKamino(model, SolverKamino.Config(use_fk_solver=True, use_collision_detector=False))
+        actuator_q = wp.array([0.35], dtype=wp.float32, device=model.device)
+        reset_config = SolverKamino.ResetConfig(
+            body_poses=SolverKamino.ResetConfig.FromActuatorQ(actuator_q),
+        )
+        state = model.state()
+        reference_state = model.state()
+
+        solver.reset(state, config=reset_config)
+        reference.reset(reference_state, config=reset_config)
+
+        np.testing.assert_allclose(state.body_q.numpy(), reference_state.body_q.numpy(), atol=1e-5)
 
     def test_invalid_actuation_mode_raises_before_update(self):
         """Invalid target modes do not mutate Kamino's actuation table."""

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -629,32 +629,25 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
             atol=1e-6,
         )
 
-    def test_fk_explicit_base_pose_update_matches_fresh_solver(self):
-        """An explicit FK base reset after notify matches a freshly built solver."""
+    def test_fk_explicit_base_pose_changes_propagate(self):
+        """Joint-property notifications refresh an explicit FK base pose."""
         model = _build_free_root()
-        config = SolverKamino.Config(use_fk_solver=True, use_collision_detector=False)
-        solver = SolverKamino(model, config)
-        model.body_q.assign(
-            [
-                wp.transformf(
-                    wp.vec3f(0.3, -0.4, 1.5),
-                    wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.25),
-                )
-            ]
+        solver = SolverKamino(
+            model,
+            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
         )
+        fk = solver._solver_kamino.solver_fk
+        new_pose = wp.transformf(
+            wp.vec3f(0.3, -0.4, 1.5),
+            wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.25),
+        )
+        model.joint_q.assign(np.asarray(new_pose))
 
-        solver.notify_model_changed(newton.ModelFlags.BODY_PROPERTIES | newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
-        reference = SolverKamino(model, SolverKamino.Config(use_fk_solver=True, use_collision_detector=False))
-        state = model.state()
-        reference_state = model.state()
+        solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES)
 
-        solver.reset(state)
-        reference.reset(reference_state)
-
-        np.testing.assert_allclose(state.body_q.numpy(), reference_state.body_q.numpy(), atol=1e-6)
         np.testing.assert_allclose(
-            solver._solver_kamino.solver_fk.base_q_default.numpy(),
-            reference._solver_kamino.solver_fk.base_q_default.numpy(),
+            fk.base_q_default.numpy()[0],
+            np.asarray(new_pose),
             atol=1e-6,
         )
 
@@ -672,7 +665,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
                 )
                 model.fk_actuation_flag.assign([0])
 
-                with self.assertRaisesRegex(RuntimeError, "FK actuation partition.*recreate"):
+                with self.assertRaisesRegex(RuntimeError, "actuated vs passive status.*recreate"):
                     solver.notify_model_changed(flag)
 
     def test_fk_base_joint_override_change_is_allowed(self):

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -107,6 +107,25 @@ def _build_free_body() -> newton.Model:
     return builder.finalize()
 
 
+def _build_free_root(*, fk_actuation_flag: int = -1) -> newton.Model:
+    """Build one body attached to the world by an explicit free root joint."""
+    builder = newton.ModelBuilder()
+    SolverKamino.register_custom_attributes(builder, fk_actuation_flags={0: fk_actuation_flag})
+    builder.begin_world()
+    bid = builder.add_link(
+        label="base",
+        mass=1.0,
+        inertia=[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        xform=wp.transformf(wp.vec3f(0.0, 0.0, 1.0), wp.quat_identity(dtype=wp.float32)),
+        lock_inertia=True,
+    )
+    builder.add_shape_box(body=bid, hx=0.1, hy=0.1, hz=0.1)
+    jid = builder.add_joint_free(parent=-1, child=bid)
+    builder.add_articulation([jid])
+    builder.end_world()
+    return builder.finalize()
+
+
 def _snapshot_model_arrays(model: newton.Model) -> dict[str, np.ndarray]:
     """Copy every allocated top-level Warp array on a model."""
     return {name: value.numpy().copy() for name, value in vars(model).items() if isinstance(value, wp.array)}
@@ -610,20 +629,67 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
             atol=1e-6,
         )
 
+    def test_fk_explicit_base_pose_update_matches_fresh_solver(self):
+        """An explicit FK base reset after notify matches a freshly built solver."""
+        model = _build_free_root()
+        config = SolverKamino.Config(use_fk_solver=True, use_collision_detector=False)
+        solver = SolverKamino(model, config)
+        model.body_q.assign(
+            [
+                wp.transformf(
+                    wp.vec3f(0.3, -0.4, 1.5),
+                    wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.25),
+                )
+            ]
+        )
+
+        solver.notify_model_changed(newton.ModelFlags.BODY_PROPERTIES | newton.ModelFlags.BODY_INERTIAL_PROPERTIES)
+        reference = SolverKamino(model, SolverKamino.Config(use_fk_solver=True, use_collision_detector=False))
+        state = model.state()
+        reference_state = model.state()
+
+        solver.reset(state)
+        reference.reset(reference_state)
+
+        np.testing.assert_allclose(state.body_q.numpy(), reference_state.body_q.numpy(), atol=1e-6)
+        np.testing.assert_allclose(
+            solver._solver_kamino.solver_fk.base_q_default.numpy(),
+            reference._solver_kamino.solver_fk.base_q_default.numpy(),
+            atol=1e-6,
+        )
+
     def test_fk_actuation_partition_change_raises(self):
         """Runtime FK override edits cannot change the FK buffer layout."""
-        model = _build_revolute(
-            actuator_mode=newton.JointTargetMode.POSITION,
-            fk_actuation_flag=1,
-        )
-        solver = SolverKamino(
-            model,
-            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
-        )
-        model.fk_actuation_flag.assign([0])
+        for flag in (newton.ModelFlags.ACTUATOR_PROPERTIES, newton.ModelFlags.JOINT_DOF_PROPERTIES):
+            with self.subTest(flag=flag.name):
+                model = _build_revolute(
+                    actuator_mode=newton.JointTargetMode.POSITION,
+                    fk_actuation_flag=1,
+                )
+                solver = SolverKamino(
+                    model,
+                    SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+                )
+                model.fk_actuation_flag.assign([0])
 
-        with self.assertRaisesRegex(RuntimeError, "FK actuation partition.*recreate"):
-            solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+                with self.assertRaisesRegex(RuntimeError, "FK actuation partition.*recreate"):
+                    solver.notify_model_changed(flag)
+
+    def test_fk_base_joint_override_change_is_allowed(self):
+        """FK overrides do not affect explicit base joints replaced by free joints."""
+        for flag in (newton.ModelFlags.ACTUATOR_PROPERTIES, newton.ModelFlags.JOINT_DOF_PROPERTIES):
+            with self.subTest(flag=flag.name):
+                model = _build_free_root(fk_actuation_flag=0)
+                solver = SolverKamino(
+                    model,
+                    SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+                )
+                fk = solver._solver_kamino.solver_fk
+                model.fk_actuation_flag.assign([1])
+
+                solver.notify_model_changed(flag)
+
+                self.assertEqual(fk.joints_act_type.numpy()[0], solver._kamino.JointActuationType.FORCE)
 
     def test_equivalent_fk_actuation_override_change_is_allowed(self):
         """Raw FK override changes are allowed when effective actuation is unchanged."""
@@ -648,18 +714,23 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
 
     def test_invalid_fk_actuation_override_raises(self):
         """Runtime FK overrides accept only the documented -1, 0, and 1 values."""
-        model = _build_revolute(
-            actuator_mode=newton.JointTargetMode.POSITION,
-            fk_actuation_flag=1,
+        models = (
+            _build_revolute(
+                actuator_mode=newton.JointTargetMode.POSITION,
+                fk_actuation_flag=1,
+            ),
+            _build_free_root(fk_actuation_flag=0),
         )
-        solver = SolverKamino(
-            model,
-            SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
-        )
-        model.fk_actuation_flag.assign([2])
+        for model in models:
+            with self.subTest(joint_type=newton.JointType(model.joint_type.numpy()[0]).name):
+                solver = SolverKamino(
+                    model,
+                    SolverKamino.Config(use_fk_solver=True, use_collision_detector=False),
+                )
+                model.fk_actuation_flag.assign([2])
 
-        with self.assertRaisesRegex(ValueError, "Invalid FK actuation flag"):
-            solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
+                with self.assertRaisesRegex(ValueError, "Invalid FK actuation flag"):
+                    solver.notify_model_changed(newton.ModelFlags.ACTUATOR_PROPERTIES)
 
     def test_fk_reset_matches_fresh_solver_after_joint_update(self):
         """An FK reset after notify matches a solver built from the updated model."""

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -518,6 +518,46 @@ class FourBarTieRodRandomPosesCheckForwardKinematics(unittest.TestCase):
     def tearDown(self):
         self.default_device = None
 
+    def test_axis_joint_frames_update_after_notify(self):
+        """Synthetic axis frames match a fresh solver after model changes."""
+        model = create_four_bar_tie_rod().finalize(device=self.default_device, requires_grad=False)
+        config = ForwardKinematicsSolver.Config(add_axis_joints=True)
+        solver = ForwardKinematicsSolver(model, config)
+        axis_body = int(solver.fk_axis_body.numpy()[0])
+        source_joint = int(solver.fk_axis_source_joint_0.numpy()[0])
+
+        body_q = model.bodies.q_i_0.numpy()
+        body_q[axis_body] = np.array(
+            wp.transformf(
+                wp.vec3f(*body_q[axis_body, :3]),
+                wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.3),
+            )
+        )
+        model.bodies.q_i_0.assign(body_q)
+        if model.joints.bid_B.numpy()[source_joint] == axis_body:
+            joint_anchor = model.joints.B_r_Bj.numpy()
+            joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
+            model.joints.B_r_Bj.assign(joint_anchor)
+        else:
+            joint_anchor = model.joints.F_r_Fj.numpy()
+            joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
+            model.joints.F_r_Fj.assign(joint_anchor)
+
+        solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES | newton.ModelFlags.BODY_PROPERTIES)
+        reference = ForwardKinematicsSolver(model, ForwardKinematicsSolver.Config(add_axis_joints=True))
+        axis_joints = solver.fk_axis_joint.numpy()
+
+        np.testing.assert_allclose(
+            solver.joints_X_Bj.numpy()[axis_joints],
+            reference.joints_X_Bj.numpy()[axis_joints],
+            atol=1e-6,
+        )
+        np.testing.assert_allclose(
+            solver.joints_X_Fj.numpy()[axis_joints],
+            reference.joints_X_Fj.numpy()[axis_joints],
+            atol=1e-6,
+        )
+
     def test_four_bar_tie_rod_model_FK_random_poses(self):
         # Initialize RNG
         test_name = "Four-bar with tie rod FK random poses check"

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -796,7 +796,7 @@ class HeterogenousModelSparseJacobianAssemblyCheck(unittest.TestCase):
             for wd_id in range(model.size.num_worlds):
                 rows, cols = int(dims[wd_id][0]), int(dims[wd_id][1])
                 residual = jac_dense_np[wd_id, :rows, :cols] - jac_sparse_np[wd_id]
-                self.assertTrue(np.max(np.abs(residual)) < 1e-10)
+                self.assertTrue(np.max(np.abs(residual)) < 1e-6)
 
 
 ###


### PR DESCRIPTION
## Description

Make `SolverKamino.notify_model_changed()` propagate model updates into the forward-kinematics solver internal model copies.

The FK solver now refreshes copied joint frames, synthetic tie-rod axis frames, and default floating-base poses after the corresponding model notifications. It also validates FK actuation overrides without rejecting explicit root joints that FK always replaces with an actuated free joint.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m unittest newton._src.solvers.kamino.tests.test_solver_kamino_notify
uv run --extra dev -m unittest newton._src.solvers.kamino.tests.test_solvers_forward_kinematics.FourBarTieRodRandomPosesCheckForwardKinematics.test_axis_joint_frames_update_after_notify
uv run --extra dev -m unittest newton._src.solvers.kamino.tests.test_core_model.TestModelConversions.test_05_model_conversions_base_assignment_non_floating_root
uvx pre-commit run -a
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward-kinematics frames now automatically refresh after model property changes (including joint/body/CoM and FK axis-joint updates).
  * Added GPU-backed validation and resolution of per-joint FK actuation overrides during model updates.
* **Bug Fixes**
  * Prevented unsupported/incompatible FK actuation partition and override changes.
  * Fixed stale FK joint frames (axis-joint frames) and default base pose after in-place notifications.
* **Tests**
  * Added coverage for axis-joint frame updates after notifications and FK override/constraint behavior.
  * Adjusted dense-vs-sparse Jacobian residual acceptance threshold for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->