### PR TITLE
[Kamino] Skip unused material updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Fix `SolverKamino` CG/CR solves silently under-iterating on CPU graph capture; the capture-safe loop path now runs on any capturing device, not only CUDA, so CPU captures no longer record a stale host-readback convergence decision at record time.
+- Fix `SolverKamino.notify_model_changed()` rejecting per-shape material changes when the solver uses externally supplied Newton collision contacts.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.
 - Fix `cloth_franka` example rendering particles at simulation scale (cm) instead of viewer scale (m)
 - Fix `ModelBuilder` merges to accept array-valued transform fields and plain-list particle color groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,6 @@
 - Fix `ModelBuilder.add_usd()` to honor `PhysicsScene.gravityDirection`, including stage-to-builder rotation and per-world imports.
 - Fix stale overlay layers remaining visible after switching examples in the OpenGL viewer.
 - Fix `SolverKamino` CG/CR solves silently under-iterating on CPU graph capture; the capture-safe loop path now runs on any capturing device, not only CUDA, so CPU captures no longer record a stale host-readback convergence decision at record time.
-- Fix `SolverKamino.notify_model_changed()` rejecting per-shape material changes when the solver uses externally supplied Newton collision contacts.
 - Reject incompatible custom attribute and frequency definitions before composing `ModelBuilder` instances.
 - Fix `cloth_franka` example rendering particles at simulation scale (cm) instead of viewer scale (m)
 - Fix `ModelBuilder` merges to accept array-valued transform fields and plain-list particle color groups.

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -981,7 +981,9 @@ class SolverKamino(SolverBase, CouplingInterface):
             # Geom offsets are derived from body_com and shape_transform.
             self._update_geom_offsets()
 
-        if flags & ModelFlags.SHAPE_PROPERTIES:
+        if flags & ModelFlags.SHAPE_PROPERTIES and self._collision_detector_kamino is not None:
+            # Kamino materials only need to be updated when using the Kamino collision detector.
+            # External Newton contacts read per-shape material values directly and don't use Kamino materials.
             self._update_materials()
 
         if flags & (ModelFlags.CONSTRAINT_PROPERTIES | ModelFlags.TENDON_PROPERTIES):

--- a/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
+++ b/newton/_src/solvers/kamino/tests/test_solver_kamino_notify.py
@@ -353,7 +353,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
     def test_material_value_update_propagates(self):
         """Two shapes sharing one material can update it together and keep sharing it."""
         model = _build_revolute(shape_materials=((0.2, 0.1), (0.2, 0.1)))
-        solver = SolverKamino(model)
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=True))
         materials = solver._model_kamino.materials
         material_pairs = solver._model_kamino.material_pairs
         arrays = (
@@ -381,7 +381,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
     def test_default_material_update_propagates_to_default_pair(self):
         """Updating material zero keeps its explicit self-pair synchronized."""
         model = _build_revolute(shape_materials=((DEFAULT_FRICTION, DEFAULT_RESTITUTION),))
-        solver = SolverKamino(model)
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=True))
         materials = solver._model_kamino.materials
         material_pairs = solver._model_kamino.material_pairs
         np.testing.assert_array_equal(solver._model_kamino.geoms.material.numpy(), [0])
@@ -400,7 +400,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
     def test_material_ids_can_converge_to_same_values(self):
         """Distinct material IDs remain valid when their coefficients become equal."""
         model = _build_revolute(shape_materials=((0.2, 0.1), (0.6, 0.5)))
-        solver = SolverKamino(model)
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=True))
         materials = solver._model_kamino.materials
         geoms = solver._model_kamino.geoms
         material_mapping = geoms.material.numpy().copy()
@@ -441,7 +441,7 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
     def test_material_structural_change_raises(self):
         """Two shapes sharing one material cannot update it to different values."""
         model = _build_revolute(shape_materials=((0.2, 0.1), (0.2, 0.1)))
-        solver = SolverKamino(model)
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=True))
         materials = solver._model_kamino.materials
         before = (
             materials.restitution.numpy().copy(),
@@ -453,6 +453,32 @@ class TestKaminoNotifyModelChanged(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "recreate"):
             solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
 
+        for actual, expected in zip(
+            (materials.restitution, materials.static_friction, materials.dynamic_friction),
+            before,
+            strict=True,
+        ):
+            np.testing.assert_array_equal(actual.numpy(), expected)
+
+    def test_external_collisions_allow_material_structural_change(self):
+        """Allow per-shape material changes when using external Newton collisions."""
+        model = _build_revolute(shape_materials=((0.2, 0.1), (0.2, 0.1)))
+        solver = SolverKamino(model, SolverKamino.Config(use_collision_detector=False))
+        materials = solver._model_kamino.materials
+        before = (
+            materials.restitution.numpy().copy(),
+            materials.static_friction.numpy().copy(),
+            materials.dynamic_friction.numpy().copy(),
+        )
+        updated_friction = np.array([0.2, 0.4], dtype=np.float32)
+        updated_restitution = np.array([0.1, 0.3], dtype=np.float32)
+        model.shape_material_mu.assign(updated_friction)
+        model.shape_material_restitution.assign(updated_restitution)
+
+        solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
+
+        np.testing.assert_array_equal(model.shape_material_mu.numpy(), updated_friction)
+        np.testing.assert_array_equal(model.shape_material_restitution.numpy(), updated_restitution)
         for actual, expected in zip(
             (materials.restitution, materials.static_friction, materials.dynamic_friction),
             before,


### PR DESCRIPTION
## Description

- Skip Kamino material-table updates when its internal collision detector is disabled.
- Allow external Newton collision contacts to use independently updated per-shape material values.
- Keep material-table update coverage explicitly scoped to the internal collision detector.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (not applicable: no user-facing API change)

## Test plan

```
uv run --extra dev -m unittest newton._src.solvers.kamino.tests.test_solver_kamino_notify
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create a `SolverKamino` with `use_collision_detector=False`.
2. Assign different material values to shapes that initially share a Kamino material.
3. Call `notify_model_changed(ModelFlags.SHAPE_PROPERTIES)`.
4. Observe a material-table conflict requiring solver recreation, despite external contacts reading the per-shape Newton values directly.

**Minimal reproduction:**

```python
solver = newton.solvers.SolverKamino(
    model, newton.solvers.SolverKamino.Config(use_collision_detector=False)
)
model.shape_material_mu.assign([0.2, 0.4])
solver.notify_model_changed(newton.ModelFlags.SHAPE_PROPERTIES)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved material handling when using external collision detection.
  - Per-shape material updates now apply correctly without unnecessarily refreshing internal collision material tables.
  - Preserved shared material associations while allowing structural material changes.

- **Tests**
  - Added coverage for external collision material updates.
  - Updated material synchronization tests for internal collision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->