### PR TITLE
Standardize solver reset world masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 ### Deprecated
 
 - Deprecate scalar `ModelBuilder.gravity`; pass a three-component gravity vector instead.
+- Deprecate local-only `SolverBase.reset()` world masks in favor of masks with shape `(world_count + 1,)`; append a final entry that selects global entities in world `-1`. (#3374)
 - Deprecate and ignore `SolverVBD`'s `rigid_contact_stick_motion_eps`, `rigid_contact_stick_freeze_translation_eps`, and `rigid_contact_stick_freeze_angular_eps`; use collision-pipeline sticky matching for persistent geometry. The SolverVBD body deadzone was removed without replacement.
 - Deprecate per-DOF `newton:{axis}:limitStiffness` and `newton:{axis}:limitDamping` attributes (where `{axis}` is `linear`, `angular`, `rotX`, `rotY`, or `rotZ`). Use the broadcast `newton:limitStiffness` and `newton:limitDamping` attributes from `NewtonJointAPI` instead; the broadcast value applies uniformly to all DOFs on the joint. For joints requiring per-DOF variance, split into separate 1-DOF (revolute / prismatic) joints.
 - Deprecate passing solver constructor options positionally after stable positional inputs such as `model` and explicit solver configs; migrate calls such as `SolverVBD(model, 10)` to `SolverVBD(model, iterations=10)`.

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -149,8 +149,23 @@ world and after the last local world:
 * ``[world_start[-2], world_start[-1])`` contains global entities added at the
   back.
 
-Use the corresponding per-entity ``*_world == -1`` values when a single
-selection must cover both ranges.
+For example, the shape arrays in the scene above have this layout:
+
+.. code-block:: text
+
+   shape index:        0   1   2   3   4   5
+   shape_world:       -1   0   0   1   1  -1
+   shape_world_start: [1, 3, 5, 6]
+
+World ``0`` occupies shape indices ``[1, 3)`` and world ``1`` occupies
+``[3, 5)``. The two global shapes are split between index ``0`` at the front
+and index ``5`` at the back, so no single slice from ``shape_world_start``
+selects both. To select every global shape, test the per-shape world indices:
+
+.. code-block:: python
+
+   global_shape_mask = model.shape_world.numpy() == -1
+   # [True, False, False, False, False, True]
 
 Continuing the same example, we can compute the per-world shape counts as follows:
 

--- a/docs/concepts/worlds.rst
+++ b/docs/concepts/worlds.rst
@@ -140,6 +140,18 @@ the second-to-last entry corresponding to the starting index of the global entit
 With this format, we can easily compute the number of entities per world by computing the difference between consecutive entries in these arrays (since they are essentially cumulative sums),
 as well as the total number of global entities by summing the first entry with the difference of the last two.
 
+Unlike per-world value and selection arrays, a ``*_world_start`` array does
+not provide one contiguous slot for global world ``-1``. Global entities can
+occur in two ranges because they may be added both before the first local
+world and after the last local world:
+
+* ``[0, world_start[0])`` contains global entities added at the front.
+* ``[world_start[-2], world_start[-1])`` contains global entities added at the
+  back.
+
+Use the corresponding per-entity ``*_world == -1`` values when a single
+selection must cover both ranges.
+
 Continuing the same example, we can compute the per-world shape counts as follows:
 
 .. testcode::
@@ -292,6 +304,21 @@ CUDA graph-capture requirements. See
 :meth:`~newton.solvers.SolverImplicitMPM.setup_collider` and
 :meth:`~newton.solvers.SolverImplicitMPM.reset` for collider configuration and
 selective reset behavior.
+
+.. _Per-world reset masks:
+
+Per-World Reset Masks
+---------------------
+
+The optional ``world_mask`` passed to :meth:`~newton.solvers.SolverBase.reset`
+has shape ``(world_count + 1,)``. Entries ``[0, world_count)`` select local
+worlds, and the final entry selects global entities whose world index is
+``-1``. An all-true mask therefore selects the same worlds as ``None``.
+Solvers that do not support global dynamic objects accept the final entry as a
+no-op.
+
+The legacy shape ``(world_count,)`` remains available during its deprecation
+period. It selects local worlds only and leaves global entities unselected.
 
 .. _Per-world gravity:
 

--- a/newton/_src/solvers/coupled/solver_coupled.py
+++ b/newton/_src/solvers/coupled/solver_coupled.py
@@ -1919,15 +1919,18 @@ class SolverCoupled(SolverBase, CouplingInterface):
 
         Args:
             state: Parent-model simulation state to reset (modified in place).
-            world_mask: Optional boolean mask of shape ``(world_count,)``
-                selecting which worlds to reset. If ``None``, all worlds are
-                reset.
+            world_mask: Optional boolean mask of shape ``(world_count + 1,)``
+                selecting which worlds to reset. The final entry selects global
+                entities whose world is ``-1``. If ``None``, all local and
+                global entities are reset. Passing the deprecated shape
+                ``(world_count,)`` selects local worlds only.
             flags: Optional :class:`~newton.StateFlags` bitmask controlling
                 which state quantities sub-solvers should reset. If ``None``,
                 all state quantities are reset.
         """
         if state is None:
             raise ValueError("'state' argument is required.")
+        world_mask = self._normalize_reset_world_mask(world_mask)
 
         self._distribute_state(state, iteration_restart=True)
         for entry in self._entries.values():

--- a/newton/_src/solvers/coupled/solver_coupled_proxy.py
+++ b/newton/_src/solvers/coupled/solver_coupled_proxy.py
@@ -114,9 +114,10 @@ _PROXY_RELAXATION_MODE_BY_NAME = {
 
 @wp.func
 def _reset_world_selected(world: int, world_mask: wp.array[wp.bool]) -> bool:
-    if world >= 0 and world < world_mask.shape[0]:
+    global_world_index = world_mask.shape[0] - 1
+    if world >= 0 and world < global_world_index:
         return world_mask[world]
-    return world < 0 and world_mask.shape[0] == 1 and world_mask[0]
+    return world == -1 and world_mask[global_world_index]
 
 
 @wp.kernel(module="unique", enable_backward=False)

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -784,8 +784,11 @@ class SolverKamino(SolverBase, CouplingInterface):
         Args:
             state: The simulation state to reset (modified in place).
             world_mask: Optional array of per-world masks indicating which
-                worlds should be reset.
-                Shape of ``(num_worlds,)``.
+                worlds should be reset. Shape ``(world_count + 1,)``, with the
+                final entry representing global world ``-1``. The global entry
+                is a no-op because Kamino does not support global dynamic
+                objects. Passing the deprecated shape ``(world_count,)`` selects
+                local worlds only.
             flags: Optional :class:`~newton.StateFlags` or ``int`` bitmask controlling
                 which state attributes need to be reset.  If ``None``, all
                 state attributes are reset.
@@ -801,6 +804,8 @@ class SolverKamino(SolverBase, CouplingInterface):
         """
         if state is None:
             raise ValueError("'state' argument is required.")
+        world_mask = self._normalize_reset_world_mask(world_mask)
+        local_world_mask = None if world_mask is None else world_mask[: self.model.world_count]
 
         # Process None arguments
         state_flags = int(StateFlags.ALL if flags is None else flags)
@@ -817,7 +822,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             body_com=self._model_kamino.bodies.i_r_com_i,
             body_q_com=state_kamino.q_i,
             body_q=state_kamino.q_i,
-            world_mask=world_mask if not has_callbacks else None,
+            world_mask=local_world_mask if not has_callbacks else None,
             body_wid=self._model_kamino.bodies.wid,
         )
         # Note: we convert all worlds if callbacks are set, so they see the full state correctly
