### PR TITLE
[Kamino] Simplify Kamino gravity to alias Newton vectors

### DIFF
--- a/newton/_src/solvers/kamino/_src/__init__.py
+++ b/newton/_src/solvers/kamino/_src/__init__.py
@@ -19,7 +19,6 @@ from .core.conversions import (
     convert_model_materials,
     validate_model_joint_updates,
 )
-from .core.gravity import convert_model_gravity
 from .core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType
 from .core.model import ModelKamino
 from .core.state import StateKamino
@@ -53,7 +52,6 @@ __all__ = [
     "convert_contacts_kamino_to_newton",
     "convert_contacts_newton_to_kamino",
     "convert_geom_offset_origin_to_com",
-    "convert_model_gravity",
     "convert_model_joint_actuation",
     "convert_model_joint_transforms",
     "convert_model_materials",

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -31,7 +31,7 @@ from .model import ModelKamino, ModelKaminoInfo
 from .shapes import ShapeDescriptorType, max_contacts_for_shape_pair
 from .size import SizeKamino
 from .time import TimeModel
-from .types import to_warp_int32_array
+from .types import ArrayLike, to_warp_int32_array
 from .world import WorldDescriptor
 
 ###
@@ -206,7 +206,7 @@ class ModelBuilderKamino:
 
     @property
     def gravity(self) -> list[GravityDescriptor]:
-        """Returns the list of gravity descriptors for each world contained in the model."""
+        """Returns the gravity descriptors for each world contained in the model."""
         return self._gravity
 
     @property
@@ -261,7 +261,7 @@ class ModelBuilderKamino:
         name: str = "world",
         uid: str | None = None,
         up_axis: Axis | None = None,
-        gravity: GravityDescriptor | None = None,
+        gravity: GravityDescriptor | ArrayLike | None = None,
     ) -> int:
         """
         Add a new world to the model.
@@ -272,8 +272,8 @@ class ModelBuilderKamino:
                 If None, a UUID will be generated.
             up_axis: The up axis of the world.
                 If None, Axis.Z will be used.
-            gravity: The gravity descriptor of the world.
-                If None, a default gravity descriptor will be used.
+            gravity: The gravity descriptor or vector [m/s²] of the world.
+                If ``None``, Newton's default gravity is used along the negative up axis.
 
         Returns:
             The index of the newly added world.
@@ -293,7 +293,9 @@ class ModelBuilderKamino:
 
         # Set gravity
         if gravity is None:
-            gravity = GravityDescriptor()
+            gravity = GravityDescriptor.default_for(up_axis)
+        elif not isinstance(gravity, GravityDescriptor):
+            gravity = GravityDescriptor(name="gravity", vector=wp.vec3f(gravity))
         self._gravity.append(gravity)
 
         # Register the default material in the new world
@@ -752,26 +754,20 @@ class ModelBuilderKamino:
         # Set the new up axis
         self._up_axes[world_index] = axis
 
-    def set_gravity(self, gravity: GravityDescriptor, world_index: int = 0):
+    def set_gravity(self, gravity: GravityDescriptor | ArrayLike, world_index: int = 0):
         """
-        Set the gravity descriptor for a specific world.
+        Set the gravity vector for a specific world.
 
         Args:
-            gravity: The new gravity descriptor to be set.
-            world_index: The index of the world for which to set the gravity descriptor.
+            gravity: The new gravity descriptor or vector [m/s²].
+            world_index: The index of the world for which to set gravity.
                 Defaults to the first world with index `0`.
-
-        Raises:
-            TypeError: If the provided gravity descriptor is not of type `GravityDescriptor`.
         """
         # Check if the world index is valid
         self._check_world_index(world_index)
 
-        # Check if the gravity descriptor is valid
         if not isinstance(gravity, GravityDescriptor):
-            raise TypeError(f"Invalid gravity descriptor type: {type(gravity)}. Must be `GravityDescriptor`.")
-
-        # Set the new gravity configurations
+            gravity = GravityDescriptor(name="gravity", vector=wp.vec3f(gravity))
         self._gravity[world_index] = gravity
 
     def set_default_material(self, material: MaterialDescriptor, world_index: int = 0):
@@ -981,7 +977,6 @@ class ModelBuilderKamino:
         info_base_jid = []
 
         # Initialize the gravity data collections
-        gravity_g_dir_acc = []
         gravity_vector = []
 
         # Initialize the body data collections
@@ -1101,8 +1096,7 @@ class ModelBuilderKamino:
         # A helper function to collect model gravity data
         def collect_gravity_model_data():
             for w in range(num_worlds):
-                gravity_g_dir_acc.append(self._gravity[w].dir_accel())
-                gravity_vector.append(self._gravity[w].vector())
+                gravity_vector.append(self._gravity[w].vector)
 
         # A helper function to collect model bodies data
         def collect_body_model_data():
@@ -1364,10 +1358,7 @@ class ModelBuilderKamino:
             )
 
             # Construct model gravity data
-            model_gravity = GravityModel(
-                g_dir_acc=wp.array(gravity_g_dir_acc, dtype=wp.vec4f),
-                vector=wp.array(gravity_vector, dtype=wp.vec4f, requires_grad=requires_grad),
-            )
+            model_gravity = GravityModel(vector=wp.array(gravity_vector, dtype=wp.vec3, requires_grad=requires_grad))
 
             # Create the bodies model
             model_bodies = RigidBodiesModel(

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -293,7 +293,7 @@ class ModelBuilderKamino:
 
         # Set gravity
         if gravity is None:
-            gravity = GravityDescriptor.default_for(up_axis)
+            gravity = GravityDescriptor.default_from_up_axis(up_axis)
         elif not isinstance(gravity, GravityDescriptor):
             gravity = GravityDescriptor.from_array(gravity)
         self._gravity.append(gravity)

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -295,7 +295,7 @@ class ModelBuilderKamino:
         if gravity is None:
             gravity = GravityDescriptor.default_for(up_axis)
         elif not isinstance(gravity, GravityDescriptor):
-            gravity = GravityDescriptor(name="gravity", vector=wp.vec3f(gravity))
+            gravity = GravityDescriptor.from_array(gravity)
         self._gravity.append(gravity)
 
         # Register the default material in the new world
@@ -767,7 +767,7 @@ class ModelBuilderKamino:
         self._check_world_index(world_index)
 
         if not isinstance(gravity, GravityDescriptor):
-            gravity = GravityDescriptor(name="gravity", vector=wp.vec3f(gravity))
+            gravity = GravityDescriptor.from_array(gravity)
         self._gravity[world_index] = gravity
 
     def set_default_material(self, material: MaterialDescriptor, world_index: int = 0):

--- a/newton/_src/solvers/kamino/_src/core/builder.py
+++ b/newton/_src/solvers/kamino/_src/core/builder.py
@@ -206,7 +206,7 @@ class ModelBuilderKamino:
 
     @property
     def gravity(self) -> list[GravityDescriptor]:
-        """Returns the gravity descriptors for each world contained in the model."""
+        """Returns the gravity descriptor for each world contained in the model."""
         return self._gravity
 
     @property

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import numpy as np
 import warp as wp
 
 from .....core.types import Axis, override
 from .....sim.model import Model
 from ....coupled.model_view import ModelView
-from .types import Descriptor
+from .types import ArrayLike, Descriptor
 
 __all__ = ["GRAVITY_DEFAULT", "GravityDescriptor", "GravityModel"]
 
@@ -33,6 +34,33 @@ class GravityDescriptor(Descriptor):
         """Return Newton's default gravity along the negative up axis."""
         vector = wp.vec3f(*(component * GRAVITY_DEFAULT for component in up_axis.to_vector()))
         return GravityDescriptor(name=name, vector=vector)
