### PR TITLE
[Kamino] feature gimbal joint

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -352,7 +352,10 @@ def joint_conversion_kernel(
         limit_upper_j[i] = joint_limit_upper[dofs_start_j + i]
         limit_lower_j[i] = joint_limit_lower[dofs_start_j + i]
     dof_type_j = JointDoFType.from_newton_wp(type_j, q_count_j, qd_count_j, dof_dim_j, limit_lower_j, limit_upper_j)
-    assert dof_type_j >= 0, "Joint DoF type must be valid"
+    joint_dof_type[joint_id] = dof_type_j
+    if dof_type_j < 0:
+        # Host-side conversion reports unsupported configurations with joint context.
+        return
 
     # Get joint type properties
     ncoords_j = JointDoFType.num_coords_wp(dof_type_j)
@@ -361,7 +364,6 @@ def joint_conversion_kernel(
     assert ncoords_j >= 0, "Number of joint coordinates must be valid"
     assert ndofs_j >= 0, "Number of joint DoFs must be valid"
     assert ncts_j >= 0, "Number of joint constraints must be valid"
-    joint_dof_type[joint_id] = dof_type_j
     joint_num_coords[joint_id] = ncoords_j
     joint_num_dofs[joint_id] = ndofs_j
 
@@ -889,6 +891,27 @@ def convert_model_joint_actuation(model: Model, joints: JointsModel) -> None:
     )
 
 
+def _validate_joint_axes(model: Model, joint_dof_type: np.ndarray) -> None:
+    """Raise if Newton joint axes violate Kamino's joint-frame assumptions."""
+    joint_qd_start = model.joint_qd_start.numpy()
+    joint_axis = model.joint_axis.numpy()
+    validation_errors = []
+    for joint_id, dof_type_value in enumerate(joint_dof_type):
+        label = model.joint_label[joint_id]
+        if dof_type_value < 0:
+            validation_errors.append(f"joint {joint_id} ('{label}'): unsupported Newton joint configuration")
+            continue
+        dof_type = JointDoFType(int(dof_type_value))
+        dofs_start = joint_qd_start[joint_id]
+        dofs_end = joint_qd_start[joint_id + 1]
+        error = JointDoFType.validate_axes(dof_type, joint_axis[dofs_start:dofs_end])
+        if error is not None:
+            validation_errors.append(f"joint {joint_id} ('{label}', {dof_type.name}): {error}")
+    if validation_errors:
+        details = "\n".join(f"  - {error}" for error in validation_errors)
+        raise ValueError(f"Invalid joint configuration for SolverKamino:\n{details}")
+
+
 def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
     """
     Converts the joint model parameterization of Newton's to Kamino's format.
@@ -904,6 +927,7 @@ def convert_model_joint_transforms(model: Model, joints: JointsModel) -> None:
         The output JointsModel instance where the converted joint data will be stored.
         This function modifies the `joints` object in-place.
     """
+    _validate_joint_axes(model, joints.dof_type.numpy())
     wp.launch(
         kernel=joint_frame_conversion_kernel,
         dim=model.joint_count,
@@ -1191,6 +1215,11 @@ def convert_joints(
         device=model.device,
     )
 
+    # Validate on the host before frame conversion. Warp assertions are disabled
+    # in release mode and therefore cannot enforce these structural assumptions.
+    joint_dof_type_np = joint_dof_type.numpy()
+    _validate_joint_axes(model, joint_dof_type_np)
+
     wp.launch(
         kernel=joint_frame_conversion_kernel,
         dim=model.joint_count,
@@ -1335,10 +1364,8 @@ def convert_joints(
     base_body_idx_np = np.full((model.world_count,), -1, dtype=int)
     base_joint_idx_np = np.full((model.world_count,), -1, dtype=int)
     body_world_start_np = model.body_world_start.numpy()
-    joint_world_start_np = model.joint_world_start.numpy()
     joint_child_np = model.joint_child.numpy()
     joint_parent_np = model.joint_parent.numpy()
-    joint_dof_type_np = joint_dof_type.numpy()
 
     # Assign base bodies based on articulation roots (if articulations are present)
     world_has_non_floating_root = np.zeros((model.world_count,), dtype=bool)

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -265,6 +265,8 @@ class JointCorrectionMode(IntEnum):
 @wp.func
 def _axis_rotmatn_from_vec3f(vec: wp.vec3f) -> wp.mat33f:
     n = wp.norm_l2(vec)
+    # Host-side conversion validates this in `JointDoFType.validate_axes`;
+    # retain the assertion as debug-mode redundancy.
     assert n >= 1e-12, "Joint axis cannot have near-zero length"
     ax = vec / n
     dominant = wp.int32(wp.argmax(wp.abs(ax)))
@@ -423,11 +425,16 @@ class JointDoFType(IntEnum):
     A 3-DoF D6 joint using canonical exponential-map coordinates.
 
     Coordinates:
-        3D rotation vector about the local x, y, and z axes
+        Principal rotation vector ``log(q_rel)`` about the local x, y, and z axes,
+        with norm in ``[0, pi]``. This differs from Newton's intrinsic-XYZ D6
+        coordinates and is discontinuous at rotations of ``pi`` radians.
     DoFs:
         3D relative angular velocity about the local x, y, and z axes
     Constraints:
         3D vector: {`T_x`, `T_y`, `T_z`}
+
+    Do not estimate angular velocity by differencing these coordinates across
+    the principal-logarithm discontinuity.
     """
 
     ###
@@ -448,6 +455,67 @@ class JointDoFType(IntEnum):
     def is_pure_three_dof_rotation(self) -> bool:
         """Whether the joint has exactly three rotational DoFs and no translational DoFs."""
         return self.num_dofs == 3 and self.dofs_axes == (3, 4, 5)
+
+    @staticmethod
+    def validate_axes(dof_type: JointDoFType, axes: np.ndarray, tolerance: float = 1e-6) -> str | None:
+        """Return an error message if joint axes violate Kamino's frame assumptions.
+
+        Args:
+            dof_type: Kamino joint DoF type.
+            axes: Joint DoF axes in Newton storage order, shape ``(num_dofs, 3)``.
+            tolerance: Absolute tolerance for axis comparisons.
+
+        Returns:
+            An error message for invalid axes, otherwise ``None``.
+        """
+        axes = np.asarray(axes, dtype=np.float64)
+        expected_shape = (dof_type.num_dofs, 3)
+        if axes.shape != expected_shape:
+            return f"expected axes with shape {expected_shape}, got {axes.shape}"
+        if not np.all(np.isfinite(axes)):
+            return "joint axes must contain only finite values"
+
+        if dof_type == JointDoFType.FIXED:
+            return None
+
+        if dof_type in (JointDoFType.REVOLUTE, JointDoFType.PRISMATIC):
+            if np.linalg.norm(axes[0]) < 1e-12:
+                return "primary joint axis must have nonzero length"
+            return None
+
+        if dof_type == JointDoFType.CYLINDRICAL:
+            if np.linalg.norm(axes[0]) < 1e-12:
+                return "primary joint axis must have nonzero length"
+            if not np.allclose(axes[0], axes[1], atol=tolerance, rtol=0.0):
+                return "cylindrical joint linear and angular axes must match"
+            return None
+
+        if dof_type == JointDoFType.UNIVERSAL:
+            gram = axes @ axes.T
+            if not np.allclose(gram, np.eye(2), atol=tolerance, rtol=0.0):
+                return "universal joint axes must be unit length and mutually orthogonal"
+            return None
+
+        if dof_type == JointDoFType.FREE:
+            linear_axes = axes[:3]
+            angular_axes = axes[3:]
+            if not np.allclose(linear_axes, angular_axes, atol=tolerance, rtol=0.0):
+                return "free joint linear and angular axes must match"
+            basis = linear_axes
+        elif dof_type in (JointDoFType.SPHERICAL, JointDoFType.CARTESIAN):
+            basis = axes
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
+            if not np.allclose(axes, np.eye(3), atol=tolerance, rtol=0.0):
+                return "rotation-vector joint axes must be canonical +X/+Y/+Z"
+            return None
+        else:
+            return f"unsupported joint DoF type {dof_type}"
+
+        if not np.allclose(basis @ basis.T, np.eye(3), atol=tolerance, rtol=0.0):
+            return "joint axes must form an orthonormal basis"
+        if not np.isclose(np.linalg.det(basis), 1.0, atol=tolerance, rtol=0.0):
+            return "joint axes must form a right-handed basis"
+        return None
 
     @property
     def num_coords(self) -> int:
@@ -677,6 +745,7 @@ class JointDoFType(IntEnum):
         elif self.value == self.SPHERICAL:
             return [JOINT_QMAX] * 4
         elif self.value == self.ROTATION_VECTOR:
+            # The principal logarithm is bounded by norm, not independently per component.
             return [wp.pi] * 3
         elif self.value == self.CARTESIAN:
             return [JOINT_QMAX] * 3
@@ -1039,6 +1108,8 @@ class JointDoFType(IntEnum):
         elif dof_type == JointDoFType.SPHERICAL:
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
         elif dof_type == JointDoFType.ROTATION_VECTOR:
+            # Host-side conversion validates this in `JointDoFType.validate_axes`;
+            # retain the assertion as debug-mode redundancy.
             axis_x_is_canonical = (
                 wp.abs(dof_axes[0][0] - 1.0) < 1e-6 and wp.abs(dof_axes[0][1]) < 1e-6 and wp.abs(dof_axes[0][2]) < 1e-6
             )
@@ -1053,6 +1124,8 @@ class JointDoFType(IntEnum):
         elif dof_type == JointDoFType.CARTESIAN:
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
         elif dof_type == JointDoFType.FREE:
+            # Host-side conversion validates this in `JointDoFType.validate_axes`;
+            # retain the assertions as debug-mode redundancy.
             assert wp.norm_l2(dof_axes[0] - dof_axes[3]) < 1e-6, "Linear and rotational axes for free joint must match"
             assert wp.norm_l2(dof_axes[1] - dof_axes[4]) < 1e-6, "Linear and rotational axes for free joint must match"
             assert wp.norm_l2(dof_axes[2] - dof_axes[5]) < 1e-6, "Linear and rotational axes for free joint must match"

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -418,6 +418,18 @@ class JointDoFType(IntEnum):
         6D vector: {`T_x`, `T_y`, `T_z`, `R_x`, `R_y`, `R_z`}
     """
 
+    ROTATION_VECTOR = 8
+    """
+    A 3-DoF D6 joint using canonical exponential-map coordinates.
+
+    Coordinates:
+        3D rotation vector about the local x, y, and z axes
+    DoFs:
+        3D relative angular velocity about the local x, y, and z axes
+    Constraints:
+        3D vector: {`T_x`, `T_y`, `T_z`}
+    """
+
     ###
     # Operations
     ###
@@ -431,6 +443,11 @@ class JointDoFType(IntEnum):
     def __repr__(self):
         """Returns a string representation of the joint DoF type."""
         return self.__str__()
+
+    @property
+    def is_pure_three_dof_rotation(self) -> bool:
+        """Whether the joint has exactly three rotational DoFs and no translational DoFs."""
+        return self.num_dofs == 3 and self.dofs_axes == (3, 4, 5)
 
     @property
     def num_coords(self) -> int:
@@ -449,6 +466,8 @@ class JointDoFType(IntEnum):
             return 2  # 2D angles
         elif self.value == self.SPHERICAL:
             return 4  # 4D unit-quaternion
+        elif self.value == self.ROTATION_VECTOR:
+            return 3  # 3D rotation vector
         elif self.value == self.CARTESIAN:
             return 3  # 3D distances
         elif self.value == self.FIXED:
@@ -472,6 +491,8 @@ class JointDoFType(IntEnum):
         elif self.value == self.UNIVERSAL:
             return 2  # 2D angular velocities
         elif self.value == self.SPHERICAL:
+            return 3  # 3D angular velocities
+        elif self.value == self.ROTATION_VECTOR:
             return 3  # 3D angular velocities
         elif self.value == self.CARTESIAN:
             return 3  # 3D linear velocities
@@ -497,6 +518,8 @@ class JointDoFType(IntEnum):
             return 4  # 4D vector for `{R_x, R_y, R_z, R_w}`
         elif self.value == self.SPHERICAL:
             return 3  # 3D vector for `{R_x, R_y, R_z}`
+        elif self.value == self.ROTATION_VECTOR:
+            return 3  # 3D vector for `{T_x, T_y, T_z}`
         elif self.value == self.CARTESIAN:
             return 3  # 3D vector for `{T_x, T_y, T_z}`
         elif self.value == self.FIXED:
@@ -520,6 +543,8 @@ class JointDoFType(IntEnum):
         elif self.value == self.UNIVERSAL:
             return wp.constant(wp.vec4i(0, 1, 2, 5))
         elif self.value == self.SPHERICAL:
+            return wp.constant(wp.vec3i(0, 1, 2))
+        elif self.value == self.ROTATION_VECTOR:
             return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.CARTESIAN:
             return wp.constant(wp.vec3i(3, 4, 5))
@@ -545,6 +570,8 @@ class JointDoFType(IntEnum):
             return wp.constant(wp.vec2i(3, 4))
         elif self.value == self.SPHERICAL:
             return wp.constant(wp.vec3i(3, 4, 5))
+        elif self.value == self.ROTATION_VECTOR:
+            return wp.constant(wp.vec3i(3, 4, 5))
         elif self.value == self.CARTESIAN:
             return wp.constant(wp.vec3i(0, 1, 2))
         elif self.value == self.FIXED:
@@ -569,6 +596,8 @@ class JointDoFType(IntEnum):
             return wp.vec2f
         elif self.value == self.SPHERICAL:
             return wp.vec4f
+        elif self.value == self.ROTATION_VECTOR:
+            return wp.vec3f
         elif self.value == self.CARTESIAN:
             return wp.vec3f
         elif self.value == self.FIXED:
@@ -593,6 +622,8 @@ class JointDoFType(IntEnum):
             return wp.vec2f
         elif self.value == self.SPHERICAL:
             return wp.quatf
+        elif self.value == self.ROTATION_VECTOR:
+            return wp.vec3f
         elif self.value == self.CARTESIAN:
             return wp.vec3f
         elif self.value == self.FIXED:
@@ -617,6 +648,8 @@ class JointDoFType(IntEnum):
             return [0.0, 0.0]
         elif self.value == self.SPHERICAL:
             return [0.0, 0.0, 0.0, 1.0]
+        elif self.value == self.ROTATION_VECTOR:
+            return [0.0, 0.0, 0.0]
         elif self.value == self.CARTESIAN:
             return [0.0, 0.0, 0.0]
         elif self.value == self.FIXED:
@@ -643,6 +676,8 @@ class JointDoFType(IntEnum):
             return [rotation_bound, rotation_bound]
         elif self.value == self.SPHERICAL:
             return [JOINT_QMAX] * 4
+        elif self.value == self.ROTATION_VECTOR:
+            return [wp.pi] * 3
         elif self.value == self.CARTESIAN:
             return [JOINT_QMAX] * 3
         elif self.value == self.FIXED:
@@ -676,6 +711,7 @@ class JointDoFType(IntEnum):
             JointDoFType.CARTESIAN: JointType.D6,
             JointDoFType.CYLINDRICAL: JointType.D6,
             JointDoFType.UNIVERSAL: JointType.D6,
+            JointDoFType.ROTATION_VECTOR: JointType.D6,
         }
         joint_type = _MAP_TO_NEWTON.get(dof_type, None)
         if joint_type is None:
@@ -770,7 +806,7 @@ class JointDoFType(IntEnum):
             elif q_count == 3 and qd_count == 3 and dof_dim == (3, 0):
                 dof_type = JointDoFType.CARTESIAN
             elif q_count == 3 and qd_count == 3 and dof_dim == (0, 3):
-                raise ValueError("Unsupported joint type: GIMBAL joints are not currently supported.")
+                dof_type = JointDoFType.ROTATION_VECTOR
             elif q_count == 4 and qd_count == 3 and dof_dim == (0, 3):
                 dof_type = JointDoFType.SPHERICAL
             elif q_count == 7 and qd_count == 6:
@@ -851,7 +887,7 @@ class JointDoFType(IntEnum):
         elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(3, 0):
             return JointDoFType.CARTESIAN
         elif q_count == 3 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
-            return -1
+            return JointDoFType.ROTATION_VECTOR
         elif q_count == 4 and qd_count == 3 and dof_dim == wp.vec2i(0, 3):
             return JointDoFType.SPHERICAL
         elif q_count == 7 and qd_count == 6:
@@ -889,6 +925,8 @@ class JointDoFType(IntEnum):
             return 2  # 2D angles
         elif dof_type == JointDoFType.SPHERICAL:
             return 4  # 4D unit-quaternion
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
+            return 3  # 3D rotation vector
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D distances
         elif dof_type == JointDoFType.FIXED:
@@ -919,6 +957,8 @@ class JointDoFType(IntEnum):
         elif dof_type == JointDoFType.UNIVERSAL:
             return 2  # 2D angular velocities
         elif dof_type == JointDoFType.SPHERICAL:
+            return 3  # 3D angular velocities
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
             return 3  # 3D angular velocities
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D linear velocities
@@ -951,6 +991,8 @@ class JointDoFType(IntEnum):
             return 4  # 4D vector for `{R_x, R_y, R_z, R_w}`
         elif dof_type == JointDoFType.SPHERICAL:
             return 3  # 3D vector for `{R_x, R_y, R_z}`
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
+            return 3  # 3D vector for `{T_x, T_y, T_z}`
         elif dof_type == JointDoFType.CARTESIAN:
             return 3  # 3D vector for `{T_x, T_y, T_z}`
         elif dof_type == JointDoFType.FIXED:
@@ -996,6 +1038,18 @@ class JointDoFType(IntEnum):
             R_axis_j = wp.matrix_from_cols(ax, ay, az)
         elif dof_type == JointDoFType.SPHERICAL:
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
+            axis_x_is_canonical = (
+                wp.abs(dof_axes[0][0] - 1.0) < 1e-6 and wp.abs(dof_axes[0][1]) < 1e-6 and wp.abs(dof_axes[0][2]) < 1e-6
+            )
+            axis_y_is_canonical = (
+                wp.abs(dof_axes[1][0]) < 1e-6 and wp.abs(dof_axes[1][1] - 1.0) < 1e-6 and wp.abs(dof_axes[1][2]) < 1e-6
+            )
+            axis_z_is_canonical = (
+                wp.abs(dof_axes[2][0]) < 1e-6 and wp.abs(dof_axes[2][1]) < 1e-6 and wp.abs(dof_axes[2][2] - 1.0) < 1e-6
+            )
+            axes_are_canonical = axis_x_is_canonical and axis_y_is_canonical and axis_z_is_canonical
+            assert axes_are_canonical, "Rotation-vector joint axes must be canonical +X/+Y/+Z"
         elif dof_type == JointDoFType.CARTESIAN:
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
         elif dof_type == JointDoFType.FREE:
@@ -1458,13 +1512,15 @@ class JointDescriptor(Descriptor):
         # Validate that the specified parameters are valid
         self._check_parameter_values()
 
-        # TODO: Add support for dynamic multi-dof joints in the future.
-        # Ensure that only revolute and prismatic joints are dynamically constrained
-        supported_implicit_joint_types = (JointDoFType.REVOLUTE, JointDoFType.PRISMATIC)
+        supported_implicit_joint_types = (
+            JointDoFType.REVOLUTE,
+            JointDoFType.PRISMATIC,
+            JointDoFType.ROTATION_VECTOR,
+        )
         if (self.is_dynamic or self.is_implicit_pd) and self.dof_type not in supported_implicit_joint_types:
             raise ValueError(
                 "Invalid joint: Kamino currently supports dynamic/implicit joints "
-                f"for those that are REVOLUTE or PRISMATIC (name={self.name}, uid={self.uid})."
+                f"for REVOLUTE, PRISMATIC, or ROTATION_VECTOR types (name={self.name}, uid={self.uid})."
             )
 
         # TODO: Add more checks based on JointDoFType because how do we

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -206,6 +206,11 @@ def store_joint_cts_jacobian_dense(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
         )
 
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        wp.static(make_store_joint_jacobian_dense_func(JointDoFType.ROTATION_VECTOR.cts_axes))(
+            J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
+        )
+
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_dense_func(JointDoFType.CARTESIAN.cts_axes))(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
@@ -258,6 +263,11 @@ def store_joint_dofs_jacobian_dense(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
         )
 
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        wp.static(make_store_joint_jacobian_dense_func(JointDoFType.ROTATION_VECTOR.dofs_axes))(
+            J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
+        )
+
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_dense_func(JointDoFType.CARTESIAN.dofs_axes))(
             J_row_offset, num_body_dofs, bid_offset, bid_B, bid_F, JT_B, JT_F, J_data
@@ -307,6 +317,11 @@ def store_joint_cts_jacobian_sparse(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
         )
 
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.ROTATION_VECTOR.cts_axes))(
+            is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
+        )
+
     elif dof_type == JointDoFType.CARTESIAN:
         wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.CARTESIAN.cts_axes))(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
@@ -353,6 +368,11 @@ def store_joint_dofs_jacobian_sparse(
 
     elif dof_type == JointDoFType.SPHERICAL:
         wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.SPHERICAL.dofs_axes))(
+            is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
+        )
+
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        wp.static(make_store_joint_jacobian_sparse_func(JointDoFType.ROTATION_VECTOR.dofs_axes))(
             is_binary, JT_B_j, JT_F_j, J_nzb_offset, J_nzb_values
         )
 

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -735,7 +735,6 @@ def compute_and_write_joint_implicit_dynamics(
     data_joint_dq_b_j: wp.array[wp.float32],
 ):
     q_error = wp.vec3f(0.0)
