### PR TITLE
Resolve MJCF <position dampratio> for joint-target actuators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - Fix panel-parallel RCM-blocked LLT factorization hanging when a matrix ends in a partial tile.
 - Fix `ModelBuilder.add_usd()` marking a `guide`-purpose collider visible when it has a bound render material. Such a collider is not viewport geometry, and the extra `VISIBLE` flag left it drawn by the viewer's visual toggle instead of its collision toggle. `force_show_colliders` still reveals it.
 - Fix USD capsule, cylinder, and cone visual and site scaling to follow the authored primitive axis.
+- Fix MJCF `<position dampratio="...">` being dropped for joint-target actuators, which imported a drive the asset author tuned as critically damped with `joint_target_kd` left at zero. The ratio is now resolved against the compiled reflected inertia using MuJoCo's own formula. (#3698)
 - Fix USD plane visual width and length to scale along the axes defined by the `UsdGeomPlane` schema, and orient X- and Y-axis plane visuals along the authored axis.
 - Validate `ArticulationView` mask shapes and devices before launching selection kernels. (#3448)
 - Exclude active particles with non-finite positions from rebuildable `SolverImplicitMPM` sparse-grid packing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,7 @@
 - Fix MJCF contact pairs ignoring properties inherited from pair default classes.
 - Fix disabled USD colliders participating in particle collisions when visual shape loading is disabled.
 - Fix `ArticulationView.is_fixed_base` for roots with zero effective degrees of freedom, including fully locked D6 joints. (#3727)
+- Fix MJCF `<position dampratio="...">` being dropped for joint-target actuators, which imported a drive the asset author tuned as critically damped with `joint_target_kd` left at zero. The ratio is now resolved against the compiled reflected inertia using MuJoCo's own formula. (#3698)
 - Fix USD plane visual width and length to scale along the axes defined by the `UsdGeomPlane` schema, and orient X- and Y-axis plane visuals along the authored axis.
 - Validate `ArticulationView` mask shapes and devices before launching selection kernels. (#3448)
 - Exclude active particles with non-finite positions from rebuildable `SolverImplicitMPM` sparse-grid packing.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -6564,6 +6564,70 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_data = mujoco.MjData(self.mj_model)
         mujoco.mj_setConst(self.mj_model, self.mj_data)
 
+        # Resolve <position dampratio="..."> for JOINT_TARGET actuators.
+        #
+        # The MJCF importer stores an unresolved dampratio as a positive
+        # ``mujoco:actuator_biasprm[2]`` placeholder and leaves
+        # ``joint_target_kd`` at zero, because the reflected inertia needed to
+        # turn a ratio into a gain is only known once MuJoCo has compiled the
+        # model. CTRL_DIRECT actuators get resolved by ``mj_setConst`` above,
+        # but JOINT_TARGET actuators read ``joint_target_kd`` directly (both
+        # here and in ``update_axis_properties_kernel``), so without this step
+        # a drive authored as critically damped imports completely undamped.
+        #
+        # ``actuator_acc0`` is MuJoCo's unit-force acceleration for the
+        # actuator, i.e. 1 / dof_M0, so MuJoCo's compile-time formula
+        # ``kv = 2 * dampratio * sqrt(kp * dof_M0)`` becomes
+        # ``2 * dampratio * sqrt(kp / acc0)``.
+        if mujoco_attrs is not None:
+            act_biasprm = get_custom_attribute("actuator_biasprm")
+            act_gainprm = get_custom_attribute("actuator_gainprm")
+            act_trnid = get_custom_attribute("actuator_trnid")
+            act_ctrl_source = get_custom_attribute("ctrl_source")
+            act_ctrl_type = get_custom_attribute("ctrl_type")
+            if (
+                act_biasprm is not None
+                and act_gainprm is not None
+                and act_trnid is not None
+                and act_ctrl_source is not None
+                and act_ctrl_type is not None
+            ):
+                resolved_kd: dict[int, float] = {}
+                for row in range(len(act_biasprm)):
+                    if int(act_ctrl_source[row]) != int(SolverMuJoCo.CtrlSource.JOINT_TARGET):
+                        continue
+                    if int(act_ctrl_type[row]) != int(SolverMuJoCo.CtrlType.POSITION):
+                        continue
+                    dampratio = float(act_biasprm[row][2])
+                    # Negative encodes an explicit kv, zero means neither was authored.
+                    if dampratio <= 0.0:
+                        continue
+                    kp = float(act_gainprm[row][0])
+                    if kp <= 0.0:
+                        continue
+                    joint_idx = int(act_trnid[row][0])
+                    if joint_idx < 0 or joint_idx >= len(joint_qd_start):
+                        continue
+                    dof_start = int(joint_qd_start[joint_idx])
+                    lin_dofs, ang_dofs = joint_dof_dim[joint_idx]
+                    for dof in range(dof_start, dof_start + int(lin_dofs) + int(ang_dofs)):
+                        mjc_actuator = int(axis_to_actuator[dof, 0]) if dof < len(axis_to_actuator) else -1
+                        if mjc_actuator < 0:
+                            continue
+                        acc0 = float(self.mj_model.actuator_acc0[mjc_actuator])
+                        if acc0 <= 0.0:
+                            continue
+                        resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp / acc0)
+                if resolved_kd:
+                    kd_host = model.joint_target_kd.numpy()
+                    for dof, kd_value in resolved_kd.items():
+                        # An explicit kv, or a kd already set by a velocity
+                        # actuator on the same DOF, takes precedence.
+                        if kd_host[dof] == 0.0:
+                            kd_host[dof] = kd_value
+                            joint_target_kd[dof] = kd_value
+                    model.joint_target_kd.assign(wp.array(kd_host, dtype=float, device=model.device))
+
         # Build MuJoCo qpos/qvel start index arrays for coordinate conversion kernels.
         # These map Newton template joint index → MuJoCo qpos/qvel start.
         # Loop joints get -1 (they have no MuJoCo qpos/qvel slots).

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -6575,14 +6575,17 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # here and in ``update_axis_properties_kernel``), so without this step
         # a drive authored as critically damped imports completely undamped.
         #
-        # ``actuator_acc0`` is MuJoCo's unit-force acceleration for the
-        # actuator, i.e. 1 / dof_M0, so MuJoCo's compile-time formula
-        # ``kv = 2 * dampratio * sqrt(kp * dof_M0)`` becomes
-        # ``2 * dampratio * sqrt(kp / acc0)``.
+        # MuJoCo's compile-time formula is ``kv = 2 * dampratio * sqrt(kp * dof_M0)``,
+        # where ``dof_M0`` is the reflected inertia of the driven DOF in the
+        # reference configuration. Note this is *not* interchangeable with
+        # ``1 / actuator_acc0``: the two agree only when the actuated joint is the
+        # sole DOF in its kinematic subtree, and diverge badly otherwise (on a
+        # three-link chain the acc0 form is off by roughly 6x).
         if mujoco_attrs is not None:
             act_biasprm = get_custom_attribute("actuator_biasprm")
             act_gainprm = get_custom_attribute("actuator_gainprm")
             act_trnid = get_custom_attribute("actuator_trnid")
+            act_trntype = get_custom_attribute("actuator_trntype")
             act_ctrl_source = get_custom_attribute("ctrl_source")
             act_ctrl_type = get_custom_attribute("ctrl_type")
             if (
@@ -6598,6 +6601,10 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         continue
                     if int(act_ctrl_type[row]) != int(SolverMuJoCo.CtrlType.POSITION):
                         continue
+                    # trnid only names a DOF for joint transmissions; for tendon/body/site
+                    # actuators it indexes a different array entirely.
+                    if act_trntype is not None and int(act_trntype[row]) != int(SolverMuJoCo.TrnType.JOINT):
+                        continue
                     dampratio = float(act_biasprm[row][2])
                     # Negative encodes an explicit kv, zero means neither was authored.
                     if dampratio <= 0.0:
@@ -6605,19 +6612,27 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     kp = float(act_gainprm[row][0])
                     if kp <= 0.0:
                         continue
-                    joint_idx = int(act_trnid[row][0])
-                    if joint_idx < 0 or joint_idx >= len(joint_qd_start):
+                    # For joint transmissions actuator_trnid[:, 0] is the Newton DOF
+                    # index itself (see import_mjcf.py, which stores qd_start here),
+                    # not a joint index -- an actuator drives exactly that one DOF.
+                    dof = int(act_trnid[row][0])
+                    if dof < 0 or dof >= len(axis_to_actuator):
                         continue
-                    dof_start = int(joint_qd_start[joint_idx])
-                    lin_dofs, ang_dofs = joint_dof_dim[joint_idx]
-                    for dof in range(dof_start, dof_start + int(lin_dofs) + int(ang_dofs)):
-                        mjc_actuator = int(axis_to_actuator[dof, 0]) if dof < len(axis_to_actuator) else -1
-                        if mjc_actuator < 0:
-                            continue
-                        acc0 = float(self.mj_model.actuator_acc0[mjc_actuator])
-                        if acc0 <= 0.0:
-                            continue
-                        resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp / acc0)
+                    mjc_actuator = int(axis_to_actuator[dof, 0])
+                    if mjc_actuator < 0:
+                        continue
+                    # Resolve the MuJoCo DOF this actuator drives so we can read its
+                    # reflected inertia; trnid on the compiled model is a joint index.
+                    mjc_jnt = int(self.mj_model.actuator_trnid[mjc_actuator, 0])
+                    if mjc_jnt < 0 or mjc_jnt >= self.mj_model.njnt:
+                        continue
+                    mjc_dof = int(self.mj_model.jnt_dofadr[mjc_jnt])
+                    if mjc_dof < 0 or mjc_dof >= self.mj_model.nv:
+                        continue
+                    dof_m0 = float(self.mj_model.dof_M0[mjc_dof])
+                    if dof_m0 <= 0.0:
+                        continue
+                    resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp * dof_m0)
                 if resolved_kd:
                     kd_host = model.joint_target_kd.numpy()
                     for dof, kd_value in resolved_kd.items():

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7559,6 +7559,70 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         self.mj_data = mujoco.MjData(self.mj_model)
         mujoco.mj_setConst(self.mj_model, self.mj_data)
 
+        # Resolve <position dampratio="..."> for JOINT_TARGET actuators.
+        #
+        # The MJCF importer stores an unresolved dampratio as a positive
+        # ``mujoco:actuator_biasprm[2]`` placeholder and leaves
+        # ``joint_target_kd`` at zero, because the reflected inertia needed to
+        # turn a ratio into a gain is only known once MuJoCo has compiled the
+        # model. CTRL_DIRECT actuators get resolved by ``mj_setConst`` above,
+        # but JOINT_TARGET actuators read ``joint_target_kd`` directly (both
+        # here and in ``update_axis_properties_kernel``), so without this step
+        # a drive authored as critically damped imports completely undamped.
+        #
+        # ``actuator_acc0`` is MuJoCo's unit-force acceleration for the
+        # actuator, i.e. 1 / dof_M0, so MuJoCo's compile-time formula
+        # ``kv = 2 * dampratio * sqrt(kp * dof_M0)`` becomes
+        # ``2 * dampratio * sqrt(kp / acc0)``.
+        if mujoco_attrs is not None:
+            act_biasprm = get_custom_attribute("actuator_biasprm")
+            act_gainprm = get_custom_attribute("actuator_gainprm")
+            act_trnid = get_custom_attribute("actuator_trnid")
+            act_ctrl_source = get_custom_attribute("ctrl_source")
+            act_ctrl_type = get_custom_attribute("ctrl_type")
+            if (
+                act_biasprm is not None
+                and act_gainprm is not None
+                and act_trnid is not None
+                and act_ctrl_source is not None
+                and act_ctrl_type is not None
+            ):
+                resolved_kd: dict[int, float] = {}
+                for row in range(len(act_biasprm)):
+                    if int(act_ctrl_source[row]) != int(SolverMuJoCo.CtrlSource.JOINT_TARGET):
+                        continue
+                    if int(act_ctrl_type[row]) != int(SolverMuJoCo.CtrlType.POSITION):
+                        continue
+                    dampratio = float(act_biasprm[row][2])
+                    # Negative encodes an explicit kv, zero means neither was authored.
+                    if dampratio <= 0.0:
+                        continue
+                    kp = float(act_gainprm[row][0])
+                    if kp <= 0.0:
+                        continue
+                    joint_idx = int(act_trnid[row][0])
+                    if joint_idx < 0 or joint_idx >= len(joint_qd_start):
+                        continue
+                    dof_start = int(joint_qd_start[joint_idx])
+                    lin_dofs, ang_dofs = joint_dof_dim[joint_idx]
+                    for dof in range(dof_start, dof_start + int(lin_dofs) + int(ang_dofs)):
+                        mjc_actuator = int(axis_to_actuator[dof, 0]) if dof < len(axis_to_actuator) else -1
+                        if mjc_actuator < 0:
+                            continue
+                        acc0 = float(self.mj_model.actuator_acc0[mjc_actuator])
+                        if acc0 <= 0.0:
+                            continue
+                        resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp / acc0)
+                if resolved_kd:
+                    kd_host = model.joint_target_kd.numpy()
+                    for dof, kd_value in resolved_kd.items():
+                        # An explicit kv, or a kd already set by a velocity
+                        # actuator on the same DOF, takes precedence.
+                        if kd_host[dof] == 0.0:
+                            kd_host[dof] = kd_value
+                            joint_target_kd[dof] = kd_value
+                    model.joint_target_kd.assign(wp.array(kd_host, dtype=float, device=model.device))
+
         # Build MuJoCo qpos/qvel start index arrays for coordinate conversion kernels.
         # These map Newton template joint index → MuJoCo qpos/qvel start.
         # Loop joints get -1 (they have no MuJoCo qpos/qvel slots).

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -7570,14 +7570,17 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # here and in ``update_axis_properties_kernel``), so without this step
         # a drive authored as critically damped imports completely undamped.
         #