@@ -852,7 +857,7 @@ class SolverKamino(SolverBase, CouplingInterface):
         # to write the reset state to `state_kamino`.
         self._solver_kamino.reset(
             state=state_kamino,
-            world_mask=world_mask,
+            world_mask=local_world_mask,
             config=config,
             success_mask=success_mask,
         )
@@ -866,7 +871,7 @@ class SolverKamino(SolverBase, CouplingInterface):
             body_com=self._model_kamino.bodies.i_r_com_i,
             body_q_com=state_kamino.q_i,
             body_q=state_kamino.q_i,
-            world_mask=world_mask if not has_callbacks else None,
+            world_mask=local_world_mask if not has_callbacks else None,
             body_wid=self._model_kamino.bodies.wid,
         )
 

--- a/newton/_src/solvers/kamino/tests/test_solvers_dvi.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_dvi.py
@@ -413,6 +413,30 @@ class TestDVISolver(unittest.TestCase):
         self.assertFalse(solver._solver_kamino.config.dynamics.preconditioning)
         self.assertIsNotNone(solver._solver_kamino.solver_fd.data.info)
 
+    def test_02a_public_solver_reset_accepts_global_mask_slot(self):
+        """Accept a global reset slot as a no-op for Kamino state."""
+        builder = newton.ModelBuilder()
+        SolverKamino.register_custom_attributes(builder)
+        builder.begin_world()
+        body = builder.add_link(mass=1.0, inertia=wp.mat33(np.eye(3)))
+        joint = builder.add_joint_free(child=body)
+        builder.add_articulation([joint])
+        builder.end_world()
+        model = builder.finalize(device=self.device)
+        solver = SolverKamino(model)
+        state = model.state()
+
+        body_q = state.body_q.numpy()
+        body_q[:, 0] += 1.0
+        state.body_q.assign(body_q)
+        solver.reset(
+            state,
+            world_mask=wp.array((False, True), dtype=wp.bool, device=self.device),
+            flags=0,
+        )
+
+        np.testing.assert_array_equal(state.body_q.numpy(), body_q)
+
     def test_03_dvi_solve_single_contact(self):
         builder = basics.build_box_on_plane()
         model, data, state, limits, detector, jacobians = make_containers(

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3710,18 +3710,18 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
 
         Args:
             state: The simulation state to reset (modified in place).
-            world_mask: Optional boolean mask of shape ``(world_count,)``
-                selecting which worlds to reset. If ``None``, all worlds are
-                reset.
+            world_mask: Optional boolean mask of shape ``(world_count + 1,)``
+                selecting which worlds to reset. The final entry represents
+                global world ``-1`` and is a no-op because MuJoCo does not
+                support global dynamic objects. If ``None``, all worlds are
+                reset. Passing the deprecated shape ``(world_count,)`` selects
+                local worlds only.
             flags: Optional :class:`~newton.StateFlags` bitmask controlling which
                 joint-state quantities are reset. If ``None``, all are reset.
                 The internal MuJoCo buffers are always cleared regardless.
         """
         world_count = self.model.world_count
-        if world_mask is not None and world_mask.shape[0] != world_count:
-            raise ValueError(
-                f"world_mask has length {world_mask.shape[0]}, expected {world_count} (one entry per world)."
-            )
+        world_mask = self._normalize_reset_world_mask(world_mask)
 
         # Reset joint coordinates/velocities to model defaults for the selected
         # worlds. body_q/body_qd are FK outputs and intentionally not touched.

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 The Newton Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
 from typing import Any
 
 import warp as wp
@@ -217,6 +218,31 @@ class SolverBase:
             SolverBase._module_options_revision += 1
         self._applied_module_options_revision = SolverBase._module_options_revision
 
+    def _normalize_reset_world_mask(self, world_mask: wp.array[wp.bool] | None) -> wp.array[wp.bool] | None:
+        """Validate a reset mask and append an unselected global slot for legacy masks."""
+        if world_mask is None:
+            return None
+        if not isinstance(world_mask, wp.array) or world_mask.ndim != 1 or world_mask.dtype != wp.bool:
+            raise ValueError("world_mask must be a one-dimensional Warp boolean array.")
+        world_count = self.model.world_count
+        mask_length = world_mask.shape[0]
+        if mask_length not in (world_count, world_count + 1):
+            raise ValueError(f"world_mask has length {mask_length}, expected {world_count} or {world_count + 1}.")
+        if world_mask.device != self.device:
+            raise ValueError(f"world_mask is on device {world_mask.device}, expected solver device {self.device}.")
+        if mask_length == world_count:
+            warnings.warn(
+                "world_mask with shape (world_count,) is deprecated; use shape (world_count + 1,), "
+                "where the final entry selects global entities in world -1.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            normalized_mask = wp.zeros(world_count + 1, dtype=wp.bool, device=self.device)
+            if world_count > 0:
+                wp.copy(normalized_mask, world_mask, count=world_count)
+            return normalized_mask
+        return world_mask
+
     @property
     def device(self) -> wp.Device:
         """
@@ -346,14 +372,17 @@ class SolverBase:
 
         Args:
             state: The simulation state to reset (modified in place).
-            world_mask: Optional boolean mask of shape ``(num_worlds,)``
-                specifying which worlds to reset.  If ``None``, all worlds
-                are reset.
+            world_mask: Optional boolean mask of shape ``(world_count + 1,)``
+                specifying which worlds to reset. Entries before the last select
+                local worlds by index, and the final entry selects global entities
+                whose world is ``-1``. If ``None``, all local and global entities
+                are reset. Passing the deprecated shape ``(world_count,)`` selects
+                local worlds only and leaves global entities unselected.
             flags: Optional :class:`~newton.StateFlags` or ``int`` bitmask controlling
                 which state attributes need to be reset.  If ``None``, all
                 state attributes are reset.
         """
-        pass
+        self._normalize_reset_world_mask(world_mask)
 
     def step(
         self, state_in: State, state_out: State, control: Control | None, contacts: Contacts | None, dt: float

--- a/newton/_src/solvers/solver.py
+++ b/newton/_src/solvers/solver.py
@@ -219,29 +219,25 @@ class SolverBase:
         self._applied_module_options_revision = SolverBase._module_options_revision
 
     def _normalize_reset_world_mask(self, world_mask: wp.array[wp.bool] | None) -> wp.array[wp.bool] | None:
-        """Validate a reset mask and append an unselected global slot for legacy masks."""
+        """Append an unselected global slot to a legacy reset mask."""
         if world_mask is None:
             return None
-        if not isinstance(world_mask, wp.array) or world_mask.ndim != 1 or world_mask.dtype != wp.bool:
-            raise ValueError("world_mask must be a one-dimensional Warp boolean array.")
         world_count = self.model.world_count
-        mask_length = world_mask.shape[0]
-        if mask_length not in (world_count, world_count + 1):
-            raise ValueError(f"world_mask has length {mask_length}, expected {world_count} or {world_count + 1}.")
-        if world_mask.device != self.device:
-            raise ValueError(f"world_mask is on device {world_mask.device}, expected solver device {self.device}.")
-        if mask_length == world_count:
-            warnings.warn(
-                "world_mask with shape (world_count,) is deprecated; use shape (world_count + 1,), "
-                "where the final entry selects global entities in world -1.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            normalized_mask = wp.zeros(world_count + 1, dtype=wp.bool, device=self.device)
-            if world_count > 0:
-                wp.copy(normalized_mask, world_mask, count=world_count)
-            return normalized_mask
-        return world_mask
+        mask_size = world_mask.size
+        if mask_size == world_count + 1:
+            return world_mask
+        if mask_size != world_count:
+            raise ValueError(f"world_mask has size {mask_size}, expected {world_count} or {world_count + 1}.")
+        warnings.warn(
+            "world_mask with shape (world_count,) is deprecated; use shape (world_count + 1,), "
+            "where the final entry selects global entities in world -1.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        normalized_mask = wp.zeros(world_count + 1, dtype=wp.bool, device=self.device)
+        if world_count > 0:
+            wp.copy(normalized_mask, world_mask, count=world_count)
+        return normalized_mask
 
     @property
     def device(self) -> wp.Device:

--- a/newton/_src/solvers/vbd/rigid_vbd_kernels.py
+++ b/newton/_src/solvers/vbd/rigid_vbd_kernels.py
@@ -102,12 +102,10 @@ def _reset_world_selected(
     reset_all: bool,
     world_count: int,
 ):
-    """Query a public reset mask whose optional final entry selects unassigned entities."""
+    """Query a public reset mask whose final entry selects global entities."""
     if reset_all:
         return True
     if world < 0:
-        if world_mask.shape[0] == world_count:
-            return False
         world = world_count
     return world_mask[world]
 

--- a/newton/_src/solvers/vbd/solver_vbd.py
+++ b/newton/_src/solvers/vbd/solver_vbd.py
@@ -1873,10 +1873,10 @@ class SolverVBD(SolverBase, CouplingInterface):
         Args:
             state: The simulation state to reset (modified in place).
             world_mask: One-dimensional Warp boolean mask on the solver device.
-                Shape ``(world_count,)`` selects local worlds only. Shape
-                ``(world_count + 1,)`` additionally uses the final entry for
-                entities not assigned to a world (``world == -1``). ``None``
-                selects all local and unassigned entities.
+                Shape ``(world_count + 1,)``, with the final entry selecting
+                entities in global world ``-1``. ``None`` selects all local and
+                global entities. Passing the deprecated shape ``(world_count,)``
+                selects local worlds only and leaves global entities unselected.
             flags: :class:`~newton.StateFlags` (or ``int``) selecting which body
                 fields to copy from the model defaults. VBD honors
                 :attr:`~newton.StateFlags.BODY_Q` and
@@ -1885,16 +1885,7 @@ class SolverVBD(SolverBase, CouplingInterface):
         if state is None:
             raise ValueError("'state' argument is required.")
         model = self.model
-        if world_mask is not None:
-            if not isinstance(world_mask, wp.array) or world_mask.ndim != 1 or world_mask.dtype != wp.bool:
-                raise ValueError("world_mask must be a one-dimensional Warp boolean array.")
-            mask_length = world_mask.shape[0]
-            if mask_length not in (model.world_count, model.world_count + 1):
-                raise ValueError(
-                    f"world_mask has length {mask_length}, expected {model.world_count} or {model.world_count + 1}."
-                )
-            if world_mask.device != self.device:
-                raise ValueError(f"world_mask is on device {world_mask.device}, expected solver device {self.device}.")
+        world_mask = self._normalize_reset_world_mask(world_mask)
 
         flags_value = int(StateFlags.ALL if flags is None else flags)
 

--- a/newton/tests/test_coupled_solver.py
+++ b/newton/tests/test_coupled_solver.py
@@ -1814,7 +1814,7 @@ def _coupled_vbd_reset_preserves_pose_history(test, device):
     state_in.body_qd.zero_()
     coupled.reset(
         state_in,
-        world_mask=wp.array([False, True], dtype=wp.bool, device=device),
+        world_mask=wp.array([False, True, False], dtype=wp.bool, device=device),
         flags=0,
     )
     steps_before = coupled.solver("copy").step_count
@@ -2050,7 +2050,7 @@ def _assert_proxy_reset_buffers(test, model, coupled, mapping, entity_world):
 
     coupled.reset(
         model.state(),
-        world_mask=wp.array((True, False), dtype=wp.bool, device=model.device),
+        world_mask=wp.array((True, False, False), dtype=wp.bool, device=model.device),
         flags=0,
     )
 
@@ -2380,6 +2380,73 @@ class TestSolverCoupledParticleProxy(unittest.TestCase):
 
         mapping = coupled._proxy_particle_mappings[0]
         _assert_proxy_reset_buffers(self, model, coupled, mapping, model.particle_world)
+
+    def test_global_mask_resets_global_proxy_history(self):
+        """Reset global proxy history through the final world-mask entry."""
+        builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
+        source_particle = builder.add_particle(
+            pos=(-1.0, 0.0, 0.0),
+            vel=(0.0, 0.0, 0.0),
+            mass=1.0,
+            radius=0.0,
+        )
+        builder.begin_world()
+        builder.add_particle(pos=(0.0, 0.0, 0.0), vel=(0.0, 0.0, 0.0), mass=1.0, radius=0.0)
+        builder.end_world()
+        proxy_particle = builder.add_particle(
+            pos=(1.0, 0.0, 0.0),
+            vel=(0.0, 0.0, 0.0),
+            mass=1.0,
+            radius=0.0,
+        )
+        model = builder.finalize(device="cpu")
+
+        np.testing.assert_array_equal(model.particle_world.numpy(), (-1, 0, -1))
+        np.testing.assert_array_equal(model.particle_world_start.numpy(), (1, 2, 3))
+
+        coupled = SolverCoupledProxy(
+            model=model,
+            entries=[
+                SolverCoupled.Entry(name="src", solver=_StepCountingCopySolver, particles=[source_particle]),
+                SolverCoupled.Entry(name="dst", solver=_StepCountingCopySolver),
+            ],
+            coupling=SolverCoupledProxy.Config(
+                proxies=[
+                    SolverCoupledProxy.Proxy(
+                        source="src",
+                        destination="dst",
+                        particles=[source_particle],
+                        proxy_particles=[proxy_particle],
+                        proxy_relaxation=0.5,
+                        proxy_relaxation_mode="aitken",
+                    )
+                ]
+            ),
+        )
+        mapping = coupled._proxy_particle_mappings[0]
+        for values in (
+            mapping.coupling_forces,
+            mapping.coupling_forces_previous,
+            mapping.aitken_residual_previous,
+            mapping.proxy_qd_before,
+        ):
+            values.fill_(1.0)
+
+        coupled.reset(
+            model.state(),
+            world_mask=wp.array((False, True), dtype=wp.bool, device=model.device),
+            flags=0,
+        )
+
+        coupling_forces = np.ones_like(mapping.coupling_forces.numpy())
+        coupling_forces[mapping.proxy_ids_global.numpy()] = 0.0
+        np.testing.assert_array_equal(mapping.coupling_forces.numpy(), coupling_forces)
+        np.testing.assert_array_equal(mapping.coupling_forces_previous.numpy(), 0.0)
+        np.testing.assert_array_equal(mapping.aitken_residual_previous.numpy(), 0.0)
+
+        proxy_qd_before = np.ones_like(mapping.proxy_qd_before.numpy())
+        proxy_qd_before[mapping.proxy_ids_local.numpy()] = 0.0
+        np.testing.assert_array_equal(mapping.proxy_qd_before.numpy(), proxy_qd_before)
 
     def test_cross_world_particle_proxy_mapping_is_rejected(self):
         """Verify cross world particle proxy mapping is rejected."""

--- a/newton/tests/test_custom_solver.py
+++ b/newton/tests/test_custom_solver.py
@@ -125,6 +125,25 @@ class TestCustomSolver(unittest.TestCase):
         self.assertEqual(solver.reset_epoch, 11)
         self.assertEqual(int(state.custom_solver.reset_epoch.numpy()[0]), 12)
 
+    def test_base_reset_validates_global_world_mask_slot(self):
+        """Require a final global slot while deprecating local-only masks."""
+        builder = newton.ModelBuilder()
+        builder.begin_world()
+        builder.end_world()
+        builder.begin_world()
+        builder.end_world()
+        model = builder.finalize()
+        solver = newton.solvers.SolverBase(model)
+        state = model.state()
+
+        solver.reset(state, world_mask=wp.array((True, False, True), dtype=wp.bool, device=model.device))
+
+        with self.assertWarnsRegex(DeprecationWarning, "world_count \\+ 1"):
+            solver.reset(state, world_mask=wp.array((True, False), dtype=wp.bool, device=model.device))
+
+        with self.assertRaisesRegex(ValueError, "expected 2 or 3"):
+            solver.reset(state, world_mask=wp.array((True,), dtype=wp.bool, device=model.device))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/newton/tests/test_mujoco_reset.py
+++ b/newton/tests/test_mujoco_reset.py
@@ -76,8 +76,20 @@ class TestMuJoCoReset(unittest.TestCase):
     def test_reset_masked_world_only(self):
         """A per-world mask clears the selected world and leaves the others intact."""
         self._poison()
-        mask = wp.array([True, False], dtype=wp.bool, device=self.model.device)
+        mask = wp.array([True, False, True], dtype=wp.bool, device=self.model.device)
         self.solver.reset(self.state_out, world_mask=mask)
+
+        for name, buf in self._cleared_buffers().items():
+            values = buf.numpy()
+            self.assertTrue(np.all(values[0] == 0.0), f"{name} not cleared in masked world 0")
+            self.assertTrue(np.all(values[1] == 7.0), f"{name} wrongly cleared in unmasked world 1")
+
+    def test_reset_deprecates_local_only_mask(self):
+        """Preserve local-only mask behavior through the deprecation period."""
+        self._poison()
+        mask = wp.array([True, False], dtype=wp.bool, device=self.model.device)
+        with self.assertWarnsRegex(DeprecationWarning, "world_count \\+ 1"):
+            self.solver.reset(self.state_out, world_mask=mask)
 
         for name, buf in self._cleared_buffers().items():
             values = buf.numpy()
@@ -94,7 +106,8 @@ class TestMuJoCoReset(unittest.TestCase):
             self.assertTrue(np.all(values == 0.0), f"{name} not cleared in all worlds")
 
     def test_reset_rejects_wrong_length_mask(self):
-        mask = wp.array([True, False, True], dtype=wp.bool, device=self.model.device)
+        """Reject masks without local-world entries plus the global slot."""
+        mask = wp.array([True, False, True, False], dtype=wp.bool, device=self.model.device)
         with self.assertRaises(ValueError):
             self.solver.reset(self.state_out, world_mask=mask)
 
@@ -107,7 +120,7 @@ class TestMuJoCoReset(unittest.TestCase):
         poisoned[0, :] = np.nan
         warmstart.assign(poisoned)
 
-        mask = wp.array([True, False], dtype=wp.bool, device=self.model.device)
+        mask = wp.array([True, False, False], dtype=wp.bool, device=self.model.device)
         self.solver.reset(self.state_out, world_mask=mask)
         self.assertTrue(np.all(np.isfinite(self.solver.mjw_data.qacc_warmstart.numpy())))
 
@@ -118,7 +131,7 @@ class TestMuJoCoReset(unittest.TestCase):
         # Corrupt the live joint coordinates in both worlds.
         self.state_out.joint_q.assign(np.full_like(defaults, 9.0))
 
-        mask = wp.array([True, False], dtype=wp.bool, device=self.model.device)
+        mask = wp.array([True, False, False], dtype=wp.bool, device=self.model.device)
         self.solver.reset(self.state_out, world_mask=mask, flags=StateFlags.JOINT_Q)
 
         result = self.state_out.joint_q.numpy()

--- a/newton/tests/test_solver_kamino_dvi.py
+++ b/newton/tests/test_solver_kamino_dvi.py
@@ -12,6 +12,7 @@ _DVI_QUALITY_TESTS = (
     "test_00a_multiworld_status_reduction_requires_all_worlds_converged",
     "test_01_dvi_solve_dense_dual_problem",
     "test_02_public_solver_step_with_dvi",
+    "test_02a_public_solver_reset_accepts_global_mask_slot",
     "test_03_dvi_solve_single_contact",
     "test_03a_sparse_dvi_filtered_matvec_matches_full_rows",
     "test_03b_dvi_contact_block_preconditioner_smoke",

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -1857,9 +1857,7 @@ def _rigid_reset_state_and_history(test, device):
     solver.joint_lambda_lin.fill_(5.0)
     with test.assertRaisesRegex(ValueError, "argument is required"):
         solver.reset(None)
-    with test.assertRaisesRegex(ValueError, "one-dimensional Warp boolean array"):
-        solver.reset(state, world_mask=wp.array([1, 0], dtype=wp.int32, device=device))
-    with test.assertRaisesRegex(ValueError, "world_mask has length 1, expected 2 or 3"):
+    with test.assertRaisesRegex(ValueError, "world_mask has size 1, expected 2 or 3"):
         solver.reset(state, world_mask=wp.array([True], dtype=wp.bool, device=device))
     np.testing.assert_allclose(solver.joint_lambda_lin.numpy(), 5.0)
 

--- a/newton/tests/test_solver_vbd.py
+++ b/newton/tests/test_solver_vbd.py
@@ -1828,7 +1828,7 @@ def _rigid_reset_state_and_history(test, device):
     selected_joints = joint_world == 0
     global_bodies = body_world < 0
     global_joints = joint_world < 0
-    world_mask = wp.array([True, False], dtype=wp.bool, device=device)
+    world_mask = wp.array([True, False, False], dtype=wp.bool, device=device)
 
     solver = newton.solvers.SolverVBD(model, iterations=0)
     # A history-disabled solver (the default) allocates no contact-reset state.
@@ -1915,7 +1915,8 @@ def _rigid_reset_state_and_history(test, device):
 
     # Phase 4: an all-false reset arms nothing, so the next step finite-differences
     # a known delta for every body (a leaked pose baseline would zero some world).
-    solver.reset(state, world_mask=wp.array([False, False], dtype=wp.bool, device=device))
+    with test.assertWarnsRegex(DeprecationWarning, "world_count \\+ 1"):
+        solver.reset(state, world_mask=wp.array([False, False], dtype=wp.bool, device=device))
     all_false_delta = 2.0
     moved_q = base_q.copy()
     moved_q[:, 0] += all_false_delta
@@ -2046,7 +2047,7 @@ def _rigid_reset_replays_captured_step(test, device):
 
     # reset() runs after capture. Its device-side mask write must be visible when
     # replaying the graph, while post-reset pose preparation remains authoritative.
-    world_mask = wp.array([True, False], dtype=wp.bool, device=device)
+    world_mask = wp.array([True, False, False], dtype=wp.bool, device=device)
     solver.reset(state_in, world_mask=world_mask, flags=0)
     reset_q = model.body_q.numpy()
     reset_q[:, 0] += 1.0
@@ -2092,7 +2093,7 @@ def _rigid_contact_reset_lifecycle(test, device):
     builder.add_world(template, xform=wp.transform(wp.vec3(1.0, 0.0, 0.0), wp.quat_identity()))
     builder.color()
     model = builder.finalize(device=device)
-    reset_mask = wp.array([True, False], dtype=wp.bool, device=device)
+    reset_mask = wp.array([True, False, False], dtype=wp.bool, device=device)
     dt = 1.0e-2
 
     pipeline = newton.CollisionPipeline(model, broad_phase="nxn", contact_matching="latest")


### PR DESCRIPTION
## Description

Closes #3374.

Standardize `SolverBase.reset()` and solver implementations on a boolean `world_mask` with shape `(world_count + 1,)`. Local worlds retain their zero-based slots and the final slot consistently selects global world `-1`.

Legacy masks with shape `(world_count,)` remain supported with a `DeprecationWarning` and leave the global world unselected. Coupled, VBD, MuJoCo, Kamino, and implicit MPM reset paths now accept the same public convention; solvers without global reset state treat the final slot as a no-op.

Document how `world_start` arrays encode leading and trailing global rows, and add coverage for global proxy history, solver validation, and public solver entry points.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev python -m unittest newton.tests.test_mujoco_reset newton.tests.test_solver_vbd newton.tests.test_coupled_solver newton.tests.test_implicit_mpm newton.tests.test_implicit_mpm_multiworld_sparse -k reset
uv run --extra dev python -m unittest newton.tests.test_custom_solver.TestCustomSolver.test_base_reset_validates_global_world_mask_slot newton.tests.test_coupled_solver.TestSolverCoupledParticleProxy.test_global_mask_resets_global_proxy_history newton.tests.test_solver_kamino_dvi.TestDVISolver.test_02a_public_solver_reset_accepts_global_mask_slot
uvx pre-commit run -a
```

## Bug fix

**Steps to reproduce:**

1. Build a model with one or more local worlds and global-world entities.
2. Pass a reset mask intended to select global world `-1`.
3. Observe that solver-specific mask shapes either reject the global slot or cannot select global state consistently.

**Minimal reproduction:**

```python
import warp as wp
import newton

builder = newton.ModelBuilder()
builder.begin_world()
builder.end_world()
model = builder.finalize()
solver = newton.solvers.SolverSemiImplicit(model)
state = model.state()

# Slot 0 selects local world 0; the final slot selects global world -1.
world_mask = wp.array((False, True), dtype=wp.bool, device=model.device)
solver.reset(state, world_mask=world_mask)
```

## New feature / API change

```python
# Canonical mask layout: [local world 0, ..., local world N-1, global world -1]
solver.reset(state, world_mask=world_mask)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated solver reset mask handling to accept a `(world_count + 1,)` form, with the final entry selecting global (`world = -1`) entities.
  * Standardized behavior across solvers and consistently emits a deprecation warning for the legacy `(world_count,)` local-only mask.

* **Documentation**
  * Clarified how global entities are arranged and how to select them using per-entity `world == -1`.
  * Added details for the optional reset mask and the deprecation guidance.

* **Bug Fixes**
  * Corrected global/public reset selection behavior in coupled and VBD flows, including proxy history.

* **Tests**
  * Added and updated regression and quality-gate tests covering the global mask slot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->