### PR TITLE
Update Kamino Jacobians to Newton free joint wrench convention

### DIFF
--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -59,6 +59,65 @@ wp.set_module_options({"enable_backward": False, "default_grid_stride": False})
 ###
 
 
+@wp.func
+def build_full_joint_jacobian(
+    joint_id: wp.int32,
+    dof_type: wp.int32,
+    bid_B: wp.int32,
+    bid_F: wp.int32,
+    model_joints_X_Bj: wp.array[wp.mat33f],
+    model_joints_X_Fj: wp.array[wp.mat33f],
+    state_joints_p: wp.array[wp.transformf],
+    state_bodies_q: wp.array[wp.transformf],
+):
+    """
+    Computes the full (6x6) joint Jacobian (constraint and DoFs) for a specific joint.
+    """
+    # Retrieve the pose transform of the joint
+    T_j = state_joints_p[joint_id]
+    r_j = wp.transform_get_translation(T_j)
+    R_X_j = wp.quat_to_matrix(wp.transform_get_rotation(T_j))
+
+    # Retrieve the pose transforms of each body
+    T_B_j = wp.transform_identity()
+    if bid_B > -1:
+        T_B_j = state_bodies_q[bid_B]
+    T_F_j = state_bodies_q[bid_F]
+    r_B_j = wp.transform_get_translation(T_B_j)
+    r_F_j = wp.transform_get_translation(T_F_j)
+
+    if dof_type == JointDoFType.FREE:
+        # By Newton's convention, a free joint's twist and wrench (specified in `joint_qd` and
+        # `joint_f`) are both defined at the child's center of mass, with world-aligned axes. Since
+        # Kamino avoids a conversion, the change of reference frame needs to be taken into account
+        # in the Jacobian.
+        JT_F_j = wp.identity(n=6, dtype=wp.float32)
+        JT_B_j = -screw_transform_matrix_from_points(r_F_j, r_B_j)
+
+    else:
+        # Compute the wrench matrices
+        # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
+        W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
+        W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
+
+        # General case: Compute the effective projector to joint frame and expand to 6D
+        if dof_type != JointDoFType.UNIVERSAL:
+            R_X_bar_j = expand6d(R_X_j)
+        # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
+        else:
+            j_q_j = compute_joint_relative_quaternion(
+                T_B_j, T_F_j, model_joints_X_Bj[joint_id], model_joints_X_Fj[joint_id]
+            )
+            R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
+            R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
+
+        # Compute the extended jacobians, i.e. without the selection-matrix multiplication
+        JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
+        JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
+
+    return JT_B_j, JT_F_j
+
+
 def make_store_joint_jacobian_dense_func(axes: Any):
     """
     Generates a warp function to store body-pair Jacobian blocks into a target flat
@@ -472,45 +531,17 @@ def _build_joint_jacobians_dense(
     J_jdc_row_start = J_cjmio + nbd * (jdcgo + dyn_cts_offset_world)
     J_jkc_row_start = J_cjmio + nbd * (jkcgo + kin_cts_offset_world)
 
-    # Retrieve the pose transform of the joint
-    T_j = state_joints_p[jid]
-    r_j = wp.transform_get_translation(T_j)
-    R_X_j = wp.quat_to_matrix(wp.transform_get_rotation(T_j))
-
-    # Retrieve the pose transforms of each body
-    T_B_j = wp.transform_identity()
-    if bid_B > -1:
-        T_B_j = state_bodies_q[bid_B]
-    T_F_j = state_bodies_q[bid_F]
-    r_B_j = wp.transform_get_translation(T_B_j)
-    r_F_j = wp.transform_get_translation(T_F_j)
-
-    if dof_type == JointDoFType.FREE:
-        # By Newton's convention, a free joint's twist and wrench (specified in `joint_qd` and
-        # `joint_f`) are both defined at the child's center of mass, with world-aligned axes. Since
-        # Kamino avoids a conversion, the change of reference frame needs to be taken into account
-        # in the Jacobian.
-        JT_F_j = wp.identity(n=6, dtype=wp.float32)
-        JT_B_j = -screw_transform_matrix_from_points(r_F_j, r_B_j)
-
-    else:
-        # Compute the wrench matrices
-        # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
-        W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
-        W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
-
-        # General case: Compute the effective projector to joint frame and expand to 6D
-        if dof_type != JointDoFType.UNIVERSAL:
-            R_X_bar_j = expand6d(R_X_j)
-        # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
-        else:
-            j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
-            R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
-            R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
-
-        # Compute the extended jacobians, i.e. without the selection-matrix multiplication
-        JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
-        JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
+    # Compute the full jacobians, i.e. without the selection-matrix multiplication
+    JT_B_j, JT_F_j = build_full_joint_jacobian(
+        jid,
+        dof_type,
+        bid_B,
+        bid_F,
+        model_joints_X_Bj,
+        model_joints_X_Fj,
+        state_joints_p,
+        state_bodies_q,
+    )
 
     # Store joint dynamic constraint jacobians if applicable
     # NOTE: We use the extraction method for DoFs since dynamic constraints are in DoF-space
@@ -570,45 +601,17 @@ def _build_joint_jacobians_sparse(
     bid_B = model_joints_bid_B[jid]
     bid_F = model_joints_bid_F[jid]
 
-    # Retrieve the pose transform of the joint
-    T_j = state_joints_p[jid]
-    r_j = wp.transform_get_translation(T_j)
-    R_X_j = wp.quat_to_matrix(wp.transform_get_rotation(T_j))
-
-    # Retrieve the pose transforms of each body
-    T_B_j = wp.transform_identity()
-    if bid_B > -1:
-        T_B_j = state_bodies_q[bid_B]
-    T_F_j = state_bodies_q[bid_F]
-    r_B_j = wp.transform_get_translation(T_B_j)
-    r_F_j = wp.transform_get_translation(T_F_j)
-
-    if dof_type == JointDoFType.FREE:
-        # By Newton's convention, a free joint's twist and wrench (specified in `joint_qd` and
-        # `joint_f`) are both defined at the child's center of mass, with world-aligned axes. Since
-        # Kamino avoids a conversion, the change of reference frame needs to be taken into account
-        # in the Jacobian.
-        JT_F_j = wp.identity(n=6, dtype=wp.float32)
-        JT_B_j = -screw_transform_matrix_from_points(r_F_j, r_B_j)
-
-    else:
-        # Compute the wrench matrices
-        # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
-        W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
-        W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
-
-        # General case: Compute the effective projector to joint frame and expand to 6D
-        if dof_type != JointDoFType.UNIVERSAL:
-            R_X_bar_j = expand6d(R_X_j)
-        # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
-        else:
-            j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
-            R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
-            R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
-
-        # Compute the extended jacobians, i.e. without the selection-matrix multiplication
-        JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
-        JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
+    # Compute the full jacobians, i.e. without the selection-matrix multiplication
+    JT_B_j, JT_F_j = build_full_joint_jacobian(
+        jid,
+        dof_type,
+        bid_B,
+        bid_F,
+        model_joints_X_Bj,
+        model_joints_X_Fj,
+        state_joints_p,
+        state_bodies_q,
+    )
 
     # Store joint dynamic constraint jacobians if applicable
     # NOTE: We use the extraction method for DoFs since dynamic constraints are in DoF-space

--- a/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
+++ b/newton/_src/solvers/kamino/_src/kinematics/jacobians.py
@@ -485,23 +485,32 @@ def _build_joint_jacobians_dense(
     r_B_j = wp.transform_get_translation(T_B_j)
     r_F_j = wp.transform_get_translation(T_F_j)
 
-    # Compute the wrench matrices
-    # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
-    W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
-    W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
+    if dof_type == JointDoFType.FREE:
+        # By Newton's convention, a free joint's twist and wrench (specified in `joint_qd` and
+        # `joint_f`) are both defined at the child's center of mass, with world-aligned axes. Since
+        # Kamino avoids a conversion, the change of reference frame needs to be taken into account
+        # in the Jacobian.
+        JT_F_j = wp.identity(n=6, dtype=wp.float32)
+        JT_B_j = -screw_transform_matrix_from_points(r_F_j, r_B_j)
 
-    # General case: Compute the effective projector to joint frame and expand to 6D
-    if dof_type != JointDoFType.UNIVERSAL:
-        R_X_bar_j = expand6d(R_X_j)
-    # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
     else:
-        j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
-        R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
-        R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
+        # Compute the wrench matrices
+        # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
+        W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
+        W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
 
-    # Compute the extended jacobians, i.e. without the selection-matrix multiplication
-    JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
-    JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
+        # General case: Compute the effective projector to joint frame and expand to 6D
+        if dof_type != JointDoFType.UNIVERSAL:
+            R_X_bar_j = expand6d(R_X_j)
+        # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
+        else:
+            j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
+            R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
+            R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
+
+        # Compute the extended jacobians, i.e. without the selection-matrix multiplication
+        JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
+        JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
 
     # Store joint dynamic constraint jacobians if applicable
     # NOTE: We use the extraction method for DoFs since dynamic constraints are in DoF-space
@@ -574,23 +583,32 @@ def _build_joint_jacobians_sparse(
     r_B_j = wp.transform_get_translation(T_B_j)
     r_F_j = wp.transform_get_translation(T_F_j)
 
-    # Compute the wrench matrices
-    # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
-    W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
-    W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
+    if dof_type == JointDoFType.FREE:
+        # By Newton's convention, a free joint's twist and wrench (specified in `joint_qd` and
+        # `joint_f`) are both defined at the child's center of mass, with world-aligned axes. Since
+        # Kamino avoids a conversion, the change of reference frame needs to be taken into account
+        # in the Jacobian.
+        JT_F_j = wp.identity(n=6, dtype=wp.float32)
+        JT_B_j = -screw_transform_matrix_from_points(r_F_j, r_B_j)
 
-    # General case: Compute the effective projector to joint frame and expand to 6D
-    if dof_type != JointDoFType.UNIVERSAL:
-        R_X_bar_j = expand6d(R_X_j)
-    # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
     else:
-        j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
-        R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
-        R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
+        # Compute the wrench matrices
+        # TODO: Since the lever-arm is a relative position, can we just use B_r_Bj and F_r_Fj instead?
+        W_j_B = screw_transform_matrix_from_points(r_j, r_B_j)
+        W_j_F = screw_transform_matrix_from_points(r_j, r_F_j)
 
-    # Compute the extended jacobians, i.e. without the selection-matrix multiplication
-    JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
-    JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
+        # General case: Compute the effective projector to joint frame and expand to 6D
+        if dof_type != JointDoFType.UNIVERSAL:
+            R_X_bar_j = expand6d(R_X_j)
+        # Universal joint: replace R_X_j with the frame of the intermediate body for rotation constraints
+        else:
+            j_q_j = compute_joint_relative_quaternion(T_B_j, T_F_j, model_joints_X_Bj[jid], model_joints_X_Fj[jid])
+            R_intermediate = compute_intermediate_body_frame_universal_joint(j_q_j)
+            R_X_bar_j = concat6d(R_X_j, R_X_j @ R_intermediate)
+
+        # Compute the extended jacobians, i.e. without the selection-matrix multiplication
+        JT_B_j = -W_j_B @ R_X_bar_j  # Reaction is on the Base body body ; (6 x 6)
+        JT_F_j = W_j_F @ R_X_bar_j  # Action is on the Follower body    ; (6 x 6)
 
     # Store joint dynamic constraint jacobians if applicable
     # NOTE: We use the extraction method for DoFs since dynamic constraints are in DoF-space

--- a/newton/tests/test_body_force.py
+++ b/newton/tests/test_body_force.py
@@ -558,6 +558,11 @@ com_solvers = {
         1e-3,
         True,
     ),
+    "kamino": (
+        newton.solvers.SolverKamino,
+        1e-3,
+        True,
+    ),
 }
 
 # Test configurations for non-zero CoM tests


### PR DESCRIPTION
## Description

Newton follows the convention that the joint wrench of a free joint (as specified in `joint_f`) is defined on the center of mass of the child body in global axes. The same holds for joint twists in `joint_qd`. To properly account for this in Kamino, we need to handle the free joint as a special case when building the DoF Jacobian.

This also adds Kamino to the CoM body force tests that would have failed before without the fix.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_body_force.TestBodyForce
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jacobian computation for free joints to ensure more accurate kinematics and force/torque mapping.
  * Refined joint Jacobian generation consistently across dense and sparse solver paths for improved correctness.
  * Fixed Kamino solver force/torque behavior when the center of mass is offset.

* **Tests**
  * Expanded center-of-mass offset coverage to run the existing force/torque tests for the Kamino solver as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->