### PR TITLE
Disable implicit VBD Dahl-friction defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Changed
 
+- Disable the implicit positive Dahl-friction defaults in `SolverVBD.register_custom_attributes()` (deprecated in 1.3.0): `vbd:dahl_eps_max` and `vbd:dahl_tau` now default to zero, and Dahl cable friction is enabled only where both are authored positive. Pass `dahl_defaults_enabled=True` to temporarily restore the old defaults; the compatibility mode will be removed in a future release.
 - Compile tiled camera render kernels with CUDA fast math by default for faster rendering; set `SensorTiledCamera.render_config.enable_fast_math = False` for bit-exact, IEEE-precise output.
 - Optimize raycast/raytrace queries by restructuring ray-shape intersection into local-space primitives and compile specialized depth/shadow variants that skip unused surface-normal work (mesh shadows also use any-hit queries).
 - Change experimental `SolverVBD` cable constraint slots from `[STRETCH=0, BEND=1]` to `[STRETCH=0, SHEAR=1, BEND=2, TWIST=3]`, allowing each stiffness and constraint mode to be configured independently. Existing cable calls using raw `slot=1` or `JointSlot.ANGULAR` now select shear; use `JointSlot.BEND` (now slot 2) to select bending.

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -1544,7 +1544,7 @@ class SolverVBD(SolverBase, CouplingInterface):
 
     @override
     @classmethod
-    def register_custom_attributes(cls, builder: ModelBuilder, *, dahl_defaults_enabled: bool = True) -> None:
+    def register_custom_attributes(cls, builder: ModelBuilder, *, dahl_defaults_enabled: bool = False) -> None:
         """Register SolverVBD custom Model attributes.
 
         Currently registers:
@@ -1554,19 +1554,26 @@ class SolverVBD(SolverBase, CouplingInterface):
         Attributes are declared in the ``vbd`` namespace so they can be authored
         in scenes and in USD as ``newton:vbd:<attr>``.
 
+        Dahl cable friction is enabled per joint only where both
+        ``model.vbd.dahl_eps_max`` and ``model.vbd.dahl_tau`` are authored
+        positive; the attributes default to zero.
+
         Args:
             builder: Model builder to register attributes on.
             dahl_defaults_enabled: Deprecated compatibility mode. When True, Dahl parameters
-                default to positive values. Prefer passing ``False`` and explicitly authoring
-                positive Dahl values only when Dahl cable friction is desired.
+                default to positive values instead of zero.
+
+                .. deprecated:: 1.5
+                    The compatibility mode will be removed; author positive Dahl
+                    values explicitly when Dahl cable friction is desired.
         """
         dahl_eps_default = 0.5 if dahl_defaults_enabled else 0.0
         dahl_tau_default = 1.0 if dahl_defaults_enabled else 0.0
         if dahl_defaults_enabled:
             warnings.warn(
-                "Implicit positive Dahl defaults in SolverVBD.register_custom_attributes() are deprecated "
-                "and will be disabled by default in a future release. Pass dahl_defaults_enabled=False and "
-                "explicitly author positive model.vbd.dahl_eps_max and model.vbd.dahl_tau values to enable "
+                "SolverVBD.register_custom_attributes(dahl_defaults_enabled=True) is deprecated "
+                "and the compatibility mode will be removed in a future release. Explicitly author "
+                "positive model.vbd.dahl_eps_max and model.vbd.dahl_tau values to enable "
                 "Dahl cable friction.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -1720,7 +1727,7 @@ class SolverVBD(SolverBase, CouplingInterface):
         build time via the ``vbd:joint_is_hard`` custom attribute, avoiding a
         runtime :meth:`set_joint_constraint_mode` call::
 
-            SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)  # before adding joints
+            SolverVBD.register_custom_attributes(builder)  # before adding joints
             builder.add_joint_fixed(..., custom_attributes={"vbd:joint_is_hard": 0})
             model = builder.finalize()
             solver = SolverVBD(model, ...)

--- a/newton/examples/cable/example_cable_bundle_hysteresis.py
+++ b/newton/examples/cable/example_cable_bundle_hysteresis.py
@@ -184,7 +184,7 @@ class Example:
 
         # Dahl plasticity parameters live on the Model as VBD custom attributes.
         if with_dahl:
-            newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+            newton.solvers.SolverVBD.register_custom_attributes(builder)
         builder.gravity = (0.0, 0.0, -9.81)
 
         # Set default material properties for cables (cable-to-cable contact)

--- a/newton/examples/contacts/example_contacts_rj45_plug.py
+++ b/newton/examples/contacts/example_contacts_rj45_plug.py
@@ -241,7 +241,7 @@ class Example:
         latch_mesh, lc = _load_mesh(stage, "/World/Latch")
 
         builder = newton.ModelBuilder(gravity=(0.0, 0.0, -9.81))
