### PR TITLE
Honor MuJoCo pairs for Newton contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.
 - Bound Kamino DVI contact allocation with a per-world geometry heuristic instead of sizing every contact pair simultaneously; set `collision_detector.max_contacts_per_world` to override the inferred capacity.
 - Fix panel-parallel RCM-blocked LLT factorization hanging when a matrix ends in a partial tile.
+- Honor explicit MuJoCo contact-pair parameters when `SolverMuJoCo` consumes contacts from Newton's collision pipeline.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix MJCF contact pairs ignoring properties inherited from pair default classes.
 - Fix disabled USD colliders participating in particle collisions when visual shape loading is disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,6 @@
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.
 - Bound Kamino DVI contact allocation with a per-world geometry heuristic instead of sizing every contact pair simultaneously; set `collision_detector.max_contacts_per_world` to override the inferred capacity.
 - Fix panel-parallel RCM-blocked LLT factorization hanging when a matrix ends in a partial tile.
-- Honor explicit MuJoCo contact-pair parameters when `SolverMuJoCo` consumes contacts from Newton's collision pipeline.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix MJCF contact pairs ignoring properties inherited from pair default classes.
 - Fix disabled USD colliders participating in particle collisions when visual shape loading is disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ### Fixed
 
+- Honor explicit MuJoCo contact-pair parameters when `SolverMuJoCo` consumes contacts from Newton's collision pipeline.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix USD plane visual width and length to scale along the axes defined by the `UsdGeomPlane` schema, and orient X- and Y-axis plane visuals along the authored axis.
 - Validate `ArticulationView` mask shapes and devices before launching selection kernels. (#3448)

--- a/changelog/3644.fixed.1.md
+++ b/changelog/3644.fixed.1.md
@@ -1,0 +1,1 @@
+Use MuJoCo's `(0, 0)` `solreffriction` default for contact pairs that omit the attribute.

--- a/changelog/3644.fixed.md
+++ b/changelog/3644.fixed.md
@@ -1,0 +1,1 @@
+Honor explicit MuJoCo contact-pair parameters when `SolverMuJoCo` consumes contacts from Newton's collision pipeline.

--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -488,6 +488,17 @@ contact overrides. They are implemented through the MuJoCo
 parsed into MuJoCo's geom-pair contact structures by
 ``SolverMuJoCo._init_pairs``.
 
+With ``use_mujoco_contacts=False``, an explicit pair overrides the
+contact's ``condim``, friction, ``solref``, ``solreffriction``, ``solimp``,
+margin, and gap. Newton's per-contact stiffness, damping, and friction
+scale still take precedence.
+
+This only changes contacts that Newton's collision pipeline already
+emits. An explicit MuJoCo pair does not create a Newton collision
+candidate, so pair-only contacts and pair margins wider than Newton's
+detection range still require matching Newton collision configuration.
+MuJoCo collision sensors do not consume these injected contacts.
+
 
 Multi-world support
 -------------------

--- a/docs/solvers/mujoco.rst
+++ b/docs/solvers/mujoco.rst
@@ -592,6 +592,17 @@ contact overrides. They are implemented through the MuJoCo
 parsed into MuJoCo's geom-pair contact structures by
 ``SolverMuJoCo._init_pairs``.
 
+With ``use_mujoco_contacts=False``, an explicit pair overrides the
+contact's ``condim``, friction, ``solref``, ``solreffriction``, ``solimp``,
+margin, and gap. Newton's per-contact stiffness, damping, and friction
+scale still take precedence.
+
+This only changes contacts that Newton's collision pipeline already
+emits. An explicit MuJoCo pair does not create a Newton collision
+candidate, so pair-only contacts and pair margins wider than Newton's
+detection range still require matching Newton collision configuration.
+MuJoCo collision sensors do not consume these injected contacts.
+
 
 Multi-world support
 -------------------

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -37,11 +37,19 @@ def _import_contact_force_fn():
 vec10 = wp.types.vector(length=10, dtype=wp.float32)
 vec11 = wp.types.vector(length=11, dtype=wp.float32)
 
+CONTACT_TYPE_CONSTRAINT = 1
+
 
 # Utility functions
 @wp.func
 def safe_div(x: float, y: float) -> float:
     return x / wp.where(y != 0.0, y, MJ_MINVAL)
+
+
+@wp.func
+def upper_tri_index(n: int, i: int, j: int) -> int:
+    """Return the index of ``(i, j)`` in an upper triangle without its diagonal."""
+    return (i * (2 * n - i - 3)) // 2 + j - 1
 
 
 @wp.func
@@ -101,6 +109,8 @@ def write_contact(
     contact_geom_out: wp.array[wp.vec2i],
     contact_efc_address_out: wp.array2d[int],
     contact_worldid_out: wp.array[int],
+    contact_type_out: wp.array[int],
+    contact_geomcollisionid_out: wp.array[int],
 ):
     # See function write_contact in mujoco_warp, file collision_primitive.py
 
@@ -110,6 +120,9 @@ def write_contact(
     contact_frame_out[cid] = frame_in
     contact_geom_out[cid] = geoms_in
     contact_worldid_out[cid] = worldid_in
+    contact_type_out[cid] = CONTACT_TYPE_CONSTRAINT
+    # Injected Newton contacts do not carry MuJoCo collision-sensor metadata.
+    contact_geomcollisionid_out[cid] = 0
     contact_includemargin_out[cid] = margin_in
     contact_dim_out[cid] = condim_in
     contact_friction_out[cid] = friction_in
@@ -132,7 +145,15 @@ def contact_params(
     geom_friction: wp.array2d[wp.vec3],
     geom_margin: wp.array2d[float],
     geom_gap: wp.array2d[float],
+    pair_dim: wp.array[int],
+    pair_solref: wp.array2d[wp.vec2],
+    pair_solreffriction: wp.array2d[wp.vec2],
+    pair_solimp: wp.array2d[vec5],
+    pair_margin: wp.array2d[float],
+    pair_gap: wp.array2d[float],
+    pair_friction: wp.array2d[vec5],
     geoms: wp.vec2i,
+    pairid: int,
     worldid: int,
 ):
     # See function contact_params in mujoco_warp, file collision_core.py
@@ -140,50 +161,68 @@ def contact_params(
     g1 = geoms[0]
     g2 = geoms[1]
 
-    p1 = geom_priority[g1]
-    p2 = geom_priority[g2]
-
-    condim1 = geom_condim[g1]
-    condim2 = geom_condim[g2]
-
-    if p1 > p2:
-        mix = 1.0
-        condim = condim1
-        resolved_friction = geom_friction[worldid, g1]
-    elif p2 > p1:
-        mix = 0.0
-        condim = condim2
-        resolved_friction = geom_friction[worldid, g2]
+    if pairid >= 0:
+        pair_worldid = worldid % pair_solref.shape[0]
+        margin = pair_margin[pair_worldid, pairid]
+        gap = pair_gap[pair_worldid, pairid]
+        condim = pair_dim[pairid]
+        friction = pair_friction[pair_worldid, pairid]
+        solref = pair_solref[pair_worldid, pairid]
+        solreffriction = pair_solreffriction[pair_worldid, pairid]
+        solimp = pair_solimp[pair_worldid, pairid]
+        mix = 0.5
     else:
-        solmix1 = geom_solmix[worldid, g1]
-        solmix2 = geom_solmix[worldid, g2]
-        mix = safe_div(solmix1, solmix1 + solmix2)
-        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
-        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
-        mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
-        condim = wp.max(condim1, condim2)
-        resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
+        p1 = geom_priority[g1]
+        p2 = geom_priority[g2]
+
+        condim1 = geom_condim[g1]
+        condim2 = geom_condim[g2]
+
+        if p1 > p2:
+            mix = 1.0
+            condim = condim1
+            resolved_friction = geom_friction[worldid, g1]
+        elif p2 > p1:
+            mix = 0.0
+            condim = condim2
+            resolved_friction = geom_friction[worldid, g2]
+        else:
+            solmix1 = geom_solmix[worldid, g1]
+            solmix2 = geom_solmix[worldid, g2]
+            mix = safe_div(solmix1, solmix1 + solmix2)
+            mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
+            mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
+            mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
+            condim = wp.max(condim1, condim2)
+            resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
+
+        friction = vec5(
+            resolved_friction[0],
+            resolved_friction[0],
+            resolved_friction[1],
+            resolved_friction[2],
+            resolved_friction[2],
+        )
+
+        # Sum margins for consistency with thickness summing
+        margin = geom_margin[worldid, g1] + geom_margin[worldid, g2]
+        gap = geom_gap[worldid, g1] + geom_gap[worldid, g2]
+
+        if geom_solref[worldid, g1].x > 0.0 and geom_solref[worldid, g2].x > 0.0:
+            solref = mix * geom_solref[worldid, g1] + (1.0 - mix) * geom_solref[worldid, g2]
+        else:
+            solref = wp.min(geom_solref[worldid, g1], geom_solref[worldid, g2])
+
+        solreffriction = wp.vec2(0.0, 0.0)
+        solimp = mix * geom_solimp[worldid, g1] + (1.0 - mix) * geom_solimp[worldid, g2]
 
     friction = vec5(
-        wp.max(MJ_MINMU, resolved_friction[0]),
-        wp.max(MJ_MINMU, resolved_friction[0]),
-        wp.max(MJ_MINMU, resolved_friction[1]),
-        wp.max(MJ_MINMU, resolved_friction[2]),
-        wp.max(MJ_MINMU, resolved_friction[2]),
+        wp.max(MJ_MINMU, friction[0]),
+        wp.max(MJ_MINMU, friction[1]),
+        wp.max(MJ_MINMU, friction[2]),
+        wp.max(MJ_MINMU, friction[3]),
+        wp.max(MJ_MINMU, friction[4]),
     )
-
-    # Sum margins for consistency with thickness summing
-    margin = geom_margin[worldid, g1] + geom_margin[worldid, g2]
-    gap = geom_gap[worldid, g1] + geom_gap[worldid, g2]
-
-    if geom_solref[worldid, g1].x > 0.0 and geom_solref[worldid, g2].x > 0.0:
-        solref = mix * geom_solref[worldid, g1] + (1.0 - mix) * geom_solref[worldid, g2]
-    else:
-        solref = wp.min(geom_solref[worldid, g1], geom_solref[worldid, g2])
-
-    solreffriction = wp.vec2(0.0, 0.0)
-
-    solimp = mix * geom_solimp[worldid, g1] + (1.0 - mix) * geom_solimp[worldid, g2]
 
     return margin, gap, condim, friction, solref, solreffriction, solimp, mix
 
@@ -399,6 +438,15 @@ def convert_newton_contacts_to_mjwarp_kernel(
     geom_friction: wp.array2d[wp.vec3],
     geom_margin: wp.array2d[float],
     geom_gap: wp.array2d[float],
+    ngeom: int,
+    nxn_pairid: wp.array[wp.vec2i],
+    pair_dim: wp.array[int],
+    pair_solref: wp.array2d[wp.vec2],
+    pair_solreffriction: wp.array2d[wp.vec2],
+    pair_solimp: wp.array2d[vec5],
+    pair_margin: wp.array2d[float],
+    pair_gap: wp.array2d[float],
+    pair_friction: wp.array2d[vec5],
     # Newton shape-material force-space inputs (issue #2009)
     shape_material_ke: wp.array[float],
     shape_material_kd: wp.array[float],
@@ -435,6 +483,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
     contact_geom_out: wp.array[wp.vec2i],
     contact_efc_address_out: wp.array2d[int],
     contact_worldid_out: wp.array[int],
+    contact_type_out: wp.array[int],
+    contact_geomcollisionid_out: wp.array[int],
     # Values to clear - see _zero_collision_arrays kernel from mujoco_warp
     nworld_in: int,
     ncollision_out: wp.array[int],
@@ -544,12 +594,21 @@ def convert_newton_contacts_to_mjwarp_kernel(
         frame = make_frame(n)
 
         geoms = wp.vec2i(geom_a, geom_b)
+        geom_lo = wp.min(geom_a, geom_b)
+        geom_hi = wp.max(geom_a, geom_b)
+        if geom_lo == geom_hi:
+            tid_to_cid[tid] = -1
+            return
+        pairid = nxn_pairid[upper_tri_index(ngeom, geom_lo, geom_hi)][0]
+        if pairid == -2:
+            tid_to_cid[tid] = -1
+            return
 
         worldid = body_a // bodies_per_world
         if body_a < 0:
             worldid = body_b // bodies_per_world
 
-        margin, _gap, condim, friction, solref, solreffriction, solimp, mix = contact_params(
+        margin, gap, condim, friction, solref, solreffriction, solimp, mix = contact_params(
             geom_condim,
             geom_priority,
             geom_solmix,
@@ -558,15 +617,27 @@ def convert_newton_contacts_to_mjwarp_kernel(
             geom_friction,
             geom_margin,
             geom_gap,
+            pair_dim,
+            pair_solref,
+            pair_solreffriction,
+            pair_solimp,
+            pair_margin,
+            pair_gap,
+            pair_friction,
             geoms,
+            pairid,
             worldid,
         )
+
+        if pairid >= 0 and dist >= margin + gap:
+            tid_to_cid[tid] = -1
+            return
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
         # solref averaging and recompute the solref from the combined
         # two-body factor. See docs/solvers/mujoco.rst > "Shape-material
         # contact stiffness and damping" for the mechanism.
-        if shape_mjc_solref_mode:
+        if pairid < 0 and shape_mjc_solref_mode:
             mode_a = shape_mjc_solref_mode[shape_a]
             mode_b = shape_mjc_solref_mode[shape_b]
             if mode_a == SOLREF_MODE_FORCE_SPACE and mode_b == SOLREF_MODE_FORCE_SPACE:
@@ -658,6 +729,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
             contact_geom_out=contact_geom_out,
             contact_efc_address_out=contact_efc_address_out,
             contact_worldid_out=contact_worldid_out,
+            contact_type_out=contact_type_out,
+            contact_geomcollisionid_out=contact_geomcollisionid_out,
         )
     else:
         # ── FAST PATH ────────────────────────────────────────────────────
@@ -3087,7 +3160,7 @@ def convert_qfrc_actuator_from_mj_kernel(
 
 @wp.kernel
 def update_pair_properties_kernel(
-    pairs_per_world: int,
+    mjc_pair_to_newton_pair: wp.array2d[int],
     pair_solref_in: wp.array[wp.vec2],
     pair_solreffriction_in: wp.array[wp.vec2],
     pair_solimp_in: wp.array[vec5],
@@ -3108,7 +3181,9 @@ def update_pair_properties_kernel(
     (solref, solimp, margin, gap, friction) from Newton custom attributes.
     """
     world, mjc_pair = wp.tid()
-    newton_pair = world * pairs_per_world + mjc_pair
+    newton_pair = mjc_pair_to_newton_pair[world, mjc_pair]
+    if newton_pair < 0:
+        return
 
     if pair_solref_in:
         pair_solref_out[world, mjc_pair] = pair_solref_in[newton_pair]

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -703,7 +703,7 @@ def convert_newton_contacts_to_mjwarp_kernel(
 
         # Match Newton's force-space friction slope using MuJoCo's inverse-weight
         # approximation; positive solref lets refsafe limit overly stiff damping.
-        if shape_material_kf and use_kf_mapping:
+        if pairid < 0 and shape_material_kf and use_kf_mapping:
             kf1 = shape_material_kf[shape_a]
             kf2 = shape_material_kf[shape_b]
             kf = mix * kf1 + (1.0 - mix) * kf2

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -37,11 +37,19 @@ def _import_contact_force_fn():
 vec10 = wp.types.vector(length=10, dtype=wp.float32)
 vec11 = wp.types.vector(length=11, dtype=wp.float32)
 
+CONTACT_TYPE_CONSTRAINT = 1
+
 
 # Utility functions
 @wp.func
 def safe_div(x: float, y: float) -> float:
     return x / wp.where(y != 0.0, y, MJ_MINVAL)
+
+
+@wp.func
+def upper_tri_index(n: int, i: int, j: int) -> int:
+    """Return the index of ``(i, j)`` in an upper triangle without its diagonal."""
+    return (i * (2 * n - i - 3)) // 2 + j - 1
 
 
 @wp.func
@@ -101,6 +109,8 @@ def write_contact(
     contact_geom_out: wp.array[wp.vec2i],
     contact_efc_address_out: wp.array2d[int],
     contact_worldid_out: wp.array[int],
+    contact_type_out: wp.array[int],
+    contact_geomcollisionid_out: wp.array[int],
 ):
     # See function write_contact in mujoco_warp, file collision_primitive.py
 
@@ -110,6 +120,9 @@ def write_contact(
     contact_frame_out[cid] = frame_in
     contact_geom_out[cid] = geoms_in
     contact_worldid_out[cid] = worldid_in
+    contact_type_out[cid] = CONTACT_TYPE_CONSTRAINT
+    # Injected Newton contacts do not carry MuJoCo collision-sensor metadata.
+    contact_geomcollisionid_out[cid] = 0
     contact_includemargin_out[cid] = margin_in
     contact_dim_out[cid] = condim_in
     contact_friction_out[cid] = friction_in
@@ -132,7 +145,15 @@ def contact_params(
     geom_friction: wp.array2d[wp.vec3],
     geom_margin: wp.array2d[float],
     geom_gap: wp.array2d[float],
+    pair_dim: wp.array[int],
+    pair_solref: wp.array2d[wp.vec2],
+    pair_solreffriction: wp.array2d[wp.vec2],
+    pair_solimp: wp.array2d[vec5],
+    pair_margin: wp.array2d[float],
+    pair_gap: wp.array2d[float],
+    pair_friction: wp.array2d[vec5],
     geoms: wp.vec2i,
+    pairid: int,
     worldid: int,
 ):
     # See function contact_params in mujoco_warp, file collision_core.py
@@ -140,50 +161,68 @@ def contact_params(
     g1 = geoms[0]
     g2 = geoms[1]
 
-    p1 = geom_priority[g1]
-    p2 = geom_priority[g2]
-
-    condim1 = geom_condim[g1]
-    condim2 = geom_condim[g2]
-
-    if p1 > p2:
-        mix = 1.0
-        condim = condim1
-        resolved_friction = geom_friction[worldid, g1]
-    elif p2 > p1:
-        mix = 0.0
-        condim = condim2
-        resolved_friction = geom_friction[worldid, g2]
+    if pairid >= 0:
+        pair_worldid = worldid % pair_solref.shape[0]
+        margin = pair_margin[pair_worldid, pairid]
+        gap = pair_gap[pair_worldid, pairid]
+        condim = pair_dim[pairid]
+        friction = pair_friction[pair_worldid, pairid]
+        solref = pair_solref[pair_worldid, pairid]
+        solreffriction = pair_solreffriction[pair_worldid, pairid]
+        solimp = pair_solimp[pair_worldid, pairid]
+        mix = 0.5
     else:
-        solmix1 = geom_solmix[worldid, g1]
-        solmix2 = geom_solmix[worldid, g2]
-        mix = safe_div(solmix1, solmix1 + solmix2)
-        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
-        mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
-        mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
-        condim = wp.max(condim1, condim2)
-        resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
+        p1 = geom_priority[g1]
+        p2 = geom_priority[g2]
+
+        condim1 = geom_condim[g1]
+        condim2 = geom_condim[g2]
+
+        if p1 > p2:
+            mix = 1.0
+            condim = condim1
+            resolved_friction = geom_friction[worldid, g1]
+        elif p2 > p1:
+            mix = 0.0
+            condim = condim2
+            resolved_friction = geom_friction[worldid, g2]
+        else:
+            solmix1 = geom_solmix[worldid, g1]
+            solmix2 = geom_solmix[worldid, g2]
+            mix = safe_div(solmix1, solmix1 + solmix2)
+            mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 < MJ_MINVAL), 0.5, mix)
+            mix = wp.where((solmix1 < MJ_MINVAL) and (solmix2 >= MJ_MINVAL), 0.0, mix)
+            mix = wp.where((solmix1 >= MJ_MINVAL) and (solmix2 < MJ_MINVAL), 1.0, mix)
+            condim = wp.max(condim1, condim2)
+            resolved_friction = wp.max(geom_friction[worldid, g1], geom_friction[worldid, g2])
+
+        friction = vec5(
+            resolved_friction[0],
+            resolved_friction[0],
+            resolved_friction[1],
+            resolved_friction[2],
+            resolved_friction[2],
+        )
+
+        # Sum margins for consistency with thickness summing
+        margin = geom_margin[worldid, g1] + geom_margin[worldid, g2]
+        gap = geom_gap[worldid, g1] + geom_gap[worldid, g2]
+
+        if geom_solref[worldid, g1].x > 0.0 and geom_solref[worldid, g2].x > 0.0:
+            solref = mix * geom_solref[worldid, g1] + (1.0 - mix) * geom_solref[worldid, g2]
+        else:
+            solref = wp.min(geom_solref[worldid, g1], geom_solref[worldid, g2])
+
+        solreffriction = wp.vec2(0.0, 0.0)
+        solimp = mix * geom_solimp[worldid, g1] + (1.0 - mix) * geom_solimp[worldid, g2]
 
     friction = vec5(
-        wp.max(MJ_MINMU, resolved_friction[0]),
-        wp.max(MJ_MINMU, resolved_friction[0]),
-        wp.max(MJ_MINMU, resolved_friction[1]),
-        wp.max(MJ_MINMU, resolved_friction[2]),
-        wp.max(MJ_MINMU, resolved_friction[2]),
+        wp.max(MJ_MINMU, friction[0]),
+        wp.max(MJ_MINMU, friction[1]),
+        wp.max(MJ_MINMU, friction[2]),
+        wp.max(MJ_MINMU, friction[3]),
+        wp.max(MJ_MINMU, friction[4]),
     )
-
-    # Sum margins for consistency with thickness summing
-    margin = geom_margin[worldid, g1] + geom_margin[worldid, g2]
-    gap = geom_gap[worldid, g1] + geom_gap[worldid, g2]
-
-    if geom_solref[worldid, g1].x > 0.0 and geom_solref[worldid, g2].x > 0.0:
-        solref = mix * geom_solref[worldid, g1] + (1.0 - mix) * geom_solref[worldid, g2]
-    else:
-        solref = wp.min(geom_solref[worldid, g1], geom_solref[worldid, g2])
-
-    solreffriction = wp.vec2(0.0, 0.0)
-
-    solimp = mix * geom_solimp[worldid, g1] + (1.0 - mix) * geom_solimp[worldid, g2]
 
     return margin, gap, condim, friction, solref, solreffriction, solimp, mix
 
@@ -400,6 +439,15 @@ def convert_newton_contacts_to_mjwarp_kernel(
     geom_friction: wp.array2d[wp.vec3],
     geom_margin: wp.array2d[float],
     geom_gap: wp.array2d[float],
+    ngeom: int,
+    nxn_pairid: wp.array[wp.vec2i],
+    pair_dim: wp.array[int],
+    pair_solref: wp.array2d[wp.vec2],
+    pair_solreffriction: wp.array2d[wp.vec2],
+    pair_solimp: wp.array2d[vec5],
+    pair_margin: wp.array2d[float],
+    pair_gap: wp.array2d[float],
+    pair_friction: wp.array2d[vec5],
     # Newton shape-material force-space inputs (issue #2009)
     shape_material_ke: wp.array[float],
     shape_material_kd: wp.array[float],
@@ -439,6 +487,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
     contact_geom_out: wp.array[wp.vec2i],
     contact_efc_address_out: wp.array2d[int],
     contact_worldid_out: wp.array[int],
+    contact_type_out: wp.array[int],
+    contact_geomcollisionid_out: wp.array[int],
     # Values to clear - see _zero_collision_arrays kernel from mujoco_warp
     nworld_in: int,
     ncollision_out: wp.array[int],
@@ -548,12 +598,21 @@ def convert_newton_contacts_to_mjwarp_kernel(
         frame = make_frame(n)
 
         geoms = wp.vec2i(geom_a, geom_b)
+        geom_lo = wp.min(geom_a, geom_b)
+        geom_hi = wp.max(geom_a, geom_b)
+        if geom_lo == geom_hi:
+            tid_to_cid[tid] = -1
+            return
+        pairid = nxn_pairid[upper_tri_index(ngeom, geom_lo, geom_hi)][0]
+        if pairid == -2:
+            tid_to_cid[tid] = -1
+            return
 
         worldid = body_a // bodies_per_world
         if body_a < 0:
             worldid = body_b // bodies_per_world
 
-        margin, _gap, condim, friction, solref, solreffriction, solimp, mix = contact_params(
+        margin, gap, condim, friction, solref, solreffriction, solimp, mix = contact_params(
             geom_condim,
             geom_priority,
             geom_solmix,
@@ -562,15 +621,27 @@ def convert_newton_contacts_to_mjwarp_kernel(
             geom_friction,
             geom_margin,
             geom_gap,
+            pair_dim,
+            pair_solref,
+            pair_solreffriction,
+            pair_solimp,
+            pair_margin,
+            pair_gap,
+            pair_friction,
             geoms,
+            pairid,
             worldid,
         )
+
+        if pairid >= 0 and dist >= margin + gap:
+            tid_to_cid[tid] = -1
+            return
 
         # FORCE_SPACE per-contact override: bypass contact_params' per-geom
         # solref averaging and recompute the solref from the combined
         # two-body factor. See docs/solvers/mujoco.rst > "Shape-material
         # contact stiffness and damping" for the mechanism.
-        if shape_mjc_solref_mode:
+        if pairid < 0 and shape_mjc_solref_mode:
             mode_a = shape_mjc_solref_mode[shape_a]
             mode_b = shape_mjc_solref_mode[shape_b]
             if mode_a == SOLREF_MODE_FORCE_SPACE and mode_b == SOLREF_MODE_FORCE_SPACE:
@@ -682,6 +753,8 @@ def convert_newton_contacts_to_mjwarp_kernel(
             contact_geom_out=contact_geom_out,
             contact_efc_address_out=contact_efc_address_out,
             contact_worldid_out=contact_worldid_out,
+            contact_type_out=contact_type_out,
+            contact_geomcollisionid_out=contact_geomcollisionid_out,
         )
     else:
         # ── FAST PATH ────────────────────────────────────────────────────
@@ -3133,7 +3206,7 @@ def convert_qfrc_actuator_from_mj_kernel(
 
 @wp.kernel
 def update_pair_properties_kernel(
-    pairs_per_world: int,
+    mjc_pair_to_newton_pair: wp.array2d[int],
     pair_solref_in: wp.array[wp.vec2],
     pair_solreffriction_in: wp.array[wp.vec2],
     pair_solimp_in: wp.array[vec5],
@@ -3154,7 +3227,9 @@ def update_pair_properties_kernel(
     (solref, solimp, margin, gap, friction) from Newton custom attributes.
     """
     world, mjc_pair = wp.tid()
-    newton_pair = world * pairs_per_world + mjc_pair
+    newton_pair = mjc_pair_to_newton_pair[world, mjc_pair]
+    if newton_pair < 0:
+        return
 
     if pair_solref_in:
         pair_solref_out[world, mjc_pair] = pair_solref_in[newton_pair]

--- a/newton/_src/solvers/mujoco/kernels.py
+++ b/newton/_src/solvers/mujoco/kernels.py
@@ -604,9 +604,6 @@ def convert_newton_contacts_to_mjwarp_kernel(
             tid_to_cid[tid] = -1
             return
         pairid = nxn_pairid[upper_tri_index(ngeom, geom_lo, geom_hi)][0]
-        if pairid == -2:
-            tid_to_cid[tid] = -1
-            return
 
         worldid = body_a // bodies_per_world
         if body_a < 0:

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1350,7 +1350,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 name="pair_solreffriction",
                 frequency="mujoco:pair",
                 dtype=wp.vec2,
-                default=wp.vec2(0.02, 1.0),
+                default=wp.vec2(0.0, 0.0),
                 namespace="mujoco",
                 mjcf_attribute_name="solreffriction",
             )
@@ -3387,6 +3387,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         """Mapping from MuJoCo [world, body] to Newton body index. Shape [nworld, nbody], dtype int32."""
         self.mjc_geom_to_newton_shape: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, geom] to Newton shape index. Shape [nworld, ngeom], dtype int32."""
+        self.mjc_pair_to_newton_pair: wp.array2d[wp.int32] | None = None
+        """Mapping from MuJoCo [world, pair] to Newton pair index. Shape [nworld, npair], dtype int32."""
         # Template-relative for per-world sites and absolute for global sites.
         self._mjc_site_shape_index: wp.array[wp.int32] | None = None
         self._mjc_site_is_global: wp.array[bool] | None = None
@@ -3995,6 +3997,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 self.mjw_model.geom_friction,
                 self.mjw_model.geom_margin,
                 self.mjw_model.geom_gap,
+                self.mj_model.ngeom,
+                self.mjw_model.nxn_pairid,
+                self.mjw_model.pair_dim,
+                self.mjw_model.pair_solref,
+                self.mjw_model.pair_solreffriction,
+                self.mjw_model.pair_solimp,
+                self.mjw_model.pair_margin,
+                self.mjw_model.pair_gap,
+                self.mjw_model.pair_friction,
                 # Newton shape-material force-space inputs (issue #2009)
                 model.shape_material_ke,
                 model.shape_material_kd,
@@ -4031,6 +4042,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 self.mjw_data.contact.geom,
                 self.mjw_data.contact.efc_address,
                 self.mjw_data.contact.worldid,
+                self.mjw_data.contact.type,
+                self.mjw_data.contact.geomcollisionid,
                 # Data to clear
                 self.mjw_data.nworld,
                 self.mjw_data.ncollision,
@@ -6669,6 +6682,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     device=model.device,
                 )
 
+            self._create_pair_mapping(
+                geom_to_shape_idx_np,
+                geom_is_static_np,
+                shape_world,
+                nworld,
+            )
+
             site_to_shape_idx_np = np.full((self.mj_model.nsite,), -1, dtype=np.int32)
             site_is_global_np = np.zeros((self.mj_model.nsite,), dtype=bool)
             for site_idx, abs_shape_idx in site_to_shape_idx.items():
@@ -8114,6 +8134,133 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         )
         self.mj_model.jnt_solref[:] = self.mjw_model.jnt_solref.numpy()[0]
 
+    def _create_pair_mapping(
+        self,
+        geom_to_shape: np.ndarray,
+        geom_is_static: np.ndarray,
+        shape_world: np.ndarray,
+        nworld: int,
+    ) -> None:
+        """Map compiled MuJoCo pairs to their exact Newton pair records."""
+        npair = self.mj_model.npair
+        pair_mapping = np.full((nworld, npair), -1, dtype=np.int32)
+        if npair == 0:
+            self.mjc_pair_to_newton_pair = wp.array(pair_mapping, dtype=wp.int32, device=self.model.device)
+            return
+
+        mujoco_attrs = getattr(self.model, "mujoco", None)
+        pair_count = self.model.custom_frequency_counts.get("mujoco:pair", 0)
+        required_names = ("pair_world", "pair_geom1", "pair_geom2", "pair_condim")
+        if (
+            mujoco_attrs is None
+            or pair_count == 0
+            or any(getattr(mujoco_attrs, name, None) is None for name in required_names)
+        ):
+            raise ValueError("MuJoCo contact pairs require Newton pair topology attributes.")
+
+        pair_world = mujoco_attrs.pair_world.numpy()
+        pair_geom1 = mujoco_attrs.pair_geom1.numpy()
+        pair_geom2 = mujoco_attrs.pair_geom2.numpy()
+        pair_condim = mujoco_attrs.pair_condim.numpy()
+        if any(len(values) < pair_count for values in (pair_world, pair_geom1, pair_geom2, pair_condim)):
+            raise ValueError("MuJoCo pair topology attributes have inconsistent lengths.")
+
+        def shape_key(shape: int) -> tuple[int, int]:
+            if shape < 0 or shape >= self.model.shape_count:
+                raise ValueError(f"MuJoCo pair references invalid Newton shape {shape}.")
+            world = int(shape_world[shape])
+            if world < 0:
+                return (0, shape)
+            shape_local = shape - (self._first_env_shape_base + world * self._shapes_per_world)
+            if shape_local < 0 or shape_local >= self._shapes_per_world:
+                raise ValueError(f"Newton shape {shape} is outside the regular per-world layout.")
+            return (1, shape_local)
+
+        def topology_key(shape1: int, shape2: int) -> tuple[tuple[int, int], tuple[int, int]]:
+            key1 = shape_key(shape1)
+            key2 = shape_key(shape2)
+            return (key1, key2) if key1 <= key2 else (key2, key1)
+
+        pair_by_world = {}
+        pair_global = {}
+        for pair in range(pair_count):
+            shape1 = int(pair_geom1[pair])
+            shape2 = int(pair_geom2[pair])
+            key = topology_key(shape1, shape2)
+            world = int(pair_world[pair])
+            if world < 0:
+                if key in pair_global:
+                    raise ValueError(
+                        f"Duplicate MuJoCo pair topology for Newton pair records {pair_global[key]} and {pair}."
+                    )
+                pair_global[key] = pair
+            else:
+                lookup_key = (world, key)
+                if lookup_key in pair_by_world:
+                    raise ValueError(
+                        "Duplicate MuJoCo pair topology for Newton pair records "
+                        f"{pair_by_world[lookup_key]} and {pair}."
+                    )
+                pair_by_world[lookup_key] = pair
+
+            endpoint_worlds = {int(shape_world[shape]) for shape in (shape1, shape2) if int(shape_world[shape]) >= 0}
+            if len(endpoint_worlds) > 1 or (world >= 0 and endpoint_worlds and endpoint_worlds != {world}):
+                raise ValueError(f"Newton pair record {pair} has endpoints from the wrong world.")
+
+        geom1 = self.mj_model.pair_geom1
+        geom2 = self.mj_model.pair_geom2
+        compiled_condim = self.mj_model.pair_dim
+
+        def mapped_shape(world: int, geom: int) -> int:
+            template_or_static_shape = int(geom_to_shape[geom])
+            if template_or_static_shape < 0:
+                raise ValueError(f"MuJoCo pair references unmapped geom {geom}.")
+            if geom_is_static[geom]:
+                return template_or_static_shape
+            return self._first_env_shape_base + template_or_static_shape + world * self._shapes_per_world
+
+        used_pairs = set()
+        for world in range(nworld):
+            for mjc_pair in range(npair):
+                shape1 = mapped_shape(world, int(geom1[mjc_pair]))
+                shape2 = mapped_shape(world, int(geom2[mjc_pair]))
+                key = topology_key(shape1, shape2)
+                endpoint_worlds = {
+                    int(shape_world[shape]) for shape in (shape1, shape2) if int(shape_world[shape]) >= 0
+                }
+                if len(endpoint_worlds) > 1:
+                    raise ValueError(f"MuJoCo pair {mjc_pair} maps across Newton worlds.")
+
+                pair = -1
+                if endpoint_worlds:
+                    pair_world_id = next(iter(endpoint_worlds))
+                    pair = pair_by_world.get((pair_world_id, key), -1)
+                if pair < 0:
+                    pair = pair_global.get(key, -1)
+                if pair < 0 and not endpoint_worlds:
+                    matching_pairs = [
+                        candidate
+                        for (_candidate_world, candidate_key), candidate in pair_by_world.items()
+                        if candidate_key == key
+                    ]
+                    if len(matching_pairs) == 1:
+                        pair = matching_pairs[0]
+                if pair < 0:
+                    raise ValueError(f"MuJoCo pair {mjc_pair} has no matching Newton pair record in world {world}.")
+                if int(pair_condim[pair]) != int(compiled_condim[mjc_pair]):
+                    raise ValueError(
+                        f"MuJoCo pair {mjc_pair} condim is {int(compiled_condim[mjc_pair])}, "
+                        f"but Newton pair record {pair} has {int(pair_condim[pair])}."
+                    )
+                pair_mapping[world, mjc_pair] = pair
+                used_pairs.add(pair)
+
+        if nworld == self.model.world_count and len(used_pairs) != pair_count:
+            unused_pairs = sorted(set(range(pair_count)) - used_pairs)
+            raise ValueError(f"MuJoCo pair records {unused_pairs} do not match the compiled pair topology.")
+
+        self.mjc_pair_to_newton_pair = wp.array(pair_mapping, dtype=wp.int32, device=self.model.device)
+
     def _update_pair_properties(self):
         """Update MuJoCo contact pair properties from Newton custom attributes.
 
@@ -8151,21 +8298,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             attr is not None
             for attr in [pair_solref, pair_solreffriction, pair_solimp, pair_margin, pair_gap, pair_friction]
         ):
-            # Compute pairs_per_world from Newton custom attributes
-            pair_world_attr = getattr(mujoco_attrs, "pair_world", None)
-            if pair_world_attr is not None:
-                total_pairs = len(pair_world_attr)
-                pairs_per_world = total_pairs // self.model.world_count
-            else:
-                pairs_per_world = npair
-
             world_count = self.mjw_data.nworld
 
             wp.launch(
                 update_pair_properties_kernel,
                 dim=(world_count, npair),
                 inputs=[
-                    pairs_per_world,
+                    self.mjc_pair_to_newton_pair,
                     pair_solref,
                     pair_solreffriction,
                     pair_solimp,

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -1408,7 +1408,7 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 name="pair_solreffriction",
                 frequency="mujoco:pair",
                 dtype=wp.vec2,
-                default=wp.vec2(0.02, 1.0),
+                default=wp.vec2(0.0, 0.0),
                 namespace="mujoco",
                 mjcf_attribute_name="solreffriction",
             )
@@ -3525,6 +3525,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         """Mapping from MuJoCo [world, body] to Newton body index. Shape [nworld, nbody], dtype int32."""
         self.mjc_geom_to_newton_shape: wp.array2d[wp.int32] | None = None
         """Mapping from MuJoCo [world, geom] to Newton shape index. Shape [nworld, ngeom], dtype int32."""
+        self.mjc_pair_to_newton_pair: wp.array2d[wp.int32] | None = None
+        """Mapping from MuJoCo [world, pair] to Newton pair index. Shape [nworld, npair], dtype int32."""
         # Template-relative for per-world sites and absolute for global sites.
         self._mjc_site_shape_index: wp.array[wp.int32] | None = None
         self._mjc_site_is_global: wp.array[bool] | None = None
@@ -4287,6 +4289,15 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 self.mjw_model.geom_friction,
                 self.mjw_model.geom_margin,
                 self.mjw_model.geom_gap,
+                self.mj_model.ngeom,
+                self.mjw_model.nxn_pairid,
+                self.mjw_model.pair_dim,
+                self.mjw_model.pair_solref,
+                self.mjw_model.pair_solreffriction,
+                self.mjw_model.pair_solimp,
+                self.mjw_model.pair_margin,
+                self.mjw_model.pair_gap,
+                self.mjw_model.pair_friction,
                 # Newton shape-material force-space inputs (issue #2009)
                 model.shape_material_ke,
                 model.shape_material_kd,
@@ -4326,6 +4337,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 self.mjw_data.contact.geom,
                 self.mjw_data.contact.efc_address,
                 self.mjw_data.contact.worldid,
+                self.mjw_data.contact.type,
+                self.mjw_data.contact.geomcollisionid,
                 # Data to clear
                 self.mjw_data.nworld,
                 self.mjw_data.ncollision,
@@ -7191,6 +7204,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     device=model.device,
                 )
 
+            self._create_pair_mapping(
+                geom_to_shape_idx_np,
+                geom_is_static_np,
+                shape_world,
+                nworld,
+            )
+
             site_to_shape_idx_np = np.full((self.mj_model.nsite,), -1, dtype=np.int32)
             site_is_global_np = np.zeros((self.mj_model.nsite,), dtype=bool)
             for site_idx, abs_shape_idx in site_to_shape_idx.items():
@@ -8664,6 +8684,133 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         )
         self.mj_model.jnt_solref[:] = self.mjw_model.jnt_solref.numpy()[0]
 
+    def _create_pair_mapping(
+        self,
+        geom_to_shape: np.ndarray,
+        geom_is_static: np.ndarray,
+        shape_world: np.ndarray,
+        nworld: int,
+    ) -> None:
+        """Map compiled MuJoCo pairs to their exact Newton pair records."""
+        npair = self.mj_model.npair
+        pair_mapping = np.full((nworld, npair), -1, dtype=np.int32)
+        if npair == 0:
+            self.mjc_pair_to_newton_pair = wp.array(pair_mapping, dtype=wp.int32, device=self.model.device)
+            return
+
+        mujoco_attrs = getattr(self.model, "mujoco", None)
+        pair_count = self.model.custom_frequency_counts.get("mujoco:pair", 0)
+        required_names = ("pair_world", "pair_geom1", "pair_geom2", "pair_condim")
+        if (
+            mujoco_attrs is None
+            or pair_count == 0
+            or any(getattr(mujoco_attrs, name, None) is None for name in required_names)
+        ):
+            raise ValueError("MuJoCo contact pairs require Newton pair topology attributes.")
+
+        pair_world = mujoco_attrs.pair_world.numpy()
+        pair_geom1 = mujoco_attrs.pair_geom1.numpy()
+        pair_geom2 = mujoco_attrs.pair_geom2.numpy()
+        pair_condim = mujoco_attrs.pair_condim.numpy()
+        if any(len(values) < pair_count for values in (pair_world, pair_geom1, pair_geom2, pair_condim)):
+            raise ValueError("MuJoCo pair topology attributes have inconsistent lengths.")
+
+        def shape_key(shape: int) -> tuple[int, int]:
+            if shape < 0 or shape >= self.model.shape_count:
+                raise ValueError(f"MuJoCo pair references invalid Newton shape {shape}.")
+            world = int(shape_world[shape])
+            if world < 0:
+                return (0, shape)
+            shape_local = shape - (self._first_env_shape_base + world * self._shapes_per_world)
+            if shape_local < 0 or shape_local >= self._shapes_per_world:
+                raise ValueError(f"Newton shape {shape} is outside the regular per-world layout.")
+            return (1, shape_local)
+
+        def topology_key(shape1: int, shape2: int) -> tuple[tuple[int, int], tuple[int, int]]:
+            key1 = shape_key(shape1)
+            key2 = shape_key(shape2)
+            return (key1, key2) if key1 <= key2 else (key2, key1)
+
+        pair_by_world = {}
+        pair_global = {}
+        for pair in range(pair_count):
+            shape1 = int(pair_geom1[pair])
+            shape2 = int(pair_geom2[pair])
+            key = topology_key(shape1, shape2)
+            world = int(pair_world[pair])
+            if world < 0:
+                if key in pair_global:
+                    raise ValueError(
+                        f"Duplicate MuJoCo pair topology for Newton pair records {pair_global[key]} and {pair}."
+                    )
+                pair_global[key] = pair
+            else:
+                lookup_key = (world, key)
+                if lookup_key in pair_by_world:
+                    raise ValueError(
+                        "Duplicate MuJoCo pair topology for Newton pair records "
+                        f"{pair_by_world[lookup_key]} and {pair}."
+                    )
+                pair_by_world[lookup_key] = pair
+
+            endpoint_worlds = {int(shape_world[shape]) for shape in (shape1, shape2) if int(shape_world[shape]) >= 0}
+            if len(endpoint_worlds) > 1 or (world >= 0 and endpoint_worlds and endpoint_worlds != {world}):
+                raise ValueError(f"Newton pair record {pair} has endpoints from the wrong world.")
+
+        geom1 = self.mj_model.pair_geom1
+        geom2 = self.mj_model.pair_geom2
+        compiled_condim = self.mj_model.pair_dim
+
+        def mapped_shape(world: int, geom: int) -> int:
+            template_or_static_shape = int(geom_to_shape[geom])
+            if template_or_static_shape < 0:
+                raise ValueError(f"MuJoCo pair references unmapped geom {geom}.")
+            if geom_is_static[geom]:
+                return template_or_static_shape
+            return self._first_env_shape_base + template_or_static_shape + world * self._shapes_per_world
+
+        used_pairs = set()
+        for world in range(nworld):
+            for mjc_pair in range(npair):
+                shape1 = mapped_shape(world, int(geom1[mjc_pair]))
+                shape2 = mapped_shape(world, int(geom2[mjc_pair]))
+                key = topology_key(shape1, shape2)
+                endpoint_worlds = {
+                    int(shape_world[shape]) for shape in (shape1, shape2) if int(shape_world[shape]) >= 0
+                }
+                if len(endpoint_worlds) > 1:
+                    raise ValueError(f"MuJoCo pair {mjc_pair} maps across Newton worlds.")
+
+                pair = -1
+                if endpoint_worlds:
+                    pair_world_id = next(iter(endpoint_worlds))
+                    pair = pair_by_world.get((pair_world_id, key), -1)
+                if pair < 0:
+                    pair = pair_global.get(key, -1)
+                if pair < 0 and not endpoint_worlds:
+                    matching_pairs = [
+                        candidate
+                        for (_candidate_world, candidate_key), candidate in pair_by_world.items()
+                        if candidate_key == key
+                    ]
+                    if len(matching_pairs) == 1:
+                        pair = matching_pairs[0]
+                if pair < 0:
+                    raise ValueError(f"MuJoCo pair {mjc_pair} has no matching Newton pair record in world {world}.")
+                if int(pair_condim[pair]) != int(compiled_condim[mjc_pair]):
+                    raise ValueError(
+                        f"MuJoCo pair {mjc_pair} condim is {int(compiled_condim[mjc_pair])}, "
+                        f"but Newton pair record {pair} has {int(pair_condim[pair])}."
+                    )
+                pair_mapping[world, mjc_pair] = pair
+                used_pairs.add(pair)
+
+        if nworld == self.model.world_count and len(used_pairs) != pair_count:
+            unused_pairs = sorted(set(range(pair_count)) - used_pairs)
+            raise ValueError(f"MuJoCo pair records {unused_pairs} do not match the compiled pair topology.")
+
+        self.mjc_pair_to_newton_pair = wp.array(pair_mapping, dtype=wp.int32, device=self.model.device)
+
     def _update_pair_properties(self):
         """Update MuJoCo contact pair properties from Newton custom attributes.
 
@@ -8701,21 +8848,13 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
             attr is not None
             for attr in [pair_solref, pair_solreffriction, pair_solimp, pair_margin, pair_gap, pair_friction]
         ):
-            # Compute pairs_per_world from Newton custom attributes
-            pair_world_attr = getattr(mujoco_attrs, "pair_world", None)
-            if pair_world_attr is not None:
-                total_pairs = len(pair_world_attr)
-                pairs_per_world = total_pairs // self.model.world_count
-            else:
-                pairs_per_world = npair
-
             world_count = self.mjw_data.nworld
 
             wp.launch(
                 update_pair_properties_kernel,
                 dim=(world_count, npair),
                 inputs=[
-                    pairs_per_world,
+                    self.mjc_pair_to_newton_pair,
                     pair_solref,
                     pair_solreffriction,
                     pair_solimp,

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8147,6 +8147,213 @@ class TestMuJoCoArticulationConversion(unittest.TestCase):
 class TestMuJoCoSolverPairProperties(unittest.TestCase):
     """Test contact pair property conversion and runtime updates across multiple worlds."""
 
+    @staticmethod
+    def _make_explicit_pair_contact_model(*, box_height=0.095, geom_margin=0.0, include_solreffriction=True):
+        solreffriction = ' solreffriction="0.02 3"' if include_solreffriction else ""
+        mjcf = f"""<mujoco model="explicit_pair_probe">
+            <option cone="elliptic"/>
+            <default>
+                <geom condim="1" friction="0.2 0.01 0.001"
+                      solref="0.04 1" solimp="0.8 0.9 0.001 0.5 2"
+                      margin="{geom_margin}"/>
+            </default>
+            <worldbody>
+                <geom name="floor" type="plane" size="1 1 0.1"/>
+                <body name="box" pos="0 0 {box_height}">
+                    <freejoint/>
+                    <geom name="box" type="box" size="0.1 0.1 0.1"/>
+                </body>
+            </worldbody>
+            <contact>
+                <pair geom1="floor" geom2="box" condim="3"
+                      friction="0.8 0.7 0.02 0.003 0.004"
+                      solref="0.01 2"{solreffriction}
+                      solimp="0.95 0.99 0.001 0.5 2"
+                      margin="0.003" gap="0.001"/>
+            </contact>
+        </mujoco>"""
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_mjcf(mjcf)
+        return builder.finalize()
+
+    @staticmethod
+    def _make_newton_contact_case(model, *, per_contact_properties=False):
+        state_in = model.state()
+        state_out = model.state()
+        control = model.control()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+        collision_pipeline = newton.CollisionPipeline(model)
+        if per_contact_properties:
+            contacts = newton.Contacts(
+                rigid_contact_max=collision_pipeline.rigid_contact_max,
+                soft_contact_max=collision_pipeline.soft_contact_max,
+                device=model.device,
+                per_contact_shape_properties=True,
+            )
+        else:
+            contacts = collision_pipeline.contacts()
+        collision_pipeline.collide(state_in, contacts)
+        solver = SolverMuJoCo(model, use_mujoco_contacts=False, nconmax=64, njmax=256, iterations=1)
+        solver.mjw_data.contact.type.zero_()
+        solver.mjw_data.contact.geomcollisionid.fill_(-1)
+        return solver, state_in, state_out, control, contacts
+
+    @classmethod
+    def _step_with_newton_contacts(cls, model):
+        solver, state_in, state_out, control, contacts = cls._make_newton_contact_case(model)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+        return solver
+
+    def test_explicit_pair_parameters_used_for_newton_contacts(self):
+        """Use the explicit pair instead of the shapes' contact material."""
+        model = self._make_explicit_pair_contact_model()
+        model.mujoco.solref_mode.fill_(SOLREF_MODE_FORCE_SPACE)
+        model.shape_material_ke.fill_(1.0e6)
+        model.shape_material_kd.fill_(1.0e4)
+        solver = self._step_with_newton_contacts(model)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+
+        np.testing.assert_array_equal(contact.type.numpy()[:contact_count], np.ones(contact_count, dtype=np.int32))
+        np.testing.assert_array_equal(contact.dim.numpy()[:contact_count], np.full(contact_count, 3, dtype=np.int32))
+        np.testing.assert_array_equal(
+            contact.geomcollisionid.numpy()[:contact_count],
+            np.zeros(contact_count, dtype=np.int32),
+        )
+        np.testing.assert_allclose(contact.dist.numpy()[:contact_count], -0.005, atol=1.0e-6)
+        np.testing.assert_allclose(contact.includemargin.numpy()[:contact_count], 0.003, atol=1.0e-7)
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.8, 0.7, 0.02, 0.003, 0.004], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.01, 2.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solreffriction.numpy()[:contact_count],
+            np.tile([0.02, 3.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.95, 0.99, 0.001, 0.5, 2.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+
+    def test_pair_margin_and_gap_filter_newton_contacts(self):
+        """Keep inactive pair contacts and drop contacts beyond the pair gap."""
+        inactive_model = self._make_explicit_pair_contact_model(box_height=0.1035, geom_margin=0.01)
+        inactive_solver = self._step_with_newton_contacts(inactive_model)
+        inactive_count = int(inactive_solver.mjw_data.nacon.numpy()[0])
+
+        self.assertGreater(inactive_count, 0)
+        np.testing.assert_allclose(
+            inactive_solver.mjw_data.contact.dist.numpy()[:inactive_count],
+            0.0035,
+            atol=1.0e-6,
+        )
+        np.testing.assert_array_equal(
+            inactive_solver.mjw_data.contact.efc_address.numpy()[:inactive_count, 0],
+            np.full(inactive_count, -1, dtype=np.int32),
+        )
+
+        absent_model = self._make_explicit_pair_contact_model(box_height=0.1045, geom_margin=0.01)
+        absent_solver = self._step_with_newton_contacts(absent_model)
+        self.assertEqual(int(absent_solver.mjw_data.nacon.numpy()[0]), 0)
+
+    def test_pairid_rejection_drops_newton_contact(self):
+        """Drop contacts rejected by MuJoCo's compiled pair table."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(model)
+        solver.mjw_model.nxn_pairid.fill_(wp.vec2i(-2, -1))
+
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        self.assertEqual(int(solver.mjw_data.nacon.numpy()[0]), 0)
+
+    def test_pair_update_refreshes_newton_contact(self):
+        """Refresh injected contacts after pair material updates."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(model)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        model.mujoco.pair_solref.assign(wp.array([[0.03, 4.0]], dtype=wp.vec2, device=model.device))
+        model.mujoco.pair_solreffriction.assign(wp.array([[0.04, 5.0]], dtype=wp.vec2, device=model.device))
+        model.mujoco.pair_solimp.assign(wp.array([[0.8, 0.9, 0.002, 0.6, 3.0]], dtype=vec5, device=model.device))
+        model.mujoco.pair_margin.assign(wp.array([0.006], dtype=wp.float32, device=model.device))
+        model.mujoco.pair_gap.assign(wp.array([0.002], dtype=wp.float32, device=model.device))
+        model.mujoco.pair_friction.assign(wp.array([[0.6, 0.5, 0.04, 0.005, 0.006]], dtype=vec5, device=model.device))
+        solver.notify_model_changed(ModelFlags.SHAPE_PROPERTIES)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.03, 4.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solreffriction.numpy()[:contact_count],
+            np.tile([0.04, 5.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.8, 0.9, 0.002, 0.6, 3.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.6, 0.5, 0.04, 0.005, 0.006], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(contact.includemargin.numpy()[:contact_count], 0.006, atol=1.0e-7)
+
+    def test_per_contact_properties_override_pair(self):
+        """Apply Newton per-contact overrides after the explicit pair."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(
+            model,
+            per_contact_properties=True,
+        )
+        contacts.rigid_contact_stiffness.fill_(100.0)
+        contacts.rigid_contact_damping.fill_(20.0)
+        contacts.rigid_contact_friction.fill_(0.5)
+
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.1, 10.0], (contact_count, 1)),
+            atol=5.0e-6,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.99, 0.99, 0.001, 1.0, 0.5], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.4, 0.35, 0.02, 0.003, 0.004], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+
+    def test_pair_solreffriction_default_matches_mujoco(self):
+        """Use MuJoCo's zero solreffriction default when a pair omits it."""
+        model = self._make_explicit_pair_contact_model(include_solreffriction=False)
+        np.testing.assert_array_equal(model.mujoco.pair_solreffriction.numpy(), [[0.0, 0.0]])
+
     def test_pair_properties_conversion_and_update(self):
         """
         Test validation of contact pair custom attributes:
@@ -8198,7 +8405,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         total_pairs = world_count * pairs_per_world
         shapes_per_world = template_builder.shape_count
 
-        for w in range(world_count):
+        world_order = (2, 0, 1)
+        for w in world_order:
             world_shape_offset = w * shapes_per_world + 1  # +1 for ground plane
 
             # Pair 1: shape1 <-> shape2
@@ -8245,6 +8453,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         # Verify MuJoCo has the pairs (only from template world, which is world 0)
         npair = solver.mj_model.npair
         self.assertEqual(npair, pairs_per_world)
+        expected_mapping = np.array([[2, 3], [4, 5], [0, 1]], dtype=np.int32)
+        np.testing.assert_array_equal(solver.mjc_pair_to_newton_pair.numpy(), expected_mapping)
 
         # --- Step 1: Verify initial conversion ---
         # Use .copy() to ensure we capture the values, not a view (important for CPU mode)
@@ -8265,9 +8475,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
 
         # Check values for each world and pair
         for w in range(world_count):
-            newton_pair_base = w * pairs_per_world
             for p in range(pairs_per_world):
-                newton_pair = newton_pair_base + p
+                newton_pair = expected_mapping[w, p]
 
                 np.testing.assert_allclose(
                     mjw_pair_solref[w, p],
@@ -8344,7 +8553,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
 
         for w in range(world_count):
             for p in range(pairs_per_world):
-                newton_pair = w * pairs_per_world + p
+                newton_pair = expected_mapping[w, p]
 
                 np.testing.assert_allclose(
                     mjw_pair_solref_updated[w, p],
@@ -8398,7 +8607,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             )
         np.testing.assert_allclose(
             mujoco_contacts_solver.mjw_model.pair_gap.numpy(),
-            new_gap.reshape(world_count, pairs_per_world),
+            new_gap[expected_mapping],
         )
         np.testing.assert_array_equal(
             mujoco_contacts_solver.mjw_model.pair_margin.numpy(),
@@ -8410,12 +8619,18 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         mujoco_contacts_solver.notify_model_changed(ModelFlags.SHAPE_PROPERTIES)
         np.testing.assert_allclose(
             mujoco_contacts_solver.mjw_model.pair_gap.numpy(),
-            final_gap.reshape(world_count, pairs_per_world),
+            final_gap[expected_mapping],
         )
         np.testing.assert_array_equal(
             mujoco_contacts_solver.mjw_model.pair_margin.numpy(),
             np.zeros_like(mujoco_contacts_solver.mjw_model.pair_margin.numpy()),
         )
+
+        bad_condim = model.mujoco.pair_condim.numpy()
+        bad_condim[0] = 4
+        model.mujoco.pair_condim.assign(wp.array(bad_condim, dtype=wp.int32, device=model.device))
+        with self.assertRaisesRegex(ValueError, "condim"):
+            SolverMuJoCo(model, separate_worlds=True, iterations=1, use_mujoco_contacts=False)
 
     def test_global_pair_exported_to_spec(self):
         """Pairs with pair_world=-1 (global) should be included in the MuJoCo spec.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8652,15 +8652,34 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         absent_solver = self._step_with_newton_contacts(absent_model)
         self.assertEqual(int(absent_solver.mjw_data.nacon.numpy()[0]), 0)
 
-    def test_pairid_rejection_drops_newton_contact(self):
-        """Drop contacts rejected by MuJoCo's compiled pair table."""
-        model = self._make_explicit_pair_contact_model()
+    def test_filtered_pairid_preserves_newton_contact(self):
+        """Preserve a Newton parent-child contact excluded by MuJoCo filtering."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        parent = builder.add_link(mass=1.0, com=wp.vec3(0.0), inertia=wp.mat33(np.eye(3)))
+        child = builder.add_link(mass=1.0, com=wp.vec3(0.0), inertia=wp.mat33(np.eye(3)))
+        builder.add_shape_sphere(parent, radius=0.1)
+        builder.add_shape_sphere(child, radius=0.1)
+        root_joint = builder.add_joint_free(parent)
+        child_joint = builder.add_joint_ball(
+            parent,
+            child,
+            parent_xform=wp.transform(wp.vec3(0.15, 0.0, 0.0), wp.quat_identity()),
+            collision_filter_parent=False,
+        )
+        builder.add_articulation([root_joint, child_joint])
+        model = builder.finalize()
         solver, state_in, state_out, control, contacts = self._make_newton_contact_case(model)
-        solver.mjw_model.nxn_pairid.fill_(wp.vec2i(-2, -1))
 
+        self.assertGreater(int(contacts.rigid_contact_count.numpy()[0]), 0)
+        self.assertEqual(int(solver.mjw_model.nxn_pairid.numpy()[0, 0]), -2)
         solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
 
-        self.assertEqual(int(solver.mjw_data.nacon.numpy()[0]), 0)
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        np.testing.assert_array_equal(
+            solver.mjw_data.contact.dim.numpy()[:contact_count],
+            np.full(contact_count, 3, dtype=np.int32),
+        )
 
     def test_pair_update_refreshes_newton_contact(self):
         """Refresh injected contacts after pair material updates."""

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8538,7 +8538,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             <option cone="elliptic"/>
             <default>
                 <geom condim="1" friction="0.2 0.01 0.001"
-                      solref="0.04 1" solimp="0.8 0.9 0.001 0.5 2"
+                      solref="0.04 1" solreffriction="0.04 1.5"
+                      solimp="0.8 0.9 0.001 0.5 2"
                       margin="{geom_margin}"/>
             </default>
             <worldbody>
@@ -8737,6 +8738,13 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         """Use MuJoCo's zero solreffriction default when a pair omits it."""
         model = self._make_explicit_pair_contact_model(include_solreffriction=False)
         np.testing.assert_array_equal(model.mujoco.pair_solreffriction.numpy(), [[0.0, 0.0]])
+        solver = self._step_with_newton_contacts(model)
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        np.testing.assert_allclose(
+            solver.mjw_data.contact.solreffriction.numpy()[:contact_count],
+            np.zeros((contact_count, 2)),
+        )
 
     def test_pair_properties_conversion_and_update(self):
         """

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8538,8 +8538,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             <option cone="elliptic"/>
             <default>
                 <geom condim="1" friction="0.2 0.01 0.001"
-                      solref="0.04 1" solreffriction="0.04 1.5"
-                      solimp="0.8 0.9 0.001 0.5 2"
+                      solref="0.04 1" solimp="0.8 0.9 0.001 0.5 2"
                       margin="{geom_margin}"/>
             </default>
             <worldbody>
@@ -8596,6 +8595,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         model.mujoco.solref_mode.fill_(SOLREF_MODE_FORCE_SPACE)
         model.shape_material_ke.fill_(1.0e6)
         model.shape_material_kd.fill_(1.0e4)
+        model.shape_material_kf.fill_(1000.0)
         solver = self._step_with_newton_contacts(model)
 
         contact_count = int(solver.mjw_data.nacon.numpy()[0])
@@ -8737,6 +8737,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
     def test_pair_solreffriction_default_matches_mujoco(self):
         """Use MuJoCo's zero solreffriction default when a pair omits it."""
         model = self._make_explicit_pair_contact_model(include_solreffriction=False)
+        model.shape_material_kf.fill_(1000.0)
         np.testing.assert_array_equal(model.mujoco.pair_solreffriction.numpy(), [[0.0, 0.0]])
         solver = self._step_with_newton_contacts(model)
         contact_count = int(solver.mjw_data.nacon.numpy()[0])

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8531,6 +8531,213 @@ class TestMuJoCoArticulationConversion(unittest.TestCase):
 class TestMuJoCoSolverPairProperties(unittest.TestCase):
     """Test contact pair property conversion and runtime updates across multiple worlds."""
 
+    @staticmethod
+    def _make_explicit_pair_contact_model(*, box_height=0.095, geom_margin=0.0, include_solreffriction=True):
+        solreffriction = ' solreffriction="0.02 3"' if include_solreffriction else ""
+        mjcf = f"""<mujoco model="explicit_pair_probe">
+            <option cone="elliptic"/>
+            <default>
+                <geom condim="1" friction="0.2 0.01 0.001"
+                      solref="0.04 1" solimp="0.8 0.9 0.001 0.5 2"
+                      margin="{geom_margin}"/>
+            </default>
+            <worldbody>
+                <geom name="floor" type="plane" size="1 1 0.1"/>
+                <body name="box" pos="0 0 {box_height}">
+                    <freejoint/>
+                    <geom name="box" type="box" size="0.1 0.1 0.1"/>
+                </body>
+            </worldbody>
+            <contact>
+                <pair geom1="floor" geom2="box" condim="3"
+                      friction="0.8 0.7 0.02 0.003 0.004"
+                      solref="0.01 2"{solreffriction}
+                      solimp="0.95 0.99 0.001 0.5 2"
+                      margin="0.003" gap="0.001"/>
+            </contact>
+        </mujoco>"""
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_mjcf(mjcf)
+        return builder.finalize()
+
+    @staticmethod
+    def _make_newton_contact_case(model, *, per_contact_properties=False):
+        state_in = model.state()
+        state_out = model.state()
+        control = model.control()
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)
+        collision_pipeline = newton.CollisionPipeline(model)
+        if per_contact_properties:
+            contacts = newton.Contacts(
+                rigid_contact_max=collision_pipeline.rigid_contact_max,
+                soft_contact_max=collision_pipeline.soft_contact_max,
+                device=model.device,
+                per_contact_shape_properties=True,
+            )
+        else:
+            contacts = collision_pipeline.contacts()
+        collision_pipeline.collide(state_in, contacts)
+        solver = SolverMuJoCo(model, use_mujoco_contacts=False, nconmax=64, njmax=256, iterations=1)
+        solver.mjw_data.contact.type.zero_()
+        solver.mjw_data.contact.geomcollisionid.fill_(-1)
+        return solver, state_in, state_out, control, contacts
+
+    @classmethod
+    def _step_with_newton_contacts(cls, model):
+        solver, state_in, state_out, control, contacts = cls._make_newton_contact_case(model)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+        return solver
+
+    def test_explicit_pair_parameters_used_for_newton_contacts(self):
+        """Use the explicit pair instead of the shapes' contact material."""
+        model = self._make_explicit_pair_contact_model()
+        model.mujoco.solref_mode.fill_(SOLREF_MODE_FORCE_SPACE)
+        model.shape_material_ke.fill_(1.0e6)
+        model.shape_material_kd.fill_(1.0e4)
+        solver = self._step_with_newton_contacts(model)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+
+        np.testing.assert_array_equal(contact.type.numpy()[:contact_count], np.ones(contact_count, dtype=np.int32))
+        np.testing.assert_array_equal(contact.dim.numpy()[:contact_count], np.full(contact_count, 3, dtype=np.int32))
+        np.testing.assert_array_equal(
+            contact.geomcollisionid.numpy()[:contact_count],
+            np.zeros(contact_count, dtype=np.int32),
+        )
+        np.testing.assert_allclose(contact.dist.numpy()[:contact_count], -0.005, atol=1.0e-6)
+        np.testing.assert_allclose(contact.includemargin.numpy()[:contact_count], 0.003, atol=1.0e-7)
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.8, 0.7, 0.02, 0.003, 0.004], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.01, 2.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solreffriction.numpy()[:contact_count],
+            np.tile([0.02, 3.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.95, 0.99, 0.001, 0.5, 2.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+
+    def test_pair_margin_and_gap_filter_newton_contacts(self):
+        """Keep inactive pair contacts and drop contacts beyond the pair gap."""
+        inactive_model = self._make_explicit_pair_contact_model(box_height=0.1035, geom_margin=0.01)
+        inactive_solver = self._step_with_newton_contacts(inactive_model)
+        inactive_count = int(inactive_solver.mjw_data.nacon.numpy()[0])
+
+        self.assertGreater(inactive_count, 0)
+        np.testing.assert_allclose(
+            inactive_solver.mjw_data.contact.dist.numpy()[:inactive_count],
+            0.0035,
+            atol=1.0e-6,
+        )
+        np.testing.assert_array_equal(
+            inactive_solver.mjw_data.contact.efc_address.numpy()[:inactive_count, 0],
+            np.full(inactive_count, -1, dtype=np.int32),
+        )
+
+        absent_model = self._make_explicit_pair_contact_model(box_height=0.1045, geom_margin=0.01)
+        absent_solver = self._step_with_newton_contacts(absent_model)
+        self.assertEqual(int(absent_solver.mjw_data.nacon.numpy()[0]), 0)
+
+    def test_pairid_rejection_drops_newton_contact(self):
+        """Drop contacts rejected by MuJoCo's compiled pair table."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(model)
+        solver.mjw_model.nxn_pairid.fill_(wp.vec2i(-2, -1))
+
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        self.assertEqual(int(solver.mjw_data.nacon.numpy()[0]), 0)
+
+    def test_pair_update_refreshes_newton_contact(self):
+        """Refresh injected contacts after pair material updates."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(model)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        model.mujoco.pair_solref.assign(wp.array([[0.03, 4.0]], dtype=wp.vec2, device=model.device))
+        model.mujoco.pair_solreffriction.assign(wp.array([[0.04, 5.0]], dtype=wp.vec2, device=model.device))
+        model.mujoco.pair_solimp.assign(wp.array([[0.8, 0.9, 0.002, 0.6, 3.0]], dtype=vec5, device=model.device))
+        model.mujoco.pair_margin.assign(wp.array([0.006], dtype=wp.float32, device=model.device))
+        model.mujoco.pair_gap.assign(wp.array([0.002], dtype=wp.float32, device=model.device))
+        model.mujoco.pair_friction.assign(wp.array([[0.6, 0.5, 0.04, 0.005, 0.006]], dtype=vec5, device=model.device))
+        solver.notify_model_changed(ModelFlags.SHAPE_PROPERTIES)
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.03, 4.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solreffriction.numpy()[:contact_count],
+            np.tile([0.04, 5.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.8, 0.9, 0.002, 0.6, 3.0], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.6, 0.5, 0.04, 0.005, 0.006], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(contact.includemargin.numpy()[:contact_count], 0.006, atol=1.0e-7)
+
+    def test_per_contact_properties_override_pair(self):
+        """Apply Newton per-contact overrides after the explicit pair."""
+        model = self._make_explicit_pair_contact_model()
+        solver, state_in, state_out, control, contacts = self._make_newton_contact_case(
+            model,
+            per_contact_properties=True,
+        )
+        contacts.rigid_contact_stiffness.fill_(100.0)
+        contacts.rigid_contact_damping.fill_(20.0)
+        contacts.rigid_contact_friction.fill_(0.5)
+
+        solver.step(state_in, state_out, control, contacts, 1.0 / 240.0)
+
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        contact = solver.mjw_data.contact
+        np.testing.assert_allclose(
+            contact.solref.numpy()[:contact_count],
+            np.tile([0.1, 10.0], (contact_count, 1)),
+            atol=5.0e-6,
+        )
+        np.testing.assert_allclose(
+            contact.solimp.numpy()[:contact_count],
+            np.tile([0.99, 0.99, 0.001, 1.0, 0.5], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+        np.testing.assert_allclose(
+            contact.friction.numpy()[:contact_count],
+            np.tile([0.4, 0.35, 0.02, 0.003, 0.004], (contact_count, 1)),
+            atol=1.0e-7,
+        )
+
+    def test_pair_solreffriction_default_matches_mujoco(self):
+        """Use MuJoCo's zero solreffriction default when a pair omits it."""
+        model = self._make_explicit_pair_contact_model(include_solreffriction=False)
+        np.testing.assert_array_equal(model.mujoco.pair_solreffriction.numpy(), [[0.0, 0.0]])
+
     def test_pair_properties_conversion_and_update(self):
         """
         Test validation of contact pair custom attributes:
@@ -8582,7 +8789,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         total_pairs = world_count * pairs_per_world
         shapes_per_world = template_builder.shape_count
 
-        for w in range(world_count):
+        world_order = (2, 0, 1)
+        for w in world_order:
             world_shape_offset = w * shapes_per_world + 1  # +1 for ground plane
 
             # Pair 1: shape1 <-> shape2
@@ -8629,6 +8837,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         # Verify MuJoCo has the pairs (only from template world, which is world 0)
         npair = solver.mj_model.npair
         self.assertEqual(npair, pairs_per_world)
+        expected_mapping = np.array([[2, 3], [4, 5], [0, 1]], dtype=np.int32)
+        np.testing.assert_array_equal(solver.mjc_pair_to_newton_pair.numpy(), expected_mapping)
 
         # --- Step 1: Verify initial conversion ---
         # Use .copy() to ensure we capture the values, not a view (important for CPU mode)
@@ -8649,9 +8859,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
 
         # Check values for each world and pair
         for w in range(world_count):
-            newton_pair_base = w * pairs_per_world
             for p in range(pairs_per_world):
-                newton_pair = newton_pair_base + p
+                newton_pair = expected_mapping[w, p]
 
                 np.testing.assert_allclose(
                     mjw_pair_solref[w, p],
@@ -8728,7 +8937,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
 
         for w in range(world_count):
             for p in range(pairs_per_world):
-                newton_pair = w * pairs_per_world + p
+                newton_pair = expected_mapping[w, p]
 
                 np.testing.assert_allclose(
                     mjw_pair_solref_updated[w, p],
@@ -8782,7 +8991,7 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             )
         np.testing.assert_allclose(
             mujoco_contacts_solver.mjw_model.pair_gap.numpy(),
-            new_gap.reshape(world_count, pairs_per_world),
+            new_gap[expected_mapping],
         )
         np.testing.assert_array_equal(
             mujoco_contacts_solver.mjw_model.pair_margin.numpy(),
@@ -8794,12 +9003,18 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         mujoco_contacts_solver.notify_model_changed(ModelFlags.SHAPE_PROPERTIES)
         np.testing.assert_allclose(
             mujoco_contacts_solver.mjw_model.pair_gap.numpy(),
-            final_gap.reshape(world_count, pairs_per_world),
+            final_gap[expected_mapping],
         )
         np.testing.assert_array_equal(
             mujoco_contacts_solver.mjw_model.pair_margin.numpy(),
             np.zeros_like(mujoco_contacts_solver.mjw_model.pair_margin.numpy()),
         )
+
+        bad_condim = model.mujoco.pair_condim.numpy()
+        bad_condim[0] = 4
+        model.mujoco.pair_condim.assign(wp.array(bad_condim, dtype=wp.int32, device=model.device))
+        with self.assertRaisesRegex(ValueError, "condim"):
+            SolverMuJoCo(model, separate_worlds=True, iterations=1, use_mujoco_contacts=False)
 
     def test_global_pair_exported_to_spec(self):
         """Pairs with pair_world=-1 (global) should be included in the MuJoCo spec.

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -8154,7 +8154,8 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
             <option cone="elliptic"/>
             <default>
                 <geom condim="1" friction="0.2 0.01 0.001"
-                      solref="0.04 1" solimp="0.8 0.9 0.001 0.5 2"
+                      solref="0.04 1" solreffriction="0.04 1.5"
+                      solimp="0.8 0.9 0.001 0.5 2"
                       margin="{geom_margin}"/>
             </default>
             <worldbody>
@@ -8353,6 +8354,13 @@ class TestMuJoCoSolverPairProperties(unittest.TestCase):
         """Use MuJoCo's zero solreffriction default when a pair omits it."""
         model = self._make_explicit_pair_contact_model(include_solreffriction=False)
         np.testing.assert_array_equal(model.mujoco.pair_solreffriction.numpy(), [[0.0, 0.0]])
+        solver = self._step_with_newton_contacts(model)
+        contact_count = int(solver.mjw_data.nacon.numpy()[0])
+        self.assertGreater(contact_count, 0)
+        np.testing.assert_allclose(
+            solver.mjw_data.contact.solreffriction.numpy()[:contact_count],
+            np.zeros((contact_count, 2)),
+        )
 
     def test_pair_properties_conversion_and_update(self):
         """


### PR DESCRIPTION
## Description

I make explicit MuJoCo `<pair>` parameters apply when `SolverMuJoCo` consumes contacts generated by Newton. This covers the parameter-propagation part of #3644.

I keep collision selection out of scope. Newton must already emit the contact; an explicit MuJoCo pair does not create a Newton collision candidate. MuJoCo-filtered lookup entries now fall back to geom parameters instead of deleting a contact that Newton emitted. #3662 adds the explicit-pair selection step.

After rebasing onto current `main`, I keep #3580's `kf` mapping behind `pairid < 0`, so an explicit `pair_solreffriction` still wins.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] Changelog fragments cover the user-facing changes

## Test plan

- `uv run --extra dev -m newton.tests -p test_mujoco_solver.py -k 'test_mujoco_solver.TestMuJoCoSolverPairProperties' --no-cache-clear`: 9 passed
- `uv run --extra dev -m newton.tests -p test_mujoco_solver.py -k 'test_mujoco_solver.TestMuJoCoSolverContactKf' --no-cache-clear`: 10 passed
- `uv run --extra dev -m newton.tests -p test_mujoco_solver.py --no-cache-clear`: 279 run, 7 skipped
- `uvx --from towncrier==25.8.0 towncrier build --draft --version 1.6.0 --date 2026-08-26`: passed
- `uvx pre-commit run -a`: passed

## Bug fix

Before this change, Newton-generated contacts always used geom-level parameters. Explicit pair `condim`, friction, `solref`, `solreffriction`, `solimp`, margin, and gap were ignored.

MuJoCo's compiled filter table no longer removes contacts that Newton's collision pipeline already emitted when `use_mujoco_contacts=False`; negative pair IDs use the geom-parameter path.