### PR TITLE
Gate benchmark CI on runtime metrics

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -137,13 +137,13 @@ jobs:
 
       - name: Run Benchmarks
         run: |
-          # ASV assumes smaller values are better, so compare only metrics with that direction.
+          # Gate this PR job on directly measured runtimes only.
           uvx --with virtualenv asv continuous \
             --launch-method spawn \
             --interleave-rounds \
             --append-samples \
             --no-only-changed \
-            -e -b '^(?!.*track_(simulation_steps_per_second|real_time_factor)).*Fast' \
+            -e -b '^(?!.*FastNewtonOverhead).*Fast.*\.(?:time_.*|track_(?:simulate|(?:mean|p95)_.*(?:time|ms))(?:\(|$))' \
             ${{ inputs.base_ref }} \
             ${{ inputs.ref }}
         continue-on-error: true

--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -143,7 +143,10 @@ jobs:
             --interleave-rounds \
             --append-samples \
             --no-only-changed \
-            -e -b '^(?!.*FastNewtonOverhead).*Fast.*\.(?:time_.*|track_(?:simulate|(?:mean|p95)_.*(?:time|ms))(?:\(|$))' \
+            -e \
+            -b 'Fast\w*\.time_' \
+            -b 'Fast(?!NewtonOverhead)\w*\.track_simulate(\(|$)' \
+            -b 'Fast\w*\.track_(mean|p95)_\w*(time|ms)(\(|$)' \
             ${{ inputs.base_ref }} \
             ${{ inputs.ref }}
         continue-on-error: true

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -182,6 +183,41 @@ class TestSimulationBenchmarks(unittest.TestCase):
         """Give the DR Legs cache longer than ASV's default timeout."""
         config = json.loads((BENCHMARK_DIR.parents[1] / "asv.conf.json").read_text(encoding="utf-8"))
         self.assertGreater(bench_kamino.KpiDRLegs.setup_cache.timeout, config["default_benchmark_timeout"])
+
+    def test_aws_benchmark_comparison_gates_only_runtime_metrics(self):
+        """Gate PR comparisons on runtime while retaining dashboard metrics."""
+        workflow_path = BENCHMARK_DIR.parents[1] / ".github" / "workflows" / "aws_gpu_benchmarks.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+        selection = re.search(r"-b '([^']+)'", workflow)
+        self.assertIsNotNone(selection)
+        pattern = re.compile(selection.group(1))
+
+        blocking_benchmarks = (
+            "simulation.bench_mujoco.FastG1.track_simulate(8192)",
+            "simulation.bench_mujoco.FastG1.track_p95_step_time(8192)",
+            "simulation.bench_anymal.FastMetricsExampleAnymalPretrained.track_mean_world_step_time",
+            "simulation.bench_teleop_mujoco.FastTeleopMuJoCo.track_mean_loop_ms('graph')",
+            "simulation.bench_kamino.FastDRLegs.time_simulate",
+            "simulation.bench_viewer.FastViewerGL.time_rendering_frame('g1', 256)",
+        )
+        dashboard_benchmarks = (
+            "simulation.bench_mujoco.FastG1.track_solver_niter_mean(8192)",
+            "simulation.bench_mujoco.FastG1.track_solver_niter_max(8192)",
+            "simulation.bench_mujoco.FastG1.track_simulation_steps_per_second(8192)",
+            "simulation.bench_mujoco.FastG1.track_real_time_factor(8192)",
+            "simulation.bench_mujoco.FastG1.track_steady_state_gpu_memory(8192)",
+            "simulation.bench_mujoco.FastG1.track_sim_dt(8192)",
+            "simulation.bench_mujoco.FastG1.track_sim_substeps(8192)",
+            "simulation.bench_mujoco.FastNewtonOverheadG1.track_simulate(8192)",
+            "simulation.bench_teleop_mujoco.FastTeleopMuJoCo.track_step_rate_hz('graph')",
+        )
+
+        for benchmark in blocking_benchmarks:
+            with self.subTest(benchmark=benchmark):
+                self.assertRegex(benchmark, pattern)
+        for benchmark in dashboard_benchmarks:
+            with self.subTest(benchmark=benchmark):
+                self.assertNotRegex(benchmark, pattern)
 
     def test_anymal_short_horizon_validation(self):
         """Validate short-horizon ANYmal posture and forward progress."""