+
+    @staticmethod
+    def from_array(vector: ArrayLike, *, name: str = "gravity") -> GravityDescriptor:
+        """Create a gravity descriptor from a three-component vector."""
+        components = np.asarray(vector, dtype=np.float32)
+        if components.shape != (3,):
+            raise ValueError(f"Gravity vector must have shape (3,), got {components.shape}.")
+        return GravityDescriptor(name=name, vector=wp.vec3f(*components))
+
+    @staticmethod
+    def from_usd(
+        direction: ArrayLike, magnitude: float, up_axis: Axis, distance_unit: float, *, name: str = "gravity"
+    ) -> GravityDescriptor:
+        """Create a gravity descriptor from OpenUSD scene attributes."""
+        direction_array = np.asarray(direction, dtype=np.float32)
+        if direction_array.shape != (3,):
+            raise ValueError(f"Gravity direction must have shape (3,), got {direction_array.shape}.")
+
+        direction_length = np.linalg.norm(direction_array)
+        if direction_length == 0.0:
+            direction_array = -np.asarray(up_axis.to_vector(), dtype=np.float32)
+        else:
+            direction_array /= direction_length
+
+        if magnitude < 0.0:
+            magnitude = abs(GRAVITY_DEFAULT)
+        return GravityDescriptor.from_array(direction_array * (distance_unit * magnitude), name=name)
 
     @override
     def __repr__(self) -> str:

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -1,245 +1,53 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
-"""The gravity descriptor and model used throughout Kamino"""
+"""Gravity containers used by Kamino."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import warp as wp
 
-from .....core.types import override
+from .....core.types import Axis, override
 from .....sim.model import Model
-from ..utils import logger as msg
-from .types import ArrayLike, Descriptor
+from ....coupled.model_view import ModelView
+from .types import Descriptor
 
-###
-# Module interface
-###
-
-__all__ = [
-    "GRAVITY_ACCEL_DEFAULT",
-    "GRAVITY_DIREC_DEFAULT",
-    "GRAVITY_NAME_DEFAULT",
-    "GravityDescriptor",
-    "GravityModel",
-    "convert_model_gravity",
-]
+__all__ = ["GRAVITY_DEFAULT", "GravityDescriptor", "GravityModel"]
 
 
-###
-# Module configs
-###
-
-wp.set_module_options({"enable_backward": False})
+GRAVITY_DEFAULT = -9.81
+"""Default gravity along the world's up axis [m/s²]."""
 
 
-###
-# Constants
-###
-
-GRAVITY_NAME_DEFAULT = "Earth"
-"""The default gravity descriptor name, set as 'Earth'."""
-
-GRAVITY_ACCEL_DEFAULT = 9.8067
-"""
-The default gravitational acceleration in m/s^2.
-Equal to Earth's standard gravity of approximately 9.8067 m/s^2.
-"""
-
-GRAVITY_DIREC_DEFAULT = wp.constant(wp.vec3f(wp.float32(0.0), wp.float32(0.0), wp.float32(-1.0)))
-"""The default direction of gravity defined as -Z."""
-
-
-###
-# Containers
-###
-
-
+@dataclass
 class GravityDescriptor(Descriptor):
-    """
-    A container to describe a world's gravity.
+    """Describe a world's gravity vector."""
 
-    Attributes:
-        name: The name of the gravity descriptor.
-        uid: The unique identifier of the gravity descriptor.
-        enabled: Whether gravity is enabled.
-        acceleration: The gravitational acceleration magnitude [m/s²].
-        direction: The normalized direction vector of gravity.
-    """
+    vector: wp.vec3f = field(default_factory=lambda: GravityDescriptor.default_for(Axis.Z).vector)
+    """Gravity vector [m/s²]."""
 
-    def __init__(
-        self,
-        enabled: bool = True,
-        acceleration: float = GRAVITY_ACCEL_DEFAULT,
-        direction: ArrayLike = GRAVITY_DIREC_DEFAULT,
-        name: str = GRAVITY_NAME_DEFAULT,
-        uid: str | None = None,
-    ):
-        """
-        Initialize the gravity descriptor.
-
-        Args:
-            enabled: Whether gravity is enabled.
-                Defaults to `True` to enable gravity by default.
-            acceleration: The gravitational acceleration magnitude in m/s^2.
-                Defaults to 9.8067 m/s^2 (Earth's gravity).
-            direction: The normalized direction vector of gravity.
-                Defaults to pointing down the -Z axis.
-            name: The name of the gravity descriptor.
-            uid: Optional unique identifier of the gravity descriptor.
-        """
-        super().__init__(name, uid)
-        self._enabled: bool = enabled
-        self._acceleration: float = acceleration
-        self._direction: wp.vec3f = wp.normalize(wp.vec3f(direction))
+    @staticmethod
+    def default_for(up_axis: Axis, *, name: str = "gravity") -> GravityDescriptor:
+        """Return Newton's default gravity along the negative up axis."""
+        vector = wp.vec3f(*(component * GRAVITY_DEFAULT for component in up_axis.to_vector()))
+        return GravityDescriptor(name=name, vector=vector)
 
     @override
-    def __repr__(self):
-        """Returns a human-readable string representation of the GravityDescriptor."""
-        return (
-            f"GravityDescriptor(\n"
-            f"name={self.name},\n"
-            f"uid={self.uid},\n"
-            f"enabled={self.enabled},\n"
-            f"acceleration={self.acceleration},\n"
-            f"direction={self.direction}\n"
-            f")"
-        )
-
-    @property
-    def enabled(self) -> bool:
-        """Returns whether gravity is enabled."""
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, on: bool):
-        """Sets whether gravity is enabled."""
-        self._enabled = on
-
-    @property
-    def acceleration(self) -> float:
-        """Returns the gravitational acceleration."""
-        return self._acceleration
-
-    @acceleration.setter
-    def acceleration(self, g: float):
-        """Sets the gravitational acceleration."""
-        self._acceleration = g
-
-    @property
-    def direction(self) -> wp.vec3f:
-        """Returns the normalized direction vector of gravity."""
-        return self._direction
-
-    @direction.setter
-    def direction(self, direction: wp.vec3f):
-        """Sets the normalized direction vector of gravity."""
-        self._direction = wp.normalize(direction)
-
-    def dir_accel(self) -> wp.vec4f:
-        """Returns the gravity direction and acceleration as compactly as a :class:`wp.vec4f`."""
-        return wp.vec4f([self.direction[0], self.direction[1], self.direction[2], self.acceleration])
-
-    def vector(self) -> wp.vec4f:
-        """Returns the effective gravity vector and enabled flag compactly as a :class:`wp.vec4f`."""
-        g = wp.vec3f(self.acceleration * self.direction)
-        return wp.vec4f([g[0], g[1], g[2], float(self.enabled)])
+    def __repr__(self) -> str:
+        """Return a human-readable representation."""
+        return f"GravityDescriptor(name={self.name!r}, uid={self.uid!r}, vector={self.vector})"
 
 
 @dataclass
 class GravityModel:
