### PR TITLE
Fix XPBD joint separation after large errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - Fix masked `SolverCoupledProxy.reset()` calls clearing proxy feedback history for unselected worlds.
 - Fix hydroelastic primitive texture SDF generation to sample analytic primitive distances instead of temporary tessellated meshes. (#3239)
 - Fix MJCF, URDF, and USD imports rendering collision-only bodies as visuals when the asset authors visual geometry elsewhere. (#3291)
+- Fix fully locked XPBD joints becoming permanently separated after large transient anchor errors.
 - Fix `SchemaResolverPhysx` reading every D6 translational limit gain from the `linear` instance instead of its `transX`, `transY`, or `transZ` instance.
 - Fix USD capsule, cylinder, and cone visuals and sites without authored `radius`/`height` to use the UsdGeom schema fallbacks, matching collision shapes.
 - Fix `ViewerUSD` texture consumers observing partially written PNGs by publishing generated textures atomically (#3288)

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -1746,9 +1746,11 @@ def solve_body_joints(
         axis_limits_upper = wp.spatial_bottom(axis_limits)
 
         frame_p = wp.quat_to_matrix(wp.transform_get_rotation(X_wp))
-        # note that x_c appearing in both is correct
         r_p = x_c - world_com_p
-        r_c = x_c - wp.transform_point(pose_c, com_c)
+        if lin_axis_count == 0:
+            # Keep angular effective mass independent of anchor separation.
+            r_p = wp.transform_get_translation(X_wp) - world_com_p
+        r_c = x_c - world_com_c
 
         # for loop will be unrolled, so we can modify local variables
         for dim in range(3):

--- a/newton/_src/solvers/xpbd/kernels.py
+++ b/newton/_src/solvers/xpbd/kernels.py
@@ -1745,11 +1745,27 @@ def solve_body_joints(
         axis_limits_lower = wp.spatial_top(axis_limits)
         axis_limits_upper = wp.spatial_bottom(axis_limits)
 
+        # A relative offset can contain both valid joint motion and error. For example,
+        # a prismatic joint may be 0.5 m along its free axis and 1 m off it.
+        # Start from the current offset so unconstrained coordinates keep their extension.
+        projected_rel_p = rel_p
+        for dim in range(3):
+            lower = axis_limits_lower[dim]
+            upper = axis_limits_upper[dim]
+            # Limit violations project to the nearest admissible boundary.
+            if rel_p[dim] < lower:
+                projected_rel_p[dim] = lower
+            elif rel_p[dim] > upper:
+                projected_rel_p[dim] = upper
+            # A position-driven coordinate projects to its target. Locked coordinates
+            # have zero-width limits above and therefore already project to zero.
+            elif axis_stiffness[dim] > 0.0:
+                projected_rel_p[dim] = wp.clamp(axis_target_pos[dim], lower, upper)
+
         frame_p = wp.quat_to_matrix(wp.transform_get_rotation(X_wp))
-        r_p = x_c - world_com_p
-        if lin_axis_count == 0:
-            # Keep angular effective mass independent of anchor separation.
-            r_p = wp.transform_get_translation(X_wp) - world_com_p
+        # Use the admissible point for the parent lever arm: the parent anchor would
+        # discard valid extension, while the child anchor would include separation error.
+        r_p = wp.transform_point(X_wp, projected_rel_p) - world_com_p
         r_c = x_c - world_com_c
 
         # for loop will be unrolled, so we can modify local variables

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -153,10 +153,8 @@ def test_ball_joint_recovers_from_large_anchor_separation(test, device):
     capsule_radius = 0.0625
     capsule_half_height = 0.25
     capsule_half_extent = capsule_radius + capsule_half_height
-    capsule_volume = np.pi * capsule_radius**2 * (2.0 * capsule_half_height) + 4.0 / 3.0 * np.pi * capsule_radius**3
 
-    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
-    shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0 / capsule_volume, collision_group=0)
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
     shape_xform = wp.transform(
         wp.vec3(0.0),
         wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.5 * wp.pi),
@@ -168,7 +166,6 @@ def test_ball_joint_recovers_from_large_anchor_separation(test, device):
         xform=shape_xform,
         radius=capsule_radius,
         half_height=capsule_half_height,
-        cfg=shape_cfg,
     )
     child = builder.add_link(xform=wp.transform(wp.vec3(2.0 * capsule_half_extent, 0.0, 0.0), wp.quat_identity()))
     builder.add_shape_capsule(
@@ -176,7 +173,6 @@ def test_ball_joint_recovers_from_large_anchor_separation(test, device):
         xform=shape_xform,
         radius=capsule_radius,
         half_height=capsule_half_height,
-        cfg=shape_cfg,
     )
 
     root_joint = builder.add_joint_free(child=parent)
@@ -189,32 +185,28 @@ def test_ball_joint_recovers_from_large_anchor_separation(test, device):
     builder.add_articulation([root_joint, ball_joint])
 
     model = builder.finalize(device=device)
-    model.set_gravity((0.0, 0.0, 0.0))
-    state_0 = model.state()
-    state_1 = model.state()
-    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+    state0 = model.state()
+    state1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
 
-    body_q = state_0.body_q.numpy()
+    body_q = state0.body_q.numpy()
     body_q[child, :3] += np.array((1.0, 1.0, 0.0), dtype=np.float32)
-    state_0.body_q.assign(body_q)
+    state0.body_q.assign(body_q)
 
     solver = newton.solvers.SolverXPBD(model, iterations=2)
-    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+    solver.step(state0, state1, None, None, 1.0 / 240.0)
 
-    body_q = state_1.body_q.numpy()
+    body_q = state1.body_q.numpy()
 
-    def transform_point(transform, point):
-        p = transform[:3]
-        q = transform[3:]
-        qv = q[:3]
-        rotated = (
-            2.0 * np.dot(qv, point) * qv + (q[3] * q[3] - np.dot(qv, qv)) * point + 2.0 * q[3] * np.cross(qv, point)
-        )
-        return p + rotated
-
-    parent_anchor = transform_point(body_q[parent], np.array((capsule_half_extent, 0.0, 0.0)))
-    child_anchor = transform_point(body_q[child], np.array((-capsule_half_extent, 0.0, 0.0)))
-    anchor_gap = float(np.linalg.norm(child_anchor - parent_anchor))
+    parent_anchor = wp.transform_point(
+        wp.transform(*body_q[parent]),
+        wp.vec3(capsule_half_extent, 0.0, 0.0),
+    )
+    child_anchor = wp.transform_point(
+        wp.transform(*body_q[child]),
+        wp.vec3(-capsule_half_extent, 0.0, 0.0),
+    )
+    anchor_gap = float(wp.length(child_anchor - parent_anchor))
 
     test.assertLess(
         anchor_gap,
@@ -227,10 +219,8 @@ def test_prismatic_joint_recovers_from_large_transverse_separation(test, device)
     """Recover transverse errors while retaining a valid prismatic coordinate."""
     capsule_radius = 0.0625
     capsule_half_height = 0.25
-    capsule_volume = np.pi * capsule_radius**2 * (2.0 * capsule_half_height) + 4.0 / 3.0 * np.pi * capsule_radius**3
 
-    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
-    shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0 / capsule_volume, collision_group=0)
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
     shape_xform = wp.transform(
         wp.vec3(0.0),
         wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.5 * wp.pi),
@@ -242,7 +232,6 @@ def test_prismatic_joint_recovers_from_large_transverse_separation(test, device)
         xform=shape_xform,
         radius=capsule_radius,
         half_height=capsule_half_height,
-        cfg=shape_cfg,
     )
     child = builder.add_link()
     builder.add_shape_capsule(
@@ -250,7 +239,6 @@ def test_prismatic_joint_recovers_from_large_transverse_separation(test, device)
         xform=shape_xform,
         radius=capsule_radius,
         half_height=capsule_half_height,
-        cfg=shape_cfg,
     )
 
     root_joint = builder.add_joint_free(child=parent)
@@ -264,29 +252,24 @@ def test_prismatic_joint_recovers_from_large_transverse_separation(test, device)
     builder.add_articulation([root_joint, prismatic_joint])
 
     model = builder.finalize(device=device)
-    model.set_gravity((0.0, 0.0, 0.0))
-    state_0 = model.state()
-    state_1 = model.state()
-    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+    state0 = model.state()
+    state1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
 
-    body_q = state_0.body_q.numpy()
+    body_q = state0.body_q.numpy()
     body_q[child, :3] += np.array((0.5, 1.0, 1.0), dtype=np.float32)
-    state_0.body_q.assign(body_q)
+    state0.body_q.assign(body_q)
 
     solver = newton.solvers.SolverXPBD(model, iterations=2)
-    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+    solver.step(state0, state1, None, None, 1.0 / 240.0)
 
-    body_q = state_1.body_q.numpy()
-    parent_q = body_q[parent, 3:]
-    parent_q_inv = np.array((-parent_q[0], -parent_q[1], -parent_q[2], parent_q[3]))
-    qv = parent_q_inv[:3]
-    offset = body_q[child, :3] - body_q[parent, :3]
-    relative_offset = (
-        2.0 * np.dot(qv, offset) * qv
-        + (parent_q_inv[3] * parent_q_inv[3] - np.dot(qv, qv)) * offset
-        + 2.0 * parent_q_inv[3] * np.cross(qv, offset)
+    body_q = state1.body_q.numpy()
+    relative_offset = wp.transform_point(
+        wp.transform_inverse(wp.transform(*body_q[parent])),
+        wp.vec3(*body_q[child, :3]),
     )
-    transverse_gap = float(np.linalg.norm(relative_offset[1:]))
+    joint_position = float(relative_offset[0])
+    transverse_gap = float(np.hypot(relative_offset[1], relative_offset[2]))
 
     test.assertLess(
         transverse_gap,
@@ -294,14 +277,14 @@ def test_prismatic_joint_recovers_from_large_transverse_separation(test, device)
         msg=f"Prismatic joint did not recover from transverse separation: gap={transverse_gap:.6g} m",
     )
     test.assertGreaterEqual(
-        float(relative_offset[0]),
+        joint_position,
         -2.0,
-        msg=f"Prismatic joint violated its lower limit: position={relative_offset[0]:.6g} m",
+        msg=f"Prismatic joint violated its lower limit: position={joint_position:.6g} m",
     )
     test.assertLessEqual(
-        float(relative_offset[0]),
+        joint_position,
         2.0,
-        msg=f"Prismatic joint violated its upper limit: position={relative_offset[0]:.6g} m",
+        msg=f"Prismatic joint violated its upper limit: position={joint_position:.6g} m",
     )
 
 
@@ -310,7 +293,7 @@ def test_prismatic_joint_retains_extension_in_parent_moment_arm(test, device):
     extension = 0.5
     transverse_error = 0.1
 
-    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0))
     parent = builder.add_link()
     builder.add_shape_sphere(parent, radius=0.25)
     child = builder.add_link()
@@ -328,19 +311,18 @@ def test_prismatic_joint_retains_extension_in_parent_moment_arm(test, device):
     builder.add_articulation([root_joint, prismatic_joint])
 
     model = builder.finalize(device=device)
-    model.set_gravity((0.0, 0.0, 0.0))
-    state_0 = model.state()
-    state_1 = model.state()
-    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+    state0 = model.state()
+    state1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state0)
 