-    dq_ref = wp.vec3f(0.0)
     if dof_type == JointDoFType.ROTATION_VECTOR:
         q = wp.vec3f(
             data_joint_q_j[coords_offset],
@@ -747,14 +746,10 @@ def compute_and_write_joint_implicit_dynamics(
             data_joint_q_j_ref[coords_offset + 1],
             data_joint_q_j_ref[coords_offset + 2],
         )
-        dq_ref_authored = wp.vec3f(
-            data_joint_dq_j_ref[dofs_offset],
-            data_joint_dq_j_ref[dofs_offset + 1],
-            data_joint_dq_j_ref[dofs_offset + 2],
-        )
+        # Left (spatial) error, i.e. expressed in the joint frame on the Base body,
+        # which is the frame of both the DoF velocities and the actuation torques.
         q_rel = quat_exp(q_ref) * wp.quat_inverse(quat_exp(q))
         q_error = quat_log(q_rel)
-        dq_ref = dq_ref_authored
 
     # Iterate over the dynamic constraints of the joint and
     # compute and store the implicit dynamics intermediates
@@ -786,10 +781,15 @@ def compute_and_write_joint_implicit_dynamics(
         pd_q_j_error = pd_q_j_ref - q_j
         if dof_type == JointDoFType.ROTATION_VECTOR:
             pd_q_j_error = q_error[j]
-            pd_dq_j_ref = dq_ref[j]
         pd_tau_j_ff = data_joint_tau_j_ref[dofs_offset_j] if data_joint_tau_j_ref else 0.0
 
         # Compute the implicit joint dynamics intermediates
+        # NOTE: The `dt * dt * k_p_j` stiffness contribution to `m_j` assumes
+        # `d(pd_q_j_error)/d(dq_j) = -dt`, which holds exactly only for the
+        # translational and single-axis rotational DoF types. For rotation-vector
+        # DoFs the exact derivative is a dense 3x3 matrix (the left Jacobian of
+        # the exponential map), so this per-axis diagonal treatment is a
+        # first-order approximation that degrades with the orientation error.
         m_j = a_j + dt * b_j
         tau_j_tot = tau_j
         if act_type == JointActuationType.FORCE:

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -13,7 +13,12 @@ import warp as wp
 
 from ..core.data import DataKamino
 from ..core.joints import JointActuationType, JointCorrectionMode, JointDoFType
-from ..core.math import FLOAT32_MAX, quat_log, quat_twist_angle
+from ..core.math import (
+    FLOAT32_MAX,
+    quat_exp,
+    quat_log,
+    quat_twist_angle,
+)
 from ..core.model import ModelKamino
 from ..core.types import (
     vec1f,
@@ -133,6 +138,14 @@ def correct_joint_coord_spherical(
 
 
 @wp.func
+def correct_joint_coord_rotation_vector(
+    q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
+) -> wp.vec3f:
+    """Keep the principal rotation vector selected by the quaternion logarithm."""
+    return q_j_in
+
+
+@wp.func
 def correct_joint_coord_cartesian(
     q_j_in: wp.vec3f, q_j_ref: wp.vec3f, q_j_limit: wp.vec3f = DEFAULT_LIMIT_V3F
 ) -> wp.vec3f:
@@ -157,6 +170,8 @@ def get_joint_coord_correction_function(dof_type: JointDoFType):
         return correct_joint_coord_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return correct_joint_coord_spherical
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        return correct_joint_coord_rotation_vector
     elif dof_type == JointDoFType.CARTESIAN:
         return correct_joint_coord_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -225,6 +240,12 @@ def map_to_joint_coords_spherical(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec4f:
 
 
 @wp.func
+def map_to_joint_coords_rotation_vector(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
+    """Return the principal logarithm of the relative rotation."""
+    return quat_log(j_q_j)
+
+
+@wp.func
 def map_to_joint_coords_cartesian(j_r_j: wp.vec3f, j_q_j: wp.quatf) -> wp.vec3f:
     """Returns the 3D translational."""
     return j_r_j
@@ -247,6 +268,8 @@ def get_joint_coords_mapping_function(dof_type: JointDoFType):
         return map_to_joint_coords_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return map_to_joint_coords_spherical
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        return map_to_joint_coords_rotation_vector
     elif dof_type == JointDoFType.CARTESIAN:
         return map_to_joint_coords_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -311,6 +334,8 @@ def get_joint_constraint_angular_residual_function(dof_type: JointDoFType):
     elif dof_type == JointDoFType.UNIVERSAL:
         return joint_constraint_angular_residual_universal
     elif dof_type == JointDoFType.SPHERICAL:
+        return joint_constraint_angular_residual_free
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
         return joint_constraint_angular_residual_free
     elif dof_type == JointDoFType.CARTESIAN:
         return joint_constraint_angular_residual_fixed
@@ -542,6 +567,21 @@ def make_write_joint_data(correction: JointCorrectionMode = JointCorrectionMode.
                 data_dq_j,
             )
 
+        elif dof_type == JointDoFType.ROTATION_VECTOR:
+            wp.static(make_typed_write_joint_data(JointDoFType.ROTATION_VECTOR, JointCorrectionMode.NONE))(
+                cts_offset,
+                dofs_offset,
+                coords_offset,
+                j_r_j,
+                j_q_j,
+                j_u_j,
+                q_j_p,
+                data_r_j,
+                data_dr_j,
+                data_q_j,
+                data_dq_j,
+            )
+
         elif dof_type == JointDoFType.CARTESIAN:
             wp.static(make_typed_write_joint_data(JointDoFType.CARTESIAN))(
                 cts_offset,
@@ -672,6 +712,7 @@ def compute_joint_pose_and_relative_motion(
 def compute_and_write_joint_implicit_dynamics(
     # Constants:
     dt: wp.float32,
+    dof_type: wp.int32,
     act_type: wp.int32,
     coords_offset: wp.int32,
     dofs_offset: wp.int32,
@@ -693,6 +734,28 @@ def compute_and_write_joint_implicit_dynamics(
     data_joint_inv_m_j: wp.array[wp.float32],
     data_joint_dq_b_j: wp.array[wp.float32],
 ):
+    q_error = wp.vec3f(0.0)
+    dq_ref = wp.vec3f(0.0)
+    if dof_type == JointDoFType.ROTATION_VECTOR:
+        q = wp.vec3f(
+            data_joint_q_j[coords_offset],
+            data_joint_q_j[coords_offset + 1],
+            data_joint_q_j[coords_offset + 2],
+        )
+        q_ref = wp.vec3f(
+            data_joint_q_j_ref[coords_offset],
+            data_joint_q_j_ref[coords_offset + 1],
+            data_joint_q_j_ref[coords_offset + 2],
+        )
+        dq_ref_authored = wp.vec3f(
+            data_joint_dq_j_ref[dofs_offset],
+            data_joint_dq_j_ref[dofs_offset + 1],
+            data_joint_dq_j_ref[dofs_offset + 2],
+        )
+        q_rel = quat_exp(q_ref) * wp.quat_inverse(quat_exp(q))
+        q_error = quat_log(q_rel)
+        dq_ref = dq_ref_authored
+
     # Iterate over the dynamic constraints of the joint and
     # compute and store the implicit dynamics intermediates
     # TODO: We currently do not handle implicit dynamics of
@@ -720,6 +783,10 @@ def compute_and_write_joint_implicit_dynamics(
         # Retrieve PD control references
         pd_q_j_ref = data_joint_q_j_ref[coords_offset_j]
         pd_dq_j_ref = data_joint_dq_j_ref[dofs_offset_j]
+        pd_q_j_error = pd_q_j_ref - q_j
+        if dof_type == JointDoFType.ROTATION_VECTOR:
+            pd_q_j_error = q_error[j]
+            pd_dq_j_ref = dq_ref[j]
         pd_tau_j_ff = data_joint_tau_j_ref[dofs_offset_j] if data_joint_tau_j_ref else 0.0
 
         # Compute the implicit joint dynamics intermediates
@@ -729,16 +796,16 @@ def compute_and_write_joint_implicit_dynamics(
             tau_j_tot += pd_tau_j_ff
         elif act_type == JointActuationType.POSITION:
             m_j += dt * k_d_j + dt * dt * k_p_j
-            tau_j_tot += k_p_j * (pd_q_j_ref - q_j)
+            tau_j_tot += k_p_j * pd_q_j_error
         elif act_type == JointActuationType.VELOCITY:
             m_j += dt * k_d_j
             tau_j_tot += k_d_j * pd_dq_j_ref
         elif act_type == JointActuationType.POSITION_VELOCITY:
             m_j += dt * k_d_j + dt * dt * k_p_j
-            tau_j_tot += k_p_j * (pd_q_j_ref - q_j) + k_d_j * pd_dq_j_ref
+            tau_j_tot += k_p_j * pd_q_j_error + k_d_j * pd_dq_j_ref
         elif act_type == JointActuationType.POSITION_VELOCITY_FORCE:
             m_j += dt * k_d_j + dt * dt * k_p_j
-            tau_j_tot += pd_tau_j_ff + k_p_j * (pd_q_j_ref - q_j) + k_d_j * pd_dq_j_ref
+            tau_j_tot += pd_tau_j_ff + k_p_j * pd_q_j_error + k_d_j * pd_dq_j_ref
         # Enforce minimum mass to avoid division by zero
         m_j = wp.max(1e-6, m_j)
         inv_m_j = 1.0 / m_j
@@ -864,6 +931,7 @@ def make_compute_joints_data_kernel(correction: JointCorrectionMode = JointCorre
         # for the dynamic constraints of the joint
         compute_and_write_joint_implicit_dynamics(
             dt,
+            dof_type,
             act_type,
             coords_offset,
             dofs_offset,

--- a/newton/_src/solvers/kamino/_src/kinematics/joints.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/joints.py
@@ -735,7 +735,12 @@ def compute_and_write_joint_implicit_dynamics(
     data_joint_dq_b_j: wp.array[wp.float32],
 ):
     q_error = wp.vec3f(0.0)
-    if dof_type == JointDoFType.ROTATION_VECTOR:
+    uses_position_target = (
+        act_type == JointActuationType.POSITION
+        or act_type == JointActuationType.POSITION_VELOCITY
+        or act_type == JointActuationType.POSITION_VELOCITY_FORCE
+    )
+    if dof_type == JointDoFType.ROTATION_VECTOR and uses_position_target:
         q = wp.vec3f(
             data_joint_q_j[coords_offset],
             data_joint_q_j[coords_offset + 1],
@@ -753,8 +758,6 @@ def compute_and_write_joint_implicit_dynamics(
 
     # Iterate over the dynamic constraints of the joint and
     # compute and store the implicit dynamics intermediates
-    # TODO: We currently do not handle implicit dynamics of
-    # multi-dof joints, but we should generalize this.
     for j in range(num_dynamic_cts):
         coords_offset_j = coords_offset + j
         dofs_offset_j = dofs_offset + j

--- a/newton/_src/solvers/kamino/_src/kinematics/limits.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/limits.py
@@ -230,6 +230,12 @@ def map_joint_coords_to_dofs_spherical(q_j: wp.vec4f) -> wp.vec3f:
 
 
 @wp.func
+def map_joint_coords_to_dofs_rotation_vector(q_j: wp.vec3f) -> wp.vec3f:
+    """Return logarithmic rotation coordinates unchanged in DoF space."""
+    return q_j
+
+
+@wp.func
 def map_joint_coords_to_dofs_cartesian(q_j: wp.vec3f) -> wp.vec3f:
     """No mapping needed for cartesian joints."""
     return q_j
@@ -252,6 +258,8 @@ def get_joint_coords_to_dofs_mapping_function(dof_type: JointDoFType):
         return map_joint_coords_to_dofs_universal
     elif dof_type == JointDoFType.SPHERICAL:
         return map_joint_coords_to_dofs_spherical
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        return map_joint_coords_to_dofs_rotation_vector
     elif dof_type == JointDoFType.CARTESIAN:
         return map_joint_coords_to_dofs_cartesian
     elif dof_type == JointDoFType.FIXED:
@@ -361,6 +369,15 @@ def read_joint_coords_map_and_limits(
 
     elif dof_type == JointDoFType.SPHERICAL:
         d_j, q_j_min, q_j_max, q_j_map = wp.static(make_read_joint_coords_map_and_limits(JointDoFType.SPHERICAL))(
+            dofs_offset,
+            coords_offset,
+            model_joint_q_j_min,
+            model_joint_q_j_max,
+            state_joints_q_j,
+        )
+
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        d_j, q_j_min, q_j_max, q_j_map = wp.static(make_read_joint_coords_map_and_limits(JointDoFType.ROTATION_VECTOR))(
             dofs_offset,
             coords_offset,
             model_joint_q_j_min,

--- a/newton/_src/solvers/kamino/_src/kinematics/resets.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/resets.py
@@ -55,7 +55,10 @@ def make_correct_joint_coords(dof_type: JointDoFType):
         coords_ref: wp.array[wp.float32],
     ) -> Any:  # dof_type.coords_storage_type
         if wp.static(
-            dof_type == JointDoFType.CARTESIAN or dof_type == JointDoFType.FIXED or dof_type == JointDoFType.PRISMATIC
+            dof_type == JointDoFType.CARTESIAN
+            or dof_type == JointDoFType.FIXED
+            or dof_type == JointDoFType.PRISMATIC
+            or dof_type == JointDoFType.ROTATION_VECTOR
         ):
             pass  # No correction needed
 
@@ -172,6 +175,12 @@ def _compute_and_write_joint_coords_and_vel(
     elif dof_type == JointDoFType.FREE:
         wp.static(make_compute_and_write_joint_coords(JointDoFType.FREE))(r_j, q_j, coords_offset, joint_q_ref, joint_q)
         wp.static(make_compute_and_write_joint_vel(JointDoFType.FREE))(q_j, u_j, dofs_offset, joint_u)
+
+    elif dof_type == JointDoFType.ROTATION_VECTOR:
+        wp.static(make_compute_and_write_joint_coords(JointDoFType.ROTATION_VECTOR))(
+            r_j, q_j, coords_offset, joint_q_ref, joint_q
+        )
+        wp.static(make_compute_and_write_joint_vel(JointDoFType.ROTATION_VECTOR))(q_j, u_j, dofs_offset, joint_u)
 
     elif dof_type == JointDoFType.PRISMATIC:
         wp.static(make_compute_and_write_joint_coords(JointDoFType.PRISMATIC))(

--- a/newton/_src/solvers/kamino/_src/models/builders/testing.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/testing.py
@@ -51,6 +51,7 @@ __all__ = [
     "build_unary_cylindrical_joint_test",
     "build_unary_prismatic_joint_test",
     "build_unary_revolute_joint_test",
+    "build_unary_rotation_vector_joint_test",
     "build_unary_spherical_joint_test",
     "build_unary_universal_joint_test",
     "make_shape_pairs_builder",
@@ -1119,6 +1120,89 @@ def build_binary_spherical_joint_test(
         )
 
     # Return the populated builder
+    return _builder
+
+
+def build_unary_rotation_vector_joint_test(
+    builder: ModelBuilderKamino | None = None,
+    z_offset: float = 0.0,
+    new_world: bool = True,
+    limits: bool = True,
+    ground: bool = True,
+    dynamic: bool = False,
+    implicit_pd: bool = False,
+    world_index: int = 0,
+) -> ModelBuilderKamino:
+    """Build a world containing one unary rotation-vector joint.
+
+    Args:
+        builder: Optional builder to populate.
+        z_offset: Vertical body offset.
+        new_world: Whether to create a new world.
+        limits: Whether to enable joint limits.
+        ground: Whether to include a ground geometry.
+        dynamic: Whether to enable implicit joint dynamics.
+        implicit_pd: Whether to enable implicit PD control.
+        world_index: Existing world index used when ``new_world`` is ``False``.
+
+    Returns:
+        The populated model builder.
+    """
+    if builder is None:
+        _builder = ModelBuilderKamino(default_world=False)
+    else:
+        _builder = builder
+
+    if new_world or builder is None:
+        world_index = _builder.add_world(name="unary_rotation_vector_joint_test")
+
+    bid_F = _builder.add_rigid_body(
+        name="follower",
+        m_i=1.0,
+        i_I_i=I_3,
+        q_i_0=wp.transformf(wp.vec3f(0.5, 0.0, z_offset), wp.quat_identity()),
+        u_i_0=wp.spatial_vectorf(0.0),
+        world_index=world_index,
+    )
+    _builder.add_joint(
+        name="world_to_follower_rotation_vector",
+        dof_type=JointDoFType.ROTATION_VECTOR,
+        act_type=JointActuationType.POSITION_VELOCITY if implicit_pd else JointActuationType.FORCE,
+        bid_B=-1,
+        bid_F=bid_F,
+        B_r_Bj=wp.vec3f(0.25, -0.25, -0.25),
+        F_r_Fj=wp.vec3f(-0.25, -0.25, -0.25),
+        X_Bj=axis_to_mat33(Axis.X),
+        q_j_min=[-0.6 * math.pi] * 3 if limits else None,
+        q_j_max=[0.6 * math.pi] * 3 if limits else None,
+        a_j=[0.1, 0.2, 0.3] if dynamic else None,
+        b_j=[0.01, 0.02, 0.03] if dynamic else None,
+        k_p_j=[10.0, 20.0, 30.0] if implicit_pd else None,
+        k_d_j=[0.01, 0.02, 0.03] if implicit_pd else None,
+        world_index=world_index,
+    )
+    _builder.add_geometry(
+        name="base/box",
+        body=-1,
+        shape=BoxShape(0.25, 0.25, 0.25),
+        world_index=world_index,
+        group=2,
+        collides=2,
+    )
+    _builder.add_geometry(
+        name="follower/box",
+        body=bid_F,
+        shape=BoxShape(0.25, 0.25, 0.25),
+        world_index=world_index,
+    )
+    if ground:
+        _builder.add_geometry(
+            body=-1,
+            shape=BoxShape(10.0, 10.0, 0.5),
+            offset=wp.transformf(0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 1.0),
+            world_index=world_index,
+        )
+
     return _builder
 
 

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -12,6 +12,7 @@ import warp as wp
 from ...core.joints import JointActuationType, JointDoFType
 from ...core.math import (
     G_of,
+    quat_exp,
     quat_left_jacobian_inverse,
     quat_log,
     unit_quat_apply,
@@ -341,7 +342,7 @@ def _compute_fk_axis_joint_frames(
     joint_1 = axis_joint_1[axis_joint]
     body_q = model_body_q_0[body]
 
-    # Locate both spherical-joint anchors in the tie-rod body frame.
+    # Locate both 3 DoF rotation-joint anchors in the tie-rod body frame.
     local_0 = model_joint_F_r_Fj[joint_0]
     if model_joint_bid_B[joint_0] == body:
         local_0 = model_joint_B_r_Bj[joint_0]
@@ -543,6 +544,10 @@ def _joint_transform_to_coords(
         wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.REVOLUTE))(pos_rel, q_rel, offset, output)
     elif dof_type == FKJointDoFType.SPHERICAL:
         wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.SPHERICAL))(pos_rel, q_rel, offset, output)
+    elif dof_type == FKJointDoFType.ROTATION_VECTOR:
+        wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.ROTATION_VECTOR))(
+            pos_rel, q_rel, offset, output
+        )
     elif dof_type == FKJointDoFType.UNIVERSAL:
         wp.static(_make_typed_joint_transform_to_coords_func(JointDoFType.UNIVERSAL))(pos_rel, q_rel, offset, output)
 
@@ -651,7 +656,10 @@ def _correct_actuator_coords(
     # Apply correction based on DoFs
     dof_type = joints_dof_type[joint_id]
     if (
-        dof_type == FKJointDoFType.CARTESIAN or dof_type == FKJointDoFType.FIXED or dof_type == FKJointDoFType.PRISMATIC
+        dof_type == FKJointDoFType.CARTESIAN
+        or dof_type == FKJointDoFType.FIXED
+        or dof_type == FKJointDoFType.PRISMATIC
+        or dof_type == FKJointDoFType.ROTATION_VECTOR
     ):  # No correction needed
         return
     elif dof_type == FKJointDoFType.CYLINDRICAL:  # Correct angle up to +/- 2 pi
@@ -897,6 +905,16 @@ def _eval_target_relative_transformations(
             elif dof_type_j == FKJointDoFType.SPHERICAL:
                 q_X_B = wp.quat_from_matrix(X_B)
                 q_loc = read_quat_from_array(actuators_q, offset_q_j, normalize_quaternions)
+                q = q_X_B * q_loc * wp.quat_inverse(q_X_B)
+            elif dof_type_j == FKJointDoFType.ROTATION_VECTOR:
+                q_X_B = wp.quat_from_matrix(X_B)
+                q_loc = quat_exp(
+                    wp.vec3f(
+                        actuators_q[offset_q_j],
+                        actuators_q[offset_q_j + 1],
+                        actuators_q[offset_q_j + 2],
+                    )
+                )
                 q = q_X_B * q_loc * wp.quat_inverse(q_X_B)
             elif dof_type_j == FKJointDoFType.UNIVERSAL:
                 q_x = wp.quat_from_axis_angle(wp.vec3f(X_B[:, 0]), actuators_q[offset_q_j])
@@ -2116,6 +2134,10 @@ def _eval_target_constraint_velocities(
         elif dof_type_j == FKJointDoFType.REVOLUTE:
             target_cts_u[wd_id, offset_cts_j + 3] = actuators_u[offset_u_j]
         elif dof_type_j == FKJointDoFType.SPHERICAL:
+            target_cts_u[wd_id, offset_cts_j + 3] = actuators_u[offset_u_j]
+            target_cts_u[wd_id, offset_cts_j + 4] = actuators_u[offset_u_j + 1]
+            target_cts_u[wd_id, offset_cts_j + 5] = actuators_u[offset_u_j + 2]
+        elif dof_type_j == FKJointDoFType.ROTATION_VECTOR:
             target_cts_u[wd_id, offset_cts_j + 3] = actuators_u[offset_u_j]
             target_cts_u[wd_id, offset_cts_j + 4] = actuators_u[offset_u_j + 1]
             target_cts_u[wd_id, offset_cts_j + 5] = actuators_u[offset_u_j + 2]

--- a/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/solver.py
@@ -297,25 +297,27 @@ class ForwardKinematicsSolver:
 
             # Add axis joints as needed
             if self.config.add_axis_joints:
-                # Find all bodies incident to two spherical joints (and nothing more)
+                # Find all bodies incident to two pure 3-DoF rotation joints (and nothing more)
                 num_joints_per_body = np.zeros(dtype=np.int32, shape=num_bodies[wd_id])
-                spherical_joints_per_body = [[] for i in range(num_bodies[wd_id])]
+                rotation_joints_per_body = [[] for _ in range(num_bodies[wd_id])]
                 for jt_id_prev in world_joint_ids:
-                    is_spherical = joints_dof_type_prev[jt_id_prev] == JointDoFType.SPHERICAL
+                    is_pure_three_dof_rotation = JointDoFType(
+                        joints_dof_type_prev[jt_id_prev]
+                    ).is_pure_three_dof_rotation
                     bid_B = joints_bid_B_prev[jt_id_prev]
                     if bid_B >= 0:
                         bid_B -= first_body_id[wd_id]
                         num_joints_per_body[bid_B] += 1
-                        if is_spherical:
-                            spherical_joints_per_body[bid_B].append(jt_id_prev)
+                        if is_pure_three_dof_rotation:
+                            rotation_joints_per_body[bid_B].append(jt_id_prev)
                     bid_F = joints_bid_F_prev[jt_id_prev] - first_body_id[wd_id]
                     num_joints_per_body[bid_F] += 1
-                    if is_spherical:
-                        spherical_joints_per_body[bid_F].append(jt_id_prev)
+                    if is_pure_three_dof_rotation:
+                        rotation_joints_per_body[bid_F].append(jt_id_prev)
 
                 # Add an axis joint for each such body
                 for rb_id in range(num_bodies[wd_id]):
-                    if num_joints_per_body[rb_id] != 2 or len(spherical_joints_per_body[rb_id]) != 2:
+                    if num_joints_per_body[rb_id] != 2 or len(rotation_joints_per_body[rb_id]) != 2:
                         continue
                     rb_id_tot = first_body_id[wd_id] + rb_id
                     joints_dof_type.append(FKJointDoFType.AXIS)
@@ -325,8 +327,8 @@ class ForwardKinematicsSolver:
                     joints_source_id.append(-1)
                     fk_axis_joint.append(len(joints_dof_type) - 1)
                     fk_axis_body.append(rb_id_tot)
-                    fk_axis_source_joint_0.append(spherical_joints_per_body[rb_id][0])
-                    fk_axis_source_joint_1.append(spherical_joints_per_body[rb_id][1])
+                    fk_axis_source_joint_0.append(rotation_joints_per_body[rb_id][0])
+                    fk_axis_source_joint_1.append(rotation_joints_per_body[rb_id][1])
                     joints_num_actuated_coords.append(0)
                     joints_num_actuated_dofs.append(0)
 
@@ -444,6 +446,10 @@ class ForwardKinematicsSolver:
                         for i in range(3):
                             constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
                         ct_count += 3
+                    elif dof_type == FKJointDoFType.ROTATION_VECTOR:
+                        for i in range(3):
+                            constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
+                        ct_count += 3
                     elif dof_type == FKJointDoFType.UNIVERSAL:
                         for i in range(3):
                             constraint_full_to_red_map[6 * jt_id + i] = ct_count + i
@@ -497,6 +503,9 @@ class ForwardKinematicsSolver:
                     elif dof_type == FKJointDoFType.SPHERICAL:
                         for i in range(4):
                             delta_q_max[coord_id + i] = max_step_quat
+                    elif dof_type == FKJointDoFType.ROTATION_VECTOR:
+                        for i in range(3):
+                            delta_q_max[coord_id + i] = max_step_angular
                     elif dof_type == FKJointDoFType.UNIVERSAL:
                         delta_q_max[coord_id] = max_step_angular
                         delta_q_max[coord_id + 1] = max_step_angular

--- a/newton/_src/solvers/kamino/_src/solvers/fk/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/types.py
@@ -33,8 +33,8 @@ wp.set_module_options({"enable_backward": False})
 class FKJointDoFType(IntEnum):
     """
     Joint dof types for the FK solver, which currently differs from Kamino's main joint types
-    by the addition of the axis joint, used to regularize tie rods between two spherical joints
-    (taking out the rotation dof about their own axis).
+    by the addition of the axis joint, used to regularize tie rods between two pure 3-DoF
+    rotation joints (taking out the rotation dof about their own axis).
 
     Importantly, the integer value is the same for all joints not specific to FK, allowing seamless
     conversions.
@@ -48,7 +48,8 @@ class FKJointDoFType(IntEnum):
     SPHERICAL = 5
     CARTESIAN = 6
     FIXED = 7
-    AXIS = 8
+    ROTATION_VECTOR = 8
+    AXIS = 9
 
 
 class ForwardKinematicsPreconditionerType(IntEnum):

--- a/newton/_src/solvers/kamino/config.py
+++ b/newton/_src/solvers/kamino/config.py
@@ -1012,8 +1012,8 @@ class ForwardKinematicsSolverConfig:
 
     add_axis_joints: bool = True
     """
-    Whether to automatically add axis joints to take out superfluous DoFs at tie rods,
-    that otherwise render the FK problem ill-posed.
+    Whether to automatically add axis joints to take out superfluous DoFs at tie rods
+    connected by pure 3-DoF rotation joints, which otherwise render the FK problem ill-posed.
     Changes to this setting after the solver's initialization will have no effect.
     Defaults to `True`.
     """

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -1148,7 +1148,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         - springs
         - triangles, edges, tetrahedra
         - muscles
-        - distance, cable, or gimbal joints
+        - distance or cable joints
 
         Args:
             model: The Newton model to validate.
@@ -1174,26 +1174,17 @@ class SolverKamino(SolverBase, CouplingInterface):
         # Check for unsupported joint types
         if model.joint_count > 0:
             joint_type_np = model.joint_type.numpy()
-            joint_dof_dim_np = model.joint_dof_dim.numpy()
-            joint_q_start_np = model.joint_q_start.numpy()
-            joint_qd_start_np = model.joint_qd_start.numpy()
 
             unsupported_joint_types = {}
 
             for j in range(model.joint_count):
                 joint_type = int(joint_type_np[j])
-                dof_dim = (int(joint_dof_dim_np[j][0]), int(joint_dof_dim_np[j][1]))
-                q_count = int(joint_q_start_np[j + 1] - joint_q_start_np[j])
-                qd_count = int(joint_qd_start_np[j + 1] - joint_qd_start_np[j])
 
                 # Check for explicitly unsupported joint types
                 if joint_type == JointType.DISTANCE:
                     unsupported_joint_types["DISTANCE"] = unsupported_joint_types.get("DISTANCE", 0) + 1
                 elif joint_type == JointType.CABLE:
                     unsupported_joint_types["CABLE"] = unsupported_joint_types.get("CABLE", 0) + 1
-                # Check for GIMBAL configuration (3 coords, 3 DoFs, 0 linear/3 angular)
-                elif joint_type == JointType.D6 and q_count == 3 and qd_count == 3 and dof_dim == (0, 3):
-                    unsupported_joint_types["D6 (GIMBAL)"] = unsupported_joint_types.get("D6 (GIMBAL)", 0) + 1
 
             if len(unsupported_joint_types) > 0:
                 joint_desc = [f"{name} ({count} instances)" for name, count in unsupported_joint_types.items()]

--- a/newton/_src/solvers/kamino/tests/test_core_joints.py
+++ b/newton/_src/solvers/kamino/tests/test_core_joints.py
@@ -5,11 +5,15 @@
 
 import unittest
 
+import numpy as np
 import warp as wp
 
+import newton
 from newton._src.solvers.kamino._src.core.joints import JointDoFType
+from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino.tests import setup_tests, test_context
+from newton.solvers import SolverKamino
 
 ###
 # Tests
@@ -64,6 +68,61 @@ class TestCoreJoints(unittest.TestCase):
         for dof_type in JointDoFType:
             with self.subTest(dof_type=dof_type):
                 self.assertEqual(dof_type.is_pure_three_dof_rotation, dof_type in expected)
+
+    def test_validate_joint_axes(self):
+        """Accept valid joint frames and reject every unsupported axis layout."""
+        identity = np.eye(3, dtype=np.float32)
+        valid_axes = {
+            JointDoFType.FREE: np.vstack((identity, identity)),
+            JointDoFType.REVOLUTE: identity[:1],
+            JointDoFType.PRISMATIC: identity[:1],
+            JointDoFType.CYLINDRICAL: np.vstack((identity[0], identity[0])),
+            JointDoFType.UNIVERSAL: identity[:2],
+            JointDoFType.SPHERICAL: identity,
+            JointDoFType.CARTESIAN: identity,
+            JointDoFType.FIXED: np.empty((0, 3), dtype=np.float32),
+            JointDoFType.ROTATION_VECTOR: identity,
+        }
+        for dof_type, axes in valid_axes.items():
+            with self.subTest(dof_type=dof_type, valid=True):
+                self.assertIsNone(JointDoFType.validate_axes(dof_type, axes))
+
+        invalid_axes = {
+            JointDoFType.FREE: np.vstack((identity, identity[[0, 2, 1]])),
+            JointDoFType.REVOLUTE: np.zeros((1, 3), dtype=np.float32),
+            JointDoFType.PRISMATIC: np.zeros((1, 3), dtype=np.float32),
+            JointDoFType.CYLINDRICAL: identity[:2],
+            JointDoFType.UNIVERSAL: np.vstack((identity[0], identity[0])),
+            JointDoFType.SPHERICAL: identity[[0, 2, 1]],
+            JointDoFType.CARTESIAN: np.vstack((identity[0], identity[1], [0.1, 0.0, 1.0])),
+            JointDoFType.ROTATION_VECTOR: identity[[0, 2, 1]],
+        }
+        for dof_type, axes in invalid_axes.items():
+            with self.subTest(dof_type=dof_type, valid=False):
+                self.assertIsNotNone(JointDoFType.validate_axes(dof_type, axes))
+
+    def test_newton_conversion_rejects_noncanonical_rotation_vector_axes(self):
+        """Reject noncanonical rotation-vector axes before launching frame conversion."""
+        builder = newton.ModelBuilder()
+        SolverKamino.register_custom_attributes(builder)
+        body = builder.add_link(mass=1.0)
+        joint = builder.add_joint(
+            newton.JointType.D6,
+            parent=-1,
+            child=body,
+            linear_axes=[],
+            angular_axes=[
+                newton.ModelBuilder.JointDofConfig(axis=newton.Axis.X),
+                newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Z),
+                newton.ModelBuilder.JointDofConfig(axis=newton.Axis.Y),
+            ],
+            label="noncanonical_rotation",
+        )
+        builder.add_articulation([joint])
+        model = builder.finalize(device=self.default_device, skip_validation_joints=True)
+
+        with self.assertRaisesRegex(ValueError, "noncanonical_rotation.*canonical"):
+            ModelKamino.from_newton(model)
 
 
 ###

--- a/newton/_src/solvers/kamino/tests/test_core_joints.py
+++ b/newton/_src/solvers/kamino/tests/test_core_joints.py
@@ -55,6 +55,16 @@ class TestCoreJoints(unittest.TestCase):
         self.assertEqual(doftype.cts_axes, (0, 1, 2, 4, 5))
         self.assertEqual(doftype.dofs_axes, (3,))
 
+    def test_pure_three_dof_rotation_metadata(self):
+        """Identify joints with exactly three rotational DoFs and no translational DoFs."""
+        expected = {
+            JointDoFType.SPHERICAL,
+            JointDoFType.ROTATION_VECTOR,
+        }
+        for dof_type in JointDoFType:
+            with self.subTest(dof_type=dof_type):
+                self.assertEqual(dof_type.is_pure_three_dof_rotation, dof_type in expected)
+
 
 ###
 # Test execution

--- a/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
+++ b/newton/_src/solvers/kamino/tests/test_kinematics_joints.py
@@ -13,7 +13,10 @@ from newton._src.solvers.kamino._src.core.data import DataKamino
 from newton._src.solvers.kamino._src.core.math import quat_exp
 from newton._src.solvers.kamino._src.core.model import ModelKamino
 from newton._src.solvers.kamino._src.kinematics.joints import JointActuationType, compute_joints_data
-from newton._src.solvers.kamino._src.models.builders.testing import build_unary_revolute_joint_test
+from newton._src.solvers.kamino._src.models.builders.testing import (
+    build_unary_revolute_joint_test,
+    build_unary_rotation_vector_joint_test,
+)
 from newton._src.solvers.kamino._src.models.builders.utils import make_homogeneous_builder
 from newton._src.solvers.kamino._src.utils import logger as msg
 from newton._src.solvers.kamino.tests import setup_tests, test_context
@@ -110,6 +113,27 @@ def _set_joint_follower_body_state(
     state_body_u_i[bid_F] = wp.spatial_vectorf(*v_F_new, *omega_F_new)
 
 
+@wp.kernel
+def _set_rotation_vector_joint_state(
+    model_joint_bid_F: wp.array[wp.int32],
+    model_joint_B_r_Bj: wp.array[wp.vec3f],
+    model_joint_F_r_Fj: wp.array[wp.vec3f],
+    model_joint_X_Bj: wp.array[wp.mat33f],
+    model_joint_X_Fj: wp.array[wp.mat33f],
+    rotation_vector: wp.vec3f,
+    state_body_q_i: wp.array[wp.transformf],
+    state_body_u_i: wp.array[wp.spatial_vectorf],
+):
+    """Set a unary joint body to a requested relative rotation."""
+    jid = wp.tid()
+    bid_F = model_joint_bid_F[jid]
+    R_F = model_joint_X_Bj[jid] @ wp.quat_to_matrix(quat_exp(rotation_vector)) @ wp.transpose(model_joint_X_Fj[jid])
+    q_F = wp.quat_from_matrix(R_F)
+    r_F = model_joint_B_r_Bj[jid] - R_F @ model_joint_F_r_Fj[jid]
+    state_body_q_i[bid_F] = wp.transformation(r_F, q_F, dtype=wp.float32)
+    state_body_u_i[bid_F] = wp.spatial_vectorf(0.0)
+
+
 ###
 # Launchers
 ###
@@ -130,6 +154,50 @@ def set_joint_follower_body_state(model: ModelKamino, data: DataKamino):
         ],
         device=model.device,
     )
+
+
+def set_rotation_vector_joint_state(model: ModelKamino, data: DataKamino, rotation_vector: np.ndarray):
+    """Set the body state for a unary rotation-vector joint."""
+    wp.launch(
+        _set_rotation_vector_joint_state,
+        dim=model.size.sum_of_num_joints,
+        inputs=[
+            model.joints.bid_F,
+            model.joints.B_r_Bj,
+            model.joints.F_r_Fj,
+            model.joints.X_Bj,
+            model.joints.X_Fj,
+            wp.vec3f(*rotation_vector),
+            data.bodies.q_i,
+            data.bodies.u_i,
+        ],
+        device=model.device,
+    )
+
+
+def rotation_vector_error(current: np.ndarray, target: np.ndarray) -> np.ndarray:
+    """Compute ``log(exp(target) * inverse(exp(current)))`` independently."""
+
+    def quat_exp_np(vector: np.ndarray) -> np.ndarray:
+        angle = np.linalg.norm(vector)
+        if angle < 1e-12:
+            return np.array([0.5 * vector[0], 0.5 * vector[1], 0.5 * vector[2], 1.0])
+        return np.concatenate((np.sin(0.5 * angle) * vector / angle, [np.cos(0.5 * angle)]))
+
+    def quat_multiply_np(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+        imaginary = left[3] * right[:3] + right[3] * left[:3] + np.cross(left[:3], right[:3])
+        real = left[3] * right[3] - np.dot(left[:3], right[:3])
+        return np.concatenate((imaginary, [real]))
+
+    q_target = quat_exp_np(target)
+    q_current_inv = quat_exp_np(-current)
+    q_error = quat_multiply_np(q_target, q_current_inv)
+    if q_error[3] < 0.0:
+        q_error = -q_error
+    imaginary_norm = np.linalg.norm(q_error[:3])
+    if imaginary_norm < 1e-12:
+        return 2.0 * q_error[:3]
+    return 2.0 * np.arctan2(imaginary_norm, q_error[3]) * q_error[:3] / imaginary_norm
 
 
 ###
@@ -528,6 +596,57 @@ class TestKinematicsJoints(unittest.TestCase):
         inv_m_j_np = data.joints.inv_m_j.numpy().copy()
         self.assertTrue(m_j_np[0] > 0, "Internal effective inertia should be positive.")
         self.assertFalse(math.isnan(inv_m_j_np[0]), "Inverse internal effective inertia should be valid number.")
+
+    def test_06_rotation_vector_implicit_pd_error(self):
+        """Apply implicit PD using the left rotation-vector error."""
+        builder = build_unary_rotation_vector_joint_test(
+            dynamic=True,
+            implicit_pd=True,
+            limits=False,
+            ground=False,
+        )
+        model = builder.finalize(device=self.default_device)
+        data = model.data(device=self.default_device)
+        model.time.set_uniform_timestep(0.01)
+        data.joints.tau_j.zero_()
+        data.joints.dq_j_ref.zero_()
+
+        cases = (
+            (
+                np.array([0.4, -0.2, 0.1], dtype=np.float32),
+                np.array([-0.1, 0.3, 0.2], dtype=np.float32),
+            ),
+            (
+                np.array([0.2, -0.1, 0.3], dtype=np.float32),
+                np.array([0.2, -0.1, 0.3], dtype=np.float32),
+            ),
+            (
+                np.array([0.2, 0.0, 0.0], dtype=np.float32),
+                np.array([0.5, 0.0, 0.0], dtype=np.float32),
+            ),
+        )
+
+        dt = float(model.time.dt.numpy()[0])
+        a_j = model.joints.a_j.numpy()
+        b_j = model.joints.b_j.numpy()
+        k_p_j = model.joints.k_p_j.numpy()
+        k_d_j = model.joints.k_d_j.numpy()
+        m_j_expected = a_j + dt * (b_j + k_d_j) + dt * dt * k_p_j
+        inv_m_j_expected = 1.0 / m_j_expected
+
+        for current, target in cases:
+            with self.subTest(current=current, target=target):
+                set_rotation_vector_joint_state(model, data, current)
+                data.joints.q_j_ref.assign(target)
+                compute_joints_data(model=model, data=data, q_j_p=wp.zeros_like(data.joints.q_j))
+
+                error = rotation_vector_error(current, target)
+                dq_b_j_expected = dt * k_p_j * error * inv_m_j_expected
+                np.testing.assert_allclose(data.joints.q_j.numpy(), current, atol=1e-6)
+                np.testing.assert_allclose(data.joints.dq_j.numpy(), 0.0, atol=1e-6)
+                np.testing.assert_allclose(data.joints.m_j.numpy(), m_j_expected, atol=1e-6)
+                np.testing.assert_allclose(data.joints.inv_m_j.numpy(), inv_m_j_expected, atol=1e-6)
+                np.testing.assert_allclose(data.joints.dq_b_j.numpy(), dq_b_j_expected, atol=1e-6)
 
 
 ###

--- a/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_forward_kinematics.py
@@ -48,10 +48,13 @@ wp.set_module_options({"enable_backward": False})
 ###
 
 
-def create_four_bar_tie_rod() -> ModelBuilderKamino:
-    """
-    Creates a four-bar linkage, but with two revolute joints replaced with
-    spherical joints so as to create a tie rod (to test axis joints).
+def create_four_bar_tie_rod(
+    rotation_dof_type: JointDoFType = JointDoFType.SPHERICAL,
+) -> ModelBuilderKamino:
+    """Create a four-bar linkage with a tie rod connected by rotation joints.
+
+    Args:
+        rotation_dof_type: Pure 3-DoF rotation type for both tie-rod joints.
     """
     builder_revolute = build_boxes_fourbar(
         fixedbase=False,
@@ -63,19 +66,19 @@ def create_four_bar_tie_rod() -> ModelBuilderKamino:
         implicit_pd=False,
         actuator_ids=[1],
     )
-    builder_spherical = ModelBuilderKamino(default_world=True)
+    builder_rotation = ModelBuilderKamino(default_world=True)
     for body in builder_revolute.bodies[0]:
-        builder_spherical.add_rigid_body_descriptor(copy.deepcopy(body))
+        builder_rotation.add_rigid_body_descriptor(copy.deepcopy(body))
     for joint in builder_revolute.joints[0]:
         joint_copy = copy.deepcopy(joint)
         if joint.name == "link2_to_link3" or joint.name == "link3_to_link4":
-            joint_copy.dof_type = JointDoFType.SPHERICAL
-        builder_spherical.add_joint_descriptor(joint_copy)
+            joint_copy.dof_type = rotation_dof_type
+        builder_rotation.add_joint_descriptor(joint_copy)
     for geom in builder_revolute.geoms[0]:
         geom_copy = copy.deepcopy(geom)
         geom_copy.shape = builder_revolute.shapes[geom.uid]
-        builder_spherical.add_geometry_descriptor(geom_copy)
-    return builder_spherical
+        builder_rotation.add_geometry_descriptor(geom_copy)
+    return builder_rotation
 
 
 class JacobianCheckForwardKinematics(unittest.TestCase):
@@ -554,83 +557,99 @@ class FourBarTieRodRandomPosesCheckForwardKinematics(unittest.TestCase):
 
     def test_axis_joint_frames_update_after_notify(self):
         """Synthetic axis frames match a fresh solver after model changes."""
-        model = create_four_bar_tie_rod().finalize(device=self.default_device, requires_grad=False)
-        config = ForwardKinematicsSolver.Config(add_axis_joints=True)
-        solver = ForwardKinematicsSolver(model, config)
-        axis_body = int(solver.fk_axis_body.numpy()[0])
-        source_joint = int(solver.fk_axis_source_joint_0.numpy()[0])
+        for dof_type in (
+            JointDoFType.SPHERICAL,
+            JointDoFType.ROTATION_VECTOR,
+        ):
+            with self.subTest(dof_type=dof_type):
+                model = create_four_bar_tie_rod(dof_type).finalize(device=self.default_device, requires_grad=False)
+                config = ForwardKinematicsSolver.Config(add_axis_joints=True)
+                solver = ForwardKinematicsSolver(model, config)
+                axis_body = int(solver.fk_axis_body.numpy()[0])
+                source_joint = int(solver.fk_axis_source_joint_0.numpy()[0])
 
-        body_q = model.bodies.q_i_0.numpy()
-        body_q[axis_body] = np.array(
-            wp.transformf(
-                wp.vec3f(*body_q[axis_body, :3]),
-                wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.3),
-            )
-        )
-        model.bodies.q_i_0.assign(body_q)
-        if model.joints.bid_B.numpy()[source_joint] == axis_body:
-            joint_anchor = model.joints.B_r_Bj.numpy()
-            joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
-            model.joints.B_r_Bj.assign(joint_anchor)
-        else:
-            joint_anchor = model.joints.F_r_Fj.numpy()
-            joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
-            model.joints.F_r_Fj.assign(joint_anchor)
+                body_q = model.bodies.q_i_0.numpy()
+                body_q[axis_body] = np.array(
+                    wp.transformf(
+                        wp.vec3f(*body_q[axis_body, :3]),
+                        wp.quat_from_axis_angle(wp.vec3f(0.0, 1.0, 0.0), 0.3),
+                    )
+                )
+                model.bodies.q_i_0.assign(body_q)
+                if model.joints.bid_B.numpy()[source_joint] == axis_body:
+                    joint_anchor = model.joints.B_r_Bj.numpy()
+                    joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
+                    model.joints.B_r_Bj.assign(joint_anchor)
+                else:
+                    joint_anchor = model.joints.F_r_Fj.numpy()
+                    joint_anchor[source_joint] += np.array([0.05, -0.02, 0.01], dtype=np.float32)
+                    model.joints.F_r_Fj.assign(joint_anchor)
 
-        solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES | newton.ModelFlags.BODY_PROPERTIES)
-        reference = ForwardKinematicsSolver(model, ForwardKinematicsSolver.Config(add_axis_joints=True))
-        axis_joints = solver.fk_axis_joint.numpy()
+                solver.notify_model_changed(newton.ModelFlags.JOINT_PROPERTIES | newton.ModelFlags.BODY_PROPERTIES)
+                reference = ForwardKinematicsSolver(model, ForwardKinematicsSolver.Config(add_axis_joints=True))
+                axis_joints = solver.fk_axis_joint.numpy()
 
-        np.testing.assert_allclose(
-            solver.joints_X_Bj.numpy()[axis_joints],
-            reference.joints_X_Bj.numpy()[axis_joints],
-            atol=1e-6,
-        )
-        np.testing.assert_allclose(
-            solver.joints_X_Fj.numpy()[axis_joints],
-            reference.joints_X_Fj.numpy()[axis_joints],
-            atol=1e-6,
-        )
+                np.testing.assert_allclose(
+                    solver.joints_X_Bj.numpy()[axis_joints],
+                    reference.joints_X_Bj.numpy()[axis_joints],
+                    atol=1e-6,
+                )
+                np.testing.assert_allclose(
+                    solver.joints_X_Fj.numpy()[axis_joints],
+                    reference.joints_X_Fj.numpy()[axis_joints],
+                    atol=1e-6,
+                )
+
+    def test_adds_axis_joints_for_three_dof_rotation_joints(self):
+        """Add an axis joint for each pure 3-DoF rotation joint variant."""
+        for dof_type in (
+            JointDoFType.SPHERICAL,
+            JointDoFType.ROTATION_VECTOR,
+        ):
+            with self.subTest(dof_type=dof_type):
+                model = create_four_bar_tie_rod(dof_type).finalize(device=self.default_device, requires_grad=False)
+                solver = ForwardKinematicsSolver(
+                    model,
+                    ForwardKinematicsSolver.Config(add_axis_joints=True),
+                )
+                self.assertEqual(len(solver.fk_axis_joint), 1)
 
     def test_four_bar_tie_rod_model_FK_random_poses(self):
-        # Initialize RNG
-        test_name = "Four-bar with tie rod FK random poses check"
-        seed = int(hashlib.sha256(test_name.encode("utf8")).hexdigest(), 16)
-        rng = np.random.default_rng(seed)
+        """Solve spherical and rotation-vector tie-rod poses with both axis-joints and regularization."""
+        for dof_type in (JointDoFType.SPHERICAL, JointDoFType.ROTATION_VECTOR):
+            with self.subTest(dof_type=dof_type):
+                seed = int(hashlib.sha256(dof_type.name.encode("utf8")).hexdigest(), 16)
+                rng = np.random.default_rng(seed)
 
-        # Create a builder with 10 worlds, each with a four-bar with a tie rod
-        builder = make_homogeneous_builder(num_worlds=10, build_fn=create_four_bar_tie_rod)
-        model = builder.finalize(device=self.default_device, requires_grad=False)
+                # Create a builder with 10 worlds, each with a four-bar with a tie rod
+                builder = make_homogeneous_builder(
+                    num_worlds=10,
+                    build_fn=partial(create_four_bar_tie_rod, dof_type),
+                )
+                model = builder.finalize(device=self.default_device, requires_grad=False)
+                # Generate helper function to simulate random poses
+                num_poses = 30
+                simulate_function = partial(
+                    simulate_random_poses,
+                    model,
+                    num_poses,
+                    rng,
+                    use_graph=self.has_cuda and not wp.config.verify_cuda,
+                    verbose=self.verbose,
+                    reset_state=True,
+                    use_incremental_solve=True,
+                    preconditioner="jacobi_block_diagonal",
+                )
 
-        # Generate helper function to simulate random poses
-        num_poses = 30
-        simulate_function = partial(
-            simulate_random_poses,
-            model,
-            num_poses,
-            rng,
-            use_graph=self.has_cuda and not wp.config.verify_cuda,
-            verbose=self.verbose,
-            reset_state=True,
-            use_incremental_solve=True,
-            preconditioner="jacobi_block_diagonal",
-        )
-
-        # Simulate random poses, adding axis joints to handle tie rod (dense solver)
-        success = simulate_function(add_axis_joints=True, tolerance=1e-6, use_sparsity=False)
-        self.assertTrue(success)
-
-        # Simulate random poses, adding axis joints to handle tie rod (sparse solver)
-        success = simulate_function(add_axis_joints=True, tolerance=1e-6, use_sparsity=True)
-        self.assertTrue(success)
-
-        # Simulate random poses, using regularization to handle tie rod (dense solver)
-        success = simulate_function(add_axis_joints=False, use_regularization=True, tolerance=1e-5, use_sparsity=False)
-        self.assertTrue(success)
-
-        # Simulate random poses, using regularization to handle tie rod (sparse solver)
-        success = simulate_function(add_axis_joints=False, use_regularization=True, tolerance=1e-5, use_sparsity=True)
-        self.assertTrue(success)
+                # Test both dense and sparse solvers for axis joints and regularization.
+                for solver_config in (
+                    {"add_axis_joints": True, "tolerance": 1e-6},
+                    {"add_axis_joints": False, "use_regularization": True, "tolerance": 1e-5},
+                ):
+                    for use_sparsity in (False, True):
+                        with self.subTest(**solver_config, use_sparsity=use_sparsity):
+                            success = simulate_function(**solver_config, use_sparsity=use_sparsity)
+                            self.assertTrue(success)
 
 
 class AllJointsExampleRandomPosesCheckForwardKinematics(unittest.TestCase):


### PR DESCRIPTION
## Description

Implement a Gimbal joint according to Newton's D6 joint convention with 3 rotational DoFs.

## Checklist

- [x] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ROTATION_VECTOR` joints (3 rotational DoFs) with coordinate handling, limits, mapping, and reset behavior.
  * Updated Jacobians, kinematics/implicit dynamics, and forward-kinematics workflows to support rotation-vector joints.
  * Enabled interoperability with D6 joints; added a unary rotation-vector test model builder.

* **Bug Fixes**
  * Improved joint conversion validation, including rejection of non-canonical rotation-vector axes.
  * Refined model-compatibility checks and limited material refreshes to relevant collision-detector scenarios.

* **Tests**
  * Expanded unit tests for rotation-vector metadata/validation, FK scenarios, and implicit PD error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->