-    """
-    A container to hold the time-invariant gravity model data.
+    """Hold per-world gravity vectors."""
 
-    Attributes:
-        g_dir_acc: The gravity direction and acceleration vector as ``[g_dir_x, g_dir_y, g_dir_z, g_accel]``.
-            Shape of ``(num_worlds,)``.
-        vector: The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.
-            Shape of ``(num_worlds,)``.
-    """
-
-    g_dir_acc: wp.array[wp.vec4f] | None = None
-    """
-    The gravity direction and acceleration vector.
-    Shape of ``(num_worlds,)``.
-    """
-
-    vector: wp.array[wp.vec4f] | None = None
-    """
-    The gravity vector defined as ``[g_x, g_y, g_z, enabled]``.
-    Shape of ``(num_worlds,)``.
-    """
-
-    ###
-    # Operations
-    ###
+    vector: wp.array[wp.vec3] | None = None
+    """Per-world gravity vectors [m/s²], shape [world_count]."""
 
     @staticmethod
-    def from_newton(model_in: Model) -> GravityModel:
-        return convert_model_gravity(model_in)
-
-
-###
-#  Utilities
-###
-
-
-@wp.kernel
-def _convert_model_gravity_kernel(
-    gravity: wp.array[wp.vec3f],
-    g_dir_acc: wp.array[wp.vec4f],
-    vector: wp.array[wp.vec4f],
-):
-    world = wp.tid()
-    gravity_vector = gravity[world]
-    acceleration = wp.length(gravity_vector)
-    direction = GRAVITY_DIREC_DEFAULT
-    enabled = 0.0
-    if acceleration > 0.0:
-        direction = gravity_vector / acceleration
-        enabled = 1.0
-    g_dir_acc[world] = wp.vec4f(direction[0], direction[1], direction[2], acceleration)
-    vector[world] = wp.vec4f(gravity_vector[0], gravity_vector[1], gravity_vector[2], enabled)
-
-
-def convert_model_gravity(model_in: Model, gravity_out: GravityModel | None = None) -> GravityModel:
-    """
-    Converts the gravity representation from the Newton model to the Kamino format.
-
-    Args:
-        model_in: The input Newton model containing the gravity information to be converted.
-        gravity_out: The output GravityModel instance where the converted gravity data will be stored.
-            If `None`, a new GravityModel instance will be created and returned.
-            If the arrays within `gravity_out` are not already allocated
-            with the appropriate shapes, this function will allocate them.
-    """
-    if gravity_out is None:
-        with wp.ScopedDevice(model_in.device):
-            gravity_out = GravityModel(
-                g_dir_acc=wp.empty(model_in.world_count, dtype=wp.vec4f),
-                vector=wp.empty(model_in.world_count, dtype=wp.vec4f),
-            )
-    else:
-        if gravity_out.g_dir_acc is None or gravity_out.g_dir_acc.shape != (model_in.world_count,):
-            msg.warning("Output `GravityModel.g_dir_acc` array does not have matching shape. Allocating a new array.")
-            gravity_out.g_dir_acc = wp.empty(model_in.world_count, dtype=wp.vec4f, device=model_in.device)
-        if gravity_out.vector is None or gravity_out.vector.shape != (model_in.world_count,):
-            msg.warning("Output `GravityModel.vector` array does not have matching shape. Allocating a new array.")
-            gravity_out.vector = wp.empty(model_in.world_count, dtype=wp.vec4f, device=model_in.device)
-
-    wp.launch(
-        kernel=_convert_model_gravity_kernel,
-        dim=model_in.world_count,
-        inputs=[
-            # Inputs:
-            model_in.gravity,
-            # Outputs:
-            gravity_out.g_dir_acc,
-            gravity_out.vector,
-        ],
-        device=model_in.device,
-    )
-
-    return gravity_out
+    def from_newton(model: Model | ModelView) -> GravityModel:
+        """Create a gravity model that aliases Newton's gravity array."""
+        return GravityModel(vector=model.gravity)

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -26,11 +26,11 @@ GRAVITY_DEFAULT = -9.81
 class GravityDescriptor(Descriptor):
     """Describe a world's gravity vector."""
 
-    vector: wp.vec3f = field(default_factory=lambda: GravityDescriptor.default_for(Axis.Z).vector)
+    vector: wp.vec3f = field(default_factory=lambda: GravityDescriptor.default_from_up_axis(Axis.Z).vector)
     """Gravity vector [m/s²]."""
 
     @staticmethod
-    def default_for(up_axis: Axis, *, name: str = "gravity") -> GravityDescriptor:
+    def default_from_up_axis(up_axis: Axis, *, name: str = "gravity") -> GravityDescriptor:
         """Return Newton's default gravity along the negative up axis."""
         vector = wp.vec3f(*(component * GRAVITY_DEFAULT for component in up_axis.to_vector()))
         return GravityDescriptor(name=name, vector=vector)

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -58,7 +58,7 @@ class GravityDescriptor(Descriptor):
         else:
             direction_array /= direction_length
 
-        if magnitude < 0.0:
+        if magnitude == -float("inf"):
             magnitude = abs(GRAVITY_DEFAULT)
         return GravityDescriptor.from_array(direction_array * (distance_unit * magnitude), name=name)
 

