### PR TITLE
Restrict release build permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594  # v2.16.0


### PR DESCRIPTION
## Description

Removes `actions: write` from the release workflow's build job. The job checks out source, installs uv, builds the distribution, and uploads the result; none of those steps uses the Actions API through `GITHUB_TOKEN`. The job retains `contents: read`.

The permission was added while addressing CodeQL's missing-workflow-permissions warning, even though CodeQL's minimal recommendation was only `contents: read`. Removing it reduces the token's capabilities without changing release behavior.

## Checklist

- [x] New or existing tests cover these changes (not applicable; workflow permission only)
- [x] The documentation is up to date with these changes (not applicable)
- [x] `CHANGELOG.md` has been updated (not applicable; no user-facing change)

## Test plan

- `uvx pre-commit run -a`
- No unit tests were run because this change only restricts a workflow token permission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened release workflow security by limiting its permissions to read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->