-    body_q = state_0.body_q.numpy()
+    body_q = state0.body_q.numpy()
     body_q[child, :2] += np.array((extension, transverse_error), dtype=np.float32)
-    state_0.body_q.assign(body_q)
+    state0.body_q.assign(body_q)
 
     solver = newton.solvers.SolverXPBD(model, iterations=2, angular_damping=0.0)
-    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+    solver.step(state0, state1, None, None, 1.0 / 240.0)
 
-    parent_rotation_z = abs(float(state_1.body_q.numpy()[parent, 5]))
+    parent_rotation_z = abs(float(state1.body_q.numpy()[parent, 5]))
     test.assertGreater(
         parent_rotation_z,
         0.01,

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -223,6 +223,131 @@ def test_ball_joint_recovers_from_large_anchor_separation(test, device):
     )
 
 
+def test_prismatic_joint_recovers_from_large_transverse_separation(test, device):
+    """Recover transverse errors while retaining a valid prismatic coordinate."""
+    capsule_radius = 0.0625
+    capsule_half_height = 0.25
+    capsule_volume = np.pi * capsule_radius**2 * (2.0 * capsule_half_height) + 4.0 / 3.0 * np.pi * capsule_radius**3
+
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
+    shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0 / capsule_volume, collision_group=0)
+    shape_xform = wp.transform(
+        wp.vec3(0.0),
+        wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.5 * wp.pi),
+    )
+
+    parent = builder.add_link()
+    builder.add_shape_capsule(
+        parent,
+        xform=shape_xform,
+        radius=capsule_radius,
+        half_height=capsule_half_height,
+        cfg=shape_cfg,
+    )
+    child = builder.add_link()
+    builder.add_shape_capsule(
+        child,
+        xform=shape_xform,
+        radius=capsule_radius,
+        half_height=capsule_half_height,
+        cfg=shape_cfg,
+    )
+
+    root_joint = builder.add_joint_free(child=parent)
+    prismatic_joint = builder.add_joint_prismatic(
+        parent=parent,
+        child=child,
+        axis=newton.Axis.X,
+        limit_lower=-2.0,
+        limit_upper=2.0,
+    )
+    builder.add_articulation([root_joint, prismatic_joint])
+
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, 0.0))
+    state_0 = model.state()
+    state_1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    body_q = state_0.body_q.numpy()
+    body_q[child, :3] += np.array((0.5, 1.0, 1.0), dtype=np.float32)
+    state_0.body_q.assign(body_q)
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2)
+    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+
+    body_q = state_1.body_q.numpy()
+    parent_q = body_q[parent, 3:]
+    parent_q_inv = np.array((-parent_q[0], -parent_q[1], -parent_q[2], parent_q[3]))
+    qv = parent_q_inv[:3]
+    offset = body_q[child, :3] - body_q[parent, :3]
+    relative_offset = (
+        2.0 * np.dot(qv, offset) * qv
+        + (parent_q_inv[3] * parent_q_inv[3] - np.dot(qv, qv)) * offset
+        + 2.0 * parent_q_inv[3] * np.cross(qv, offset)
+    )
+    transverse_gap = float(np.linalg.norm(relative_offset[1:]))
+
+    test.assertLess(
+        transverse_gap,
+        0.5,
+        msg=f"Prismatic joint did not recover from transverse separation: gap={transverse_gap:.6g} m",
+    )
+    test.assertGreaterEqual(
+        float(relative_offset[0]),
+        -2.0,
+        msg=f"Prismatic joint violated its lower limit: position={relative_offset[0]:.6g} m",
+    )
+    test.assertLessEqual(
+        float(relative_offset[0]),
+        2.0,
+        msg=f"Prismatic joint violated its upper limit: position={relative_offset[0]:.6g} m",
+    )
+
+
+def test_prismatic_joint_retains_extension_in_parent_moment_arm(test, device):
+    """Retain valid prismatic extension in the parent moment arm."""
+    extension = 0.5
+    transverse_error = 0.1
+
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
+    parent = builder.add_link()
+    builder.add_shape_sphere(parent, radius=0.25)
+    child = builder.add_link()
+    builder.add_shape_sphere(child, radius=0.25)
+
+    root_joint = builder.add_joint_free(child=parent)
+    prismatic_joint = builder.add_joint_prismatic(
+        parent=parent,
+        child=child,
+        axis=newton.Axis.X,
+        limit_lower=-2.0,
+        limit_upper=2.0,
+        damping=0.0,
+    )
+    builder.add_articulation([root_joint, prismatic_joint])
+
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, 0.0))
+    state_0 = model.state()
+    state_1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    body_q = state_0.body_q.numpy()
+    body_q[child, :2] += np.array((extension, transverse_error), dtype=np.float32)
+    state_0.body_q.assign(body_q)
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2, angular_damping=0.0)
+    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+
+    parent_rotation_z = abs(float(state_1.body_q.numpy()[parent, 5]))
+    test.assertGreater(
+        parent_rotation_z,
+        0.01,
+        msg="Prismatic correction omitted torque from the valid joint extension",
+    )
+
+
 def test_optional_control_and_contacts(test, device):
     """Test that XPBD accepts omitted control and contact data.
 
@@ -1667,6 +1792,22 @@ add_function_test(
     TestSolverXPBD,
     "test_ball_joint_recovers_from_large_anchor_separation",
     test_ball_joint_recovers_from_large_anchor_separation,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_prismatic_joint_recovers_from_large_transverse_separation",
+    test_prismatic_joint_recovers_from_large_transverse_separation,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_prismatic_joint_retains_extension_in_parent_moment_arm",
+    test_prismatic_joint_retains_extension_in_parent_moment_arm,
     devices=devices,
     check_output=False,
 )

--- a/newton/tests/test_solver_xpbd.py
+++ b/newton/tests/test_solver_xpbd.py
@@ -148,6 +148,81 @@ def test_particle_particle_friction_uses_relative_velocity(test, device):
     )
 
 
+def test_ball_joint_recovers_from_large_anchor_separation(test, device):
+    """Recover a ball joint from a large off-axis anchor separation."""
+    capsule_radius = 0.0625
+    capsule_half_height = 0.25
+    capsule_half_extent = capsule_radius + capsule_half_height
+    capsule_volume = np.pi * capsule_radius**2 * (2.0 * capsule_half_height) + 4.0 / 3.0 * np.pi * capsule_radius**3
+
+    builder = newton.ModelBuilder(gravity=(0.0, 0.0, 0.0), up_axis=newton.Axis.Y)
+    shape_cfg = newton.ModelBuilder.ShapeConfig(density=1.0 / capsule_volume, collision_group=0)
+    shape_xform = wp.transform(
+        wp.vec3(0.0),
+        wp.quat_from_axis_angle(wp.vec3(0.0, 1.0, 0.0), 0.5 * wp.pi),
+    )
+
+    parent = builder.add_link()
+    builder.add_shape_capsule(
+        parent,
+        xform=shape_xform,
+        radius=capsule_radius,
+        half_height=capsule_half_height,
+        cfg=shape_cfg,
+    )
+    child = builder.add_link(xform=wp.transform(wp.vec3(2.0 * capsule_half_extent, 0.0, 0.0), wp.quat_identity()))
+    builder.add_shape_capsule(
+        child,
+        xform=shape_xform,
+        radius=capsule_radius,
+        half_height=capsule_half_height,
+        cfg=shape_cfg,
+    )
+
+    root_joint = builder.add_joint_free(child=parent)
+    ball_joint = builder.add_joint_ball(
+        parent=parent,
+        child=child,
+        parent_xform=wp.transform(wp.vec3(capsule_half_extent, 0.0, 0.0), wp.quat_identity()),
+        child_xform=wp.transform(wp.vec3(-capsule_half_extent, 0.0, 0.0), wp.quat_identity()),
+    )
+    builder.add_articulation([root_joint, ball_joint])
+
+    model = builder.finalize(device=device)
+    model.set_gravity((0.0, 0.0, 0.0))
+    state_0 = model.state()
+    state_1 = model.state()
+    newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+    body_q = state_0.body_q.numpy()
+    body_q[child, :3] += np.array((1.0, 1.0, 0.0), dtype=np.float32)
+    state_0.body_q.assign(body_q)
+
+    solver = newton.solvers.SolverXPBD(model, iterations=2)
+    solver.step(state_0, state_1, None, None, 1.0 / 240.0)
+
+    body_q = state_1.body_q.numpy()
+
+    def transform_point(transform, point):
+        p = transform[:3]
+        q = transform[3:]
+        qv = q[:3]
+        rotated = (
+            2.0 * np.dot(qv, point) * qv + (q[3] * q[3] - np.dot(qv, qv)) * point + 2.0 * q[3] * np.cross(qv, point)
+        )
+        return p + rotated
+
+    parent_anchor = transform_point(body_q[parent], np.array((capsule_half_extent, 0.0, 0.0)))
+    child_anchor = transform_point(body_q[child], np.array((-capsule_half_extent, 0.0, 0.0)))
+    anchor_gap = float(np.linalg.norm(child_anchor - parent_anchor))
+
+    test.assertLess(
+        anchor_gap,
+        0.5,
+        msg=f"Ball joint did not recover from a large anchor separation: gap={anchor_gap:.6g} m",
+    )
+
+
 def test_optional_control_and_contacts(test, device):
     """Test that XPBD accepts omitted control and contact data.
 