-        # ``actuator_acc0`` is MuJoCo's unit-force acceleration for the
-        # actuator, i.e. 1 / dof_M0, so MuJoCo's compile-time formula
-        # ``kv = 2 * dampratio * sqrt(kp * dof_M0)`` becomes
-        # ``2 * dampratio * sqrt(kp / acc0)``.
+        # MuJoCo's compile-time formula is ``kv = 2 * dampratio * sqrt(kp * dof_M0)``,
+        # where ``dof_M0`` is the reflected inertia of the driven DOF in the
+        # reference configuration. Note this is *not* interchangeable with
+        # ``1 / actuator_acc0``: the two agree only when the actuated joint is the
+        # sole DOF in its kinematic subtree, and diverge badly otherwise (on a
+        # three-link chain the acc0 form is off by roughly 6x).
         if mujoco_attrs is not None:
             act_biasprm = get_custom_attribute("actuator_biasprm")
             act_gainprm = get_custom_attribute("actuator_gainprm")
             act_trnid = get_custom_attribute("actuator_trnid")
+            act_trntype = get_custom_attribute("actuator_trntype")
             act_ctrl_source = get_custom_attribute("ctrl_source")
             act_ctrl_type = get_custom_attribute("ctrl_type")
             if (
@@ -7593,6 +7596,10 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                         continue
                     if int(act_ctrl_type[row]) != int(SolverMuJoCo.CtrlType.POSITION):
                         continue
+                    # trnid only names a DOF for joint transmissions; for tendon/body/site
+                    # actuators it indexes a different array entirely.
+                    if act_trntype is not None and int(act_trntype[row]) != int(SolverMuJoCo.TrnType.JOINT):
+                        continue
                     dampratio = float(act_biasprm[row][2])
                     # Negative encodes an explicit kv, zero means neither was authored.
                     if dampratio <= 0.0:
@@ -7600,19 +7607,27 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                     kp = float(act_gainprm[row][0])
                     if kp <= 0.0:
                         continue
-                    joint_idx = int(act_trnid[row][0])
-                    if joint_idx < 0 or joint_idx >= len(joint_qd_start):
+                    # For joint transmissions actuator_trnid[:, 0] is the Newton DOF
+                    # index itself (see import_mjcf.py, which stores qd_start here),
+                    # not a joint index -- an actuator drives exactly that one DOF.
+                    dof = int(act_trnid[row][0])
+                    if dof < 0 or dof >= len(axis_to_actuator):
                         continue
-                    dof_start = int(joint_qd_start[joint_idx])
-                    lin_dofs, ang_dofs = joint_dof_dim[joint_idx]
-                    for dof in range(dof_start, dof_start + int(lin_dofs) + int(ang_dofs)):
-                        mjc_actuator = int(axis_to_actuator[dof, 0]) if dof < len(axis_to_actuator) else -1
-                        if mjc_actuator < 0:
-                            continue
-                        acc0 = float(self.mj_model.actuator_acc0[mjc_actuator])
-                        if acc0 <= 0.0:
-                            continue
-                        resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp / acc0)
+                    mjc_actuator = int(axis_to_actuator[dof, 0])
+                    if mjc_actuator < 0:
+                        continue
+                    # Resolve the MuJoCo DOF this actuator drives so we can read its
+                    # reflected inertia; trnid on the compiled model is a joint index.
+                    mjc_jnt = int(self.mj_model.actuator_trnid[mjc_actuator, 0])
+                    if mjc_jnt < 0 or mjc_jnt >= self.mj_model.njnt:
+                        continue
+                    mjc_dof = int(self.mj_model.jnt_dofadr[mjc_jnt])
+                    if mjc_dof < 0 or mjc_dof >= self.mj_model.nv:
+                        continue
+                    dof_m0 = float(self.mj_model.dof_M0[mjc_dof])
+                    if dof_m0 <= 0.0:
+                        continue
+                    resolved_kd[dof] = 2.0 * dampratio * np.sqrt(kp * dof_m0)
                 if resolved_kd:
                     kd_host = model.joint_target_kd.numpy()
                     for dof, kd_value in resolved_kd.items():

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8120,6 +8120,85 @@ class TestMjcfPositionDampratioParsing(unittest.TestCase):
         self.assertAlmostEqual(float(biasprm[1, 2]), -3.0, places=6)
 
 
