### PR TITLE
Fix dropped MJC joint equality from NewtonMimicAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@
 - Fix `ModelBuilder.add_usd()` ignoring enabled collider mass properties and counting disabled colliders toward body mass. (#3594)
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
+- Fix `ModelBuilder.add_usd()` silently dropping a MuJoCo joint equality constraint when the asset supplies the leader joint and coefficients through `NewtonMimicAPI` instead of the deprecated `mjc:target`, `mjc:coef0`, and `mjc:coef1`. `MjcEqualityJointAPI` builds on `NewtonMimicAPI`, so both spellings are now accepted.
 - Fix `SolverVBD` failing to construct on large multi-world scenes containing particles and rigid shapes. (#3660)
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix a use-after-free where finalizing a second model built from shared mesh geometry (e.g. via `ModelBuilder.replicate()` or `ModelBuilder.add_builder()`) invalidated the meshes referenced by previously finalized models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,12 +128,12 @@
 - Report malformed MJCF free-joint and inertial inputs with deterministic validation errors, and ignore MJCF mesh geom `size` lengths consistently.
 - Fix MJCF imports ignoring material and inline RGBA colors on primitive geoms.
 - Fix `ModelBuilder.add_usd()` silently dropping a MuJoCo joint equality constraint when the asset supplies the leader joint and coefficients through `NewtonMimicAPI` instead of the deprecated `mjc:target`, `mjc:coef0`, and `mjc:coef1`. `MjcEqualityJointAPI` builds on `NewtonMimicAPI`, so both spellings are now accepted.
+- Fix `ModelBuilder.add_usd()` ignoring `newton:mimicEnabled` on a joint with `MjcEqualityJointAPI` applied. Such a joint is now imported disabled rather than coupled, which also stops the default equality conversion from enforcing the coupling in every solver.
 - Fix `SolverVBD` failing to construct on large multi-world scenes containing particles and rigid shapes. (#3660)
 - Fix Style3D solver divergence caused by isolated vertices.
 - Fix a use-after-free where finalizing a second model built from shared mesh geometry (e.g. via `ModelBuilder.replicate()` or `ModelBuilder.add_builder()`) invalidated the meshes referenced by previously finalized models.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
-- Fix `ModelBuilder.add_usd()` ignoring `newton:mimicEnabled` on a joint with `MjcEqualityJointAPI` applied. Such a joint is now imported disabled rather than coupled, which also stops the default equality conversion from enforcing the coupling in every solver.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix `eval_ik()` and `SolverSemiImplicit` rounding small float32 revolute-joint angles to zero. (#3434)
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - Fix a use-after-free where finalizing a second model built from shared mesh geometry (e.g. via `ModelBuilder.replicate()` or `ModelBuilder.add_builder()`) invalidated the meshes referenced by previously finalized models.
 - Fix compiler warnings about overflowing int32 constants when compiling SDF texture and `SensorTiledCamera` kernels.
 - Fix USD site import to discover sites beneath non-visual containers, collider prims, and instanceable rigid-body prims independently of `load_visual_shapes`; the reworked traversal also speeds up import of scenes with many nested `Xform` or instance prims.
+- Fix `ModelBuilder.add_usd()` ignoring `newton:mimicEnabled` on a joint with `MjcEqualityJointAPI` applied. Such a joint is now imported disabled rather than coupled, which also stops the default equality conversion from enforcing the coupling in every solver.
 - Fix `SolverFeatherstone` BALL joints to apply passive `joint_damping` on all three angular DOFs.
 - Fix `eval_ik()` and `SolverSemiImplicit` rounding small float32 revolute-joint angles to zero. (#3434)
 - Fix excessive memory usage when importing MJCF or URDF models containing many visual-only shapes with self-collisions disabled.

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4511,6 +4511,7 @@ def parse_usd(
 
         coef0 = usd.get_attribute(joint_prim, "newton:mimicCoef0")
         if coef0 is None:
+            # The deprecated alias was always authored in radians, so it skips the conversion.
             coef0 = usd.get_attribute(joint_prim, "mjc:coef0", default=0.0)
         elif joint_prim.IsA(UsdPhysics.RevoluteJoint):
             coef0 *= DegreesToRadian

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4479,6 +4479,47 @@ def parse_usd(
                         existing_filter_pairs.add(pair)
                         builder.add_shape_collision_filter_pair(*pair)
 
+    def _resolve_newton_mimic(joint_prim: Usd.Prim) -> tuple[Sdf.Path | None, float, float]:
+        """Resolve the mimic leader joint and coefficients from a follower joint prim.
+
+        ``MjcEqualityJointAPI`` builds on ``NewtonMimicAPI``, so the equality and the plain
+        mimic import paths read the same properties through here. The deprecated
+        ``mjc:target``, ``mjc:coef0``, and ``mjc:coef1`` aliases are honored as a fallback
+        for assets authored before those properties moved to the ``newton:`` namespace.
+
+        ``newton:mimicCoef0`` is authored in the follower's position units, so a revolute
+        follower is converted from degrees into the joint coordinates the constraint is
+        evaluated in; the deprecated ``mjc:coef0`` is already in radians. ``coef1`` is
+        dimensionless. A multi-DOF follower has no defined unit, so its offset is passed
+        through unconverted and callers warn about it.
+
+        Returns:
+            The leader joint path, or ``None`` when no target is authored, followed by
+            ``coef0`` in joint coordinates and the dimensionless ``coef1``.
+        """
+        mimic_rel = joint_prim.GetRelationship("newton:mimicJoint")
+        targets = mimic_rel.GetTargets() if mimic_rel and mimic_rel.HasAuthoredTargets() else []
+        if not targets:
+            target_rel = joint_prim.GetRelationship("mjc:target")
+            targets = target_rel.GetTargets() if target_rel else []
+
+        leader_path = None
+        if targets:
+            leader_path = targets[0]
+            if not leader_path.IsAbsolutePath():
+                leader_path = joint_prim.GetPath().GetParentPath().AppendPath(leader_path)
+
+        coef0 = usd.get_attribute(joint_prim, "newton:mimicCoef0")
+        if coef0 is None:
+            coef0 = usd.get_attribute(joint_prim, "mjc:coef0", default=0.0)
+        elif joint_prim.IsA(UsdPhysics.RevoluteJoint):
+            coef0 *= DegreesToRadian
+        coef1 = usd.get_attribute(joint_prim, "newton:mimicCoef1")
+        if coef1 is None:
+            coef1 = usd.get_attribute(joint_prim, "mjc:coef1", default=1.0)
+
+        return leader_path, float(coef0), float(coef1)
+
     # Parse MjcEquality constraints *before* collapsing fixed joints so that the
     # builder's collapse logic can remap body/joint indices and adjust anchors/relposes
     # for any bodies that get merged.
@@ -4638,16 +4679,15 @@ def parse_usd(
                     )
                     continue
 
-                target_rel = joint_prim.GetRelationship("mjc:target")
-                targets = target_rel.GetTargets() if target_rel else []
-                if not targets:
+                leader_path, coef0, coef1 = _resolve_newton_mimic(joint_prim)
+                if leader_path is None:
                     warnings.warn(
-                        f"MjcEqualityJointAPI on '{joint_path}' has no mjc:target relationship; skipping.",
+                        f"MjcEqualityJointAPI on '{joint_path}' has no newton:mimicJoint relationship; skipping.",
                         stacklevel=2,
                     )
                     continue
 
-                target_path = str(targets[0])
+                target_path = str(leader_path)
                 joint2_idx = path_joint_map.get(target_path)
                 if joint2_idx is None:
                     warnings.warn(
@@ -4656,16 +4696,11 @@ def parse_usd(
                     )
                     continue
 
-                polycoef = []
-                for attr_name, default in (
-                    ("mjc:coef0", 0.0),
-                    ("mjc:coef1", 1.0),
-                    ("mjc:coef2", 0.0),
-                    ("mjc:coef3", 0.0),
-                    ("mjc:coef4", 0.0),
-                ):
-                    attr = joint_prim.GetAttribute(attr_name)
-                    polycoef.append(float(attr.Get()) if attr and attr.HasValue() else default)
+                # Only the constant and linear terms moved to NewtonMimicAPI; the
+                # higher-order polynomial terms remain MuJoCo-specific.
+                polycoef = [coef0, coef1]
+                for attr_name in ("mjc:coef2", "mjc:coef3", "mjc:coef4"):
+                    polycoef.append(float(usd.get_attribute(joint_prim, attr_name, default=0.0)))
 
                 if convert_mjc_equality_constraints:
                     if mjc_polycoef_has_higher_order(polycoef):
@@ -4841,19 +4876,11 @@ def parse_usd(
         mimic_enabled = usd.get_attribute(joint_prim, "newton:mimicEnabled", default=True)
         if not mimic_enabled:
             continue
-        mimic_rel = joint_prim.GetRelationship("newton:mimicJoint")
-        if not mimic_rel or not mimic_rel.HasAuthoredTargets():
+        leader_path, coef0, coef1 = _resolve_newton_mimic(joint_prim)
+        if leader_path is None:
             if verbose:
                 print(f"NewtonMimicAPI on {joint_path} has no newton:mimicJoint target; skipping")
             continue
-        targets = mimic_rel.GetTargets()
-        if not targets:
-            if verbose:
-                print(f"NewtonMimicAPI on {joint_path}: newton:mimicJoint has no targets; skipping")
-            continue
-        leader_path = targets[0]
-        if not leader_path.IsAbsolutePath():
-            leader_path = joint_prim.GetPath().GetParentPath().AppendPath(leader_path)
         leader_path_str = str(leader_path)
         if leader_path_str not in path_joint_map:
             warnings.warn(
@@ -4861,24 +4888,16 @@ def parse_usd(
                 stacklevel=2,
             )
             continue
-        coef0 = usd.get_attribute(joint_prim, "newton:mimicCoef0", default=0.0)
-        coef1 = usd.get_attribute(joint_prim, "newton:mimicCoef1", default=1.0)
-        # NewtonMimicAPI documents newton:mimicCoef0 in the follower's position units,
-        # which is degrees for a single angular DOF. Newton mimic constraints operate on
-        # joint coordinates, so such a follower needs radians. coef1 is dimensionless.
-        #
         # Classify from the authored USD prim rather than builder.joint_type: several
         # single-DOF prims sharing a body pair are merged into one D6 (see
         # parse_merged_joints), which would otherwise misread an angular follower.
         follower_is_revolute = joint_prim.IsA(UsdPhysics.RevoluteJoint)
         follower_is_prismatic = joint_prim.IsA(UsdPhysics.PrismaticJoint)
-        if follower_is_revolute:
-            coef0 *= DegreesToRadian
-        elif not follower_is_prismatic:
+        if not follower_is_revolute and not follower_is_prismatic:
             # Spherical and D6 followers hold more than one DOF, and a ball joint's
             # coordinates are a quaternion rather than a scalar angle, so a single offset
             # has no defined unit. NewtonMimicAPI says as much: multi-DOF behavior is
-            # undefined. Pass the value through and say so.
+            # undefined. _resolve_newton_mimic passes the value through; say so here.
             warnings.warn(
                 f"NewtonMimicAPI on {joint_path}: newton:mimicCoef0 has no defined unit for a "
                 f"{joint_prim.GetTypeName()} follower, which is not a single-DOF joint. Using the "

--- a/newton/_src/utils/import_usd.py
+++ b/newton/_src/utils/import_usd.py
@@ -4703,6 +4703,11 @@ def parse_usd(
                 for attr_name in ("mjc:coef2", "mjc:coef3", "mjc:coef4"):
                     polycoef.append(float(usd.get_attribute(joint_prim, attr_name, default=0.0)))
 
+                # NewtonMimicAPI's opt-out governs both spellings of the constraint. The
+                # plain mimic loop below skips these prims, so it is folded into the
+                # runtime enabled flag here rather than dropping the constraint.
+                eq_enabled = enabled and bool(usd.get_attribute(joint_prim, "newton:mimicEnabled", default=True))
+
                 if convert_mjc_equality_constraints:
                     if mjc_polycoef_has_higher_order(polycoef):
                         warnings.warn(
@@ -4717,7 +4722,7 @@ def parse_usd(
                         joint2_idx,
                         polycoef,
                         joint_path,
-                        enabled,
+                        eq_enabled,
                         eq_custom_attrs,
                     )
                 else:
@@ -4728,7 +4733,7 @@ def parse_usd(
                         joint2=joint2_idx,
                         polycoef=polycoef,
                         label=joint_path,
-                        enabled=enabled,
+                        enabled=eq_enabled,
                         custom_attributes=eq_custom_attrs,
                     )
 

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -9708,6 +9708,77 @@ def Xform "Articulation" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mjc_equality_joint_parsing_honors_mimic_enabled(self):
+        """Test that newton:mimicEnabled disables an MjcEqualityJointAPI constraint.
+
+        MjcEqualityJointAPI builds on NewtonMimicAPI, so the opt-out has to govern both
+        spellings. The plain mimic loop skips prims carrying MjcEqualityJointAPI, so the
+        equality path is the only place that can honor it.
+        """
+        from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics
+
+        def build_stage():
+            stage = Usd.Stage.CreateInMemory()
+            UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+            UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+            UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+            articulation = UsdGeom.Xform.Define(stage, "/World/Articulation")
+            UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+            links = []
+            for name in ("Root", "Link1", "Link2"):
+                link = UsdGeom.Xform.Define(stage, f"/World/Articulation/{name}")
+                UsdPhysics.RigidBodyAPI.Apply(link.GetPrim())
+                links.append(link)
+
+            fixed = UsdPhysics.FixedJoint.Define(stage, "/World/Articulation/RootToWorld")
+            fixed.CreateBody0Rel().SetTargets([links[0].GetPath()])
+            fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+            fixed.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+            fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+
+            for index in (1, 2):
+                joint = UsdPhysics.RevoluteJoint.Define(stage, f"/World/Articulation/Joint{index}")
+                joint.CreateBody0Rel().SetTargets([links[index - 1].GetPath()])
+                joint.CreateBody1Rel().SetTargets([links[index].GetPath()])
+                joint.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                joint.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+                joint.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+                joint.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+                joint.CreateAxisAttr().Set("Z")
+
+            follower = stage.GetPrimAtPath("/World/Articulation/Joint2")
+            follower.SetMetadata(
+                "apiSchemas", Sdf.TokenListOp.Create(prependedItems=["MjcEqualityJointAPI", "NewtonMimicAPI"])
+            )
+            follower.CreateRelationship("newton:mimicJoint").SetTargets(["/World/Articulation/Joint1"])
+            follower.CreateAttribute("newton:mimicEnabled", Sdf.ValueTypeNames.Bool).Set(False)
+            return stage
+
+        # The MuJoCo-native path authors the equality row directly.
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(build_stage(), convert_mjc_equality_constraints=False)
+        model = builder.finalize()
+
+        self.assertEqual(model.mujoco.equality_constraint_count, 1)
+        self.assertFalse(bool(model.mujoco.equality_constraint_enabled.numpy()[0]))
+
+        # The default path additionally lowers a generic mimic constraint, which would
+        # otherwise enforce the coupling for every solver rather than only SolverMuJoCo.
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        builder.add_usd(build_stage(), convert_mjc_equality_constraints=True)
+        model = builder.finalize()
+
+        self.assertEqual(model.mujoco.equality_constraint_count, 1)
+        self.assertFalse(bool(model.mujoco.equality_constraint_enabled.numpy()[0]))
+        self.assertEqual(model.constraint_mimic_count, 1)
+        self.assertFalse(bool(model.constraint_mimic_enabled.numpy()[0]))
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_mjc_equality_connect_site_parsing(self):
         """Test that MjcEqualityConnectAPI on a spherical joint is parsed as a connect equality constraint."""
         from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics

--- a/newton/tests/test_import_usd.py
+++ b/newton/tests/test_import_usd.py
@@ -9630,6 +9630,84 @@ def Xform "Articulation" (
         )
 
     @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
+    def test_mjc_equality_joint_parsing_newton_mimic_properties(self):
+        """Test that MjcEqualityJointAPI is parsed from the NewtonMimicAPI properties.
+
+        MjcEqualityJointAPI builds on NewtonMimicAPI, which supersedes the deprecated
+        mjc:target, mjc:coef0, and mjc:coef1. An asset authoring only the newton:mimic
+        properties must still yield an equality constraint, with the offset converted
+        from the degrees a revolute follower is authored in.
+        """
+        from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics
+
+        stage = Usd.Stage.CreateInMemory()
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+        UsdGeom.SetStageMetersPerUnit(stage, 1.0)
+        UsdPhysics.Scene.Define(stage, "/physicsScene")
+
+        articulation = UsdGeom.Xform.Define(stage, "/World/Articulation")
+        UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+
+        root = UsdGeom.Xform.Define(stage, "/World/Articulation/Root")
+        UsdPhysics.RigidBodyAPI.Apply(root.GetPrim())
+        link1 = UsdGeom.Xform.Define(stage, "/World/Articulation/Link1")
+        UsdPhysics.RigidBodyAPI.Apply(link1.GetPrim())
+        link2 = UsdGeom.Xform.Define(stage, "/World/Articulation/Link2")
+        UsdPhysics.RigidBodyAPI.Apply(link2.GetPrim())
+
+        fixed = UsdPhysics.FixedJoint.Define(stage, "/World/Articulation/RootToWorld")
+        fixed.CreateBody0Rel().SetTargets([root.GetPath()])
+        fixed.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        fixed.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        fixed.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+
+        joint1 = UsdPhysics.RevoluteJoint.Define(stage, "/World/Articulation/Joint1")
+        joint1.CreateBody0Rel().SetTargets([root.GetPath()])
+        joint1.CreateBody1Rel().SetTargets([link1.GetPath()])
+        joint1.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint1.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint1.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint1.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint1.CreateAxisAttr().Set("Z")
+
+        joint2 = UsdPhysics.RevoluteJoint.Define(stage, "/World/Articulation/Joint2")
+        joint2.CreateBody0Rel().SetTargets([link1.GetPath()])
+        joint2.CreateBody1Rel().SetTargets([link2.GetPath()])
+        joint2.CreateLocalPos0Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint2.CreateLocalPos1Attr().Set(Gf.Vec3f(0.0, 0.0, 0.0))
+        joint2.CreateLocalRot0Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint2.CreateLocalRot1Attr().Set(Gf.Quatf(1.0, 0.0, 0.0, 0.0))
+        joint2.CreateAxisAttr().Set("Z")
+
+        # Author only the current properties: no mjc:target, mjc:coef0, or mjc:coef1.
+        joint2_prim = joint2.GetPrim()
+        joint2_prim.SetMetadata(
+            "apiSchemas", Sdf.TokenListOp.Create(prependedItems=["MjcEqualityJointAPI", "NewtonMimicAPI"])
+        )
+        joint2_prim.CreateRelationship("newton:mimicJoint").SetTargets([joint1.GetPrim().GetPath()])
+        joint2_prim.CreateAttribute("newton:mimicCoef0", Sdf.ValueTypeNames.Float).Set(90.0)
+        joint2_prim.CreateAttribute("newton:mimicCoef1", Sdf.ValueTypeNames.Float).Set(1.5)
+        joint2_prim.CreateAttribute("mjc:coef2", Sdf.ValueTypeNames.Double).Set(0.1)
+
+        builder = newton.ModelBuilder()
+        SolverMuJoCo.register_custom_attributes(builder)
+        result = builder.add_usd(stage, convert_mjc_equality_constraints=False)
+        model = builder.finalize()
+
+        self.assertEqual(model.mujoco.equality_constraint_count, 1)
+        joint1_idx = result["path_joint_map"]["/World/Articulation/Joint1"]
+        joint2_idx = result["path_joint_map"]["/World/Articulation/Joint2"]
+        self.assertEqual(model.mujoco.equality_constraint_joint1.numpy()[0], joint2_idx)
+        self.assertEqual(model.mujoco.equality_constraint_joint2.numpy()[0], joint1_idx)
+        np.testing.assert_allclose(
+            model.mujoco.equality_constraint_polycoef.numpy()[0],
+            np.array([np.pi / 2.0, 1.5, 0.1, 0.0, 0.0], dtype=np.float32),
+            rtol=1e-6,
+            atol=1e-6,
+        )
+
+    @unittest.skipUnless(USD_AVAILABLE, "Requires usd-core")
     def test_mjc_equality_connect_site_parsing(self):
         """Test that MjcEqualityConnectAPI on a spherical joint is parsed as a connect equality constraint."""
         from pxr import Gf, Sdf, Usd, UsdGeom, UsdPhysics


### PR DESCRIPTION
## Description

`MjcEqualityJointAPI` builds on `NewtonMimicAPI`, and mujoco 3.10 deprecates `mjc:target`, `mjc:coef0`, and `mjc:coef1` in favor of `newton:mimicJoint`, `newton:mimicCoef0`, and `newton:mimicCoef1` (see `mjcPhysics/equalityJointAPI.h`).

`ModelBuilder.add_usd()` never read the current spellings for equality joints:

- `_parse_mjc_equality_constraints()` resolved the leader only from `mjc:target`, skipping the prim with a warning when it was absent.
- The `NewtonMimicAPI` loop skips any prim carrying `MjcEqualityJointAPI`, on the assumption the equality path owns it.

An asset authoring only the current properties matches neither path, so the constraint is dropped silently. This did not surface earlier because the pinned `newton-assets` fixtures were produced by `mujoco-usd-converter` v0.1.0a8, which still authored `mjc:target`. Converter 0.4.0 stopped authoring the deprecated aliases, so any asset converted with 0.4.x hits this.

Both paths now resolve the leader joint and coefficients through a shared `_resolve_newton_mimic()` helper, which also puts the degrees-to-radians conversion for an angular follower in one place instead of two. The deprecated `mjc:` names remain as a fallback so assets authored before the properties moved to the `newton:` namespace keep loading.

Note this is specific to the equality path: `SchemaResolverNewton` already covers the attribute-level deprecations (`newton:contactMargin`, `newton:maxHullVertices`, `newton:torsionalFriction`, and so on). `mjc:target` is a *relationship*, which `SchemaResolver.SchemaAttribute` cannot express, and the equality parser reads prim properties directly rather than going through a resolver.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```
uv run --extra dev -m newton.tests -k test_import_usd -k test_equality_constraints
```

481 tests pass. The new test fails without the fix (`AssertionError: 0 != 1`) and passes with it. `test_mjc_equality_joint_parsing` continues to cover the deprecated spelling, so both are pinned.

Also verified end to end against `newton-assets` reconverted with `mujoco-usd-converter` 0.4.1: `TestMenagerieUsdImport` goes from 1 failure (`test_import_robotiq_2f85_v4`, `equality_constraint_count` 2 != 3) to all 35 passing.

## Bug fix

**Steps to reproduce:**

1. Author a `UsdPhysics.RevoluteJoint` with `MjcEqualityJointAPI` applied.
2. Supply the leader joint via `newton:mimicJoint` only, with no `mjc:target`.
3. Import with `ModelBuilder.add_usd()` and observe `Model.mujoco.equality_constraint_count` is 0.

Equivalently, import any `usd_structured` asset converted with `mujoco-usd-converter` 0.4.x: a Robotiq 2F-85 gripper yields 2 equality constraints instead of 3, leaving the left and right driver joints uncoupled.

**Minimal reproduction:**

```python
import newton
from newton.solvers import SolverMuJoCo
from pxr import Sdf, Usd, UsdGeom, UsdPhysics

stage = Usd.Stage.CreateInMemory()
UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
UsdPhysics.Scene.Define(stage, "/physicsScene")

# ... define /World/Articulation with Root, Link1, Link2 and joints Joint1, Joint2 ...

joint2_prim = stage.GetPrimAtPath("/World/Articulation/Joint2")
joint2_prim.SetMetadata(
    "apiSchemas", Sdf.TokenListOp.Create(prependedItems=["MjcEqualityJointAPI", "NewtonMimicAPI"])
)
joint2_prim.CreateRelationship("newton:mimicJoint").SetTargets(["/World/Articulation/Joint1"])
joint2_prim.CreateAttribute("newton:mimicCoef0", Sdf.ValueTypeNames.Float).Set(90.0)
joint2_prim.CreateAttribute("newton:mimicCoef1", Sdf.ValueTypeNames.Float).Set(1.5)

builder = newton.ModelBuilder()
SolverMuJoCo.register_custom_attributes(builder)
builder.add_usd(stage, convert_mjc_equality_constraints=False)
model = builder.finalize()

print(model.mujoco.equality_constraint_count)  # 0 before this PR, 1 after
```

See `test_mjc_equality_joint_parsing_newton_mimic_properties` for the complete stage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USD import handling for MuJoCo equality-joint constraints using Newton mimic properties.
  * Added fallback support for legacy MuJoCo attributes.
  * Correctly converts revolute joint offsets from degrees to radians while preserving polynomial coefficients.
  * Improved leader-joint resolution and validation during import.
  * Respects settings that disable mimic behavior while retaining constraint records.

* **Tests**
  * Added regression coverage for Newton mimic-based equality-joint imports, conversions, and joint mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->