-        SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+        SolverVBD.register_custom_attributes(builder)
         builder.rigid_gap = 0.005
 
         builder.add_ground_plane()

--- a/newton/examples/multiphysics/example_franka_cable_ik_pick_place.py
+++ b/newton/examples/multiphysics/example_franka_cable_ik_pick_place.py
@@ -158,7 +158,7 @@ class Example:
         template = newton.ModelBuilder(gravity=(0.0, 0.0, -9.81))
         template.rigid_gap = 0.01
         SolverMuJoCo.register_custom_attributes(template)
-        SolverVBD.register_custom_attributes(template, dahl_defaults_enabled=False)
+        SolverVBD.register_custom_attributes(template)
         self._emit_template(template)
 
         bodies_per_world = template.body_count

--- a/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
+++ b/newton/examples/multiphysics/example_mujoco_franka_vbd_cable_admm_solver.py
@@ -126,7 +126,7 @@ class Example:
         template.rigid_gap = 0.005
         SolverMuJoCo.register_custom_attributes(template)
         if self.payload_kind == "vbd-cable":
-            SolverVBD.register_custom_attributes(template, dahl_defaults_enabled=False)
+            SolverVBD.register_custom_attributes(template)
         self._emit_template(template)
 
         bodies_per_world = template.body_count

--- a/newton/examples/multiphysics/example_proxy_joint_gripper.py
+++ b/newton/examples/multiphysics/example_proxy_joint_gripper.py
@@ -64,7 +64,7 @@ class Example:
 
         builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
         SolverMuJoCo.register_custom_attributes(builder)
-        SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+        SolverVBD.register_custom_attributes(builder)
         builder.default_particle_radius = 0.01
 
         self.soft_particle_start = builder.particle_count

--- a/newton/examples/vbd/example_cable_dahl_hysteresis.py
+++ b/newton/examples/vbd/example_cable_dahl_hysteresis.py
@@ -98,7 +98,7 @@ class Example:
         self.cycle_duration = self.NUM_PHASES * self.PHASE_DURATION
 
         builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
-        newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+        newton.solvers.SolverVBD.register_custom_attributes(builder)
 
         self.cases: list[dict] = []
         for name, mode, has_dahl in (

--- a/newton/tests/test_cable.py
+++ b/newton/tests/test_cable.py
@@ -5496,7 +5496,7 @@ def _split_cable_kinematic_arc_yields_uniform_curvature(test, device):
     half_segment = 0.5 * segment_length
 
     builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
-    newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+    newton.solvers.SolverVBD.register_custom_attributes(builder)
 
     points = newton.utils.create_straight_cable_points(
         start=wp.vec3(0.0, 0.0, 0.0),
@@ -5736,7 +5736,7 @@ def _split_cable_bend_twist_deformation_derivative_matches_finite_difference(tes
 def _split_cable_dahl_full_step_state_stays_in_active_subspace(test, device):
     """A solver step with Dahl enabled should not leak pure bend history into twist, or vice versa."""
     builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
-    newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+    newton.solvers.SolverVBD.register_custom_attributes(builder)
 
     bend_body = builder.add_link(xform=wp.transform_identity())
     twist_body = builder.add_link(xform=wp.transform_identity())

--- a/newton/tests/test_coupled_solver.py
+++ b/newton/tests/test_coupled_solver.py
@@ -2771,7 +2771,7 @@ class TestSolverCoupledVBDColoring(unittest.TestCase):
     def test_compacted_custom_namespace_does_not_mutate_parent(self):
         """Compacted entry namespaces must be view-local, not parent aliases."""
         builder = newton.ModelBuilder()
-        SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+        SolverVBD.register_custom_attributes(builder)
         for _ in range(5):
             builder.add_body(mass=1.0, inertia=wp.mat33(np.eye(3)))
         soft_joint = builder.add_joint_fixed(parent=3, child=4, custom_attributes={"vbd:joint_is_hard": 0})

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -2200,19 +2200,7 @@ def _vbd_custom_attribute_registration_controls_dahl_defaults(test, device):
     del device
 
     builder = newton.ModelBuilder()
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always", DeprecationWarning)
-        newton.solvers.SolverVBD.register_custom_attributes(builder)
-    test.assertIn("vbd:joint_is_hard", builder.custom_attributes)
-    test.assertIn("vbd:dahl_eps_max", builder.custom_attributes)
-    test.assertIn("vbd:dahl_tau", builder.custom_attributes)
-    test.assertEqual(builder.custom_attributes["vbd:joint_is_hard"].default, 1)
-    test.assertEqual(builder.custom_attributes["vbd:dahl_eps_max"].default, 0.5)
-    test.assertEqual(builder.custom_attributes["vbd:dahl_tau"].default, 1.0)
-    test.assertTrue(any(issubclass(w.category, DeprecationWarning) for w in caught))
-
-    builder = newton.ModelBuilder()
-    newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=False)
+    newton.solvers.SolverVBD.register_custom_attributes(builder)
     test.assertIn("vbd:joint_is_hard", builder.custom_attributes)
     test.assertIn("vbd:dahl_eps_max", builder.custom_attributes)
     test.assertIn("vbd:dahl_tau", builder.custom_attributes)
@@ -2221,11 +2209,11 @@ def _vbd_custom_attribute_registration_controls_dahl_defaults(test, device):
     test.assertEqual(builder.custom_attributes["vbd:dahl_tau"].default, 0.0)
 
 
-def _make_vbd_dahl_detection_model(device, *, dahl_defaults_enabled, dahl_eps_max=None, dahl_tau=None):
+def _make_vbd_dahl_detection_model(device, *, dahl_eps_max=None, dahl_tau=None):
     builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        newton.solvers.SolverVBD.register_custom_attributes(builder, dahl_defaults_enabled=dahl_defaults_enabled)
+        newton.solvers.SolverVBD.register_custom_attributes(builder)
 
     parent = builder.add_link(xform=wp.transform(wp.vec3(0.0, 0.0, 0.0), wp.quat_identity()))
     child = builder.add_link(xform=wp.transform(wp.vec3(1.0, 0.0, 0.0), wp.quat_identity()))
@@ -2249,35 +2237,28 @@ def _make_vbd_dahl_detection_model(device, *, dahl_defaults_enabled, dahl_eps_ma
 
 
 def _vbd_dahl_detection_requires_positive_values(test, device):
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=False)
+    model = _make_vbd_dahl_detection_model(device)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         solver = newton.solvers.SolverVBD(model)
     test.assertFalse(solver.enable_dahl_friction)
 
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=False, dahl_eps_max=0.5)
+    model = _make_vbd_dahl_detection_model(device, dahl_eps_max=0.5)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         solver = newton.solvers.SolverVBD(model)
     test.assertFalse(solver.enable_dahl_friction)
 
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=False, dahl_tau=1.0)
+    model = _make_vbd_dahl_detection_model(device, dahl_tau=1.0)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         solver = newton.solvers.SolverVBD(model)
     test.assertFalse(solver.enable_dahl_friction)
 
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=True)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        solver = newton.solvers.SolverVBD(model)
-    test.assertTrue(solver.enable_dahl_friction)
-
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=False, dahl_eps_max=0.5, dahl_tau=1.0)
+    model = _make_vbd_dahl_detection_model(device, dahl_eps_max=0.5, dahl_tau=1.0)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -2287,7 +2268,7 @@ def _vbd_dahl_detection_requires_positive_values(test, device):
 
 def _rigid_reset_cable_history(test, device):
     """Reset defers the cable tuple, then rebaselines it from the post-reset pose."""
