### PR TITLE
Use newton-usd-schemas 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ importers = [
     "usd-exchange>=2.2.0 ; platform_machine == 'aarch64' and python_version < '3.13'",
 
     # Newton USD Schemas
-    "newton-usd-schemas>=0.4.0",
+    "newton-usd-schemas>=0.4.1",
 ]
 
 # Remeshing dependencies (for SurfaceReconstructor)

--- a/uv.lock
+++ b/uv.lock
@@ -3949,7 +3949,7 @@ requires-dist = [
     { name = "newton", extras = ["importers"], marker = "extra == 'rtx'" },
     { name = "newton", extras = ["onnx"], marker = "extra == 'examples'" },
     { name = "newton", extras = ["sim"], marker = "extra == 'examples'" },
-    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.4.0" },
+    { name = "newton-usd-schemas", marker = "extra == 'importers'", specifier = ">=0.4.1" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'importers') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'importers')", specifier = ">=0.19.0" },
     { name = "open3d", marker = "(python_full_version < '3.13' and platform_machine != 'aarch64' and extra == 'remesh') or (python_full_version < '3.13' and sys_platform != 'linux' and extra == 'remesh')", specifier = ">=0.19.0" },
     { name = "ovrtx", marker = "extra == 'rtx'", specifier = ">=0.3" },
@@ -3988,11 +3988,11 @@ dev = [{ name = "asv", specifier = ">=0.6.4" }]
 
 [[package]]
 name = "newton-usd-schemas"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/12/a837c15d0ab7c8d89e67ff11fd0d071446f016ae5ff15b06b14baf5715db/newton_usd_schemas-0.4.0.tar.gz", hash = "sha256:d2706f90fdda1f1bbf66198fe41e3f4a9d3d78f86694cd882f5db4b3981383f3", size = 68824, upload-time = "2026-07-03T17:45:28.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5f/aad1672263880d7e0ee3a7ce9b877ef16e99dba45fb5eb8084181eb7ee1e/newton_usd_schemas-0.4.1.tar.gz", hash = "sha256:1f6946ce2741d7a86ca8e3e84d7b64328c88b42a3b29160a7607b2ce0c837bf4", size = 69561, upload-time = "2026-07-30T17:40:41.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/b5/82058bdb0c64c94953d77010558700d14666ff577de2ca7e8daf8c59b306/newton_usd_schemas-0.4.0-py3-none-any.whl", hash = "sha256:212182de78191fed320631bf38b02a62467ddf77d5f43672b11758bcf2d86e47", size = 19333, upload-time = "2026-07-03T17:45:27.573Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/24/d1d44f682dbd28392ef0b6f9e6f9e40374c6009af06e494fa6a9308f79e2/newton_usd_schemas-0.4.1-py3-none-any.whl", hash = "sha256:8911e846c65448426609a2945db6d1135d33e84bf4107efd888a62287b1aa93d", size = 19424, upload-time = "2026-07-30T17:40:40.076Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bump `newton-usd-schemas` to 0.4.1, [released to PyPI today](https://pypi.org/project/newton-usd-schemas/0.4.1/).

The 0.4.1 patch contains two changes:

- **`NewtonActuator` base type corrected** from a partially implemented `UsdGeomImageable` to `UsdTyped`. Actuators are not renderable, so nothing should have been treating them as imageable. A consequence worth knowing: actuators can no longer be rendered in Hydra-compatible viewers, so a viewer wanting actuator manipulators has to special-case them, or the content author has to parent a `UsdGeomImageable` beneath them.
- **`NewtonMimicAPI` documentation clarified** to state that the leader and follower must share a joint type; multi-DOF behaviour remains undefined and unsupported. This matches what the importer already assumes — see #3728, which reads `newton:mimicCoef0` as degrees based on the follower's joint type.

Newton identifies actuator prims by type name (`prim.GetTypeName() != "NewtonActuator"` in `newton/_src/actuators/usd_parser.py`), so parsing behaves identically against either version. The floor is raised anyway so that authored stages and the importer describe actuators the same way.

No `CHANGELOG.md` entry: no Newton-side behaviour changes, matching the precedent for standalone schema bumps (#2012). Happy to add one if you'd rather record it.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev --extra importers -m unittest newton.tests.test_import_usd          # 298 tests, OK
uv run --extra dev --extra importers -m unittest newton.tests.test_actuators newton.tests.test_schema_resolver  # 88 tests, OK (15 skipped)
uvx pre-commit run -a                                                                  # all passed, incl. uv-lock
```

Confirmed the installed schema actually changed, rather than trusting the version string:

```python
>>> import importlib.metadata as md; md.version("newton-usd-schemas")
'0.4.1'
>>> from pxr import Usd, UsdGeom
>>> prim = Usd.Stage.CreateInMemory().DefinePrim("/A", "NewtonActuator")
>>> prim.IsA(UsdGeom.Imageable)
False
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional importer dependency to require version 0.4.1 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->