### PR TITLE
Fix contact residual metric

### DIFF
--- a/newton/_src/solvers/kamino/_src/geometry/contacts.py
+++ b/newton/_src/solvers/kamino/_src/geometry/contacts.py
@@ -623,7 +623,7 @@ class ContactsKamino:
 
         The ``w`` component stores the signed ``distance`` between margin-shifted surfaces:
         - ``w < 0`` means penetration past the resting separation defined by the margin
-        - ``w > 0`` means separation within the detection ``distance = gap + margin``
+        - ``w > 0`` means margin-shifted separation within the detection gap
         """
         self._assert_has_data()
         return self._data.gapfunc

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -240,10 +240,9 @@ class SolutionMetricsData:
     """
     The largest constraint violation residual across all contact constraints.
 
-    Computed as the maximum absolute value (i.e. infinity-norm) over contact constraint residuals.
-
-    Equivalent to `r_cts_contacts := || d_k ||_inf`, where `d_k` would be an array of
-    contact penetrations extracted from the `gapfunc` elements of :class:`ContactsKaminoData`.
+    Equivalent to `r_cts_contacts := max_k max(0, -d_k)`, where `d_k` is the
+    margin-shifted signed distance stored in the ``w`` component of the contact
+    `gapfunc`. Negative `d_k` denotes penetration.
 
     Shape of ``(num_worlds,)``.
     """
@@ -871,12 +870,12 @@ def _compute_cts_contacts_residual(
     wcid = contact_cid[cid]
     gapfunc = contact_gapfunc[cid]
 
-    # Compute the per-contact constraint residual (infinity-norm)
-    r_cts_contacts_k = wp.abs(gapfunc[3])
+    # Compute unilateral penetration depth from the margin-shifted signed distance.
+    r_cts_contacts_k = wp.max(0.0, -gapfunc[3])
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_cts_contacts, wid, r_cts_contacts_k)
-    if r_cts_contacts_k >= previous_max:
+    if r_cts_contacts_k > 0.0 and r_cts_contacts_k >= previous_max:
         wp.atomic_exch(metric_r_cts_contacts_argmax, wid, wcid)
 
 

--- a/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
@@ -229,6 +229,47 @@ class TestSolverMetrics(unittest.TestCase):
         if self.verbose:
             msg.reset_log_level()
 
+    def _evaluate_contact_residuals(self, contacts: list[tuple[int, int, float]]) -> tuple[np.ndarray, np.ndarray]:
+        """Evaluate contact residuals from explicitly supplied signed distances."""
+
+        def build_two_boxes_on_planes():
+            builder = build_box_on_plane()
+            return build_box_on_plane(builder=builder)
+
+        test = TestSetup(
+            builder_fn=build_two_boxes_on_planes,
+            max_world_contacts=4,
+            gravity=False,
+            perturb=False,
+            device=self.default_device,
+        )
+
+        num_contacts = len(contacts)
+        wid = test.contacts.wid.numpy()
+        cid = test.contacts.cid.numpy()
+        gapfunc = test.contacts.gapfunc.numpy()
+        wid[:num_contacts] = [contact[0] for contact in contacts]
+        cid[:num_contacts] = [contact[1] for contact in contacts]
+        gapfunc[:num_contacts] = [(0.0, 0.0, 1.0, contact[2]) for contact in contacts]
+
+        test.contacts.model_active_contacts.assign(np.array([num_contacts], dtype=np.int32))
+        test.contacts.world_active_contacts.assign(
+            np.bincount([contact[0] for contact in contacts], minlength=2).astype(np.int32)
+        )
+        test.contacts.wid.assign(wid)
+        test.contacts.cid.assign(cid)
+        test.contacts.gapfunc.assign(gapfunc)
+
+        metrics = SolutionMetrics(model=test.model)
+        metrics.reset()
+        metrics._evaluate_constraint_violations_perf(
+            model=test.model,
+            data=test.data,
+            contacts=test.contacts,
+        )
+        wp.synchronize()
+        return metrics.data.r_cts_contacts.numpy(), metrics.data.r_cts_contacts_argmax.numpy()
+
     def test_00_make_default(self):
         """
         Test creating a SolutionMetrics instance with default initialization.
@@ -355,12 +396,15 @@ class TestSolverMetrics(unittest.TestCase):
         msg.info("metrics.r_ncp_compl: %s", metrics.data.r_ncp_compl)
         msg.info("metrics.r_vi_natmap: %s\n", metrics.data.r_vi_natmap)
 
-        # Extract the maximum contact penetration to use for validation
+        # Extract the maximum unilateral penetration depth, max(0, -d).
         nc = test.contacts.model_active_contacts.numpy()[0]
-        max_contact_penetration = 0.0
-        for cid in range(nc):
-            pen = test.contacts.gapfunc.numpy()[cid][3]
-            max_contact_penetration = max(max_contact_penetration, pen)
+        signed_distances = test.contacts.gapfunc.numpy()[:nc, 3]
+        contact_residuals = np.maximum(0.0, -signed_distances)
+        max_contact_penetration = np.max(contact_residuals, initial=0.0)
+        max_contact_argmax = -1
+        for cid, residual in enumerate(contact_residuals):
+            if residual > 0.0 and residual >= max_contact_penetration:
+                max_contact_argmax = cid
 
         # Check that all metrics are zero
         np.testing.assert_allclose(metrics.data.r_eom.numpy()[0], 0.0)