+class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
+    """Regression for #3698: <position dampratio> must reach joint_target_kd.
+
+    The importer stores an unresolved dampratio as a positive biasprm[2]
+    placeholder because the reflected inertia is only known after MuJoCo
+    compiles the model. CTRL_DIRECT actuators are resolved by mj_setConst,
+    but JOINT_TARGET actuators read joint_target_kd directly, so a drive the
+    asset author tuned to be critically damped used to import with kd == 0.
+    """
+
+    MJCF = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="link">
+                <joint name="hinge" type="hinge" axis="0 0 1"/>
+                <geom type="sphere" size="0.05" mass="1"/>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="100" dampratio="1"/>
+        </actuator>
+    </mujoco>
+    """
+
+    @staticmethod
+    def _expected_kd(kp, dampratio, acc0):
+        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0), with dof_M0 == 1 / acc0.
+        return 2.0 * dampratio * np.sqrt(kp / acc0)
+
+    def test_dampratio_resolved_into_joint_target_kd(self):
+        """A dampratio-only position actuator must not import undamped."""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(self.MJCF)
+        model = builder.finalize()
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+        solver = newton.solvers.SolverMuJoCo(model)
+        kd = float(model.joint_target_kd.numpy()[0])
+
+        self.assertGreater(kd, 0.0, "dampratio was dropped; drive imported undamped")
+        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.actuator_acc0[0]))
+        self.assertAlmostEqual(kd, expected, places=4)
+
+    def test_matches_native_mujoco(self):
+        """The resolved kd must match MuJoCo's own compile-time value."""
+        import mujoco
+
+        mj_model = mujoco.MjModel.from_xml_string(self.MJCF)
+        native_kv = -float(mj_model.actuator_biasprm[0][2])
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(self.MJCF)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), native_kv, places=4)
+
+    def test_explicit_kv_is_not_overwritten(self):
+        """An explicit kv must still win; dampratio must not clobber it."""
+        mjcf = self.MJCF.replace('kp="100" dampratio="1"', 'kp="100" kv="3.0" dampratio="1"')
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 3.0, places=6)
+
+    def test_no_dampratio_stays_undamped(self):
+        """Neither kv nor dampratio authored => kd stays zero."""
+        mjcf = self.MJCF.replace('kp="100" dampratio="1"', 'kp="100"')
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+
 class TestActuatorDefaultKpKv(unittest.TestCase):
     """Regression: position/velocity actuators must default kp=1/kv=1.
 

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8145,9 +8145,9 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
     """
 
     @staticmethod
