### PR TITLE
Remove redundant wp.static wrappers and fix a uint32 overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix Style3D solver divergence caused by isolated vertices.
-- Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` render kernels.
+- Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.

--- a/newton/_src/geometry/sdf_hydroelastic.py
+++ b/newton/_src/geometry/sdf_hydroelastic.py
@@ -171,7 +171,7 @@ def mc_calc_face_texture(
         p_0 = wp.vec3f(corner_offsets_table[v_idx_from])
         p_1 = wp.vec3f(corner_offsets_table[v_idx_to])
         val_diff = wp.float32(val_1 - val_0)
-        if wp.abs(val_diff) < wp.static(MC_EDGE_VAL_DIFF_EPS):
+        if wp.abs(val_diff) < MC_EDGE_VAL_DIFF_EPS:
             t = float(0.5)
         else:
             # Clamp t away from cube corners to prevent vertex collapse when
@@ -194,7 +194,7 @@ def mc_calc_face_texture(
 
     n = wp.cross(face_verts[1] - face_verts[0], face_verts[2] - face_verts[0])
     n_sq = wp.dot(n, n)
-    if n_sq < wp.static(MC_DEGENERATE_N_SQ_EPS):
+    if n_sq < MC_DEGENERATE_N_SQ_EPS:
         # Degenerate triangle — return zero area with a valid (non-NaN) normal.
         area = 0.0
         normal = wp.vec3(0.0, 0.0, 1.0)

--- a/newton/_src/geometry/sdf_mc.py
+++ b/newton/_src/geometry/sdf_mc.py
@@ -195,14 +195,14 @@ def mc_calc_face(
         p_0 = wp.vec3f(corner_offsets_table[v_idx_from])
         p_1 = wp.vec3f(corner_offsets_table[v_idx_to])
         val_diff = wp.float32(val_1 - val_0)
-        if wp.abs(val_diff) < wp.static(MC_EDGE_VAL_DIFF_EPS):
+        if wp.abs(val_diff) < MC_EDGE_VAL_DIFF_EPS:
             p = 0.5 * (p_0 + p_1)
         else:
             # Clamp t away from cube corners to prevent vertex collapse when
             # corner values are near zero (e.g. at SDF ridge boundaries).
             # Without the clamp, t close to 0 or 1 places multiple vertices
             # at the same corner, producing degenerate (zero-area) triangles.
-            t = wp.clamp((isovalue - val_0) / val_diff, wp.static(MC_EDGE_CLAMP_MIN), wp.static(MC_EDGE_CLAMP_MAX))
+            t = wp.clamp((isovalue - val_0) / val_diff, MC_EDGE_CLAMP_MIN, MC_EDGE_CLAMP_MAX)
             p = p_0 + t * (p_1 - p_0)
         vol_idx = p + int_to_vec3f(x_id, y_id, z_id)
         p_scaled = wp.volume_index_to_world(sdf_a, vol_idx)
@@ -216,7 +216,7 @@ def mc_calc_face(
 
     n = wp.cross(face_verts[1] - face_verts[0], face_verts[2] - face_verts[0])
     n_sq = wp.dot(n, n)
-    if n_sq < wp.static(MC_DEGENERATE_N_SQ_EPS):
+    if n_sq < MC_DEGENERATE_N_SQ_EPS:
         # Degenerate triangle — return zero area with a valid (non-NaN) normal.
         area = 0.0
         normal = wp.vec3(0.0, 0.0, 1.0)

--- a/newton/_src/geometry/sdf_texture.py
+++ b/newton/_src/geometry/sdf_texture.py
@@ -856,7 +856,7 @@ def _read_cell_corners(
     ty = loc.ty
     tz = loc.tz
 
-    if loc.start_slot >= wp.static(SLOT_LINEAR):
+    if loc.start_slot >= SLOT_LINEAR:
         cx = float(loc.x_base)
         cy = float(loc.y_base)
         cz = float(loc.z_base)
@@ -951,7 +951,7 @@ def texture_sample_sdf_at_voxel(
 
     start_slot = sdf.subgrid_start_slots[x_base, y_base, z_base]
 
-    if start_slot < wp.static(SLOT_LINEAR):
+    if start_slot < SLOT_LINEAR:
         block_x = float(start_slot & wp.uint32(0x3FF))
         block_y = float((start_slot >> wp.uint32(10)) & wp.uint32(0x3FF))
         block_z = float((start_slot >> wp.uint32(20)) & wp.uint32(0x3FF))
@@ -1023,7 +1023,7 @@ def texture_sample_sdf(
     ty = loc.ty
     tz = loc.tz
 
-    if loc.start_slot >= wp.static(SLOT_LINEAR):
+    if loc.start_slot >= SLOT_LINEAR:
         cx = float(loc.x_base)
         cy = float(loc.y_base)
         cz = float(loc.z_base)
@@ -1107,7 +1107,7 @@ def texture_sample_sdf_hw(
 
     sdf_val = float(0.0)
 
-    if loc.start_slot >= wp.static(SLOT_LINEAR):
+    if loc.start_slot >= SLOT_LINEAR:
         # ``cx + tx + 0.5`` lands at the centre of voxel (cx, cy, cz) and
         # ``+tx`` walks toward (cx+1, ...). The HW filter returns the
         # interpolated value in one fetch.
@@ -2526,10 +2526,10 @@ def _generate_isomesh_texture_kernel(
             p_0 = wp.vec3f(corner_offsets_table[v_from])
             p_1 = wp.vec3f(corner_offsets_table[v_to])
             val_diff = val_1 - val_0
-            if wp.abs(val_diff) < wp.static(MC_EDGE_VAL_DIFF_EPS):
+            if wp.abs(val_diff) < MC_EDGE_VAL_DIFF_EPS:
                 p = 0.5 * (p_0 + p_1)
             else:
-                t = wp.clamp((isovalue - val_0) / val_diff, wp.static(MC_EDGE_CLAMP_MIN), wp.static(MC_EDGE_CLAMP_MAX))
+                t = wp.clamp((isovalue - val_0) / val_diff, MC_EDGE_CLAMP_MIN, MC_EDGE_CLAMP_MAX)
                 p = p_0 + t * (p_1 - p_0)
             vol_idx = p + wp.vec3(float(x_id), float(y_id), float(z_id))
             local_pos = sdf.sdf_box_lower + wp.cw_mul(vol_idx, sdf.voxel_size)

--- a/newton/_src/geometry/sdf_utils.py
+++ b/newton/_src/geometry/sdf_utils.py
@@ -1521,10 +1521,10 @@ def _generate_dense_mc_kernel(
             p_0 = wp.vec3f(corner_offsets_table[ev[0]])
             p_1 = wp.vec3f(corner_offsets_table[ev[1]])
             val_diff = val_1 - val_0
-            if wp.abs(val_diff) < wp.static(MC_EDGE_VAL_DIFF_EPS):
+            if wp.abs(val_diff) < MC_EDGE_VAL_DIFF_EPS:
                 p = 0.5 * (p_0 + p_1)
             else:
-                t = wp.clamp((0.0 - val_0) / val_diff, wp.static(MC_EDGE_CLAMP_MIN), wp.static(MC_EDGE_CLAMP_MAX))
+                t = wp.clamp((0.0 - val_0) / val_diff, MC_EDGE_CLAMP_MIN, MC_EDGE_CLAMP_MAX)
                 p = p_0 + t * (p_1 - p_0)
             local = base + p
             face_verts[vi] = wp.vec3(
@@ -1534,7 +1534,7 @@ def _generate_dense_mc_kernel(
             )
         n = wp.cross(face_verts[1] - face_verts[0], face_verts[2] - face_verts[0])
         n_sq = wp.dot(n, n)
-        if n_sq < wp.static(MC_DEGENERATE_N_SQ_EPS):
+        if n_sq < MC_DEGENERATE_N_SQ_EPS:
             normal = wp.vec3(0.0, 0.0, 1.0)
         else:
             normal = n / wp.sqrt(n_sq)

--- a/newton/_src/sensors/warp_raytrace/utils.py
+++ b/newton/_src/sensors/warp_raytrace/utils.py
@@ -18,6 +18,10 @@ from .types import RenderConfig, RenderLightType, TextureData
 if TYPE_CHECKING:
     from .render_context import RenderContext
 
+# Knuth multiplicative hash constant (2^32 / golden ratio).
+# Typed uint32 so kernel codegen doesn't overflow an int32 constant.
+HASH_MULTIPLIER = wp.uint32(2654435761)
+
 
 def _resolve_fisheye_image_size(
     axis: str,
@@ -225,7 +229,7 @@ def unpack_shape_index_hash_to_rgba_kernel(
     # Knuth multiplicative hash, masked to 24 bits. ``idx + 1`` keeps shape 0
     # away from the all-zero hash that collides with the miss color; the
     # miss sentinel ``0xFFFFFFFF`` wraps back to 0 and intentionally renders black.
-    h = ((idx + wp.uint32(1)) * wp.uint32(2654435761)) & wp.uint32(0xFFFFFF)
+    h = ((idx + wp.uint32(1)) * HASH_MULTIPLIER) & wp.uint32(0xFFFFFF)
     out[n, y, x, 0] = wp.uint8((h >> wp.uint32(16)) & wp.uint32(0xFF))
     out[n, y, x, 1] = wp.uint8((h >> wp.uint32(8)) & wp.uint32(0xFF))
     out[n, y, x, 2] = wp.uint8(h & wp.uint32(0xFF))


### PR DESCRIPTION
## Description

Newton's SDF kernels wrapped module-level constants in `wp.static()`: the subgrid slot sentinel `SLOT_LINEAR` in `sdf_texture.py`, and the marching-cubes thresholds `MC_EDGE_VAL_DIFF_EPS`, `MC_EDGE_CLAMP_MIN`, `MC_EDGE_CLAMP_MAX` and `MC_DEGENERATE_N_SQ_EPS` across `sdf_mc.py`, `sdf_utils.py`, `sdf_hydroelastic.py` and `sdf_texture.py`. 17 wrappers in total.

None of them need static evaluation. `SLOT_LINEAR` became a typed `wp.uint32` in #3638, so Warp lowers the external constant directly, and Warp already lowers untyped Python floats to `float32`.

They are also not free. Each `wp.static()` call site materializes its own constant object, so Warp cannot share one declaration between two sites even when the wrapped value is identical. Inside an unrolled loop the same constant is re-emitted once per site:

| Kernel / func | `1e-10` | `0.02` | `0.98` | `1e-20` | Generated lines |
|---|---|---|---|---|---|
| `_generate_dense_mc_kernel` | 15 -> 1 | 15 -> 1 | 15 -> 1 | 5 -> 1 | 2850 -> 2804 |
| `_generate_isomesh_texture_kernel` | 15 -> 1 | 15 -> 1 | 15 -> 1 | n/a | 2055 -> 2013 |
| `mc_calc_face` | 3 -> 1 | 3 -> 1 | 3 -> 1 | 1 -> 1 | 431 -> 425 |
| `mc_calc_face_texture` | 3 -> 1 | n/a | n/a | 1 -> 1 | 448 -> 446 |

Referencing the constants directly emits one declaration reused at every site.

The following `wp.static()` uses are deliberately left in place, since they genuinely require static evaluation:

- `wp.static(MAXVAL * 0.99)` in `sdf_mc.py` and `sdf_utils.py`: a compile-time expression, so the wrapper folds a multiply out of the kernel.
- `wp.static(edge_clamp_min)` / `wp.static(edge_clamp_max)` and the `wp.static(pressure_func)` / `wp.static(output_vertices)` family in `sdf_hydroelastic.py`: closure-captured configuration values and flags driving dead-branch elimination.

The rule separating the two groups: only a module-level constant can be referenced directly. Anything bound per specialization still needs `wp.static()`.

Follow-up to #3638. No behavior change.

### Also: one remaining `-Wconstant-conversion` site

Verifying the above surfaced a live instance of the exact bug class #3638 fixed, in a file that PR's audit missed. `newton/_src/sensors/warp_raytrace/utils.py` multiplied by a bare `2654435761` inside `unpack_shape_index_hash_to_rgba_kernel()`:

```
wp_newton._src.sensors.warp_raytrace.utils_836bed3.cpp:595:30: warning: implicit conversion
from 'long' to 'const wp::int32' changes value from 2654435761 to -1640531535
[-Wconstant-conversion]
  595 |     const wp::int32 var_16 = 2654435761;
