### PR TITLE
Fail closed for AWS approval gates

### DIFF
--- a/.github/workflows/aws_gpu_benchmarks.yml
+++ b/.github/workflows/aws_gpu_benchmarks.yml
@@ -112,6 +112,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/pr_target_aws_gpu_benchmarks.yml
+++ b/.github/workflows/pr_target_aws_gpu_benchmarks.yml
@@ -96,7 +96,17 @@ jobs:
     needs:
       - check-author-membership
       - require-approval
-    if: github.repository == 'newton-physics/newton' && (!cancelled())
+    if: >-
+      github.repository == 'newton-physics/newton' &&
+      !cancelled() &&
+      needs.check-author-membership.result == 'success' &&
+      (
+        needs.require-approval.result == 'success' ||
+        (
+          needs.require-approval.result == 'skipped' &&
+          needs.check-author-membership.outputs.membership_status == 'CONFIRMED_MEMBER'
+        )
+      )
     uses: ./.github/workflows/aws_gpu_benchmarks.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr_target_aws_gpu_tests.yml
+++ b/.github/workflows/pr_target_aws_gpu_tests.yml
@@ -96,7 +96,17 @@ jobs:
     needs:
       - check-author-membership
       - require-approval
-    if: github.repository == 'newton-physics/newton' && (!cancelled())
+    if: >-
+      github.repository == 'newton-physics/newton' &&
+      !cancelled() &&
+      needs.check-author-membership.result == 'success' &&
+      (
+        needs.require-approval.result == 'success' ||
+        (
+          needs.require-approval.result == 'skipped' &&
+          needs.check-author-membership.outputs.membership_status == 'CONFIRMED_MEMBER'
+        )
+      )
     uses: ./.github/workflows/aws_gpu_tests.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Description

Fail closed before dispatching the reusable AWS GPU test and benchmark workflows.

The AWS callers currently use `!cancelled()` after depending on the manual-approval job. Rejecting or timing out the `external-pr-approval` environment review fails that job rather than cancelling it. Because `!cancelled()` remains true, the caller can continue and execute the pull request head on a self-hosted AWS runner.

This change requires:

- the membership check to succeed; and
- either explicit approval for an external contributor or a skipped approval backed by a confirmed organization member.

It also sets `persist-credentials: false` on the benchmark checkout so the checkout token is not retained in the repository's Git configuration.

`pull_request_target` remains in use because the workflow needs trusted base-branch configuration and AWS OIDC access. `secrets: inherit` is unchanged. The pull request head is checked out only after the corrected gate permits the reusable workflow to start.

### Gate behavior

| Membership/approval state | AWS workflow |
| --- | --- |
| Confirmed member; approval skipped | Run |
| External contributor; approval succeeded | Run |
| External contributor; approval rejected or timed out | Skip |
| Membership check failed or was cancelled | Skip |

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (no user-facing documentation changes)
- [x] `CHANGELOG.md` has been updated (not applicable; this changes internal CI security behavior)

## Test plan

### Repository verification

```text
uvx pre-commit run -a
```

All hooks passed, including YAML validation.

Focused assertions also verified that:

- both `pull_request_target` callers require the same membership and approval outcomes;
- the complete test and benchmark gate conditions are identical;
- the benchmark checkout uses `persist-credentials: false`; and
- `secrets: inherit` remains present.

### Live verification on `shi-eric/newton`

The fork is authorized to assume the same AWS OIDC runner role, allowing the gate behavior to be tested without modifying the upstream repository.

1. **Reproduced the vulnerable rejected-approval behavior**

   [Workflow run](https://github.com/shi-eric/newton/actions/runs/30079934005)

   - The external approval job concluded `failure`.
   - The reusable AWS workflow nevertheless started.
   - The EC2 start job succeeded and the GPU job entered `in_progress`.
   - The run was then cancelled to minimize EC2 usage.
   - The normal stop-runner job succeeded.

2. **Verified that the corrected condition blocks rejection**

   [Workflow run](https://github.com/shi-eric/newton/actions/runs/30080619055)

   - The external approval job concluded `failure`.
   - `Run GPU Tests` concluded `skipped`.
   - No `Start self-hosted EC2 runner` job was created.
   - A cross-region AWS audit found no matching runner.

3. **Verified that explicit approval still permits execution**

   [Workflow run](https://github.com/shi-eric/newton/actions/runs/30080713744)

   - The external approval job concluded `success`.
   - The EC2 start job succeeded.
   - The GPU job entered `in_progress`.
   - The run was immediately cancelled to minimize EC2 usage.

   The normal stop job subsequently stalled while configuring AWS credentials after cancellation. A scoped cleanup workflow terminated the fork-tagged instance, and the [final cross-region audit](https://github.com/shi-eric/newton/actions/runs/30081811494) confirmed that no matching instances remained. This PR does not modify the reusable stop-runner workflow.

The benchmark workflow was intentionally not launched. Its caller uses the same gate condition as the live-tested unit-test caller, with exact condition parity verified locally.

## Bug fix

**Steps to reproduce:**

1. Open an external pull request that triggers an AWS `pull_request_target` workflow.
2. Let the membership job classify the author as external.
3. Reject the `external-pr-approval` environment review.
4. Observe that `require-approval` fails.
5. Observe that the dependent AWS workflow still starts because `!cancelled()` is true for a failed dependency.

**Minimal reproduction:**

```yaml
jobs:
  gated:
    needs:
      - require-approval
    if: ${{ !cancelled() }}
```

Rejecting the protected-environment deployment fails `require-approval`; it does not cancel the workflow. The dependent job therefore remains eligible to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved workflow security by preventing temporary GitHub credentials from being retained after repository checkout.

* **Chores**
  * Added stricter authorization checks for GPU benchmarks and tests.
  * GPU workloads now run only after required approval or verified membership conditions are satisfied, reducing unintended executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->