### PR TITLE
Set PYTHONHASHSEED in CI to fix Warp kernel caching

### DIFF
--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -149,9 +149,9 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: /actions-runner/.cache/warp
-          key: warp-kernels-gpu-v2-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          key: warp-kernels-gpu-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
           restore-keys: |
-            warp-kernels-gpu-v2-
+            warp-kernels-gpu-
 
       - name: Check disk space
         run: df -h

--- a/.github/workflows/aws_gpu_tests.yml
+++ b/.github/workflows/aws_gpu_tests.yml
@@ -149,9 +149,9 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: /actions-runner/.cache/warp
-          key: warp-kernels-gpu-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          key: warp-kernels-gpu-v2-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
           restore-keys: |
-            warp-kernels-gpu-
+            warp-kernels-gpu-v2-
 
       - name: Check disk space
         run: df -h
@@ -161,6 +161,8 @@ jobs:
           PYTHONFAULTHANDLER: "1"
           # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
           COVERAGE_CORE: "sysmon"
+          # Warp names lambda-generated kernels via Python's salted hash(); fix the seed so kernel caches are reusable across processes
+          PYTHONHASHSEED: "0"
         run: uv run --extra dev --extra torch-cu13 -m newton.tests --strict-warnings --no-cache-clear --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml
 
       - name: Check disk space (post-test)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,9 @@ jobs:
             ~/.cache/warp
             ~/Library/Caches/warp
             ~\AppData\Local\NVIDIA\warp\Cache
-          key: warp-kernels-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
           restore-keys: |
-            warp-kernels-v2-${{ runner.os }}-${{ runner.arch }}-
+            warp-kernels-${{ runner.os }}-${{ runner.arch }}-
       - name: Run Tests
         env:
           PYTHONFAULTHANDLER: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,14 +130,16 @@ jobs:
             ~/.cache/warp
             ~/Library/Caches/warp
             ~\AppData\Local\NVIDIA\warp\Cache
-          key: warp-kernels-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
+          key: warp-kernels-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('uv.lock', 'newton/**/*.py') }}
           restore-keys: |
-            warp-kernels-${{ runner.os }}-${{ runner.arch }}-
+            warp-kernels-v2-${{ runner.os }}-${{ runner.arch }}-
       - name: Run Tests
         env:
           PYTHONFAULTHANDLER: "1"
           # sys.monitoring coverage core: avoids settrace overhead in unmeasured code
           COVERAGE_CORE: "sysmon"
+          # Warp names lambda-generated kernels via Python's salted hash(); fix the seed so kernel caches are reusable across processes
+          PYTHONHASHSEED: "0"
         run: >
           uv run --extra dev -m newton.tests
           --strict-warnings


### PR DESCRIPTION
## Description

The main push run [30091930217](https://github.com/newton-physics/newton/actions/runs/30091930217) failed `test_basic.example_basic_shapes_vbd_cuda_0` with `Warp CUDA error 500: named symbol not found` and `KeyError: 'test_body_state__locals__test_fn_kernel_4bd54437_cuda_kernel_forward_smem_bytes'`, on a commit that only touched workflow YAML.

Root cause: Warp names lambda-generated functions with Python's builtin `hash()` (`warp/_src/utils.py`, `unique_name`), which is salted per process. Every test subprocess computes different kernel/module hashes for the closure kernels created by the `newton.examples` test helpers (`test_body_state`, `test_particle_state`), so these kernels never hit the Warp kernel cache across processes and every CI run adds a batch of one-off entries to the shared cache blobs (currently 2.33 GB each). Warp's on-disk module directories truncate the module hash to 7 hex chars while kernel symbols embed a different hash that is not validated on a cache hit, so among the accumulated salted variants a 28-bit collision eventually serves a stale binary that lacks the expected kernel symbol — which is exactly the failure above. The mechanism was reproduced line-for-line against the pinned warp wheel (1.16.0.dev20260716) by simulating the module-hash collision between two processes.

This PR sets `PYTHONHASHSEED=0` for the test steps that use Warp kernel caches (AWS GPU tests and the CPU CI matrix), making kernel hashing deterministic so the cache is hit across processes and runs. The previously accumulated nondeterministic cache entries were removed by manually deleting all `warp-kernels-*` caches, so no cache key change is needed; the next run per key recompiles from scratch and is expected to be slower once.

The root fix (content-hashing the generated function name, and validating the full module hash on cache load) belongs in Warp and will be filed upstream.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

CI-only change; exercised by every run of the touched workflows. Root cause verified locally against the pinned wheel: running an identical closure-kernel script repeatedly yields a different kernel hash per process (cache miss + new cache directory every run), while `PYTHONHASHSEED=0` yields identical hashes and a cache hit on the second run. Pinning one process's module hash to another's (simulating the 28-bit directory collision) reproduces the CI failure signature exactly, including the traceback locations (`context.py:10429`/`context.py:3015`).

## Bug fix

**Steps to reproduce:**

1. Run any example test that uses `newton.examples.test_body_state` twice in separate processes with a shared `WARP_CACHE_PATH` and observe both runs compile (`(compiled)`, never `(cached)`) and each run adds a new `wp_newton.examples_*` cache directory.
2. The CI failure itself is probabilistic (truncated-hash collision against accumulated cache entries) and reproduced deterministically by pinning the module hash across two processes.

**Minimal reproduction:**

```python
import warp as wp

def make_kernel():
    threshold = 0.05
    fn, _ = wp.utils.create_warp_function(lambda q, qd: q[2] > threshold)

    @wp.kernel
    def test_fn_kernel(body_q: wp.array(dtype=wp.transform), body_qd: wp.array(dtype=wp.spatial_vector), failures: wp.array(dtype=bool)):
        tid = wp.tid()
        failures[tid] = not wp.bool(fn(body_q[tid], body_qd[tid]))

    return test_fn_kernel

k = make_kernel()
wp.launch(k, dim=1, inputs=[wp.zeros(1, dtype=wp.transform), wp.zeros(1, dtype=wp.spatial_vector)], outputs=[wp.zeros(1, dtype=bool)], device="cuda:0")
print(k.hash.hex()[:8])  # differs on every invocation of this script; stable with PYTHONHASHSEED=0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test reliability by setting `PYTHONHASHSEED=0` in CI and GPU unit test runs to make generated kernel naming deterministic.
  * This enhances reuse of the restored kernel cache across processes and reduces cache mismatch issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->