### PR TITLE
Fix scale-dependent MPR contacts on large mesh triangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 
 ### Fixed
 
+- Fix MPR returning scale-dependent, excessively deep contacts for small convex shapes on large mesh triangles while preserving triangle-specific shared-edge manifold witnesses.
 - Make deterministic collision pipelines cover hydroelastic contact generation and reduction, including unique reduced-contact sort keys and overflow-safe fixed-point pressure accumulation.
 - Convert `newton:mimicCoef0` from degrees to radians when the mimic follower joint is angular. Assets authored against the old behavior need the value rescaled to degrees.
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.

--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -230,49 +230,53 @@ def create_support_map_function(support_func: Any):
             center_b_local = 0.5 * (min_b + max_b)
 
         center_b_world = position_b + wp.quat_rotate(orientation_b, center_b_local)
+        center_b_to_a = center_a - center_b_world
 
         if geom_a.shape_type == int(GeoTypeEx.TRIANGLE) or geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
-            # Project shape B's center onto the triangle for a starting
-            # point near the contact region — this dramatically improves
-            # MPR convergence for large triangles.
-            #
-            # Nudge toward the centroid so the point moves into the face
-            # interior when possible.  This does NOT prevent an MPR
-            # degeneracy (MPR works fine from an edge point); it improves
-            # *manifold quality*.
-            # When shape B projects onto a shared mesh edge, both adjacent
-            # triangles get the same v0, producing MPR witness points biased
-            # toward the edge.  The manifold builder (multicontact.py) uses
-            # these witness points as its center for perturbed support
-            # mapping, so edge-biased centers cause overlapping contact
-            # polygons across the two triangles instead of distinct ones —
-            # resulting in asymmetric force distribution and spurious torque.
-            # Keep that triangle-specific direction, but limit the tangential
-            # displacement to 1% of the normal center-to-plane distance.  A
-            # face projection therefore tilts the initial ray by at most
-            # atan(0.01), about 0.57 degrees, regardless of triangle size.  A
-            # pure barycentric blend scales with the triangle and can make the
-            # initial ray almost tangential when a small partner lies on a
-            # large terrain face, causing MPR to converge to a non-minimum
-            # portal.
+            # Start near the local contact region.  A small centroid bias keeps
+            # adjacent triangles' manifold witnesses distinct at a shared
+            # edge, but bound it by the normal center-to-plane distance so a
+            # large face cannot turn the initial MPR ray nearly tangential.
             tri_a = wp.vec3(0.0, 0.0, 0.0)
             tri_b = geom_a.scale
             tri_c = geom_a.auxiliary
-            proj = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
-            centroid = (tri_a + tri_b + tri_c) / 3.0
-            to_centroid = centroid - proj
-            distance_to_centroid = wp.length(to_centroid)
             face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
-            face_normal_length = wp.length(face_normal)
-            if distance_to_centroid > 1.0e-12 and face_normal_length > 1.0e-12:
-                center_to_plane = wp.abs(wp.dot(center_b_world - proj, face_normal)) / face_normal_length
-                nudge_distance = 0.01 * wp.min(distance_to_centroid, center_to_plane)
-                center_a = proj + to_centroid * (nudge_distance / distance_to_centroid)
+            face_normal_length_sq = wp.length_sq(face_normal)
+            proj = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
+
+            if face_normal_length_sq >= 1.0e-20:
+                face_normal_length = wp.sqrt(face_normal_length_sq)
+                face_normal_unit = face_normal / face_normal_length
+                signed_plane_distance = wp.dot(center_b_world - tri_a, face_normal_unit)
+                plane_proj = center_b_world - signed_plane_distance * face_normal_unit
+
+                # Reconstruct face-region offsets directly.  Subtracting two
+                # large, nearby positions can otherwise leave a spurious
+                # tangential component in the initial MPR ray.
+                inside_face = (
+                    wp.dot(wp.cross(tri_b - tri_a, plane_proj - tri_a), face_normal) >= 0.0
+                    and wp.dot(wp.cross(tri_c - tri_b, plane_proj - tri_b), face_normal) >= 0.0
+                    and wp.dot(wp.cross(tri_a - tri_c, plane_proj - tri_c), face_normal) >= 0.0
+                )
+                if inside_face:
+                    proj = plane_proj
+                    center_b_to_a = -signed_plane_distance * face_normal_unit
+                else:
+                    center_b_to_a = proj - center_b_world
+
+                centroid = (tri_a + tri_b + tri_c) / 3.0
+                to_centroid = centroid - proj
+                to_centroid -= wp.dot(to_centroid, face_normal_unit) * face_normal_unit
+                distance_to_centroid = wp.length(to_centroid)
+                if distance_to_centroid > 1.0e-12:
+                    nudge_distance = 0.01 * wp.min(distance_to_centroid, wp.abs(signed_plane_distance))
+                    center_b_to_a += to_centroid * (nudge_distance / distance_to_centroid)
+
             else:
-                center_a = proj
+                center_b_to_a = proj - center_b_world
 
         center.B = center_b_world
-        center.BtoA = center_a - center_b_world
+        center.BtoA = center_b_to_a
 
         return center
 
@@ -351,20 +355,44 @@ def create_solve_mpr(support_func: Any, _support_funcs: Any = None):
 
         normal = v0.BtoA
         if wp.length_sq(normal) < NUMERIC_EPSILON:
-            # Centers coincide — probe three orthogonal directions and
-            # pick the one with the largest Minkowski support, giving
-            # MPR the most room to find a valid portal.
-            best_dot = float(-1.0e30)
-            best_dir = wp.vec3(1.0, 0.0, 0.0)
-            for axis_idx in range(3):
-                probe = wp.vec3(0.0, 0.0, 0.0)
-                probe[axis_idx] = 1.0
-                sv = minkowski_support(geom_a, geom_b, probe, orientation_b, position_b, extend, data_provider)
-                d = wp.dot(sv.BtoA, probe)
-                if d > best_dot:
-                    best_dot = d
-                    best_dir = probe
-            v0.BtoA = best_dir * 1e-05
+            used_triangle_fallback = bool(False)
+            if geom_a.shape_type == int(GeoTypeEx.TRIANGLE) or geom_a.shape_type == int(GeoTypeEx.TRIANGLE_PRISM):
+                tri_a = wp.vec3(0.0, 0.0, 0.0)
+                tri_b = geom_a.scale
+                tri_c = geom_a.auxiliary
+                face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
+                face_normal_length_sq = wp.length_sq(face_normal)
+                if face_normal_length_sq >= 1.0e-20:
+                    face_normal = face_normal / wp.sqrt(face_normal_length_sq)
+                    proj = closest_point_on_triangle(v0.B, tri_a, tri_b, tri_c)
+                    centroid = (tri_a + tri_b + tri_c) / 3.0
+                    to_centroid = centroid - proj
+                    to_centroid -= wp.dot(to_centroid, face_normal) * face_normal
+                    to_centroid_length_sq = wp.length_sq(to_centroid)
+
+                    # Use the face normal for coincident triangle/convex
+                    # centers, retaining a small triangle-specific bias.
+                    fallback_dir = -face_normal
+                    if wp.dot(v0.B - proj, face_normal) < 0.0:
+                        fallback_dir = face_normal
+                    if to_centroid_length_sq > 1.0e-20:
+                        fallback_dir += 0.01 * to_centroid / wp.sqrt(to_centroid_length_sq)
+                    v0.BtoA = wp.normalize(fallback_dir) * 1.0e-5
+                    used_triangle_fallback = True
+
+            if not used_triangle_fallback:
+                # Probe three axes and use the direction with most support.
+                best_dot = float(-1.0e30)
+                best_dir = wp.vec3(1.0, 0.0, 0.0)
+                for axis_idx in range(3):
+                    probe = wp.vec3(0.0, 0.0, 0.0)
+                    probe[axis_idx] = 1.0
+                    sv = minkowski_support(geom_a, geom_b, probe, orientation_b, position_b, extend, data_provider)
+                    d = wp.dot(sv.BtoA, probe)
+                    if d > best_dot:
+                        best_dot = d
+                        best_dir = probe
+                v0.BtoA = best_dir * 1e-05
 
         normal = -v0.BtoA
 