--- a/newton/_src/solvers/kamino/_src/core/gravity.py
+++ b/newton/_src/solvers/kamino/_src/core/gravity.py
@@ -73,7 +73,7 @@ class GravityModel:
     """Hold per-world gravity vectors."""
 
     vector: wp.array[wp.vec3] | None = None
-    """Per-world gravity vectors [m/s²], shape [world_count]."""
+    """Per-world gravity vector [m/s²]. Shape of ``(num_worlds,)``."""
 
     @staticmethod
     def from_newton(model: Model | ModelView) -> GravityModel:

--- a/newton/_src/solvers/kamino/_src/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/dual.py
@@ -370,7 +370,7 @@ def gravity_plus_coriolis_wrench_split(
 def _build_nonlinear_generalized_force(
     # Inputs:
     model_time_dt: wp.array[wp.float32],
-    model_gravity_vector: wp.array[wp.vec4f],
+    model_gravity_vector: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_m_i: wp.array[wp.float32],
     state_bodies_u_i: wp.array[wp.spatial_vectorf],
@@ -393,10 +393,7 @@ def _build_nonlinear_generalized_force(
 
     # Get world data
     dt = model_time_dt[wid]
-    gv = model_gravity_vector[wid]
-
-    # Extract the effective gravity vector
-    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
+    g = model_gravity_vector[wid]
 
     # Extract the linear and angular components of the generalized velocity
     omega_i = wp.spatial_bottom(u_i)
@@ -412,7 +409,7 @@ def _build_nonlinear_generalized_force(
 def _build_generalized_free_velocity(
     # Inputs:
     model_time_dt: wp.array[wp.float32],
-    model_gravity_vector: wp.array[wp.vec4f],
+    model_gravity_vector: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_m_i: wp.array[wp.float32],
     model_bodies_inv_m_i: wp.array[wp.float32],
@@ -439,10 +436,7 @@ def _build_generalized_free_velocity(
 
     # Get world data
     dt = model_time_dt[wid]
-    gv = model_gravity_vector[wid]
-
-    # Extract the effective gravity vector
-    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
+    g = model_gravity_vector[wid]
 
     # Extract the linear and angular components of the generalized velocity
     v_i = wp.spatial_top(u_i)

--- a/newton/_src/solvers/kamino/_src/integrators/euler.py
+++ b/newton/_src/solvers/kamino/_src/integrators/euler.py
@@ -91,7 +91,7 @@ def _integrate_semi_implicit_euler_inplace(
     # Inputs:
     alpha: float,
     model_dt: wp.array[wp.float32],
-    model_gravity: wp.array[wp.vec4f],
+    model_gravity: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_inv_m: wp.array[wp.float32],
     model_bodies_I: wp.array[wp.mat33f],
@@ -109,8 +109,7 @@ def _integrate_semi_implicit_euler_inplace(
 
     # Retrieve the time step and gravity vector
     dt = model_dt[wid]
-    gv = model_gravity[wid]
-    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
+    g = model_gravity[wid]
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]

--- a/newton/_src/solvers/kamino/_src/integrators/moreau.py
+++ b/newton/_src/solvers/kamino/_src/integrators/moreau.py
@@ -126,7 +126,7 @@ def _integrate_moreau_jean_second_inplace(
     # Inputs:
     alpha: float,
     model_dt: wp.array[wp.float32],
-    model_gravity: wp.array[wp.vec4f],
+    model_gravity: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_inv_m: wp.array[wp.float32],
     model_bodies_I: wp.array[wp.mat33f],
@@ -145,8 +145,7 @@ def _integrate_moreau_jean_second_inplace(
     # Retrieve the configured time-step and the
     # gravity vector of the corresponding world
     dt = model_dt[wid]
-    gv = model_gravity[wid]
-    g = gv.w * wp.vec3f(gv.x, gv.y, gv.z)
+    g = model_gravity[wid]
 
     # Retrieve the model data
     inv_m_i = model_bodies_inv_m[tid]

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -591,7 +591,7 @@ def compute_vector_difference_infnorm(
 def _compute_eom_residual(
     # Inputs
     model_time_dt: wp.array[wp.float32],
-    model_gravity: wp.array[wp.vec4f],
+    model_gravity: wp.array[wp.vec3f],
     model_bodies_wid: wp.array[wp.int32],
     model_bodies_m_i: wp.array[wp.float32],
     state_bodies_I_i: wp.array[wp.mat33f],
@@ -615,8 +615,7 @@ def _compute_eom_residual(
 
     # Retrieve the time step
     dt = model_time_dt[wid]
-    gravity = model_gravity[wid]
-    g = gravity.w * wp.vec3f(gravity.x, gravity.y, gravity.z)
+    g = model_gravity[wid]
 
     # Decompose into linear and angular parts
     f_i = wp.spatial_top(w_i)

--- a/newton/_src/solvers/kamino/_src/utils/benchmark/problems.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/problems.py
@@ -99,8 +99,9 @@ def make_benchmark_problem_fourbar(
             build_fn=basics.build_boxes_fourbar,
             ground=ground,
         )
-        for w in range(num_worlds):
-            builder.gravity[w].enabled = gravity
+        if not gravity:
+            for w in range(num_worlds):
+                builder.set_gravity(wp.vec3f(0.0), w)
         return builder
 
     control = ControlConfig(decimation=20, scale=10.0)
@@ -142,8 +143,9 @@ def make_benchmark_problem_dr_legs(
             for w in range(num_worlds):
                 add_ground_box(builder, world_index=w)
         # Set gravity
-        for w in range(builder.num_worlds):
-            builder.gravity[w].enabled = gravity
+        if not gravity:
+            for w in range(builder.num_worlds):
+                builder.set_gravity(wp.vec3f(0.0), w)
         return builder
 
     # Set control configurations

--- a/newton/_src/solvers/kamino/_src/utils/io/usd.py
+++ b/newton/_src/solvers/kamino/_src/utils/io/usd.py
@@ -18,6 +18,7 @@ from ......utils.topology import topological_sort_undirected
 from ...core.bodies import RigidBodyDescriptor
 from ...core.builder import ModelBuilderKamino
 from ...core.geometry import GeometryDescriptor
+from ...core.gravity import GravityDescriptor
 from ...core.joints import (
     JOINT_QMAX,
     JOINT_QMIN,
@@ -1799,6 +1800,8 @@ class USDImporter:
         # World
         ###
 
+        stage_up_axis = Axis.from_string(str(self.UsdGeom.GetStageUpAxis(stage)))
+
         # Parse for PhysicsScene prims
         if self.UsdPhysics.ObjectType.Scene in ret_dict:
             # Retrieve the phusics sene path and description
@@ -1809,17 +1812,25 @@ class USDImporter:
                 msg.error("Multiple PhysicsScene prims found in the USD file. Only the first prim will be considered.")
 
             # Extract the world gravity from the physics scene
-            gravity = wp.normalize(wp.vec3f(scene_desc.gravityDirection)) * (
-                distance_unit * scene_desc.gravityMagnitude
+            gravity = GravityDescriptor.from_usd(
+                scene_desc.gravityDirection,
+                scene_desc.gravityMagnitude,
+                stage_up_axis,
+                distance_unit,
             )
             builder.set_gravity(gravity)
-            msg.debug(f"World gravity: {gravity}")
+            msg.debug(f"World gravity: {gravity.vector}")
 
-            # Set the world up-axis based on the gravity direction
-            up_axis = Axis.from_any(int(np.argmax(np.abs(scene_desc.gravityDirection))))
+            # Set the world up-axis based on the resolved gravity vector.
+            gravity_vector = np.asarray(gravity.vector, dtype=np.float32)
+            up_axis = (
+                stage_up_axis
+                if np.linalg.norm(gravity_vector) == 0.0
+                else Axis.from_any(int(np.argmax(np.abs(gravity_vector))))
+            )
         else:
             # NOTE: Gravity is left with default values
-            up_axis = Axis.from_string(str(self.UsdGeom.GetStageUpAxis(stage)))
+            up_axis = stage_up_axis
 
         # Determine the up-axis transformation
         if apply_up_axis_from_stage:

--- a/newton/_src/solvers/kamino/_src/utils/io/usd.py
+++ b/newton/_src/solvers/kamino/_src/utils/io/usd.py
@@ -18,7 +18,6 @@ from ......utils.topology import topological_sort_undirected
 from ...core.bodies import RigidBodyDescriptor
 from ...core.builder import ModelBuilderKamino
 from ...core.geometry import GeometryDescriptor
-from ...core.gravity import GravityDescriptor
 from ...core.joints import (
     JOINT_QMAX,
     JOINT_QMIN,
@@ -1800,9 +1799,6 @@ class USDImporter:
         # World
         ###
 
-        # Initialize the world properties
-        gravity = GravityDescriptor()
-
         # Parse for PhysicsScene prims
         if self.UsdPhysics.ObjectType.Scene in ret_dict:
             # Retrieve the phusics sene path and description
@@ -1813,8 +1809,9 @@ class USDImporter:
                 msg.error("Multiple PhysicsScene prims found in the USD file. Only the first prim will be considered.")
 
             # Extract the world gravity from the physics scene
-            gravity.acceleration = distance_unit * scene_desc.gravityMagnitude
-            gravity.direction = wp.vec3f(scene_desc.gravityDirection)
+            gravity = wp.normalize(wp.vec3f(scene_desc.gravityDirection)) * (
+                distance_unit * scene_desc.gravityMagnitude
+            )
             builder.set_gravity(gravity)
             msg.debug(f"World gravity: {gravity}")
 

--- a/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
@@ -136,7 +136,7 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = False
+            self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/rl/test_multi_env_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/rl/test_multi_env_dr_legs.py
@@ -63,8 +63,6 @@ def run_test(num_worlds: int, num_steps: int, device):
     builder.max_contacts_per_pair = 8  # Cap contact budget to avoid Warp tile API shared memory bug
     offset = wp.transformf(0.0, 0.0, 0.265, 0.0, 0.0, 0.0, 1.0)
     set_uniform_body_pose_offset(builder=builder, offset=offset)
-    for w in range(builder.num_worlds):
-        builder.gravity[w].enabled = True
 
     # Create simulator
     msg.info("Creating simulator...")

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
@@ -108,8 +108,8 @@ class Example:
         self.builder: ModelBuilderKamino = basics.make_basics_heterogeneous_builder(ground=ground)
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
@@ -109,7 +109,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
@@ -59,7 +59,7 @@ def _control_callback(
     # Apply a time-dependent external force
     if t > t_start and t < t_end and wnc > 0:
         m = wp.float32(1.0)  # Mass of the box
-        g = wp.float32(9.8067)  # Gravitational acceleration
+        g = wp.float32(9.81)  # Gravitational acceleration
         mu = wp.float32(0.9)  # Friction coefficient
         f_ext = 1.1 * m * g * mu  # Magnitude of the external force
         state_w_i_e[bid] = wp.spatial_vectorf(f_ext, 0.0, 0.0, 0.0, 0.0, 0.0)
@@ -141,7 +141,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
@@ -140,8 +140,8 @@ class Example:
             )
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
@@ -71,7 +71,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
@@ -70,8 +70,8 @@ class Example:
             )
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
@@ -227,7 +227,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
@@ -226,8 +226,8 @@ class Example:
         set_uniform_body_pose_offset(builder=self.builder, offset=offset)
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
@@ -127,8 +127,8 @@ class Example:
             )
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
@@ -128,7 +128,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
@@ -151,7 +151,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Demo of printing builder contents in debug logging mode
         msg.info("self.builder.gravity:\n%s", self.builder.gravity)

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
@@ -150,8 +150,8 @@ class Example:
             )
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Demo of printing builder contents in debug logging mode

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -200,8 +200,8 @@ class Example:
                 add_ground_box(self.builder, world_index=w)
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set joint armatures, and verify that correct gains were loaded from the USD file

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -201,7 +201,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set joint armatures, and verify that correct gains were loaded from the USD file
         for joint in self.builder.all_joints:

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
@@ -62,7 +62,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
@@ -61,8 +61,8 @@ class Example:
         msg.info("total diag inertia: %f", self.builder.worlds[0].inertia_total)
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
@@ -60,7 +60,8 @@ class Example:
 
         # Set gravity
         for w in range(self.builder.num_worlds):
-            self.builder.gravity[w].enabled = gravity
+            if not gravity:
+                self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config
         config = Simulator.Config()

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
@@ -59,8 +59,8 @@ class Example:
         )
 
         # Set gravity
-        for w in range(self.builder.num_worlds):
-            if not gravity:
+        if not gravity:
+            for w in range(self.builder.num_worlds):
                 self.builder.set_gravity(wp.vec3f(0.0), w)
 
         # Set solver config

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -896,7 +896,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._update_actuation_types()
 
         if flags & ModelFlags.MODEL_PROPERTIES:
-            self._update_gravity()
+            pass
 
         if flags & (ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):
             # q_i_0 is derived from both model.body_q and model.body_com.
@@ -1186,10 +1186,6 @@ class SolverKamino(SolverBase, CouplingInterface):
     def _update_actuation_types(self) -> None:
         """Refresh actuation modes without changing the passive/actuated layout."""
         self._kamino.convert_model_joint_actuation(self.model, self._model_kamino.joints)
-
-    def _update_gravity(self):
-        """Update Kamino's :class:`GravityModel` from Newton's ``model.gravity``."""
-        self._kamino.convert_model_gravity(self.model, self._model_kamino.gravity)
 
     def _update_body_initial_pose(self):
         """Recompute Kamino's CoM-frame initial body poses."""

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -896,6 +896,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             self._update_actuation_types()
 
         if flags & ModelFlags.MODEL_PROPERTIES:
+            # All model properties are aliased.
             pass
 
         if flags & (ModelFlags.BODY_PROPERTIES | ModelFlags.BODY_INERTIAL_PROPERTIES):

--- a/newton/_src/solvers/kamino/tests/test_core_builder.py
+++ b/newton/_src/solvers/kamino/tests/test_core_builder.py
@@ -195,6 +195,31 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(builder.up_axes[wid], Axis.Y)
         np.testing.assert_array_equal(builder.gravity[wid].vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
 
+    def test_add_world_accepts_arraylike_gravity(self):
+        """Store a list gravity vector when adding a world."""
+        builder = ModelBuilderKamino()
+
+        wid = builder.add_world(gravity=[1.0, -2.0, 3.0])
+
+        np.testing.assert_array_equal(builder.gravity[wid].vector, np.array([1.0, -2.0, 3.0], dtype=np.float32))
+
+    def test_set_gravity_accepts_numpy_vector(self):
+        """Store a NumPy gravity vector after adding a world."""
+        builder = ModelBuilderKamino()
+        builder.add_world()
+
+        builder.set_gravity(np.array([1.0, -2.0, 3.0], dtype=np.float32))
+
+        np.testing.assert_array_equal(builder.gravity[0].vector, np.array([1.0, -2.0, 3.0], dtype=np.float32))
+
+    def test_set_gravity_rejects_invalid_vector_shape(self):
+        """Reject gravity vectors without exactly three components."""
+        builder = ModelBuilderKamino()
+        builder.add_world()
+
+        with self.assertRaisesRegex(ValueError, r"shape \(3,\)"):
+            builder.set_gravity([0.0, -9.81])
+
     def test_03_add_rigid_body(self):
         builder = ModelBuilderKamino()
         wid = builder.add_world(name="test_world", up_axis=Axis.Z)

--- a/newton/_src/solvers/kamino/tests/test_core_builder.py
+++ b/newton/_src/solvers/kamino/tests/test_core_builder.py
@@ -14,11 +14,6 @@ from newton._src.core.types import Axis
 from newton._src.solvers.kamino._src.core.bodies import RigidBodyDescriptor
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
 from newton._src.solvers.kamino._src.core.geometry import GeometryDescriptor
-from newton._src.solvers.kamino._src.core.gravity import (
-    GRAVITY_ACCEL_DEFAULT,
-    GRAVITY_DIREC_DEFAULT,
-    GRAVITY_NAME_DEFAULT,
-)
 from newton._src.solvers.kamino._src.core.joints import JointActuationType, JointDescriptor, JointDoFType
 from newton._src.solvers.kamino._src.core.materials import MaterialDescriptor
 from newton._src.solvers.kamino._src.core.model import ModelKamino
@@ -188,6 +183,7 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(len(builder.geoms), 1)
         self.assertEqual(len(builder.geoms[0]), 0)
         self.assertEqual(len(builder.materials), 1)  # Default material is always created
+        np.testing.assert_array_equal(builder.gravity[0].vector, np.array([0.0, 0.0, -9.81], dtype=np.float32))
 
     def test_02_add_world(self):
         builder = ModelBuilderKamino()
@@ -197,9 +193,7 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(builder.worlds[wid].wid, wid)
         self.assertEqual(builder.worlds[wid].name, "test_world")
         self.assertEqual(builder.up_axes[wid], Axis.Y)
-        self.assertEqual(builder.gravity[wid].name, GRAVITY_NAME_DEFAULT)
-        self.assertEqual(builder.gravity[wid].acceleration, GRAVITY_ACCEL_DEFAULT)
-        np.testing.assert_array_equal(builder.gravity[wid].direction, np.array(GRAVITY_DIREC_DEFAULT, dtype=np.float32))
+        np.testing.assert_array_equal(builder.gravity[wid].vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
 
     def test_03_add_rigid_body(self):
         builder = ModelBuilderKamino()

--- a/newton/_src/solvers/kamino/tests/test_core_world.py
+++ b/newton/_src/solvers/kamino/tests/test_core_world.py
@@ -12,12 +12,7 @@ import warp as wp
 from newton._src.geometry.types import GeoType
 from newton._src.solvers.kamino._src.core.bodies import RigidBodyDescriptor
 from newton._src.solvers.kamino._src.core.geometry import GeometryDescriptor
-from newton._src.solvers.kamino._src.core.gravity import (
-    GRAVITY_ACCEL_DEFAULT,
-    GRAVITY_DIREC_DEFAULT,
-    GRAVITY_NAME_DEFAULT,
-    GravityDescriptor,
-)
+from newton._src.solvers.kamino._src.core.gravity import GravityDescriptor
 from newton._src.solvers.kamino._src.core.joints import (
     JOINT_DQMAX,
     JOINT_QMAX,
@@ -44,71 +39,19 @@ from newton._src.solvers.kamino.tests import setup_tests, test_context
 
 
 class TestGravityDescriptor(unittest.TestCase):
-    def setUp(self):
-        if not test_context.setup_done:
-            setup_tests(clear_cache=False)
-        self.default_device = wp.get_device(test_context.device)
-        self.verbose = test_context.verbose
+    def test_default_vector(self):
+        """Use Newton's default gravity along negative Z."""
+        gravity = GravityDescriptor(name="gravity")
 
-        # Set debug-level logging to print verbose test output to console
-        if self.verbose:
-            print("\n")  # Add newline before test output for better readability
-            msg.set_log_level(msg.LogLevel.DEBUG)
-        else:
-            msg.reset_log_level()
+        self.assertEqual(gravity.name, "gravity")
+        np.testing.assert_array_equal(gravity.vector, np.array([0.0, 0.0, -9.81], dtype=np.float32))
 
-    def tearDown(self):
-        self.default_device = None
-        if self.verbose:
-            msg.reset_log_level()
+    def test_custom_vector(self):
+        """Store a custom gravity vector directly."""
+        gravity = GravityDescriptor(vector=wp.vec3f(1.0, -2.0, 3.0), name="custom")
 
-    def test_00_default_construction(self):
-        gravity = GravityDescriptor()
-        msg.info(f"gravity: {gravity}")
-        self.assertIsInstance(gravity, GravityDescriptor)
-        self.assertEqual(gravity.name, GRAVITY_NAME_DEFAULT)
-        self.assertEqual(gravity.enabled, True)
-        self.assertEqual(gravity.acceleration, GRAVITY_ACCEL_DEFAULT)
-        expected_direction = np.array(GRAVITY_DIREC_DEFAULT, dtype=np.float32)
-        expected_dir_accel = np.array([*GRAVITY_DIREC_DEFAULT, GRAVITY_ACCEL_DEFAULT], dtype=np.float32)
-        expected_vector = np.array([0.0, 0.0, -GRAVITY_ACCEL_DEFAULT, 1.0], dtype=np.float32)
-        np.testing.assert_array_equal(gravity.direction, expected_direction)
-        np.testing.assert_array_equal(gravity.dir_accel(), expected_dir_accel)
-        np.testing.assert_array_equal(gravity.vector(), expected_vector)
-
-    def test_01_with_parameters_and_dir_as_list(self):
-        gravity = GravityDescriptor(name="test_gravity", enabled=False, acceleration=15.0, direction=[1.0, 0.0, 0.0])
-        msg.info(f"gravity: {gravity}")
-        self.assertIsInstance(gravity, GravityDescriptor)
-        self.assertEqual(gravity.name, "test_gravity")
-        self.assertEqual(gravity.enabled, False)
-        self.assertEqual(gravity.acceleration, 15.0)
-        np.testing.assert_array_equal(gravity.direction, np.array([1.0, 0.0, 0.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.dir_accel(), np.array([1.0, 0.0, 0.0, 15.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.vector(), np.array([15.0, 0.0, 0.0, 0.0], dtype=np.float32))
-
-    def test_02_with_parameters_and_dir_as_tuple(self):
-        gravity = GravityDescriptor(name="test_gravity", enabled=False, acceleration=9.0, direction=(1.0, 0.0, 0.0))
-        msg.info(f"gravity: {gravity}")
-        self.assertIsInstance(gravity, GravityDescriptor)
-        self.assertEqual(gravity.name, "test_gravity")
-        self.assertEqual(gravity.enabled, False)
-        self.assertEqual(gravity.acceleration, 9.0)
-        np.testing.assert_array_equal(gravity.direction, np.array([1.0, 0.0, 0.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.dir_accel(), np.array([1.0, 0.0, 0.0, 9.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.vector(), np.array([9.0, 0.0, 0.0, 0.0], dtype=np.float32))
-
-    def test_03_with_parameters_and_dir_as_nparray(self):
-        direction = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-        gravity = GravityDescriptor(name="test_gravity", enabled=False, acceleration=12.0, direction=direction)
-        msg.info(f"gravity: {gravity}")
-        self.assertIsInstance(gravity, GravityDescriptor)
-        self.assertEqual(gravity.name, "test_gravity")
-        self.assertEqual(gravity.enabled, False)
-        self.assertEqual(gravity.acceleration, 12.0)
-        np.testing.assert_array_equal(gravity.direction, np.array([1.0, 0.0, 0.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.dir_accel(), np.array([1.0, 0.0, 0.0, 12.0], dtype=np.float32))
-        np.testing.assert_array_equal(gravity.vector(), np.array([12.0, 0.0, 0.0, 0.0], dtype=np.float32))
+        self.assertEqual(gravity.name, "custom")
+        np.testing.assert_array_equal(gravity.vector, np.array([1.0, -2.0, 3.0], dtype=np.float32))
 
 
 class TestBodyDescriptor(unittest.TestCase):

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -12,7 +12,6 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton._src.solvers.kamino._src.core.gravity import GRAVITY_DIREC_DEFAULT
 from newton._src.solvers.kamino._src.core.materials import DEFAULT_FRICTION, DEFAULT_RESTITUTION
 from newton._src.solvers.kamino.solver_kamino import SolverKamino
 from newton._src.solvers.kamino.tests import setup_tests, test_context
@@ -115,6 +114,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         solver = SolverKamino(model)
         snapshot = _snapshot_model_arrays(model)
         noop_flags = (
+            newton.ModelFlags.MODEL_PROPERTIES,
             newton.ModelFlags.BODY_PROPERTIES,
             newton.ModelFlags.BODY_INERTIAL_PROPERTIES,
             newton.ModelFlags.SHAPE_PROPERTIES,
@@ -160,9 +160,11 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         bodies = solver._model_kamino.bodies
         joints = solver._model_kamino.joints
         geoms = solver._model_kamino.geoms
+        gravity = solver._model_kamino.gravity
 
         # (Newton model attribute, Kamino container, Kamino attribute) for each direct alias.
         aliased_properties = [
+            ("gravity", gravity, "vector"),
             ("body_mass", bodies, "m_i"),
             ("body_inv_mass", bodies, "inv_m_i"),
             ("body_com", bodies, "i_r_com_i"),
@@ -197,33 +199,6 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
                 perturbed = newton_array.numpy() + np.float32(1.0)
                 newton_array.assign(perturbed)
                 np.testing.assert_array_equal(kamino_array.numpy(), perturbed)
-
-    def test_gravity_update(self):
-        """Model-property notifications refresh Kamino's gravity representation."""
-        model = _build_revolute(limited=True)
-        solver = SolverKamino(model)
-        gravity = np.tile(np.array([1.0, -2.0, 3.0], dtype=np.float32), (model.world_count, 1))
-        acceleration = np.linalg.norm(gravity, axis=1)
-
-        model.gravity.assign(gravity)
-        solver.notify_model_changed(newton.ModelFlags.MODEL_PROPERTIES)
-
-        expected_g_dir_acc = np.column_stack((gravity / acceleration[:, None], acceleration))
-        expected_vector = np.column_stack((gravity, np.ones(model.world_count, dtype=np.float32)))
-        np.testing.assert_allclose(solver._model_kamino.gravity.g_dir_acc.numpy(), expected_g_dir_acc, atol=1e-6)
-        np.testing.assert_allclose(solver._model_kamino.gravity.vector.numpy(), expected_vector, atol=1e-6)
-
-    def test_zero_gravity_update(self):
-        """Zero gravity uses Kamino's fallback direction and disables gravity."""
-        model = _build_revolute(limited=True)
-        solver = SolverKamino(model)
-        model.gravity.zero_()
-
-        solver.notify_model_changed(newton.ModelFlags.MODEL_PROPERTIES)
-
-        expected_g_dir_acc = np.append(np.asarray(GRAVITY_DIREC_DEFAULT), 0.0)[None, :]
-        np.testing.assert_array_equal(solver._model_kamino.gravity.g_dir_acc.numpy(), expected_g_dir_acc)
-        np.testing.assert_array_equal(solver._model_kamino.gravity.vector.numpy(), [[0.0, 0.0, 0.0, 0.0]])
 
     def test_joint_transform_update(self):
         """Joint-property notifications recompute Kamino's parent and child frames."""

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -49,7 +49,8 @@ class TestSetup:
         self.builder: ModelBuilderKamino = builder_fn(**kwargs)
 
         # Set ad-hoc configurations
-        self.builder.gravity[0].enabled = gravity
+        if not gravity:
+            self.builder.set_gravity(wp.vec3f(0.0))
         if perturb:
             u_0 = wp.spatial_vectorf(10.0, 0.0, 0.0, 0.0, 0.0, 0.0)
             for body in self.builder.all_bodies:

--- a/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
@@ -49,11 +49,17 @@ class TestUSDImporter(unittest.TestCase):
         if self.verbose:
             msg.reset_log_level()
 
-    def test_gravity_descriptor_from_usd_sentinels(self):
-        """Resolve raw OpenUSD gravity sentinels to finite vectors."""
-        for magnitude in (-float("inf"), -1.0):
-            gravity = GravityDescriptor.from_usd((0.0, 0.0, 0.0), magnitude, Axis.Y, 1.0)
-            np.testing.assert_array_equal(gravity.vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
+    def test_gravity_descriptor_from_usd_default_magnitude(self):
+        """Resolve OpenUSD's negative-infinity gravity sentinel."""
+        gravity = GravityDescriptor.from_usd((0.0, 0.0, 0.0), -float("inf"), Axis.Y, 1.0)
+
+        np.testing.assert_array_equal(gravity.vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
+
+    def test_gravity_descriptor_from_usd_negative_magnitude(self):
+        """Preserve an explicitly authored negative gravity magnitude."""
+        gravity = GravityDescriptor.from_usd((0.0, 0.0, -1.0), -1.0, Axis.Y, 1.0)
+
+        np.testing.assert_array_equal(gravity.vector, np.array([0.0, 0.0, 1.0], dtype=np.float32))
 
     def test_gravity_descriptor_from_usd_explicit_values(self):
         """Normalize and scale explicitly authored OpenUSD gravity."""

--- a/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
+++ b/newton/_src/solvers/kamino/tests/test_utils_io_usd.py
@@ -11,9 +11,11 @@ import warp as wp
 
 import newton
 from newton import Model, ModelBuilder
+from newton._src.core.types import Axis
 from newton._src.geometry.types import GeoType
 from newton._src.solvers.kamino import SolverKamino
 from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino
+from newton._src.solvers.kamino._src.core.gravity import GravityDescriptor
 from newton._src.solvers.kamino._src.core.joints import JOINT_QMAX, JOINT_QMIN, JointActuationType, JointDoFType
 from newton._src.solvers.kamino._src.models.builders import basics
 from newton._src.solvers.kamino._src.utils import logger as msg
@@ -46,6 +48,48 @@ class TestUSDImporter(unittest.TestCase):
         self.default_device = None
         if self.verbose:
             msg.reset_log_level()
+
+    def test_gravity_descriptor_from_usd_sentinels(self):
+        """Resolve raw OpenUSD gravity sentinels to finite vectors."""
+        for magnitude in (-float("inf"), -1.0):
+            gravity = GravityDescriptor.from_usd((0.0, 0.0, 0.0), magnitude, Axis.Y, 1.0)
+            np.testing.assert_array_equal(gravity.vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
+
+    def test_gravity_descriptor_from_usd_explicit_values(self):
+        """Normalize and scale explicitly authored OpenUSD gravity."""
+        gravity = GravityDescriptor.from_usd((3.0, 4.0, 0.0), 8.0, Axis.Z, 0.5)
+
+        np.testing.assert_allclose(gravity.vector, np.array([2.4, 3.2, 0.0], dtype=np.float32))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_default_physics_scene_gravity(self):
+        """Import the resolved default gravity of a USD physics scene."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/PhysicsScene")
+
+        builder = USDImporter().import_from(stage, load_static_geometry=False, load_materials=False)
+
+        np.testing.assert_array_equal(builder.gravity[0].vector, np.array([0.0, -9.81, 0.0], dtype=np.float32))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_import_zero_gravity_uses_stage_up_axis(self):
+        """Retain the stage up axis when imported gravity is zero."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.y)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        scene = UsdPhysics.Scene.Define(stage, "/PhysicsScene")
+        scene.CreateGravityMagnitudeAttr(0.0)
+
+        builder = USDImporter().import_from(stage, load_static_geometry=False, load_materials=False)
+
+        self.assertEqual(builder.up_axes[0], Axis.Y)
+        np.testing.assert_array_equal(builder.gravity[0].vector, np.zeros(3, dtype=np.float32))
 
     ###
     # Joints supported natively by USD


### PR DESCRIPTION
## Description

Simple cleanup after discussing with @vastsoun that we no longer need the custom GravityModel. Refactors Kamino's gravity representation to match Newton's per-world `vec3` gravity vectors instead of maintaining a separate direction/acceleration/enabled encoding.

- Replace `GravityDescriptor` direction/acceleration/enabled fields with a single `vector` field and `default_for(up_axis)` helper aligned with Newton's default gravity.
- Simplify `GravityModel` to store only `wp.array[wp.vec3]` and alias Newton's `model.gravity` via `from_newton()`.
- Remove `convert_model_gravity` and the `_update_gravity` notify path; gravity updates propagate through the aliased array.
- Update integrators, dynamics kernels, examples, and tests to read gravity vectors directly.
- Update the default gravity to match Newton's default 9.81

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests -k test_core_builder
uv run --extra dev -m newton.tests -k test_core_world
uv run --extra dev -m newton.tests -k test_solver_kamino_notify
uv run --extra dev -m newton.tests -k test_solvers_padmm
```

## New feature / API change

```python
import warp as wp
from newton._src.solvers.kamino._src.core.builder import ModelBuilderKamino

builder = ModelBuilderKamino()
builder.set_gravity(wp.vec3f(0.0, 0.0, -9.81))
# or pass a vector when adding a world:
builder.add_world(gravity=wp.vec3f(0.0, 0.0, -9.81))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Gravity is standardized on 3D gravity vectors (`[m/s²]`) throughout solvers and integrators (previous 4D gravity handling removed).
  * Gravity configuration accepts gravity descriptors or 3D vectors (array-like), with sensible defaults derived from the selected up axis.
  * USD import resolves gravity direction/magnitude correctly and uses stage up-axis when gravity magnitude is zero.
  * Simulation examples/benchmarks now disable gravity by setting a zero gravity vector per world.

* **API Changes**
  * Removed legacy public gravity conversion from package exports; gravity descriptors/models are vector-based.

* **Tests**
  * Updated and expanded gravity unit and USD importer coverage, including default and zero-magnitude behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->