### PR TITLE
Fix PR author auto-assignment

### DIFF
--- a/.github/workflows/pr_auto_assign_creator.yml
+++ b/.github/workflows/pr_auto_assign_creator.yml
@@ -49,11 +49,16 @@ jobs:
             }
 
             try {
-              await github.rest.issues.checkUserCanBeAssigned({
-                owner,
-                repo,
-                assignee: author,
-              });
+              // PR participants may be assignable without repository-wide access.
+              await github.request(
+                'GET /repos/{owner}/{repo}/issues/{issue_number}/assignees/{assignee}',
+                {
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  assignee: author,
+                }
+              );
             } catch (error) {
               if (error.status === 404) {
                 core.warning(


### PR DESCRIPTION
## Description

Check whether the PR creator can be assigned to the specific pull request
instead of using the repository-wide eligibility endpoint.

The repository-wide endpoint rejects external contributors who are nevertheless
eligible as participants in their own PR. This caused the workflow to warn and
skip assignment even though GitHub allowed the author to be assigned manually.

## Checklist

- [x] New or existing tests cover these changes (live API regression check)
- [x] The documentation is up to date with these changes (not applicable)
- [x] `CHANGELOG.md` has been updated (not applicable; workflow-only change)

## Test plan

- Run `/usr/bin/env UV_CACHE_DIR=/tmp/newton-uv-cache UV_TOOL_DIR=/tmp/newton-uv-tools PRE_COMMIT_HOME=/tmp/newton-pre-commit-cache uvx --python 3.12 pre-commit run -a`.
- Verify the repository-wide assignee endpoint returns `404` for the author of
  PR #3649.
- Verify the PR-specific assignee endpoint returns `204` for the same author.

## Bug fix

**Steps to reproduce:**

1. Open a draft PR as an external contributor who lacks repository-wide
   assignment eligibility.
2. Mark the PR ready for review.
3. Observe the auto-assignment workflow warn that the author is not assignable
   and leave the PR unassigned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request author eligibility checks during automatic assignment.
  * Added more reliable handling when an author cannot be assigned, including warning messages and skipping assignment when appropriate.
  * Continued verification that the author was successfully added as an assignee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->