--- a/newton/_src/geometry/mpr.py
+++ b/newton/_src/geometry/mpr.py
@@ -236,9 +236,10 @@ def create_support_map_function(support_func: Any):
             # point near the contact region — this dramatically improves
             # MPR convergence for large triangles.
             #
-            # Blend 1% toward the centroid so the point is strictly in the
-            # face interior.  This does NOT prevent an MPR degeneracy (MPR
-            # works fine from an edge point); it improves *manifold quality*.
+            # Nudge toward the centroid so the point moves into the face
+            # interior when possible.  This does NOT prevent an MPR
+            # degeneracy (MPR works fine from an edge point); it improves
+            # *manifold quality*.
             # When shape B projects onto a shared mesh edge, both adjacent
             # triangles get the same v0, producing MPR witness points biased
             # toward the edge.  The manifold builder (multicontact.py) uses
@@ -246,14 +247,29 @@ def create_support_map_function(support_func: Any):
             # mapping, so edge-biased centers cause overlapping contact
             # polygons across the two triangles instead of distinct ones —
             # resulting in asymmetric force distribution and spurious torque.
-            # The 1% nudge gives each triangle a unique v0 pulled toward its
-            # own interior, yielding well-separated manifold centers.
+            # Keep that triangle-specific direction, but limit the tangential
+            # displacement to 1% of the normal center-to-plane distance.  A
+            # face projection therefore tilts the initial ray by at most
+            # atan(0.01), about 0.57 degrees, regardless of triangle size.  A
+            # pure barycentric blend scales with the triangle and can make the
+            # initial ray almost tangential when a small partner lies on a
+            # large terrain face, causing MPR to converge to a non-minimum
+            # portal.
             tri_a = wp.vec3(0.0, 0.0, 0.0)
             tri_b = geom_a.scale
             tri_c = geom_a.auxiliary
             proj = closest_point_on_triangle(center_b_world, tri_a, tri_b, tri_c)
             centroid = (tri_a + tri_b + tri_c) / 3.0
-            center_a = proj + 0.01 * (centroid - proj)
+            to_centroid = centroid - proj
+            distance_to_centroid = wp.length(to_centroid)
+            face_normal = wp.cross(tri_b - tri_a, tri_c - tri_a)
+            face_normal_length = wp.length(face_normal)
+            if distance_to_centroid > 1.0e-12 and face_normal_length > 1.0e-12:
+                center_to_plane = wp.abs(wp.dot(center_b_world - proj, face_normal)) / face_normal_length
+                nudge_distance = 0.01 * wp.min(distance_to_centroid, center_to_plane)
+                center_a = proj + to_centroid * (nudge_distance / distance_to_centroid)
+            else:
+                center_a = proj
 
         center.B = center_b_world
         center.BtoA = center_a - center_b_world

