### PR TITLE
Fix SensorIMU per-world gravity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
+- Fix `SensorIMU` to use per-world gravity for world-local sites not attached to a body.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix `eval_ik()` and `SolverSemiImplicit` rounding small float32 revolute-joint angles to zero. (#3434)

--- a/newton/_src/sensors/sensor_imu.py
+++ b/newton/_src/sensors/sensor_imu.py
@@ -19,6 +19,7 @@ def compute_sensor_imu_kernel(
     body_world: wp.array[wp.int32],
     body_com: wp.array[wp.vec3],
     shape_body: wp.array[int],
+    shape_world: wp.array[wp.int32],
     shape_transform: wp.array[wp.transform],
     sensor_sites: wp.array[int],
     body_q: wp.array[wp.transform],
@@ -40,7 +41,9 @@ def compute_sensor_imu_kernel(
     site_transform = shape_transform[site_idx]
 
     if body_idx < 0:
-        accelerometer[sensor_idx] = wp.quat_rotate_inv(site_transform.q, -gravity[0])
+        world_idx = shape_world[site_idx]
+        world_g = gravity[wp.max(world_idx, 0)]
+        accelerometer[sensor_idx] = wp.quat_rotate_inv(site_transform.q, -world_g)
         gyroscope[sensor_idx] = wp.vec3(0.0)
         return
 
@@ -191,6 +194,7 @@ class SensorIMU:
                 self.model.body_world,
                 self.model.body_com,
                 self.model.shape_body,
+                self.model.shape_world,
                 self.model.shape_transform,
                 self.sensor_sites_arr,
                 state.body_q,

--- a/newton/tests/test_sensor_imu.py
+++ b/newton/tests/test_sensor_imu.py
@@ -148,6 +148,31 @@ class TestSensorIMU(unittest.TestCase):
         np.testing.assert_allclose(acc, -gravity, atol=1e-5)
         np.testing.assert_allclose(gyro, [0, 0, 0], atol=1e-5)
 
+    def test_sensor_world_frame_sites_use_per_world_gravity(self):
+        """Use each world-local site's gravity for body-less IMUs."""
+        builder = newton.ModelBuilder()
+
+        builder.begin_world(gravity=(0.0, 0.0, -1.0))
+        site_0 = builder.add_site(-1)
+        builder.end_world()
+
+        builder.begin_world(gravity=(0.0, 0.0, -5.0))
+        site_1 = builder.add_site(-1)
+        builder.end_world()
+
+        model = builder.finalize()
+        sensor = SensorIMU(model, sites=[site_0, site_1])
+        state = model.state()
+
+        state.body_qdd.zero_()
+        sensor.update(state)
+
+        np.testing.assert_allclose(
+            sensor.accelerometer.numpy(),
+            [[0.0, 0.0, 1.0], [0.0, 0.0, 5.0]],
+            atol=1e-5,
+        )
+
     def test_sensor_rotated_site(self):
         """Test IMU with rotated site frame."""
         builder = newton.ModelBuilder()


### PR DESCRIPTION
## Description

Fixes #3715. Use each world-frame IMU site's `shape_world` to select gravity when
the site is not attached to a body. Preserve the existing world-0
fallback for global sites.

The early-return path for sites with `body=-1` previously indexed
`gravity[0]` directly, bypassing per-world gravity selection.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run --extra dev python -m unittest newton.tests.test_sensor_imu.TestSensorIMU.test_sensor_world_frame_sites_use_per_world_gravity
uv run --extra dev python -m unittest newton.tests.test_sensor_imu
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Create two worlds with different gravity values.
2. Add a site with `body=-1` inside each world.
3. Update a `SensorIMU` containing both sites.
4. Observe that both accelerometers use world 0's gravity.

**Minimal reproduction:**

```python
import newton
from newton.sensors import SensorIMU

builder = newton.ModelBuilder()

builder.begin_world(gravity=(0.0, 0.0, -1.0))
site_0 = builder.add_site(-1)
builder.end_world()

builder.begin_world(gravity=(0.0, 0.0, -5.0))
site_1 = builder.add_site(-1)
builder.end_world()

model = builder.finalize(device="cpu")
sensor = SensorIMU(model, sites=[site_0, site_1])
state = model.state()

state.body_qdd.zero_()
sensor.update(state)

print(sensor.accelerometer.numpy())
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - IMU sensors on world-local sites now correctly use the gravity setting of their respective world.
  - Fixed accelerometer readings when multiple worlds have different gravity values.

- **Tests**
  - Added coverage verifying correct per-world gravity readings for world-local IMU sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->