### PR TITLE
Fix external contact cache lifetime under CUDA graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@
 ### Fixed
 
 - Make deterministic collision pipelines cover hydroelastic contact generation and reduction, including unique reduced-contact sort keys and overflow-safe fixed-point pressure accumulation.
+- Fix `SolverMuJoCo` retaining an invalid external-contact cache when its first step is captured in a CUDA graph. (#3767)
 - Convert `newton:mimicCoef0` from degrees to radians when the mimic follower joint is angular. Assets authored against the old behavior need the value rescaled to degrees.
 - Complete Kamino RCM traversal for large and disconnected systems and reuse the resulting permutation by default; set `reuse_permutation=False` to recompute it for changing matrix topology.
 - Bound Kamino DVI contact allocation with a per-world geometry heuristic instead of sizing every contact pair simultaneously; set `collision_detector.max_contacts_per_world` to override the inferred capacity.

--- a/newton/_src/solvers/mujoco/solver_mujoco.py
+++ b/newton/_src/solvers/mujoco/solver_mujoco.py
@@ -3692,13 +3692,9 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         # Initialised before _convert_to_mjc because notify_model_changed (called
         # during conversion) may call _invalidate_contact_fast_path.
         #
-        # Eagerly pre-allocate the device tracking buffers here (rather than
-        # lazily inside _convert_contacts_to_mjwarp).  Lazy wp.full(...) calls
-        # that happen on the first step often run while a CUDA graph is being
-        # captured; the resulting buffers can have a tangled lifetime and
-        # _invalidate_contact_fast_path() — which is called from outside the
-        # captured graph (e.g. notify_model_changed) — would then touch stale
-        # captured memory and trigger CUDA 700 (illegal memory access).
+        # Allocate the generation and count buffers before conversion because
+        # notify_model_changed() may invalidate them during conversion. The
+        # contact map is allocated below once the converted capacity is known.
         self._contact_tid_to_cid: wp.array[wp.int32] | None = None
         self._last_contact_generation = wp.full(1, _GENERATION_SENTINEL, dtype=wp.int32, device=self.device)
         self._last_nacon_count = wp.zeros(1, dtype=wp.int32, device=self.device)
@@ -3751,6 +3747,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
                 include_sites=include_sites,
                 skip_visual_only_geoms=skip_visual_only_geoms,
             )
+        if not use_mujoco_cpu and not use_mujoco_contacts:
+            self._contact_tid_to_cid = wp.full(self.mjw_data.naconmax, -1, dtype=wp.int32, device=self.device)
         self._initial_model_sync = False
         self.update_data_interval = update_data_interval
         self._step = 0
@@ -4216,8 +4214,8 @@ class SolverMuJoCo(SolverBase, CouplingInterface):
         naconmax = self.mjw_data.naconmax
         launch_dim = min(contacts.rigid_contact_max, naconmax)
 
-        # Lazy-allocate the tid_to_cid buffer; reallocate if launch_dim grew
-        # (e.g. a different Contacts object with a larger rigid_contact_max).
+        # Grow the tid_to_cid buffer if the MJWarp data capacity changed after
+        # construction.
         # Invalidate the cached tid_to_cid mapping whenever any of the
         # invariants it depends on change:
         #

--- a/newton/tests/test_mujoco_solver.py
+++ b/newton/tests/test_mujoco_solver.py
@@ -4477,14 +4477,23 @@ class TestMuJoCoSolverNewtonContacts(unittest.TestCase):
             solver._last_nacon_count,
             "_last_nacon_count must be eagerly pre-allocated in __init__",
         )
+        self.assertIsNotNone(
+            solver._contact_tid_to_cid,
+            "_contact_tid_to_cid must be eagerly pre-allocated in __init__",
+        )
         self.assertIsInstance(solver._last_contact_generation, wp.array)
         self.assertIsInstance(solver._last_nacon_count, wp.array)