--- a/newton/tests/test_mpr.py
+++ b/newton/tests/test_mpr.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Minkowski Portal Refinement (MPR)."""
+
+import unittest
+
+import numpy as np
+import warp as wp
+
+from newton import GeoType
+from newton._src.geometry.mpr import create_solve_mpr
+from newton._src.geometry.support_function import (
+    GenericShapeData,
+    GeoTypeEx,
+    SupportMapDataProvider,
+    support_map,
+)
+
+
+@wp.kernel
+def _triangle_mpr_kernel(
+    triangle_b: wp.array[wp.vec3],
+    triangle_c: wp.array[wp.vec3],
+    shape_b_type: int,
+    shape_b_scale: wp.vec3,
+    shape_b_position: wp.array[wp.vec3],
+    shape_b_orientation: wp.array[wp.quat],
+    collision_out: wp.array[int],
+    point_a_out: wp.array[wp.vec3],
+    point_b_out: wp.array[wp.vec3],
+    normal_out: wp.array[wp.vec3],
+    penetration_out: wp.array[float],
+):
+    """Run MPR directly, with each triangle's first vertex at the origin."""
+    i = wp.tid()
+
+    shape_a = GenericShapeData()
+    shape_a.shape_type = int(GeoTypeEx.TRIANGLE)
+    shape_a.scale = triangle_b[i]
+    shape_a.auxiliary = triangle_c[i]
+
+    shape_b = GenericShapeData()
+    shape_b.shape_type = shape_b_type
+    shape_b.scale = shape_b_scale
+    shape_b.auxiliary = wp.vec3(0.0)
+
+    data_provider = SupportMapDataProvider()
+    collision, point_a, point_b, normal, penetration = wp.static(create_solve_mpr(support_map).core)(
+        shape_a,
+        shape_b,
+        shape_b_orientation[i],
+        shape_b_position[i],
+        0.0,
+        data_provider,
+    )
+
+    collision_out[i] = int(collision)
+    point_a_out[i] = point_a
+    point_b_out[i] = point_b
+    normal_out[i] = normal
+    penetration_out[i] = penetration
+
+
+def _run_triangle_mpr(triangle_b, triangle_c, shape_type, shape_scale, shape_positions, shape_orientations):
+    """Run direct triangle-vs-convex MPR cases on CPU and return NumPy outputs."""
+    device = "cpu"
+    count = len(triangle_b)
+
+    triangle_b_wp = wp.array(np.asarray(triangle_b, dtype=np.float32), dtype=wp.vec3, device=device)
+    triangle_c_wp = wp.array(np.asarray(triangle_c, dtype=np.float32), dtype=wp.vec3, device=device)
+    shape_positions_wp = wp.array(np.asarray(shape_positions, dtype=np.float32), dtype=wp.vec3, device=device)
+    shape_orientations_wp = wp.array(np.asarray(shape_orientations, dtype=np.float32), dtype=wp.quat, device=device)
+
+    collision = wp.zeros(count, dtype=int, device=device)
+    point_a = wp.zeros(count, dtype=wp.vec3, device=device)
+    point_b = wp.zeros(count, dtype=wp.vec3, device=device)
+    normal = wp.zeros(count, dtype=wp.vec3, device=device)
+    penetration = wp.zeros(count, dtype=float, device=device)
+
+    wp.launch(
+        _triangle_mpr_kernel,
+        dim=count,
+        inputs=[
+            triangle_b_wp,
+            triangle_c_wp,
+            int(shape_type),
+            wp.vec3(*shape_scale),
+            shape_positions_wp,
+            shape_orientations_wp,
+        ],
+        outputs=[collision, point_a, point_b, normal, penetration],
+        device=device,
+    )
+
+    return (
+        collision.numpy(),
+        point_a.numpy(),
+        point_b.numpy(),
+        normal.numpy(),
+        penetration.numpy(),
+    )
+
+
+class TestMPRTriangleInitialization(unittest.TestCase):
+    """Test triangle MPR initialization across disparate geometry scales."""
+
+    def test_small_cylinder_on_large_triangle(self):
+        """A small cylinder on a large triangle must resolve along the face normal.
+
+        A fixed 1% triangle-centroid blend moves the initial point by nearly
+        half a meter in this case.  With the cylinder center only 0.36 mm above
+        the face, that makes the MPR ray almost tangential and used to produce
+        a 58.8 m penetration instead of the geometric 61.7 mm penetration.
+        """
+        cylinder_position = np.array([28.87991333, 260.53430176, 0.00036136055], dtype=np.float32)
+        cylinder_orientation = np.array(
+            [-0.16498479, 0.36682746, -0.48718625, 0.77515626],
+            dtype=np.float32,
+        )
+        radius = 0.02
+        half_height = 0.07
+
+        collision, _point_a, _point_b, normals, penetrations = _run_triangle_mpr(
+            triangle_b=[[100.0, 320.0, 0.0]],
+            triangle_c=[[0.0, 320.0, 0.0]],
+            shape_type=GeoType.CYLINDER,
+            shape_scale=(radius, half_height, radius),
+            shape_positions=[cylinder_position],
+            shape_orientations=[cylinder_orientation],
+        )
+
+        # The cylinder axis is its rotated local Z axis.  Its support extent
+        # along world Z is h*|axis_z| + r*sqrt(1-axis_z^2).
+        qx, qy, _qz, _qw = cylinder_orientation
+        axis_z = 1.0 - 2.0 * (qx * qx + qy * qy)
+        vertical_extent = half_height * abs(axis_z) + radius * np.sqrt(max(0.0, 1.0 - axis_z * axis_z))
+        expected_penetration = vertical_extent - cylinder_position[2]
+
+        self.assertEqual(collision[0], 1)
+        self.assertAlmostEqual(float(penetrations[0]), float(expected_penetration), delta=2.0e-5)
+        np.testing.assert_allclose(normals[0], [0.0, 0.0, 1.0], atol=2.0e-4)
+
+    def test_shared_edge_witnesses_remain_triangle_specific(self):
+        """The bounded nudge must retain distinct witnesses across a mesh seam.
+
+        The two triangles form a square split along x=y, and the box center is
+        directly above that shared edge.  The witness on each triangle should
+        lie on its own side of the seam rather than both being edge-biased.
+        """
+        collision, points_a, _points_b, normals, penetrations = _run_triangle_mpr(
+            triangle_b=[[2.0, 0.0, 0.0], [2.0, 2.0, 0.0]],
+            triangle_c=[[2.0, 2.0, 0.0], [0.0, 2.0, 0.0]],
+            shape_type=GeoType.BOX,
+            shape_scale=(0.15, 0.12, 0.1),
+            shape_positions=[[1.0, 1.0, 0.095], [1.0, 1.0, 0.095]],
+            shape_orientations=[[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]],
+        )
+
+        np.testing.assert_array_equal(collision, [1, 1])
+        self.assertGreater(float(points_a[0, 0] - points_a[0, 1]), 1.0e-4)
+        self.assertGreater(float(points_a[1, 1] - points_a[1, 0]), 1.0e-4)
+        np.testing.assert_allclose(normals, [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], atol=1.0e-5)
+        np.testing.assert_allclose(penetrations, [0.005, 0.005], atol=1.0e-5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, failfast=True)