```

Same latent CI risk as before: the warning reaches stderr during cold-cache compilation, so it fails an example test's strict stderr capture whenever that module happens to compile inside one.

Fixed the same way, by hoisting to a typed module-level `wp.uint32`. Results were never wrong, because the wrapped value converted back through the `uint32` cast that followed it; the fix also drops that now-redundant conversion instruction.

I re-ran the audit across `newton/_src` for integer literals above `int32` max and found no other affected site. Casts to 64-bit types such as `wp.int64(0xFFFFFFFF)` are safe: the literal is materialized as `int64`, which holds the value. Only a 32-bit target overflows, which is the distinction the original audit missed.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

The `wp.static` removals get no changelog entry: generated code is equivalent and simulation results are unchanged, so there is nothing for a user to act on.

For the `-Wconstant-conversion` fix, rather than adding a second entry I widened the one #3638 already added under `Fixed`, dropping the word "render" so it covers this kernel too. Neither entry has shipped and they describe the same fix, so a reader is better served by one line:

```
- Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
```

## Test plan

All runs from a fresh `WARP_CACHE_PATH`, on CUDA and CPU.

```
uv run --extra dev -m newton.tests -k test_sdf                                  # 236 tests, OK (14 skipped)
uv run --extra dev -m newton.tests -k test_hydroelastic                         #  80 tests, OK (2 skipped)
uv run --extra dev --extra examples -m newton.tests -k example_basic_conveyor   #  26 tests, OK
uv run --extra dev -m newton.tests -k test_sensor                               # 152 tests, OK
uv run --extra dev -m newton.tests                                              # 5938 tests, OK (157 skipped)
```

The conveyor run reproduces the cold-cache CPU scenario from #3638, whose strict stderr capture is what surfaced the original `-Wconstant-conversion` warning. No compiler warnings appeared on stderr in any run.

Equivalence was also checked directly against the generated source:

- Generated C++ for the four `SLOT_LINEAR` sites is byte-identical before and after, on both the CPU (clang) and CUDA (nvrtc) paths, forward and backward. The sentinel still emits as `const wp::uint32 var_N = 4294967294u;`, with no overflowing `int32` literal anywhere in the cache.
- For the marching-cubes constants, the single surviving declaration was confirmed referenced at all 15 comparison sites and all 15 `wp::clamp` sites, so the constant is shared rather than dropped.
- Numerical A/B over the dense marching-cubes path: isosurface output for 5 primitives at 2 offsets each, plus the volume path through `mc_calc_face`. All 22 arrays identical. Comparison is order-independent because `wp.atomic_add(face_count, 0, num_faces)` permutes vertex order between runs; a control run of unmodified code twice reproduced exactly the same permutation differences, which validates the comparison.

For the hash multiplier, forcing a CPU build of every module carrying an out-of-`int32`-range literal showed exactly one `-Wconstant-conversion` warning before the change and zero after, with the constant now emitted as `const wp::uint32 var_16 = 2654435761u;`. The palette output was checked against a NumPy reference across shape indices `0, 1, 2, 3, 7, 255, 4096, 0xFFFFFFFE, 0xFFFFFFFF` and matches exactly, including the `0xFFFFFFFF` miss sentinel rendering black.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compiler warnings caused by overflowing integer constants in SDF texture and tiled-camera kernel compilation.
  * Improved reliability of SDF sampling and marching-cubes processing across supported texture and geometry paths.
  * Preserved existing interpolation, clamping, degeneracy handling, and shape-index hashing behavior while improving kernel constant handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->