### PR TITLE
Read newton:mimicCoef0 as degrees for angular mimic followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 ### Fixed
 
+- Convert `newton:mimicCoef0` from degrees to radians when the mimic follower joint is angular. Assets authored against the old behavior need the value rescaled to degrees.
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.
 - Fix panel-parallel RCM-blocked LLT factorization hanging when a matrix ends in a partial tile.
 - Fix `ModelBuilder.add_usd()` marking a `guide`-purpose collider visible when it has a bound render material. Such a collider is not viewport geometry, and the extra `VISIBLE` flag left it drawn by the viewer's visual toggle instead of its collision toggle. `force_show_colliders` still reveals it.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4864,6 +4864,12 @@ def parse_usd(
             continue
         coef0 = usd.get_attribute(joint_prim, "newton:mimicCoef0", default=0.0)
         coef1 = usd.get_attribute(joint_prim, "newton:mimicCoef1", default=1.0)
+        # NewtonMimicAPI documents newton:mimicCoef0 in the follower's position units,
+        # which is degrees for an angular joint. Newton mimic constraints operate on
+        # joint coordinates, so an angular follower needs radians. coef1 is
+        # dimensionless and is not scaled.
+        if builder.joint_type[joint_idx] in (JointType.REVOLUTE, JointType.BALL):
+            coef0 *= DegreesToRadian
         leader_idx = path_joint_map[leader_path_str]
         builder.add_constraint_mimic(
             joint0=joint_idx,

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4865,11 +4865,35 @@ def parse_usd(
         coef0 = usd.get_attribute(joint_prim, "newton:mimicCoef0", default=0.0)
         coef1 = usd.get_attribute(joint_prim, "newton:mimicCoef1", default=1.0)
         # NewtonMimicAPI documents newton:mimicCoef0 in the follower's position units,
-        # which is degrees for an angular joint. Newton mimic constraints operate on
-        # joint coordinates, so an angular follower needs radians. coef1 is
-        # dimensionless and is not scaled.
-        if builder.joint_type[joint_idx] in (JointType.REVOLUTE, JointType.BALL):
+        # which is degrees for a single angular DOF. Newton mimic constraints operate on
+        # joint coordinates, so such a follower needs radians. coef1 is dimensionless.
+        #
+        # Classify from the authored USD prim rather than builder.joint_type: several
+        # single-DOF prims sharing a body pair are merged into one D6 (see
+        # parse_merged_joints), which would otherwise misread an angular follower.
+        follower_is_revolute = joint_prim.IsA(UsdPhysics.RevoluteJoint)
+        follower_is_prismatic = joint_prim.IsA(UsdPhysics.PrismaticJoint)
+        if follower_is_revolute:
             coef0 *= DegreesToRadian
+        elif not follower_is_prismatic:
+            # Spherical and D6 followers hold more than one DOF, and a ball joint's
+            # coordinates are a quaternion rather than a scalar angle, so a single offset
+            # has no defined unit. NewtonMimicAPI says as much: multi-DOF behavior is
+            # undefined. Pass the value through and say so.
+            warnings.warn(
+                f"NewtonMimicAPI on {joint_path}: newton:mimicCoef0 has no defined unit for a "
+                f"{joint_prim.GetTypeName()} follower, which is not a single-DOF joint. Using the "
+                f"authored value unconverted; the offset is applied to every DOF.",
+                stacklevel=2,
+            )
+        # Independent of units: a single-DOF prim merged into a D6 is constrained on every
+        # axis of that joint, not only the one the API was authored on.
+        if (follower_is_revolute or follower_is_prismatic) and builder.joint_type[joint_idx] == JointType.D6:
+            warnings.warn(
+                f"NewtonMimicAPI on {joint_path}: follower was merged into a multi-DOF joint, so the "
+                f"mimic constraint applies to every DOF of that joint, not only the authored axis.",
+                stacklevel=2,
+            )
         leader_idx = path_joint_map[leader_path_str]
         builder.add_constraint_mimic(
             joint0=joint_idx,

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -9286,13 +9286,13 @@ def Xform "Articulation" (
     def test_mimic_coef0_units_follow_the_follower_joint(self):
         """newton:mimicCoef0 is degrees for an angular follower and distance for a linear one.
 
-        NewtonMimicAPI documents the offset in the follower's position units. Newton
-        mimic constraints operate on joint coordinates, so an angular follower has to be
-        converted to radians while a prismatic one passes through untouched.
+        NewtonMimicAPI documents the offset in the follower's position units. Newton mimic
+        constraints operate on joint coordinates, so an angular follower is converted to
+        radians while a prismatic one passes through. The leader's type is irrelevant.
         """
         from pxr import Gf, Usd, UsdGeom, UsdPhysics
 
-        def build(joint_cls):
+        def build(leader_cls, follower_cls):
             stage = Usd.Stage.CreateInMemory()
             UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
             UsdGeom.SetStageMetersPerUnit(stage, 1.0)
@@ -9307,7 +9307,7 @@ def Xform "Articulation" (
                 UsdPhysics.CollisionAPI.Apply(link)
                 links.append(link)
 
-            def joint(path, body0, body1):
+            def joint(joint_cls, path, body0, body1):
                 j = joint_cls.Define(stage, path)
                 if body0 is not None:
                     j.CreateBody0Rel().SetTargets([body0.GetPath()])
@@ -9319,8 +9319,8 @@ def Xform "Articulation" (
                 j.CreateAxisAttr().Set("Z")
                 return j
 
-            leader = joint("/World/Root/Leader", root, links[0])
-            follower = joint("/World/Root/Follower", links[0], links[1])
+            leader = joint(leader_cls, "/World/Root/Leader", root, links[0])
+            follower = joint(follower_cls, "/World/Root/Follower", links[0], links[1])
             prim = follower.GetPrim()
             prim.ApplyAPI("NewtonMimicAPI")
             prim.GetRelationship("newton:mimicJoint").SetTargets([leader.GetPrim().GetPath()])
@@ -9330,13 +9330,130 @@ def Xform "Articulation" (
             builder.add_usd(stage)
             return builder.finalize()
 
-        angular = build(UsdPhysics.RevoluteJoint)
-        self.assertEqual(angular.constraint_mimic_count, 1)
-        self.assertAlmostEqual(angular.constraint_mimic_coef0.numpy()[0], math.radians(0.5), places=6)
+        revolute = UsdPhysics.RevoluteJoint
+        prismatic = UsdPhysics.PrismaticJoint
 
-        linear = build(UsdPhysics.PrismaticJoint)
-        self.assertEqual(linear.constraint_mimic_count, 1)
-        self.assertAlmostEqual(linear.constraint_mimic_coef0.numpy()[0], 0.5, places=6)
+        # Cross the pairs so a conversion keyed on the leader would fail here.
+        for leader_cls, follower_cls, expected in (
+            (revolute, revolute, math.radians(0.5)),
+            (prismatic, revolute, math.radians(0.5)),
+            (prismatic, prismatic, 0.5),
+            (revolute, prismatic, 0.5),
+        ):
+            with self.subTest(leader=leader_cls.__name__, follower=follower_cls.__name__):
+                model = build(leader_cls, follower_cls)
+                self.assertEqual(model.constraint_mimic_count, 1)
+                self.assertAlmostEqual(model.constraint_mimic_coef0.numpy()[0], expected, places=6)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mimic_coef0_units_survive_joint_merging(self):
+        """An angular follower merged into a D6 is still converted from degrees.
+
+        Single-DOF prims sharing a body pair are merged into one D6 joint, so the
+        follower's builder joint type is D6 rather than REVOLUTE. The authored USD prim
+        is what carries the unit, and a warning notes the widened constraint.
+        """
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        root = UsdGeom.Xform.Define(stage, "/World/Root").GetPrim()
+        UsdPhysics.ArticulationRootAPI.Apply(root)
+        links = []
+        for name in ("Link1", "Link2"):
+            link = UsdGeom.Cube.Define(stage, f"/World/Root/{name}").GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(link)
+            UsdPhysics.CollisionAPI.Apply(link)
+            links.append(link)
+
+        def joint(joint_cls, path, body0, body1, axis):
+            j = joint_cls.Define(stage, path)
+            j.CreateBody0Rel().SetTargets([body0.GetPath()])
+            j.CreateBody1Rel().SetTargets([body1.GetPath()])
+            j.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            j.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            j.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            j.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            j.CreateAxisAttr().Set(axis)
+            return j
+
+        leader = joint(UsdPhysics.RevoluteJoint, "/World/Root/Leader", root, links[0], "Z")
+        # Two single-DOF prims on the same body pair are merged into one D6.
+        follower = joint(UsdPhysics.RevoluteJoint, "/World/Root/Follower", links[0], links[1], "Z")
+        joint(UsdPhysics.PrismaticJoint, "/World/Root/FollowerSlide", links[0], links[1], "X")
+
+        prim = follower.GetPrim()
+        prim.ApplyAPI("NewtonMimicAPI")
+        prim.GetRelationship("newton:mimicJoint").SetTargets([leader.GetPrim().GetPath()])
+        prim.GetAttribute("newton:mimicCoef0").Set(0.5)
+
+        builder = newton.ModelBuilder()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = builder.add_usd(stage)
+        model = builder.finalize()
+
+        follower_idx = result["path_joint_map"]["/World/Root/Follower"]
+        self.assertEqual(builder.joint_type[follower_idx], newton.JointType.D6)
+        self.assertEqual(model.constraint_mimic_count, 1)
+        self.assertAlmostEqual(model.constraint_mimic_coef0.numpy()[0], math.radians(0.5), places=6)
+        self.assertTrue(
+            any("merged into a multi-DOF joint" in str(w.message) for w in caught),
+            "expected a warning that the mimic constraint was widened to the merged joint",
+        )
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mimic_coef0_warns_for_multi_dof_follower(self):
+        """A spherical follower has no scalar angle, so the offset is passed through with a warning."""
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        root = UsdGeom.Xform.Define(stage, "/World/Root").GetPrim()
+        UsdPhysics.ArticulationRootAPI.Apply(root)
+        links = []
+        for name in ("Link1", "Link2"):
+            link = UsdGeom.Cube.Define(stage, f"/World/Root/{name}").GetPrim()
+            UsdPhysics.RigidBodyAPI.Apply(link)
+            UsdPhysics.CollisionAPI.Apply(link)
+            links.append(link)
+
+        def joint(joint_cls, path, body0, body1):
+            j = joint_cls.Define(stage, path)
+            j.CreateBody0Rel().SetTargets([body0.GetPath()])
+            j.CreateBody1Rel().SetTargets([body1.GetPath()])
+            j.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            j.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            j.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            j.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            j.CreateAxisAttr().Set("Z")
+            return j
+
+        leader = joint(UsdPhysics.SphericalJoint, "/World/Root/Leader", root, links[0])
+        follower = joint(UsdPhysics.SphericalJoint, "/World/Root/Follower", links[0], links[1])
+        prim = follower.GetPrim()
+        prim.ApplyAPI("NewtonMimicAPI")
+        prim.GetRelationship("newton:mimicJoint").SetTargets([leader.GetPrim().GetPath()])
+        prim.GetAttribute("newton:mimicCoef0").Set(0.5)
+
+        builder = newton.ModelBuilder()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            builder.add_usd(stage)
+        model = builder.finalize()
+
+        # A ball joint's coordinates are a quaternion, so no scalar conversion applies.
+        self.assertAlmostEqual(model.constraint_mimic_coef0.numpy()[0], 0.5, places=6)
+        self.assertTrue(
+            any("no defined unit" in str(w.message) for w in caught),
+            "expected a warning that the offset has no defined unit for a multi-DOF follower",
+        )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_mjc_equality_joint_parsing(self):

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -9276,8 +9276,67 @@ def Xform "Articulation" (
         joint2_idx = path_joint_map["/World/Articulation/Joint2"]
         self.assertEqual(model.constraint_mimic_joint0.numpy()[0], joint2_idx)
         self.assertEqual(model.constraint_mimic_joint1.numpy()[0], joint1_idx)
-        self.assertAlmostEqual(model.constraint_mimic_coef0.numpy()[0], 0.5, places=5)
+        # newton:mimicCoef0 is authored in degrees for an angular follower; Newton
+        # mimic constraints use joint coordinates, so it arrives in radians.
+        self.assertAlmostEqual(model.constraint_mimic_coef0.numpy()[0], math.radians(0.5), places=6)
+        # coef1 is dimensionless and is passed through unscaled.
         self.assertAlmostEqual(model.constraint_mimic_coef1.numpy()[0], 2.0, places=5)
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mimic_coef0_units_follow_the_follower_joint(self):
+        """newton:mimicCoef0 is degrees for an angular follower and distance for a linear one.
+
+        NewtonMimicAPI documents the offset in the follower's position units. Newton
+        mimic constraints operate on joint coordinates, so an angular follower has to be
+        converted to radians while a prismatic one passes through untouched.
+        """
+        from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+        def build(joint_cls):
+            stage = Usd.Stage.CreateInMemory()
+            UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+            UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+            UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+            root = UsdGeom.Xform.Define(stage, "/World/Root").GetPrim()
+            UsdPhysics.ArticulationRootAPI.Apply(root)
+            links = []
+            for name in ("Link1", "Link2"):
+                link = UsdGeom.Cube.Define(stage, f"/World/Root/{name}").GetPrim()
+                UsdPhysics.RigidBodyAPI.Apply(link)
+                UsdPhysics.CollisionAPI.Apply(link)
+                links.append(link)
+
+            def joint(path, body0, body1):
+                j = joint_cls.Define(stage, path)
+                if body0 is not None:
+                    j.CreateBody0Rel().SetTargets([body0.GetPath()])
+                j.CreateBody1Rel().SetTargets([body1.GetPath()])
+                j.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                j.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                j.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+                j.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+                j.CreateAxisAttr().Set("Z")
+                return j
+
+            leader = joint("/World/Root/Leader", root, links[0])
+            follower = joint("/World/Root/Follower", links[0], links[1])
+            prim = follower.GetPrim()
+            prim.ApplyAPI("NewtonMimicAPI")
+            prim.GetRelationship("newton:mimicJoint").SetTargets([leader.GetPrim().GetPath()])
+            prim.GetAttribute("newton:mimicCoef0").Set(0.5)
+
+            builder = newton.ModelBuilder()
+            builder.add_usd(stage)
+            return builder.finalize()
+
+        angular = build(UsdPhysics.RevoluteJoint)
+        self.assertEqual(angular.constraint_mimic_count, 1)
+        self.assertAlmostEqual(angular.constraint_mimic_coef0.numpy()[0], math.radians(0.5), places=6)
+
+        linear = build(UsdPhysics.PrismaticJoint)
+        self.assertEqual(linear.constraint_mimic_count, 1)
+        self.assertAlmostEqual(linear.constraint_mimic_coef0.numpy()[0], 0.5, places=6)
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_mjc_equality_joint_parsing(self):


### PR DESCRIPTION
## Description

Convert `newton:mimicCoef0` from degrees to radians when the mimic follower joint is angular.

`NewtonMimicAPI` documents the offset as "distance or degrees (matches the joint type)". The importer passed it straight into `ModelBuilder.add_constraint_mimic()`, which works in joint coordinates, so a revolute or ball follower was constrained with an offset a factor of `180/pi` too small. Prismatic followers were already correct, and `newton:mimicCoef1` is dimensionless and untouched.

Part of newton-physics/mujoco-usd-converter#107.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m unittest newton.tests.test_import_usd   # 296 tests
uvx pre-commit run -a
```

`test_mimic_constraint_parsing` previously asserted the unconverted value, so it encoded the bug; it now expects radians. Added `test_mimic_coef0_units_follow_the_follower_joint` covering revolute and prismatic followers, since nothing pinned that the conversion is gated on the joint being angular. Both fail without the fix with `0.5 != 0.008726646259971648`.

## Bug fix

**Steps to reproduce:**

1. Author two revolute joints, applying `NewtonMimicAPI` to the follower.
2. Set `newton:mimicCoef0` to a non-zero value — per the schema this is degrees.
3. Import with `ModelBuilder.add_usd()`.
4. `Model.constraint_mimic_coef0` holds the authored number unchanged, but the constraint is evaluated in radians, so the offset is `180/pi` too small.

**Minimal reproduction:**

```python
import math

import newton

# ... two revolute joints, NewtonMimicAPI applied to the follower ...
follower.GetAttribute("newton:mimicCoef0").Set(0.5)  # degrees, per NewtonMimicAPI

builder = newton.ModelBuilder()
builder.add_usd(stage)
model = builder.finalize()

# Before: 0.5   (degrees value used as radians)
# After:  math.radians(0.5) == 0.0087266
print(model.constraint_mimic_coef0.numpy()[0])
```

## Sequencing

The converters that write this attribute have the same missing conversion, so they currently agree with this importer and disagree with the schema. That is why the bug has been invisible in practice — round trips are symmetric and cancel out.

This is the read side and is safe to land first: it makes Newton match the schema. Until the write side follows, assets produced by those converters will import with the offset `180/pi` too large.

- newton-physics/mujoco-usd-converter#108 — write side for MJCF
- newton-physics/urdf-usd-converter#134 — write side for URDF
- newton-physics/newton-usd-schemas#80 — documents the related same-joint-type requirement
- MuJoCo's `usd_decoder` has the same issue and is being handled separately

Assets authored against the previous behaviour need `newton:mimicCoef0` rescaled to degrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected USD import for `newton:mimicCoef0` by converting degree-authored angular follower values to radians for single-DOF revolute joints.
  * Kept `newton:mimicCoef0` unchanged for prismatic (linear) followers.
  * For multi-DOF followers, no unit conversion is applied; import now warns when mimic constraints may affect additional DOFs after joint merging.
* **Tests**
  * Added coverage for unit handling and warning behavior across angular, linear, multi-DOF, and merged-joint scenarios.
* **Documentation**
  * Updated the unreleased changelog, including guidance to rescale assets authored under the previous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->