### PR TITLE
Miscellaneous small fixes in Kamino

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -1378,7 +1378,7 @@ def convert_joints(
                 continue
             base_body_idx_np[wid] = body_world_start_np[wid]
 
-    # Only warn for worlds where a skipped root left the world without a base
+    # Warn user if an articulation root couldn't be used as base because it is not a free joint
     if np.any(world_has_non_floating_root & (base_body_idx_np == -1)):
         msg.warning(
             "Model has articulations whose root is not a free joint attached to the world, "

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -1742,9 +1742,10 @@ class JointsModel:
     """
     Minimum (a.k.a. lower) joint DoF limits of each joint (as flat array).
 
-    Limits are dimensioned according to the number of DoFs of each joint,
-    as opposed to the number of coordinates in order to handle cases such
-    where joints have more coordinates than DoFs (e.g. spherical joints).
+    Although applying to joint coordinates, limits are dimensioned
+    according to the number of DoFs of each joint, as the number of limits
+    depends on the intrinsic number of DoFs, not on its (possibly redundant,
+    e.g. for spherical joints) parameterization into coordinates.
 
     Shape of ``(sum_of_num_joint_dofs,)``.
     """
@@ -1753,9 +1754,10 @@ class JointsModel:
     """
     Maximum (a.k.a. upper) joint DoF limits of each joint (as flat array).
 
-    Limits are dimensioned according to the number of DoFs of each joint,
-    as opposed to the number of coordinates in order to handle cases such
-    where joints have more coordinates than DoFs (e.g. spherical joints).
+    Although applying to joint coordinates, limits are dimensioned
+    according to the number of DoFs of each joint, as the number of limits
+    depends on the intrinsic number of DoFs, not on its (possibly redundant,
+    e.g. for spherical joints) parameterization into coordinates.
 
     Shape of ``(sum_of_num_joint_dofs,)``.
     """

--- a/newton/_src/solvers/kamino/_src/core/materials.py
+++ b/newton/_src/solvers/kamino/_src/core/materials.py
@@ -39,7 +39,6 @@ from .types import Descriptor
 ###
 
 __all__ = [
-    "DEFAULT_DENSITY",
     "DEFAULT_FRICTION",
     "DEFAULT_RESTITUTION",
     "MaterialDescriptor",
@@ -53,12 +52,6 @@ __all__ = [
 ###
 # Constants
 ###
-
-DEFAULT_DENSITY = 1000.0
-"""
-The global default density for materials, in kg/m^3.
-Equals ``1000.0`` kg/m^3.
-"""
 
 DEFAULT_RESTITUTION = 0.0
 """
@@ -122,17 +115,13 @@ class MaterialDescriptor(Descriptor):
     """
     A container to represent a managed material.
 
-    This descriptor holds both intrinsic and extrinsic properties of a material. While the former
-    are truly dependent on the material itself (e.g., density), the latter are actually dependent
-    on the pairwise interactions of the material with others (e.g., friction, restitution). These
-    extrinsic properties are stored here to support model specifications such as USD which
-    currently do not support material-pair definitions.
+    To support model specifications such as USD (which currently do not support material-pair
+    definitions), this descriptor holds extrinsic properties of a material (e.g., friction, restitution),
+    which are actually dependent on the pairwise interactions of the material with others.
 
     Attributes:
         name: The name of the material.
         uid: The unique identifier (UUID) of the material.
-        density: The density of the material [kg/m³].
-            Defaults to the global default of ``1000.0`` kg/m³.
         restitution: The coefficient of restitution, according to the Newtonian impact model.
             Defaults to the global default of ``0.0``.
         static_friction: The coefficient of static friction, according to the Coulomb friction model.
@@ -148,12 +137,6 @@ class MaterialDescriptor(Descriptor):
     ###
     # Attributes
     ###
-
-    density: float = DEFAULT_DENSITY
-    """
-    The density of the material, in kg/m^3.
-    Defaults to the global default of ``1000.0`` kg/m^3.
-    """
 
     restitution: float = DEFAULT_RESTITUTION
     """
@@ -196,7 +179,6 @@ class MaterialDescriptor(Descriptor):
             f"MaterialDescriptor(\n"
             f"name: {self.name},\n"
             f"uid: {self.uid},\n"
-            f"density: {self.density},\n"
             f"restitution: {self.restitution},\n"
             f"static_friction: {self.static_friction},\n"
             f"dynamic_friction: {self.dynamic_friction}\n"
@@ -254,8 +236,6 @@ class MaterialsModel:
 
     Attributes:
         num_materials: Total number of materials represented in the model.
-        density: Array of material density values of each registered material.
-            Shape of ``(num_materials,)``.
         restitution: Array of restitution coefficients for each registered material.
             Shape of ``(num_materials,)``.
         static_friction: Array of static friction coefficients for each registered material.
@@ -266,12 +246,6 @@ class MaterialsModel:
 
     num_materials: int = 0
     """Total number of materials represented in the model."""
-
-    density: wp.array[wp.float32] | None = None
-    """
-    Array of material density values of each registered material.
-    Shape of ``(num_materials,)``.
-    """
 
     restitution: wp.array[wp.float32] | None = None
     """

--- a/newton/_src/solvers/kamino/_src/core/types.py
+++ b/newton/_src/solvers/kamino/_src/core/types.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Iterable
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -28,7 +28,7 @@ FloatType = wp.float16 | wp.float32 | wp.float64
 IntType = wp.int16 | wp.int32 | wp.int64
 VecIntType = wp.vec2s | wp.vec2i | wp.vec2l
 
-ArrayLike = np.ndarray | list | tuple | Iterable
+ArrayLike = np.ndarray | list | tuple | Sequence
 """An Array-like structure for aliasing various data types compatible with numpy."""
 
 

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -891,7 +891,7 @@ def make_compute_joints_data_kernel(correction: JointCorrectionMode = JointCorre
 @wp.kernel
 def _extract_actuators_state_from_joints(
     # Inputs:
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     model_joint_wid: wp.array[wp.int32],
     model_joint_act_type: wp.array[wp.int32],
     model_joint_coords_offset: wp.array[wp.int32],
@@ -912,7 +912,7 @@ def _extract_actuators_state_from_joints(
     act_type = model_joint_act_type[jid]
 
     # Early exit the operation if the joint's world is flagged as skipped or if the joint is not actuated
-    if not world_mask[wid] or act_type == JointActuationType.PASSIVE:
+    if (world_mask and not world_mask[wid]) or act_type == JointActuationType.PASSIVE:
         return
 
     # Retrieve the joint model data
@@ -1059,11 +1059,11 @@ def compute_joints_data(
 
 def extract_actuators_state_from_joints(
     model: ModelKamino,
-    world_mask: wp.array[wp.bool],
     joint_q: wp.array[wp.float32],
     joint_u: wp.array[wp.float32],
     actuator_q: wp.array[wp.float32],
     actuator_u: wp.array[wp.float32],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Extracts the states of the actuated joints from the full joint state arrays.
@@ -1081,7 +1081,7 @@ def extract_actuators_state_from_joints(
             Shape of ``(sum_of_num_actuated_joint_coords,)``.
         actuator_u: The output array to store the actuated joint velocities.
             Shape of ``(sum_of_actuated_joint_dofs,)``.
-        world_mask: An array indicating which worlds are active (True) or skipped (False).
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
             Shape of ``(num_worlds,)``.
     """
     wp.launch(

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -206,7 +206,7 @@ def _get_base_q_from_joint_q_and_body_q(
     model_joint_coords_offset: wp.array[wp.int32],
     state_joint_q: wp.array[wp.float32],
     state_body_q: wp.array[wp.transformf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs:
     base_q: wp.array[wp.transformf],
 ):
@@ -214,7 +214,7 @@ def _get_base_q_from_joint_q_and_body_q(
     wid = wp.tid()
 
     # Early return based on mask
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Read base_q from joint_q if a base joint was set for this world
@@ -247,7 +247,7 @@ def _get_base_u_from_joint_u_and_body_u(
     model_joint_dofs_offset: wp.array[wp.int32],
     state_joint_u: wp.array[wp.float32],
     state_body_u: wp.array[wp.spatial_vectorf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs:
     base_u: wp.array[wp.spatial_vectorf],
 ):
@@ -255,7 +255,7 @@ def _get_base_u_from_joint_u_and_body_u(
     wid = wp.tid()
 
     # Early return based on mask
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Read base_u from joint_u if a base joint was set for this world
@@ -284,13 +284,13 @@ def _set_body_q(
     # Inputs:
     body_world_id: wp.array[wp.int32],
     body_q_in: wp.array[wp.transformf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs:
     body_q_out: wp.array[wp.transformf],
 ):
     body_id = wp.tid()
     wid = body_world_id[body_id]
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
     body_q_out[body_id] = body_q_in[body_id]
 
@@ -312,7 +312,7 @@ def _reset_joints_state_from_bodies_state(
     joint_q_0: wp.array[wp.float32],
     body_q: wp.array[wp.transformf],
     body_u: wp.array[wp.spatial_vectorf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs
     joint_q: wp.array[wp.float32],
     joint_q_prev: wp.array[wp.float32],
@@ -324,7 +324,7 @@ def _reset_joints_state_from_bodies_state(
 
     # Early return based on mask
     wid = joint_world_id[jid]
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Retrieve the joint model data
@@ -369,7 +369,7 @@ def _reset_joints_state_from_bodies_state(
 def _reset_body_velocities(
     # Inputs
     body_world_id: wp.array[wp.int32],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs
     body_u: wp.array[wp.spatial_vectorf],
 ):
@@ -378,7 +378,7 @@ def _reset_body_velocities(
 
     # Early return based on mask
     wid = body_world_id[body_id]
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Reset velocities to zero
@@ -389,7 +389,7 @@ def _reset_body_velocities(
 def _reset_body_wrenches(
     # Inputs
     body_world_id: wp.array[wp.int32],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs
     body_w: wp.array[wp.spatial_vectorf],
     body_w_e: wp.array[wp.spatial_vectorf],
@@ -399,7 +399,7 @@ def _reset_body_wrenches(
 
     # Early return based on mask
     wid = body_world_id[body_id]
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Reset wrenches to zero
@@ -410,7 +410,7 @@ def _reset_body_wrenches(
 @wp.kernel
 def _reset_time_of_select_worlds(
     # Inputs:
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs:
     data_time: wp.array[wp.float32],
     data_steps: wp.array[wp.int32],
@@ -419,7 +419,7 @@ def _reset_time_of_select_worlds(
     wid = wp.tid()
 
     # Skip resetting time if the world has not been marked for reset
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Reset both the physical time and step count to zero
@@ -440,7 +440,7 @@ def _eval_floating_base_relative_transform(
     base_u: wp.array[wp.spatial_vectorf],  # None also supported
     body_q: wp.array[wp.transformf],
     body_u: wp.array[wp.spatial_vectorf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     relative_base_u: wp.bool,
     # Outputs:
     rel_transform: wp.array[wp.transformf],
@@ -451,7 +451,7 @@ def _eval_floating_base_relative_transform(
     wid = wp.tid()
 
     # Early return based on mask
-    if not world_mask[wid]:
+    if world_mask and not world_mask[wid]:
         return
 
     # Determine new pose of the base body (= follower of the base joint if there is a base joint)
@@ -529,7 +529,7 @@ def _apply_floating_base_transform(
     rel_transform: wp.array[wp.transformf],
     rel_velocity: wp.array[wp.spatial_vectorf],
     new_base_pos: wp.array[wp.vec3f],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool],  # None also supported
     # Outputs:
     body_q: wp.array[wp.transformf],
     body_u: wp.array[wp.spatial_vectorf],
@@ -539,7 +539,7 @@ def _apply_floating_base_transform(
 
     # Early return based on mask or absence of floating base
     wid = body_world_id[body_id]
-    if not world_mask[wid] or model_base_body_index[wid] < 0:
+    if (world_mask and not world_mask[wid]) or model_base_body_index[wid] < 0:
         return
 
     # Transform body pose
@@ -570,7 +570,7 @@ def reset_time(
     model: ModelKamino,
     time: wp.array[wp.float32],
     steps: wp.array[wp.int32],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     wp.launch(
         _reset_time_of_select_worlds,
@@ -591,7 +591,7 @@ def get_base_q_from_joint_q_and_body_q(
     joint_q: wp.array[wp.float32],
     body_q: wp.array[wp.transformf],
     base_q: wp.array[wp.transformf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Infer the floating base pose from joint coordinates, if a base joint was set, or from body poses,
@@ -602,7 +602,7 @@ def get_base_q_from_joint_q_and_body_q(
         joint_q: joint coordinates array.
         body_q: body poses array.
         base_q: array of per-world floating base pose, to set from joint_q/body_q as applicable.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
     """
     wp.launch(
         _get_base_q_from_joint_q_and_body_q,
@@ -625,7 +625,7 @@ def get_base_u_from_joint_u_and_body_u(
     joint_u: wp.array[wp.float32],
     body_u: wp.array[wp.spatial_vectorf],
     base_u: wp.array[wp.spatial_vectorf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Infer the floating base velocity from joint velocities, if a base joint was set, or from body velocities,
@@ -636,7 +636,7 @@ def get_base_u_from_joint_u_and_body_u(
         joint_u: joint velocities array.
         body_u: body velocities array.
         base_u: array of per-world floating base velocity, to set from joint_u/body_u as applicable.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
     """
     wp.launch(
         _get_base_u_from_joint_u_and_body_u,
@@ -658,7 +658,7 @@ def set_body_q(
     model: ModelKamino,
     body_q_in: wp.array[wp.transformf],
     body_q_out: wp.array[wp.transformf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Set the body poses of select worlds to prescribed values.
@@ -667,7 +667,7 @@ def set_body_q(
         model: Kamino model.
         body_q_in: prescribed body poses.
         body_q_out: body poses to overwrite with those in body_q_in, in active worlds.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
     """
     wp.launch(
         _set_body_q,
@@ -683,7 +683,7 @@ def set_floating_base(
     base_u: wp.array[wp.spatial_vectorf] | None,
     body_q: wp.array[wp.transformf],
     body_u: wp.array[wp.spatial_vectorf],
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
     relative_base_u: bool = False,
 ):
     """
@@ -698,7 +698,7 @@ def set_floating_base(
                 If None, no additional velocity is composed to match the base velocity.
         body_q: body poses to update.
         body_u: body velocities to update.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
         relative_base_u: Boolean indicating whether base_u should be interpreted as expressed relative
                          to the new pose (after transforming so as to match base_q).
     """
@@ -755,7 +755,7 @@ def set_floating_base(
 def reset_joints_state_from_bodies_state(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Reset joint-based components of the state given body poses and velocities, inferring consistent
@@ -764,7 +764,7 @@ def reset_joints_state_from_bodies_state(
     Args:
         model: Kamino model.
         state: Kamino state.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
     """
     wp.launch(
         _reset_joints_state_from_bodies_state,
@@ -797,7 +797,7 @@ def reset_joints_state_from_bodies_state(
 def reset_body_velocities(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Reset body velocities in the state to zero.
@@ -818,7 +818,7 @@ def reset_body_velocities(
 def reset_body_wrenches(
     model: ModelKamino,
     state: StateKamino,
-    world_mask: wp.array[wp.bool],
+    world_mask: wp.array[wp.bool] | None = None,
 ):
     """
     Reset body wrenches in the state to zero.
@@ -826,7 +826,7 @@ def reset_body_wrenches(
     Args:
         model: Kamino model.
         state: Kamino state.
-        world_mask: Per-world boolean mask, indicating in which worlds to perform the operation.
+        world_mask: Per-world boolean mask. If provided, indicates in which worlds to perform the operation.
     """
     wp.launch(
         _reset_body_wrenches,

--- a/newton/_src/solvers/kamino/_src/linalg/conjugate.py
+++ b/newton/_src/solvers/kamino/_src/linalg/conjugate.py
@@ -415,7 +415,7 @@ def less_than_op(i: wp.int32, threshold: wp.int32) -> wp.float32:
 def make_dot_kernel(tile_size: int, maxdim: int):
     num_tiles = (maxdim + tile_size - 1) // tile_size
 
-    @wp.kernel
+    @wp.kernel(module="unique", module_options={"enable_backward": False, "default_grid_stride": False})
     def dot(
         a: wp.array2d[Any],
         b: wp.array2d[Any],

--- a/newton/_src/solvers/kamino/_src/models/builders/testing.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/testing.py
@@ -1392,10 +1392,7 @@ def build_all_joints_test_model(
             geom_.shape = builder.shapes[geom.uid]
             geom_.body = geom.body - 1
             if geom_.body == -1:
-                # wp.transform_set_translation(geom_.offset, body_0_offset)
-                geom_.offset[0] = body_0_offset[0]
-                geom_.offset[1] = body_0_offset[1]
-                geom_.offset[2] = body_0_offset[2]
+                wp.transform_set_translation(geom_.offset, body_0_offset)
             builder_unary.add_geometry_descriptor(geom_)
         return builder_unary
 

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -282,7 +282,6 @@ class SolverKaminoImpl(SolverBase):
 
         # Allocate additional internal data for reset operations
         with wp.ScopedDevice(self._model.device):
-            self._all_worlds_mask = wp.ones(shape=(self._model.size.num_worlds,), dtype=wp.bool)
             self._base_q = wp.zeros(shape=(self._model.size.num_worlds,), dtype=wp.transformf)
             self._base_u = wp.zeros(shape=(self._model.size.num_worlds,), dtype=wp.spatial_vectorf)
             self._bodies_u_zeros = wp.zeros(shape=(self._model.size.sum_of_num_bodies,), dtype=wp.spatial_vectorf)
@@ -441,8 +440,7 @@ class SolverKaminoImpl(SolverBase):
             if data is not None and data.shape[0] != expected:
                 raise ValueError(f"Invalid shape for {name}: Expected ({expected},), but got {data.shape}.")
 
-        # Resolve and validate world mask
-        world_mask = self._all_worlds_mask if world_mask is None else world_mask
+        # Validate world mask
         _check_length(world_mask, "world_mask", self._model.size.num_worlds)
 
         # Resolve and validate reset config
@@ -520,11 +518,11 @@ class SolverKaminoImpl(SolverBase):
             # Extract joint state into pre-allocated actuator state buffers
             extract_actuators_state_from_joints(
                 model=self._model,
-                world_mask=world_mask,
                 joint_q=joint_q if joint_q is not None else state.q_j,
                 joint_u=joint_u if joint_u is not None else state.dq_j,
                 actuator_q=self._actuators_q,
                 actuator_u=self._actuators_u,
+                world_mask=world_mask,
             )
             actuator_q = self._actuators_q if joint_q is not None else actuator_q
             actuator_u = self._actuators_u if joint_u is not None else actuator_u
@@ -658,8 +656,10 @@ class SolverKaminoImpl(SolverBase):
             # Currently, only the position-level (iterative) FK solve can fail
             if actuator_q is not None:
                 wp.copy(success_mask, self._solver_fk.newton_success)
-            else:
+            elif world_mask is not None:
                 wp.copy(success_mask, world_mask)
+            else:
+                success_mask.fill_(True)
 
         # Run the post-reset callback if it has been set
         self._run_post_reset_callback(state_out=state)

--- a/newton/_src/solvers/kamino/_src/utils/io/usd.py
+++ b/newton/_src/solvers/kamino/_src/utils/io/usd.py
@@ -29,7 +29,6 @@ from ...core.joints import (
     JointDoFType,
 )
 from ...core.materials import (
-    DEFAULT_DENSITY,
     DEFAULT_FRICTION,
     DEFAULT_RESTITUTION,
     MaterialDescriptor,
@@ -502,12 +501,9 @@ class USDImporter:
         ###
 
         # Retrieve the USD material properties
-        density_scale = mass_unit / distance_unit**3
-        density = (density_scale) * self._parse_float(material_prim, "physics:density", default=DEFAULT_DENSITY)
         restitution = self._parse_float(material_prim, "physics:restitution", default=DEFAULT_RESTITUTION)
         static_friction = self._parse_float(material_prim, "physics:staticFriction", default=DEFAULT_FRICTION)
         dynamic_friction = self._parse_float(material_prim, "physics:dynamicFriction", default=DEFAULT_FRICTION)
-        msg.debug(f"density: {density}")
         msg.debug(f"restitution: {restitution}")
         msg.debug(f"static_friction: {static_friction}")
         msg.debug(f"dynamic_friction: {dynamic_friction}")
@@ -519,7 +515,6 @@ class USDImporter:
         return MaterialDescriptor(
             name=name,
             uid=uid,
-            density=density,
             restitution=restitution,
             static_friction=static_friction,
             dynamic_friction=dynamic_friction,

--- a/newton/_src/solvers/kamino/tests/__init__.py
+++ b/newton/_src/solvers/kamino/tests/__init__.py
@@ -43,7 +43,7 @@ test_context = TestContext()
 ###
 
 
-def setup_tests(verbose: bool = False, device: wp.DeviceLike | str | None = None, clear_cache: bool = True):
+def setup_tests(verbose: bool = False, device: wp.DeviceLike | str | None = None, clear_cache: bool = False):
     # Numpy configuration
     np.set_printoptions(
         linewidth=999999, edgeitems=999999, threshold=999999, precision=10, suppress=True

--- a/newton/_src/solvers/kamino/tests/__main__.py
+++ b/newton/_src/solvers/kamino/tests/__main__.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--clear-cache",
-        default=True,  # Edit to enable/disable cache clear (if not running in command line)
+        default=False,  # Edit to enable/disable cache clear (if not running in command line)
         action=argparse.BooleanOptionalAction,
         help="Whether to clear the warp cache before running tests.",
     )

--- a/newton/_src/solvers/kamino/tests/test_core_builder.py
+++ b/newton/_src/solvers/kamino/tests/test_core_builder.py
@@ -420,9 +420,7 @@ class TestModelBuilder(unittest.TestCase):
         wid = builder.add_world(name="test_world", up_axis=Axis.Z)
         self.assertEqual(builder.num_materials, 1)  # Default material exists
 
-        material = MaterialDescriptor(
-            name="test_material", density=500.0, restitution=0.8, static_friction=0.6, dynamic_friction=0.4
-        )
+        material = MaterialDescriptor(name="test_material", restitution=0.8, static_friction=0.6, dynamic_friction=0.4)
 
         mid = builder.add_material(material=material)
         self.assertEqual(builder.num_materials, 2)
@@ -430,7 +428,6 @@ class TestModelBuilder(unittest.TestCase):
         self.assertEqual(mid, builder.materials[mid].mid)
         self.assertEqual(builder.materials[mid].name, "test_material")
         self.assertEqual(builder.materials[mid].wid, wid)
-        self.assertEqual(builder.materials[mid].density, 500.0)
         self.assertEqual(builder.materials[mid].restitution, 0.8)
         self.assertEqual(builder.materials[mid].static_friction, 0.6)
         self.assertEqual(builder.materials[mid].dynamic_friction, 0.4)

--- a/newton/_src/solvers/kamino/tests/test_core_model.py
+++ b/newton/_src/solvers/kamino/tests/test_core_model.py
@@ -277,8 +277,7 @@ class TestModelConversions(unittest.TestCase):
         model_newton: Model = builder_newton.finalize(skip_validation_joints=True, device=self.default_device)
         model_kamino: ModelKamino = builder_kamino.finalize(device=self.default_device)
         model_kamino_converted: ModelKamino = ModelKamino.from_newton(model_newton)
-        excluded = ["base_joint_index"]
-        test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino, excluded=excluded)
+        test_util_checks.assert_model_equal(self, model_kamino_converted, model_kamino)
 
         # TODO: IMPLEMENT THIS CHECK: We wanna see if the both generate
         # the same data containers and unilateral constraint info
@@ -396,7 +395,7 @@ class TestModelConversions(unittest.TestCase):
         #   geom-pairs of joint neighbours to `shape_collision_filter_pairs` regardless of
         #   whether they are actually collidable or not, which leads to differences in the
         #   number of excluded pairs and their contents
-        excluded = ["base_joint_index", "ptr", "group", "gap", "num_excluded_pairs", "excluded_pairs"]
+        excluded = ["ptr", "group", "gap", "num_excluded_pairs", "excluded_pairs"]
         rtol = {"inv_i_I_i": 1e-5}
         atol = {"inv_i_I_i": 1e-6}
         test_util_checks.assert_model_equal(

--- a/newton/_src/solvers/kamino/tests/test_core_world.py
+++ b/newton/_src/solvers/kamino/tests/test_core_world.py
@@ -23,7 +23,6 @@ from newton._src.solvers.kamino._src.core.joints import (
     JointDoFType,
 )
 from newton._src.solvers.kamino._src.core.materials import (
-    DEFAULT_DENSITY,
     DEFAULT_FRICTION,
     DEFAULT_RESTITUTION,
     MaterialDescriptor,
@@ -326,7 +325,6 @@ class TestMaterialDescriptor(unittest.TestCase):
 
         self.assertIsInstance(mat, MaterialDescriptor)
         self.assertEqual(mat.name, "test_mat")
-        self.assertEqual(mat.density, DEFAULT_DENSITY)
         self.assertEqual(mat.restitution, DEFAULT_RESTITUTION)
         self.assertEqual(mat.static_friction, DEFAULT_FRICTION)
         self.assertEqual(mat.dynamic_friction, DEFAULT_FRICTION)
@@ -336,7 +334,6 @@ class TestMaterialDescriptor(unittest.TestCase):
     def test_01_with_properties(self):
         mat = MaterialDescriptor(
             name="test_mat",
-            density=500.0,
             restitution=0.5,
             static_friction=0.6,
             dynamic_friction=0.4,
@@ -345,7 +342,6 @@ class TestMaterialDescriptor(unittest.TestCase):
 
         self.assertIsInstance(mat, MaterialDescriptor)
         self.assertEqual(mat.name, "test_mat")
-        self.assertEqual(mat.density, 500.0)
         self.assertEqual(mat.restitution, 0.5)
         self.assertEqual(mat.static_friction, 0.6)
         self.assertEqual(mat.dynamic_friction, 0.4)

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -424,7 +424,7 @@ class DRLegsRandomPosesCheckForwardKinematics(unittest.TestCase):
         seed = int(hashlib.sha256(test_name.encode("utf8")).hexdigest(), 16)
         rng = np.random.default_rng(seed)
 
-        # Load the DR TestMech and DR Legs models from the `newton-assets` repository
+        # Load the DR Legs model from the `newton-assets` repository
         asset_path = newton.utils.download_asset("disneyresearch")
         asset_file = str(asset_path / "dr_legs" / "usd" / "dr_legs_with_boxes.usda")
         builder = USDImporter().import_from(asset_file)

--- a/newton/_src/solvers/kamino/tests/utils/checks.py
+++ b/newton/_src/solvers/kamino/tests/utils/checks.py
@@ -282,7 +282,6 @@ def assert_builders_equal(
         for m in range(builder1.num_materials):
             test.assertEqual(builder1.materials[m].wid, builder2.materials[m].wid)
             test.assertEqual(builder1.materials[m].mid, builder2.materials[m].mid)
-            test.assertEqual(builder1.materials[m].density, builder2.materials[m].density)
             test.assertEqual(builder1.materials[m].restitution, builder2.materials[m].restitution)
             test.assertEqual(builder1.materials[m].static_friction, builder2.materials[m].static_friction)
             test.assertEqual(builder1.materials[m].dynamic_friction, builder2.materials[m].dynamic_friction)
@@ -524,7 +523,6 @@ def assert_model_materials_equal(
 ) -> None:
     assert_scalar_attributes_equal(test, materials0, materials1, ["num_materials"])
     array_attributes = [
-        # "density",
         "restitution",
         "static_friction",
         "dynamic_friction",

--- a/newton/_src/solvers/kamino/tests/utils/sampling.py
+++ b/newton/_src/solvers/kamino/tests/utils/sampling.py
@@ -66,7 +66,7 @@ def sample_base_state(
     max_lin_vel: float = 0.5,
     max_ang_vel: float = np.radians(90.0),
     unit_quaternions: bool = True,
-) -> np.ndarray:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Helper sampling random base_q, base_u given the number of worlds.
 


### PR DESCRIPTION
## Description

This groups a bunch of small fixes that would not warrant an individual PR by themselves. It is recommended to review commit by commit to see the independent changes better.

The two "bigger" changes among these are removing the density field from materials in Kamino (after an offline discussion with @vastsoun, this is not used currently nor is there a potential usage for this); and ensuring that a bunch of kernels/functions support the world_mask being passed as None (to signal no masking is needed), allowing a few tiny optimizations in some cases.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

Kamino internal unit tests are all passing after these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * World masks are now optional for joint-state extraction and reset operations; when omitted, operations apply to all worlds.
  * Material definitions and imported materials now use restitution and friction properties without density.
* **Bug Fixes**
  * Improved reset success reporting when no mask or forward-kinematics result is provided.
  * Corrected floating-base and geometry transform handling.
* **Documentation**
  * Clarified joint-limit behavior and warning conditions.
* **Tests**
  * Updated coverage for material properties, model conversion, and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->