### PR TITLE
Keep guide-purpose colliders off the visual toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 ### Fixed
 
+- Fix `ModelBuilder.add_usd()` marking a `guide`-purpose collider visible when it has a bound render material. Such a collider is not viewport geometry, and the extra `VISIBLE` flag left it drawn by the viewer's visual toggle instead of its collision toggle. `force_show_colliders` still reveals it.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
 - Fix USD plane visual width and length to scale along the axes defined by the `UsdGeomPlane` schema, and orient X- and Y-axis plane visuals along the authored axis.
 - Validate `ArticulationView` mask shapes and devices before launching selection kernels. (#3448)

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1200,11 +1200,11 @@ def parse_usd(
 
         USD viewports draw the ``default`` and ``proxy`` purposes and hide ``guide`` and
         ``render``; the allowlist also keeps any future purpose hidden until explicitly
-        handled. Colliders deliberately do not use this check: ``guide`` is the conventional
-        purpose for authored collision geometry (e.g. the MuJoCo USD exporter), and the
-        collider display policy (``force_show_colliders`` / ``hide_collision_shapes``) is the
-        explicit mechanism for revealing colliders — gating them on purpose would make
-        ``force_show_colliders`` a no-op on such assets.
+        handled. ``guide`` is the conventional purpose for authored collision geometry
+        (e.g. the MuJoCo USD exporter), so it gates only whether a collider inherits
+        visibility from a bound render material. The collider display policy
+        (``force_show_colliders`` / ``hide_collision_shapes``) is checked independently and
+        still reveals ``guide`` colliders.
         """
         if not _is_effectively_visible(prim):
             return False
@@ -3359,7 +3359,15 @@ def parse_usd(
                 model_has_visual_shapes = load_visual_shapes and bool(bodies_with_visual_shapes)
                 material_props = _get_material_props_cached(prim)
                 collider_has_visual_material = (
-                    key == UsdPhysics.ObjectType.MeshShape and _has_visual_material_properties(material_props)
+                    key == UsdPhysics.ObjectType.MeshShape
+                    and _has_visual_material_properties(material_props)
+                    # A ``guide``/``render`` purpose collider is not viewport geometry, so it
+                    # must not inherit visibility from a bound render material: that would
+                    # give it the VISIBLE flag, and the viewer draws on ``(COLLIDE and
+                    # show_collision) or (VISIBLE and show_visual)``, leaving the collision
+                    # toggle unable to hide it. ``force_show_colliders`` is deliberately
+                    # checked separately below and still reveals such colliders.
+                    and _is_viewport_drawn(prim)
                 )
 
                 # Explicit hide_collision_shapes overrides material-based visibility:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -11350,6 +11350,33 @@ def Xform "Body" (
         self.assertTrue(flags & ShapeFlags.VISIBLE)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_guide_purpose_collider_with_material_is_not_visible(self):
+        """A guide-purpose collider does not inherit VISIBLE from its render material.
+
+        ``guide`` is the conventional purpose for authored collision geometry. Such a
+        collider is not viewport geometry, so binding a render material to it must not
+        set VISIBLE: viewers draw on ``(COLLIDE and show_collision) or (VISIBLE and
+        show_visual)``, and a VISIBLE collider cannot be hidden by the collision toggle.
+        """
+        from pxr import UsdGeom
+
+        stage = self._create_stage_with_pbr_collision_mesh(
+            color=(0.9, 0.1, 0.2), roughness=0.55, metallic=0.25, add_visual_sphere=True
+        )
+        UsdGeom.Imageable(stage.GetPrimAtPath("/Body/CollisionMesh")).CreatePurposeAttr(UsdGeom.Tokens.guide)
+
+        builder = newton.ModelBuilder()
+        collision_shape = builder.add_usd(stage)["path_shape_map"]["/Body/CollisionMesh"]
+        flags = builder.shape_flags[collision_shape]
+        self.assertTrue(flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags & ShapeFlags.VISIBLE)
+
+        # force_show_colliders is an explicit display policy and still reveals it.
+        forced = newton.ModelBuilder()
+        forced_shape = forced.add_usd(stage, force_show_colliders=True)["path_shape_map"]["/Body/CollisionMesh"]
+        self.assertTrue(forced.shape_flags[forced_shape] & ShapeFlags.VISIBLE)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_invisible_collision_shape_is_hidden(self):
         """Effective USD invisibility clears VISIBLE on colliders while preserving collision."""
         from pxr import Usd


### PR DESCRIPTION
## Description

A collider with a bound render material was given the `VISIBLE` flag regardless of its
purpose. Viewers draw a shape when `(COLLIDE and show_collision) or (VISIBLE and
show_visual)`, so such a collider was drawn by the *visual* toggle and could not be
hidden by the *collision* toggle — it occluded the very visual shapes it sat beside.

`guide` is the conventional purpose for authored collision geometry (the MuJoCo USD
exporter emits it), so honour it: purpose now gates only whether a collider inherits
visibility from its bound render material. `force_show_colliders` is checked
independently and still reveals `guide` colliders, which is what the previous
behaviour was protecting — that concern is preserved, it was just conflated with
material-inherited visibility.

Note for reviewers: this changes behaviour for existing assets. A `guide`-purpose
collider with a render material used to render and now does not, unless
`force_show_colliders=True`. Filed under `Fixed` since the old behaviour made the
viewer's collision toggle inoperative on such assets, but it is worth a second
opinion if anyone is relying on it.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m unittest newton.tests.test_import_usd -k guide_purpose_collider_with_material
uv run --extra dev -m unittest newton.tests.test_import_usd   # 282 tests
uv run --extra dev -m newton.tests -k viewer                  # 221 tests
uvx pre-commit run -a
```

Verified the new test fails without the fix (`AssertionError: 1 is not false`) and
passes with it.

## Bug fix

**Steps to reproduce:**

1. Author a rigid body with a visual mesh and a separate collision mesh.
2. Give the collision mesh `uniform token purpose = "guide"` and bind a render
   material to it.
3. Import with `ModelBuilder.add_usd()` and inspect the collider's shape flags, or
   view it with `show_visual=True, show_collision=False`.
4. The collider carries `VISIBLE`, so it is drawn by the visual toggle and the
   collision toggle cannot hide it.

**Minimal reproduction:**

```python
import newton
from newton import ShapeFlags

builder = newton.ModelBuilder()
shape = builder.add_usd(stage)["path_shape_map"]["/Body/CollisionMesh"]

# Before: True  (guide-purpose collider drawn by the visual toggle)
# After:  False (collision toggle owns it; force_show_colliders still reveals it)
print(bool(builder.shape_flags[shape] & ShapeFlags.VISIBLE))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visibility handling for guide-purpose colliders with bound render materials.
  * These colliders now follow collision display settings instead of being shown automatically.
  * The force-show-colliders option continues to display them when enabled.

* **Tests**
  * Added regression coverage for collider visibility and force-show behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->