@@ -1584,6 +1659,14 @@ add_function_test(
     TestSolverXPBD,
     "test_particle_particle_friction_uses_relative_velocity",
     test_particle_particle_friction_uses_relative_velocity,
+    devices=devices,
+    check_output=False,
+)
+
+add_function_test(
+    TestSolverXPBD,
+    "test_ball_joint_recovers_from_large_anchor_separation",
+    test_ball_joint_recovers_from_large_anchor_separation,
     devices=devices,
     check_output=False,
 )


### PR DESCRIPTION
## Description

Fix XPBD joint constraints becoming permanently separated after a large transient anchor error.

The joint solver used the child anchor to compute the parent body's moment arm. As the anchors separated, that moment arm grew with the error, inflated the angular effective-mass term, and progressively reduced positional correction until the joint could no longer catch up.

Compute the parent moment arm from the relative offset projected onto the joint's admissible linear coordinates. Locked coordinates project to zero, limit violations project to the nearest boundary, position-driven coordinates project to their target, and unconstrained coordinates retain their valid extension. This removes separation error from the lever arm without discarding legitimate prismatic or D6 motion.

## Checklist

- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
- [x] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

```text
uv run --extra dev -m newton.tests -k test_prismatic_joint
uv run --extra dev -m newton.tests -k test_ball_joint_recovers_from_large_anchor_separation
uvx pre-commit run -a
```

