### PR TITLE
Fix SolverVBD per-world particle gravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
+- Fix `SolverVBD` particles using world 0 gravity in multi-world models instead of their assigned world's gravity. (#3692)
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix `eval_ik()` and `SolverSemiImplicit` rounding small float32 revolute-joint angles to zero. (#3434)

--- a/newton/_src/solvers/vbd/particle_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/particle_vbd_kernels.py
@@ -1351,6 +1351,7 @@ def compute_friction(mu: float, normal_contact_force: float, T: mat32, u: wp.vec
 def forward_step(
     dt: float,
     gravity: wp.array[wp.vec3],
+    particle_world: wp.array[wp.int32],
     pos_prev: wp.array[wp.vec3],
     pos: wp.array[wp.vec3],
     vel: wp.array[wp.vec3],
@@ -1368,7 +1369,9 @@ def forward_step(
         if displacements_out:
             displacements_out[particle] = wp.vec3(0.0, 0.0, 0.0)
         return
-    vel_new = vel[particle] + (gravity[0] + external_force[particle] * inv_mass[particle]) * dt
+    world_idx = particle_world[particle]
+    world_g = gravity[wp.max(world_idx, 0)]
+    vel_new = vel[particle] + (world_g + external_force[particle] * inv_mass[particle]) * dt
     inertia = pos[particle] + vel_new * dt
     inertia_out[particle] = inertia
     if displacements_out:

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -2082,6 +2082,7 @@ class SolverVBD(SolverBase, CouplingInterface):
             inputs=[
                 dt,
                 model.gravity,
+                model.particle_world,
                 self.particle_q_prev,
                 state_in.particle_q,
                 state_in.particle_qd,

--- a/newton/tests/test_runtime_gravity.py
+++ b/newton/tests/test_runtime_gravity.py
@@ -8,7 +8,7 @@ import numpy as np
 import warp as wp
 
 import newton
-from newton.solvers import SolverKamino, SolverSemiImplicit, SolverXPBD
+from newton.solvers import SolverKamino, SolverSemiImplicit, SolverVBD, SolverXPBD
 from newton.tests.unittest_utils import add_function_test, get_test_devices
 
 
@@ -316,6 +316,27 @@ def test_per_world_gravity_bodies(test, device, solver_fn):
 
     # World 2 (full gravity) should be falling fastest
     test.assertLess(z_vel_world2, -0.5)
+
+
+def test_per_world_gravity_particles_vbd(test, device):
+    """Verify SolverVBD applies each world's gravity to its particles."""
+    builder = newton.ModelBuilder()
+    for x in (0.0, 1.0):
+        builder.begin_world()
+        builder.add_particle(pos=(x, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=1.0)
+        builder.end_world()
+
+    builder.color()
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, -1.0), world=0)
+    model.set_gravity((0.0, 0.0, -5.0), world=1)
+
+    state_in, state_out = model.state(), model.state()
+    solver = SolverVBD(model)
+    solver.step(state_in, state_out, model.control(), None, 0.1)
+
+    np.testing.assert_allclose(state_out.particle_qd.numpy()[:, 2], [-0.1, -0.5], atol=1.0e-6)
+    np.testing.assert_allclose(state_out.particle_q.numpy()[:, 2], [-0.01, -0.05], atol=1.0e-6)
 
 
 def test_per_world_gravity_bodies_mujoco_warp(test, device):
@@ -712,6 +733,13 @@ for device in devices:
             devices=[device],
             solver_fn=solver_fn,
         )
+
+    add_function_test(
+        TestRuntimeGravity,
+        "test_per_world_gravity_particles_vbd",
+        test_per_world_gravity_particles_vbd,
+        devices=[device],
+    )
 
     # Per-world gravity for MuJoCo Warp (only on CUDA - CPU MuJoCo uses single gravity)
     if device.is_cuda:


### PR DESCRIPTION
## Description

Fixes #3692.

`SolverVBD`'s particle forward step always selected `gravity[0]`, so
world-local particles ignored the gravity assigned to their world.

Pass `model.particle_world` to the kernel and select the corresponding
gravity while preserving world 0 as the fallback for global particles.
Add a two-world regression test covering particle velocities and
positions after one VBD step.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv run --extra dev -m newton.tests -k test_per_world_gravity_particles_vbd`
- `uv run --extra dev -m newton.tests -k test_runtime_gravity`
- `uv run --extra dev -m newton.tests -k test_solver_vbd`
- `uvx pre-commit run -a`

All applicable tests passed on the CPU backend. CUDA was unavailable in
this environment, so CUDA-specific tests were skipped.

## Bug fix

**Steps to reproduce:**

1. Create particles assigned to two different worlds.
2. Configure a different gravity value for each world.
3. Advance the model with `SolverVBD`.
4. Observe that both particles use world 0's gravity without this fix.

**Minimal reproduction:**

See `test_per_world_gravity_particles_vbd` in
`newton/tests/test_runtime_gravity.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed particle gravity handling for `SolverVBD` simulations with multiple worlds.
  - Particles now apply the gravity assigned to their own world instead of always using world 0’s gravity.
- **Tests**
  - Added a unit test that validates per-world gravity updates particle velocities and positions for `SolverVBD`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->