### PR TITLE
Fix shared USD collider visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
+- Fix `ModelBuilder.add_usd()` hiding default- and proxy-purpose collision prims that also serve as visual geometry.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
 - Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -1200,11 +1200,9 @@ def parse_usd(
 
         USD viewports draw the ``default`` and ``proxy`` purposes and hide ``guide`` and
         ``render``; the allowlist also keeps any future purpose hidden until explicitly
-        handled. Colliders deliberately do not use this check: ``guide`` is the conventional
-        purpose for authored collision geometry (e.g. the MuJoCo USD exporter), and the
-        collider display policy (``force_show_colliders`` / ``hide_collision_shapes``) is the
-        explicit mechanism for revealing colliders — gating them on purpose would make
-        ``force_show_colliders`` a no-op on such assets.
+        handled. For colliders, this identifies geometry authored to serve as both a visual
+        and collision shape. Explicit collider display remains independent of purpose so
+        ``force_show_colliders`` can still reveal ``guide`` geometry for debugging.
         """
         if not _is_effectively_visible(prim):
             return False
@@ -3370,9 +3368,10 @@ def parse_usd(
                     model_has_visual_shapes=model_has_visual_shapes,
                 )
                 collider_is_visible = (
-                    show_collider_by_policy or collider_has_visual_material
+                    show_collider_by_policy or collider_has_visual_material or _is_viewport_drawn(prim)
                 ) and not hide_collider_for_body
-                # visibility only — see _is_viewport_drawn for why purpose does not gate colliders
+                # Explicit collider display may reveal guide geometry, but inherited
+                # visibility still applies.
                 collider_is_visible = collider_is_visible and _is_effectively_visible(prim)
 
                 # Contact response precedence:

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -10950,8 +10950,7 @@ class TestImportSampleAssetsComposition(unittest.TestCase):
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_collision_shape_visibility_flags(self):
-        """Collision shapes on bodies with visual shapes should not have the
-        VISIBLE flag so they are toggleable via the viewer's 'Show Collision'."""
+        """Keep guide-purpose collision shapes hidden in mixed USD imports."""
         from pxr import Usd
 
         usd_content = """#usda 1.0
@@ -10975,6 +10974,7 @@ def Xform "BodyWithVisuals" (
     )
     {
         double size = 1.0
+        token purpose = "guide"
     }
 
     def Sphere "VisualSphere"
@@ -10995,6 +10995,7 @@ def Xform "BodyWithoutVisuals" (
     )
     {
         double radius = 0.5
+        token purpose = "guide"
     }
 }
 """
@@ -11050,6 +11051,41 @@ def Xform "BodyWithoutVisuals" (
         flags_no_load = builder4.shape_flags[collision_no_load]
         self.assertTrue(flags_no_load & ShapeFlags.COLLIDE_SHAPES)
         self.assertTrue(flags_no_load & ShapeFlags.VISIBLE)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_shared_collision_visual_geometry_is_visible(self):
+        """Keep renderable USD colliders visible when geometry is shared."""
+        from pxr import Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+
+        shared_body = UsdGeom.Xform.Define(stage, "/World/SharedGeometryBody").GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(shared_body)
+        shared_geometry = UsdGeom.Cube.Define(stage, "/World/SharedGeometryBody/SharedGeometry").GetPrim()
+        UsdPhysics.CollisionAPI.Apply(shared_geometry)
+
+        separate_body = UsdGeom.Xform.Define(stage, "/World/SeparateGeometryBody").GetPrim()
+        UsdPhysics.RigidBodyAPI.Apply(separate_body)
+        guide_collider = UsdGeom.Cube.Define(stage, "/World/SeparateGeometryBody/Collider").GetPrim()
+        UsdPhysics.CollisionAPI.Apply(guide_collider)
+        UsdGeom.Imageable(guide_collider).CreatePurposeAttr().Set(UsdGeom.Tokens.guide)
+        UsdGeom.Sphere.Define(stage, "/World/SeparateGeometryBody/Visual")
+
+        builder = newton.ModelBuilder()
+        result = builder.add_usd(stage)
+        path_shape_map = result["path_shape_map"]
+
+        shared_flags = builder.shape_flags[path_shape_map["/World/SharedGeometryBody/SharedGeometry"]]
+        self.assertTrue(shared_flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertTrue(shared_flags & ShapeFlags.VISIBLE)
+
+        guide_flags = builder.shape_flags[path_shape_map["/World/SeparateGeometryBody/Collider"]]
+        self.assertTrue(guide_flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertFalse(guide_flags & ShapeFlags.VISIBLE)
+
+        visual_flags = builder.shape_flags[path_shape_map["/World/SeparateGeometryBody/Visual"]]
+        self.assertFalse(visual_flags & ShapeFlags.COLLIDE_SHAPES)
+        self.assertTrue(visual_flags & ShapeFlags.VISIBLE)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_collision_only_asset_keeps_colliders_visible(self):
@@ -11488,11 +11524,12 @@ def Xform "Body" (
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_primitive_collider_with_roughness_only_material_stays_hidden(self):
-        """Primitive (non-mesh) colliders must not become visible from roughness-only materials.
+        """Keep guide-purpose primitive colliders hidden with roughness-only materials.
 
         When a body already has visual shapes, ``show_collider_by_policy`` is
-        ``False``. Only ``collider_has_visual_material`` can promote a collider
-        to visible, and that promotion is restricted to mesh colliders only.
+        ``False`` and guide geometry is not viewport-drawn. Only
+        ``collider_has_visual_material`` can promote the collider to visible,
+        and that promotion is restricted to mesh colliders only.
         """
         from pxr import Sdf, Usd, UsdGeom, UsdPhysics, UsdShade
 
@@ -11521,6 +11558,7 @@ def Xform "Body" (
         # Add a collision box with a roughness-only PBR material.
         box_prim = UsdGeom.Cube.Define(stage, "/Body/CollisionBox").GetPrim()
         UsdPhysics.CollisionAPI.Apply(box_prim)
+        UsdGeom.Imageable(box_prim).CreatePurposeAttr().Set(UsdGeom.Tokens.guide)
         material = UsdShade.Material.Define(stage, "/Materials/RoughnessOnly")
         shader = UsdShade.Shader.Define(stage, "/Materials/RoughnessOnly/PreviewSurface")
         shader.CreateIdAttr("UsdPreviewSurface")


### PR DESCRIPTION
## Description

Preserve visibility for USD collision prims whose effective purpose is `default` or `proxy`, allowing one geometry prim to serve as both visual and collision geometry.

Previously, collider fallback visibility was scoped to the whole import: once any separate visual geometry was present, colliders elsewhere lost `ShapeFlags.VISIBLE`. This hid a default-purpose shared collider merely because another body authored a separate visual shape. The importer now uses its existing viewport-purpose predicate when deciding collider visibility. Dedicated `guide` colliders remain hidden by default, while `force_show_colliders=True` still reveals them for debugging.

The existing collision-only tests now explicitly author dedicated proxies as `purpose="guide"`, and a new in-memory USD test covers mixed shared and separate geometry.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

- `uv run --extra dev python -m unittest newton.tests.test_import_usd`
- `uvx pre-commit run -a`

## Bug fix

**Steps to reproduce:**

1. Create a USD stage with a default-purpose collider that is also intended as visual geometry.
2. Add separate visual geometry on another body and a dedicated guide-purpose collider.
3. Import with `ModelBuilder.add_usd(..., force_show_colliders=False)`.
4. Observe that the shared collider is collision-enabled but lacks `ShapeFlags.VISIBLE`.

**Minimal reproduction:**

```python
from pxr import Usd, UsdGeom, UsdPhysics

import newton

stage = Usd.Stage.CreateInMemory()

shared_body = UsdGeom.Xform.Define(stage, "/World/SharedBody").GetPrim()
UsdPhysics.RigidBodyAPI.Apply(shared_body)
shared = UsdGeom.Cube.Define(stage, "/World/SharedBody/Geometry").GetPrim()
UsdPhysics.CollisionAPI.Apply(shared)

separate_body = UsdGeom.Xform.Define(stage, "/World/SeparateBody").GetPrim()
UsdPhysics.RigidBodyAPI.Apply(separate_body)
UsdGeom.Sphere.Define(stage, "/World/SeparateBody/Visual")

builder = newton.ModelBuilder()
result = builder.add_usd(stage)
shared_flags = builder.shape_flags[result["path_shape_map"]["/World/SharedBody/Geometry"]]
assert shared_flags & newton.ShapeFlags.VISIBLE
assert shared_flags & newton.ShapeFlags.COLLIDE_SHAPES
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed USD collider visibility so collision geometry shared with visual purposes remains visible in the viewport.
  * Colliders marked for guide purposes remain hidden when appropriate, while their corresponding visual geometry stays visible.
  * Improved handling of collision shapes with material properties and viewport display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->