-    def _expected_kd(kp, dampratio, acc0):
-        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0), with dof_M0 == 1 / acc0.
-        return 2.0 * dampratio * np.sqrt(kp / acc0)
+    def _expected_kd(kp, dampratio, dof_m0):
+        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0).
+        return 2.0 * dampratio * np.sqrt(kp * dof_m0)
 
     def test_dampratio_resolved_into_joint_target_kd(self):
         """A dampratio-only position actuator must not import undamped."""
@@ -8161,7 +8161,7 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
         kd = float(model.joint_target_kd.numpy()[0])
 
         self.assertGreater(kd, 0.0, "dampratio was dropped; drive imported undamped")
-        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.actuator_acc0[0]))
+        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.dof_M0[0]))
         self.assertAlmostEqual(kd, expected, places=4)
 
     def test_matches_native_mujoco(self):
@@ -8197,6 +8197,111 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
         newton.solvers.SolverMuJoCo(model)
 
         self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+    # Scenes where the actuated hinge is NOT the first DOF, and where the
+    # reflected inertia is not simply the actuator's own. actuator_trnid stores
+    # a DOF index, so anything that reads it as a joint index lands on the wrong
+    # target (or out of range, silently dropping the damping); and dof_M0 only
+    # coincides with 1 / actuator_acc0 when the driven joint is alone in its
+    # subtree, so a chain exposes the difference too.
+    MJCF_BALL_THEN_HINGE = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="ball_link">
+                <joint name="ball" type="ball"/>
+                <geom type="sphere" size="0.05" mass="1"/>
+                <body name="link" pos="0.2 0 0">
+                    <joint name="hinge" type="hinge" axis="0 0 1"/>
+                    <geom type="sphere" size="0.05" mass="1"/>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="100" dampratio="1"/>
+        </actuator>
+    </mujoco>
+    """
+
+    MJCF_FREE_THEN_HINGE = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="floating">
+                <freejoint/>
+                <geom type="box" size="0.1 0.1 0.1" mass="3"/>
+                <body name="link" pos="0.2 0 0">
+                    <joint name="hinge" type="hinge" axis="0 1 0"/>
+                    <geom type="sphere" size="0.05" mass="1"/>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="80" dampratio="1.5"/>
+        </actuator>
+    </mujoco>
+    """
+
+    MJCF_CHAIN = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="a">
+                <joint name="h0" type="hinge" axis="0 0 1"/>
+                <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                <body name="b" pos="0.3 0 0">
+                    <joint name="h1" type="hinge" axis="0 0 1"/>
+                    <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                    <body name="c" pos="0.3 0 0">
+                        <joint name="h2" type="hinge" axis="0 0 1"/>
+                        <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                    </body>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="h0" kp="50" dampratio="0.7"/>
+        </actuator>
+    </mujoco>
+    """
+
+    def _assert_matches_native(self, mjcf):
+        import mujoco
+
+        mj_model = mujoco.MjModel.from_xml_string(mjcf)
+        native_kv = -float(mj_model.actuator_biasprm[0][2])
+        self.assertGreater(native_kv, 0.0)
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        dof = int(model.mujoco.actuator_trnid.numpy()[0, 0])
+        kd = float(model.joint_target_kd.numpy()[dof])
+        self.assertGreater(kd, 0.0, "dampratio was dropped for a non-leading DOF")
+        self.assertAlmostEqual(kd / native_kv, 1.0, places=5)
+        return model, dof
+
+    def test_dampratio_after_ball_joint(self):
+        """A 3-DOF ball joint ahead of the hinge must not misdirect the damping."""
+        model, dof = self._assert_matches_native(self.MJCF_BALL_THEN_HINGE)
+        self.assertEqual(dof, 3)
+        # Only the actuated DOF is damped; the ball joint's DOFs stay untouched.
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[:3], 0.0, atol=1e-9)
+
+    def test_dampratio_after_free_joint(self):
+        """A 6-DOF free joint ahead of the hinge must not misdirect the damping."""
+        model, dof = self._assert_matches_native(self.MJCF_FREE_THEN_HINGE)
+        self.assertEqual(dof, 6)
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[:6], 0.0, atol=1e-9)
+
+    def test_dampratio_uses_reflected_inertia_of_chain(self):
+        """kv must use the driven DOF's dof_M0, not 1 / actuator_acc0."""
+        model, dof = self._assert_matches_native(self.MJCF_CHAIN)
+        self.assertEqual(dof, 0)
+        # Only the actuated DOF picks up damping.
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[1:], 0.0, atol=1e-9)
 
 
 class TestActuatorDefaultKpKv(unittest.TestCase):

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8510,9 +8510,9 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
     """
 
     @staticmethod
-    def _expected_kd(kp, dampratio, acc0):
-        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0), with dof_M0 == 1 / acc0.
-        return 2.0 * dampratio * np.sqrt(kp / acc0)
+    def _expected_kd(kp, dampratio, dof_m0):
+        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0).
+        return 2.0 * dampratio * np.sqrt(kp * dof_m0)
 
     def test_dampratio_resolved_into_joint_target_kd(self):
         """A dampratio-only position actuator must not import undamped."""
@@ -8526,7 +8526,7 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
         kd = float(model.joint_target_kd.numpy()[0])
 
         self.assertGreater(kd, 0.0, "dampratio was dropped; drive imported undamped")
-        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.actuator_acc0[0]))
+        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.dof_M0[0]))
         self.assertAlmostEqual(kd, expected, places=4)
 
     def test_matches_native_mujoco(self):
@@ -8562,6 +8562,111 @@ class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
         newton.solvers.SolverMuJoCo(model)
 
         self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+    # Scenes where the actuated hinge is NOT the first DOF, and where the
+    # reflected inertia is not simply the actuator's own. actuator_trnid stores
+    # a DOF index, so anything that reads it as a joint index lands on the wrong
+    # target (or out of range, silently dropping the damping); and dof_M0 only
+    # coincides with 1 / actuator_acc0 when the driven joint is alone in its
+    # subtree, so a chain exposes the difference too.
+    MJCF_BALL_THEN_HINGE = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="ball_link">
+                <joint name="ball" type="ball"/>
+                <geom type="sphere" size="0.05" mass="1"/>
+                <body name="link" pos="0.2 0 0">
+                    <joint name="hinge" type="hinge" axis="0 0 1"/>
+                    <geom type="sphere" size="0.05" mass="1"/>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="100" dampratio="1"/>
+        </actuator>
+    </mujoco>
+    """
+
+    MJCF_FREE_THEN_HINGE = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="floating">
+                <freejoint/>
+                <geom type="box" size="0.1 0.1 0.1" mass="3"/>
+                <body name="link" pos="0.2 0 0">
+                    <joint name="hinge" type="hinge" axis="0 1 0"/>
+                    <geom type="sphere" size="0.05" mass="1"/>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="80" dampratio="1.5"/>
+        </actuator>
+    </mujoco>
+    """
+
+    MJCF_CHAIN = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="a">
+                <joint name="h0" type="hinge" axis="0 0 1"/>
+                <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                <body name="b" pos="0.3 0 0">
+                    <joint name="h1" type="hinge" axis="0 0 1"/>
+                    <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                    <body name="c" pos="0.3 0 0">
+                        <joint name="h2" type="hinge" axis="0 0 1"/>
+                        <geom type="capsule" fromto="0 0 0 0.3 0 0" size="0.04" mass="2"/>
+                    </body>
+                </body>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="h0" kp="50" dampratio="0.7"/>
+        </actuator>
+    </mujoco>
+    """
+
+    def _assert_matches_native(self, mjcf):
+        import mujoco
+
+        mj_model = mujoco.MjModel.from_xml_string(mjcf)
+        native_kv = -float(mj_model.actuator_biasprm[0][2])
+        self.assertGreater(native_kv, 0.0)
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        dof = int(model.mujoco.actuator_trnid.numpy()[0, 0])
+        kd = float(model.joint_target_kd.numpy()[dof])
+        self.assertGreater(kd, 0.0, "dampratio was dropped for a non-leading DOF")
+        self.assertAlmostEqual(kd / native_kv, 1.0, places=5)
+        return model, dof
+
+    def test_dampratio_after_ball_joint(self):
+        """A 3-DOF ball joint ahead of the hinge must not misdirect the damping."""
+        model, dof = self._assert_matches_native(self.MJCF_BALL_THEN_HINGE)
+        self.assertEqual(dof, 3)
+        # Only the actuated DOF is damped; the ball joint's DOFs stay untouched.
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[:3], 0.0, atol=1e-9)
+
+    def test_dampratio_after_free_joint(self):
+        """A 6-DOF free joint ahead of the hinge must not misdirect the damping."""
+        model, dof = self._assert_matches_native(self.MJCF_FREE_THEN_HINGE)
+        self.assertEqual(dof, 6)
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[:6], 0.0, atol=1e-9)
+
+    def test_dampratio_uses_reflected_inertia_of_chain(self):
+        """kv must use the driven DOF's dof_M0, not 1 / actuator_acc0."""
+        model, dof = self._assert_matches_native(self.MJCF_CHAIN)
+        self.assertEqual(dof, 0)
+        # Only the actuated DOF picks up damping.
+        kd_all = model.joint_target_kd.numpy()
+        np.testing.assert_allclose(kd_all[1:], 0.0, atol=1e-9)
 
 
 class TestActuatorDefaultKpKv(unittest.TestCase):