@@ -393,9 +437,7 @@ class TestSolverMetrics(unittest.TestCase):
         # NOTE: all contacts will have the same residual,
         # so the argmax will evaluate to the last constraint
         np.testing.assert_allclose(metrics.data.r_v_plus_argmax.numpy()[0], 11)
-        # NOTE: all contacts will have the same penetration,
-        # so the argmax will evaluate to the last contact
-        np.testing.assert_allclose(metrics.data.r_cts_contacts_argmax.numpy()[0], 3)
+        np.testing.assert_allclose(metrics.data.r_cts_contacts_argmax.numpy()[0], max_contact_argmax)
         np.testing.assert_allclose(metrics.data.r_ncp_primal_argmax.numpy()[0], 3)
         np.testing.assert_allclose(metrics.data.r_ncp_dual_argmax.numpy()[0], 3)
         np.testing.assert_allclose(metrics.data.r_ncp_compl_argmax.numpy()[0], 3)
@@ -459,12 +501,10 @@ class TestSolverMetrics(unittest.TestCase):
         msg.info("metrics.r_ncp_compl: %s", metrics.data.r_ncp_compl)
         msg.info("metrics.r_vi_natmap: %s\n", metrics.data.r_vi_natmap)
 
-        # Extract the maximum contact penetration to use for validation
+        # Extract the maximum unilateral penetration depth, max(0, -d).
         nc = test.contacts.model_active_contacts.numpy()[0]
-        max_contact_penetration = 0.0
-        for cid in range(nc):
-            pen = test.contacts.gapfunc.numpy()[cid][3]
-            max_contact_penetration = max(max_contact_penetration, pen)
+        signed_distances = test.contacts.gapfunc.numpy()[:nc, 3]
+        max_contact_penetration = np.max(np.maximum(0.0, -signed_distances), initial=0.0)
 
         # Check that all metrics are zero
         accuracy = 5  # number of decimal places for accuracy
@@ -547,11 +587,9 @@ class TestSolverMetrics(unittest.TestCase):
         msg.info("metrics.r_ncp_compl: %s", metrics.data.r_ncp_compl)
         msg.info("metrics.r_vi_natmap: %s\n", metrics.data.r_vi_natmap)
 
-        # Extract the maximum contact penetration to use for validation
-        max_contact_penetration = 0.0
-        for cid in range(nc):
-            pen = test.contacts.gapfunc.numpy()[cid][3]
-            max_contact_penetration = max(max_contact_penetration, pen)
+        # Extract the maximum unilateral penetration depth, max(0, -d).
+        signed_distances = test.contacts.gapfunc.numpy()[:nc, 3]
+        max_contact_penetration = np.max(np.maximum(0.0, -signed_distances), initial=0.0)
 
         # Check that all metrics are zero
         accuracy = 5  # number of decimal places for accuracy
@@ -822,6 +860,32 @@ class TestSolverMetrics(unittest.TestCase):
         np.testing.assert_allclose(
             metrics_dense.data.r_vi_natmap.numpy(), metrics_sparse.data.r_vi_natmap.numpy(), rtol=rtol, atol=atol
         )
+
+    def test_07_contact_residual_positive_gaps(self):
+        residual, argmax = self._evaluate_contact_residuals(
+            [
+                (0, 0, 0.0),
+                (0, 1, 0.1),
+                (1, 0, 0.2),
+            ]
+        )
+
+        np.testing.assert_allclose(residual, [0.0, 0.0])
+        np.testing.assert_array_equal(argmax, [-1, -1])
+
+    def test_08_contact_residual_mixed_signed_distances(self):
+        residual, argmax = self._evaluate_contact_residuals(
+            [
+                (0, 0, 0.5),
+                (0, 1, -0.1),
+                (1, 0, -0.2),
+                (1, 1, 0.3),
+                (1, 2, -0.4),
+            ]
+        )
+
+        np.testing.assert_allclose(residual, [0.1, 0.4])
+        np.testing.assert_array_equal(argmax, [1, 2])
 
 
 ###


### PR DESCRIPTION
## Description

Compute the Kamino contact-constraint residual as unilateral penetration depth from the margin-shifted signed distance, rather than its absolute value. Positive gaps now produce zero residual and leave the contact argmax unset; mixed distances report the deepest penetration.

These are evaluation metrics only and do not affect the solver.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (not user-facing)

## Test plan

- Added coverage for positive gaps and mixed signed contact distances in `test_solvers_metrics.py`.
- Not run locally (request was to create the PR from the current committed branch).

## Bug fix

**Steps to reproduce:**

1. Evaluate solution metrics for a contact whose margin-shifted signed distance is positive.
2. Observe the contact residual reported as the positive gap, rather than zero.

**Minimal reproduction:**

```python
# A positive `gapfunc.w` represents separation, so its contact residual is 0.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contact violation metrics now report only unilateral penetration, ignoring non-penetrating gaps.
  * Maximum penetration tracking and contact index reporting are now more accurate.

* **Documentation**
  * Clarified the meaning of positive gap-function values in contact detection.

* **Tests**
  * Added coverage for positive gaps and mixed contact distances.
  * Improved validation of penetration values and maximum-contact identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->