### PR TITLE
Fix MJCF primitive material colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Fix builder merging (`ModelBuilder.add_builder()`, `add_world()`, `replicate()`) offsetting negative reference sentinels in custom attribute values stored as NumPy or Warp integer scalars.
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
+- Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -826,6 +826,7 @@ def parse_mjcf(
                         float(rgba_values[1]),
                         float(rgba_values[2]),
                     )
+                    shape_kwargs["color"] = material_color
 
             texture = None
             texture_name = material_info.get("texture")

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -9326,5 +9326,56 @@ class TestOverrideRootXform(unittest.TestCase):
             )
 
 
+class TestMjcfPrimitiveColors(unittest.TestCase):
+    def test_named_material_colors_primitives(self):
+        """Verify named MJCF materials color every primitive shape."""
+        mjcf = """
+<mujoco model="primitive_materials">
+    <asset>
+        <material name="dark" rgba="0.2 0.3 0.4 1"/>
+    </asset>
+    <worldbody>
+        <geom name="sphere" type="sphere" size="0.1" material="dark" contype="0" conaffinity="0"/>
+        <geom name="box" type="box" size="0.1 0.2 0.3" material="dark" contype="0" conaffinity="0"/>
+        <geom name="capsule" type="capsule" size="0.1 0.2" material="dark" contype="0" conaffinity="0"/>
+        <geom name="cylinder" type="cylinder" size="0.1 0.2" material="dark" contype="0" conaffinity="0"/>
+        <geom name="ellipsoid" type="ellipsoid" size="0.1 0.2 0.3" material="dark" contype="0" conaffinity="0"/>
+        <geom name="plane" type="plane" size="1 1 0.1" material="dark" contype="0" conaffinity="0"/>
+    </worldbody>
+</mujoco>
+"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+
+        self.assertEqual(builder.shape_count, 6)
+        for color in builder.shape_color:
+            np.testing.assert_allclose(color, [0.2, 0.3, 0.4], atol=1.0e-6)
+
+    def test_inline_rgba_overrides_primitive_material(self):
+        """Verify inline MJCF RGBA overrides a primitive's named material."""
+        mjcf = """
+<mujoco model="primitive_rgba">
+    <asset>
+        <material name="red" rgba="1 0 0 1"/>
+    </asset>
+    <worldbody>
+        <geom
+            name="sphere"
+            type="sphere"
+            size="0.1"
+            material="red"
+            rgba="0 1 0 1"
+            contype="0"
+            conaffinity="0"
+        />
+    </worldbody>
+</mujoco>
+"""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+
+        np.testing.assert_allclose(builder.shape_color[0], [0.0, 1.0, 0.0], atol=1.0e-6)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Forward resolved MJCF material and inline `rgba` colors through the common shape arguments so primitive geoms preserve their authored display colors, just like mesh geoms. Inline `rgba` continues to take precedence over a named material.

This covers spheres, boxes, capsules, cylinders, ellipsoids, and planes.

Closes #3630.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev python -m unittest newton.tests.test_import_mjcf.TestMjcfPrimitiveColors -v
uv run --extra dev python -m unittest newton.tests.test_import_mjcf -v
uv run --extra dev python -m unittest newton.tests.test_shape_colors -v
uvx pre-commit run -a
```

All 234 MJCF import tests, all 7 shape-color tests, and all pre-commit hooks pass.

## Bug fix

**Steps to reproduce:**

1. Import an MJCF containing a primitive geom with a named material or inline `rgba`.
2. Inspect `builder.shape_color` or render the resulting model.
3. Observe that the primitive uses Newton's palette color instead of the authored MJCF color.

**Minimal reproduction:**

```python
import newton

mjcf = """
<mujoco>
  <asset>
    <material name="dark" rgba="0.2 0.3 0.4 1"/>
  </asset>
  <worldbody>
    <geom type="sphere" size="0.1" material="dark" contype="0" conaffinity="0"/>
  </worldbody>
</mujoco>
"""

builder = newton.ModelBuilder()
builder.add_mjcf(mjcf)
print(tuple(builder.shape_color[0]))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MJCF imports so authored material colors and inline RGBA colors are applied to primitive shapes.
  * Inline geom colors now take precedence over named material colors.

* **Tests**
  * Added coverage for material and inline color handling across supported primitive shapes.

* **Documentation**
  * Updated the changelog with the MJCF color import fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->