--- a/newton/tests/test_benchmark_simulation.py
+++ b/newton/tests/test_benchmark_simulation.py
@@ -188,9 +188,8 @@ class TestSimulationBenchmarks(unittest.TestCase):
         """Gate PR comparisons on runtime while retaining dashboard metrics."""
         workflow_path = BENCHMARK_DIR.parents[1] / ".github" / "workflows" / "aws_gpu_benchmarks.yml"
         workflow = workflow_path.read_text(encoding="utf-8")
-        selection = re.search(r"-b '([^']+)'", workflow)
-        self.assertIsNotNone(selection)
-        pattern = re.compile(selection.group(1))
+        patterns = tuple(re.compile(selection) for selection in re.findall(r"-b '([^']+)'", workflow))
+        self.assertTrue(patterns)
 
         blocking_benchmarks = (
             "simulation.bench_mujoco.FastG1.track_simulate(8192)",
@@ -209,15 +208,15 @@ class TestSimulationBenchmarks(unittest.TestCase):
             "simulation.bench_mujoco.FastG1.track_sim_dt(8192)",
             "simulation.bench_mujoco.FastG1.track_sim_substeps(8192)",
             "simulation.bench_mujoco.FastNewtonOverheadG1.track_simulate(8192)",
-            "simulation.bench_teleop_mujoco.FastTeleopMuJoCo.track_step_rate_hz('graph')",
+            "simulation.bench_teleop_mujoco.TeleopMuJoCo.track_frame_overrun_pct('graph')",
         )
 
         for benchmark in blocking_benchmarks:
             with self.subTest(benchmark=benchmark):
-                self.assertRegex(benchmark, pattern)
+                self.assertTrue(any(pattern.search(benchmark) for pattern in patterns), benchmark)
         for benchmark in dashboard_benchmarks:
             with self.subTest(benchmark=benchmark):
-                self.assertNotRegex(benchmark, pattern)
+                self.assertFalse(any(pattern.search(benchmark) for pattern in patterns), benchmark)
 
     def test_anymal_short_horizon_validation(self):
         """Validate short-horizon ANYmal posture and forward progress."""


### PR DESCRIPTION
## Description

Gate AWS pull-request benchmark comparisons on directly measured runtime results. Diagnostic and derived tracks remain available as ASV results for dashboard reporting, but no longer determine the `asv continuous` exit status.

This prevents expected diagnostic changes from blocking unrelated work. In #3575, `FastG1.track_solver_niter_max` changed from 5 to 6 while both mean and p95 runtime improved, yet the AWS benchmark job failed.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not required; this only changes PR CI gating)

## Test plan

- `uv run --extra dev -m newton.tests -k test_aws_benchmark_comparison_gates_only_runtime_metrics`
- `uv run --extra dev -m newton.tests -k test_benchmark_simulation`
- `uvx --with virtualenv asv check`
- `uvx pre-commit run -a`

## Bug fix

**Steps to reproduce:**

1. Run the AWS benchmark comparison for #3575.
2. Observe that the only significant change is `FastG1.track_solver_niter_max` from 5 to 6.
3. Observe that the workflow exits with status 2 despite slightly improved mean and p95 runtime.

**Minimal reproduction:**

```bash
uvx --with virtualenv asv continuous \
  --launch-method spawn \
  --interleave-rounds \
  --append-samples \
  --no-only-changed \
  -e -b '^(?!.*track_(simulation_steps_per_second|real_time_factor)).*Fast' \
  <base-ref> <ref>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS GPU benchmark comparison gating to focus on directly measured runtime/timing metrics only, excluding overhead and dashboard-only metrics.
* **Tests**
  * Added a workflow-selection validation test to ensure the benchmark metrics filters continue matching only the intended runtime metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->