### PR TITLE
Fix Kamino documentation for mixed vector quantity convention

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -304,6 +304,8 @@ class JointDoFType(IntEnum):
     Conventions:
     - Each joint connects a Base body `B` to a Follower body `F`.
     - The relative motion of body `F' w.r.t. body `B` defines the positive direction of the joint's DoFs.
+    - Mixed linear/angular vectors follow Newton's ``(linear, angular)`` ordering; translational entries
+      before rotational entries.
     - `R_x`, `R_y`, `R_z`: denote rotational DoFs about the local x, y, z axes respectively.
     - `T_x`, `T_y`, `T_z`: denote translational DoFs along the local x, y, z axes respectively.
     - Joints are indexed by `j`, and we often employ the subscript notation `*_j`.
@@ -315,13 +317,13 @@ class JointDoFType(IntEnum):
 
     FREE = 0
     """
-    A 6-DoF free-floating joint, with rotational + translational DoFs
-    along {`R_x`, `R_y`, `R_z`, `T_x`, `T_y`, `T_z`}.
+    A 6-DoF free-floating joint, with translational + rotational DoFs
+    along {`T_x`, `T_y`, `T_z`, `R_x`, `R_y`, `R_z`}.
 
     Coordinates:
         7D transform: 3D position + 4D unit quaternion
     DoFs:
-        6D twist: 3D angular velocity + 3D linear velocity
+        6D twist: 3D linear velocity + 3D angular velocity
     Constraints:
         None
     """
@@ -352,12 +354,12 @@ class JointDoFType(IntEnum):
 
     CYLINDRICAL = 3
     """
-    A 2-DoF cylindrical joint, with rotational + translational DoFs along {`R_x`, `T_x`}.
+    A 2-DoF cylindrical joint, with translational + rotational DoFs along {`T_x`, `R_x`}.
 
     Coordinates:
-        2D vector of angle {`R_x`} + 1D distance {`T_x`}
+        2D vector of distance {`T_x`} + angle {`R_x`}
     DoFs:
-        2D vector of angular velocity {`R_x`} + linear velocity {`T_x`}
+        2D vector of linear velocity {`T_x`} + angular velocity {`R_x`}
     """
 
     # TODO: Add support for PLANAR joints with 2D linear DOFS along {`T_x`, `T_y`}
@@ -443,7 +445,7 @@ class JointDoFType(IntEnum):
         elif self.value == self.PRISMATIC:
             return 1  # 1D distance
         elif self.value == self.CYLINDRICAL:
-            return 2  # 2D vector of angle + distance
+            return 2  # 2D vector of distance + angle
         elif self.value == self.UNIVERSAL:
             return 2  # 2D angles
         elif self.value == self.SPHERICAL:
@@ -461,13 +463,13 @@ class JointDoFType(IntEnum):
         Returns the number of DoFs defined by the joint DoF type.
         """
         if self.value == self.FREE:
-            return 6  # 3D angular velocity + 3D linear velocity
+            return 6  # 3D linear velocity + 3D angular velocity
         elif self.value == self.REVOLUTE:
             return 1  # 1D angular velocity
         elif self.value == self.PRISMATIC:
             return 1  # 1D linear velocity
         elif self.value == self.CYLINDRICAL:
-            return 2  # 1D angular velocity + 1D linear velocity
+            return 2  # 1D linear velocity + 1D angular velocity
         elif self.value == self.UNIVERSAL:
             return 2  # 2D angular velocities
         elif self.value == self.SPHERICAL:
@@ -883,7 +885,7 @@ class JointDoFType(IntEnum):
         elif dof_type == JointDoFType.PRISMATIC:
             return 1  # 1D distance
         elif dof_type == JointDoFType.CYLINDRICAL:
-            return 2  # 2D vector of angle + distance
+            return 2  # 2D vector of distance + angle
         elif dof_type == JointDoFType.UNIVERSAL:
             return 2  # 2D angles
         elif dof_type == JointDoFType.SPHERICAL:
@@ -908,13 +910,13 @@ class JointDoFType(IntEnum):
             invalid.
         """
         if dof_type == JointDoFType.FREE:
-            return 6  # 3D angular velocity + 3D linear velocity
+            return 6  # 3D linear velocity + 3D angular velocity
         elif dof_type == JointDoFType.REVOLUTE:
             return 1  # 1D angular velocity
         elif dof_type == JointDoFType.PRISMATIC:
             return 1  # 1D linear velocity
         elif dof_type == JointDoFType.CYLINDRICAL:
-            return 2  # 1D angular velocity + 1D linear velocity
+            return 2  # 1D linear velocity + 1D angular velocity
         elif dof_type == JointDoFType.UNIVERSAL:
             return 2  # 2D angular velocities
         elif dof_type == JointDoFType.SPHERICAL:


### PR DESCRIPTION
## Description

Newton is globally using the `(linear, angular)` ordering convention for spatial vectors and related quantities. Kamino does too, but some of the documentation is still referring to a previous `(angular, linear)` convention and needs to be fixed.

## Checklist

- [ ] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified joint coordinate and degree-of-freedom ordering to consistently use the linear-then-angular convention.
  * Updated explanatory comments for free and cylindrical joints.
  * No functional behavior or numeric values changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->