The new ball and prismatic regressions pass on CPU and CUDA. The selected test runs completed 46 and 42 tests respectively, and all pre-commit hooks pass.

The regression tests were also verified to fail before their corresponding fix: the original ball-joint case retained a 1.318 m gap after one step, and the fully-locked-only fix left 1.389 m of transverse error in the prismatic case.

## Bug fix

**Steps to reproduce:**

1. Connect thin rigid bodies with a ball or prismatic joint.
2. Introduce a large anchor separation transverse to every permitted linear coordinate.
3. Advance `SolverXPBD` with a low iteration count.
4. Observe the old solver convert much of the correction into rotation and leave a large residual gap. Under sustained load, the gap grows and appears to be a broken joint.

**Minimal reproduction:**

```python
body_q = state_0.body_q.numpy()
body_q[child, :3] += np.array((0.5, 1.0, 1.0), dtype=np.float32)
state_0.body_q.assign(body_q)

solver = newton.solvers.SolverXPBD(model, iterations=2)
solver.step(state_0, state_1, None, None, 1.0 / 240.0)
```

The complete recovery and valid-extension torque assertions are in `test_solver_xpbd.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fully locked joints becoming permanently separated after large temporary anchor displacements.
  * Improved joint correction behavior to preserve valid extension, respect movement limits, and recover from transverse separation.
  * Prevented anchor separation from incorrectly affecting rotational constraint calculations.

* **Tests**
  * Added regression coverage for ball-joint recovery, prismatic-joint separation correction, limit preservation, and valid extension torque.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->