### PR TITLE
Type 32-bit sentinel constants as uint32 for kernel codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Fix `ModelBuilder.add_usd()` requiring the optional `mujoco` package when handling `MjcActuator` prims, including during default MJC equality conversion.
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix Style3D solver divergence caused by isolated vertices.
+- Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` render kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.

--- a/newton/_src/geometry/sdf_texture.py
+++ b/newton/_src/geometry/sdf_texture.py
@@ -40,9 +40,9 @@ from .sdf_utils import (
 from .types import GeoType
 
 # Sentinel values for subgrid indirection slots.
-# Plain int so wp.static() works in kernels; numpy casts on assignment.
-SLOT_EMPTY = 0xFFFFFFFF  # No subgrid data (empty/far-field cell)
-SLOT_LINEAR = 0xFFFFFFFE  # Subgrid demoted to coarse interpolation
+# Typed uint32 so kernel codegen doesn't overflow an int32 constant.
+SLOT_EMPTY = wp.uint32(0xFFFFFFFF)  # No subgrid data (empty/far-field cell)
+SLOT_LINEAR = wp.uint32(0xFFFFFFFE)  # Subgrid demoted to coarse interpolation
 
 # Inside/outside sign strategies for the mesh distance queries during the
 # bake. Winding is 0 so a legacy ``use_parity`` boolean maps onto the same

--- a/newton/_src/sensors/warp_raytrace/render.py
+++ b/newton/_src/sensors/warp_raytrace/render.py
@@ -64,9 +64,9 @@ def create_kernel(
         out_hdr_color: wp.array[wp.vec3f],
     ):
         if wp.static(state.render_color):
-            out_color[out_index] = wp.uint32(wp.static(clear_data.clear_color))
+            out_color[out_index] = wp.static(wp.uint32(clear_data.clear_color))
         if wp.static(state.render_albedo):
-            out_albedo[out_index] = wp.uint32(wp.static(clear_data.clear_albedo))
+            out_albedo[out_index] = wp.static(wp.uint32(clear_data.clear_albedo))
         if wp.static(state.render_hdr_color):
             out_hdr_color[out_index] = wp.vec3f(0.0)
         if wp.static(state.render_depth):
@@ -80,7 +80,7 @@ def create_kernel(
                 wp.static(clear_data.clear_normal[2]),
             )
         if wp.static(state.render_shape_index):
-            out_shape_index[out_index] = wp.uint32(wp.static(clear_data.clear_shape_index))
+            out_shape_index[out_index] = wp.static(wp.uint32(clear_data.clear_shape_index))
 
     @wp.kernel(enable_backward=False, module="unique", module_options={"fast_math": config.enable_fast_math})
     def render_megakernel(


### PR DESCRIPTION
## Description

Warp types untyped Python int constants as `int32` in kernel codegen, so 32-bit sentinels like `0xFFFFFFFE` are emitted as overflowing literals (`const wp::int32 var_46 = 4294967294;`). Clang warns with `-Wconstant-conversion`, and the warning lands on stderr during kernel compilation, which trips the strict stderr capture in example tests whenever the module compiles from a cold cache — see [this windows-latest CI failure on main](https://github.com/newton-physics/newton/actions/runs/30027537838/job/89276106717), where `example_basic_conveyor_cpu` failed because the SDF contact kernel happened to compile during it.

Simulation results were never affected: the wrapped value (`-2`) converts back to the intended unsigned value under C++ arithmetic conversions in the `uint32` comparisons.

Two fixes:

- `sdf_texture.py`: type `SLOT_EMPTY`/`SLOT_LINEAR` as `wp.uint32`. NumPy host-side uses (`np.full`, element assignment, comparisons) work unchanged with the typed values.
- `warp_raytrace/render.py`: move the clear-value casts inside `wp.static()` (`wp.static(wp.uint32(...))` instead of `wp.uint32(wp.static(...))`). The previous form materializes the untyped int as an `int32` constant before the cast, producing the same warning class for the default `clear_shape_index=0xFFFFFFFF` and the gray preset colors.

With this change the generated code contains properly typed, `u`-suffixed constants (`const wp::uint32 var_46 = 4294967294u;`) and no warnings.

An audit of the rest of `newton/_src` found no other untyped out-of-int32-range constants reaching kernels; other sentinels are already typed via `wp.constant(wp.uint64(...))` etc., and direct constructor calls like `wp.int64(0xFFFFFFFF)` are constant-folded correctly by Warp.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_sdf_texture       # 53 tests OK
uv run --extra dev -m newton.tests -k test_sensor_tiled_camera  # 57 tests OK
```

Both run with a fresh `WARP_CACHE_PATH`; inspected the generated C++ in the cache to confirm the sentinels are now emitted as `uint32` with a `u` suffix and no overflowing `int32` constants remain.

## Bug fix

**Steps to reproduce:**

1. Clear the Warp kernel cache
2. On a platform where Warp compiles CPU kernels with clang (e.g. Windows), run `uv run --extra dev -m newton.tests -k test_basic.example_basic_conveyor_cpu` (or any test that first compiles the SDF contact module)
3. The test fails on unexpected stderr: `warning: implicit conversion from 'long long' to 'const wp::int32' changes value from 4294967294 to -2 [-Wconstant-conversion]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compiler warnings when compiling SDF textures with large sentinel values.
  * Fixed compiler warnings in tiled camera rendering kernels.
  * Preserved correct clear values for color, albedo, and shape-index outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->