--- a/newton/tests/test_import_mjcf.py
+++ b/newton/tests/test_import_mjcf.py
@@ -8485,6 +8485,85 @@ class TestMjcfPositionDampratioParsing(unittest.TestCase):
         self.assertAlmostEqual(float(biasprm[1, 2]), -3.0, places=6)
 
 
+class TestMjcfPositionDampratioResolvedForJointTarget(unittest.TestCase):
+    """Regression for #3698: <position dampratio> must reach joint_target_kd.
+
+    The importer stores an unresolved dampratio as a positive biasprm[2]
+    placeholder because the reflected inertia is only known after MuJoCo
+    compiles the model. CTRL_DIRECT actuators are resolved by mj_setConst,
+    but JOINT_TARGET actuators read joint_target_kd directly, so a drive the
+    asset author tuned to be critically damped used to import with kd == 0.
+    """
+
+    MJCF = """<?xml version="1.0" ?>
+    <mujoco>
+        <worldbody>
+            <body name="link">
+                <joint name="hinge" type="hinge" axis="0 0 1"/>
+                <geom type="sphere" size="0.05" mass="1"/>
+            </body>
+        </worldbody>
+        <actuator>
+            <position name="motor" joint="hinge" kp="100" dampratio="1"/>
+        </actuator>
+    </mujoco>
+    """
+
+    @staticmethod
+    def _expected_kd(kp, dampratio, acc0):
+        # MuJoCo: kv = 2 * dampratio * sqrt(kp * dof_M0), with dof_M0 == 1 / acc0.
+        return 2.0 * dampratio * np.sqrt(kp / acc0)
+
+    def test_dampratio_resolved_into_joint_target_kd(self):
+        """A dampratio-only position actuator must not import undamped."""
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(self.MJCF)
+        model = builder.finalize()
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+        solver = newton.solvers.SolverMuJoCo(model)
+        kd = float(model.joint_target_kd.numpy()[0])
+
+        self.assertGreater(kd, 0.0, "dampratio was dropped; drive imported undamped")
+        expected = self._expected_kd(100.0, 1.0, float(solver.mj_model.actuator_acc0[0]))
+        self.assertAlmostEqual(kd, expected, places=4)
+
+    def test_matches_native_mujoco(self):
+        """The resolved kd must match MuJoCo's own compile-time value."""
+        import mujoco
+
+        mj_model = mujoco.MjModel.from_xml_string(self.MJCF)
+        native_kv = -float(mj_model.actuator_biasprm[0][2])
+
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(self.MJCF)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), native_kv, places=4)
+
+    def test_explicit_kv_is_not_overwritten(self):
+        """An explicit kv must still win; dampratio must not clobber it."""
+        mjcf = self.MJCF.replace('kp="100" dampratio="1"', 'kp="100" kv="3.0" dampratio="1"')
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 3.0, places=6)
+
+    def test_no_dampratio_stays_undamped(self):
+        """Neither kv nor dampratio authored => kd stays zero."""
+        mjcf = self.MJCF.replace('kp="100" dampratio="1"', 'kp="100"')
+        builder = newton.ModelBuilder()
+        builder.add_mjcf(mjcf)
+        model = builder.finalize()
+        newton.solvers.SolverMuJoCo(model)
+
+        self.assertAlmostEqual(float(model.joint_target_kd.numpy()[0]), 0.0, places=6)
+
+
 class TestActuatorDefaultKpKv(unittest.TestCase):
     """Regression: position/velocity actuators must default kp=1/kv=1.
 


### PR DESCRIPTION
Fixes #3698.

## The problem

MuJoCo's `<position>` actuator accepts damping either as an explicit `kv` or as a `dampratio`, where the compiler resolves `kv = 2 * dampratio * sqrt(kp * dof_M0)` once it knows the joint's reflected inertia. Newton's MJCF importer handles the `dampratio` case by stashing the unresolved ratio as a positive `mujoco:actuator_biasprm[2]` placeholder — it can't do better at parse time, since `dof_M0` doesn't exist until the model is compiled.

`SolverMuJoCo` resolves that placeholder for CTRL_DIRECT actuators: the `mj_setConst()` call after `spec.compile()` recomputes them, which is why `ctrl_direct=True` gives the right answer today. JOINT_TARGET actuators — the default path for a joint-targeted `<position>` — never see it. They read `joint_target_kd` directly, both when building the MuJoCo actuator and again every step in `update_axis_properties_kernel`, and the importer leaves that array at zero when only a `dampratio` was authored.

The net effect is that a drive the asset author tuned to be critically damped imports as an undamped proportional drive, silently. Comparing the two paths on the issue's MJCF makes it obvious:

```
CTRL_DIRECT  compiled biasprm: [0, -100, -0.63245555]   # correct
JOINT_TARGET compiled biasprm: [0, -100, -0.0       ]   # dampratio dropped
native MuJoCo               : [0, -100, -0.63245553]
```

## The fix

Resolve the placeholder in `_convert_to_mjc`, right after `spec.compile()` and `mj_setConst()`, at the point where `actuator_acc0` is available. `actuator_acc0` is MuJoCo's unit-force acceleration, i.e. `1 / dof_M0`, so MuJoCo's formula becomes `2 * dampratio * sqrt(kp / acc0)`.

Only rows that are JOINT_TARGET *and* POSITION *and* carry a positive `biasprm[2]` are touched — a negative value already encodes an explicit `kv`, and zero means neither was authored. Writing the result into `joint_target_kd` (rather than patching `mj_model.actuator_biasprm`) is deliberate: the per-step gain sync reads `joint_target_kd`, so anything written only into the compiled model would be overwritten on the next `notify_model_changed`.

An explicit `kv`, or a `kd` already set by a velocity actuator on the same DOF, still wins — the write is guarded on the existing value being zero.

## Testing

`newton/tests/test_import_mjcf.py` gained `TestMjcfPositionDampratioResolvedForJointTarget` (4 cases): the ratio is resolved, it matches native MuJoCo's own `actuator_biasprm[2]`, an explicit `kv` is not clobbered, and a plain `kp`-only actuator stays undamped.

Reverting just the one assignment line makes the two bug-detecting cases fail with the bug's signature, while the two guard cases stay green:

```
AssertionError: 0.0 not greater than 0.0 : dampratio was dropped; drive imported undamped
AssertionError: 0.0 != 0.6324555320336759 within 4 places
```

I also checked it end-to-end rather than trusting the gain value alone — stepping a hinge released at 1.0 rad toward a target of 0.0:

| | `joint_target_kd` | peak overshoot | value at t=1.67s |
|---|---|---|---|
| before | `0.0` | `-1.0008` | `-0.3256` (still ringing) |
| after | `10.02` | `-1.7e-05` | `5.1e-14` (settled) |

Suites run (Python 3.12, MuJoCo 3.10.0, warp 1.17.0.dev20260729):

```
python -m unittest newton.tests.test_import_mjcf            → Ran 241 tests   OK
python -m unittest newton.tests.test_actuators              → Ran  54 tests   OK (skipped=30)
python -m unittest newton.tests.test_mujoco_general_actuators → Ran 24 tests  OK (skipped=6)
python -m unittest newton.tests.test_mujoco_solver          → Ran 259 tests   1 error
```

The single `test_mujoco_solver` error is `ModuleNotFoundError: No module named 'pxr'` in `test_mjc_damping_from_usd_via_schema_resolver` — a missing optional USD dependency in my environment. It reproduces identically on pristine `main` with the branch stashed, so it's pre-existing and unrelated.

Lint is clean with the pinned ruff from `.pre-commit-config.yaml`:

```
ruff 0.15.20 check  → All checks passed!
ruff 0.15.20 format --check → 2 files already formatted
```

## Note on scope

I deliberately kept this to the `<position dampratio>` → `joint_target_kd` route named in the issue. The issue's fallback suggestion (warn when a `dampratio` actuator ends up with `kd == 0`) is no longer reachable for this path, and the ball-joint / free-joint drive concerns raised in the companion issues (#3699, #3701) are left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MJCF position actuators with `dampratio` settings being imported without the expected damping.
  * Damping is now calculated using the compiled model’s reflected inertia, including joints following ball, free, or chained joints.
  * Explicit velocity damping settings continue to take precedence.
  * Drives without damping settings remain undamped as intended.

* **Tests**
  * Added regression coverage for damping resolution, reflected inertia, and parity with native MuJoCo behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->