+        self.assertIsInstance(solver._contact_tid_to_cid, wp.array)
         self.assertEqual(solver._last_contact_generation.dtype, wp.int32)
         self.assertEqual(solver._last_nacon_count.dtype, wp.int32)
+        self.assertEqual(solver._contact_tid_to_cid.dtype, wp.int32)
         self.assertEqual(solver._last_contact_generation.shape, (1,))
         self.assertEqual(solver._last_nacon_count.shape, (1,))
+        self.assertEqual(solver._contact_tid_to_cid.shape, (solver.mjw_data.naconmax,))
         self.assertEqual(solver._last_contact_generation.device, model.device)
         self.assertEqual(solver._last_nacon_count.device, model.device)
+        self.assertEqual(solver._contact_tid_to_cid.device, model.device)
+        self.assertTrue(np.all(solver._contact_tid_to_cid.numpy() == -1))
 
         # Calling _invalidate_contact_fast_path() before any step must succeed
         # cleanly — this is the exact path that previously hit stale captured


### PR DESCRIPTION
## Description

`SolverMuJoCo` already creates the contact fast-path generation and count buffers before the first step, but the thread-to-contact map was still created lazily in `_convert_contacts_to_mjwarp()`. When the first step was captured in a CUDA graph, the solver kept a pointer to that captured allocation after capture ended.

This allocates the map after model conversion, when `mjw_data.naconmax` is known. The allocation is limited to the GPU path with external Newton contacts. The existing capacity check remains in place in case the MJWarp data capacity changes later.

The fast-path buffer test now covers the map's type, size, device, and initial contents.

Closes #3767.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```bash
uv run --extra dev python -m unittest newton.tests.test_mujoco_solver.TestMuJoCoSolverNewtonContacts
uvx pre-commit run -a
```

The eight external-contact MuJoCo solver tests pass. I also ran the reproduction from #3767 directly:

- `main`: prints the cache pointer, then exits with code 139 on `cache.numpy()`
- this branch: reads all 200 entries successfully and exits with code 0

I verified the regression test separately with the source change removed; it fails because `_contact_tid_to_cid` is `None`.

## Bug fix

**Steps to reproduce:**

1. Construct `SolverMuJoCo` with `use_mujoco_contacts=False` on CUDA.
2. Run its first contact step inside `wp.ScopedCapture`.
3. Read back `solver._contact_tid_to_cid` after capture.
4. The process segfaults while copying the cache to the host.

**Minimal reproduction:**

```python
import newton
import warp as wp

from newton.solvers import SolverMuJoCo


device = wp.get_device("cuda:0")
builder = newton.ModelBuilder()
builder.add_ground_plane()
body = builder.add_body(xform=wp.transform(wp.vec3(0.0, 0.0, 0.18), wp.quat_identity()))
builder.add_shape_box(body, hx=0.1, hy=0.1, hz=0.1)
model = builder.finalize(device=device)

solver = SolverMuJoCo(model, use_mujoco_contacts=False, njmax=200, nconmax=200)
collision_pipeline = newton.CollisionPipeline(model)
contacts = collision_pipeline.contacts()
state_in, state_out, control = model.state(), model.state(), model.control()
newton.eval_fk(model, model.joint_q, model.joint_qd, state_in)

with wp.ScopedCapture(device=device):
    state_in.clear_forces()
    collision_pipeline.collide(state_in, contacts)
    solver.step(state_in, state_out, control, contacts, 0.002)

cache = solver._contact_tid_to_cid
print(f"cache ptr={cache.ptr}, shape={cache.shape}, device={cache.device}", flush=True)
print(cache.numpy(), flush=True)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid external-contact data could persist when the first simulation step was captured in a CUDA graph.
  * Improved contact mapping allocation and cache invalidation to keep contact data accurate as simulation capacity changes.
  * Ensured contact buffers are initialized with the correct size, device, type, and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->