--- a/newton/tests/test_mpr.py
+++ b/newton/tests/test_mpr.py
@@ -103,10 +103,10 @@ def _run_triangle_mpr(triangle_b, triangle_c, shape_type, shape_scale, shape_pos
 
 
 class TestMPRTriangleInitialization(unittest.TestCase):
-    """Test triangle MPR initialization across disparate geometry scales."""
+    """Cover triangle MPR initialization across disparate geometry scales."""
 
     def test_small_cylinder_on_large_triangle(self):
-        """A small cylinder on a large triangle must resolve along the face normal.
+        """Resolve a small cylinder on a large triangle along the face normal.
 
         A fixed 1% triangle-centroid blend moves the initial point by nearly
         half a meter in this case.  With the cylinder center only 0.36 mm above
@@ -121,7 +121,7 @@ class TestMPRTriangleInitialization(unittest.TestCase):
         radius = 0.02
         half_height = 0.07
 
-        collision, _point_a, _point_b, normals, penetrations = _run_triangle_mpr(
+        collision, points_a, points_b, normals, penetrations = _run_triangle_mpr(
             triangle_b=[[100.0, 320.0, 0.0]],
             triangle_c=[[0.0, 320.0, 0.0]],
             shape_type=GeoType.CYLINDER,
@@ -140,9 +140,40 @@ class TestMPRTriangleInitialization(unittest.TestCase):
         self.assertEqual(collision[0], 1)
         self.assertAlmostEqual(float(penetrations[0]), float(expected_penetration), delta=2.0e-5)
         np.testing.assert_allclose(normals[0], [0.0, 0.0, 1.0], atol=2.0e-4)
+        self.assertLess(float(np.linalg.norm(points_a[0, :2] - cylinder_position[:2])), 0.1)
+        self.assertLess(float(np.linalg.norm(points_b[0] - cylinder_position)), 0.08)
+
+    def test_coplanar_cylinder_center_on_large_triangle(self):
+        """Handle an exactly coplanar convex center without a tangential roundoff ray."""
+        cylinder_orientation = np.array(
+            [-0.16498479, 0.36682746, -0.48718625, 0.77515626],
+            dtype=np.float32,
+        )
+        radius = 0.02
+        half_height = 0.07
+
+        cylinder_position = np.array([28.87991333, 260.53430176, 0.0], dtype=np.float32)
+        collision, points_a, points_b, normals, penetrations = _run_triangle_mpr(
+            triangle_b=[[100.0, 320.0, 0.0]],
+            triangle_c=[[0.0, 320.0, 0.0]],
+            shape_type=GeoType.CYLINDER,
+            shape_scale=(radius, half_height, radius),
+            shape_positions=[cylinder_position],
+            shape_orientations=[cylinder_orientation],
+        )
+
+        qx, qy, _qz, _qw = cylinder_orientation
+        axis_z = 1.0 - 2.0 * (qx * qx + qy * qy)
+        expected_penetration = half_height * abs(axis_z) + radius * np.sqrt(max(0.0, 1.0 - axis_z * axis_z))
+
+        self.assertEqual(collision[0], 1)
+        self.assertAlmostEqual(float(penetrations[0]), float(expected_penetration), delta=2.0e-5)
+        np.testing.assert_allclose(normals[0], [0.0, 0.0, 1.0], atol=2.0e-4)
+        self.assertLess(float(np.linalg.norm(points_a[0, :2] - cylinder_position[:2])), 0.1)
+        self.assertLess(float(np.linalg.norm(points_b[0] - cylinder_position)), 0.08)
 
     def test_shared_edge_witnesses_remain_triangle_specific(self):
-        """The bounded nudge must retain distinct witnesses across a mesh seam.
+        """Retain distinct witnesses across a mesh seam with the bounded nudge.
 
         The two triangles form a square split along x=y, and the box center is
         directly above that shared edge.  The witness on each triangle should
@@ -162,6 +193,23 @@ class TestMPRTriangleInitialization(unittest.TestCase):
         self.assertGreater(float(points_a[1, 1] - points_a[1, 0]), 1.0e-4)
         np.testing.assert_allclose(normals, [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], atol=1.0e-5)
         np.testing.assert_allclose(penetrations, [0.005, 0.005], atol=1.0e-5)
+
+    def test_coplanar_shared_edge_witnesses_remain_triangle_specific(self):
+        """Retain the triangle-specific fallback when both centers coincide."""
+        collision, points_a, _points_b, normals, penetrations = _run_triangle_mpr(
+            triangle_b=[[2.0, 0.0, 0.0], [2.0, 2.0, 0.0]],
+            triangle_c=[[2.0, 2.0, 0.0], [0.0, 2.0, 0.0]],
+            shape_type=GeoType.BOX,
+            shape_scale=(0.15, 0.12, 0.1),
+            shape_positions=[[1.0, 1.0, 0.0], [1.0, 1.0, 0.0]],
+            shape_orientations=[[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]],
+        )
+
+        np.testing.assert_array_equal(collision, [1, 1])
+        self.assertGreater(float(points_a[0, 0] - points_a[0, 1]), 1.0e-4)
+        self.assertGreater(float(points_a[1, 1] - points_a[1, 0]), 1.0e-4)
+        np.testing.assert_allclose(normals, [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], atol=1.0e-5)
+        np.testing.assert_allclose(penetrations, [0.1, 0.1], atol=1.0e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

### Problem

In some poses, MPR turns a local contact between a small cylinder and a large triangle into a false, tens-of-metres penetration with witness points far from the cylinder. In the deterministic reproduction, the correct penetration is `0.061719 m`, but Newton `ee84505a` returns `58.826744 m`; only the overlap boolean is correct.

The vulnerable case is near-coplanar: the convex center is close to the triangle plane, while its projection lies inside a large face but far from the triangle centroid. The existing initialization shifts that projection toward the centroid by `1%` of their separation. Here that adds `0.474106 m` tangentially against only `0.000361 m` normally, making the initial MPR direction nearly tangent to the face. An instrumented trace in #3773 shows the resulting pose-sensitive portal branch and nonlocal witness reconstruction.

### Changes

This PR preserves the shared-edge manifold intent of #2276 without letting the initialization scale with triangle size:

- For projections in the closed face region, construct the base Minkowski center offset directly as `-d * n` from signed plane distance `d` and face normal `n`. This avoids a false tangent residual from subtracting large nearby float32 positions.
- For `|d| > 0`, bound the centroid-directed tangent bias to `0.01 * min(|G-P|, |d|)`. Its tangent/normal ratio is therefore at most `0.01`, independent of triangle size.
- For exact `d=0`, use a triangle-specific face-normal fallback with the same centroid direction instead of the generic world-axis probe.
- Preserve the real tangent distance outside the face and the existing degenerate-triangle behavior.
- Add direct regressions for the reported pose, exact coplanarity, and shared-edge witnesses both above and on the plane.

Simply removing the centroid bias is not sufficient: it fixes the large-face case but makes adjacent triangles produce seam-biased witnesses. The bounded rule and triangle-specific fallback preserve those distinct witnesses, including at `d=0`.

Closes #3773. Related: #2276 and isaac-sim/IsaacLab#5071.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes (no public API or workflow change)
- [x] `CHANGELOG.md` has been updated (user-facing collision fix)

## Test plan

Validated with Warp `1.16.0.dev20260716`, the version locked by base commit `ee84505a`, and Python `3.12.3`:

```bash
python -m unittest -v newton.tests.test_mpr
python -m unittest -v newton.tests.test_gjk
python -m unittest -v \
  newton.tests.test_narrow_phase.TestExtremeMeshTriangles.test_huge_triangle_center \
  newton.tests.test_narrow_phase.TestExtremeMeshTriangles.test_huge_triangle_near_edge \
  newton.tests.test_narrow_phase.TestExtremeMeshTriangles.test_huge_triangle_near_vertex \
  newton.tests.test_narrow_phase.TestExtremeMeshTriangles.test_shared_edge_flat
pre-commit run --files newton/_src/geometry/mpr.py newton/tests/test_mpr.py CHANGELOG.md
```

All listed tests and hooks pass. Additional deterministic validation covered:

- `1001` heights from `0` to `2 mm` in `2 μm` steps, with no invalid depth, normal, or witness result;
- triangle scales from `0.005x` to `10x`, with penetration within `2.9e-5` relative error and `normal.z >= 0.99999994`;
- the exact reported input: `58.826744 m` on `ee84505a`, `0.061719764 m` with this PR.

## Bug fix

**Steps to reproduce:**

1. Run the standalone CPU reproduction in #3773 on Newton `ee84505a`.
2. Observe `overlap=True`, penetration `58.826744 m`, a mostly tangential normal, and nonlocal witnesses.
3. Compare with the analytic cylinder-plane penetration `0.061719150 m`.
4. Run the same case with this PR and observe local witnesses, a face-normal contact, and penetration `0.061719764 m`.

**Minimal reproduction:**

The standalone script is in #3773. The executable regression in `newton/tests/test_mpr.py` calls `create_solve_mpr(support_map).core` directly, so broad phase, contact reduction, and dynamics solvers are not involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collision detection for small convex shapes contacting large mesh triangles.
  * Improved contact positioning, normals, and penetration depth accuracy across differently sized and coplanar shapes.
  * Preserved consistent collision results near shared triangle edges, including fallback contact scenarios.
  * Improved reliability when handling degenerate triangle geometry and coincident shape centers.

* **Tests**
  * Added regression coverage for triangle-versus-convex collisions, including large triangles, coplanar cylinders, shared edges, and witness data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->