### PR TITLE
[Kamino] Fix Kamino preserve reset for COM-offset bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix masked PID state reset to execute on the integral-state device. (#3447)
+- Fix `SolverKamino.reset()` with `ResetConfig.preserve()` shifting `joint_q` for bodies with non-zero center-of-mass offsets by always converting body poses between Newton body-origin and Kamino CoM frames during reset.
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@
 - Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.
 - Fix masked PID state reset to execute on the integral-state device. (#3447)
-- Fix `SolverKamino.reset()` with `ResetConfig.preserve()` shifting `joint_q` for bodies with non-zero center-of-mass offsets by always converting body poses between Newton body-origin and Kamino CoM frames during reset.
 - Preserve muscles and rigid-body color groups when copying or replicating a `ModelBuilder`.
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -386,11 +386,6 @@ class SolverKamino(SolverBase, CouplingInterface):
         Configuration for a call to the reset() operation, specifying the behaviour (common or separate)
         for body poses, body velocities as well as floating base pose and velocity.
 
-        After body poses and velocities are updated (or preserved), joint coordinates and velocities
-        are always re-derived from the resulting body state for consistency. Joint constraint forces
-        are reset to zero. When body and joint state are already consistent, re-derived joint values
-        match the preserved inputs.
-
         Example
         -------
 
@@ -709,6 +704,11 @@ class SolverKamino(SolverBase, CouplingInterface):
 
         All state components are reset consistently with the new body poses and velocities
         (unless prescribed otherwise by state flags), and solver-internal buffers are cleared.
+        More specifically, joint coordinates and velocities are re-derived from the
+        resulting body state for consistency, and joint constraint forces are reset to
+        zero. If flags exclude :attr:`~newton.StateFlags.JOINT_Q` or
+        :attr:`~newton.StateFlags.JOINT_QD`, the corresponding joint coordinates or
+        velocities are restored after the reset instead.
 
         Args:
             state: The simulation state to reset (modified in place).

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -386,6 +386,11 @@ class SolverKamino(SolverBase, CouplingInterface):
         Configuration for a call to the reset() operation, specifying the behaviour (common or separate)
         for body poses, body velocities as well as floating base pose and velocity.
 
+        After body poses and velocities are updated (or preserved), joint coordinates and velocities
+        are always re-derived from the resulting body state for consistency. Joint constraint forces
+        are reset to zero. When body and joint state are already consistent, re-derived joint values
+        match the preserved inputs.
+
         Example
         -------
 
@@ -395,7 +400,7 @@ class SolverKamino(SolverBase, CouplingInterface):
                 reset_config = newton.solvers.SolverKamino.ResetConfig.to_default()
                 solver.reset(state=state, config=reset_config)
 
-                # Preserve the current body/joint state, while resetting time, forces/torques and solver internals
+                # Preserve the current body state, while resetting time, forces/torques and solver internals
                 reset_config = newton.solvers.SolverKamino.ResetConfig.preserve()
                 solver.reset(state=state, config=reset_config)
 
@@ -422,7 +427,7 @@ class SolverKamino(SolverBase, CouplingInterface):
 
         @dataclass(frozen=True)
         class Preserve:
-            """Reset option, to preserve current values, assuming without check that they are consistent."""
+            """Reset option, to preserve current body/base values, assuming without check that they are consistent."""
 
         @dataclass(frozen=True)
         class FromJointQ:
@@ -735,22 +740,16 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._model_kamino.size, self.model, state, convert_to_com_frame=False
         )
 
-        # Convert body poses from origin to CoM if needed
+        # Convert Newton origin-frame body poses to Kamino CoM frame before reset.
         has_callbacks = self._solver_kamino._pre_reset_cb is not None or self._solver_kamino._post_reset_cb is not None
-        need_CoM_conversion = (
-            not isinstance(config.body_poses, SolverKamino.ResetConfig.Preserve)
-            or not isinstance(config.base_pose, SolverKamino.ResetConfig.Preserve)
-            or has_callbacks
+        self._kamino.convert_body_origin_to_com(
+            body_com=self._model_kamino.bodies.i_r_com_i,
+            body_q_com=state_kamino.q_i,
+            body_q=state_kamino.q_i,
+            world_mask=world_mask if not has_callbacks else None,
+            body_wid=self._model_kamino.bodies.wid,
         )
-        if need_CoM_conversion:
-            self._kamino.convert_body_origin_to_com(
-                body_com=self._model_kamino.bodies.i_r_com_i,
-                body_q_com=state_kamino.q_i,
-                body_q=state_kamino.q_i,
-                world_mask=world_mask if not has_callbacks else None,
-                body_wid=self._model_kamino.bodies.wid,
-            )
-            # Note: we convert all worlds if callbacks are set, so they see the full state correctly
+        # Note: we convert all worlds if callbacks are set, so they see the full state correctly
 
         # Convert base pose from origin to CoM if needed
         if isinstance(config.base_pose, SolverKamino.ResetConfig.FromBaseQ):
@@ -792,14 +791,13 @@ class SolverKamino(SolverBase, CouplingInterface):
             wp.copy(array, snapshot)
 
         # Convert back body poses from COM-frame (Kamino) to body-origin frame (Newton)
-        if need_CoM_conversion:
-            self._kamino.convert_body_com_to_origin(
-                body_com=self._model_kamino.bodies.i_r_com_i,
-                body_q_com=state_kamino.q_i,
-                body_q=state_kamino.q_i,
-                world_mask=world_mask if not has_callbacks else None,
-                body_wid=self._model_kamino.bodies.wid,
-            )
+        self._kamino.convert_body_com_to_origin(
+            body_com=self._model_kamino.bodies.i_r_com_i,
+            body_q_com=state_kamino.q_i,
+            body_q=state_kamino.q_i,
+            world_mask=world_mask if not has_callbacks else None,
+            body_wid=self._model_kamino.bodies.wid,
+        )
 
         # Revert changes to config
         if isinstance(config.base_pose, SolverKamino.ResetConfig.FromBaseQ):

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -881,12 +881,10 @@ class TestModelConversions(unittest.TestCase):
 
     def test_15_preserve_reset_keeps_joint_q_consistent_with_com_offset_body(self):
         """
-        Verify preserve reset keeps joint_q consistent with body_q for COM-offset bodies.
+        Verify preserve reset leaves body_q and joint_q unchanged for COM-offset bodies.
 
-        ``ResetConfig.preserve()`` skips origin<->COM conversion but still recomputes
-        joint coordinates from body poses. That path expects COM-frame body poses, so
-        for a single floating body with a non-zero COM offset the resulting ``joint_q``
-        is shifted by the COM offset even though ``body_q`` is unchanged.
+        For a single floating body with a non-zero center-of-mass offset, a preserve
+        reset should not modify ``body_q`` or re-derived ``joint_q``.
         """
         model = self._build_single_floating_body_com_offset_model()
         solver = SolverKamino(model)

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -671,6 +671,35 @@ class TestModelConversions(unittest.TestCase):
         np.testing.assert_allclose(q_i_0_np[2, :3], [1.1, -0.3, 0.2], atol=1e-6)
         np.testing.assert_allclose(q_i_0_np[2, 3:7], body_q_np[2, 3:7], atol=1e-6)
 
+    def _build_single_floating_body_com_offset_model(self) -> Model:
+        """Build a single floating body with a non-zero COM offset."""
+        builder_newton: ModelBuilder = ModelBuilder()
+        SolverKamino.register_custom_attributes(builder_newton)
+        builder_newton.default_shape_cfg.margin = 0.0
+        builder_newton.default_shape_cfg.gap = 0.0
+
+        builder_newton.begin_world()
+
+        bid = builder_newton.add_link(
+            label="body0",
+            mass=1.0,
+            xform=wp.transformf(wp.vec3f(0.0, 0.0, 1.0), wp.quat_identity(dtype=wp.float32)),
+            com=wp.vec3f(0.1, 0.0, 0.0),
+            lock_inertia=True,
+        )
+        builder_newton.add_shape_box(label="box0", body=bid, hx=0.05, hy=0.05, hz=0.05)
+        builder_newton.add_joint_free(
+            label="world_to_body0",
+            parent=-1,
+            child=bid,
+            parent_xform=wp.transform_identity(dtype=wp.float32),
+            child_xform=wp.transform_identity(dtype=wp.float32),
+        )
+
+        builder_newton.end_world()
+
+        return builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
+
     def _build_com_offset_model(self, with_base_joint: bool = True):
         """Build a 3-body chain with non-zero COM offsets for reset tests."""
         builder_newton: ModelBuilder = ModelBuilder()
@@ -849,6 +878,39 @@ class TestModelConversions(unittest.TestCase):
                     atol=1e-6,
                     err_msg=f"Base reset (translated): body {i} rotation mismatch",
                 )
+
+    def test_15_preserve_reset_keeps_joint_q_consistent_with_com_offset_body(self):
+        """
+        Verify preserve reset keeps joint_q consistent with body_q for COM-offset bodies.
+
+        ``ResetConfig.preserve()`` skips origin<->COM conversion but still recomputes
+        joint coordinates from body poses. That path expects COM-frame body poses, so
+        for a single floating body with a non-zero COM offset the resulting ``joint_q``
+        is shifted by the COM offset even though ``body_q`` is unchanged.
+        """
+        model = self._build_single_floating_body_com_offset_model()
+        solver = SolverKamino(model)
+
+        state: State = model.state()
+        solver.reset(state=state)
+
+        body_q_before = state.body_q.numpy().copy()
+        joint_q_before = state.joint_q.numpy().copy()
+
+        solver.reset(state=state, config=SolverKamino.ResetConfig.preserve())
+
+        np.testing.assert_allclose(
+            state.body_q.numpy(),
+            body_q_before,
+            atol=1e-6,
+            err_msg="Preserve reset should not modify body_q",
+        )
+        np.testing.assert_allclose(
+            state.joint_q.numpy(),
+            joint_q_before,
+            atol=1e-6,
+            err_msg="Preserve reset should not modify joint_q when body_q is unchanged",
+        )
 
     def test_14_model_conversions_shape_offset_com_relative(self):
         """


### PR DESCRIPTION
## Description

Fix `SolverKamino.reset()` with `ResetConfig.preserve()` corrupting `joint_q` for bodies with non-zero center-of-mass offsets.

Preserve reset skips body pose updates but still re-derives joint coordinates from body state. The Newton wrapper previously skipped origin↔COM conversion on preserve paths, so Kamino inferred joints from origin-frame `body_q` as if it were COM-frame, shifting `joint_q` by the COM offset.

This PR always converts body poses between Newton body-origin and Kamino CoM frames around reset (matching `step()`), adds a regression test, and clarifies `ResetConfig` docs that joint coordinates are re-derived from the resulting body state.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev python -m newton._src.solvers.kamino.tests.test_core_model \
  TestModelConversions.test_15_preserve_reset_keeps_joint_q_consistent_with_com_offset_body

uv run --extra dev python -m newton._src.solvers.kamino.tests.test_core_model \
  TestModelConversions.test_12_reset_produces_body_origin_frame \
  TestModelConversions.test_13_base_reset_produces_body_origin_frame

uv run --extra dev python -m newton._src.solvers.kamino.tests.test_solver_kamino \
  TestSolverKaminoImpl.test_06_reset_but_preserve_state
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kamino solver reset behavior to consistently preserve body poses and joint coordinates, including models with non-zero center-of-mass offsets.
  - Ensured state is consistently converted back to the expected Newton reference frame after resets.
- **Documentation**
  - Clarified the `Preserve` reset option wording to reference preserving current body/base values.
  - Updated reset example comments for better clarity.
- **Tests**
  - Added coverage to verify preserve resets keep `body_q` and `joint_q` unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->