-    model = _make_vbd_dahl_detection_model(device, dahl_defaults_enabled=False, dahl_eps_max=0.5, dahl_tau=1.0)
+    model = _make_vbd_dahl_detection_model(device, dahl_eps_max=0.5, dahl_tau=1.0)
     solver = newton.solvers.SolverVBD(model, iterations=0)
 
     state_in = model.state()


### PR DESCRIPTION
## Description

Flip the default of `dahl_defaults_enabled` in `SolverVBD.register_custom_attributes()` to `False`, completing the change announced by the 1.3.0 deprecation: `vbd:dahl_eps_max` and `vbd:dahl_tau` now default to zero, and Dahl cable friction is enabled per joint only where both are authored positive. Passing `dahl_defaults_enabled=True` still restores the old positive defaults but warns that the compatibility mode will be removed (#3633 tracks that removal).

Every in-tree caller already passed `dahl_defaults_enabled=False`; the now-redundant arguments are dropped across tests and examples, and the tests exercising the compatibility mode are removed. Behavior change for callers still on the old default: cable models silently lose implicit Dahl friction — exactly what the deprecation warning has announced since 1.3.0, and restorable per model by authoring positive `vbd:dahl_eps_max` / `vbd:dahl_tau` values (or temporarily via `dahl_defaults_enabled=True`).

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev -m newton.tests --strict-warnings -k test_solver_vbd
uv run --extra dev -m newton.tests --strict-warnings -k test_cable
uv run --extra dev -m newton.tests --strict-warnings -k test_coupled_solver
uvx pre-commit run -a
```

All pass. The Dahl registration and auto-detection tests now assert the new contract (zero defaults, no warning on the default call, friction enabled only where both values are positive).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * VBD solver registration no longer enables implicit Dahl-friction defaults.
  * Dahl friction is enabled only when both `vbd:dahl_eps_max` and `vbd:dahl_tau` are set to positive values.
  * Existing configurations can temporarily restore legacy behavior with the compatibility option `dahl_defaults_enabled=True`.
* **Documentation**
  * Updated release notes and usage examples to reflect the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->