### PR TITLE
Forward MJCF ball-joint damping into joint_damping (fixes #3703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - Fix hydroelastic primitive texture SDF generation to sample analytic primitive distances instead of temporary tessellated meshes. (#3239)
 - Fix MJCF, URDF, and USD imports rendering collision-only bodies as visuals when the asset authors visual geometry elsewhere. (#3291)
 - Fix `SchemaResolverPhysx` reading every D6 translational limit gain from the `linear` instance instead of its `transX`, `transY`, or `transZ` instance.
+- Fix MJCF import of a `<joint type="ball" damping="...">` discarding the authored damping and falling back to `ModelBuilder.default_joint_cfg.damping`, which raised a conflict at `finalize()` when a non-zero default damping was set. (#3703)
 - Fix USD capsule, cylinder, and cone visuals and sites without authored `radius`/`height` to use the UsdGeom schema fallbacks, matching collision shapes.
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)
 - Fix loading of textures packaged inside `.usdz` archives; package-relative asset paths such as `scene.usdz[tex.png]` are resolved through USD's asset resolver instead of being treated as filesystem paths.

--- a/newton/_src/utils/import_mjcf.py
+++ b/newton/_src/utils/import_mjcf.py
@@ -1686,6 +1686,11 @@ def parse_mjcf(
             # frictionloss for a native <joint type="ball"/>; captured in the ball branch
             # and read by the add_joint_ball call. Default 0.0 matches MJCF.
             ball_friction = 0.0
+            # Passive damping for a native <joint type="ball"/>; captured in the ball
+            # branch and forwarded to the add_joint_ball call. Falls back to the
+            # builder's default damping when the joint does not author one, matching
+            # the generic joint path (see the add_joint call below).
+            ball_damping = default_joint_damping
             joints = body.findall("joint")
             for i, joint in enumerate(joints):
                 joint_attrib = resolve_element_attrib(joint, "joint", defaults)
@@ -1734,6 +1739,9 @@ def parse_mjcf(
                     # Lift frictionloss into the builder's per-DOF friction array so it
                     # reaches the MuJoCo spec (joint_friction[qd_start]) on export.
                     ball_friction = parse_float(joint_attrib, "frictionloss", 0.0)
+                    # Forward the authored passive damping so it lands in joint_damping
+                    # rather than silently being replaced by default_joint_cfg.damping.
+                    ball_damping = parse_float(joint_attrib, "damping", default_joint_damping)
                     mjcf_joint_dof_offsets.append((joint_name[-1], current_dof_index))
                     current_dof_index += 3
                     break
@@ -1977,6 +1985,7 @@ def parse_mjcf(
                     child_xform=wp.transform(joint_pos, wp.quat_identity()),
                     armature=joint_armature[-1] if joint_armature else None,
                     friction=ball_friction,
+                    damping=ball_damping,
                     label=joint_label,
                     custom_attributes=joint_custom_attributes | dof_custom_attributes,
                 )

--- a/newton/tests/test_joint_damping.py
+++ b/newton/tests/test_joint_damping.py
@@ -212,6 +212,41 @@ def test_add_joint_ball_sets_passive_damping(test: TestJointDamping, device):
     np.testing.assert_allclose(model.joint_damping.numpy()[0:3], [2.5, 2.5, 2.5])
 
 
+def test_mjcf_ball_joint_damping_overrides_default(test: TestJointDamping, device):
+    # Regression test for gh #3703: an MJCF <joint type="ball" damping="..."> must
+    # forward its authored damping into joint_damping instead of silently falling
+    # back to default_joint_cfg.damping. Before the fix, importing with a non-zero
+    # default_joint_cfg.damping raised a ValueError at finalize() because the parsed
+    # damping (recorded in the deprecated dof_passive_damping alias) disagreed with
+    # the default that add_joint_ball wrote into joint_damping.
+    xml = """
+    <mujoco><worldbody><body name="base"><geom type="sphere" size="0.05" mass="1"/>
+      <body name="link" pos="0.1 0 0"><joint name="ball" type="ball" damping="7"/>
+      <geom type="sphere" size="0.04" mass="0.5"/></body></body></worldbody></mujoco>
+    """
+    for default_damping in (0.0, 99.0):
+        builder = newton.ModelBuilder()
+        builder.default_joint_cfg.damping = default_damping
+        builder.add_mjcf(xml)
+        model = builder.finalize(device=device)
+        np.testing.assert_allclose(model.joint_damping.numpy()[0:3], [7.0, 7.0, 7.0])
+
+
+def test_mjcf_ball_joint_damping_falls_back_to_default(test: TestJointDamping, device):
+    # Companion to test_mjcf_ball_joint_damping_overrides_default: when the MJCF ball
+    # joint does not author a damping, the builder default must still apply.
+    xml = """
+    <mujoco><worldbody><body name="base"><geom type="sphere" size="0.05" mass="1"/>
+      <body name="link" pos="0.1 0 0"><joint name="ball" type="ball"/>
+      <geom type="sphere" size="0.04" mass="0.5"/></body></body></worldbody></mujoco>
+    """
+    builder = newton.ModelBuilder()
+    builder.default_joint_cfg.damping = 3.5
+    builder.add_mjcf(xml)
+    model = builder.finalize(device=device)
+    np.testing.assert_allclose(model.joint_damping.numpy()[0:3], [3.5, 3.5, 3.5])
+
+
 devices = get_test_devices()
 solvers = {
     "featherstone": (lambda model: newton.solvers.SolverFeatherstone(model, angular_damping=0.0), False),
@@ -247,6 +282,18 @@ for device in devices:
         TestJointDamping,
         "test_add_joint_ball_sets_passive_damping",
         test_add_joint_ball_sets_passive_damping,
+        devices=[device],
+    )
+    add_function_test(
+        TestJointDamping,
+        "test_mjcf_ball_joint_damping_overrides_default",
+        test_mjcf_ball_joint_damping_overrides_default,
+        devices=[device],
+    )
+    add_function_test(
+        TestJointDamping,
+        "test_mjcf_ball_joint_damping_falls_back_to_default",
+        test_mjcf_ball_joint_damping_falls_back_to_default,
         devices=[device],
     )
 


### PR DESCRIPTION
## What was wrong

Importing an MJCF `<joint type="ball" damping="...">` into a `ModelBuilder` whose
`default_joint_cfg.damping` is non-zero fails at `finalize()`:

```
ValueError: Model.mujoco.dof_passive_damping conflicts with Model.joint_damping
at DOF 0: 7.0 != 99.0.
```

The MJCF parser records the ball joint's authored damping in the deprecated
`mujoco.dof_passive_damping` custom attribute, but the native-ball-joint branch
called `ModelBuilder.add_joint_ball()` **without** a `damping` argument. With no
value passed, `add_joint_ball` falls back to `default_joint_cfg.damping` and writes
*that* into the canonical `joint_damping` array. The two paths then disagree, and
`_finalize_deprecated_dof_passive_damping` raises when the canonical value is
non-zero and differs from the aliased value.

With the default builder configuration (`default_joint_cfg.damping == 0`) the bug
is masked, because the zero canonical value is simply overwritten by the alias. It
only surfaces for callers that set a non-zero default damping before importing —
which is a reasonable thing to do.

## The fix

The native ball branch already captures `frictionloss` into a local (`ball_friction`)
and forwards it to `add_joint_ball(friction=...)`. This does the same for damping:
it captures the authored `<joint ... damping="...">` value into `ball_damping`
(falling back to the builder's default when the joint doesn't author one, matching
the generic joint path) and forwards it as `add_joint_ball(damping=ball_damping)`.

So the authored MJCF damping now lands directly in `joint_damping`, the alias and
canonical paths agree, and `finalize()` no longer raises. When the joint authors no
damping, behaviour is unchanged (the builder default still applies).

Diffstat:

```
 CHANGELOG.md                       |  1 +
 newton/_src/utils/import_mjcf.py   |  9 +++++++
 newton/tests/test_joint_damping.py | 47 ++++++++++++++++++++++++++++++++++++
```

## How it was tested

Reproduction from the issue, before vs. after:

```
# before: default=0.0 -> [7 7 7]; default=99.0 -> ValueError (conflict)
# after:  default=0.0 -> [7 7 7]; default=99.0 -> [7 7 7]
```

Added two regression tests to `newton/tests/test_joint_damping.py`, mirroring the
existing `test_add_joint_ball_sets_passive_damping`:

- `test_mjcf_ball_joint_damping_overrides_default` — an MJCF ball joint with
  `damping="7"` yields `joint_damping == [7, 7, 7]` for both
  `default_joint_cfg.damping = 0.0` and `= 99.0`.
- `test_mjcf_ball_joint_damping_falls_back_to_default` — an MJCF ball joint with no
  authored damping falls back to the builder default (`3.5 -> [3.5, 3.5, 3.5]`).

I confirmed RED→GREEN: with the one-line forward removed the override test fails
with exactly the `dof_passive_damping conflicts with joint_damping` ValueError;
with the fix in place both new tests pass.

Full local runs (CPU):

- `test_joint_damping` — 20 pre-existing + 2 new tests pass.
- `test_import_mjcf` — 237 tests pass (no regressions in the MJCF importer).
- `pre-commit run --files <changed>` — ruff, ruff-format, typos, and the warp-array
  syntax check all pass.

Fixes #3703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MJCF imports for ball joints so authored damping values are preserved.
  * Ball joints without an authored damping value now correctly use the configured default damping.
  * Prevented damping conflicts during model finalization when importing MJCF files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->