### PR TITLE
Load static USD visual shapes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Add compiled regular-expression support to label-based selectors while preserving glob strings.
 - Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, timestep, and MuJoCo solver-iteration metrics to the ASV robot-learning benchmarks.
 - Add `joint_dof_mask` to `newton.ik.IKSolver` to keep selected joint DOFs fixed during LM optimization. (#3488)
+- Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default, with a `load_static_visual_shapes` importer opt-out.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,14 +39,13 @@
 - Add compiled regular-expression support to label-based selectors while preserving glob strings.
 - Add simulation throughput, real-time factor, p95 step-time, steady-state GPU-memory, timestep, and MuJoCo solver-iteration metrics to the ASV robot-learning benchmarks.
 - Add `joint_dof_mask` to `newton.ik.IKSolver` to keep selected joint DOFs fixed during LM optimization. (#3488)
-- Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default, with a `load_static_visual_shapes` importer opt-out.
-
 ### Changed
 
 - Disable the implicit positive Dahl-friction defaults in `SolverVBD.register_custom_attributes()` (deprecated in 1.3.0): `vbd:dahl_eps_max` and `vbd:dahl_tau` now default to zero, and Dahl cable friction is enabled only where both are authored positive. Pass `dahl_defaults_enabled=True` to temporarily restore the old defaults; the compatibility mode will be removed in a future release.
 - Compile tiled camera render kernels with CUDA fast math by default for faster rendering; set `SensorTiledCamera.render_config.enable_fast_math = False` for bit-exact, IEEE-precise output.
 - Optimize raycast/raytrace queries by restructuring ray-shape intersection into local-space primitives and compile specialized depth/shadow variants that skip unused surface-normal work (mesh shadows also use any-hit queries).
 - Change experimental `SolverVBD` cable constraint slots from `[STRETCH=0, BEND=1]` to `[STRETCH=0, SHEAR=1, BEND=2, TWIST=3]`, allowing each stiffness and constraint mode to be configured independently. Existing cable calls using raw `slot=1` or `JointSlot.ANGULAR` now select shear; use `JointSlot.BEND` (now slot 2) to select bending.
+- Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default; pass `load_static_visual_shapes=False` to retain the previous body-associated-visuals-only behavior.
 - Improve `SolverKamino` GPU simulation and kernel compilation performance.
 - Load solver backends lazily on first access to speed up `import newton`; access solver classes through `newton.solvers` as before, and import solver modules explicitly if module-level side effects are required.
 - Speed up `ModelBuilder.replicate()` for large world counts by merging all copies in one pass; it no longer calls `add_world()` or `add_builder()` per copy, so `ModelBuilder` subclass overrides of those methods are not invoked during replication.

--- a/changelog.d/+static-usd-visuals-7b9e4c2a.added.md
+++ b/changelog.d/+static-usd-visuals-7b9e4c2a.added.md
@@ -1,0 +1,1 @@
+Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default, with a `load_static_visual_shapes` importer opt-out.

--- a/changelog.d/+static-usd-visuals-7b9e4c2a.added.md
+++ b/changelog.d/+static-usd-visuals-7b9e4c2a.added.md
@@ -1,1 +1,0 @@
-Load visual-only USD geometry outside rigid-body hierarchies as static shapes by default, with a `load_static_visual_shapes` importer opt-out.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -3527,11 +3527,9 @@ class ModelBuilder:
             skip_mesh_approximation: If True, mesh approximation is skipped. Otherwise, meshes are approximated according to the ``physics:approximation`` attribute defined on the UsdPhysicsMeshCollisionAPI (if it is defined), using the settings from :attr:`~newton.ModelBuilder.default_mesh_approximation_cfg`. Default is False.
             load_sites: If True, sites (prims with ``NewtonSiteAPI`` or ``MjcSiteAPI``) are loaded as non-colliding reference points. If False, sites are ignored. Default is True.
             load_visual_shapes: If True, non-physics visual geometry is loaded. If False, visual-only shapes are ignored (sites are still controlled by ``load_sites``). Default is True.
-            load_static_visual_shapes: If True, visual-only geometry outside rigid-body
-                hierarchies is loaded as static shapes when ``load_visual_shapes`` is
-                also True. Static Gaussian splats retain their existing
-                ``load_visual_shapes`` behavior independently of this option. Default is
-                True.
+            load_static_visual_shapes: If True, supported visual-only geometry outside
+                rigid-body hierarchies is loaded as static shapes when
+                ``load_visual_shapes`` is also True. Default is True.
             hide_collision_shapes: If True, collision shapes on bodies that already
                 have visual-only geometry are hidden unconditionally, regardless of
                 whether the collider has authored PBR material data. Default is False.

--- a/newton/_src/sim/builder.py
+++ b/newton/_src/sim/builder.py
@@ -3420,6 +3420,7 @@ class ModelBuilder:
         skip_mesh_approximation: bool = False,
         load_sites: bool = True,
         load_visual_shapes: bool = True,
+        load_static_visual_shapes: bool = True,
         hide_collision_shapes: bool = False,
         force_show_colliders: bool = False,
         parse_mujoco_options: bool = True,
@@ -3526,6 +3527,11 @@ class ModelBuilder:
             skip_mesh_approximation: If True, mesh approximation is skipped. Otherwise, meshes are approximated according to the ``physics:approximation`` attribute defined on the UsdPhysicsMeshCollisionAPI (if it is defined), using the settings from :attr:`~newton.ModelBuilder.default_mesh_approximation_cfg`. Default is False.
             load_sites: If True, sites (prims with ``NewtonSiteAPI`` or ``MjcSiteAPI``) are loaded as non-colliding reference points. If False, sites are ignored. Default is True.
             load_visual_shapes: If True, non-physics visual geometry is loaded. If False, visual-only shapes are ignored (sites are still controlled by ``load_sites``). Default is True.
+            load_static_visual_shapes: If True, visual-only geometry outside rigid-body
+                hierarchies is loaded as static shapes when ``load_visual_shapes`` is
+                also True. Static Gaussian splats retain their existing
+                ``load_visual_shapes`` behavior independently of this option. Default is
+                True.
             hide_collision_shapes: If True, collision shapes on bodies that already
                 have visual-only geometry are hidden unconditionally, regardless of
                 whether the collider has authored PBR material data. Default is False.
@@ -3664,6 +3670,7 @@ class ModelBuilder:
             skip_mesh_approximation=skip_mesh_approximation,
             load_sites=load_sites,
             load_visual_shapes=load_visual_shapes,
+            load_static_visual_shapes=load_static_visual_shapes,
             hide_collision_shapes=hide_collision_shapes,
             force_show_colliders=force_show_colliders,
             parse_mujoco_options=parse_mujoco_options,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -213,6 +213,7 @@ def parse_usd(
     skip_mesh_approximation: bool = False,
     load_sites: bool = True,
     load_visual_shapes: bool = True,
+    load_static_visual_shapes: bool = True,
     hide_collision_shapes: bool = False,
     force_show_colliders: bool = False,
     parse_mujoco_options: bool = True,
@@ -320,6 +321,11 @@ def parse_usd(
         skip_mesh_approximation: If True, mesh approximation is skipped. Otherwise, meshes are approximated according to the ``physics:approximation`` attribute defined on the UsdPhysicsMeshCollisionAPI (if it is defined), using the settings from :attr:`~newton.ModelBuilder.default_mesh_approximation_cfg`. Default is False.
         load_sites: If True, sites (prims with ``NewtonSiteAPI`` or ``MjcSiteAPI``) are loaded as non-colliding reference points. If False, sites are ignored. Default is True.
         load_visual_shapes: If True, non-physics visual geometry is loaded. If False, visual-only shapes are ignored (sites are still controlled by ``load_sites``). Default is True.
+        load_static_visual_shapes: If True, visual-only geometry outside rigid-body
+            hierarchies is loaded as static shapes when ``load_visual_shapes`` is
+            also True. Static Gaussian splats retain their existing
+            ``load_visual_shapes`` behavior independently of this option. Default is
+            True.
         hide_collision_shapes: If True, collision shapes on bodies that already
             have visual-only geometry are hidden unconditionally, regardless of
             whether the collider has authored PBR material data. Default is False.
@@ -539,7 +545,12 @@ def parse_usd(
     # can be excluded from rigid parsing, and the buckets are reused by the deformable
     # passes below instead of re-traversing the stage.
     root_prim = stage.GetPrimAtPath(root_path)
-    _deformable_prims = _scout_deformable_prims(root_prim, ignore_paths)
+    _deformable_prims = _scout_deformable_prims(
+        root_prim,
+        ignore_paths,
+        collect_static_visuals=load_visual_shapes,
+    )
+    deformable_visual_exclude_paths = set(_deformable_prims.native_physics_exclude_paths)
     native_exclude_paths = list(
         dict.fromkeys([*non_regex_ignore_paths, *_deformable_prims.native_physics_exclude_paths])
     )
@@ -1239,6 +1250,7 @@ def parse_usd(
         body_xform: wp.transform | None = None,
         articulation_root_xform: wp.transform | None = None,
         allow_visual_shapes: bool = True,
+        recurse: bool = True,
     ):
         """Load visual shapes and sites for a prim subtree.
 
@@ -1253,6 +1265,7 @@ def parse_usd(
                 passed when override_root_xform=True. Strips the root's original
                 pose from visual prim transforms to match the rebased body transforms.
             allow_visual_shapes: Whether non-site geometry may be loaded from this subtree.
+            recurse: Whether to inspect child prims after processing ``prim``.
         """
         if prim.HasAPI(UsdPhysics.RigidBodyAPI):
             return
@@ -1260,7 +1273,8 @@ def parse_usd(
         if any(re.match(path, path_name) for path in ignore_paths):
             return
         if _is_enabled_collider(prim):
-            _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, False)
+            if recurse:
+                _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, False)
             return
 
         type_name = str(prim.GetTypeName()).lower()
@@ -1271,7 +1285,10 @@ def parse_usd(
         if is_site and not load_sites:
             return
         if not is_site and not allow_visual_shapes:
-            _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes)
+            if recurse:
+                _load_visual_shape_children(
+                    parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes
+                )
             return
         if type_name not in _visual_geom_types:
             # Skip the transform/material work below for prims that cannot produce a shape.
@@ -1282,7 +1299,10 @@ def parse_usd(
                 and verbose
             ):
                 print(f"Warning: Unsupported geometry type {type_name} at {path_name} while loading visual shapes.")
-            _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes)
+            if recurse:
+                _load_visual_shape_children(
+                    parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes
+                )
             return
 
         prim_world_mat = _get_prim_world_mat(
@@ -1452,7 +1472,8 @@ def parse_usd(
                 if verbose:
                     print(f"Added visual shape {path_name} ({type_name}) with id {shape_id}.")
 
-        _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes)
+        if recurse:
+            _load_visual_shape_children(parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes)
 
     def add_body(
         prim: Usd.Prim,
@@ -3254,6 +3275,31 @@ def parse_usd(
             if src != dst:
                 authored_filtered_path_pairs.add((src, dst) if src < dst else (dst, src))
 
+    # The deformable scout collected geometry candidates during its existing instance-proxy
+    # walk. Body visuals were already loaded by add_body(), so only untouched static candidates
+    # need geometry/material work here.
+    if load_visual_shapes:
+        rigid_body_paths = {str(path) for path in ret_dict.get(UsdPhysics.ObjectType.RigidBody, ((), ()))[0]}
+
+        def _is_in_rigid_body_hierarchy(path: str) -> bool:
+            while path:
+                if path in rigid_body_paths:
+                    return True
+                path = path.rpartition("/")[0]
+            return False
+
+        for prim in _deformable_prims.static_visuals:
+            path = str(prim.GetPath())
+            is_gaussian = str(prim.GetTypeName()) == "ParticleField3DGaussianSplat"
+            if (
+                (not load_static_visual_shapes and not is_gaussian)
+                or path in deformable_visual_exclude_paths
+                or path in path_shape_map
+                or _is_in_rigid_body_hierarchy(path)
+            ):
+                continue
+            _load_visual_shapes_impl(-1, prim, recurse=False)
+
     no_collision_shapes = set()
     collision_group_ids = {}
     rigid_body_mass_info_map = {}
@@ -3833,49 +3879,6 @@ def parse_usd(
                 for shape1 in builder.body_shapes[body1]:
                     for shape2 in builder.body_shapes[body2]:
                         builder.add_shape_collision_filter_pair(shape1, shape2)
-
-    # Load Gaussian splat prims that weren't already captured as children of rigid bodies.
-    if load_visual_shapes:
-        prims = iter(Usd.PrimRange(stage.GetPrimAtPath(root_path), Usd.TraverseInstanceProxies()))
-        for gaussian_prim in prims:
-            if str(gaussian_prim.GetPath()).startswith("/Prototypes/"):
-                continue
-
-            if gaussian_prim.HasAPI(UsdPhysics.RigidBodyAPI):
-                prims.PruneChildren()
-                continue
-
-            if str(gaussian_prim.GetTypeName()) != "ParticleField3DGaussianSplat":
-                continue
-
-            gaussian_path = str(gaussian_prim.GetPath())
-            if gaussian_path in path_shape_map:
-                continue
-            if any(re.match(p, gaussian_path) for p in ignore_paths):
-                continue
-
-            body_id = -1
-
-            prim_world_mat = _get_prim_world_mat(gaussian_prim, None, incoming_world_xform)
-
-            g_pos, g_rot, g_scale = wp.transform_decompose(prim_world_mat)
-            gaussian = usd.get_gaussian(gaussian_prim)
-            splat_cfg = copy.copy(visual_shape_cfg)
-            splat_cfg.is_visible = _is_viewport_drawn(gaussian_prim)
-            splat_material_props = _get_material_props_cached(gaussian_prim)
-            shape_id = builder.add_shape_gaussian(
-                body_id,
-                gaussian=gaussian,
-                xform=wp.transform(g_pos, g_rot),
-                scale=g_scale,
-                cfg=splat_cfg,
-                color=splat_material_props.get("color"),
-                label=gaussian_path,
-            )
-            path_shape_map[gaussian_path] = shape_id
-            path_shape_scale[gaussian_path] = g_scale
-            if verbose:
-                print(f"Added Gaussian splat shape {gaussian_path} with id {shape_id}.")
 
     def _zero_mass_information():
         """Create a reusable zero-contribution collider mass payload for callback fallback."""

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -60,7 +60,11 @@ from .import_usd_deformable_attachments import (
 )
 from .import_usd_deformable_cable import _deformable_import_cable, _deformable_import_cable_graphs
 from .import_usd_deformable_cloth import _deformable_import_cloth
-from .import_usd_deformable_utils import _DeformableImportContext, _scout_deformable_prims
+from .import_usd_deformable_utils import (
+    _LOADABLE_VISUAL_TYPE_NAMES_LOWER,
+    _DeformableImportContext,
+    _scout_deformable_prims,
+)
 from .import_usd_deformable_volume import _deformable_import_volume
 from .import_utils import should_show_collider
 
@@ -619,16 +623,6 @@ def parse_usd(
     # Create a cache for world transforms to avoid recomputing them for each prim.
     xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
     traverse_instance_proxies = Usd.TraverseInstanceProxies()
-    _visual_geom_types = {
-        "cube",
-        "sphere",
-        "plane",
-        "capsule",
-        "cylinder",
-        "cone",
-        "mesh",
-        "particlefield3dgaussiansplat",
-    }
 
     def _is_enabled_collider(prim: Usd.Prim) -> bool:
         if collider := UsdPhysics.CollisionAPI(prim):
@@ -1287,7 +1281,7 @@ def parse_usd(
                     parent_body_id, prim, body_xform, articulation_root_xform, allow_visual_shapes
                 )
             return
-        if type_name not in _visual_geom_types:
+        if type_name not in _LOADABLE_VISUAL_TYPE_NAMES_LOWER:
             # Skip the transform/material work below for prims that cannot produce a shape.
             if (
                 len(type_name) > 0

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -321,11 +321,9 @@ def parse_usd(
         skip_mesh_approximation: If True, mesh approximation is skipped. Otherwise, meshes are approximated according to the ``physics:approximation`` attribute defined on the UsdPhysicsMeshCollisionAPI (if it is defined), using the settings from :attr:`~newton.ModelBuilder.default_mesh_approximation_cfg`. Default is False.
         load_sites: If True, sites (prims with ``NewtonSiteAPI`` or ``MjcSiteAPI``) are loaded as non-colliding reference points. If False, sites are ignored. Default is True.
         load_visual_shapes: If True, non-physics visual geometry is loaded. If False, visual-only shapes are ignored (sites are still controlled by ``load_sites``). Default is True.
-        load_static_visual_shapes: If True, visual-only geometry outside rigid-body
-            hierarchies is loaded as static shapes when ``load_visual_shapes`` is
-            also True. Static Gaussian splats retain their existing
-            ``load_visual_shapes`` behavior independently of this option. Default is
-            True.
+        load_static_visual_shapes: If True, supported visual-only geometry outside
+            rigid-body hierarchies is loaded as static shapes when
+            ``load_visual_shapes`` is also True. Default is True.
         hide_collision_shapes: If True, collision shapes on bodies that already
             have visual-only geometry are hidden unconditionally, regardless of
             whether the collider has authored PBR material data. Default is False.
@@ -540,15 +538,14 @@ def parse_usd(
         )
 
     non_regex_ignore_paths = [path for path in ignore_paths if ".*" not in path]
-    # One scouting walk classifies every deformable candidate prim; it runs before the
-    # native loader so deformable-owned geometry (simulation prims and their colliders)
-    # can be excluded from rigid parsing, and the buckets are reused by the deformable
-    # passes below instead of re-traversing the stage.
+    # LoadUsdPhysicsFromRange remains the native rigid/joint descriptor parser, so this
+    # pre-pass supplies its deformable exclusions before it runs. The same walk also
+    # collects static visual leaves when requested, avoiding a third stage traversal.
     root_prim = stage.GetPrimAtPath(root_path)
     _deformable_prims = _scout_deformable_prims(
         root_prim,
         ignore_paths,
-        collect_static_visuals=load_visual_shapes,
+        collect_static_visuals=load_visual_shapes and load_static_visual_shapes,
     )
     deformable_visual_exclude_paths = set(_deformable_prims.native_physics_exclude_paths)
     native_exclude_paths = list(
@@ -3275,10 +3272,10 @@ def parse_usd(
             if src != dst:
                 authored_filtered_path_pairs.add((src, dst) if src < dst else (dst, src))
 
-    # The deformable scout collected geometry candidates during its existing instance-proxy
-    # walk. Body visuals were already loaded by add_body(), so only untouched static candidates
-    # need geometry/material work here.
-    if load_visual_shapes:
+    # The import scout collected supported visual leaf candidates during its existing
+    # instance-proxy walk. Body visuals were already loaded by add_body(), so only untouched
+    # static candidates need geometry/material work here.
+    if load_visual_shapes and load_static_visual_shapes:
         rigid_body_paths = {str(path) for path in ret_dict.get(UsdPhysics.ObjectType.RigidBody, ((), ()))[0]}
 
         def _is_in_rigid_body_hierarchy(path: str) -> bool:
@@ -3290,13 +3287,7 @@ def parse_usd(
 
         for prim in _deformable_prims.static_visuals:
             path = str(prim.GetPath())
-            is_gaussian = str(prim.GetTypeName()) == "ParticleField3DGaussianSplat"
-            if (
-                (not load_static_visual_shapes and not is_gaussian)
-                or path in deformable_visual_exclude_paths
-                or path in path_shape_map
-                or _is_in_rigid_body_hierarchy(path)
-            ):
+            if path in deformable_visual_exclude_paths or path in path_shape_map or _is_in_rigid_body_hierarchy(path):
                 continue
             _load_visual_shapes_impl(-1, prim, recurse=False)
 

--- a/newton/_src/utils/import_usd_deformable_utils.py
+++ b/newton/_src/utils/import_usd_deformable_utils.py
@@ -812,8 +812,8 @@ class _DeformablePrimBuckets:
     tetmeshes: list[Usd.Prim] = field(default_factory=list)
     attachments: list[Usd.Prim] = field(default_factory=list)
     element_filters: list[Usd.Prim] = field(default_factory=list)
-    # Optional visual candidates collected for parse_usd's static visual pass. Reusing
-    # this scout avoids a second full instance-proxy traversal of the stage.
+    # Optional supported visual leaf candidates collected for parse_usd's static visual
+    # pass. Reusing this scout avoids a second full instance-proxy traversal of the stage.
     static_visuals: list[Usd.Prim] = field(default_factory=list)
     # PhysicsDeformableBodyAPI prim path -> the single simulation geometry it governs (the
     # first candidate of any family in traversal order); a body's mass must not be applied
@@ -865,7 +865,10 @@ _SCOUT_SKIP_TYPE_NAMES = frozenset(
     }
 )
 
-_SCOUT_VISUAL_TYPE_NAMES = frozenset(
+# Keep this set aligned with _load_visual_shapes_impl's leaf-shape branches.
+# UsdGeom.Imageable is intentionally broader: it also accepts container and non-shape
+# schemas, while the static post-pass invokes the loader with child recursion disabled.
+_SCOUT_LOADABLE_VISUAL_TYPE_NAMES = frozenset(
     {
         "Cube",
         "Sphere",
@@ -918,15 +921,18 @@ def _scout_deformable_prims(
 
     for prim in Usd.PrimRange(root_prim, Usd.TraverseInstanceProxies()):
         type_name = str(prim.GetTypeName())
-        if collect_static_visuals and type_name in _SCOUT_VISUAL_TYPE_NAMES:
-            buckets.static_visuals.append(prim)
-        if type_name in _SCOUT_SKIP_TYPE_NAMES:
+        is_static_visual = collect_static_visuals and type_name in _SCOUT_LOADABLE_VISUAL_TYPE_NAMES
+        if type_name in _SCOUT_SKIP_TYPE_NAMES and not is_static_visual:
             continue
         # An ignored prim must be as-if-absent from the start: bucketing it or letting it
         # claim body ownership would let an ignored sim child block a non-ignored sibling
         # from becoming the body's simulation geometry. Children still traverse, matching
         # the per-path semantics of the lowering passes' own checks.
         if ignore_paths and _is_ignored_path(str(prim.GetPath()), ignore_paths):
+            continue
+        if is_static_visual:
+            buckets.static_visuals.append(prim)
+        if type_name in _SCOUT_SKIP_TYPE_NAMES:
             continue
         if type_name == "PhysicsAttachment":
             buckets.attachments.append(prim)

--- a/newton/_src/utils/import_usd_deformable_utils.py
+++ b/newton/_src/utils/import_usd_deformable_utils.py
@@ -812,6 +812,9 @@ class _DeformablePrimBuckets:
     tetmeshes: list[Usd.Prim] = field(default_factory=list)
     attachments: list[Usd.Prim] = field(default_factory=list)
     element_filters: list[Usd.Prim] = field(default_factory=list)
+    # Optional visual candidates collected for parse_usd's static visual pass. Reusing
+    # this scout avoids a second full instance-proxy traversal of the stage.
+    static_visuals: list[Usd.Prim] = field(default_factory=list)
     # PhysicsDeformableBodyAPI prim path -> the single simulation geometry it governs (the
     # first candidate of any family in traversal order); a body's mass must not be applied
     # once per family, so the passes skip every other candidate under the same body.
@@ -862,8 +865,26 @@ _SCOUT_SKIP_TYPE_NAMES = frozenset(
     }
 )
 
+_SCOUT_VISUAL_TYPE_NAMES = frozenset(
+    {
+        "Cube",
+        "Sphere",
+        "Plane",
+        "Capsule",
+        "Cylinder",
+        "Cone",
+        "Mesh",
+        "ParticleField3DGaussianSplat",
+    }
+)
 
-def _scout_deformable_prims(root_prim: Usd.Prim, ignore_paths: Sequence[str] = ()) -> _DeformablePrimBuckets:
+
+def _scout_deformable_prims(
+    root_prim: Usd.Prim,
+    ignore_paths: Sequence[str] = (),
+    *,
+    collect_static_visuals: bool = False,
+) -> _DeformablePrimBuckets:
     """Classify deformable candidate prims in one stage traversal.
 
     Replaces the per-family full-stage walks: the lowering passes iterate these buckets instead of
@@ -897,6 +918,8 @@ def _scout_deformable_prims(root_prim: Usd.Prim, ignore_paths: Sequence[str] = (
 
     for prim in Usd.PrimRange(root_prim, Usd.TraverseInstanceProxies()):
         type_name = str(prim.GetTypeName())
+        if collect_static_visuals and type_name in _SCOUT_VISUAL_TYPE_NAMES:
+            buckets.static_visuals.append(prim)
         if type_name in _SCOUT_SKIP_TYPE_NAMES:
             continue
         # An ignored prim must be as-if-absent from the start: bucketing it or letting it

--- a/newton/_src/utils/import_usd_deformable_utils.py
+++ b/newton/_src/utils/import_usd_deformable_utils.py
@@ -865,10 +865,9 @@ _SCOUT_SKIP_TYPE_NAMES = frozenset(
     }
 )
 
-# Keep this set aligned with _load_visual_shapes_impl's leaf-shape branches.
 # UsdGeom.Imageable is intentionally broader: it also accepts container and non-shape
 # schemas, while the static post-pass invokes the loader with child recursion disabled.
-_SCOUT_LOADABLE_VISUAL_TYPE_NAMES = frozenset(
+_LOADABLE_VISUAL_TYPE_NAMES = frozenset(
     {
         "Cube",
         "Sphere",
@@ -880,6 +879,7 @@ _SCOUT_LOADABLE_VISUAL_TYPE_NAMES = frozenset(
         "ParticleField3DGaussianSplat",
     }
 )
+_LOADABLE_VISUAL_TYPE_NAMES_LOWER = frozenset(type_name.lower() for type_name in _LOADABLE_VISUAL_TYPE_NAMES)
 
 
 def _scout_deformable_prims(
@@ -921,7 +921,7 @@ def _scout_deformable_prims(
 
     for prim in Usd.PrimRange(root_prim, Usd.TraverseInstanceProxies()):
         type_name = str(prim.GetTypeName())
-        is_static_visual = collect_static_visuals and type_name in _SCOUT_LOADABLE_VISUAL_TYPE_NAMES
+        is_static_visual = collect_static_visuals and type_name in _LOADABLE_VISUAL_TYPE_NAMES
         if type_name in _SCOUT_SKIP_TYPE_NAMES and not is_static_visual:
             continue
         # An ignored prim must be as-if-absent from the start: bucketing it or letting it

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5053,6 +5053,59 @@ class TestImportSampleAssetsBasic(unittest.TestCase):
         verify_usdphysics_parser(self, asset_path, model, compare_min_max_coords=True, floating=True)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_static_visual_shapes_loading_flag(self):
+        """Load static visual instance proxies by default with an explicit opt-out."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        asset = UsdGeom.Xform.Define(stage, "/Asset")
+        UsdGeom.Cube.Define(stage, "/Asset/VisualCube")
+
+        UsdGeom.Xform.Define(stage, "/World")
+        static_instance = stage.DefinePrim("/World/Static", "Xform")
+        static_instance.GetReferences().AddInternalReference(asset.GetPath())
+        static_instance.SetInstanceable(True)
+        static_visual_path = "/World/Static/VisualCube"
+        self.assertTrue(stage.GetPrimAtPath(static_visual_path).IsInstanceProxy())
+
+        static_collider = UsdGeom.Cube.Define(stage, "/World/StaticCollider")
+        UsdPhysics.CollisionAPI.Apply(static_collider.GetPrim())
+
+        body = UsdGeom.Cube.Define(stage, "/World/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+        UsdPhysics.CollisionAPI.Apply(body.GetPrim())
+        body_visual = UsdGeom.Sphere.Define(stage, "/World/Body/VisualSphere")
+
+        builder_default = newton.ModelBuilder()
+        result_default = builder_default.add_usd(stage, root_path="/World")
+        self.assertIn(static_visual_path, result_default["path_shape_map"])
+        default_static_shape = result_default["path_shape_map"][static_visual_path]
+        self.assertEqual(builder_default.shape_body[default_static_shape], -1)
+        self.assertIn(body_visual.GetPath().pathString, result_default["path_shape_map"])
+        self.assertIn(static_collider.GetPath().pathString, result_default["path_shape_map"])
+
+        builder_disabled = newton.ModelBuilder()
+        result_disabled = builder_disabled.add_usd(
+            stage,
+            root_path="/World",
+            load_static_visual_shapes=False,
+        )
+        self.assertNotIn(static_visual_path, result_disabled["path_shape_map"])
+        self.assertIn(body_visual.GetPath().pathString, result_disabled["path_shape_map"])
+        self.assertIn(static_collider.GetPath().pathString, result_disabled["path_shape_map"])
+
+        builder_no_visuals = newton.ModelBuilder()
+        result_no_visuals = builder_no_visuals.add_usd(
+            stage,
+            root_path="/World",
+            load_visual_shapes=False,
+            load_static_visual_shapes=True,
+        )
+        self.assertNotIn(static_visual_path, result_no_visuals["path_shape_map"])
+        self.assertNotIn(body_visual.GetPath().pathString, result_no_visuals["path_shape_map"])
+        self.assertIn(static_collider.GetPath().pathString, result_no_visuals["path_shape_map"])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_granular_loading_flags(self):
         """Test the granular control over sites and visual shapes loading."""
         from pxr import Usd

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -5106,6 +5106,74 @@ class TestImportSampleAssetsBasic(unittest.TestCase):
         self.assertIn(static_collider.GetPath().pathString, result_no_visuals["path_shape_map"])
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_static_visual_scout_excludes_ignored_prims(self):
+        """Exclude ignored prims from static visual scout buckets."""
+        from pxr import Usd, UsdGeom
+
+        from newton._src.utils.import_usd_deformable_utils import _scout_deformable_prims  # noqa: PLC0415
+
+        stage = Usd.Stage.CreateInMemory()
+        root = UsdGeom.Xform.Define(stage, "/World")
+        UsdGeom.Cube.Define(stage, "/World/Kept")
+        UsdGeom.Cube.Define(stage, "/World/Ignored")
+
+        buckets = _scout_deformable_prims(
+            root.GetPrim(),
+            ignore_paths=["/World/Ignored"],
+            collect_static_visuals=True,
+        )
+
+        self.assertEqual([str(prim.GetPath()) for prim in buckets.static_visuals], ["/World/Kept"])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_static_gaussian_respects_loading_flag(self):
+        """Control static Gaussian splats with the static visual loading flag."""
+        from pxr import Sdf, Usd, UsdGeom
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.Xform.Define(stage, "/World")
+        gaussian = stage.DefinePrim("/World/Gaussian", "ParticleField3DGaussianSplat")
+        gaussian.CreateAttribute("positions", Sdf.ValueTypeNames.Point3fArray).Set([(0.0, 0.0, 0.0)])
+
+        builder_default = newton.ModelBuilder()
+        result_default = builder_default.add_usd(stage, root_path="/World")
+        self.assertIn(gaussian.GetPath().pathString, result_default["path_shape_map"])
+
+        builder_disabled = newton.ModelBuilder()
+        result_disabled = builder_disabled.add_usd(
+            stage,
+            root_path="/World",
+            load_static_visual_shapes=False,
+        )
+        self.assertNotIn(gaussian.GetPath().pathString, result_disabled["path_shape_map"])
+
+        builder_no_visuals = newton.ModelBuilder()
+        result_no_visuals = builder_no_visuals.add_usd(
+            stage,
+            root_path="/World",
+            load_visual_shapes=False,
+            load_static_visual_shapes=True,
+        )
+        self.assertNotIn(gaussian.GetPath().pathString, result_no_visuals["path_shape_map"])
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_disabled_static_collider_loads_as_visual(self):
+        """Load disabled static colliders as visual-only shapes."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        collider = UsdGeom.Cube.Define(stage, "/DisabledCollider")
+        collider.CreatePurposeAttr(UsdGeom.Tokens.guide)
+        UsdPhysics.CollisionAPI.Apply(collider.GetPrim()).CreateCollisionEnabledAttr(False)
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage, force_show_colliders=True)
+        flags = builder.shape_flags[result["path_shape_map"][collider.GetPath().pathString]]
+
+        self.assertFalse(flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(flags & ShapeFlags.VISIBLE)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_granular_loading_flags(self):
         """Test the granular control over sites and visual shapes loading."""
         from pxr import Usd


### PR DESCRIPTION
## Description

Import visual-only USD geometry outside rigid-body hierarchies as static Newton shapes by default. Add `load_static_visual_shapes` to `ModelBuilder.add_usd()` and `parse_usd()` as an explicit opt-out.

The importer previously loaded ordinary visual geometry only while processing rigid bodies; its standalone visual pass handled Gaussian splats only. As a result, composed static visuals such as `/Table/Visuals/TableGeom` were omitted. The new path collects supported geometry candidates during the existing deformable scout traversal, avoiding another full instance-proxy walk.

Empty-case paired benchmarks found no measurable regression:

| Scene | Disabled median | Enabled median | Difference |
| --- | ---: | ---: | ---: |
| 500 rigid visual candidates, no static visuals (12 runs) | 376.53 ms | 376.12 ms | -0.11% |
| Franka robot subtree, no static visuals (6 runs) | 2444.27 ms | 2438.04 ms | -0.26% |

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated for this user-facing change

## Test plan

- Verified the default-import assertion fails against unmodified `origin/main`.
- `uv run --extra dev python -m unittest newton.tests.test_import_usd.TestImportSampleAssetsBasic.test_static_visual_shapes_loading_flag -v`
- `uv run --extra dev python -m unittest newton.tests.test_import_usd` - 280 tests passed.
- Ran Ruff lint/format checks, typos 1.48.0, the Warp array-syntax checker, and `git diff --check` directly.
- `uvx pre-commit run -a` could not start because the local Git 2.30.0 does not support the `git ls-files --deduplicate` option required by the installed pre-commit version.

## Bug fix

**Steps to reproduce:**

1. Create or open a USD stage containing visual geometry outside a rigid-body hierarchy.
2. Import the stage with `ModelBuilder.add_usd()`.
3. Observe that the visual prim is absent from `path_shape_map` on `main`.

**Minimal reproduction:**

```python
import newton
from pxr import Usd, UsdGeom

stage = Usd.Stage.CreateInMemory()
UsdGeom.Xform.Define(stage, "/World")
UsdGeom.Cube.Define(stage, "/World/VisualCube")

result = newton.ModelBuilder().add_usd(stage, root_path="/World")
assert "/World/VisualCube" in result["path_shape_map"]
```

## New feature / API change

```python
import newton

builder = newton.ModelBuilder()
builder.add_usd(stage)  # Static visual-only shapes are loaded by default.
builder.add_usd(stage, load_static_visual_shapes=False)  # Explicit opt-out.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - USD imports now load supported “visual-only” geometry outside rigid-body hierarchies as static shapes by default.
  - Added `load_static_visual_shapes` to control this behavior independently of other visual loading.
- **Bug Fixes**
  - Refined visual-shape loading logic, including more precise traversal/recursion handling and candidate filtering.
- **Documentation**
  - Updated USD importer documentation and the Unreleased changelog to reflect the new option.
- **Tests**
  - Added tests covering `load_static_visual_shapes` interactions with static visuals, colliders, and dynamic visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

