### PR TITLE
Fix small-angle revolute joint reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
+- Fix `eval_ik()` and `SolverSemiImplicit` rounding small float32 revolute-joint angles to zero. (#3434)
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.
 - Fix `FastKitchenG1` ASV metrics to build the kitchen scene instead of a plain G1 model.
 - Fix the `diffsim_bear` example crashing with its default CUDA configuration and diverging after a few training iterations.

--- a/newton/_src/sim/articulation.py
+++ b/newton/_src/sim/articulation.py
@@ -631,8 +631,7 @@ def reconstruct_angular_q_qd(q_pc: wp.quat, w_err: wp.vec3, X_wp: wp.transform, 
         qd: The joint velocity coordinate.
     """
     axis_p = wp.transform_vector(X_wp, axis)
-    twist = wp.quat_twist(axis, q_pc)
-    q = wp.acos(twist[3]) * 2.0 * wp.sign(wp.dot(axis, wp.vec3(twist[0], twist[1], twist[2])))
+    q = wp.quat_twist_angle_signed(axis, q_pc)
     qd = wp.dot(w_err, axis_p)
     return q, qd
 

--- a/newton/_src/solvers/semi_implicit/kernels_body.py
+++ b/newton/_src/solvers/semi_implicit/kernels_body.py
@@ -203,10 +203,7 @@ def eval_body_joints(
         axis_p = wp.transform_vector(X_wp, axis)
         axis_c = wp.transform_vector(X_wc, axis)
 
-        # swing twist decomposition
-        twist = wp.quat_twist(axis, r_err)
-
-        q = wp.acos(twist[3]) * 2.0 * wp.sign(wp.dot(axis, wp.vec3(twist[0], twist[1], twist[2])))
+        q = wp.quat_twist_angle_signed(axis, r_err)
         qd = wp.dot(w_err, axis_p)
 
         t_total = axis_p * (
@@ -346,10 +343,7 @@ def eval_body_joints(
             axis_p = wp.transform_vector(X_wp, axis)
             axis_c = wp.transform_vector(X_wc, axis)
 
-            # swing twist decomposition
-            twist = wp.quat_twist(axis, r_err)
-
-            q = wp.acos(twist[3]) * 2.0 * wp.sign(wp.dot(axis, wp.vec3(twist[0], twist[1], twist[2])))
+            q = wp.quat_twist_angle_signed(axis, r_err)
             qd = wp.dot(w_err, axis_p)
 
             t_total = axis_p * (

--- a/newton/tests/test_kinematics.py
+++ b/newton/tests/test_kinematics.py
@@ -92,6 +92,25 @@ def test_fk_ik(test, device):
     assert_np_equal(qd_fk, qd_ik.numpy(), tol=1e-6)
 
 
+def test_fk_ik_revolute_small_angles(test, device):
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+    child = builder.add_link()
+    joint = builder.add_joint_revolute(parent=-1, child=child, axis=newton.Axis.Z)
+    builder.add_articulation([joint])
+    model = builder.finalize(device=device)
+
+    state = model.state()
+    q_ik = wp.zeros_like(model.joint_q, device=device)
+    qd_ik = wp.zeros_like(model.joint_qd, device=device)
+    angles = np.array([-4.0, -5.0e-4, -1.0e-4, 1.0e-4, 5.0e-4, 4.0], dtype=np.float32)
+
+    for angle in angles:
+        state.joint_q.assign(np.array([angle], dtype=np.float32))
+        newton.eval_fk(model, state.joint_q, state.joint_qd, state)
+        newton.eval_ik(model, state, q_ik, qd_ik)
+        test.assertAlmostEqual(float(q_ik.numpy()[0]), float(angle), delta=1.0e-6)
+
+
 def test_fk_ik_with_analytical_solution(test, device):
     # Verify FK computes correct positions for a 2-link planar arm, and IK recovers joint angles.
     # Test parameters: length of the two links
@@ -1095,6 +1114,12 @@ class TestSimKinematics(unittest.TestCase):
 
 
 add_function_test(TestSimKinematics, "test_fk_ik", test_fk_ik, devices=devices)
+add_function_test(
+    TestSimKinematics,
+    "test_fk_ik_revolute_small_angles",
+    test_fk_ik_revolute_small_angles,
+    devices=devices,
+)
 add_function_test(
     TestSimKinematics, "test_fk_ik_with_analytical_solution", test_fk_ik_with_analytical_solution, devices=devices
 )


### PR DESCRIPTION
## Description

Fix `eval_ik()` and `SolverSemiImplicit` reconstructing small float32
revolute-joint angles as zero.

The previous calculation recovered the angle with `acos(twist.w)`. Near
the identity rotation, float32 error can make `twist.w` exactly round to `1.0`
while the quaternion vector still contains a small signed rotation. This
creates a dead zone around zero.

Use Warp's `wp.quat_twist_angle_signed()` helper instead. It uses the
remaining signed quaternion information and preserves noncanonical
branches such as `+4.0 rad`.

Added an FK/IK regression test covering:

- `±0.0001 rad`
- `±0.0005 rad`
- `±4.0 rad`
- CPU and CUDA

Closes #3434.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan


- `uv run python -u newton/tests/test_kinematics.py -k test_fk_ik_revolute_small_angles`
- `uv run python -u newton/tests/test_kinematics.py`
- `uv run --extra dev -m newton.tests -k semi_implicit`
- `uvx pre-commit run -a`


The new regression test was also run temporarily with the old reconstruction
expression. It failed because `-0.0005 rad` reconstructed as `-0.0`, then
passed after restoring the fix.

## Bug fix

**Steps to reproduce:**

1. Create an articulation containing one revolute joint.
2. Set its coordinate to a small float32 angle such as `-0.0005 rad`.
3. Run `eval_fk()` followed by `eval_ik()`.
4. Observe that the previous implementation returns `-0.0` instead of
   the original joint coordinate.

**Minimal reproduction:**

```python
import numpy as np
import warp as wp

import newton

builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
child = builder.add_link()
joint = builder.add_joint_revolute(
    parent=-1,
    child=child,
    axis=newton.Axis.Z,
)
builder.add_articulation([joint])
model = builder.finalize()

state = model.state()
state.joint_q.assign(np.array([-5.0e-4], dtype=np.float32))
newton.eval_fk(model, state.joint_q, state.joint_qd, state)

q_ik = wp.zeros_like(model.joint_q)
qd_ik = wp.zeros_like(model.joint_qd)
newton.eval_ik(model, state, q_ik, qd_ik)

print(q_ik.numpy()[0])
# Before: -0.0
# After:  -0.0005
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inverse kinematics and semi-implicit solver handling of very small revolute-joint angles, preventing valid float32 values from being rounded to zero.
  * Improved signed angle calculations for revolute and single-axis rotational joints.

* **Tests**
  * Added regression coverage for forward and inverse kinematics with small positive and negative revolute-joint angles.

* **Documentation**
  * Updated the changelog with details of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->