### PR TITLE
Fix USD cable contact materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix Style3D solver divergence caused by isolated vertices.
+- Fix USD cable capsules ignoring authored contact friction and restitution.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` render kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.

--- a/newton/_src/usd/utils.py
+++ b/newton/_src/usd/utils.py
@@ -2123,6 +2123,41 @@ def _get_physics_material_density(material_prim) -> float | None:
     return None
 
 
+def _get_physics_material_contact_properties(prim: Usd.Prim) -> dict[str, float]:
+    """Read authored contact properties from a prim's bound physics material.
+
+    Newton exposes one sliding-friction coefficient per shape, so the authored
+    dynamic friction is used. Unauthored attributes preserve the builder's shape
+    defaults instead of applying USD schema fallback values.
+    """
+    from pxr import UsdPhysics
+
+    material_prim = _find_physics_material_prim(prim)
+    if material_prim is None or not (
+        material_prim.HasAPI(UsdPhysics.MaterialAPI) or has_applied_api_schema(material_prim, "PhysicsMaterialAPI")
+    ):
+        return {}
+
+    material_api = UsdPhysics.MaterialAPI(material_prim)
+    properties: dict[str, float] = {}
+    for attribute, key, upper_bound in (
+        (material_api.GetDynamicFrictionAttr(), "mu", None),
+        (material_api.GetRestitutionAttr(), "restitution", 1.0),
+    ):
+        if not attribute or not attribute.HasAuthoredValue():
+            continue
+        value = float(attribute.Get())
+        if math.isfinite(value) and value >= 0.0 and (upper_bound is None or value <= upper_bound):
+            properties[key] = value
+            continue
+        expected = ">= 0" if upper_bound is None else f"within [0, {upper_bound:g}]"
+        warnings.warn(
+            f"{material_prim.GetPath()}: invalid {attribute.GetName()} {value}; expected {expected}, ignoring it.",
+            stacklevel=2,
+        )
+    return properties
+
+
 def _deformable_body_ancestor(prim: Usd.Prim) -> Usd.Prim | None:
     """Find the deformable body whose subtree contains ``prim`` (ownership, not governance).
 

--- a/newton/_src/utils/import_usd_deformable_cable.py
+++ b/newton/_src/utils/import_usd_deformable_cable.py
@@ -399,6 +399,7 @@ def _deformable_import_cable_graphs(ctx: _DeformableImportContext) -> tuple[set[
             density=graph_weight_density,
             has_shape_collision=collision_enabled,
             has_particle_collision=collision_enabled,
+            **usd._get_physics_material_contact_properties(rep.prim),
         )
         # Unlike single cables, the graph junction spanning tree is intrinsic topology, not a
         # caller choice, and only a tree (not the all-incident-edges joint set produced when
@@ -626,6 +627,7 @@ def _deformable_import_cable(ctx: _DeformableImportContext, consumed_cable_curve
             density=_mass_weight_density(prim, resolved_cable_density, deformable_read),
             has_shape_collision=collision_enabled,
             has_particle_collision=collision_enabled,
+            **usd._get_physics_material_contact_properties(prim),
         )
 
         cable_bodies: list[int] = []

--- a/newton/tests/test_import_usd_deformable_cable.py
+++ b/newton/tests/test_import_usd_deformable_cable.py
@@ -311,6 +311,53 @@ class TestUSDDeformableCable(unittest.TestCase):
             self.assertEqual(builder.joint_target_ke[dof0], 0.0)
             self.assertEqual(result["path_cable_attrs"]["/World/Cable"]["material"]["stretchStiffness"], 0.0)
 
+    def test_cable_contact_material_maps_to_capsules(self):
+        """Apply authored contact friction and restitution to generated cable capsules."""
+        stage = _deformable_stage()
+        points = [(0.0, 0.0, 1.0), (0.1, 0.0, 1.0), (0.2, 0.0, 1.0), (0.3, 0.0, 1.0)]
+        curves = _add_cable_curve(stage, "/World/Cable", points, thickness=None)
+        _bind_deformable_material(
+            stage,
+            curves.GetPrim(),
+            "/World/CableMat",
+            thickness=0.02,
+            staticFriction=0.6,
+            dynamicFriction=0.35,
+            restitution=0.2,
+        )
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        body_start, body_end = group_range(builder, "cable", "/World/Cable", "body")
+        cable_shapes = [shape for shape, body in enumerate(builder.shape_body) if body_start <= body < body_end]
+        self.assertEqual(len(cable_shapes), 3)
+        for shape in cable_shapes:
+            self.assertAlmostEqual(builder.shape_material_mu[shape], 0.35)
+            self.assertAlmostEqual(builder.shape_material_restitution[shape], 0.2)
+
+    def test_welded_cable_contact_material_maps_to_capsules(self):
+        """Apply representative contact properties to welded cable graph capsules."""
+        stage = self._author_attached_cable_pair(gap=0.0)
+        for suffix in ("A", "B"):
+            _bind_deformable_material(
+                stage,
+                stage.GetPrimAtPath(f"/World/Cable{suffix}"),
+                f"/World/Cable{suffix}Mat",
+                thickness=0.02,
+                staticFriction=0.6,
+                dynamicFriction=0.35,
+                restitution=0.2,
+            )
+
+        builder = newton.ModelBuilder()
+        builder.add_usd(stage)
+
+        self.assertEqual(builder.shape_count, 6)
+        for shape in range(builder.shape_count):
+            self.assertAlmostEqual(builder.shape_material_mu[shape], 0.35)
+            self.assertAlmostEqual(builder.shape_material_restitution[shape], 0.2)
+
     def test_cable_rest_length_from_rest_shape_points(self):
         """Per-joint stiffness uses the rest centerline (restShapePoints), not the possibly-deformed
         points, so an authored rest shape sets the rest length L in E*A/L (proposal: rest segment


### PR DESCRIPTION
## Description

Propagate authored `physics:dynamicFriction` and `physics:restitution` from a cable's bound physics material to the capsule shapes generated by `ModelBuilder.add_usd()`. Unauthored contact properties continue to use the builder defaults. The same behavior applies to single cables and welded cable graphs.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uvx pre-commit run -a
uv run --extra dev python -m unittest newton.tests.test_import_usd_deformable_cable -v
```

All 43 cable importer tests pass.

## Bug fix

**Steps to reproduce:**

1. Bind a material with `PhysicsMaterialAPI` and `PhysicsCurvesDeformableMaterialAPI` to a colliding `BasisCurves` cable.
2. Author `physics:dynamicFriction` or `physics:restitution` on that material.
3. Import the stage with `ModelBuilder.add_usd()`.
4. Observe that generated cable capsules retain `builder.default_shape_cfg` values.

**Minimal reproduction:**

```python
builder = newton.ModelBuilder()
builder.add_usd(stage)
print(builder.shape_material_mu)
```

The cable importer previously replaced only density and collision flags on `default_shape_cfg`; it never transferred authored base physics-material contact properties to the generated rod shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - USD-imported deformable cable capsules now correctly apply authored contact friction and restitution settings.
  - Contact properties are preserved for both individual cables and welded cable assemblies.
  - Invalid or unsupported material values are safely ignored.

- **Tests**
  - Added coverage verifying contact material settings are propagated to generated cable capsule shapes in standard and welded configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->