### PR TITLE
Extended contact visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Reject invalid `ModelBuilder.ShapeConfig` SDF and density values during shape validation. Use finite nonnegative density and SDF padding, a finite positive target voxel size, a narrow-band range satisfying `inner < 0 < outer`, and a positive maximum resolution below 65536 that is divisible by 8; set either maximum resolution or target voxel size, not both. (#3311)
 - Reject runtime changes that alter `SolverKamino`'s as-built joint constraint counts, passive/actuated partition, or finite-limit structure; recreate the solver after making one of these structural changes. (#3532)
 - Cull positive-distance speculative contacts by default when converting Newton contacts for `SolverKamino` as a temporary workaround for restitution issues. No public compatibility option restores the old behavior; if a scene needs contact forces before geometry surfaces touch, increase `ModelBuilder.ShapeConfig.margin` so margin-shifted surfaces overlap at the desired force onset, and re-test contact behavior. (#3779)
+- Refine contact visualizations (showing contact force and color-coded contact mode) in Newton viewer.
 
 ### Deprecated
 

--- a/newton/_src/solvers/kamino/_src/utils/sim/viewer.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/viewer.py
@@ -433,7 +433,7 @@ class ViewerKamino(ViewerGL):
         # ======================================================================
 
         # Allocate buffers for force arrows
-        if not hasattr(self, "_contact_force_starts"):
+        if not hasattr(self, "_contact_force_colors"):
             self._contact_force_starts = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
             self._contact_force_ends = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
             self._contact_force_colors = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)

--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -324,6 +324,213 @@ def compute_contact_lines(
     line_end[tid] = contact_center + line_vector
 
 
+@wp.func
+def _quat_from_normal_z(normal: wp.vec3) -> wp.quat:
+    """Build a rotation quaternion whose local +Z axis aligns with ``normal``.
+
+    The tangent axes are arbitrary. Implemented with :func:`orthonormal_basis`
+    for numerical stability near the poles.
+    """
+    n = wp.normalize(normal)
+    t1, t2 = orthonormal_basis(n)
+    R = wp.matrix_from_cols(t1, t2, n)
+    return wp.quat_from_matrix(R)
+
+
+@wp.kernel
+def compute_contact_disk_transforms(
+    body_q: wp.array[wp.transform],
+    body_qd: wp.array[wp.spatial_vector],
+    body_com: wp.array[wp.vec3],
+    shape_body: wp.array[int],
+    shape_world: wp.array[int],
+    world_offsets: wp.array[wp.vec3],
+    visible_worlds_mask: wp.array[int],
+    contact_count: wp.array[int],
+    contact_shape0: wp.array[int],
+    contact_shape1: wp.array[int],
+    contact_point0: wp.array[wp.vec3],
+    contact_point1: wp.array[wp.vec3],
+    contact_offset0: wp.array[wp.vec3],
+    contact_normal: wp.array[wp.vec3],
+    contact_force: wp.array[wp.spatial_vector],
+    disk_radius: float,
+    disk_thickness: float,
+    eps_force: float,
+    eps_velocity: float,
+    color_open: wp.vec3,
+    color_stick: wp.vec3,
+    color_slip: wp.vec3,
+    # outputs
+    transforms: wp.array[wp.transform],
+    scales: wp.array[wp.vec3],
+    colors: wp.array[wp.vec3],
+):
+    """Compute per-contact disk transforms, scales, and mode-coloured colors.
+
+    A thin oriented disk (rendered via a unit cylinder mesh whose local +Z
+    axis is the cylinder axis) is placed at each active contact, oriented so
+    that its axis matches ``contact_normal``.
+
+    When ``contact_force`` is provided (non-null), the disk is colored by an
+    inferred contact mode computed from the linear contact force magnitude and
+    the tangential relative velocity at the contact point:
+
+    * ``|F| < eps_force``                                  -> ``color_open``
+    * ``|F| >= eps_force and |v_tan| < eps_velocity``      -> ``color_stick``
+    * ``|F| >= eps_force and |v_tan| >= eps_velocity``     -> ``color_slip``
+
+    When ``contact_force`` is null, every active contact uses ``color_open``.
+
+    Inactive slots (beyond ``contact_count[0]`` or hidden by the visible-worlds
+    mask) receive a degenerate zero-scale transform and a black color.
+    """
+    tid = wp.tid()
+
+    zero_xform = wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity())
+    zero_vec = wp.vec3(0.0, 0.0, 0.0)
+
+    count = contact_count[0]
+    if tid >= count:
+        transforms[tid] = zero_xform
+        scales[tid] = zero_vec
+        colors[tid] = zero_vec
+        return
+
+    shape_a = contact_shape0[tid]
+    shape_b = contact_shape1[tid]
+    if shape_a == shape_b:
+        transforms[tid] = zero_xform
+        scales[tid] = zero_vec
+        colors[tid] = zero_vec
+        return
+
+    world_a = shape_world[shape_a]
+    world_b = shape_world[shape_b]
+    if visible_worlds_mask:
+        w = world_a if world_a >= 0 else world_b
+        if w >= 0:
+            if visible_worlds_mask[w] == 0:
+                transforms[tid] = zero_xform
+                scales[tid] = zero_vec
+                colors[tid] = zero_vec
+                return
+
+    body_a = shape_body[shape_a]
+    body_b = shape_body[shape_b]
+
+    X_wb_a = wp.transform_identity()
+    if body_a >= 0:
+        X_wb_a = body_q[body_a]
+
+    world_pos0 = wp.transform_point(X_wb_a, contact_point0[tid] + contact_offset0[tid])
+
+    contact_center = world_pos0
+    if world_a >= 0 or world_b >= 0:
+        contact_center += world_offsets[world_a if world_a >= 0 else world_b]
+
+    n = contact_normal[tid]
+    q = _quat_from_normal_z(n)
+
+    # Mode coloring (default to "color_open" when force is unavailable).
+    color = color_open
+    if contact_force:
+        f_lin = wp.spatial_top(contact_force[tid])
+        f_mag = wp.length(f_lin)
+        if f_mag < eps_force:
+            color = color_open
+        else:
+            # Relative tangential velocity at the contact point.
+            v_a = wp.vec3(0.0, 0.0, 0.0)
+            if body_a >= 0:
+                world_com_a = wp.transform_point(body_q[body_a], body_com[body_a])
+                r_a = world_pos0 - world_com_a
+                v_a = velocity_at_point(body_qd[body_a], r_a)
+            v_b = wp.vec3(0.0, 0.0, 0.0)
+            if body_b >= 0:
+                X_wb_b = body_q[body_b]
+                world_pos1 = wp.transform_point(X_wb_b, contact_point1[tid])
+                world_com_b = wp.transform_point(X_wb_b, body_com[body_b])
+                r_b = world_pos1 - world_com_b
+                v_b = velocity_at_point(body_qd[body_b], r_b)
+            v_rel = v_a - v_b
+            v_t = v_rel - wp.dot(v_rel, n) * n
+            if wp.length(v_t) < eps_velocity:
+                color = color_stick
+            else:
+                color = color_slip
+
+    transforms[tid] = wp.transform(contact_center, q)
+    scales[tid] = wp.vec3(disk_radius, disk_radius, disk_thickness)
+    colors[tid] = color
+
+
+@wp.kernel
+def compute_contact_force_arrows(
+    body_q: wp.array[wp.transform],
+    shape_body: wp.array[int],
+    shape_world: wp.array[int],
+    world_offsets: wp.array[wp.vec3],
+    visible_worlds_mask: wp.array[int],
+    contact_count: wp.array[int],
+    contact_shape0: wp.array[int],
+    contact_shape1: wp.array[int],
+    contact_point0: wp.array[wp.vec3],
+    contact_offset0: wp.array[wp.vec3],
+    contact_force: wp.array[wp.spatial_vector],
+    force_scale: float,
+    # outputs
+    line_start: wp.array[wp.vec3],
+    line_end: wp.array[wp.vec3],
+):
+    """Create world-space line segments visualizing the linear part of contact wrenches.
+
+    The arrow starts at the world contact point on shape 0 and points along
+    ``F = wp.spatial_top(contact_force[i])`` (the world-frame linear force on
+    body 0), with length ``force_scale * |F|``.  Inactive slots produce
+    degenerate (NaN) line segments that the renderer culls.
+    """
+    tid = wp.tid()
+    nan_line = wp.vec3(wp.nan, wp.nan, wp.nan)
+
+    count = contact_count[0]
+    if tid >= count:
+        line_start[tid] = nan_line
+        line_end[tid] = nan_line
+        return
+
+    shape_a = contact_shape0[tid]
+    shape_b = contact_shape1[tid]
+    if shape_a == shape_b:
+        line_start[tid] = nan_line
+        line_end[tid] = nan_line
+        return
+
+    world_a = shape_world[shape_a]
+    world_b = shape_world[shape_b]
+    if visible_worlds_mask:
+        w = world_a if world_a >= 0 else world_b
+        if w >= 0:
+            if visible_worlds_mask[w] == 0:
+                line_start[tid] = nan_line
+                line_end[tid] = nan_line
+                return
+
+    body_a = shape_body[shape_a]
+    X_wb_a = wp.transform_identity()
+    if body_a >= 0:
+        X_wb_a = body_q[body_a]
+
+    world_pos0 = wp.transform_point(X_wb_a, contact_point0[tid] + contact_offset0[tid])
+    contact_center = world_pos0
+    if world_a >= 0 or world_b >= 0:
+        contact_center += world_offsets[world_a if world_a >= 0 else world_b]
+
+    f_lin = -wp.spatial_top(contact_force[tid])  # Flip sign so positive force is along normal
+    line_start[tid] = contact_center
+    line_end[tid] = contact_center + force_scale * f_lin
+
+
 @wp.kernel
 def compute_joint_basis_lines(
     joint_type: wp.array[int],

--- a/newton/_src/viewer/kernels.py
+++ b/newton/_src/viewer/kernels.py
@@ -434,6 +434,7 @@ def compute_contact_disk_transforms(
 
     # Mode coloring (default to "color_open" when force is unavailable).
     color = color_open
+    thickness_scaling = 1.0  # Apply slightly different thickness based on color to avoid visible z-fighting
     if contact_force:
         f_lin = wp.spatial_top(contact_force[tid])
         f_mag = wp.length(f_lin)
@@ -457,11 +458,13 @@ def compute_contact_disk_transforms(
             v_t = v_rel - wp.dot(v_rel, n) * n
             if wp.length(v_t) < eps_velocity:
                 color = color_stick
+                thickness_scaling = 1.02
             else:
                 color = color_slip
+                thickness_scaling = 1.01
 
     transforms[tid] = wp.transform(contact_center, q)
-    scales[tid] = wp.vec3(disk_radius, disk_radius, disk_thickness)
+    scales[tid] = wp.vec3(disk_radius, disk_radius, disk_thickness * thickness_scaling)
     colors[tid] = color
 
 

--- a/newton/_src/viewer/viewer.py
+++ b/newton/_src/viewer/viewer.py
@@ -532,9 +532,19 @@ class ViewerBase(ABC):
         # Geometry mesh cache (geometry hash -> mesh path)
         layer._geometry_cache: dict[int, str] = {}
 
-        # Contact line vertices
+        # Contact normal vertices
         layer._contact_points0 = None
         layer._contact_points1 = None
+
+        # Contact disks (for contact mode color-coding)
+        layer._contact_disk_mesh: str | None = None
+        layer._contact_disk_xforms: wp.array | None = None
+        layer._contact_disk_scales: wp.array | None = None
+        layer._contact_disk_colors: wp.array | None = None
+
+        # Contact force vertices
+        layer._contact_force_starts: wp.array | None = None
+        layer._contact_force_ends: wp.array | None = None
 
         # Joint basis line vertices (3 lines per joint)
         layer._joint_points0 = None
@@ -562,6 +572,9 @@ class ViewerBase(ABC):
         layer.show_com = False
         layer.show_particles = False
         layer.show_contacts = False
+        layer.show_contact_normals = True
+        layer.show_contact_disks = True  # Note: requires the ``"force"`` extended contact attribute.
+        layer.show_contact_forces = True  # Note: requires the ``"force"`` extended contact attribute.
         layer.show_springs = False
         layer.show_triangles = True
         layer.show_gaussians = False
@@ -572,6 +585,17 @@ class ViewerBase(ABC):
         layer.show_inertia_boxes = False
         layer.show_hydro_contact_surface = False
         layer.sdf_margin_mode: ViewerBase.SDFMarginMode = ViewerBase.SDFMarginMode.OFF
+
+        # Thresholds for contact disk coloring (determining open/sticking/sliding contact modes)
+        layer.contact_mode_eps_force = 1e-4
+        layer.contact_mode_eps_velocity = 1e-3
+
+        # Scaling parameters for the contact visualization
+        # Note: these are auto-set in :meth:`set_model`, below are fallback defaults.
+        layer.contact_viz_scale = 1.0  # Length of contact normal arrows (contact disks/forces scale relatively)
+        layer.contact_force_scale = 0.5  # Length of contact force arrows, w.r.t. contact normal arrows
+        layer._contact_viz_scale_default = layer.contact_viz_scale
+        layer._contact_force_scale_default = layer.contact_force_scale
 
         layer.gaussians_max_points = 100_000  # Max number of points to visualize per gaussian
 
@@ -640,6 +664,9 @@ class ViewerBase(ABC):
             # Auto-compute world offsets if not already set
             if self.world_offsets is None:
                 self._auto_compute_world_offsets()
+
+            # Adapt contact-visualization scales to the model.
+            self._auto_compute_contact_scales()
 
     def _should_render_world(self, world_idx: int) -> bool:
         """Check if a world should be rendered based on visible worlds."""
@@ -920,6 +947,62 @@ class ViewerBase(ABC):
         # Set world offsets with computed spacing
         self.set_world_offsets(tuple(spacing))
 
+    def _auto_compute_contact_scales(self):
+        """Adapt contact-visualization scales to the current model.
+
+        Sets ``contact_viz_scale`` and ``contact_force_scale``, based on
+        aggregate model dimensions.
+
+        Falls back to the literal defaults if the relevant model data is
+        unavailable (e.g. no shapes / no dynamic bodies / zero gravity).
+        """
+        # Save the previous defaults so we can detect user overrides set
+        # before the model was attached (rare but possible).
+        prev_default_scale = self._contact_viz_scale_default
+        prev_default_force_scale = self._contact_force_scale_default
+
+        # Characteristic length L_char: 10% of the maximal extent.
+        L_char = 0.0
+        max_extents = self._get_world_extents()
+        if max_extents is not None:
+            L_char = float(0.1 * np.linalg.norm(max_extents))
+        if not np.isfinite(L_char) or L_char <= 0.0:
+            L_char = 1.0
+
+        # Characteristic force F_char = sum(dynamic body mass) * |gravity|.
+        F_char = 0.0
+        if (
+            self.model is not None
+            and self.model.body_mass is not None
+            and self.model.body_inv_mass is not None
+            and self.model.body_count > 0
+        ):
+            mass_np = self.model.body_mass.numpy()
+            inv_mass_np = self.model.body_inv_mass.numpy()
+            dyn_mask = np.isfinite(mass_np) & (inv_mass_np > 0.0)
+            total_mass = float(mass_np[dyn_mask].sum()) if dyn_mask.any() else 0.0
+            g_mag = 9.81
+            if self.model.gravity is not None:
+                g_np = self.model.gravity.numpy()
+                if g_np.size > 0:
+                    g0 = np.asarray(g_np[0], dtype=np.float64).reshape(-1)
+                    g_mag = float(np.linalg.norm(g0))
+                    if not np.isfinite(g_mag) or g_mag <= 0.0:
+                        g_mag = 9.81
+            F_char = total_mass * g_mag
+        if not np.isfinite(F_char) or F_char <= 0.0:
+            F_char = 1.0
+
+        # Set contact scales based on L_char and F_char
+        self._contact_viz_scale_default = 1.0 * L_char
+        self._contact_force_scale_default = 5.0 / F_char if F_char > 0.0 else 0.5
+
+        # Reset live attributes to new defaults, if values were still default
+        if self.contact_viz_scale == prev_default_scale:
+            self.contact_viz_scale = self._contact_viz_scale_default
+        if self.contact_force_scale == prev_default_force_scale:
+            self.contact_force_scale = self._contact_force_scale_default
+
     def begin_frame(self, time: float):
         """Begin a new frame.
 
@@ -1086,32 +1169,61 @@ class ViewerBase(ABC):
         self._log_com(state)
 
     def log_contacts(self, contacts: newton.Contacts, state: newton.State):
-        """Render contact normals as arrows.
+        """Render contact visualizations.
 
-        Each active rigid contact is drawn as an arrow from the contact point
-        along the contact normal.  When ``show_contacts`` is ``False`` the
-        arrow batch is cleared.
+        The visualization is split into three layers, each of which can be
+        toggled independently:
+
+        * ``"/contacts/normals"`` — arrows along ``rigid_contact_normal``
+          (gated on :attr:`show_contact_normals`).
+        * ``"/contacts/modes"`` — thin oriented disks at each contact, color
+          coded by inferred contact mode (open / stick / slip) when
+          ``contacts.force`` is allocated, else by a uniform default color
+          (gated on :attr:`show_contact_disks`).
+        * ``"/contacts/forces"`` — arrows along the linear part of
+          ``contacts.force`` (gated on :attr:`show_contact_forces`; hidden if
+          ``contacts.force is None``).
+
+        Sub-toggles are themselves gated by the master :attr:`show_contacts`
+        flag; setting it to ``False`` hides everything.  When sub-toggles are
+        all enabled (default) the master flag behaves exactly like the
+        previous single-layer ``"Show Contacts"`` checkbox.
 
         Args:
             contacts: The contacts to render.
-            state: The current state of the simulation.
+            state: The current state of the simulation.  Required to compute
+                world-space contact positions and (for mode coloring) body
+                velocities at the contact points.
         """
 
         if not self.show_contacts or self._layer_force_hidden():
-            self.log_arrows(self._qualify("/contacts"), None, None, None)
+            self.log_arrows(self._qualify("/contacts/normals"), None, None, None)
+            if self._contact_disk_mesh is not None:
+                self.log_instances(
+                    self._qualify("/contacts/modes"), self._contact_disk_mesh, None, None, None, None, hidden=True
+                )
+            self.log_arrows(self._qualify("/contacts/forces"), None, None, None)
             return
 
         # Get contact count, clamped to buffer size (counter may exceed max on overflow)
         max_contacts = contacts.rigid_contact_max
         num_contacts = min(int(contacts.rigid_contact_count.numpy()[0]), max_contacts)
 
-        # Ensure we have buffers for line endpoints
-        if self._contact_points0 is None or len(self._contact_points0) < max_contacts:
-            self._contact_points0 = wp.array(np.zeros((max_contacts, 3)), dtype=wp.vec3, device=self.device)
-            self._contact_points1 = wp.array(np.zeros((max_contacts, 3)), dtype=wp.vec3, device=self.device)
+        if max_contacts == 0:
+            self.log_arrows(self._qualify("/contacts/normals"), None, None, None)
+            if self._contact_disk_mesh is not None:
+                self.log_instances(
+                    self._qualify("/contacts/modes"), self._contact_disk_mesh, None, None, None, None, hidden=True
+                )
+            self.log_arrows(self._qualify("/contacts/forces"), None, None, None)
+            return
 
-        # Always run the kernel to ensure buffers are properly cleared/updated
-        if max_contacts > 0:
+        # ---- Contact-normal arrows -------------------------------
+        if self.show_contact_normals:
+            if self._contact_points0 is None or len(self._contact_points0) < max_contacts:
+                self._contact_points0 = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+                self._contact_points1 = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+
             from .kernels import compute_contact_lines  # noqa: PLC0415
 
             wp.launch(
@@ -1130,7 +1242,7 @@ class ViewerBase(ABC):
                     contacts.rigid_contact_point0,
                     contacts.rigid_contact_offset0,
                     contacts.rigid_contact_normal,
-                    self.scene_scale * self._arrow_scale(),
+                    float(self.contact_viz_scale),
                 ],
                 outputs=[
                     self._contact_points0,  # line start points
@@ -1139,19 +1251,119 @@ class ViewerBase(ABC):
                 device=self.device,
             )
 
-        # Always call log_arrows to update the renderer (handles zero contacts gracefully)
-        if num_contacts > 0:
-            # Slice arrays to only include active contacts
-            starts = self._contact_points0[:num_contacts]
-            ends = self._contact_points1[:num_contacts]
+            if num_contacts > 0:
+                self.log_arrows(
+                    self._qualify("/contacts/normals"),
+                    self._contact_points0[:num_contacts],
+                    self._contact_points1[:num_contacts],
+                    (0.0, 1.0, 0.0),  # green
+                )
+            else:
+                self.log_arrows(self._qualify("/contacts/normals"), None, None, None)
         else:
-            # Create empty arrays for zero contacts case
-            starts = wp.array([], dtype=wp.vec3, device=self.device)
-            ends = wp.array([], dtype=wp.vec3, device=self.device)
+            self.log_arrows(self._qualify("/contacts/normals"), None, None, None)
 
-        colors = (0.0, 1.0, 0.0)
+        # ---- Contact mode disks ----------------------------------
+        if self.show_contact_disks:
+            if self._contact_disk_mesh is None:
+                # Unit cylinder (radius=1, half_height=1); per-instance scaling
+                # produces the actual disk dimensions.
+                self._contact_disk_mesh = self._populate_geometry(
+                    int(newton.GeoType.CYLINDER), (1.0, 1.0), 0.0, True, geo_src=None
+                )
 
-        self.log_arrows(self._qualify("/contacts"), starts, ends, colors)
+            if self._contact_disk_xforms is None or len(self._contact_disk_xforms) < max_contacts:
+                self._contact_disk_xforms = wp.zeros(max_contacts, dtype=wp.transform, device=self.device)
+                self._contact_disk_scales = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+                self._contact_disk_colors = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+
+            from .kernels import compute_contact_disk_transforms  # noqa: PLC0415
+
+            wp.launch(
+                kernel=compute_contact_disk_transforms,
+                dim=max_contacts,
+                inputs=[
+                    state.body_q,
+                    state.body_qd,
+                    self.model.body_com,
+                    self.model.shape_body,
+                    self.model.shape_world,
+                    self.world_offsets,
+                    self._visible_worlds_mask,
+                    contacts.rigid_contact_count,
+                    contacts.rigid_contact_shape0,
+                    contacts.rigid_contact_shape1,
+                    contacts.rigid_contact_point0,
+                    contacts.rigid_contact_point1,
+                    contacts.rigid_contact_offset0,
+                    contacts.rigid_contact_normal,
+                    contacts.force,  # may be None — kernel falls back to default color
+                    float(self.contact_viz_scale * 0.2),
+                    float(self.contact_viz_scale * 0.004),  # cylinder half-height
+                    float(self.contact_mode_eps_force),
+                    float(self.contact_mode_eps_velocity),
+                    wp.vec3(0.1, 0.1, 0.1),  # open: black
+                    wp.vec3(0.6, 0.6, 0.6),  # stick: light gray
+                    wp.vec3(0.2, 0.2, 0.9),  # slip: blue
+                ],
+                outputs=[self._contact_disk_xforms, self._contact_disk_scales, self._contact_disk_colors],
+                device=self.device,
+            )
+
+            self.log_instances(
+                self._qualify("/contacts/modes"),
+                self._contact_disk_mesh,
+                self._contact_disk_xforms[:max_contacts],
+                self._contact_disk_scales[:max_contacts],
+                self._contact_disk_colors[:max_contacts],
+                None,
+                hidden=False,
+            )
+        elif self._contact_disk_mesh is not None:
+            self.log_instances(
+                self._qualify("/contacts/modes"), self._contact_disk_mesh, None, None, None, None, hidden=True
+            )
+
+        # ---- Layer C: contact force arrows --------------------------------
+        if self.show_contact_forces and contacts.force is not None:
+            if self._contact_force_starts is None or len(self._contact_force_starts) < max_contacts:
+                self._contact_force_starts = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+                self._contact_force_ends = wp.zeros(max_contacts, dtype=wp.vec3, device=self.device)
+
+            from .kernels import compute_contact_force_arrows  # noqa: PLC0415
+
+            wp.launch(
+                kernel=compute_contact_force_arrows,
+                dim=max_contacts,
+                inputs=[
+                    state.body_q,
+                    self.model.shape_body,
+                    self.model.shape_world,
+                    self.world_offsets,
+                    self._visible_worlds_mask,
+                    contacts.rigid_contact_count,
+                    contacts.rigid_contact_shape0,
+                    contacts.rigid_contact_shape1,
+                    contacts.rigid_contact_point0,
+                    contacts.rigid_contact_offset0,
+                    contacts.force,
+                    float(self.contact_viz_scale * self.contact_force_scale),
+                ],
+                outputs=[self._contact_force_starts, self._contact_force_ends],
+                device=self.device,
+            )
+
+            if num_contacts > 0:
+                self.log_arrows(
+                    self._qualify("/contacts/forces"),
+                    self._contact_force_starts[:num_contacts],
+                    self._contact_force_ends[:num_contacts],
+                    (1.0, 0.0, 1.0),  # magenta
+                )
+            else:
+                self.log_arrows(self._qualify("/contacts/forces"), None, None, None)
+        else:
+            self.log_arrows(self._qualify("/contacts/forces"), None, None, None)
 
     def log_hydro_contact_surface(
         self,

--- a/newton/_src/viewer/viewer_gui.py
+++ b/newton/_src/viewer/viewer_gui.py
@@ -809,13 +809,37 @@ class ViewerGui:
                         _, renderer.joint_scale = imgui.slider_float("Joint Scale", renderer.joint_scale, 0.25, 5.0)
                     _changed, viewer.show_contacts = imgui.checkbox("Show Contacts", viewer.show_contacts)
                     if viewer.show_contacts and renderer is not None:
-                        if hasattr(renderer, "arrow_length_scale"):
-                            _, renderer.arrow_length_scale = imgui.slider_float(
-                                "Contact Length", renderer.arrow_length_scale, 0.25, 5.0
+                        imgui.indent()
+                        _, viewer.show_contact_normals = imgui.checkbox("Normal", bool(viewer.show_contact_normals))
+                        _, viewer.show_contact_disks = imgui.checkbox("Contact Mode", bool(viewer.show_contact_disks))
+                        _, viewer.show_contact_forces = imgui.checkbox("Force", bool(viewer.show_contact_forces))
+                        imgui.unindent()
+
+                        log_flag = imgui.SliderFlags_.logarithmic.value
+                        base = float(viewer._contact_viz_scale_default) or 1.0
+                        _, viewer.contact_viz_scale = imgui.slider_float(
+                            "Contact Scale",
+                            float(viewer.contact_viz_scale),
+                            base * 0.01,
+                            base * 100.0,
+                            "%.4g",
+                            log_flag,
+                        )
+                        if viewer.show_contact_forces:
+                            base = float(viewer._contact_force_scale_default) or 0.5
+                            _, viewer.contact_force_scale = imgui.slider_float(
+                                "Force Relative Scale",
+                                float(viewer.contact_force_scale),
+                                base * 0.01,
+                                base * 100.0,
+                                "%.4g",
+                                log_flag,
                             )
-                        if hasattr(renderer, "arrow_scale"):
+                        if hasattr(renderer, "arrow_scale") and (
+                            viewer.show_contact_normals or viewer.show_contact_forces
+                        ):
                             _, renderer.arrow_scale = imgui.slider_float(
-                                "Contact Width", renderer.arrow_scale, 0.25, 5.0
+                                "Arrow Thickness", renderer.arrow_scale, 0.25, 5.0
                             )
                     _changed, viewer.show_particles = imgui.checkbox("Show Particles", viewer.show_particles)
                     _changed, viewer.show_springs = imgui.checkbox("Show Springs", viewer.show_springs)

--- a/newton/examples/kamino/example_kamino_basic_dr_testmech.py
+++ b/newton/examples/kamino/example_kamino_basic_dr_testmech.py
@@ -34,6 +34,7 @@ class Example:
         newton.solvers.SolverKamino.register_custom_attributes(robot_builder)
         robot_builder.default_shape_cfg.margin = 1e-6
         robot_builder.default_shape_cfg.gap = 0.01
+        robot_builder.request_contact_attributes("force")  # For contact visualization
 
         # Load the DR TestMech USD and add it to the builder
         asset_path = newton.utils.download_asset("disneyresearch")

--- a/newton/examples/kamino/example_kamino_basic_fourbar.py
+++ b/newton/examples/kamino/example_kamino_basic_fourbar.py
@@ -38,6 +38,7 @@ class Example:
         newton.solvers.SolverKamino.register_custom_attributes(robot_builder)
         robot_builder.default_shape_cfg.margin = 0.0
         robot_builder.default_shape_cfg.gap = 0.0
+        robot_builder.request_contact_attributes("force")  # For contact visualization
 
         # Load the basic four-bar mechanism either from USD or by manually building it
         # with the builder API, depending on the command-line argument `--from-usd`

--- a/newton/examples/kamino/example_kamino_basic_heterogeneous.py
+++ b/newton/examples/kamino/example_kamino_basic_heterogeneous.py
@@ -68,6 +68,7 @@ class Example:
             basics.make_basics_heterogeneous_builder(builder=builder, ground=True)
 
         # Create the model from the builder
+        builder.request_contact_attributes("force")  # For contact visualization
         self.model = builder.finalize(skip_validation_joints=True)
 
         # Create and configure settings for SolverKamino and the collision detector

--- a/newton/examples/kamino/example_kamino_robot_anymal_d.py
+++ b/newton/examples/kamino/example_kamino_robot_anymal_d.py
@@ -35,6 +35,7 @@ class Example:
         newton.solvers.SolverKamino.register_custom_attributes(robot_builder)
         robot_builder.default_shape_cfg.margin = 0.0
         robot_builder.default_shape_cfg.gap = 0.0
+        robot_builder.request_contact_attributes("force")  # For contact visualization
 
         # Load the Anymal D USD and add it to the builder
         asset_path = newton.utils.download_asset("anybotics_anymal_d")

--- a/newton/examples/kamino/example_kamino_robot_dr_legs.py
+++ b/newton/examples/kamino/example_kamino_robot_dr_legs.py
@@ -42,6 +42,7 @@ class Example:
         newton.solvers.SolverKamino.register_custom_attributes(robot_builder)
         robot_builder.default_shape_cfg.margin = dvi_contact_margin
         robot_builder.default_shape_cfg.gap = 1e-2
+        robot_builder.request_contact_attributes("force")  # For contact visualization
 
         # Load the DR Legs USD and add it to the builder
         asset_path = newton.utils.download_asset("disneyresearch")


### PR DESCRIPTION
## Description

This refines the (rigid) contact visualization options in the newton viewer, allowing to visualize the contact force, as well as the contact mode (open / sliding / sticking, using a color-coded disk in the tangential plane), on top of the contact normal (as per the current viewer).

The disk color (contact mode) and force visualization both require access to the contact force (e.g. through calling `builder.request_contact_attributes("force")`), but will default to black (open contact) and no force vector if not available.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

This has been incorporated for a while in my local branch for validating contact modeling and comparing solvers, so it has been indirectly tested there. Not sure what the policy is for unit testing the viewer outside of this (apart from the reviewers trying it out on the newton examples). 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate visualization controls for contact normals, contact modes, and contact forces.
  * Contact modes are shown with color-coded disks for open, sticking, and sliding behavior.
  * Contact forces appear as directional arrows when force data is available.
  * Added controls for contact scale, force scale, and arrow thickness.
  * Visualization scales adapt automatically to the model while preserving manual adjustments.

* **Documentation**
  * Updated the changelog with details about the refined contact visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->